### PR TITLE
Transparent materials are not handled correctly

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/Model/ModelUtils.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelUtils.swift
@@ -30,6 +30,22 @@ import Metal
 @_spi(RealityCoreRendererAPI) import RealityKit
 @_spi(SGInternal) import RealityKit
 
+extension simd_float4x4 {
+    var minor: simd_float3x3 {
+        .init(
+            [columns.0.x, columns.0.y, columns.0.z],
+            [columns.1.x, columns.1.y, columns.1.z],
+            [columns.2.x, columns.2.y, columns.2.z]
+        )
+    }
+
+    func transformPosition(_ position: simd_float3) -> simd_float3 {
+        var result = simd_mul(self, simd_float4(position, 1))
+        result /= result.w
+        return simd_float3(result.x, result.y, result.z)
+    }
+}
+
 func mapSemantic(_ semantic: LowLevelMesh.VertexSemantic) -> _Proto_LowLevelMeshResource_v1.VertexSemantic {
     switch semantic {
     case .position: .position

--- a/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
@@ -259,16 +259,6 @@ internal func logInfo(_ info: String) {
     Logger.modelGPU.info("\(info)")
 }
 
-extension simd_float4x4 {
-    fileprivate var minor: simd_float3x3 {
-        .init(
-            [self.columns.0.x, self.columns.0.y, self.columns.0.z],
-            [self.columns.1.x, self.columns.1.y, self.columns.1.z],
-            [self.columns.2.x, self.columns.2.y, self.columns.2.z]
-        )
-    }
-}
-
 @objc
 @implementation
 extension WKBridgeUSDConfiguration {
@@ -665,6 +655,16 @@ extension WKBridgeReceiver {
                             fatalError("Failed to get material instance \(materialIdentifier)")
                         }
 
+                        #if canImport(RealityCoreRenderer, _version: 12)
+                        let pipeline = try await renderContext.makeRenderPipelineState(
+                            descriptor: .init(
+                                mesh: meshResource.descriptor,
+                                material: material.resource,
+                                renderTargets: [renderTarget],
+                                blending: material.blending == .transparent ? .sourceOver : nil
+                            )
+                        )
+                        #else
                         let pipeline = try await renderContext.makeRenderPipelineState(
                             descriptor: .descriptor(
                                 mesh: meshResource.descriptor,
@@ -672,6 +672,7 @@ extension WKBridgeReceiver {
                                 renderTargets: [renderTarget]
                             )
                         )
+                        #endif
 
                         let meshPart = try renderContext.makeMeshPart(
                             resource: meshResource,
@@ -684,6 +685,18 @@ extension WKBridgeReceiver {
                         )
 
                         for instanceTransform in data.instanceTransforms {
+                            #if canImport(RealityCoreRenderer, _version: 12)
+                            let position = instanceTransform.transformPosition(.zero)
+                            let meshInstance = try renderContext.makeMeshInstance(
+                                meshPart: meshPart,
+                                pipeline: pipeline,
+                                geometryArguments: material.geometryArguments,
+                                surfaceArguments: material.surfaceArguments,
+                                lightingArguments: lightingArguments,
+                                transform: .single(instanceTransform),
+                                category: material.blending == .transparent ? .transparent(sortPosition: position) : .opaque
+                            )
+                            #else
                             let meshInstance = try renderContext.makeMeshInstance(
                                 meshPart: meshPart,
                                 pipeline: pipeline,
@@ -693,6 +706,7 @@ extension WKBridgeReceiver {
                                 transform: .single(instanceTransform),
                                 category: .opaque
                             )
+                            #endif
 
                             // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
                             // swift-format-ignore: NeverForceUnwrap


### PR DESCRIPTION
#### ea8c3c0022f10ad541e0246c4516a0adf4b9b0e0
<pre>
Transparent materials are not handled correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=310136">https://bugs.webkit.org/show_bug.cgi?id=310136</a>
<a href="https://rdar.apple.com/170398887">rdar://170398887</a>

Reviewed by Richard Robinson.

Add support for blending in the materials.

* Source/WebKit/GPUProcess/graphics/Model/ModelUtils.swift:
(simd_float4x4.minor):
(simd_float4x4.transformPosition(_:)):
* Source/WebKit/GPUProcess/graphics/Model/USDModel.swift:
(Material.updateMesh(_:)):
(simd_float4x4.minor): Deleted.

Canonical link: <a href="https://commits.webkit.org/309451@main">https://commits.webkit.org/309451@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb8f68c79960262ba5a6865508696b0a19459bf6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150683 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23441 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17012 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159405 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/104117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23873 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23643 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116292 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/104117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153643 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18401 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135175 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97020 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6560b486-6886-4888-b1b2-7867beff3ce6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17498 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15449 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7253 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127112 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161879 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5000 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14653 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124288 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23243 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19496 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124486 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33794 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23231 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134894 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79620 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19569 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11656 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22845 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86645 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22557 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22709 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22611 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->