### PR TITLE
REGRESSION(290430@main): Timelines recording stops on page reload even when auto-stop is disabled

### DIFF
--- a/LayoutTests/inspector/timeline/timeline-recording-autocapture-expected.txt
+++ b/LayoutTests/inspector/timeline/timeline-recording-autocapture-expected.txt
@@ -1,0 +1,24 @@
+Tests for auto-capture timeline recording.
+
+
+== Running test suite: Timeline.AutoCapture
+-- Running test case: Timeline.AutoCapture
+Loaded
+PASS: TimelineManager should not be capturing.
+Reload
+PASS: TimelineManager should be capturing after reload with auto-capture enabled.
+PASS: TimelineRecording should be capturing.
+Stop
+PASS: TimelineManager should not be capturing.
+PASS: TimelineRecording should not be capturing.
+
+-- Running test case: Timeline.AutoCaptureSuppressedDuringActiveRecording
+Start
+PASS: TimelineManager should be capturing.
+Reload
+PASS: TimelineManager should still be capturing after reload.
+PASS: TimelineManager active recording should not have changed.
+PASS: Auto-capture should not have stopped the active recording.
+Stop
+PASS: TimelineManager should not be capturing.
+

--- a/LayoutTests/inspector/timeline/timeline-recording-autocapture.html
+++ b/LayoutTests/inspector/timeline/timeline-recording-autocapture.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("Timeline.AutoCapture");
+
+    function awaitCapturingState(capturingState) {
+        return new Promise((resolve) => {
+            let listener = WI.timelineManager.addEventListener(WI.TimelineManager.Event.CapturingStateChanged, (event) => {
+                if (event.data.capturingState !== capturingState)
+                    return;
+                WI.timelineManager.removeEventListener(WI.TimelineManager.Event.CapturingStateChanged, listener);
+                resolve();
+            });
+        });
+    }
+
+    suite.addTestCase({
+        name: "Timeline.AutoCapture",
+        description: "Verify that a page reload triggers auto-capture of a timeline recording.",
+        async test() {
+            await TimelineAgent.setAutoCaptureEnabled(true);
+            await TimelineAgent.setInstruments([InspectorBackend.Enum.Timeline.Instrument.Timeline]);
+
+            InspectorTest.log("Loaded");
+            InspectorTest.expectFalse(WI.timelineManager.isCapturing(), "TimelineManager should not be capturing.");
+
+            let recording = WI.timelineManager.activeRecording;
+
+            InspectorTest.log("Reload");
+            await Promise.all([
+                InspectorTest.awaitEvent(FrontendTestHarness.Event.TestPageDidLoad),
+                InspectorTest.reloadPage(),
+                awaitCapturingState(WI.TimelineManager.CapturingState.Active),
+            ]);
+
+            InspectorTest.expectTrue(WI.timelineManager.isCapturing(), "TimelineManager should be capturing after reload with auto-capture enabled.");
+            InspectorTest.expectTrue(recording.capturing, "TimelineRecording should be capturing.");
+
+            InspectorTest.log("Stop");
+            WI.timelineManager.stopCapturing();
+            await awaitCapturingState(WI.TimelineManager.CapturingState.Inactive);
+
+            InspectorTest.expectFalse(WI.timelineManager.isCapturing(), "TimelineManager should not be capturing.");
+            InspectorTest.expectFalse(recording.capturing, "TimelineRecording should not be capturing.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "Timeline.AutoCaptureSuppressedDuringActiveRecording",
+        description: "Verify that a page reload during an active recording does not trigger auto-capture that stops the ongoing recording.",
+        async test() {
+            await TimelineAgent.setAutoCaptureEnabled(true);
+            await TimelineAgent.setInstruments([InspectorBackend.Enum.Timeline.Instrument.Timeline]);
+
+            InspectorTest.log("Start");
+            WI.timelineManager.startCapturing();
+            await awaitCapturingState(WI.TimelineManager.CapturingState.Active);
+
+            let recording = WI.timelineManager.activeRecording;
+            InspectorTest.expectTrue(WI.timelineManager.isCapturing(), "TimelineManager should be capturing.");
+
+            // If Timelines.autoCaptureStarted event is dispatched, it will stop the active recording.
+            let autoCaptureDidFire = false;
+            let autoCaptureListener = WI.timelineManager.addEventListener(WI.TimelineManager.Event.CapturingStateChanged, (event) => {
+                if (event.data.capturingState === WI.TimelineManager.CapturingState.Inactive)
+                    autoCaptureDidFire = true;
+            });
+
+            InspectorTest.log("Reload");
+            await Promise.all([
+                InspectorTest.awaitEvent(FrontendTestHarness.Event.TestPageDidLoad),
+                InspectorTest.reloadPage(),
+            ]);
+
+            WI.timelineManager.removeEventListener(WI.TimelineManager.Event.CapturingStateChanged, autoCaptureListener);
+
+            InspectorTest.expectTrue(WI.timelineManager.isCapturing(), "TimelineManager should still be capturing after reload.");
+            InspectorTest.expectEqual(WI.timelineManager.activeRecording, recording, "TimelineManager active recording should not have changed.");
+            InspectorTest.expectFalse(autoCaptureDidFire, "Auto-capture should not have stopped the active recording.");
+
+            InspectorTest.log("Stop");
+            WI.timelineManager.stopCapturing();
+            await awaitCapturingState(WI.TimelineManager.CapturingState.Inactive);
+
+            InspectorTest.expectFalse(WI.timelineManager.isCapturing(), "TimelineManager should not be capturing.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests for auto-capture timeline recording.</p>
+</body>
+</html>

--- a/Source/WebCore/inspector/agents/page/PageTimelineAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageTimelineAgent.cpp
@@ -270,6 +270,9 @@ void PageTimelineAgent::didPaint(RenderObject& renderer, const LayoutRect& clipR
 
 void PageTimelineAgent::mainFrameStartedLoading()
 {
+    if (tracking())
+        return;
+
     if (!m_autoCaptureEnabled)
         return;
 


### PR DESCRIPTION
#### cd3ed2f6e666c4dc756bfaf9e8e6d0a011c42829
<pre>
REGRESSION(290430@main): Timelines recording stops on page reload even when auto-stop is disabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=310137">https://bugs.webkit.org/show_bug.cgi?id=310137</a>
<a href="https://rdar.apple.com/169732727">rdar://169732727</a>

Reviewed by BJ Burg and Devin Rousso.

290430@main split `InspectorTimelineAgent` into `PageTimelineAgent` and
`WorkerTimelineAgent`. When `mainFrameStartedLoading()` was moved to
`PageTimelineAgent`, the `if (m_tracking) return;` guard was dropped.

This guard prevents the backend from dispatching `Timeline.autoCaptureStarted`
to the frontend when a recording is already active. Without it, every page reload
or navigation during an active recording causes `WI.TimelineManager.prototype.autoCaptureStarted()`
on the frontend to unconditionally stop the current recording and start a new one,
regardless of the &quot;Stop recording once page loads&quot; setting.

This patch restores the guard so that `PageTimelineAgent::mainFrameStartedLoading()`
is a no-op when instruments are already recording.

Added a test for auto-capture behavior.

* LayoutTests/inspector/timeline/timeline-recording-autocapture-expected.txt: Added.
* LayoutTests/inspector/timeline/timeline-recording-autocapture.html: Added.
* Source/WebCore/inspector/agents/page/PageTimelineAgent.cpp:
(WebCore::PageTimelineAgent::mainFrameStartedLoading):

Canonical link: <a href="https://commits.webkit.org/309566@main">https://commits.webkit.org/309566@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/099a3c2774d51929c6fe5db1a5cca1a5e60f8a7c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151062 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23824 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17394 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159790 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104498 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152935 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24255 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24048 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116625 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/82787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/10c24859-d9e5-4a2e-bad0-e6e07c5b9cec) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154022 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/18747 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135534 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97346 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bcb95417-9f98-4244-baff-995c997116b5) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/17840 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15792 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7636 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127458 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13451 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162263 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5388 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/15022 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/124633 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23626 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/19842 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124821 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33862 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23616 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135248 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80060 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/19890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12013 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23226 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87520 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22938 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23090 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22992 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->