### PR TITLE
ZStream: deflateEnd() called after inflateInit2() via DecompressionStream → invalid free (UB/crash)

### DIFF
--- a/Source/WebCore/Modules/compression/ZStream.cpp
+++ b/Source/WebCore/Modules/compression/ZStream.cpp
@@ -68,6 +68,8 @@ bool ZStream::initializeIfNecessary(Algorithm algorithm, Operation operation)
     }
     if (result != Z_OK)
         return false;
+
+    m_operation = operation;
     m_isInitialized = true;
     return true;
 }
@@ -79,8 +81,14 @@ ZStream::ZStream()
 
 ZStream::~ZStream()
 {
-    if (m_isInitialized)
+    if (!m_isInitialized)
+        return;
+
+    if (m_operation == Operation::Compression)
         deflateEnd(&m_stream);
+    else
+        inflateEnd(&m_stream);
+
 }
 
 }

--- a/Source/WebCore/Modules/compression/ZStream.h
+++ b/Source/WebCore/Modules/compression/ZStream.h
@@ -43,6 +43,7 @@ public:
 
 private:
     z_stream m_stream;
+    Operation m_operation { Operation::Compression };
     bool m_isInitialized { false };
 };
 


### PR DESCRIPTION
#### 43a1b0bafb0c4d47208338c97756cfcb9304fa1f
<pre>
ZStream: deflateEnd() called after inflateInit2() via DecompressionStream → invalid free (UB/crash)
<a href="https://bugs.webkit.org/show_bug.cgi?id=302216">https://bugs.webkit.org/show_bug.cgi?id=302216</a>
<a href="https://rdar.apple.com/164363410">rdar://164363410</a>

Reviewed by Chris Dumez.

Ensure that we properly select inflateEnd vs deflateEnd when closing a stream.

No new test because I was not able to get this to crash locally, but it is the correct fix.

* Source/WebCore/Modules/compression/ZStream.cpp:
(WebCore::ZStream::initializeIfNecessary):
(WebCore::ZStream::~ZStream):
* Source/WebCore/Modules/compression/ZStream.h:

Originally-landed-as: 301765.318@safari-7623-branch (f0c4a925385f). <a href="https://rdar.apple.com/172771351">rdar://172771351</a>
Canonical link: <a href="https://commits.webkit.org/309446@main">https://commits.webkit.org/309446@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d45e87b2b8c87a92ef9a8e57915ac1f2bc0a46e5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150660 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23418 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16989 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159382 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104094 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e29db352-54a6-4922-8cf2-5fd852e31611) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152533 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23850 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23593 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116275 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82585 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9eb503c0-4d60-47ee-82d7-c4d32913f4a0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153620 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18382 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135157 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97003 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6bcfcb1c-c3cd-4770-8b16-18cf3b319d00) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17480 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15428 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7230 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127094 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13081 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161856 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4976 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14635 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124273 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23220 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19475 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124471 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33791 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23208 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134876 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79597 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19560 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11638 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22822 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86621 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22534 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22686 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22588 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->