### PR TITLE
[iOS debug] http/wpt/navigation-api/scroll-behavior/manual-scroll-reload.html is a flaky text failure

### DIFF
--- a/LayoutTests/http/wpt/navigation-api/scroll-behavior/manual-scroll-reload.html
+++ b/LayoutTests/http/wpt/navigation-api/scroll-behavior/manual-scroll-reload.html
@@ -31,12 +31,13 @@ promise_test(async t => {
   buffer.remove();
   let scrollY_after_buffer_remove = window.scrollY;
   // Don't assert the exact value after buffer removal since it depends on scroll anchoring.
-
+  await new Promise(resolve => requestAnimationFrame(resolve));
   // After restoration, we should be at #frag's position
   // The scroll should be restored to make #frag visible at the same viewport position
   navigate_event.scroll();
   let frag_element = document.getElementById("frag");
   let frag_top = frag_element.offsetTop;
+  await new Promise(resolve => requestAnimationFrame(resolve));
   assert_equals(window.scrollY, frag_top);
   assert_not_equals(window.scrollY, scrollY_after_buffer_remove);
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8497,8 +8497,6 @@ media/caption-display-settings/caption-display-settings-default-anchorBounds.htm
 
 webkit.org/b/299830 imported/w3c/web-platform-tests/storage-access-api/hasStorageAccess-insecure.sub.window.html [ Pass Failure ]
 
-webkit.org/b/310111 [ Debug ] http/wpt/navigation-api/scroll-behavior/manual-scroll-reload.html [ Pass Failure ]
-
 webkit.org/b/307582 compositing/overflow/rtl-scrollbar-layer-positioning.html [ Failure ]
 
 webkit.org/b/307889 http/tests/multipart/multipart-async-image.html [ Pass Failure ]


### PR DESCRIPTION
#### 1250621b023fe2e9877e96a685a42a195ca81870
<pre>
[iOS debug] http/wpt/navigation-api/scroll-behavior/manual-scroll-reload.html is a flaky text failure
<a href="https://rdar.apple.com/172757985">rdar://172757985</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=310111">https://bugs.webkit.org/show_bug.cgi?id=310111</a>

Reviewed by Simon Fraser.

This test is flakily failing since scroll position is reported as 0 instead of 8.
The issue is that scroll positions do not settle in time on (slow) debug builds
due to overlapping async scroll updates through the scrolling coordinator.

Fix in manual-scroll-reload.html:
- Add rAF before navigate_event.scroll() so that the scroll anchoring
  from buffer.remove() can settle in the UI process.
- Add rAF after navigate_event.scroll() so that the scroll-to-fragment
  can settle in the UI process before asserting.

* LayoutTests/http/wpt/navigation-api/scroll-behavior/manual-scroll-reload.html:
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/310646@main">https://commits.webkit.org/310646@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eaf86baa155e051864f75edd123391b85808fe06

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150663 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23421 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16992 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159385 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104097 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23853 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23612 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116276 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82586 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153623 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18384 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135159 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97004 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17482 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15436 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7233 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127096 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13083 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161859 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14637 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124275 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23223 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19483 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124473 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34659 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23211 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134878 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79600 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19556 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11640 "Found 3 new test failures: http/tests/security/canvas-cors-with-two-hosts.html http/tests/site-isolation/frame-index.html http/tests/storageAccess/deny-storage-access-under-opener-ephemeral.html (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22825 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22537 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22689 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22591 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->