### PR TITLE
Web Inspector: introduce FrameDOMAgent for cross-origin iframe DOM tree access

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/dom/getDocument-frame-target-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/getDocument-frame-target-expected.txt
@@ -1,0 +1,11 @@
+Test that a cross-origin iframe's FrameDOMAgent returns a valid document tree.
+
+
+== Running test suite: SiteIsolation.DOM.FrameDOMAgent
+-- Running test case: SiteIsolation.DOM.FrameDOMAgent.GetDocument
+PASS: Frame target should have a DOMAgent.
+PASS: Frame target should have a document.
+PASS: Root should be a Document node.
+PASS: Document should have children.
+PASS: Document should have an HTML element child.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/dom/getDocument-frame-target.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/getDocument-frame-target.html
@@ -1,0 +1,53 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script>
+    function addCrossOriginIFrame() {
+        let crossOriginHost = location.hostname === "localhost" ? "127.0.0.1" : "localhost";
+        let iframe = document.createElement("iframe");
+        iframe.src = `http://${crossOriginHost}:8000/site-isolation/inspector/dom/resources/dom-frame.html`;
+        document.body.appendChild(iframe);
+    }
+
+    function test() {
+        let suite = InspectorTest.createAsyncSuite("SiteIsolation.DOM.FrameDOMAgent");
+
+        suite.addTestCase({
+            name: "SiteIsolation.DOM.FrameDOMAgent.GetDocument",
+            description: "A cross-origin iframe frame target should have a DOMAgent that returns a document.",
+            async test() {
+                let targetAddedPromise = WI.targetManager.awaitEvent(WI.TargetManager.Event.TargetAdded);
+                InspectorTest.evaluateInPage("addCrossOriginIFrame()");
+                let event = await targetAddedPromise;
+                let target = event.data.target;
+
+                InspectorTest.assert(target instanceof WI.FrameTarget);
+
+                if (target.isProvisional) {
+                    let committedEvent = await WI.targetManager.awaitEvent(WI.TargetManager.Event.DidCommitProvisionalTarget);
+                    target = committedEvent.data.target;
+                }
+
+                InspectorTest.expectNotNull(target.DOMAgent, "Frame target should have a DOMAgent.");
+
+                let frameDoc = WI.domManager.frameTargetDocumentForTarget(target);
+                if (!frameDoc) {
+                    let docEvent = await WI.domManager.awaitEvent(WI.DOMManager.Event.FrameDocumentAvailable);
+                    frameDoc = docEvent.data.document;
+                }
+
+                InspectorTest.expectNotNull(frameDoc, "Frame target should have a document.");
+                InspectorTest.expectEqual(frameDoc.nodeType(), Node.DOCUMENT_NODE, "Root should be a Document node.");
+                InspectorTest.expectThat(frameDoc.children && frameDoc.children.length > 0, "Document should have children.");
+
+                let htmlNode = frameDoc.children.find((child) => child.nodeName() === "HTML");
+                InspectorTest.expectNotNull(htmlNode, "Document should have an HTML element child.");
+            }
+        });
+
+        suite.runTestCasesAndFinish();
+    }
+</script>
+
+<body onload="runTest()">
+<p>Test that a cross-origin iframe's FrameDOMAgent returns a valid document tree.</p>
+</body>

--- a/LayoutTests/http/tests/site-isolation/inspector/dom/resources/dom-frame.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/resources/dom-frame.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Cross-Origin DOM Frame</title>
+</head>
+<body>
+    <div id="container" class="main-content" data-role="frame-root">
+        <h1 id="heading">Cross-Origin Heading</h1>
+        <p id="text-node">Hello from cross-origin frame.</p>
+        <ul id="list">
+            <li class="item">Item one</li>
+            <li class="item">Item two</li>
+        </ul>
+    </div>
+</body>
+</html>

--- a/Source/JavaScriptCore/inspector/protocol/DOM.json
+++ b/Source/JavaScriptCore/inspector/protocol/DOM.json
@@ -2,7 +2,7 @@
     "domain": "DOM",
     "description": "This domain exposes DOM read/write operations. Each DOM Node is represented with its mirror object that has an <code>id</code>. This <code>id</code> can be used to get additional information on the Node, resolve it into the JavaScript object wrapper, etc. It is important that client receives DOM events only for the nodes that are known to the client. Backend keeps track of the nodes that were sent to the client and never sends the same node twice. It is client's responsibility to collect information about the nodes that were sent to the client.<p>Note that <code>iframe</code> owner elements will return corresponding document elements as their child nodes.</p>",
     "debuggableTypes": ["itml", "web-page"],
-    "targetTypes": ["itml", "page"],
+    "targetTypes": ["itml", "frame", "page"],
     "types": [
         {
             "id": "NodeId",

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1920,6 +1920,8 @@ inspector/agents/WebConsoleAgent.cpp
 inspector/agents/WebDebuggerAgent.cpp
 inspector/agents/WebHeapAgent.cpp
 inspector/agents/frame/FrameConsoleAgent.cpp
+inspector/agents/frame/FrameDOMAgent.cpp
+inspector/agents/frame/FrameDOMAgentStubs.cpp
 inspector/agents/frame/FrameDebuggerAgent.cpp
 inspector/agents/frame/FrameWorkerAgent.cpp
 inspector/agents/page/PageAuditAgent.cpp

--- a/Source/WebCore/inspector/FrameInspectorController.cpp
+++ b/Source/WebCore/inspector/FrameInspectorController.cpp
@@ -33,6 +33,7 @@
 #include "CommonVM.h"
 #include "DocumentPage.h"
 #include "FrameConsoleAgent.h"
+#include "FrameDOMAgent.h"
 #include "FrameDebugger.h"
 #include "FrameDebuggerAgent.h"
 #include "FrameInlines.h"
@@ -129,20 +130,6 @@ void FrameInspectorController::createConsoleAgent()
     m_didCreateConsoleAgent = true;
 }
 
-void FrameInspectorController::createRuntimeAgent()
-{
-    if (m_didCreateRuntimeAgent)
-        return;
-
-    RefPtr frame = m_frame.get();
-    if (!frame)
-        return;
-
-    auto context = frameAgentContext();
-    m_agents.append(makeUniqueRef<FrameRuntimeAgent>(context));
-    m_didCreateRuntimeAgent = true;
-}
-
 void FrameInspectorController::createLazyAgents()
 {
     if (m_didCreateLazyAgents)
@@ -151,7 +138,10 @@ void FrameInspectorController::createLazyAgents()
     m_didCreateLazyAgents = true;
 
     RefPtr frame = m_frame.get();
-    if (!frame || !frame->settings().siteIsolationEnabled())
+    if (!frame)
+        return;
+
+    if (!frame->settings().siteIsolationEnabled())
         return;
 
     // Create debugger before agents that depend on it.
@@ -159,9 +149,8 @@ void FrameInspectorController::createLazyAgents()
 
     auto context = frameAgentContext();
     m_agents.append(makeUniqueRef<FrameDebuggerAgent>(context));
-
-    createRuntimeAgent();
-
+    m_agents.append(makeUniqueRef<FrameDOMAgent>(context));
+    m_agents.append(makeUniqueRef<FrameRuntimeAgent>(context));
     m_agents.append(makeUniqueRef<FrameWorkerAgent>(context));
 }
 

--- a/Source/WebCore/inspector/FrameInspectorController.h
+++ b/Source/WebCore/inspector/FrameInspectorController.h
@@ -104,7 +104,6 @@ private:
 
     FrameAgentContext frameAgentContext();
     void createConsoleAgent();
-    void createRuntimeAgent();
     void createLazyAgents();
 
     WeakRef<LocalFrame> m_frame;
@@ -117,7 +116,6 @@ private:
     Inspector::AgentRegistry m_agents;
 
     bool m_didCreateConsoleAgent { false };
-    bool m_didCreateRuntimeAgent { false };
     bool m_didCreateLazyAgents { false };
     WeakPtr<InspectorFrontendClient> m_inspectorFrontendClient;
 };

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -40,6 +40,7 @@
 #include "DocumentLoader.h"
 #include "Event.h"
 #include "EventTargetInlines.h"
+#include "FrameDOMAgent.h"
 #include "FrameDebuggerAgent.h"
 #include "FrameInspectorController.h"
 #include "FrameRuntimeAgent.h"
@@ -818,6 +819,12 @@ void InspectorInstrumentation::didCommitLoadImpl(InstrumentingAgents& instrument
 
 void InspectorInstrumentation::frameDocumentUpdatedImpl(InstrumentingAgents& instrumentingAgents, LocalFrame& frame)
 {
+    // Query the frame's own InstrumentingAgents (not the passed-in parameter) because
+    // frameDocumentUpdated needs to reach the specific frame's agent. This matches the
+    // Runtime pattern used by didClearWindowObjectInWorld.
+    if (CheckedPtr frameDOMAgent = frame.inspectorController().instrumentingAgents().persistentFrameDOMAgent())
+        frameDOMAgent->frameDocumentUpdated(frame);
+
     if (CheckedPtr domAgent = instrumentingAgents.persistentDOMAgent())
         domAgent->frameDocumentUpdated(frame);
 

--- a/Source/WebCore/inspector/InstrumentingAgents.h
+++ b/Source/WebCore/inspector/InstrumentingAgents.h
@@ -57,6 +57,7 @@ class InspectorNetworkAgent;
 class InspectorPageAgent;
 class InspectorTimelineAgent;
 class InspectorWorkerAgent;
+class FrameDOMAgent;
 class FrameDebuggerAgent;
 class FrameRuntimeAgent;
 class PageCanvasAgent;
@@ -88,6 +89,7 @@ class WebHeapAgent;
 #define DEFINE_INSPECTOR_AGENT_LayerTree(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, InspectorLayerTreeAgent, LayerTreeAgent, Getter, Setter)
 #define DEFINE_INSPECTOR_AGENT_Network(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, InspectorNetworkAgent, NetworkAgent, Getter, Setter)
 #define DEFINE_INSPECTOR_AGENT_Page(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, InspectorPageAgent, PageAgent, Getter, Setter)
+#define DEFINE_INSPECTOR_AGENT_DOM_Frame(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, FrameDOMAgent, FrameDOMAgent, Getter, Setter)
 #define DEFINE_INSPECTOR_AGENT_Runtime_Frame(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, FrameRuntimeAgent, FrameRuntimeAgent, Getter, Setter)
 #define DEFINE_INSPECTOR_AGENT_Runtime_Page(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, PageRuntimeAgent, PageRuntimeAgent, Getter, Setter)
 #define DEFINE_INSPECTOR_AGENT_ScriptProfiler(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, Inspector::InspectorScriptProfilerAgent, ScriptProfilerAgent, Getter, Setter)
@@ -117,6 +119,7 @@ class WebHeapAgent;
     DEFINE_PERSISTENT_INSPECTOR_AGENT(macro, Animation) \
     DEFINE_PERSISTENT_INSPECTOR_AGENT(macro, CPUProfiler) \
     DEFINE_PERSISTENT_INSPECTOR_AGENT(macro, DOM) \
+    DEFINE_PERSISTENT_INSPECTOR_AGENT(macro, DOM_Frame) \
     DEFINE_PERSISTENT_INSPECTOR_AGENT(macro, Heap_Web) \
     DEFINE_PERSISTENT_INSPECTOR_AGENT(macro, Inspector) \
     DEFINE_PERSISTENT_INSPECTOR_AGENT(macro, Memory) \

--- a/Source/WebCore/inspector/agents/frame/FrameDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/frame/FrameDOMAgent.cpp
@@ -1,0 +1,761 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "FrameDOMAgent.h"
+
+#include "Attr.h"
+#include "CharacterData.h"
+#include "ContainerNode.h"
+#include "Document.h"
+#include "DocumentInlines.h"
+#include "DocumentType.h"
+#include "ElementInlines.h"
+#include "FrameInlines.h"
+#include "HTMLFrameOwnerElement.h"
+#include "HTMLNames.h"
+#include "HTMLScriptElement.h"
+#include "HTMLSlotElement.h"
+#include "HTMLStyleElement.h"
+#include "HTMLTemplateElement.h"
+#include "InspectorDOMAgent.h"
+#include "InstrumentingAgents.h"
+#include "LocalFrame.h"
+#include "PseudoElement.h"
+#include "ShadowRoot.h"
+#include "Text.h"
+#include "TextNodeTraversal.h"
+#include <JavaScriptCore/InspectorProtocolObjects.h>
+#include <pal/crypto/CryptoDigest.h>
+#include <pal/text/TextEncoding.h>
+#include <wtf/TZoneMallocInlines.h>
+#include <wtf/text/Base64.h>
+#include <wtf/text/MakeString.h>
+#include <wtf/unicode/CharacterNames.h>
+
+namespace WebCore {
+
+using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FrameDOMAgent);
+
+// FIXME: <https://webkit.org/b/298980> Extract shared tree-building and node-binding logic into a base class shared with InspectorDOMAgent.
+
+static const size_t maxTextSize = 10000;
+static const char16_t horizontalEllipsisUTF16[] = { horizontalEllipsis, 0 };
+
+static bool containsOnlyASCIIWhitespace(Node* node)
+{
+    auto* text = dynamicDowncast<Text>(node);
+    return text && text->containsOnlyASCIIWhitespace();
+}
+
+static Inspector::Protocol::DOM::ShadowRootType shadowRootType(ShadowRootMode mode)
+{
+    switch (mode) {
+    case ShadowRootMode::UserAgent:
+        return Inspector::Protocol::DOM::ShadowRootType::UserAgent;
+    case ShadowRootMode::Closed:
+        return Inspector::Protocol::DOM::ShadowRootType::Closed;
+    case ShadowRootMode::Open:
+        return Inspector::Protocol::DOM::ShadowRootType::Open;
+    }
+    ASSERT_NOT_REACHED();
+    return Inspector::Protocol::DOM::ShadowRootType::UserAgent;
+}
+
+static Inspector::Protocol::DOM::CustomElementState customElementState(const Element& element)
+{
+    if (element.isDefinedCustomElement())
+        return Inspector::Protocol::DOM::CustomElementState::Custom;
+    if (element.isFailedOrPrecustomizedCustomElement())
+        return Inspector::Protocol::DOM::CustomElementState::Failed;
+    if (element.isCustomElementUpgradeCandidate())
+        return Inspector::Protocol::DOM::CustomElementState::Waiting;
+    return Inspector::Protocol::DOM::CustomElementState::Builtin;
+}
+
+static bool pseudoElementType(PseudoElementType pseudoElementType, Inspector::Protocol::DOM::PseudoType* type)
+{
+    switch (pseudoElementType) {
+    case PseudoElementType::Before:
+        *type = Inspector::Protocol::DOM::PseudoType::Before;
+        return true;
+    case PseudoElementType::After:
+        *type = Inspector::Protocol::DOM::PseudoType::After;
+        return true;
+    default:
+        return false;
+    }
+}
+
+static String computeContentSecurityPolicySHA256Hash(const Element& element)
+{
+    Ref document = element.document();
+    PAL::TextEncoding documentEncoding = document->textEncoding();
+    const PAL::TextEncoding& encodingToUse = documentEncoding.isValid() ? documentEncoding : PAL::UTF8Encoding();
+    auto content = encodingToUse.encode(TextNodeTraversal::contentsAsString(element), PAL::UnencodableHandling::Entities);
+    auto cryptoDigest = PAL::Crypto::CryptoDigest::create(PAL::Crypto::CryptoDigest::Algorithm::SHA_256);
+    cryptoDigest->addBytes(content.span());
+    auto digest = cryptoDigest->computeHash();
+    return makeString("sha256-"_s, base64Encoded(digest));
+}
+
+// MARK: - FrameDOMAgent
+
+FrameDOMAgent::FrameDOMAgent(FrameAgentContext& context)
+    : InspectorAgentBase("DOM"_s, context)
+    , m_frontendDispatcher(makeUniqueRef<Inspector::DOMFrontendDispatcher>(context.frontendRouter))
+    , m_backendDispatcher(Inspector::DOMBackendDispatcher::create(Ref { context.backendDispatcher }, this))
+    , m_instrumentingAgents(context.instrumentingAgents)
+    , m_inspectedFrame(context.inspectedFrame)
+    , m_destroyedNodesTimer(*this, &FrameDOMAgent::destroyedNodesTimerFired)
+{
+}
+
+FrameDOMAgent::~FrameDOMAgent() = default;
+
+void FrameDOMAgent::didCreateFrontendAndBackend()
+{
+    Ref { m_instrumentingAgents.get() }->setPersistentFrameDOMAgent(this);
+
+    RefPtr frame = m_inspectedFrame.get();
+    if (frame)
+        m_document = frame->document();
+}
+
+void FrameDOMAgent::willDestroyFrontendAndBackend(Inspector::DisconnectReason)
+{
+    Ref { m_instrumentingAgents.get() }->setPersistentFrameDOMAgent(nullptr);
+    m_documentRequested = false;
+    reset();
+}
+
+// MARK: - Node Binding
+
+Inspector::Protocol::DOM::NodeId FrameDOMAgent::bind(Node& node)
+{
+    return m_nodeToId.ensure(node, [&] {
+        auto id = m_lastNodeId++;
+        m_idToNode.set(id, node);
+        return id;
+    }).iterator->value;
+}
+
+void FrameDOMAgent::unbind(Node& node)
+{
+    auto id = m_nodeToId.take(node);
+    if (!id)
+        return;
+
+    m_idToNode.remove(id);
+
+    if (auto* frameOwner = dynamicDowncast<HTMLFrameOwnerElement>(node)) {
+        // FIXME: <https://webkit.org/b/298980> Skip if child frame has its own FrameDOMAgent.
+        if (RefPtr contentDocument = frameOwner->contentDocument())
+            unbind(*contentDocument);
+    }
+
+    if (RefPtr element = dynamicDowncast<Element>(node)) {
+        if (RefPtr root = element->shadowRoot())
+            unbind(*root);
+        if (RefPtr before = element->beforePseudoElement())
+            unbind(*before);
+        if (RefPtr after = element->afterPseudoElement())
+            unbind(*after);
+    }
+
+    if (m_childrenRequested.remove(id)) {
+        for (RefPtr child = InspectorDOMAgent::innerFirstChild(&node); child; child = InspectorDOMAgent::innerNextSibling(child.get()))
+            unbind(*child);
+    }
+}
+
+Inspector::Protocol::DOM::NodeId FrameDOMAgent::boundNodeId(const Node* node)
+{
+    if (!node)
+        return 0;
+    return m_nodeToId.get(*node);
+}
+
+Node* FrameDOMAgent::nodeForId(Inspector::Protocol::DOM::NodeId id)
+{
+    if (!m_idToNode.isValidKey(id))
+        return nullptr;
+    return m_idToNode.get(id);
+}
+
+void FrameDOMAgent::discardBindings()
+{
+    m_nodeToId.clear();
+    m_idToNode.clear();
+    m_childrenRequested.clear();
+}
+
+RefPtr<Node> FrameDOMAgent::assertNode(Inspector::Protocol::ErrorString& errorString, Inspector::Protocol::DOM::NodeId nodeId)
+{
+    RefPtr node = nodeForId(nodeId);
+    if (!node)
+        errorString = "Missing node for given nodeId"_s;
+    return node;
+}
+
+RefPtr<Element> FrameDOMAgent::assertElement(Inspector::Protocol::ErrorString& errorString, Inspector::Protocol::DOM::NodeId nodeId)
+{
+    RefPtr node = assertNode(errorString, nodeId);
+    if (!node)
+        return nullptr;
+    RefPtr element = dynamicDowncast<Element>(*node);
+    if (!element)
+        errorString = "Node for given nodeId is not an element"_s;
+    return element;
+}
+
+// MARK: - Tree Building
+
+Ref<Inspector::Protocol::DOM::Node> FrameDOMAgent::buildObjectForNode(Node* node, int depth)
+{
+    auto id = bind(*node);
+    String nodeName;
+    String localName;
+    String nodeValue;
+
+    switch (node->nodeType()) {
+    case NodeType::ProcessingInstruction:
+        nodeName = node->nodeName();
+        localName = node->localName();
+        [[fallthrough]];
+    case NodeType::Text:
+    case NodeType::Comment:
+    case NodeType::CDATASection:
+        nodeValue = node->nodeValue();
+        if (nodeValue.length() > maxTextSize)
+            nodeValue = makeString(StringView(nodeValue).left(maxTextSize), horizontalEllipsisUTF16);
+        break;
+    case NodeType::Attribute:
+        localName = node->localName();
+        break;
+    case NodeType::DocumentFragment:
+    case NodeType::Document:
+    case NodeType::Element:
+    default:
+        nodeName = node->nodeName();
+        localName = node->localName();
+        break;
+    }
+
+    auto value = Inspector::Protocol::DOM::Node::create()
+        .setNodeId(id)
+        .setNodeType(std::to_underlying(node->nodeType()))
+        .setNodeName(nodeName)
+        .setLocalName(localName)
+        .setNodeValue(nodeValue)
+        .release();
+
+    if (node->isContainerNode()) {
+        int nodeCount = InspectorDOMAgent::innerChildNodeCount(node);
+        value->setChildNodeCount(nodeCount);
+        auto children = buildArrayForContainerChildren(node, depth);
+        if (children->length() > 0)
+            value->setChildren(WTF::move(children));
+    }
+
+    if (RefPtr element = dynamicDowncast<Element>(*node)) {
+        value->setAttributes(buildArrayForElementAttributes(element.get()));
+
+        // FIXME: <https://webkit.org/b/298980> Skip if child frame has its own FrameDOMAgent.
+        if (RefPtr frameOwner = dynamicDowncast<HTMLFrameOwnerElement>(*element)) {
+            if (RefPtr document = frameOwner->contentDocument())
+                value->setContentDocument(buildObjectForNode(document.get(), 0));
+        }
+
+        if (RefPtr root = element->shadowRoot()) {
+            auto shadowRoots = JSON::ArrayOf<Inspector::Protocol::DOM::Node>::create();
+            shadowRoots->addItem(buildObjectForNode(root.get(), 0));
+            value->setShadowRoots(WTF::move(shadowRoots));
+        }
+
+        if (RefPtr templateElement = dynamicDowncast<HTMLTemplateElement>(*element))
+            value->setTemplateContent(buildObjectForNode(protect(templateElement->content()).ptr(), 0));
+
+        if (is<HTMLStyleElement>(element) || (is<HTMLScriptElement>(element) && !element->hasAttributeWithoutSynchronization(HTMLNames::srcAttr)))
+            value->setContentSecurityPolicyHash(computeContentSecurityPolicySHA256Hash(*element));
+
+        auto state = customElementState(*element);
+        if (state != Inspector::Protocol::DOM::CustomElementState::Builtin)
+            value->setCustomElementState(state);
+
+        if (element->pseudoElementIdentifier()) {
+            Inspector::Protocol::DOM::PseudoType pseudoType;
+            if (pseudoElementType(element->pseudoElementIdentifier()->type, &pseudoType))
+                value->setPseudoType(pseudoType);
+        } else {
+            if (auto pseudoElements = buildArrayForPseudoElements(*element))
+                value->setPseudoElements(pseudoElements.releaseNonNull());
+        }
+    } else if (RefPtr document = dynamicDowncast<Document>(*node)) {
+        value->setDocumentURL(InspectorDOMAgent::documentURLString(document.get()));
+        // FIXME: <https://webkit.org/b/298980> Set frameId for frame targets to enable frontend frame-to-target association.
+    } else if (RefPtr doctype = dynamicDowncast<DocumentType>(*node)) {
+        value->setPublicId(doctype->publicId());
+        value->setSystemId(doctype->systemId());
+    } else if (RefPtr attribute = dynamicDowncast<Attr>(*node)) {
+        value->setName(attribute->name());
+        value->setValue(attribute->value());
+    } else if (RefPtr shadowRoot = dynamicDowncast<ShadowRoot>(*node))
+        value->setShadowRootType(shadowRootType(shadowRoot->mode()));
+
+    return value;
+}
+
+Ref<JSON::ArrayOf<String>> FrameDOMAgent::buildArrayForElementAttributes(Element* element)
+{
+    auto attributesValue = JSON::ArrayOf<String>::create();
+    if (!element->hasAttributes())
+        return attributesValue;
+    for (auto& attribute : element->attributes()) {
+        attributesValue->addItem(attribute.name().toString());
+        attributesValue->addItem(attribute.value());
+    }
+    return attributesValue;
+}
+
+Ref<JSON::ArrayOf<Inspector::Protocol::DOM::Node>> FrameDOMAgent::buildArrayForContainerChildren(Node* container, int depth)
+{
+    auto children = JSON::ArrayOf<Inspector::Protocol::DOM::Node>::create();
+    if (!depth) {
+        RefPtr firstChild = container->firstChild();
+        if (firstChild && firstChild->nodeType() == NodeType::Text && !firstChild->nextSibling()) {
+            children->addItem(buildObjectForNode(firstChild.get(), 0));
+            m_childrenRequested.add(bind(*container));
+        }
+        return children;
+    }
+
+    RefPtr child = InspectorDOMAgent::innerFirstChild(container);
+    depth--;
+    m_childrenRequested.add(bind(*container));
+
+    while (child) {
+        children->addItem(buildObjectForNode(child.get(), depth));
+        child = InspectorDOMAgent::innerNextSibling(child.get());
+    }
+    return children;
+}
+
+RefPtr<JSON::ArrayOf<Inspector::Protocol::DOM::Node>> FrameDOMAgent::buildArrayForPseudoElements(const Element& element)
+{
+    RefPtr beforeElement = element.beforePseudoElement();
+    RefPtr afterElement = element.afterPseudoElement();
+    if (!beforeElement && !afterElement)
+        return nullptr;
+
+    auto pseudoElements = JSON::ArrayOf<Inspector::Protocol::DOM::Node>::create();
+    if (beforeElement)
+        pseudoElements->addItem(buildObjectForNode(beforeElement.get(), 0));
+    if (afterElement)
+        pseudoElements->addItem(buildObjectForNode(afterElement.get(), 0));
+    return pseudoElements;
+}
+
+void FrameDOMAgent::pushChildNodesToFrontend(Inspector::Protocol::DOM::NodeId nodeId, int depth)
+{
+    RefPtr node = nodeForId(nodeId);
+    if (!node || (node->nodeType() != NodeType::Element && node->nodeType() != NodeType::Document && node->nodeType() != NodeType::DocumentFragment))
+        return;
+
+    if (m_childrenRequested.contains(nodeId)) {
+        if (depth <= 1)
+            return;
+
+        depth--;
+        for (node = InspectorDOMAgent::innerFirstChild(node.get()); node; node = InspectorDOMAgent::innerNextSibling(node.get())) {
+            auto childNodeId = boundNodeId(node.get());
+            ASSERT(childNodeId);
+            pushChildNodesToFrontend(childNodeId, depth);
+        }
+        return;
+    }
+
+    auto children = buildArrayForContainerChildren(node.get(), depth);
+    m_frontendDispatcher->setChildNodes(nodeId, WTF::move(children));
+}
+
+Inspector::Protocol::DOM::NodeId FrameDOMAgent::pushNodePathToFrontend(Node* nodeToPush)
+{
+    Inspector::Protocol::ErrorString ignored;
+    return pushNodePathToFrontend(ignored, nodeToPush);
+}
+
+Inspector::Protocol::DOM::NodeId FrameDOMAgent::pushNodePathToFrontend(Inspector::Protocol::ErrorString& errorString, Node* nodeToPush)
+{
+    ASSERT(nodeToPush);
+
+    if (!m_document) {
+        errorString = "Missing document"_s;
+        return 0;
+    }
+
+    if (!m_nodeToId.contains(*m_document)) {
+        errorString = "Document must have been requested"_s;
+        return 0;
+    }
+
+    if (auto result = boundNodeId(nodeToPush))
+        return result;
+
+    RefPtr node = nodeToPush;
+    Vector<Node*> path;
+
+    while (true) {
+        RefPtr parent = InspectorDOMAgent::innerParentNode(node.get());
+        if (!parent) {
+            auto children = JSON::ArrayOf<Inspector::Protocol::DOM::Node>::create();
+            children->addItem(buildObjectForNode(node.get(), 0));
+            m_frontendDispatcher->setChildNodes(0, WTF::move(children));
+            break;
+        }
+
+        path.append(parent.get());
+        if (boundNodeId(parent.get()))
+            break;
+        node = parent;
+    }
+
+    for (int i = path.size() - 1; i >= 0; --i) {
+        RefPtr pathNode = path.at(i);
+        auto nodeId = boundNodeId(pathNode.get());
+        ASSERT(nodeId);
+        pushChildNodesToFrontend(nodeId);
+    }
+    return boundNodeId(nodeToPush);
+}
+
+void FrameDOMAgent::setDocument(Document* document)
+{
+    if (document == m_document.get())
+        return;
+
+    reset();
+    m_document = document;
+
+    if (!m_documentRequested)
+        return;
+
+    if (!document || !document->parsing())
+        m_frontendDispatcher->documentUpdated();
+}
+
+void FrameDOMAgent::reset()
+{
+    discardBindings();
+    m_document = nullptr;
+
+    m_destroyedDetachedNodeIdentifiers.clear();
+    m_destroyedAttachedNodeIdentifiers.clear();
+    if (m_destroyedNodesTimer.isActive())
+        m_destroyedNodesTimer.stop();
+}
+
+// MARK: - Protocol Commands
+
+Inspector::CommandResult<Ref<Inspector::Protocol::DOM::Node>> FrameDOMAgent::getDocument()
+{
+    m_documentRequested = true;
+
+    if (!m_document)
+        return makeUnexpected("Internal error: missing document"_s);
+
+    RefPtr<Document> document = m_document;
+    reset();
+    m_document = document;
+
+    return buildObjectForNode(m_document.get(), 2);
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::requestChildNodes(int nodeId, std::optional<int>&& depth)
+{
+    int sanitizedDepth;
+    if (!depth)
+        sanitizedDepth = 1;
+    else if (*depth == -1)
+        sanitizedDepth = INT_MAX;
+    else if (*depth > 0)
+        sanitizedDepth = *depth;
+    else
+        return makeUnexpected("Unexpected value below -1 for given depth"_s);
+
+    pushChildNodesToFrontend(nodeId, sanitizedDepth);
+    return { };
+}
+
+Inspector::CommandResult<Ref<JSON::ArrayOf<String>>> FrameDOMAgent::getAttributes(int nodeId)
+{
+    Inspector::Protocol::ErrorString errorString;
+    RefPtr element = assertElement(errorString, nodeId);
+    if (!element)
+        return makeUnexpected(errorString);
+
+    return buildArrayForElementAttributes(element.get());
+}
+
+Inspector::CommandResult<std::optional<int>> FrameDOMAgent::requestAssignedSlot(int nodeId)
+{
+    Inspector::Protocol::ErrorString errorString;
+
+    RefPtr node = assertNode(errorString, nodeId);
+    if (!node)
+        return makeUnexpected(errorString);
+
+    RefPtr slotElement = node->assignedSlot();
+    if (!slotElement)
+        return { std::optional<int>() };
+
+    auto slotElementId = pushNodePathToFrontend(errorString, slotElement.get());
+    if (!slotElementId)
+        return makeUnexpected(errorString);
+
+    return { std::optional<int>(slotElementId) };
+}
+
+Inspector::CommandResult<Ref<JSON::ArrayOf<int>>> FrameDOMAgent::requestAssignedNodes(int slotElementId)
+{
+    Inspector::Protocol::ErrorString errorString;
+
+    RefPtr node = assertNode(errorString, slotElementId);
+    if (!node)
+        return makeUnexpected(errorString);
+
+    RefPtr slotElement = dynamicDowncast<HTMLSlotElement>(node);
+    if (!slotElement)
+        return makeUnexpected("Node for given nodeId is not a slot element"_s);
+
+    auto assignedNodeIds = JSON::ArrayOf<int>::create();
+    if (const auto* weakAssignedNodes = slotElement->assignedNodes()) {
+        for (const auto& weakAssignedNode : *weakAssignedNodes) {
+            if (RefPtr assignedNode = weakAssignedNode.get()) {
+                auto assignedNodeId = pushNodePathToFrontend(errorString, assignedNode.get());
+                if (!assignedNodeId)
+                    return makeUnexpected(errorString);
+                assignedNodeIds->addItem(assignedNodeId);
+            }
+        }
+    }
+    return assignedNodeIds;
+}
+
+// MARK: - InspectorInstrumentation Hooks
+
+void FrameDOMAgent::didInsertDOMNode(Node& node)
+{
+    if (containsOnlyASCIIWhitespace(&node))
+        return;
+
+    unbind(node);
+
+    RefPtr parent = node.parentNode();
+    auto parentId = boundNodeId(parent.get());
+    if (!parentId)
+        return;
+
+    if (!m_childrenRequested.contains(parentId)) {
+        // No children are mapped yet -> only notify on changes of hasChildren.
+        m_frontendDispatcher->childNodeCountUpdated(parentId, InspectorDOMAgent::innerChildNodeCount(parent.get()));
+    } else {
+        RefPtr prevSibling = InspectorDOMAgent::innerPreviousSibling(&node);
+        auto prevId = boundNodeId(prevSibling.get());
+        auto value = buildObjectForNode(&node, 0);
+        m_frontendDispatcher->childNodeInserted(parentId, prevId, WTF::move(value));
+    }
+}
+
+void FrameDOMAgent::didRemoveDOMNode(Node& node)
+{
+    if (containsOnlyASCIIWhitespace(&node))
+        return;
+
+    RefPtr parent = node.parentNode();
+    auto parentId = boundNodeId(parent.get());
+    if (!parentId)
+        return;
+
+    if (!m_childrenRequested.contains(parentId)) {
+        if (InspectorDOMAgent::innerChildNodeCount(parent.get()) == 1)
+            m_frontendDispatcher->childNodeCountUpdated(parentId, 0);
+    } else
+        m_frontendDispatcher->childNodeRemoved(parentId, boundNodeId(&node));
+    unbind(node);
+}
+
+void FrameDOMAgent::willDestroyDOMNode(Node& node)
+{
+    if (containsOnlyASCIIWhitespace(&node))
+        return;
+
+    auto nodeId = m_nodeToId.take(node);
+    if (!nodeId)
+        return;
+
+    m_idToNode.remove(nodeId);
+    m_childrenRequested.remove(nodeId);
+
+    RefPtr parentNode = node.parentNode();
+    if (auto parentId = boundNodeId(parentNode.get()))
+        m_destroyedAttachedNodeIdentifiers.append({ parentId, nodeId });
+    else
+        m_destroyedDetachedNodeIdentifiers.append(nodeId);
+
+    if (!m_destroyedNodesTimer.isActive())
+        m_destroyedNodesTimer.startOneShot(0_s);
+}
+
+void FrameDOMAgent::destroyedNodesTimerFired()
+{
+    for (auto& [parentId, nodeId] : std::exchange(m_destroyedAttachedNodeIdentifiers, { })) {
+        if (!m_childrenRequested.contains(parentId)) {
+            RefPtr parent = nodeForId(parentId);
+            if (parent && InspectorDOMAgent::innerChildNodeCount(parent.get()) == 1)
+                m_frontendDispatcher->childNodeCountUpdated(parentId, 0);
+        } else
+            m_frontendDispatcher->childNodeRemoved(parentId, nodeId);
+    }
+
+    for (auto nodeId : std::exchange(m_destroyedDetachedNodeIdentifiers, { }))
+        m_frontendDispatcher->willDestroyDOMNode(nodeId);
+}
+
+void FrameDOMAgent::willModifyDOMAttr(Element&, const AtomString& oldValue, const AtomString& newValue)
+{
+    m_suppressAttributeModifiedEvent = (oldValue == newValue);
+}
+
+void FrameDOMAgent::didModifyDOMAttr(Element& element, const AtomString& name, const AtomString& value)
+{
+    bool shouldSuppressEvent = m_suppressAttributeModifiedEvent;
+    m_suppressAttributeModifiedEvent = false;
+    if (shouldSuppressEvent)
+        return;
+
+    auto id = boundNodeId(&element);
+    if (!id)
+        return;
+
+    m_frontendDispatcher->attributeModified(id, name, value);
+}
+
+void FrameDOMAgent::didRemoveDOMAttr(Element& element, const AtomString& name)
+{
+    auto id = boundNodeId(&element);
+    if (!id)
+        return;
+
+    m_frontendDispatcher->attributeRemoved(id, name);
+}
+
+void FrameDOMAgent::characterDataModified(CharacterData& characterData)
+{
+    auto id = boundNodeId(&characterData);
+    if (!id) {
+        didInsertDOMNode(characterData);
+        return;
+    }
+    m_frontendDispatcher->characterDataModified(id, characterData.data());
+}
+
+void FrameDOMAgent::didInvalidateStyleAttr(Element& element)
+{
+    auto id = boundNodeId(&element);
+    if (!id)
+        return;
+
+    auto nodeIds = JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>::create();
+    nodeIds->addItem(id);
+    m_frontendDispatcher->inlineStyleInvalidated(WTF::move(nodeIds));
+}
+
+void FrameDOMAgent::didPushShadowRoot(Element& host, ShadowRoot& root)
+{
+    auto hostId = boundNodeId(&host);
+    if (hostId)
+        m_frontendDispatcher->shadowRootPushed(hostId, buildObjectForNode(&root, 0));
+}
+
+void FrameDOMAgent::willPopShadowRoot(Element& host, ShadowRoot& root)
+{
+    auto hostId = boundNodeId(&host);
+    auto rootId = boundNodeId(&root);
+    if (hostId && rootId)
+        m_frontendDispatcher->shadowRootPopped(hostId, rootId);
+}
+
+void FrameDOMAgent::didChangeCustomElementState(Element& element)
+{
+    auto elementId = boundNodeId(&element);
+    if (!elementId)
+        return;
+
+    m_frontendDispatcher->customElementStateChanged(elementId, customElementState(element));
+}
+
+void FrameDOMAgent::pseudoElementCreated(PseudoElement& pseudoElement)
+{
+    RefPtr parent = pseudoElement.hostElement();
+    if (!parent)
+        return;
+
+    auto parentId = boundNodeId(parent.get());
+    if (!parentId)
+        return;
+
+    pushChildNodesToFrontend(parentId, 1);
+    m_frontendDispatcher->pseudoElementAdded(parentId, buildObjectForNode(&pseudoElement, 0));
+}
+
+void FrameDOMAgent::pseudoElementDestroyed(PseudoElement& pseudoElement)
+{
+    auto pseudoElementId = boundNodeId(&pseudoElement);
+    if (!pseudoElementId)
+        return;
+
+    RefPtr parent = pseudoElement.hostElement();
+    ASSERT(parent);
+    auto parentId = boundNodeId(parent.get());
+    ASSERT(parentId);
+
+    unbind(pseudoElement);
+    m_frontendDispatcher->pseudoElementRemoved(parentId, pseudoElementId);
+}
+
+void FrameDOMAgent::frameDocumentUpdated(LocalFrame& frame)
+{
+    RefPtr inspectedFrame = m_inspectedFrame.get();
+    if (!inspectedFrame || &frame != inspectedFrame.get())
+        return;
+
+    RefPtr document = frame.document();
+    setDocument(document.get());
+}
+
+} // namespace WebCore

--- a/Source/WebCore/inspector/agents/frame/FrameDOMAgent.h
+++ b/Source/WebCore/inspector/agents/frame/FrameDOMAgent.h
@@ -1,0 +1,187 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "EventTarget.h"
+#include "InspectorWebAgentBase.h"
+#include "Timer.h"
+#include <JavaScriptCore/InspectorBackendDispatchers.h>
+#include <JavaScriptCore/InspectorFrontendDispatchers.h>
+#include <wtf/CheckedPtr.h>
+#include <wtf/HashMap.h>
+#include <wtf/HashSet.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/WeakHashMap.h>
+#include <wtf/WeakPtr.h>
+
+namespace WebCore {
+
+class CharacterData;
+class Document;
+class Element;
+class LocalFrame;
+class Node;
+class PseudoElement;
+class ShadowRoot;
+
+// FrameDOMAgent is the per-frame DOM agent for Site Isolation.
+class FrameDOMAgent final : public InspectorAgentBase, public Inspector::DOMBackendDispatcherHandler, public CanMakeCheckedPtr<FrameDOMAgent> {
+    WTF_MAKE_NONCOPYABLE(FrameDOMAgent);
+    WTF_MAKE_TZONE_ALLOCATED(FrameDOMAgent);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FrameDOMAgent);
+public:
+    FrameDOMAgent(FrameAgentContext&);
+    ~FrameDOMAgent();
+
+    // InspectorAgentBase
+    void didCreateFrontendAndBackend() override;
+    void willDestroyFrontendAndBackend(Inspector::DisconnectReason) override;
+
+    // DOMBackendDispatcherHandler
+    Inspector::CommandResult<Ref<Inspector::Protocol::DOM::Node>> getDocument() override;
+    Inspector::CommandResult<void> requestChildNodes(int nodeId, std::optional<int>&& depth) override;
+    Inspector::CommandResult<Ref<JSON::ArrayOf<String>>> getAttributes(int nodeId) override;
+    Inspector::CommandResult<std::optional<int>> requestAssignedSlot(int nodeId) override;
+    Inspector::CommandResult<Ref<JSON::ArrayOf<int>>> requestAssignedNodes(int slotElementId) override;
+
+    Inspector::CommandResult<std::optional<int>> querySelector(int nodeId, const String& selector) override;
+    Inspector::CommandResult<Ref<JSON::ArrayOf<int>>> querySelectorAll(int nodeId, const String& selector) override;
+    Inspector::CommandResult<int> setNodeName(int nodeId, const String& name) override;
+    Inspector::CommandResult<void> setNodeValue(int nodeId, const String& value) override;
+    Inspector::CommandResult<void> removeNode(int nodeId) override;
+    Inspector::CommandResult<void> setAttributeValue(int nodeId, const String& name, const String& value) override;
+    Inspector::CommandResult<void> setAttributesAsText(int nodeId, const String& text, const String& name) override;
+    Inspector::CommandResult<void> removeAttribute(int nodeId, const String& name) override;
+    Inspector::CommandResult<Ref<JSON::ArrayOf<String>>> getSupportedEventNames() override;
+#if ENABLE(INSPECTOR_ALTERNATE_DISPATCHERS)
+    Inspector::CommandResult<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::DataBinding>>> getDataBindingsForNode(int nodeId) override;
+    Inspector::CommandResult<String> getAssociatedDataForNode(int nodeId) override;
+#endif
+    Inspector::CommandResult<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::EventListener>>> getEventListenersForNode(int nodeId, std::optional<bool>&& includeAncestors) override;
+    Inspector::CommandResult<void> setEventListenerDisabled(int eventListenerId, bool disabled) override;
+    Inspector::CommandResult<void> setBreakpointForEventListener(int eventListenerId, RefPtr<JSON::Object>&& options) override;
+    Inspector::CommandResult<void> removeBreakpointForEventListener(int eventListenerId) override;
+    Inspector::CommandResult<Ref<Inspector::Protocol::DOM::AccessibilityProperties>> getAccessibilityPropertiesForNode(int nodeId) override;
+    Inspector::CommandResult<String> getOuterHTML(int nodeId) override;
+    Inspector::CommandResult<void> setOuterHTML(int nodeId, const String& outerHTML) override;
+    Inspector::CommandResult<void> insertAdjacentHTML(int nodeId, const String& position, const String& html) override;
+    Inspector::CommandResultOf<String, int> performSearch(const String& query, RefPtr<JSON::Array>&& nodeIds, std::optional<bool>&& caseSensitive) override;
+    Inspector::CommandResult<Ref<JSON::ArrayOf<int>>> getSearchResults(const String& searchId, int fromIndex, int toIndex) override;
+    Inspector::CommandResult<void> discardSearchResults(const String& searchId) override;
+    Inspector::CommandResult<int> requestNode(const String& objectId) override;
+#if PLATFORM(IOS_FAMILY)
+    Inspector::CommandResult<void> setInspectModeEnabled(bool enabled, RefPtr<JSON::Object>&& highlightConfig, RefPtr<JSON::Object>&& gridOverlayConfig, RefPtr<JSON::Object>&& flexOverlayConfig) override;
+#else
+    Inspector::CommandResult<void> setInspectModeEnabled(bool enabled, RefPtr<JSON::Object>&& highlightConfig, RefPtr<JSON::Object>&& gridOverlayConfig, RefPtr<JSON::Object>&& flexOverlayConfig, std::optional<bool>&& showRulers) override;
+#endif
+    Inspector::CommandResult<void> highlightRect(int x, int y, int width, int height, RefPtr<JSON::Object>&& color, RefPtr<JSON::Object>&& outlineColor, std::optional<bool>&& usePageCoordinates) override;
+    Inspector::CommandResult<void> highlightQuad(Ref<JSON::Array>&& quad, RefPtr<JSON::Object>&& color, RefPtr<JSON::Object>&& outlineColor, std::optional<bool>&& usePageCoordinates) override;
+#if PLATFORM(IOS_FAMILY)
+    Inspector::CommandResult<void> highlightSelector(const String& selectorString, const String& frameId, Ref<JSON::Object>&& highlightConfig, RefPtr<JSON::Object>&& gridOverlayConfig, RefPtr<JSON::Object>&& flexOverlayConfig) override;
+    Inspector::CommandResult<void> highlightNode(std::optional<int>&& nodeId, const String& objectId, Ref<JSON::Object>&& highlightConfig, RefPtr<JSON::Object>&& gridOverlayConfig, RefPtr<JSON::Object>&& flexOverlayConfig) override;
+    Inspector::CommandResult<void> highlightNodeList(Ref<JSON::Array>&& nodeIds, Ref<JSON::Object>&& highlightConfig, RefPtr<JSON::Object>&& gridOverlayConfig, RefPtr<JSON::Object>&& flexOverlayConfig) override;
+#else
+    Inspector::CommandResult<void> highlightSelector(const String& selectorString, const String& frameId, Ref<JSON::Object>&& highlightConfig, RefPtr<JSON::Object>&& gridOverlayConfig, RefPtr<JSON::Object>&& flexOverlayConfig, std::optional<bool>&& showRulers) override;
+    Inspector::CommandResult<void> highlightNode(std::optional<int>&& nodeId, const String& objectId, Ref<JSON::Object>&& highlightConfig, RefPtr<JSON::Object>&& gridOverlayConfig, RefPtr<JSON::Object>&& flexOverlayConfig, std::optional<bool>&& showRulers) override;
+    Inspector::CommandResult<void> highlightNodeList(Ref<JSON::Array>&& nodeIds, Ref<JSON::Object>&& highlightConfig, RefPtr<JSON::Object>&& gridOverlayConfig, RefPtr<JSON::Object>&& flexOverlayConfig, std::optional<bool>&& showRulers) override;
+#endif
+    Inspector::CommandResult<void> hideHighlight() override;
+    Inspector::CommandResult<void> highlightFrame(const String& frameId, RefPtr<JSON::Object>&& contentColor, RefPtr<JSON::Object>&& contentOutlineColor) override;
+    Inspector::CommandResult<void> showGridOverlay(int nodeId, Ref<JSON::Object>&& gridOverlayConfig) override;
+    Inspector::CommandResult<void> hideGridOverlay(std::optional<int>&& nodeId) override;
+    Inspector::CommandResult<void> showFlexOverlay(int nodeId, Ref<JSON::Object>&& flexOverlayConfig) override;
+    Inspector::CommandResult<void> hideFlexOverlay(std::optional<int>&& nodeId) override;
+    Inspector::CommandResult<int> pushNodeByPathToFrontend(const String& path) override;
+    Inspector::CommandResult<Ref<Inspector::Protocol::Runtime::RemoteObject>> resolveNode(int nodeId, const String& objectGroup) override;
+    Inspector::CommandResult<int> moveTo(int nodeId, int targetNodeId, std::optional<int>&& insertBeforeNodeId) override;
+    Inspector::CommandResult<void> undo() override;
+    Inspector::CommandResult<void> redo() override;
+    Inspector::CommandResult<void> markUndoableState() override;
+    Inspector::CommandResult<void> focus(int nodeId) override;
+    Inspector::CommandResult<void> setInspectedNode(int nodeId) override;
+    Inspector::CommandResult<void> setAllowEditingUserAgentShadowTrees(bool) override;
+    Inspector::CommandResult<Ref<Inspector::Protocol::DOM::MediaStats>> getMediaStats(int nodeId) override;
+
+    // InspectorInstrumentation hooks
+    void didInsertDOMNode(Node&);
+    void didRemoveDOMNode(Node&);
+    void willDestroyDOMNode(Node&);
+    void willModifyDOMAttr(Element&, const AtomString& oldValue, const AtomString& newValue);
+    void didModifyDOMAttr(Element&, const AtomString& name, const AtomString& value);
+    void didRemoveDOMAttr(Element&, const AtomString& name);
+    void characterDataModified(CharacterData&);
+    void didInvalidateStyleAttr(Element&);
+    void didPushShadowRoot(Element& host, ShadowRoot&);
+    void willPopShadowRoot(Element& host, ShadowRoot&);
+    void didChangeCustomElementState(Element&);
+    void pseudoElementCreated(PseudoElement&);
+    void pseudoElementDestroyed(PseudoElement&);
+    void frameDocumentUpdated(LocalFrame&);
+
+    // Public accessors
+    Node* nodeForId(Inspector::Protocol::DOM::NodeId);
+    Inspector::Protocol::DOM::NodeId boundNodeId(const Node*);
+    Inspector::Protocol::DOM::NodeId pushNodePathToFrontend(Node*);
+
+private:
+    Inspector::Protocol::DOM::NodeId bind(Node&);
+    void unbind(Node&);
+    void discardBindings();
+
+    RefPtr<Node> assertNode(Inspector::Protocol::ErrorString&, Inspector::Protocol::DOM::NodeId);
+    RefPtr<Element> assertElement(Inspector::Protocol::ErrorString&, Inspector::Protocol::DOM::NodeId);
+
+    Ref<Inspector::Protocol::DOM::Node> buildObjectForNode(Node*, int depth);
+    Ref<JSON::ArrayOf<String>> buildArrayForElementAttributes(Element*);
+    Ref<JSON::ArrayOf<Inspector::Protocol::DOM::Node>> buildArrayForContainerChildren(Node* container, int depth);
+    RefPtr<JSON::ArrayOf<Inspector::Protocol::DOM::Node>> buildArrayForPseudoElements(const Element&);
+    void pushChildNodesToFrontend(Inspector::Protocol::DOM::NodeId, int depth = 1);
+    Inspector::Protocol::DOM::NodeId pushNodePathToFrontend(Inspector::Protocol::ErrorString&, Node*);
+
+    void setDocument(Document*);
+    void reset();
+    void destroyedNodesTimerFired();
+
+    const UniqueRef<Inspector::DOMFrontendDispatcher> m_frontendDispatcher;
+    const Ref<Inspector::DOMBackendDispatcher> m_backendDispatcher;
+    WeakRef<InstrumentingAgents> m_instrumentingAgents;
+    WeakRef<LocalFrame> m_inspectedFrame;
+
+    WeakHashMap<Node, Inspector::Protocol::DOM::NodeId, WeakPtrImplWithEventTargetData> m_nodeToId;
+    HashMap<Inspector::Protocol::DOM::NodeId, WeakPtr<Node, WeakPtrImplWithEventTargetData>> m_idToNode;
+    HashSet<Inspector::Protocol::DOM::NodeId> m_childrenRequested;
+    Inspector::Protocol::DOM::NodeId m_lastNodeId { 1 };
+    RefPtr<Document> m_document;
+
+    Vector<Inspector::Protocol::DOM::NodeId> m_destroyedDetachedNodeIdentifiers;
+    Vector<std::pair<Inspector::Protocol::DOM::NodeId, Inspector::Protocol::DOM::NodeId>> m_destroyedAttachedNodeIdentifiers;
+    Timer m_destroyedNodesTimer;
+
+    bool m_suppressAttributeModifiedEvent { false };
+    bool m_documentRequested { false };
+};
+
+} // namespace WebCore

--- a/Source/WebCore/inspector/agents/frame/FrameDOMAgentStubs.cpp
+++ b/Source/WebCore/inspector/agents/frame/FrameDOMAgentStubs.cpp
@@ -1,0 +1,284 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "FrameDOMAgent.h"
+
+namespace WebCore {
+
+using namespace Inspector;
+
+Inspector::CommandResult<std::optional<int>> FrameDOMAgent::querySelector(int, const String&)
+{
+    return makeUnexpected("Not yet implemented for frame targets"_s);
+}
+
+Inspector::CommandResult<Ref<JSON::ArrayOf<int>>> FrameDOMAgent::querySelectorAll(int, const String&)
+{
+    return makeUnexpected("Not yet implemented for frame targets"_s);
+}
+
+Inspector::CommandResult<int> FrameDOMAgent::setNodeName(int, const String&)
+{
+    return makeUnexpected("Not yet implemented for frame targets"_s);
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::setNodeValue(int, const String&)
+{
+    return makeUnexpected("Not yet implemented for frame targets"_s);
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::removeNode(int)
+{
+    return makeUnexpected("Not yet implemented for frame targets"_s);
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::setAttributeValue(int, const String&, const String&)
+{
+    return makeUnexpected("Not yet implemented for frame targets"_s);
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::setAttributesAsText(int, const String&, const String&)
+{
+    return makeUnexpected("Not yet implemented for frame targets"_s);
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::removeAttribute(int, const String&)
+{
+    return makeUnexpected("Not yet implemented for frame targets"_s);
+}
+
+Inspector::CommandResult<Ref<JSON::ArrayOf<String>>> FrameDOMAgent::getSupportedEventNames()
+{
+    return makeUnexpected("Not yet implemented for frame targets"_s);
+}
+
+#if ENABLE(INSPECTOR_ALTERNATE_DISPATCHERS)
+Inspector::CommandResult<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::DataBinding>>> FrameDOMAgent::getDataBindingsForNode(int)
+{
+    return makeUnexpected("Not supported for frame targets"_s);
+}
+
+Inspector::CommandResult<String> FrameDOMAgent::getAssociatedDataForNode(int)
+{
+    return makeUnexpected("Not supported for frame targets"_s);
+}
+#endif
+
+Inspector::CommandResult<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::EventListener>>> FrameDOMAgent::getEventListenersForNode(int, std::optional<bool>&&)
+{
+    return makeUnexpected("Not yet implemented for frame targets"_s);
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::setEventListenerDisabled(int, bool)
+{
+    return makeUnexpected("Not yet implemented for frame targets"_s);
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::setBreakpointForEventListener(int, RefPtr<JSON::Object>&&)
+{
+    return makeUnexpected("Not supported for frame targets"_s);
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::removeBreakpointForEventListener(int)
+{
+    return makeUnexpected("Not supported for frame targets"_s);
+}
+
+Inspector::CommandResult<Ref<Inspector::Protocol::DOM::AccessibilityProperties>> FrameDOMAgent::getAccessibilityPropertiesForNode(int)
+{
+    return makeUnexpected("Not yet implemented for frame targets"_s);
+}
+
+Inspector::CommandResult<String> FrameDOMAgent::getOuterHTML(int)
+{
+    return makeUnexpected("Not yet implemented for frame targets"_s);
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::setOuterHTML(int, const String&)
+{
+    return makeUnexpected("Not yet implemented for frame targets"_s);
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::insertAdjacentHTML(int, const String&, const String&)
+{
+    return makeUnexpected("Not yet implemented for frame targets"_s);
+}
+
+Inspector::CommandResultOf<String, int> FrameDOMAgent::performSearch(const String&, RefPtr<JSON::Array>&&, std::optional<bool>&&)
+{
+    return makeUnexpected("Not yet implemented for frame targets"_s);
+}
+
+Inspector::CommandResult<Ref<JSON::ArrayOf<int>>> FrameDOMAgent::getSearchResults(const String&, int, int)
+{
+    return makeUnexpected("Not yet implemented for frame targets"_s);
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::discardSearchResults(const String&)
+{
+    return makeUnexpected("Not yet implemented for frame targets"_s);
+}
+
+Inspector::CommandResult<int> FrameDOMAgent::requestNode(const String&)
+{
+    return makeUnexpected("Not yet implemented for frame targets"_s);
+}
+
+#if PLATFORM(IOS_FAMILY)
+Inspector::CommandResult<void> FrameDOMAgent::setInspectModeEnabled(bool, RefPtr<JSON::Object>&&, RefPtr<JSON::Object>&&, RefPtr<JSON::Object>&&)
+{
+    return makeUnexpected("Not supported for frame targets"_s);
+}
+#else
+Inspector::CommandResult<void> FrameDOMAgent::setInspectModeEnabled(bool, RefPtr<JSON::Object>&&, RefPtr<JSON::Object>&&, RefPtr<JSON::Object>&&, std::optional<bool>&&)
+{
+    return makeUnexpected("Not supported for frame targets"_s);
+}
+#endif
+
+Inspector::CommandResult<void> FrameDOMAgent::highlightRect(int, int, int, int, RefPtr<JSON::Object>&&, RefPtr<JSON::Object>&&, std::optional<bool>&&)
+{
+    return makeUnexpected("Not supported for frame targets"_s);
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::highlightQuad(Ref<JSON::Array>&&, RefPtr<JSON::Object>&&, RefPtr<JSON::Object>&&, std::optional<bool>&&)
+{
+    return makeUnexpected("Not supported for frame targets"_s);
+}
+
+#if PLATFORM(IOS_FAMILY)
+Inspector::CommandResult<void> FrameDOMAgent::highlightSelector(const String&, const String&, Ref<JSON::Object>&&, RefPtr<JSON::Object>&&, RefPtr<JSON::Object>&&)
+{
+    return makeUnexpected("Not supported for frame targets"_s);
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::highlightNode(std::optional<int>&&, const String&, Ref<JSON::Object>&&, RefPtr<JSON::Object>&&, RefPtr<JSON::Object>&&)
+{
+    return makeUnexpected("Not supported for frame targets"_s);
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::highlightNodeList(Ref<JSON::Array>&&, Ref<JSON::Object>&&, RefPtr<JSON::Object>&&, RefPtr<JSON::Object>&&)
+{
+    return makeUnexpected("Not supported for frame targets"_s);
+}
+#else
+Inspector::CommandResult<void> FrameDOMAgent::highlightSelector(const String&, const String&, Ref<JSON::Object>&&, RefPtr<JSON::Object>&&, RefPtr<JSON::Object>&&, std::optional<bool>&&)
+{
+    return makeUnexpected("Not supported for frame targets"_s);
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::highlightNode(std::optional<int>&&, const String&, Ref<JSON::Object>&&, RefPtr<JSON::Object>&&, RefPtr<JSON::Object>&&, std::optional<bool>&&)
+{
+    return makeUnexpected("Not supported for frame targets"_s);
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::highlightNodeList(Ref<JSON::Array>&&, Ref<JSON::Object>&&, RefPtr<JSON::Object>&&, RefPtr<JSON::Object>&&, std::optional<bool>&&)
+{
+    return makeUnexpected("Not supported for frame targets"_s);
+}
+#endif
+
+Inspector::CommandResult<void> FrameDOMAgent::hideHighlight()
+{
+    return makeUnexpected("Not supported for frame targets"_s);
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::highlightFrame(const String&, RefPtr<JSON::Object>&&, RefPtr<JSON::Object>&&)
+{
+    return makeUnexpected("Not supported for frame targets"_s);
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::showGridOverlay(int, Ref<JSON::Object>&&)
+{
+    return makeUnexpected("Not supported for frame targets"_s);
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::hideGridOverlay(std::optional<int>&&)
+{
+    return makeUnexpected("Not supported for frame targets"_s);
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::showFlexOverlay(int, Ref<JSON::Object>&&)
+{
+    return makeUnexpected("Not supported for frame targets"_s);
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::hideFlexOverlay(std::optional<int>&&)
+{
+    return makeUnexpected("Not supported for frame targets"_s);
+}
+
+Inspector::CommandResult<int> FrameDOMAgent::pushNodeByPathToFrontend(const String&)
+{
+    return makeUnexpected("Not yet implemented for frame targets"_s);
+}
+
+Inspector::CommandResult<Ref<Inspector::Protocol::Runtime::RemoteObject>> FrameDOMAgent::resolveNode(int, const String&)
+{
+    return makeUnexpected("Not yet implemented for frame targets"_s);
+}
+
+Inspector::CommandResult<int> FrameDOMAgent::moveTo(int, int, std::optional<int>&&)
+{
+    return makeUnexpected("Not yet implemented for frame targets"_s);
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::undo()
+{
+    return makeUnexpected("Not yet implemented for frame targets"_s);
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::redo()
+{
+    return makeUnexpected("Not yet implemented for frame targets"_s);
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::markUndoableState()
+{
+    return makeUnexpected("Not yet implemented for frame targets"_s);
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::focus(int)
+{
+    return makeUnexpected("Not supported for frame targets"_s);
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::setInspectedNode(int)
+{
+    return makeUnexpected("Not supported for frame targets"_s);
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::setAllowEditingUserAgentShadowTrees(bool)
+{
+    return makeUnexpected("Not yet implemented for frame targets"_s);
+}
+
+Inspector::CommandResult<Ref<Inspector::Protocol::DOM::MediaStats>> FrameDOMAgent::getMediaStats(int)
+{
+    return makeUnexpected("Not supported for frame targets"_s);
+}
+
+} // namespace WebCore

--- a/Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js
@@ -30,8 +30,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// FIXME: DOMManager lacks advanced multi-target support. (DOMNodes per-target)
-
 WI.DOMManager = class DOMManager extends WI.Object
 {
     constructor()
@@ -51,6 +49,10 @@ WI.DOMManager = class DOMManager extends WI.Object
         this._hasRequestedDocument = false;
         this._pendingDocumentRequestCallbacks = null;
 
+        this._frameTargetDOMData = new Map;
+        this._unsplicedFrameDocuments = [];
+        this._pageBodyChildrenRequested = false;
+
         WI.EventBreakpoint.addEventListener(WI.Breakpoint.Event.DisabledStateDidChange, this._handleEventBreakpointDisabledStateChanged, this);
         WI.EventBreakpoint.addEventListener(WI.Breakpoint.Event.ConditionDidChange, this._handleEventBreakpointEditablePropertyChanged, this);
         WI.EventBreakpoint.addEventListener(WI.Breakpoint.Event.IgnoreCountDidChange, this._handleEventBreakpointEditablePropertyChanged, this);
@@ -58,25 +60,254 @@ WI.DOMManager = class DOMManager extends WI.Object
         WI.EventBreakpoint.addEventListener(WI.Breakpoint.Event.ActionsDidChange, this._handleEventBreakpointActionsChanged, this);
 
         WI.Frame.addEventListener(WI.Frame.Event.MainResourceDidChange, this._mainResourceDidChange, this);
+        WI.targetManager.addEventListener(WI.TargetManager.Event.TargetRemoved, this._handleTargetRemoved, this);
     }
 
     // Target
 
     initializeTarget(target)
     {
-        // FIXME: This should be improved when adding better DOM multi-target support since it is really per-target.
+        if (!target.hasDomain("DOM"))
+            return;
+
+        if (target instanceof WI.FrameTarget) {
+            this._initializeFrameTarget(target);
+            return;
+        }
+
         // This currently uses a setTimeout since it doesn't need to happen immediately, and DOMManager uses the
         // global DOMAgent to request the document, so we want to make sure we've transitioned the global agents
         // to this target if necessary.
-        if (target.hasDomain("DOM")) {
-            setTimeout(() => {
-                this.ensureDocument();
-            });
+        setTimeout(() => {
+            this.ensureDocument();
+        });
 
-            if (WI.engineeringSettingsAllowed()) {
-                if (DOMManager.supportsEditingUserAgentShadowTrees({target}))
-                    target.DOMAgent.setAllowEditingUserAgentShadowTrees(WI.settings.engineeringAllowEditingUserAgentShadowTrees.value);
+        if (WI.engineeringSettingsAllowed()) {
+            if (DOMManager.supportsEditingUserAgentShadowTrees({target}))
+                target.DOMAgent.setAllowEditingUserAgentShadowTrees(WI.settings.engineeringAllowEditingUserAgentShadowTrees.value);
+        }
+    }
+
+    _initializeFrameTarget(target)
+    {
+        console.assert(target instanceof WI.FrameTarget);
+
+        let data = {document: null, target: target};
+        this._frameTargetDOMData.set(target, data);
+
+        target.DOMAgent.getDocument((error, root) => {
+            if (error) {
+                console.warn("FrameDOMAgent.getDocument failed:", error);
+                return;
             }
+
+            let doc = new WI.DOMNode(this, null, false, root, {frameTarget: target});
+
+            data.document = doc;
+
+            // Splice the frame document into the page DOM tree as the
+            // contentDocument of the matching iframe element.
+            this._spliceFrameDocumentIntoPageTree(doc);
+
+            this.dispatchEventToListeners(WI.DOMManager.Event.FrameDocumentAvailable, {target, document: doc});
+        });
+    }
+
+    _spliceFrameDocumentIntoPageTree(frameDocument)
+    {
+        if (!frameDocument || !frameDocument.documentURL)
+            return;
+
+        if (this._trySpliceFrameDocumentIntoNode(frameDocument))
+            return;
+
+        this._unsplicedFrameDocuments.push(frameDocument);
+
+        this._ensurePageBodyChildrenLoaded();
+    }
+
+    _ensurePageBodyChildrenLoaded()
+    {
+        if (this._pageBodyChildrenRequested)
+            return;
+
+        // The page document may not be loaded yet (getDocument is deferred).
+        // Request body's children so iframe elements enter _idToDOMNode.
+        this.requestDocument((document) => {
+            if (!document)
+                return;
+
+            let body = document.body;
+            if (!body) {
+                // Need <html> children first to get <body>.
+                let docElement = document.documentElement;
+                if (!docElement)
+                    return;
+                docElement.getChildNodes(() => {
+                    body = document.body;
+                    if (body)
+                        body.getChildNodes(() => this._trySpliceUnsplicedFrameDocuments());
+                });
+                return;
+            }
+
+            if (body.children) {
+                this._trySpliceUnsplicedFrameDocuments();
+                return;
+            }
+
+            body.getChildNodes(() => this._trySpliceUnsplicedFrameDocuments());
+        });
+
+        this._pageBodyChildrenRequested = true;
+    }
+
+    // FIXME: <https://webkit.org/b/298980> URL-based matching is fragile (breaks with redirects,
+    // blob: URLs, about:srcdoc, query strings). Use frame identity information (frame ID or target ID)
+    // threaded through Target.targetCreated to directly look up the parent iframe element.
+    _trySpliceFrameDocumentIntoNode(frameDocument)
+    {
+        let frameDocURL = frameDocument.documentURL;
+
+        for (let node of Object.values(this._idToDOMNode)) {
+            if (node._destroyed)
+                continue;
+
+            let nodeName = node._nodeName;
+            if (nodeName !== "IFRAME" && nodeName !== "FRAME")
+                continue;
+
+            if (node._contentDocument)
+                continue;
+
+            let srcAttr = node.getAttribute("src");
+            if (!srcAttr)
+                continue;
+
+            // Match by URL: exact match, then resolve relative src against parent document.
+            let matched = false;
+            if (srcAttr === frameDocURL)
+                matched = true;
+            else {
+                try {
+                    let srcURL = new URL(srcAttr, node.ownerDocument ? node.ownerDocument.documentURL : undefined);
+                    let docURL = new URL(frameDocURL);
+                    if (srcURL.href === docURL.href)
+                        matched = true;
+                } catch (e) {
+                }
+            }
+
+            if (matched) {
+                node._contentDocument = frameDocument;
+                frameDocument.parentNode = node;
+                node._children = [frameDocument];
+                node._renumber();
+
+                this.dispatchEventToListeners(WI.DOMManager.Event.ChildNodeCountUpdated, node);
+                this.dispatchEventToListeners(WI.DOMManager.Event.NodeInserted, {node: frameDocument, parent: node});
+                return true;
+            }
+        }
+        return false;
+    }
+
+    _trySpliceUnsplicedFrameDocuments()
+    {
+        if (!this._unsplicedFrameDocuments.length)
+            return;
+
+        this._unsplicedFrameDocuments = this._unsplicedFrameDocuments.filter((doc) => {
+            if (doc._destroyed)
+                return false;
+            return !this._trySpliceFrameDocumentIntoNode(doc);
+        });
+    }
+
+    _handleTargetRemoved(event)
+    {
+        let {target} = event.data;
+        if (target instanceof WI.FrameTarget)
+            this._cleanupFrameTarget(target);
+    }
+
+    _cleanupFrameTarget(target)
+    {
+        let data = this._frameTargetDOMData.get(target);
+        if (!data)
+            return;
+
+        let frameDocument = data.document;
+        if (frameDocument && frameDocument.parentNode) {
+            let iframeElement = frameDocument.parentNode;
+            iframeElement._contentDocument = null;
+            if (iframeElement._children && iframeElement._children.includes(frameDocument))
+                iframeElement._children = iframeElement._children.filter((child) => child !== frameDocument);
+            frameDocument.parentNode = null;
+            this.dispatchEventToListeners(WI.DOMManager.Event.NodeRemoved, {node: frameDocument, parent: iframeElement});
+        }
+
+        this._unsplicedFrameDocuments = this._unsplicedFrameDocuments.filter((doc) => doc !== frameDocument);
+
+        let prefix = target.identifier + ":";
+        for (let id of Object.keys(this._idToDOMNode)) {
+            if (typeof id === "string" && id.startsWith(prefix)) {
+                this._idToDOMNode[id].markDestroyed();
+                delete this._idToDOMNode[id];
+            }
+        }
+
+        this._frameTargetDOMData.delete(target);
+    }
+
+    frameTargetDocumentForTarget(target)
+    {
+        let data = this._frameTargetDOMData.get(target);
+        return data ? data.document : null;
+    }
+
+    nodeForIdInFrameTarget(nodeId, target)
+    {
+        let scopedId = target.identifier + ":" + nodeId;
+        return this._idToDOMNode[scopedId] || null;
+    }
+
+    _frameTargetSetChildNodes(target, parentId, payloads)
+    {
+        if (!parentId && payloads.length)
+            return; // Detached root — not applicable for frame targets.
+
+        let scopedParentId = target.identifier + ":" + parentId;
+        let parent = this._idToDOMNode[scopedParentId];
+        if (!parent)
+            return;
+
+        parent._setChildrenPayload(payloads);
+    }
+
+    _frameTargetDocumentUpdated(target)
+    {
+        this._cleanupFrameTarget(target);
+        this._initializeFrameTarget(target);
+    }
+
+    _frameTargetUnbind(node)
+    {
+        node.markDestroyed();
+        delete this._idToDOMNode[node.id];
+
+        if (node.children) {
+            for (let child of node.children)
+                this._frameTargetUnbind(child);
+        }
+        let templateContent = node.templateContent();
+        if (templateContent)
+            this._frameTargetUnbind(templateContent);
+        for (let pseudoElement of node.pseudoElements().values())
+            this._frameTargetUnbind(pseudoElement);
+        if (node._shadowRoots) {
+            for (let shadowRoot of node._shadowRoots)
+                this._frameTargetUnbind(shadowRoot);
         }
     }
 
@@ -450,10 +681,14 @@ WI.DOMManager = class DOMManager extends WI.Object
 
     _setDocument(payload)
     {
-        for (let node of Object.values(this._idToDOMNode))
+        for (let [id, node] of Object.entries(this._idToDOMNode)) {
+            if (id.includes(":"))
+                continue;
             node.markDestroyed();
+            delete this._idToDOMNode[id];
+        }
 
-        this._idToDOMNode = {};
+        this._pageBodyChildrenRequested = false;
 
         for (let breakpoint of this._breakpointsForEventListeners.values())
             WI.domDebuggerManager.dispatchEventToListeners(WI.DOMDebuggerManager.Event.EventBreakpointRemoved, {breakpoint});
@@ -490,6 +725,8 @@ WI.DOMManager = class DOMManager extends WI.Object
         }
 
         var parent = this._idToDOMNode[parentId];
+        if (!parent)
+            return;
 
         if (parent.children) {
             for (let node of parent.children)
@@ -500,11 +737,16 @@ WI.DOMManager = class DOMManager extends WI.Object
 
         for (let node of parent.children)
             this.dispatchEventToListeners(WI.DOMManager.Event.NodeInserted, {node, parent});
+
+        // New iframe elements may have been loaded — try to splice pending frame documents.
+        this._trySpliceUnsplicedFrameDocuments();
     }
 
     _childNodeCountUpdated(nodeId, newValue)
     {
         var node = this._idToDOMNode[nodeId];
+        if (!node)
+            return;
         node.childNodeCount = newValue;
         this.dispatchEventToListeners(WI.DOMManager.Event.ChildNodeCountUpdated, node);
     }
@@ -512,16 +754,23 @@ WI.DOMManager = class DOMManager extends WI.Object
     _childNodeInserted(parentId, prevId, payload)
     {
         var parent = this._idToDOMNode[parentId];
+        if (!parent)
+            return;
         var prev = this._idToDOMNode[prevId];
         var node = parent._insertChild(prev, payload);
         this._idToDOMNode[node.id] = node;
         this.dispatchEventToListeners(WI.DOMManager.Event.NodeInserted, {node, parent});
+
+        // A new iframe element may have been inserted — try to splice pending frame documents.
+        this._trySpliceUnsplicedFrameDocuments();
     }
 
     _childNodeRemoved(parentId, nodeId)
     {
         var parent = this._idToDOMNode[parentId];
         var node = this._idToDOMNode[nodeId];
+        if (!parent || !node)
+            return;
         parent._removeChild(node);
         this._unbind(node);
         this.dispatchEventToListeners(WI.DOMManager.Event.NodeRemoved, {node, parent});
@@ -683,6 +932,8 @@ WI.DOMManager = class DOMManager extends WI.Object
     hideDOMNodeHighlight()
     {
         for (let target of WI.targets) {
+            if (target instanceof WI.FrameTarget)
+                continue;
             if (target.hasCommand("DOM.hideHighlight"))
                 target.DOMAgent.hideHighlight();
         }
@@ -781,6 +1032,8 @@ WI.DOMManager = class DOMManager extends WI.Object
         this._breakpointsForEventListeners.set(eventListener.eventListenerId, breakpoint);
 
         for (let target of WI.targets) {
+            if (target instanceof WI.FrameTarget)
+                continue;
             if (target.hasDomain("DOM"))
                 this._setEventBreakpoint(breakpoint, target);
         }
@@ -854,6 +1107,8 @@ WI.DOMManager = class DOMManager extends WI.Object
             return;
 
         for (let target of WI.targets) {
+            if (target instanceof WI.FrameTarget)
+                continue;
             if (!target.hasDomain("DOM"))
                 continue;
 
@@ -923,5 +1178,6 @@ WI.DOMManager.Event = {
     ChildNodeCountUpdated: "dom-manager-child-node-count-updated",
     DOMNodeWasInspected: "dom-manager-dom-node-was-inspected",
     InspectModeStateChanged: "dom-manager-inspect-mode-state-changed",
+    FrameDocumentAvailable: "dom-manager-frame-document-available",
     InspectedNodeChanged: "dom-manager-inspected-node-changed",
 };

--- a/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
+++ b/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
@@ -32,7 +32,7 @@
 
 WI.DOMNode = class DOMNode extends WI.Object
 {
-    constructor(domManager, doc, isInShadowTree, payload)
+    constructor(domManager, doc, isInShadowTree, payload, {frameTarget} = {})
     {
         super();
 
@@ -40,8 +40,16 @@ WI.DOMNode = class DOMNode extends WI.Object
 
         this._domManager = domManager;
         this._isInShadowTree = isInShadowTree;
+        this._owningTarget = null;
+        this._rawNodeId = null;
 
-        this.id = payload.nodeId;
+        if (frameTarget) {
+            this._rawNodeId = payload.nodeId;
+            this.id = frameTarget.identifier + ":" + payload.nodeId;
+            this._owningTarget = frameTarget;
+        } else
+            this.id = payload.nodeId;
+
         this._domManager._idToDOMNode[this.id] = this;
 
         this._nodeType = payload.nodeType;
@@ -56,6 +64,13 @@ WI.DOMNode = class DOMNode extends WI.Object
         this._layoutFlags = [];
         this._layoutOverlayShowing = false;
         this._layoutOverlayColorSetting = null;
+
+        // FIXME: <https://webkit.org/b/298980> Workaround for missing FrameCSSAgent.
+        // Without this, CSS.nodeLayoutFlagsChanged is never sent for frame-target nodes,
+        // so the Elements panel hides them as "not rendered." Force Rendered until
+        // FrameCSSAgent exists to provide real layout flags.
+        if (this._owningTarget && payload.nodeType === Node.ELEMENT_NODE)
+            this._layoutFlags = [WI.DOMNode.LayoutFlag.Rendered];
 
         if (this._nodeType === Node.DOCUMENT_NODE)
             this.ownerDocument = this;
@@ -90,9 +105,10 @@ WI.DOMNode = class DOMNode extends WI.Object
         // we have both shadowRoots and child nodes.
         this._shadowRoots = [];
         if (payload.shadowRoots) {
+            let childOptions = this._owningTarget ? {frameTarget: this._owningTarget} : undefined;
             for (var i = 0; i < payload.shadowRoots.length; ++i) {
                 var root = payload.shadowRoots[i];
-                var node = new WI.DOMNode(this._domManager, this.ownerDocument, true, root);
+                var node = new WI.DOMNode(this._domManager, this.ownerDocument, true, root, childOptions);
                 node.parentNode = this;
                 this._shadowRoots.push(node);
             }
@@ -109,21 +125,24 @@ WI.DOMNode = class DOMNode extends WI.Object
             this._customElementState = null;
 
         if (payload.templateContent) {
-            this._templateContent = new WI.DOMNode(this._domManager, this.ownerDocument, false, payload.templateContent);
+            let childOptions = this._owningTarget ? {frameTarget: this._owningTarget} : undefined;
+            this._templateContent = new WI.DOMNode(this._domManager, this.ownerDocument, false, payload.templateContent, childOptions);
             this._templateContent.parentNode = this;
         }
 
         this._pseudoElements = new Map;
         if (payload.pseudoElements) {
+            let childOptions = this._owningTarget ? {frameTarget: this._owningTarget} : undefined;
             for (var i = 0; i < payload.pseudoElements.length; ++i) {
-                var node = new WI.DOMNode(this._domManager, this.ownerDocument, this._isInShadowTree, payload.pseudoElements[i]);
+                var node = new WI.DOMNode(this._domManager, this.ownerDocument, this._isInShadowTree, payload.pseudoElements[i], childOptions);
                 node.parentNode = this;
                 this._pseudoElements.set(node.pseudoType(), node);
             }
         }
 
         if (payload.contentDocument) {
-            this._contentDocument = new WI.DOMNode(this._domManager, null, false, payload.contentDocument);
+            let childOptions = this._owningTarget ? {frameTarget: this._owningTarget} : undefined;
+            this._contentDocument = new WI.DOMNode(this._domManager, null, false, payload.contentDocument, childOptions);
             this._children = [this._contentDocument];
             this._renumber();
         }
@@ -154,13 +173,17 @@ WI.DOMNode = class DOMNode extends WI.Object
             WI.DOMNode.addEventListener(WI.DOMNode.Event.DidFireEvent, this._handleDOMNodeDidFireEvent, this);
 
         // COMPATIBILITY (macOS 13.0, iOS 16.0): CSS.LayoutContextType was renamed/expanded to CSS.LayoutFlag.
-        if (!InspectorBackend.Enum.CSS.LayoutFlag) {
-            let layoutFlags = [WI.DOMNode.LayoutFlag.Rendered];
-            if (payload.layoutContextType)
-                layoutFlags.push(payload.layoutContextType);
-            this.layoutFlags = layoutFlags;
-        } else
-            this.layoutFlags = payload.layoutFlags;
+        // Frame-target nodes don't receive layout flags from the backend (no FrameCSSAgent yet).
+        // Their flags were already set above in the constructor workaround — don't overwrite them.
+        if (!frameTarget) {
+            if (!InspectorBackend.Enum.CSS.LayoutFlag) {
+                let layoutFlags = [WI.DOMNode.LayoutFlag.Rendered];
+                if (payload.layoutContextType)
+                    layoutFlags.push(payload.layoutContextType);
+                this.layoutFlags = layoutFlags;
+            } else
+                this.layoutFlags = payload.layoutFlags;
+        }
     }
 
     // Static
@@ -210,6 +233,8 @@ WI.DOMNode = class DOMNode extends WI.Object
 
     get destroyed() { return this._destroyed; }
     get frame() { return this._frame; }
+    get owningTarget() { return this._owningTarget || this.parentNode?.owningTarget || null; }
+    get backendNodeId() { return this._rawNodeId ?? this.id; }
     get nextSibling() { return this._nextSibling; }
     get previousSibling() { return this._previousSibling; }
     get children() { return this._children; }
@@ -626,6 +651,10 @@ WI.DOMNode = class DOMNode extends WI.Object
         if (this._destroyed)
             return;
 
+        // FIXME: <https://webkit.org/b/298980> Highlighting cross-origin frame nodes requires page-level coordination.
+        if (this.owningTarget)
+            return;
+
         if (this._hideDOMNodeHighlightTimeout) {
             clearTimeout(this._hideDOMNodeHighlightTimeout);
             this._hideDOMNodeHighlightTimeout = undefined;
@@ -801,8 +830,8 @@ WI.DOMNode = class DOMNode extends WI.Object
                 callback(this.children);
         }
 
-        let target = WI.assumingMainTarget();
-        target.DOMAgent.requestChildNodes(this.id, mycallback.bind(this));
+        let target = this.owningTarget || WI.assumingMainTarget();
+        target.DOMAgent.requestChildNodes(this.backendNodeId, mycallback.bind(this));
     }
 
     getSubtree(depth, callback)
@@ -818,25 +847,31 @@ WI.DOMNode = class DOMNode extends WI.Object
                 callback(error ? null : this.children);
         }
 
-        let target = WI.assumingMainTarget();
-        target.DOMAgent.requestChildNodes(this.id, depth, mycallback.bind(this));
+        let target = this.owningTarget || WI.assumingMainTarget();
+        target.DOMAgent.requestChildNodes(this.backendNodeId, depth, mycallback.bind(this));
     }
 
     async requestAssignedSlot()
     {
-        let target = WI.assumingMainTarget();
-        let {slotElementId} = await target.DOMAgent.requestAssignedSlot(this.id);
+        let target = this.owningTarget || WI.assumingMainTarget();
+        let {slotElementId} = await target.DOMAgent.requestAssignedSlot(this.backendNodeId);
+        if (!slotElementId)
+            return null;
+        if (this.owningTarget)
+            return WI.domManager.nodeForIdInFrameTarget(slotElementId, this.owningTarget);
         return WI.domManager.nodeForId(slotElementId);
     }
 
     async requestAssignedNodes()
     {
-        let target = WI.assumingMainTarget();
-        let {assignedNodeIds} = await target.DOMAgent.requestAssignedNodes(this.id);
+        let target = this.owningTarget || WI.assumingMainTarget();
+        let {assignedNodeIds} = await target.DOMAgent.requestAssignedNodes(this.backendNodeId);
 
         let assignedNodes = [];
         for (let assignedNodeId of assignedNodeIds) {
-            let assignedNode = WI.domManager.nodeForId(assignedNodeId);
+            let assignedNode = this.owningTarget
+                ? WI.domManager.nodeForIdInFrameTarget(assignedNodeId, this.owningTarget)
+                : WI.domManager.nodeForId(assignedNodeId);
             console.assert(assignedNode, this, assignedNodeId);
             if (assignedNode)
                 assignedNodes.push(assignedNode);
@@ -1140,7 +1175,8 @@ WI.DOMNode = class DOMNode extends WI.Object
 
     _insertChild(prev, payload)
     {
-        var node = new WI.DOMNode(this._domManager, this.ownerDocument, this._isInShadowTree, payload);
+        let childOptions = this._owningTarget ? {frameTarget: this._owningTarget} : undefined;
+        var node = new WI.DOMNode(this._domManager, this.ownerDocument, this._isInShadowTree, payload, childOptions);
         if (!prev) {
             if (!this._children) {
                 // First node
@@ -1173,8 +1209,9 @@ WI.DOMNode = class DOMNode extends WI.Object
             return;
 
         this._children = this._shadowRoots.slice();
+        let childOptions = this._owningTarget ? {frameTarget: this._owningTarget} : undefined;
         for (var i = 0; i < payloads.length; ++i) {
-            var node = new WI.DOMNode(this._domManager, this.ownerDocument, this._isInShadowTree, payloads[i]);
+            var node = new WI.DOMNode(this._domManager, this.ownerDocument, this._isInShadowTree, payloads[i], childOptions);
             this._children.push(node);
         }
         this._renumber();

--- a/Source/WebInspectorUI/UserInterface/Protocol/CSSObserver.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/CSSObserver.js
@@ -49,11 +49,15 @@ WI.CSSObserver = class CSSObserver extends InspectorBackend.Dispatcher
 
     nodeLayoutFlagsChanged(nodeId, layoutFlags)
     {
+        if (this._target instanceof WI.FrameTarget)
+            return; // FIXME: <https://webkit.org/b/298980> Route to frame-target handler.
         WI.domManager.nodeLayoutFlagsChanged(nodeId, layoutFlags);
     }
 
     nodeLayoutContextTypeChanged(nodeId, layoutContextType)
     {
+        if (this._target instanceof WI.FrameTarget)
+            return;
         // COMPATIBILITY (macOS 13.0, iOS 16.0): CSS.nodeLayoutContextTypeChanged was renamed/expanded to CSS.nodeLayoutFlagsChanged.
         WI.domManager.nodeLayoutFlagsChanged(nodeId, [WI.DOMNode.LayoutFlag.Rendered, layoutContextType]);
     }

--- a/Source/WebInspectorUI/UserInterface/Protocol/DOMObserver.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/DOMObserver.js
@@ -29,101 +29,145 @@ WI.DOMObserver = class DOMObserver extends InspectorBackend.Dispatcher
 
     documentUpdated()
     {
+        if (this._target instanceof WI.FrameTarget) {
+            WI.domManager._frameTargetDocumentUpdated(this._target);
+            return;
+        }
         WI.domManager._documentUpdated();
     }
 
     inspect(nodeId)
     {
+        if (this._target instanceof WI.FrameTarget)
+            return;
         WI.domManager.inspectElement(nodeId);
     }
 
     setChildNodes(parentId, nodes)
     {
+        if (this._target instanceof WI.FrameTarget) {
+            WI.domManager._frameTargetSetChildNodes(this._target, parentId, nodes);
+            return;
+        }
         WI.domManager._setChildNodes(parentId, nodes);
     }
 
     attributeModified(nodeId, name, value)
     {
+        if (this._target instanceof WI.FrameTarget)
+            return; // FIXME: <https://webkit.org/b/298980> Route to frame-target handler.
         WI.domManager._attributeModified(nodeId, name, value);
     }
 
     attributeRemoved(nodeId, name)
     {
+        if (this._target instanceof WI.FrameTarget)
+            return; // FIXME: <https://webkit.org/b/298980> Route to frame-target handler.
         WI.domManager._attributeRemoved(nodeId, name);
     }
 
     inlineStyleInvalidated(nodeIds)
     {
+        if (this._target instanceof WI.FrameTarget)
+            return; // FIXME: <https://webkit.org/b/298980> Route to frame-target handler.
         WI.domManager._inlineStyleInvalidated(nodeIds);
     }
 
     characterDataModified(nodeId, characterData)
     {
+        if (this._target instanceof WI.FrameTarget)
+            return; // FIXME: <https://webkit.org/b/298980> Route to frame-target handler.
         WI.domManager._characterDataModified(nodeId, characterData);
     }
 
     childNodeCountUpdated(nodeId, childNodeCount)
     {
+        if (this._target instanceof WI.FrameTarget)
+            return; // FIXME: <https://webkit.org/b/298980> Route to frame-target handler.
         WI.domManager._childNodeCountUpdated(nodeId, childNodeCount);
     }
 
     childNodeInserted(parentNodeId, previousNodeId, node)
     {
+        if (this._target instanceof WI.FrameTarget)
+            return; // FIXME: <https://webkit.org/b/298980> Route to frame-target handler.
         WI.domManager._childNodeInserted(parentNodeId, previousNodeId, node);
     }
 
     childNodeRemoved(parentNodeId, nodeId)
     {
+        if (this._target instanceof WI.FrameTarget)
+            return; // FIXME: <https://webkit.org/b/298980> Route to frame-target handler.
         WI.domManager._childNodeRemoved(parentNodeId, nodeId);
     }
 
     willDestroyDOMNode(nodeId)
     {
+        if (this._target instanceof WI.FrameTarget)
+            return; // FIXME: <https://webkit.org/b/298980> Route to frame-target handler.
         WI.domManager.willDestroyDOMNode(nodeId);
     }
 
     shadowRootPushed(hostId, root)
     {
+        if (this._target instanceof WI.FrameTarget)
+            return; // FIXME: <https://webkit.org/b/298980> Route to frame-target handler.
         WI.domManager._childNodeInserted(hostId, 0, root);
     }
 
     shadowRootPopped(hostId, rootId)
     {
+        if (this._target instanceof WI.FrameTarget)
+            return; // FIXME: <https://webkit.org/b/298980> Route to frame-target handler.
         WI.domManager._childNodeRemoved(hostId, rootId);
     }
 
     customElementStateChanged(nodeId, customElementState)
     {
+        if (this._target instanceof WI.FrameTarget)
+            return; // FIXME: <https://webkit.org/b/298980> Route to frame-target handler.
         WI.domManager._customElementStateChanged(nodeId, customElementState);
     }
 
     pseudoElementAdded(parentNodeId, pseudoElement)
     {
+        if (this._target instanceof WI.FrameTarget)
+            return; // FIXME: <https://webkit.org/b/298980> Route to frame-target handler.
         WI.domManager._pseudoElementAdded(parentNodeId, pseudoElement);
     }
 
     pseudoElementRemoved(parentNodeId, pseudoElementId)
     {
+        if (this._target instanceof WI.FrameTarget)
+            return; // FIXME: <https://webkit.org/b/298980> Route to frame-target handler.
         WI.domManager._pseudoElementRemoved(parentNodeId, pseudoElementId);
     }
 
     didAddEventListener(nodeId)
     {
+        if (this._target instanceof WI.FrameTarget)
+            return;
         WI.domManager.didAddEventListener(nodeId);
     }
 
     willRemoveEventListener(nodeId)
     {
+        if (this._target instanceof WI.FrameTarget)
+            return;
         WI.domManager.willRemoveEventListener(nodeId);
     }
 
     didFireEvent(nodeId, eventName, timestamp, data)
     {
+        if (this._target instanceof WI.FrameTarget)
+            return;
         WI.domManager.didFireEvent(nodeId, eventName, timestamp, data);
     }
 
     powerEfficientPlaybackStateChanged(nodeId, timestamp, isPowerEfficient)
     {
+        if (this._target instanceof WI.FrameTarget)
+            return;
         WI.domManager.powerEfficientPlaybackStateChanged(nodeId, timestamp, isPowerEfficient);
     }
 };


### PR DESCRIPTION
#### c48671aa521f9e8f4ac533e447b1889510dac80c
<pre>
Web Inspector: introduce FrameDOMAgent for cross-origin iframe DOM tree access
<a href="https://bugs.webkit.org/show_bug.cgi?id=310129">https://bugs.webkit.org/show_bug.cgi?id=310129</a>
<a href="https://rdar.apple.com/172766956">rdar://172766956</a>

Reviewed by Qianlang Chen.

This patch introduces FrameDOMAgent, a per-frame DOM agent that lives in each
frame&apos;s WebProcess and handles DOM protocol commands independently.

The read-only DOM tree access subset is implemented: getDocument, requestChildNodes
getAttributes, requestAssignedSlot, and requestAssignedNodes
DOM tree mutation event handlers are implemented in the agent but not
yet wired to InspectorInstrumentation — DOMObserver guards frame-target events with early
returns for now

Each FrameDOMAgent maintains its own node-ID-to-Node binding maps, independent from
InspectorDOMAgent. This is necessary because node IDs are process-local — an ID from one
WebProcess cannot be dereferenced in another. The frontend mirrors this by scoping
frame-target node IDs as &quot;targetId:nodeId&quot; strings in DOMManager&apos;s shared idToDOMNode map
preventing collisions between agents whose counters both start at 1

On the frontend, when a FrameTarget appears, DOMManager sends DOM.getDocument to the frame
agent, constructs DOMNode objects with scoped IDs, and splices the frame document into
page tree as the contentDocument of the matching iframe element. This makes cross-origin
iframes display inline in the Elements panel, matching same-origin iframe behavior
DOMNode.requestChildNodes and getSubtree route commands to the correct backend target
the owningTarget property, which walks the parent chain to find the owning frame target

Under site isolation in the main process, both InspectorDOMAgent and FrameDOMAgent are active on the
same nodes. The page agent owns the main tree (keyed in _idToDOMNode by raw numeric ID),
FrameDOMAgent owns each cross-origin frame&apos;s subtree (keyed by &quot;targetId:nodeId&quot;), and the Elements
tab crosses between them through a spliced contentDocument via DOMNode.owningTarget. Mutation events
from FrameDOMAgent are gated off for now; future patches enable them behind a per-domain setting.

Test: http/tests/site-isolation/inspector/dom/getDocument-frame-target.html

* LayoutTests/http/tests/site-isolation/inspector/dom/getDocument-frame-target-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/dom/getDocument-frame-target.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/dom/resources/dom-frame.html: Added.
* Source/JavaScriptCore/inspector/protocol/DOM.json:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/inspector/FrameInspectorController.cpp:
(WebCore::FrameInspectorController::createLazyAgents):
(WebCore::FrameInspectorController::createRuntimeAgent): Deleted.
* Source/WebCore/inspector/FrameInspectorController.h:
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::frameDocumentUpdatedImpl):
* Source/WebCore/inspector/InstrumentingAgents.h:
* Source/WebCore/inspector/agents/frame/FrameDOMAgent.cpp: Added.
(WebCore::containsOnlyASCIIWhitespace):
(WebCore::shadowRootType):
(WebCore::customElementState):
(WebCore::pseudoElementType):
(WebCore::computeContentSecurityPolicySHA256Hash):
(WebCore::FrameDOMAgent::FrameDOMAgent):
(WebCore::m_destroyedNodesTimer):
(WebCore::FrameDOMAgent::didCreateFrontendAndBackend):
(WebCore::FrameDOMAgent::willDestroyFrontendAndBackend):
(WebCore::FrameDOMAgent::bind):
(WebCore::FrameDOMAgent::unbind):
(WebCore::FrameDOMAgent::boundNodeId):
(WebCore::FrameDOMAgent::nodeForId):
(WebCore::FrameDOMAgent::discardBindings):
(WebCore::FrameDOMAgent::assertNode):
(WebCore::FrameDOMAgent::assertElement):
(WebCore::FrameDOMAgent::buildObjectForNode):
(WebCore::FrameDOMAgent::buildArrayForElementAttributes):
(WebCore::FrameDOMAgent::buildArrayForContainerChildren):
(WebCore::FrameDOMAgent::buildArrayForPseudoElements):
(WebCore::FrameDOMAgent::pushChildNodesToFrontend):
(WebCore::FrameDOMAgent::pushNodePathToFrontend):
(WebCore::FrameDOMAgent::setDocument):
(WebCore::FrameDOMAgent::reset):
(WebCore::FrameDOMAgent::getDocument):
(WebCore::FrameDOMAgent::requestChildNodes):
(WebCore::FrameDOMAgent::getAttributes):
(WebCore::FrameDOMAgent::requestAssignedSlot):
(WebCore::FrameDOMAgent::requestAssignedNodes):
(WebCore::FrameDOMAgent::didInsertDOMNode):
(WebCore::FrameDOMAgent::didRemoveDOMNode):
(WebCore::FrameDOMAgent::willDestroyDOMNode):
(WebCore::FrameDOMAgent::destroyedNodesTimerFired):
(WebCore::FrameDOMAgent::willModifyDOMAttr):
(WebCore::FrameDOMAgent::didModifyDOMAttr):
(WebCore::FrameDOMAgent::didRemoveDOMAttr):
(WebCore::FrameDOMAgent::characterDataModified):
(WebCore::FrameDOMAgent::didInvalidateStyleAttr):
(WebCore::FrameDOMAgent::didPushShadowRoot):
(WebCore::FrameDOMAgent::willPopShadowRoot):
(WebCore::FrameDOMAgent::didChangeCustomElementState):
(WebCore::FrameDOMAgent::pseudoElementCreated):
(WebCore::FrameDOMAgent::pseudoElementDestroyed):
(WebCore::FrameDOMAgent::frameDocumentUpdated):
* Source/WebCore/inspector/agents/frame/FrameDOMAgent.h: Added.
* Source/WebCore/inspector/agents/frame/FrameDOMAgentStubs.cpp: Added.
(WebCore::FrameDOMAgent::querySelector):
(WebCore::FrameDOMAgent::querySelectorAll):
(WebCore::FrameDOMAgent::setNodeName):
(WebCore::FrameDOMAgent::setNodeValue):
(WebCore::FrameDOMAgent::removeNode):
(WebCore::FrameDOMAgent::setAttributeValue):
(WebCore::FrameDOMAgent::setAttributesAsText):
(WebCore::FrameDOMAgent::removeAttribute):
(WebCore::FrameDOMAgent::getSupportedEventNames):
(WebCore::FrameDOMAgent::getDataBindingsForNode):
(WebCore::FrameDOMAgent::getAssociatedDataForNode):
(WebCore::FrameDOMAgent::getEventListenersForNode):
(WebCore::FrameDOMAgent::setEventListenerDisabled):
(WebCore::FrameDOMAgent::setBreakpointForEventListener):
(WebCore::FrameDOMAgent::removeBreakpointForEventListener):
(WebCore::FrameDOMAgent::getAccessibilityPropertiesForNode):
(WebCore::FrameDOMAgent::getOuterHTML):
(WebCore::FrameDOMAgent::setOuterHTML):
(WebCore::FrameDOMAgent::insertAdjacentHTML):
(WebCore::FrameDOMAgent::performSearch):
(WebCore::FrameDOMAgent::getSearchResults):
(WebCore::FrameDOMAgent::discardSearchResults):
(WebCore::FrameDOMAgent::requestNode):
(WebCore::FrameDOMAgent::setInspectModeEnabled):
(WebCore::FrameDOMAgent::highlightRect):
(WebCore::FrameDOMAgent::highlightQuad):
(WebCore::FrameDOMAgent::highlightSelector):
(WebCore::FrameDOMAgent::highlightNode):
(WebCore::FrameDOMAgent::highlightNodeList):
(WebCore::FrameDOMAgent::hideHighlight):
(WebCore::FrameDOMAgent::highlightFrame):
(WebCore::FrameDOMAgent::showGridOverlay):
(WebCore::FrameDOMAgent::hideGridOverlay):
(WebCore::FrameDOMAgent::showFlexOverlay):
(WebCore::FrameDOMAgent::hideFlexOverlay):
(WebCore::FrameDOMAgent::pushNodeByPathToFrontend):
(WebCore::FrameDOMAgent::resolveNode):
(WebCore::FrameDOMAgent::moveTo):
(WebCore::FrameDOMAgent::undo):
(WebCore::FrameDOMAgent::redo):
(WebCore::FrameDOMAgent::markUndoableState):
(WebCore::FrameDOMAgent::focus):
(WebCore::FrameDOMAgent::setInspectedNode):
(WebCore::FrameDOMAgent::setAllowEditingUserAgentShadowTrees):
(WebCore::FrameDOMAgent::getMediaStats):
* Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js:
(WI.DOMManager):
(WI.DOMManager.prototype.initializeTarget):
(WI.DOMManager.prototype._initializeFrameTarget):
(WI.DOMManager.prototype._spliceFrameDocumentIntoPageTree):
(WI.DOMManager.prototype._ensurePageBodyChildrenLoaded):
(WI.DOMManager.prototype._trySpliceFrameDocumentIntoNode):
(WI.DOMManager.prototype._trySpliceUnsplicedFrameDocuments):
(WI.DOMManager.prototype._handleTargetRemoved):
(WI.DOMManager.prototype._cleanupFrameTarget):
(WI.DOMManager.prototype.frameTargetDocumentForTarget):
(WI.DOMManager.prototype.nodeForIdInFrameTarget):
(WI.DOMManager.prototype._frameTargetSetChildNodes):
(WI.DOMManager.prototype._frameTargetDocumentUpdated):
(WI.DOMManager.prototype._frameTargetUnbind):
(WI.DOMManager.prototype._setDocument):
(WI.DOMManager.prototype._setChildNodes):
(WI.DOMManager.prototype._childNodeCountUpdated):
(WI.DOMManager.prototype._childNodeInserted):
(WI.DOMManager.prototype._childNodeRemoved):
(WI.DOMManager.prototype.hideDOMNodeHighlight):
(WI.DOMManager.prototype.setBreakpointForEventListener):
(WI.DOMManager.prototype._handleEventBreakpointDisabledStateChanged):
* Source/WebInspectorUI/UserInterface/Models/DOMNode.js:
(WI.DOMNode.prototype.get owningTarget):
(WI.DOMNode.prototype.get backendNodeId):
(WI.DOMNode.prototype.highlight):
(WI.DOMNode.prototype.getChildNodes):
(WI.DOMNode.prototype.getSubtree):
(WI.DOMNode.prototype.async requestAssignedSlot):
(WI.DOMNode.prototype.async requestAssignedNodes):
(WI.DOMNode.prototype._insertChild):
(WI.DOMNode.prototype._setChildrenPayload):
* Source/WebInspectorUI/UserInterface/Protocol/CSSObserver.js:
(WI.CSSObserver.prototype.nodeLayoutFlagsChanged):
(WI.CSSObserver.prototype.nodeLayoutContextTypeChanged):
(WI.CSSObserver):
* Source/WebInspectorUI/UserInterface/Protocol/DOMObserver.js:
(WI.DOMObserver.prototype.documentUpdated):
(WI.DOMObserver.prototype.inspect):
(WI.DOMObserver.prototype.setChildNodes):
(WI.DOMObserver.prototype.attributeModified):
(WI.DOMObserver.prototype.attributeRemoved):
(WI.DOMObserver.prototype.inlineStyleInvalidated):
(WI.DOMObserver.prototype.characterDataModified):
(WI.DOMObserver.prototype.childNodeCountUpdated):
(WI.DOMObserver.prototype.childNodeInserted):
(WI.DOMObserver.prototype.childNodeRemoved):
(WI.DOMObserver.prototype.willDestroyDOMNode):
(WI.DOMObserver.prototype.shadowRootPushed):
(WI.DOMObserver.prototype.shadowRootPopped):
(WI.DOMObserver.prototype.customElementStateChanged):
(WI.DOMObserver.prototype.pseudoElementAdded):
(WI.DOMObserver.prototype.pseudoElementRemoved):
(WI.DOMObserver.prototype.didAddEventListener):
(WI.DOMObserver.prototype.willRemoveEventListener):
(WI.DOMObserver.prototype.didFireEvent):
(WI.DOMObserver.prototype.powerEfficientPlaybackStateChanged):
(WI.DOMObserver):

Canonical link: <a href="https://commits.webkit.org/312386@main">https://commits.webkit.org/312386@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e191a04e71b350faca5828ed744a3c519143663d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159787 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33255 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/26361 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/168647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/114168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e8f31994-dc95-4bc7-890e-23a9d0afee4b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161656 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33359 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33258 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/168647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/114168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dcc39bc0-645d-4110-9977-0c1c1a762d42) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162745 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/26079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/143517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/168647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f6b10ee0-5ed9-4dc0-b45b-32350d0564b2) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/25130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16408 "Built successfully") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/151843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/134822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/21288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171138 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/20624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/17155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/22925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/132073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32933 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/27680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/132122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32918 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/143082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/91016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24316 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/26742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/19896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/192071 "Built successfully") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/32427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/98824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/49393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/31924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/32171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/32075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->