### PR TITLE
blob: URLs are allowed in <iframe>s when CSP’s `frame-src` contains `‘self’`.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/blob/frame-src-blob-matches-blob.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/blob/frame-src-blob-matches-blob.sub-expected.txt
@@ -1,0 +1,6 @@
+blob: URLs should match if the blob: scheme is explicitly specified in the frame-src directive.
+
+
+
+PASS Expecting logs: ["PASS (1/1)"]
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/blob/frame-src-blob-matches-blob.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/blob/frame-src-blob-matches-blob.sub.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline'; frame-src blob:;">
+    <title>frame-src-blob-matches-blob</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src='../support/logTest.sub.js?logs=["PASS (1/1)"]'></script>
+    <script src='../support/alertAssert.sub.js?alerts=[]'></script>
+</head>
+
+<body>
+    <p>
+        blob: URLs should match if the blob: scheme is explicitly specified in the frame-src directive.
+    </p>
+    <script>
+        window.addEventListener('securitypolicyviolation', function(e) {
+            log("FAIL");
+        });
+
+        var b = new Blob(['<html><body></body></html>'], {
+            type: 'text/html'
+        });
+        var iframe = document.createElement('iframe');
+        iframe.src = URL.createObjectURL(b);
+        iframe.onload = function() {
+            log("PASS (1/1)");
+        };
+        document.body.appendChild(iframe);
+
+    </script>
+    <div id="log"></div>
+</body>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/blob/frame-src-self-does-not-match-blob.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/blob/frame-src-self-does-not-match-blob.sub-expected.txt
@@ -1,0 +1,6 @@
+blob: URLs should not match the 'self' source in a frame-src directive because blob: is a non-HTTP(S) scheme that must be explicitly listed.
+
+
+
+PASS Expecting logs: ["violated-directive=frame-src"]
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/blob/frame-src-self-does-not-match-blob.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/blob/frame-src-self-does-not-match-blob.sub.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline'; frame-src 'self';">
+    <title>frame-src-self-does-not-match-blob</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src='../support/logTest.sub.js?logs=["violated-directive=frame-src"]'></script>
+    <script src='../support/alertAssert.sub.js?alerts=[]'></script>
+</head>
+
+<body>
+    <p>
+        blob: URLs should not match the &apos;self&apos; source in a frame-src directive because blob: is a non-HTTP(S) scheme that must be explicitly listed.
+    </p>
+    <script>
+        window.addEventListener('securitypolicyviolation', function(e) {
+            log("violated-directive=" + e.violatedDirective);
+        });
+
+        var b = new Blob(['<html><body>FAIL</body></html>'], {
+            type: 'text/html'
+        });
+        var iframe = document.createElement('iframe');
+        iframe.src = URL.createObjectURL(b);
+        document.body.appendChild(iframe);
+
+    </script>
+    <div id="log"></div>
+</body>
+
+</html>

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
@@ -27,7 +27,6 @@
 #include "config.h"
 #include "ContentSecurityPolicy.h"
 
-#include "BlobURL.h"
 #include "CSPViolationReportBody.h"
 #include "ContentSecurityPolicyClient.h"
 #include "ContentSecurityPolicyDirective.h"
@@ -334,12 +333,8 @@ void ContentSecurityPolicy::setOverrideAllowInlineStyle(bool value)
     m_overrideInlineStyleAllowed = value;
 }
 
-bool ContentSecurityPolicy::urlMatchesSelf(const URL& url, bool forFrameSrc) const
+bool ContentSecurityPolicy::urlMatchesSelf(const URL& url) const
 {
-    // As per https://w3c.github.io/webappsec-csp/#match-url-to-source-expression, we compare the URL origin with the policy origin.
-    // We get origin using https://url.spec.whatwg.org/#concept-url-origin which has specific blob URLs treatment as follow.
-    if (forFrameSrc && url.protocolIsBlob())
-        return m_selfSource->matches(BlobURL::getOriginURL(url));
     return m_selfSource->matches(url);
 }
 

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.h
@@ -205,7 +205,7 @@ public:
     void reportDirectiveAsSourceExpression(const String& directiveName, StringView sourceExpression) const;
     void reportInvalidPathCharacter(const String& directiveName, const String& value, const char) const;
     void reportInvalidSourceExpression(const String& directiveName, const String& source) const;
-    bool urlMatchesSelf(const URL&, bool forFrameSrc) const;
+    bool urlMatchesSelf(const URL&) const;
     bool allowContentSecurityPolicySourceStarToMatchAnyProtocol() const;
 
     // Used by ContentSecurityPolicyDirectiveList

--- a/Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp
@@ -132,8 +132,7 @@ bool ContentSecurityPolicySourceList::matches(const URL& url, bool didReceiveRed
     if (m_allowStar && isProtocolAllowedByStar(url))
         return true;
 
-    if (m_allowSelf && m_policy->urlMatchesSelf(url, equalIgnoringASCIICase(m_directiveName, ContentSecurityPolicyDirectiveNames::frameSrc)
-))
+    if (m_allowSelf && m_policy->urlMatchesSelf(url))
         return true;
 
     for (auto& entry : m_list) {


### PR DESCRIPTION
#### 70534942aada5b6edcf5ac964c4237fee89ae082
<pre>
blob: URLs are allowed in &lt;iframe&gt;s when CSP’s `frame-src` contains `‘self’`.
<a href="https://bugs.webkit.org/show_bug.cgi?id=308752">https://bugs.webkit.org/show_bug.cgi?id=308752</a>
<a href="https://rdar.apple.com/171268629">rdar://171268629</a>

Reviewed by Ryan Reno.

Remove the frame-src + blob: URL special case in urlMatchesSelf() that
extracts the blob: URL&apos;s creator origin and passes it through &apos;self&apos;
matching. While §6.7.2.8 step 4.1 of the CSP spec
(<a href="https://w3c.github.io/webappsec-csp/#match-url-to-source-expression)">https://w3c.github.io/webappsec-csp/#match-url-to-source-expression)</a>
compares origins - for which a blob: URL is evaluated with creator&apos;s
origin - this is a known spec bug (github.com/w3c/webappsec-csp/issues/487).

Tests: imported/w3c/web-platform-tests/content-security-policy/blob/frame-src-blob-matches-blob.sub.html
       imported/w3c/web-platform-tests/content-security-policy/blob/frame-src-self-does-not-match-blob.sub.html

* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/blob/frame-src-blob-matches-blob.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/blob/frame-src-blob-matches-blob.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/blob/frame-src-self-does-not-match-blob.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/blob/frame-src-self-does-not-match-blob.sub.html: Added.
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
(WebCore::ContentSecurityPolicy::urlMatchesSelf const):
* Source/WebCore/page/csp/ContentSecurityPolicy.h:
* Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp:
(WebCore::ContentSecurityPolicySourceList::matches const):

Canonical link: <a href="https://commits.webkit.org/309559@main">https://commits.webkit.org/309559@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6fd5c20621bc038c6defa54964999cac47a16d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150890 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23652 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17222 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159617 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104326 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ba0be973-b27e-4bfa-a043-b0c487c96cee) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152763 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24083 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23867 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116480 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82703 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5ac6d9ea-1a01-45db-9fa6-12dbbbedb4c4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153850 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18590 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135375 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97200 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eb2e5972-2900-4f84-ad6c-d5a33a2774c7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17685 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15641 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7464 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127303 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13292 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162091 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5216 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14860 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124485 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23454 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19691 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124672 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33859 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23444 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135089 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79851 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19746 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11854 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23054 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87140 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22766 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22918 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22820 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->