### PR TITLE
[Site Isolation] UI process crash via unchecked mouse event queue access during DidReceiveEvent IPC handling

### DIFF
--- a/LayoutTests/ipc/remote-user-input-event-data-with-empty-event-deque-expected.txt
+++ b/LayoutTests/ipc/remote-user-input-event-data-with-empty-event-deque-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash.

--- a/LayoutTests/ipc/remote-user-input-event-data-with-empty-event-deque.html
+++ b/LayoutTests/ipc/remote-user-input-event-data-with-empty-event-deque.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true SiteIsolationEnabled=true ] -->
+<html>
+<head>
+<script src="../resources/ipc.js"></script>
+<title>Sending remote user input event data through DidReceiveEvent IPC should not crash the UI process with an empty mouse event deque.</title>
+</head>
+<body>
+<p>This test passes if WebKit does not crash.</p>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+if (window.IPC) {
+    import('./coreipc.js').then(async ({ CoreIPC }) => {
+        CoreIPC.UI.WebPageProxy.DidReceiveEventIPC(IPC.webPageProxyID, {
+            eventType: 1, // MouseDown
+            handled: false,
+            remoteUserInputEventData: {
+                optionalValue: {
+                    targetFrameID: Number(IPC.frameID),
+                    transformedPoint: { x: 100.0, y: 100.0 }
+                }
+            }
+        });
+
+        await asyncFlush('UI');
+
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }).catch(e => {
+        document.body.textContent = "FAIL: " + e;
+        if (window.testRunner)
+            testRunner.notifyDone();
+    });
+} else if (window.testRunner) {
+    testRunner.notifyDone();
+}
+</script>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -11783,6 +11783,7 @@ void WebPageProxy::setCursorHiddenUntilMouseMoves(bool hiddenUntilMouseMoves)
 
 void WebPageProxy::mouseEventHandlingCompleted(std::optional<WebEventType> eventType, bool handled, std::optional<RemoteUserInputEventData> remoteUserInputEventData)
 {
+    MESSAGE_CHECK(m_legacyMainFrameProcess, !internals().mouseEventQueue.isEmpty());
     if (remoteUserInputEventData) {
         CheckedRef event = internals().mouseEventQueue.first();
         const auto originalPosition = event->position();
@@ -11806,7 +11807,6 @@ void WebPageProxy::mouseEventHandlingCompleted(std::optional<WebEventType> event
     }
 
     // Retire the last sent event now that WebProcess is done handling it.
-    MESSAGE_CHECK(m_legacyMainFrameProcess, !internals().mouseEventQueue.isEmpty());
     auto event = internals().mouseEventQueue.takeFirst();
     if (eventType) {
         MESSAGE_CHECK(m_legacyMainFrameProcess, *eventType == event.type());


### PR DESCRIPTION
#### a73af3d73e478fc7a5190b3d83f5d0cc5ee96c03
<pre>
[Site Isolation] UI process crash via unchecked mouse event queue access during DidReceiveEvent IPC handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=310142">https://bugs.webkit.org/show_bug.cgi?id=310142</a>
<a href="https://rdar.apple.com/172721665">rdar://172721665</a>

Reviewed by Charlie Wolfe.

A compromised web content process can send unsolicited DidReceiveEvent
IPC messages with remoteUserInputEventData set, causing the UI process
to call mouseEventQueue.first() on an empty deque. The MESSAGE_CHECK
that guards against an empty queue was only in the else branch, so
supplying remoteUserInputEventData bypassed it entirely.

This patch addresses the crash by hoisting the MESSAGE_CHECK above the
remoteUserInputEventData branch so it covers both paths. In the longer
term, we could just replace DidReceiveEvent with completion handlers,
which would categorically eliminate this kind of bug.

Test: ipc/remote-user-input-event-data-with-empty-event-deque.html

* LayoutTests/ipc/remote-user-input-event-data-with-empty-event-deque-expected.txt: Added.
* LayoutTests/ipc/remote-user-input-event-data-with-empty-event-deque.html: Added.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::mouseEventHandlingCompleted):

Canonical link: <a href="https://commits.webkit.org/309473@main">https://commits.webkit.org/309473@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14f7817ba90aafc85ab33f829d2ac1c6ec7f6d82

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150700 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23458 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17029 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159422 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104134 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/862af130-3a0d-4a49-bd63-910cbe184ed0) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23890 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23660 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116309 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82603 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/29b4e2ab-d55a-4ca0-91cc-daebc70c29b4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153660 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18420 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135197 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97037 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5f4849f3-2e69-4bb9-a724-a0169be82674) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17517 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15466 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7270 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127131 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13121 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161896 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5017 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14675 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/api/crashtests/huge-fetch.any.sharedworker.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124308 "Found 1 new test failure: media/media-vp8-webm.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23260 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19513 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124507 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23248 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134916 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79637 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23167 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19586 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11678 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22862 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86662 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22574 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22726 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22628 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->