### PR TITLE
Find in page should show yellow indicator even if no valid selection

### DIFF
--- a/Source/WebCore/dom/DocumentMarker.h
+++ b/Source/WebCore/dom/DocumentMarker.h
@@ -100,6 +100,8 @@ enum class DocumentMarkerType : uint32_t {
 #endif
     TransparentContent = 1 << 17,
     DictationStreamingOpacity = 1 << 18,
+    // FIXME(172843016)
+    ActiveTextMatch = 1 << 19,
 };
 
 // A range of a node within a document that is "marked", such as the range of a misspelled word.
@@ -218,6 +220,7 @@ constexpr auto DocumentMarker::allMarkers() -> OptionSet<DocumentMarkerType>
 #endif
         DocumentMarkerType::TransparentContent,
         DocumentMarkerType::DictationStreamingOpacity,
+        DocumentMarkerType::ActiveTextMatch,
     };
 }
 

--- a/Source/WebCore/dom/DocumentMarkerController.h
+++ b/Source/WebCore/dom/DocumentMarkerController.h
@@ -151,7 +151,7 @@ WEBCORE_EXPORT void DocumentMarkerController::forEach<DocumentMarkerController::
 
 WEBCORE_EXPORT void addMarker(const SimpleRange&, DocumentMarkerType, const DocumentMarker::Data& = { });
 void addMarker(Node&, unsigned startOffset, unsigned length, DocumentMarkerType, DocumentMarker::Data&& = { });
-void removeMarkers(const SimpleRange&, OptionSet<DocumentMarkerType> = DocumentMarker::allMarkers(), RemovePartiallyOverlappingMarker = RemovePartiallyOverlappingMarker::No);
+WEBCORE_EXPORT void removeMarkers(const SimpleRange&, OptionSet<DocumentMarkerType> = DocumentMarker::allMarkers(), RemovePartiallyOverlappingMarker = RemovePartiallyOverlappingMarker::No);
 
 WEBCORE_EXPORT SimpleRange makeSimpleRange(Node&, const DocumentMarker&);
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1452,6 +1452,14 @@ void Page::unmarkAllTextMatches()
     });
 }
 
+void Page::removeAllActiveTextMatches()
+{
+    forEachDocument([] (Document& document) {
+        if (CheckedPtr markers = document.markersIfExists())
+            markers->removeMarkers(DocumentMarkerType::ActiveTextMatch);
+    });
+}
+
 #if ENABLE(EDITABLE_REGION)
 
 void Page::setEditableRegionEnabled(bool enabled)

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -568,6 +568,7 @@ public:
     WEBCORE_EXPORT unsigned markAllMatchesForText(const String&, FindOptions, bool shouldHighlight, unsigned maxMatchCount);
 
     WEBCORE_EXPORT void unmarkAllTextMatches();
+    WEBCORE_EXPORT void removeAllActiveTextMatches();
 
     WEBCORE_EXPORT void dispatchBeforePrintEvent();
     WEBCORE_EXPORT void dispatchAfterPrintEvent();

--- a/Source/WebCore/rendering/MarkedText.cpp
+++ b/Source/WebCore/rendering/MarkedText.cpp
@@ -218,6 +218,8 @@ Vector<MarkedText> MarkedText::collectForDocumentMarkers(const RenderText& rende
         case DocumentMarkerType::DictationPhraseWithAlternatives:
             return MarkedText::Type::DictationPhraseWithAlternatives;
 #endif
+        case DocumentMarkerType::ActiveTextMatch:
+            return MarkedText::Type::ActiveTextMatch;
         default:
             return MarkedText::Type::Unmarked;
         }
@@ -250,6 +252,10 @@ Vector<MarkedText> MarkedText::collectForDocumentMarkers(const RenderText& rende
         case DocumentMarkerType::TextMatch:
             if (!renderer.frame().editor().markedTextMatchesAreHighlighted())
                 continue;
+            if (phase == MarkedText::PaintPhase::Decoration)
+                continue;
+            break;
+        case DocumentMarkerType::ActiveTextMatch:
             if (phase == MarkedText::PaintPhase::Decoration)
                 continue;
             break;
@@ -309,6 +315,7 @@ Vector<MarkedText> MarkedText::collectForDocumentMarkers(const RenderText& rende
         // FIXME: See <rdar://problem/8933352>. Also, remove the PLATFORM(IOS_FAMILY)-guard.
         case DocumentMarkerType::DictationPhraseWithAlternatives:
 #endif
+        case DocumentMarkerType::ActiveTextMatch:
         case DocumentMarkerType::TextMatch: {
             auto [clampedStart, clampedEnd] = selectableRange.clamp(marker->startOffset(), marker->endOffset());
 

--- a/Source/WebCore/rendering/MarkedText.h
+++ b/Source/WebCore/rendering/MarkedText.h
@@ -68,6 +68,7 @@ struct MarkedText : public CanMakeCheckedPtr<MarkedText, WTF::DefaultedOperatorE
         DraggedContent,
         TransparentContent,
         DictationStreamingOpacity,
+        ActiveTextMatch,
     };
 
     enum class PaintPhase {

--- a/Source/WebCore/rendering/StyledMarkedText.cpp
+++ b/Source/WebCore/rendering/StyledMarkedText.cpp
@@ -138,6 +138,7 @@ static StyledMarkedText resolveStyleForMarkedText(const MarkedText& markedText, 
             style.backgroundColor = selectionBackgroundColor.invertedColorWithAlpha(1.0);
         break;
     }
+    case MarkedText::Type::ActiveTextMatch:
     case MarkedText::Type::TextMatch: {
         // Text matches always use the light system appearance.
 #if PLATFORM(MAC)

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.h
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.h
@@ -141,6 +141,8 @@ public:
 
     Color platformAnnotationHighlightBackgroundColor(OptionSet<StyleColorOptions>) const final;
 
+    Color platformTextSearchHighlightColor(OptionSet<StyleColorOptions>) const final;
+
 #if ENABLE(CSS_TAP_HIGHLIGHT_COLOR)
     Color platformTapHighlightColor() const final { return SRGBA<uint8_t> { 26, 26, 26, 77 } ; }
 #endif

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -1057,6 +1057,11 @@ Color RenderThemeIOS::platformAnnotationHighlightBackgroundColor(OptionSet<Style
     return SRGBA<uint8_t> { 255, 238, 190 };
 }
 
+Color RenderThemeIOS::platformTextSearchHighlightColor(OptionSet<StyleColorOptions>) const
+{
+    return SRGBA<uint8_t> { 255, 228, 56 };
+}
+
 bool RenderThemeIOS::shouldHaveSpinButton(const HTMLInputElement&) const
 {
     return false;

--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -325,7 +325,7 @@ void FindController::findString(const String& string, OptionSet<FindOptions> opt
     // and reveal the selection in FindIndicatorStrategy::didFindString.
     coreOptions.add(FindOption::DoNotRevealSelection);
 
-    m_findIndicator->willFindString();
+    protect(protect(m_webPage.get())->corePage())->removeAllActiveTextMatches();
 
     bool foundStringStartsAfterSelection = false;
     RefPtr webPage { m_webPage.get() };
@@ -359,7 +359,13 @@ void FindController::findString(const String& string, OptionSet<FindOptions> opt
     }
 
     if (found && !options.contains(FindOptions::DoNotSetSelection)) {
-        m_findIndicator->didFindString(frameWithSelection(protect(m_webPage->corePage()).get()));
+        RefPtr selectedFrame = frameWithSelection(protect(m_webPage->corePage()).get());
+        m_findIndicator->didFindString(selectedFrame);
+
+        if (selectedFrame) {
+            if (std::optional<SimpleRange> range = selectedFrame->selection().selection().range())
+                addMarker(*range, DocumentMarkerType::ActiveTextMatch);
+        }
 
         if (!foundStringStartsAfterSelection && options.contains(FindOptions::DetermineMatchIndex)) {
             if (m_foundStringMatchIndex) {
@@ -435,7 +441,7 @@ void FindController::selectFindMatch(uint32_t matchIndex)
 
 void FindController::indicateFindMatch(uint32_t matchIndex)
 {
-    m_findIndicator->willFindString();
+    protect(protect(m_webPage.get())->corePage())->removeAllActiveTextMatches();
 
     selectFindMatch(matchIndex);
     RefPtr selectedFrame = frameWithSelection(protect(protect(m_webPage.get())->corePage()).get());
@@ -443,6 +449,10 @@ void FindController::indicateFindMatch(uint32_t matchIndex)
         return;
 
     m_findIndicator->didFindString(selectedFrame);
+
+    if (std::optional<SimpleRange> range = selectedFrame->selection().selection().range())
+        addMarker(*range, DocumentMarkerType::ActiveTextMatch);
+
     m_findIndicator->update(selectedFrame, !!m_findPageOverlay);
 }
 
@@ -459,6 +469,7 @@ void FindController::hideFindUI()
 #endif
         protect(protect(m_webPage.get())->corePage())->unmarkAllTextMatches();
 
+    protect(protect(m_webPage.get())->corePage())->removeAllActiveTextMatches();
     m_findIndicator->hide();
     resetMatchIndex();
 

--- a/Source/WebKit/WebProcess/WebPage/FindIndicator.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindIndicator.cpp
@@ -86,7 +86,7 @@ void FindIndicator::hide()
     if (!m_isShowingFindIndicator)
         return;
 
-    m_webPage->send(Messages::WebPageProxy::ClearTextIndicator());
+    protect(m_webPage.get())->send(Messages::WebPageProxy::ClearTextIndicator());
     m_isShowingFindIndicator = false;
 }
 

--- a/Source/WebKit/WebProcess/WebPage/FindIndicator.h
+++ b/Source/WebKit/WebProcess/WebPage/FindIndicator.h
@@ -46,7 +46,6 @@ public:
     virtual ~FindIndicator() = default;
     virtual bool update(WebCore::LocalFrame* selectedFrame, bool isShowingOverlay, bool shouldAnimate = true);
     virtual void hide();
-    virtual void willFindString() { }
     virtual void didFindString(WebCore::LocalFrame* selectedFrame);
     constexpr virtual bool shouldHideOnScroll() const { return true; }
     bool isShowing() const { return m_isShowingFindIndicator; }
@@ -67,7 +66,6 @@ public:
         : FindIndicator(webPage) { };
     bool update(WebCore::LocalFrame* selectedFrame, bool isShowingOverlay, bool shouldAnimate = true) override;
     void hide() override;
-    void willFindString() override;
     void didFindString(WebCore::LocalFrame* selectedFrame) override;
     constexpr bool shouldHideOnScroll() const override { return false; }
 private:

--- a/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
@@ -187,6 +187,8 @@ void WebFoundTextRangeController::decorateTextRangeWithStyle(const WebFoundTextR
     if (currentStyleForRange == FindDecorationStyle::Highlighted && range == m_highlightedRange) {
         m_textIndicator = nullptr;
         m_highlightedRange = { };
+
+        protect(protect(m_webPage.get())->corePage())->removeAllActiveTextMatches();
     }
 
     if (auto simpleRange = simpleRangeFromFoundTextRange(range)) {
@@ -202,6 +204,8 @@ void WebFoundTextRangeController::decorateTextRangeWithStyle(const WebFoundTextR
         }
         case FindDecorationStyle::Highlighted: {
             m_highlightedRange = range;
+
+            protect(protect(simpleRange->start.document())->markers())->addMarker(*simpleRange, WebCore::DocumentMarkerType::ActiveTextMatch);
 
             auto ancestorsRevealed = revealClosedDetailsAndHiddenUntilFoundAncestors(protect(simpleRange->startContainer()));
 
@@ -284,7 +288,9 @@ void WebFoundTextRangeController::clearAllDecoratedFoundText()
     clearCachedRanges();
     m_decoratedRanges.clear();
     m_unhighlightedFoundRanges.clear();
-    protect(protect(m_webPage.get())->corePage())->unmarkAllTextMatches();
+    RefPtr corePage = protect(m_webPage.get())->corePage();
+    corePage->unmarkAllTextMatches();
+    corePage->removeAllActiveTextMatches();
 
     m_highlightedRange = { };
     m_textIndicator = nullptr;

--- a/Source/WebKit/WebProcess/WebPage/ios/FindIndicatorIOS.cpp
+++ b/Source/WebKit/WebProcess/WebPage/ios/FindIndicatorIOS.cpp
@@ -146,14 +146,11 @@ void FindIndicatorIOS::hide()
     if (!m_isShowingFindIndicator)
         return;
 
-    protect(*m_webPage)->corePage()->pageOverlayController().uninstallPageOverlay(*protect(m_findIndicatorOverlay), PageOverlay::FadeMode::DoNotFade);
+    RefPtr webPage = { m_webPage.get() };
+    protect(webPage->corePage())->pageOverlayController().uninstallPageOverlay(*protect(m_findIndicatorOverlay), PageOverlay::FadeMode::DoNotFade);
     m_findIndicatorOverlay = nullptr;
     m_isShowingFindIndicator = false;
-    setSelectionChangeUpdatesEnabledInAllFrames(protect(*m_webPage), false);
-}
-
-void FindIndicatorIOS::willFindString()
-{
+    setSelectionChangeUpdatesEnabledInAllFrames(*webPage, false);
 }
 
 void FindIndicatorIOS::didFindString(WebCore::LocalFrame* selectedFrame)

--- a/Tools/TestWebKitAPI/Tests/WebCore/MarkedText.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/MarkedText.cpp
@@ -74,6 +74,8 @@ std::ostream& operator<<(std::ostream& os, MarkedText::Type type)
         return os << "TransparentContent";
     case MarkedText::Type::DictationStreamingOpacity:
         return os << "DictationStreamingOpacity";
+    case MarkedText::Type::ActiveTextMatch:
+        return os << "ActiveTextMatch";
     case MarkedText::Type::Unmarked:
         return os << "Unmarked";
     }


### PR DESCRIPTION
#### 41317199e5d48efc750d62c6feddfc77015f1b67
<pre>
Find in page should show yellow indicator even if no valid selection
<a href="https://bugs.webkit.org/show_bug.cgi?id=310141">https://bugs.webkit.org/show_bug.cgi?id=310141</a>
<a href="https://rdar.apple.com/172781422">rdar://172781422</a>

Reviewed by Ryosuke Niwa.

When there is no valid selection, the text indicator cannot properly
show the yellow box to highlight a match.

I added a new document mark that represents an active text match. Now,
even if there is no valid selection, the match will be colored correctly.

This is a work around. The TextIndicator cannot render elements tagged
with user-select: none properly. If that is resolved,
DocumentMarkerType::ActiveTextMatch should be removed.

Test: Tools/TestWebKitAPI/Tests/WebCore/MarkedText.cpp

* Source/WebCore/dom/DocumentMarker.h:
(WebCore::DocumentMarker::allMarkers):
* Source/WebCore/dom/DocumentMarkerController.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::removeAllActiveTextMatches):
* Source/WebCore/page/Page.h:
* Source/WebCore/rendering/MarkedText.cpp:
(WebCore::MarkedText::collectForDocumentMarkers):
* Source/WebCore/rendering/MarkedText.h:
* Source/WebCore/rendering/StyledMarkedText.cpp:
(WebCore::resolveStyleForMarkedText):
* Source/WebCore/rendering/ios/RenderThemeIOS.h:
* Source/WebCore/rendering/ios/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::platformTextSearchHighlightColor const):
* Source/WebKit/WebProcess/WebPage/FindController.cpp:
(WebKit::FindController::findString):
(WebKit::FindController::indicateFindMatch):
(WebKit::FindController::hideFindUI):
* Source/WebKit/WebProcess/WebPage/FindIndicator.cpp:
(WebKit::FindIndicator::hide):
* Source/WebKit/WebProcess/WebPage/FindIndicator.h:
(WebKit::FindIndicator::willFindString): Deleted.
* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp:
(WebKit::WebFoundTextRangeController::decorateTextRangeWithStyle):
(WebKit::WebFoundTextRangeController::clearAllDecoratedFoundText):
* Source/WebKit/WebProcess/WebPage/ios/FindIndicatorIOS.cpp:
(WebKit::FindIndicatorIOS::hide):
(WebKit::FindIndicatorIOS::willFindString):
* Tools/TestWebKitAPI/Tests/WebCore/MarkedText.cpp:
(WebCore::operator&lt;&lt;):

Canonical link: <a href="https://commits.webkit.org/309494@main">https://commits.webkit.org/309494@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aae6ff39fe1a8b77a6913f198f1b4bb07a70eb56

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150857 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23617 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17189 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159584 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/104293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152730 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24050 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23826 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/116454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/104293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153817 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/18564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/135346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/97174 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/17661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/15613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7431 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/127279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/13263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162058 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/5183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14831 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/124456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23421 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/19663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124644 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33820 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23411 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/135060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79817 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19713 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/11825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23021 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/87105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22733 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22885 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22787 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->