### PR TITLE
[JSC] for-using statement should not dispose on continue

### DIFF
--- a/JSTests/stress/for-using-initializer-continue-dispose-once.js
+++ b/JSTests/stress/for-using-initializer-continue-dispose-once.js
@@ -1,0 +1,209 @@
+//@ requireOptions("--useExplicitResourceManagement=1")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`Expected ${expected} but got ${actual}`);
+}
+
+{
+    let n = 0, i = 0;
+    for (using x = { [Symbol.dispose]() { n++; } }; i < 3; i++) {
+        if (i === 1) continue;
+    }
+    shouldBe(n, 1);
+}
+
+{
+    let n = 0, i = 0;
+    for (using x = { [Symbol.dispose]() { n++; } }; i < 5; i++) {
+        continue;
+    }
+    shouldBe(n, 1);
+}
+
+{
+    let n = 0, i = 0;
+    outer: for (using x = { [Symbol.dispose]() { n++; } }; i < 3; i++) {
+        if (i === 1) continue outer;
+    }
+    shouldBe(n, 1);
+}
+
+{
+    let outerN = 0, innerN = 0, i = 0;
+    for (using x = { [Symbol.dispose]() { outerN++; } }; i < 2; i++) {
+        let j = 0;
+        for (using y = { [Symbol.dispose]() { innerN++; } }; j < 3; j++) {
+            if (j === 1) continue;
+        }
+    }
+    shouldBe(outerN, 1);
+    shouldBe(innerN, 2);
+}
+
+{
+    let outerN = 0, innerN = 0, i = 0;
+    outer: for (using x = { [Symbol.dispose]() { outerN++; } }; i < 3; i++) {
+        let j = 0;
+        for (using y = { [Symbol.dispose]() { innerN++; } }; j < 3; j++) {
+            if (j === 1) continue outer;
+        }
+    }
+    shouldBe(outerN, 1);
+    shouldBe(innerN, 3);
+}
+
+{
+    let order = [], i = 0;
+    outer: for (using x = { [Symbol.dispose]() { order.push("outer"); } }; i < 3; i++) {
+        let j = 0;
+        for (using y = { [Symbol.dispose]() { order.push("inner"); } }; j < 3; j++) {
+            if (j === 1) break outer;
+        }
+    }
+    shouldBe(order.join(","), "inner,outer");
+}
+
+{
+    let n = 0, i = 0;
+    outer: for (using x = { [Symbol.dispose]() { n++; } }; i < 3; i++) {
+        if (i === 1) break outer;
+    }
+    shouldBe(n, 1);
+}
+
+{
+    let outerN = 0, innerN = 0, i = 0;
+    outer: for (using x = { [Symbol.dispose]() { outerN++; } }; i < 3; i++) {
+        for (let j = 0; j < 3; j++) {
+            using y = { [Symbol.dispose]() { innerN++; } };
+            if (j === 1) break outer;
+        }
+    }
+    shouldBe(outerN, 1);
+    shouldBe(innerN, 2);
+}
+
+{
+    let n = 0, finallyN = 0, i = 0;
+    for (using x = { [Symbol.dispose]() { n++; } }; i < 3; i++) {
+        try {
+            if (i === 1) continue;
+        } finally {
+            finallyN++;
+        }
+    }
+    shouldBe(n, 1);
+    shouldBe(finallyN, 3);
+}
+
+{
+    let n = 0, i = 0;
+    for (using x = { [Symbol.dispose]() { n++; } }; i < 10; i++) {
+        if (i === 2) continue;
+        if (i === 5) break;
+    }
+    shouldBe(n, 1);
+}
+
+{
+    let n = 0, log = [], i = 0;
+    for (using x = { [Symbol.dispose]() { n++; } }; i < 3; i++) {
+        {
+            let inner = i * 10;
+            if (i === 1) continue;
+            log.push(inner);
+        }
+    }
+    shouldBe(n, 1);
+    shouldBe(log.join(","), "0,20");
+}
+
+{
+    let a = 0, b = 0, i = 0;
+    for (using x = { [Symbol.dispose]() { a++; } }, y = { [Symbol.dispose]() { b++; } }; i < 3; i++) {
+        if (i === 1) continue;
+    }
+    shouldBe(a, 1);
+    shouldBe(b, 1);
+}
+
+{
+    let headN = 0, bodyN = 0, i = 0;
+    for (using x = { [Symbol.dispose]() { headN++; } }; i < 3; i++) {
+        using y = { [Symbol.dispose]() { bodyN++; } };
+        if (i === 1) continue;
+    }
+    shouldBe(headN, 1);
+    shouldBe(bodyN, 3);
+}
+
+{
+    let order = [], i = 0;
+    for (using x = { [Symbol.dispose]() { order.push("dispose"); } }; i < 5; i++) {
+        order.push("iter" + i);
+        if (i === 1) continue;
+        if (i === 3) break;
+    }
+    shouldBe(order.join(","), "iter0,iter1,iter2,iter3,dispose");
+}
+
+{
+    let finallyN = 0, i = 0;
+    for (; i < 3; i++) {
+        try {
+            if (i === 1) continue;
+        } finally {
+            finallyN++;
+        }
+    }
+    shouldBe(finallyN, 3);
+}
+
+{
+    let n = 0, caught, i = 0;
+    try {
+        for (using x = { [Symbol.dispose]() { n++; throw new Error("E"); } }; i < 3; i++) {
+            if (i === 1) continue;
+        }
+    } catch (e) {
+        caught = e;
+    }
+    shouldBe(n, 1);
+    shouldBe(caught.message, "E");
+}
+
+async function testAwaitUsing() {
+    {
+        let n = 0, i = 0;
+        for (await using x = { [Symbol.asyncDispose]() { n++; } }; i < 3; i++) {
+            if (i === 1) continue;
+        }
+        shouldBe(n, 1);
+    }
+
+    {
+        let n = 0, i = 0;
+        for (await using x = { [Symbol.asyncDispose]() { n++; } }; i < 5; i++) {
+            continue;
+        }
+        shouldBe(n, 1);
+    }
+
+    {
+        let outerN = 0, innerN = 0, i = 0;
+        outer: for (await using x = { [Symbol.asyncDispose]() { outerN++; } }; i < 3; i++) {
+            let j = 0;
+            for (await using y = { [Symbol.asyncDispose]() { innerN++; } }; j < 3; j++) {
+                if (j === 1) continue outer;
+            }
+        }
+        shouldBe(outerN, 1);
+        shouldBe(innerN, 3);
+    }
+}
+
+let asyncDone = false;
+testAwaitUsing().then(() => { asyncDone = true; }, e => { print(e); throw e; });
+drainMicrotasks();
+shouldBe(asyncDone, true);

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -4645,51 +4645,43 @@ void ForNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)
     if (generator.shouldBeConcernedWithCompletionValue() && m_statement->hasEarlyBreakOrContinue())
         generator.emitLoad(dst, jsUndefined());
 
-    Ref<LabelScope> scope = generator.newLabelScope(LabelScope::Loop);
-
     RegisterID* forLoopSymbolTable = nullptr;
     generator.pushLexicalScope(this, BytecodeGenerator::ScopeType::LetConstScope, BytecodeGenerator::TDZCheckOptimization::Optimize, BytecodeGenerator::NestedScopeType::IsNested, &forLoopSymbolTable);
 
-    Ref<Label> loopEnd = generator.newLabel();
-    Label& conditionFalseTarget = usingDeclarationCount() ? loopEnd.get() : scope->breakTarget();
-
-    auto emitLoopBody = [&](BytecodeGenerator& generator) {
-        if (m_expr1) {
-            generator.emitNodeInIgnoreResultPosition(m_expr1);
-            if (m_initializerContainsClosure)
-                generator.prepareLexicalScopeForNextForLoopIteration(this, forLoopSymbolTable);
-        }
-
-        Ref<Label> topOfLoop = generator.newLabel();
-        if (m_expr2)
-            generator.emitNodeInConditionContext(m_expr2, topOfLoop.get(), conditionFalseTarget, FallThroughMeansTrue);
-
-        generator.emitLabel(topOfLoop.get());
-        generator.emitLoopHint();
-        generator.emitProfileControlFlow(m_statement->startOffset());
-
-        generator.emitNodeInTailPosition(dst, m_statement);
-
-        generator.emitLabel(*scope->continueTarget());
-        generator.prepareLexicalScopeForNextForLoopIteration(this, forLoopSymbolTable);
-        if (m_expr3)
-            generator.emitNodeInIgnoreResultPosition(m_expr3);
-
-        if (m_expr2)
-            generator.emitNodeInConditionContext(m_expr2, topOfLoop.get(), conditionFalseTarget, FallThroughMeansFalse);
-        else
-            generator.emitJump(topOfLoop.get());
-
-        generator.emitLabel(loopEnd.get());
-    };
-
     generator.emitBodyWithUsingIfNeeded(usingDeclarationCount(), hasAwaitUsingDeclaration(),
         scopedLambda<void(BytecodeGenerator&)>([&](BytecodeGenerator& generator) {
-            emitLoopBody(generator);
+            Ref<LabelScope> scope = generator.newLabelScope(LabelScope::Loop);
+
+            if (m_expr1) {
+                generator.emitNodeInIgnoreResultPosition(m_expr1);
+                if (m_initializerContainsClosure)
+                    generator.prepareLexicalScopeForNextForLoopIteration(this, forLoopSymbolTable);
+            }
+
+            Ref<Label> topOfLoop = generator.newLabel();
+            if (m_expr2)
+                generator.emitNodeInConditionContext(m_expr2, topOfLoop.get(), scope->breakTarget(), FallThroughMeansTrue);
+
+            generator.emitLabel(topOfLoop.get());
+            generator.emitLoopHint();
+            generator.emitProfileControlFlow(m_statement->startOffset());
+
+            generator.emitNodeInTailPosition(dst, m_statement);
+
+            generator.emitLabel(*scope->continueTarget());
+            generator.prepareLexicalScopeForNextForLoopIteration(this, forLoopSymbolTable);
+            if (m_expr3)
+                generator.emitNodeInIgnoreResultPosition(m_expr3);
+
+            if (m_expr2)
+                generator.emitNodeInConditionContext(m_expr2, topOfLoop.get(), scope->breakTarget(), FallThroughMeansFalse);
+            else
+                generator.emitJump(topOfLoop.get());
+
+            generator.emitLabel(scope->breakTarget());
         })
     );
 
-    generator.emitLabel(scope->breakTarget());
     generator.popLexicalScope(this);
     generator.emitProfileControlFlow(m_statement->endOffset() + (m_statement->isBlock() ? 1 : 0));
 }


### PR DESCRIPTION
#### 6c959cf9637eca10c90f2a66689a8a6d2e77052b
<pre>
[JSC] for-using statement should not dispose on continue
<a href="https://bugs.webkit.org/show_bug.cgi?id=310144">https://bugs.webkit.org/show_bug.cgi?id=310144</a>

Reviewed by Yusuke Suzuki.

ForNode created its LabelScope before emitBodyWithUsingIfNeeded pushes
the finally control-flow scope, so the recorded scope depth predates the
finally. ContinueNode compared against that pre-finally depth, concluded
that a finally sits between it and the target, and routed the jump
through the finally. This disposed the using resource on every continue
in addition to the normal end-of-loop disposal; per ForLoopEvaluation [1]
step 13, DisposeResources runs once after ForBodyEvaluation returns.

Move newLabelScope into the emitBodyWithUsingIfNeeded lambda so it runs
after the finally scope is pushed. The recorded depth then matches the
depth seen by ContinueNode, so continue jumps directly. Break also jumps
directly: breakTarget is now emitted at the end of the lambda, and since
emitUsingBodyScope falls through from the try body into the finally on
normal completion, break still disposes. Labeled break still routes
through the finally because LabelNode&apos;s NamedLabel scope sits outside the
try. This is the same arrangement emitGenericEnumeration already uses.

The loopEnd label and conditionFalseTarget branching are no longer
needed: breakTarget serves both the non-using and using cases now that
it lives inside the lambda.

[1]: <a href="https://tc39.es/proposal-explicit-resource-management/#sec-runtime-semantics-forloopevaluation">https://tc39.es/proposal-explicit-resource-management/#sec-runtime-semantics-forloopevaluation</a>

* JSTests/stress/for-using-initializer-continue-dispose-once.js: Added.
(shouldBe):
(async testAwaitUsing):
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::ForNode::emitBytecode):

Canonical link: <a href="https://commits.webkit.org/309590@main">https://commits.webkit.org/309590@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c68a6120cd23d7dfa371a534124750f5162c182

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150958 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23720 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17290 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159686 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104394 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24151 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23937 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116535 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82732 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153918 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18655 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135432 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97255 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17749 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15697 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7532 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/142942 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127367 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13349 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162159 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/11757 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5284 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14920 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124542 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23522 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19747 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124729 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33875 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23512 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135146 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79919 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19791 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11911 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/182483 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23122 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87287 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46608 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22834 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22986 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22888 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->