### PR TITLE
Delegate same-document navigation check to BackForwardClient for back/forward navigation.

### DIFF
--- a/Source/WebCore/history/BackForwardClient.h
+++ b/Source/WebCore/history/BackForwardClient.h
@@ -54,6 +54,7 @@ public:
     virtual unsigned backListCount() const = 0;
     virtual unsigned forwardListCount() const = 0;
     virtual bool containsItem(const HistoryItem&) const = 0;
+    virtual bool isSameDocumentNavigation(int steps) const = 0;
 
     virtual void close() = 0;
     virtual bool isWebBackForwardListProxy() const { return false; }

--- a/Source/WebCore/history/BackForwardController.cpp
+++ b/Source/WebCore/history/BackForwardController.cpp
@@ -149,6 +149,11 @@ bool BackForwardController::containsItem(const HistoryItem& item) const
     return m_client->containsItem(item);
 }
 
+bool BackForwardController::isSameDocumentNavigation(int steps) const
+{
+    return m_client->isSameDocumentNavigation(steps);
+}
+
 unsigned BackForwardController::count() const
 {
     Ref client = m_client;

--- a/Source/WebCore/history/BackForwardController.h
+++ b/Source/WebCore/history/BackForwardController.h
@@ -66,6 +66,7 @@ public:
     WEBCORE_EXPORT unsigned forwardCount() const;
 
     bool containsItem(const HistoryItem&) const;
+    bool isSameDocumentNavigation(int steps) const;
 
     WEBCORE_EXPORT RefPtr<HistoryItem> backItem(std::optional<FrameIdentifier> = std::nullopt);
     WEBCORE_EXPORT RefPtr<HistoryItem> currentItem(std::optional<FrameIdentifier> = std::nullopt);

--- a/Source/WebCore/history/HistoryItem.h
+++ b/Source/WebCore/history/HistoryItem.h
@@ -167,7 +167,7 @@ public:
     WEBCORE_EXPORT const Vector<Ref<HistoryItem>>& NODELETE children() const LIFETIME_BOUND;
     void clearChildren();
 
-    bool NODELETE shouldDoSameDocumentNavigationTo(HistoryItem& otherItem) const;
+    WEBCORE_EXPORT bool NODELETE shouldDoSameDocumentNavigationTo(HistoryItem& otherItem) const;
 
     bool isCurrentDocument(Document&) const;
     

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -130,6 +130,7 @@ class EmptyBackForwardClient final : public BackForwardClient {
     unsigned NODELETE forwardListCount() const final { return 0; }
     bool NODELETE containsItem(const HistoryItem&) const final { return false; }
     void NODELETE close() final { }
+    bool isSameDocumentNavigation(int) const final { return false; }
 };
 
 #if ENABLE(CONTEXT_MENUS)

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -318,11 +318,9 @@ public:
             return;
         }
 
-        RefPtr historyItem = targetHistoryItem(*localFrame);
+        Ref rootFrame = localFrame->rootFrame();
+        RefPtr historyItem = protect(page->backForward())->itemAtIndex(m_steps, rootFrame->frameID());
         if (!historyItem)
-            return;
-
-        if (!protect(page->backForward())->containsItem(*historyItem))
             return;
 
         if (RefPtr currentItem = protect(page->backForward())->currentItem(); currentItem && currentItem->itemID() == historyItem->itemID()) {
@@ -330,7 +328,6 @@ public:
             return;
         }
 
-        Ref rootFrame = localFrame->rootFrame();
         page->goToItem(rootFrame, *historyItem, FrameLoadType::IndexedBackForward, ShouldTreatAsContinuingLoad::No);
     }
 
@@ -340,12 +337,11 @@ public:
         if (!localFrame)
             return false;
 
-        RefPtr historyItem = targetHistoryItem(*localFrame);
-        if (!historyItem)
+        RefPtr page { localFrame->page() };
+        if (!page)
             return false;
 
-        RefPtr currentItem = localFrame->loader().history().currentItem();
-        return currentItem && historyItem->shouldDoSameDocumentNavigationTo(*currentItem);
+        return protect(page->backForward())->isSameDocumentNavigation(m_steps);
     }
 
     ShouldCancel adjustForNewBackForwardEntry() final
@@ -358,18 +354,6 @@ public:
     }
 
 private:
-    HistoryItem* targetHistoryItem(LocalFrame& localFrame) const
-    {
-        if (!m_historyItem) {
-            RefPtr page = localFrame.page();
-            if (!page)
-                return nullptr;
-            m_historyItem = protect(page->backForward())->itemAtIndex(m_steps, localFrame.rootFrame().frameID());
-        }
-        return m_historyItem.get();
-    }
-
-    mutable RefPtr<HistoryItem> m_historyItem;
     int m_steps;
 };
 

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
@@ -98,6 +98,11 @@ WebBackForwardListFrameItem* WebBackForwardListFrameItem::childItemAtIndex(uint6
     return m_children[index].ptr();
 }
 
+bool WebBackForwardListFrameItem::isSameDocumentNavigation(WebBackForwardListFrameItem& other)
+{
+    return frameState().documentSequenceNumber == other.frameState().documentSequenceNumber;
+}
+
 WebBackForwardListItem* WebBackForwardListFrameItem::backForwardListItem() const
 {
     return m_backForwardListItem.get();

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.h
@@ -61,6 +61,7 @@ public:
     Ref<WebBackForwardListFrameItem> mainFrame();
     WebBackForwardListFrameItem* NODELETE childItemForFrameID(WebCore::FrameIdentifier);
     WebBackForwardListFrameItem* NODELETE childItemAtIndex(uint64_t);
+    bool isSameDocumentNavigation(WebBackForwardListFrameItem&);
 
     WebBackForwardListItem* NODELETE backForwardListItem() const;
 

--- a/Source/WebKit/Shared/WebBackForwardListItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListItem.cpp
@@ -221,4 +221,25 @@ void WebBackForwardListItem::updateFrameID(FrameIdentifier oldFrameID, FrameIden
         m_navigatedFrameID = newFrameID;
 }
 
+bool WebBackForwardListItem::isSameDocumentNavigation(WebBackForwardListItem& targetItem)
+{
+    Ref targetMainFrame = targetItem.mainFrameItem();
+    Ref currentMainFrame = mainFrameItem();
+
+    if (!targetMainFrame->isSameDocumentNavigation(currentMainFrame))
+        return false;
+
+    // Main frame is same-document. Check if the navigated child frame changed document.
+    auto frameID = this->navigatedFrameID();
+    if (!frameID || *frameID == targetMainFrame->frameID())
+        return true;
+
+    RefPtr targetChild = targetMainFrame->childItemForFrameID(*frameID);
+    RefPtr currentChild = currentMainFrame->childItemForFrameID(*frameID);
+    if (!targetChild || !currentChild)
+        return false;
+
+    return targetChild->isSameDocumentNavigation(*currentChild);
+}
+
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebBackForwardListItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListItem.h
@@ -105,6 +105,7 @@ public:
     EnhancedSecurity enhancedSecurity() const { return m_enhancedSecurity; }
 
     void updateFrameID(WebCore::FrameIdentifier oldFrameID, WebCore::FrameIdentifier newFrameID);
+    bool isSameDocumentNavigation(WebBackForwardListItem&);
 
 private:
     WebBackForwardListItem(Ref<FrameState>&&, WebPageProxyIdentifier, std::optional<WebCore::FrameIdentifier>, BrowsingContextGroup*);

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -699,6 +699,16 @@ void WebBackForwardList::updateFrameIdentifier(FrameIdentifier oldFrameID, Frame
         entry->updateFrameID(oldFrameID, newFrameID);
 }
 
+bool WebBackForwardList::isSameDocumentNavigation(int32_t steps)
+{
+    RefPtr targetItem = itemAtIndex(steps);
+    RefPtr current = currentItem();
+    if (!targetItem || !current)
+        return false;
+
+    return current->isSameDocumentNavigation(*targetItem);
+}
+
 void WebBackForwardList::backForwardGoToItem(BackForwardItemIdentifier itemID, CompletionHandler<void(const WebBackForwardListCounts&)>&& completionHandler)
 {
     // On process swap, we tell the previous process to ignore the load, which causes it to restore its current back forward item to its previous
@@ -755,6 +765,11 @@ void WebBackForwardList::backForwardItemAtIndex(int32_t index, FrameIdentifier f
 void WebBackForwardList::backForwardListCounts(CompletionHandler<void(WebBackForwardListCounts&&)>&& completionHandler)
 {
     completionHandler(counts());
+}
+
+void WebBackForwardList::backForwardIsSameDocumentNavigation(int32_t steps, CompletionHandler<void(bool)>&& completionHandler)
+{
+    completionHandler(isSameDocumentNavigation(steps));
 }
 
 FrameState* WebBackForwardList::findFrameStateInItem(WebCore::BackForwardItemIdentifier itemID, WebCore::FrameIdentifier parentFrameID, uint64_t childFrameIndex)

--- a/Source/WebKit/UIProcess/WebBackForwardList.h
+++ b/Source/WebKit/UIProcess/WebBackForwardList.h
@@ -111,6 +111,7 @@ private:
     const BackForwardListItemVector& entries() const LIFETIME_BOUND { return m_entries; }
     WebBackForwardListCounts NODELETE counts() const;
     Ref<FrameState> completeFrameStateForNavigation(Ref<FrameState>&&);
+    bool isSameDocumentNavigation(int32_t steps);
 
     // IPC messages
     void backForwardAddItem(IPC::Connection&, Ref<FrameState>&&);
@@ -122,6 +123,7 @@ private:
     void backForwardItemAtIndex(int32_t index, WebCore::FrameIdentifier, CompletionHandler<void(RefPtr<FrameState>&&)>&&);
     void backForwardListContainsItem(WebCore::BackForwardItemIdentifier, CompletionHandler<void(bool)>&&);
     void backForwardListCounts(CompletionHandler<void(WebBackForwardListCounts&&)>&&);
+    void backForwardIsSameDocumentNavigation(int32_t steps, CompletionHandler<void(bool)>&&);
 
     WeakPtr<WebPageProxy> m_page;
     BackForwardListItemVector m_entries;

--- a/Source/WebKit/UIProcess/WebBackForwardList.messages.in
+++ b/Source/WebKit/UIProcess/WebBackForwardList.messages.in
@@ -36,4 +36,5 @@ messages -> WebBackForwardList {
     BackForwardItemAtIndex(int32_t itemIndex, WebCore::FrameIdentifier frameID) -> (RefPtr<WebKit::FrameState> frameState) Synchronous
     BackForwardListContainsItem(WebCore::BackForwardItemIdentifier itemID) -> (bool contains) Synchronous
     BackForwardListCounts() -> (struct WebKit::WebBackForwardListCounts counts) Synchronous
+    BackForwardIsSameDocumentNavigation(int32_t steps) -> (bool isSameDocument) Synchronous
 }

--- a/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp
@@ -136,6 +136,13 @@ bool WebBackForwardListProxy::containsItem(const WebCore::HistoryItem& item) con
     return contains;
 }
 
+bool WebBackForwardListProxy::isSameDocumentNavigation(int steps) const
+{
+    auto sendResult = m_page->sendSync(Messages::WebBackForwardList::BackForwardIsSameDocumentNavigation(steps));
+    auto [isSameDocument] = sendResult.takeReplyOr(false);
+    return isSameDocument;
+}
+
 const WebBackForwardListCounts& WebBackForwardListProxy::cacheListCountsIfNecessary() const
 {
     if (!m_cachedBackForwardListCounts) {

--- a/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.h
+++ b/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.h
@@ -57,6 +57,7 @@ private:
     unsigned backListCount() const override;
     unsigned forwardListCount() const override;
     bool containsItem(const WebCore::HistoryItem&) const final;
+    bool isSameDocumentNavigation(int steps) const final;
     bool isWebBackForwardListProxy() const final { return true; }
     const WebBackForwardListCounts& cacheListCountsIfNecessary() const;
 

--- a/Source/WebKitLegacy/mac/History/BackForwardList.h
+++ b/Source/WebKitLegacy/mac/History/BackForwardList.h
@@ -68,6 +68,7 @@ public:
     unsigned backListCount() const override;
     unsigned forwardListCount() const override;
     bool containsItem(const WebCore::HistoryItem&) const final;
+    bool isSameDocumentNavigation(int) const final;
 
     void close() override;
     bool NODELETE closed();

--- a/Source/WebKitLegacy/mac/History/BackForwardList.mm
+++ b/Source/WebKitLegacy/mac/History/BackForwardList.mm
@@ -260,3 +260,17 @@ bool BackForwardList::containsItem(const HistoryItem& entry) const
 {
     return m_entryHash.contains(const_cast<HistoryItem*>(&entry));
 }
+
+bool BackForwardList::isSameDocumentNavigation(int steps) const
+{
+    if (m_current == NoCurrentItemIndex)
+        return false;
+
+    int target = static_cast<int>(m_current) + steps;
+    if (target < 0 || target >= static_cast<int>(m_entries.size()))
+        return false;
+
+    Ref currentItem = m_entries[m_current];
+    Ref targetItem = m_entries[target];
+    return currentItem->shouldDoSameDocumentNavigationTo(targetItem);
+}


### PR DESCRIPTION
#### e1fbb3992092d81edb2b61af796fdbc26fa32ff3
<pre>
Delegate same-document navigation check to BackForwardClient for back/forward navigation.
<a href="https://bugs.webkit.org/show_bug.cgi?id=310131">https://bugs.webkit.org/show_bug.cgi?id=310131</a>
<a href="https://rdar.apple.com/172771174">rdar://172771174</a>

Reviewed by NOBODY (OOPS!).

For JavaScript-initiated history.back() that only affects subframes,
the same-document navigation check is now delegated to the UIProcess via
a sync IPC through the back/forward list. This is necessary because the
WebProcess-side check only compares the main frame&apos;s documentSequenceNumber
and misses subframe document changes, causing subframe-only back/forward
navigations to be incorrectly treated as same-document navigations.

No new tests, covered by existing back/forward tests.

* Source/WebCore/history/BackForwardClient.h:
* Source/WebCore/history/BackForwardController.cpp:
(WebCore::BackForwardController::isSameDocumentNavigation const):
* Source/WebCore/history/BackForwardController.h:
* Source/WebCore/history/HistoryItem.h:
* Source/WebCore/loader/EmptyClients.cpp:
* Source/WebCore/loader/NavigationScheduler.cpp:
* Source/WebKit/Shared/WebBackForwardListFrameItem.cpp:
(WebKit::WebBackForwardListFrameItem::isSameDocumentNavigation):
* Source/WebKit/Shared/WebBackForwardListFrameItem.h:
* Source/WebKit/Shared/WebBackForwardListItem.cpp:
(WebKit::WebBackForwardListItem::isSameDocumentNavigation):
* Source/WebKit/Shared/WebBackForwardListItem.h:
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::isSameDocumentNavigation):
(WebKit::WebBackForwardList::backForwardIsSameDocumentNavigation):
* Source/WebKit/UIProcess/WebBackForwardList.h:
* Source/WebKit/UIProcess/WebBackForwardList.messages.in:
* Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp:
(WebKit::WebBackForwardListProxy::isSameDocumentNavigation const):
* Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.h:
* Source/WebKitLegacy/mac/History/BackForwardList.h:
* Source/WebKitLegacy/mac/History/BackForwardList.mm:
(BackForwardList::isSameDocumentNavigation const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1fbb3992092d81edb2b61af796fdbc26fa32ff3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150661 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23419 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16990 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159383 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104095 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c2c20a41-bb9e-4f5c-8025-9f9275e7055c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152534 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23851 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23596 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116278 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82584 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e9baa7f8-45bc-4cc5-afd6-1d6a8c65db6b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153621 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18389 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135160 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97006 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c8e0bac1-12f8-43c4-a786-c1ac061f8584) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17487 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15430 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7231 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127101 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13084 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161857 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4977 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14638 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124279 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23221 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19477 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124477 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23209 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134879 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79598 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19555 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11641 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22823 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86622 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22535 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22687 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22589 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->