### PR TITLE
REGRESSION(309358@main): [macOS] Create color picker synchronously in WebPageProxy::showColorPicker

### DIFF
--- a/Source/WebKit/UIProcess/API/gtk/WebKitColorChooser.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitColorChooser.cpp
@@ -67,7 +67,7 @@ void WebKitColorChooser::colorChooserRequestRGBAChanged(WebKitColorChooserReques
     colorChooser->didChooseColor(gdkRGBAToColor(rgba));
 }
 
-void WebKitColorChooser::showColorPicker(const Color& color)
+void WebKitColorChooser::showColorPicker(const Color& color, const IntRect& rect)
 {
     m_initialColor = colorToGdkRGBA(color);
     GRefPtr<WebKitColorChooserRequest> request = adoptGRef(webkitColorChooserRequestCreate(this));
@@ -77,7 +77,7 @@ void WebKitColorChooser::showColorPicker(const Color& color)
     if (webkitWebViewEmitRunColorChooser(WEBKIT_WEB_VIEW(m_webView), request.get()))
         m_request = request;
     else
-        WebColorPickerGtk::showColorPicker(color);
+        WebColorPickerGtk::showColorPicker(color, rect);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/API/gtk/WebKitColorChooser.h
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitColorChooser.h
@@ -42,7 +42,7 @@ private:
     WebKitColorChooser(WebPageProxy&, const WebCore::Color&, const WebCore::IntRect&, std::optional<WebCore::FrameIdentifier>);
 
     void endPicker() override;
-    void showColorPicker(const WebCore::Color&) override;
+    void showColorPicker(const WebCore::Color&, const WebCore::IntRect&) override;
 
     static void colorChooserRequestFinished(WebKitColorChooserRequest*, WebKitColorChooser*);
     static void colorChooserRequestRGBAChanged(WebKitColorChooserRequest*, GParamSpec*, WebKitColorChooser*);

--- a/Source/WebKit/UIProcess/WebColorPicker.cpp
+++ b/Source/WebKit/UIProcess/WebColorPicker.cpp
@@ -51,7 +51,7 @@ void WebColorPicker::setSelectedColor(const WebCore::Color& color)
         client->didChooseColor(color);
 }
 
-void WebColorPicker::showColorPicker(const WebCore::Color&)
+void WebColorPicker::showColorPicker(const WebCore::Color&, const WebCore::IntRect&)
 {
     ASSERT_NOT_REACHED();
     return;

--- a/Source/WebKit/UIProcess/WebColorPicker.h
+++ b/Source/WebKit/UIProcess/WebColorPicker.h
@@ -32,6 +32,7 @@
 
 namespace WebCore {
 class Color;
+class IntRect;
 }
 
 namespace WebKit {
@@ -62,7 +63,7 @@ public:
 
     virtual void endPicker();
     virtual void setSelectedColor(const WebCore::Color&);
-    virtual void showColorPicker(const WebCore::Color&);
+    virtual void showColorPicker(const WebCore::Color&, const WebCore::IntRect&);
 
     std::optional<WebCore::FrameIdentifier> frameID() const { return m_frameID; }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -10505,19 +10505,20 @@ void WebPageProxy::showColorPicker(IPC::Connection& connection, const WebCore::C
 {
     MESSAGE_CHECK_BASE(supportsAlpha == ColorControlSupportsAlpha::No || protect(preferences())->inputTypeColorEnhancementsEnabled(), connection);
 
-    convertRectToMainFrameCoordinates(elementRect, rootFrameID, [weakThis = WeakPtr { *this }, initialColor, supportsAlpha, suggestions = WTF::move(suggestions), rootFrameID](std::optional<FloatRect> convertedRect) mutable {
+    RefPtr pageClient = this->pageClient();
+    if (!pageClient)
+        return;
+
+    internals().colorPicker = pageClient->createColorPicker(*this, initialColor, elementRect, supportsAlpha, WTF::move(suggestions), rootFrameID);
+
+    convertRectToMainFrameCoordinates(elementRect, rootFrameID, [weakThis = WeakPtr { *this }, initialColor](std::optional<FloatRect> convertedRect) mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis || !convertedRect)
             return;
 
-        RefPtr pageClient = protectedThis->pageClient();
-        if (!pageClient)
-            return;
-
-        protectedThis->internals().colorPicker = pageClient->createColorPicker(*protectedThis, initialColor, IntRect(*convertedRect), supportsAlpha, WTF::move(suggestions), rootFrameID);
         // FIXME: Remove this conditional once all ports have a functional PageClientImpl::createColorPicker.
         if (RefPtr colorPicker = protectedThis->internals().colorPicker)
-            colorPicker->showColorPicker(initialColor);
+            colorPicker->showColorPicker(initialColor, IntRect(*convertedRect));
     });
 }
 
@@ -10549,6 +10550,9 @@ void WebPageProxy::hasVideoInPictureInPictureDidChange(bool value)
 
 void WebPageProxy::Internals::didChooseColor(const WebCore::Color& color)
 {
+    if (!colorPicker)
+        return;
+
     Ref protectedPage = page.get();
     if (!protectedPage->hasRunningProcess())
         return;

--- a/Source/WebKit/UIProcess/gtk/WebColorPickerGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/WebColorPickerGtk.cpp
@@ -85,7 +85,7 @@ void WebColorPickerGtk::colorChooserDialogResponseCallback(GtkColorChooser*, int
     colorPicker->endPicker();
 }
 
-void WebColorPickerGtk::showColorPicker(const Color& color)
+void WebColorPickerGtk::showColorPicker(const Color& color, const IntRect&)
 {
     if (!client())
         return;

--- a/Source/WebKit/UIProcess/gtk/WebColorPickerGtk.h
+++ b/Source/WebKit/UIProcess/gtk/WebColorPickerGtk.h
@@ -43,7 +43,7 @@ public:
     virtual ~WebColorPickerGtk();
 
     void endPicker() override;
-    void showColorPicker(const WebCore::Color&) override;
+    void showColorPicker(const WebCore::Color&, const WebCore::IntRect&) override;
 
     void cancel();
 

--- a/Source/WebKit/UIProcess/mac/WebColorPickerMac.h
+++ b/Source/WebKit/UIProcess/mac/WebColorPickerMac.h
@@ -46,7 +46,7 @@ class WebColorPickerMac;
 }
 
 @protocol WKColorPickerUIMac <NSObject>
-- (void)setAndShowPicker:(WebKit::WebColorPickerMac*)picker withColor:(NSColor *)color supportsAlpha:(WebKit::ColorControlSupportsAlpha)supportsAlpha suggestions:(Vector<WebCore::Color>&&)suggestions;
+- (void)setAndShowPicker:(WebKit::WebColorPickerMac*)picker withColor:(NSColor *)color supportsAlpha:(WebKit::ColorControlSupportsAlpha)supportsAlpha suggestions:(Vector<WebCore::Color>&&)suggestions rect:(const WebCore::IntRect&)rect;
 - (void)invalidate;
 - (void)setColor:(NSColor *)color;
 - (void)didChooseColor:(id)sender;
@@ -55,14 +55,14 @@ class WebColorPickerMac;
 namespace WebKit {
     
 class WebColorPickerMac final : public WebColorPicker {
-public:        
+public:
     static Ref<WebColorPickerMac> create(WebColorPicker::Client*, const WebCore::Color&, const WebCore::IntRect&, WebKit::ColorControlSupportsAlpha, Vector<WebCore::Color>&&, NSView *, std::optional<WebCore::FrameIdentifier> = std::nullopt);
     virtual ~WebColorPickerMac();
 
     void endPicker() final;
     void setSelectedColor(const WebCore::Color&) final;
-    void showColorPicker(const WebCore::Color&) final;
-    
+    void showColorPicker(const WebCore::Color&, const WebCore::IntRect&) final;
+
     void didChooseColor(const WebCore::Color&);
 
 private:

--- a/Source/WebKit/UIProcess/mac/WebColorPickerMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebColorPickerMac.mm
@@ -69,8 +69,9 @@ static const CGFloat colorPickerMatrixSwatchWidth = 13.0;
     BOOL _lastChangedByUser;
     WeakPtr<WebKit::WebColorPickerMac> _picker;
     RetainPtr<WKPopoverColorWell> _popoverWell;
+    WeakObjCPtr<NSView> _owningView;
 }
-- (id)initWithFrame:(const WebCore::IntRect &)rect inView:(NSView *)view;
+- (id)initWithFrame:(const WebCore::IntRect&)rect inView:(NSView *)view;
 @end
 
 namespace WebKit {
@@ -117,12 +118,12 @@ void WebColorPickerMac::didChooseColor(const WebCore::Color& color)
         client->didChooseColor(color);
 }
 
-void WebColorPickerMac::showColorPicker(const WebCore::Color& color)
+void WebColorPickerMac::showColorPicker(const WebCore::Color& color, const WebCore::IntRect& rect)
 {
     if (!client())
         return;
 
-    [m_colorPickerUI setAndShowPicker:this withColor:cocoaColor(color).get() supportsAlpha:m_supportsAlpha suggestions:WTF::move(m_suggestions)];
+    [m_colorPickerUI setAndShowPicker:this withColor:cocoaColor(color).get() supportsAlpha:m_supportsAlpha suggestions:WTF::move(m_suggestions) rect:rect];
 }
 
 } // namespace WebKit
@@ -208,11 +209,12 @@ void WebColorPickerMac::showColorPicker(const WebCore::Color& color)
 @end
 
 @implementation WKColorPopoverMac
-- (id)initWithFrame:(const WebCore::IntRect &)rect inView:(NSView *)view
+- (id)initWithFrame:(const WebCore::IntRect&)rect inView:(NSView *)view
 {
     if(!(self = [super init]))
         return self;
 
+    _owningView = view;
     _popoverWell = adoptNS([[WKPopoverColorWell alloc] initWithFrame:[view convertRect:NSRectFromCGRect(rect) toView:nil]]);
     if (!_popoverWell)
         return self;
@@ -223,9 +225,12 @@ void WebColorPickerMac::showColorPicker(const WebCore::Color& color)
     return self;
 }
 
-- (void)setAndShowPicker:(WebKit::WebColorPickerMac*)picker withColor:(NSColor *)color supportsAlpha:(WebKit::ColorControlSupportsAlpha)supportsAlpha suggestions:(Vector<WebCore::Color>&&)suggestions
+- (void)setAndShowPicker:(WebKit::WebColorPickerMac*)picker withColor:(NSColor *)color supportsAlpha:(WebKit::ColorControlSupportsAlpha)supportsAlpha suggestions:(Vector<WebCore::Color>&&)suggestions rect:(const WebCore::IntRect&)rect
 {
     _picker = picker;
+
+    if (RetainPtr view = _owningView.get())
+        [_popoverWell setFrame:[view convertRect:NSRectFromCGRect(rect) toView:nil]];
 
     [_popoverWell setTarget:self];
     [_popoverWell setWebDelegate:self];


### PR DESCRIPTION
#### edd3097fc18981a8c0bbf29e22e13ed83820d380
<pre>
REGRESSION(309358@main): [macOS] Create color picker synchronously in WebPageProxy::showColorPicker
<a href="https://bugs.webkit.org/show_bug.cgi?id=310135">https://bugs.webkit.org/show_bug.cgi?id=310135</a>
<a href="https://rdar.apple.com/172774966">rdar://172774966</a>

Reviewed by Aditya Keerthi.

301062@main moved color picker creation inside the asynchronous
convertRectToMainFrameCoordinates callback so the popover could be
positioned with converted coordinates. This meant internals().colorPicker
was null until the callback fired, causing a flaky assertion failure when
didChooseColor was called before the callback completed.

Fix by creating the color picker synchronously and deferring only
showColorPicker until coordinates are ready. On Mac, the WKColorPopoverMac
well creation moves from the WebColorPickerMac constructor into
showColorPicker, which now receives the converted rect. This matches
the GTK implementation which already creates its dialog at show time.

Also add a null check in didChooseColor as defense-in-depth, matching
the existing pattern in didEndColorPicker.

No new tests, as this is fixing a flaky test.

* Source/WebKit/UIProcess/API/gtk/WebKitColorChooser.cpp:
(WebKit::WebKitColorChooser::showColorPicker):
* Source/WebKit/UIProcess/API/gtk/WebKitColorChooser.h:
* Source/WebKit/UIProcess/WebColorPicker.cpp:
(WebKit::WebColorPicker::showColorPicker):
* Source/WebKit/UIProcess/WebColorPicker.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::showColorPicker):
(WebKit::WebPageProxy::Internals::didChooseColor):
* Source/WebKit/UIProcess/gtk/WebColorPickerGtk.cpp:
(WebKit::WebColorPickerGtk::showColorPicker):
* Source/WebKit/UIProcess/gtk/WebColorPickerGtk.h:
* Source/WebKit/UIProcess/mac/WebColorPickerMac.h:
* Source/WebKit/UIProcess/mac/WebColorPickerMac.mm:
(WebKit::WebColorPickerMac::showColorPicker):
(-[WKColorPopoverMac initWithFrame:inView:]):
(-[WKColorPopoverMac setAndShowPicker:withColor:supportsAlpha:suggestions:rect:]):
(-[WKColorPopoverMac setAndShowPicker:withColor:supportsAlpha:suggestions:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/309512@main">https://commits.webkit.org/309512@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26a0cb5020ae36013346647404a0f3c2e3da3db6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150924 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23686 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17256 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159652 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/104360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24117 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23900 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116506 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/104360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153884 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18619 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/135405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97226 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/17713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/15666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7498 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/127331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162125 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5250 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14892 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124511 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23488 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/19716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124698 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33833 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23478 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135119 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/79885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19762 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11884 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23088 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/87225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22800 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22952 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22854 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->