### PR TITLE
[JSC] Nested using blocks lose outer disposals

### DIFF
--- a/JSTests/stress/nested-using-blocks.js
+++ b/JSTests/stress/nested-using-blocks.js
@@ -1,0 +1,62 @@
+//@ requireOptions("--useExplicitResourceManagement=1")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`Expected ${expected} but got ${actual}`);
+}
+
+for (let depth of [5, 8, 9, 16, 17, 20, 32, 64, 128]) {
+    eval(
+        "{using a=null;" +
+        "{using a=null;".repeat(depth - 1) +
+        "0;" +
+        "}".repeat(depth)
+    );
+}
+
+{
+    let n = 0;
+    eval(
+        "{using a={[Symbol.dispose](){n++}};" +
+        "{using a={[Symbol.dispose](){n++}};".repeat(19) +
+        "0;" +
+        "}".repeat(20)
+    );
+    shouldBe(n, 20);
+}
+
+{
+    let order = [];
+    eval(
+        "{using a={[Symbol.dispose](){order.push(0)}};" +
+        Array.from({length: 15}, (_, i) =>
+            `{using a={[Symbol.dispose](){order.push(${i + 1})}};`
+        ).join("") +
+        "0;" +
+        "}".repeat(16)
+    );
+    shouldBe(order.join(","), "15,14,13,12,11,10,9,8,7,6,5,4,3,2,1,0");
+}
+
+for (let depth = 1; depth <= 20; depth++) {
+    let n = 0;
+    let code = "";
+    for (let i = 0; i < depth; i++)
+        code += `{using a${i}={[Symbol.dispose](){n++}};using b${i}={[Symbol.dispose](){n++}};`;
+    code += "0;" + "}".repeat(depth);
+    eval(code);
+    shouldBe(n, depth * 2);
+}
+
+(async () => {
+    for (let depth of [8, 9, 16, 20]) {
+        let n = 0;
+        let code = "(async()=>{";
+        for (let i = 0; i < depth; i++)
+            code += `{await using a${i}={[Symbol.asyncDispose](){n++}};`;
+        code += "0;" + "}".repeat(depth) + "})()";
+        await eval(code);
+        shouldBe(n, depth);
+    }
+})().then(() => {}, e => { print(e); throw e; });
+drainMicrotasks();

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
@@ -1375,7 +1375,7 @@ namespace JSC {
         Vector<SwitchInfo> m_switchContextStack;
         Vector<Ref<ForInContext>> m_forInContextStack;
         Vector<TryContext> m_tryContextStack;
-        Vector<UsingScope> m_usingScopeStack;
+        SegmentedVector<UsingScope, 8> m_usingScopeStack;
         unsigned m_yieldPoints { 0 };
         bool m_needsGeneratorification { false };
 


### PR DESCRIPTION
#### 57a48c393902a8921ac35c6d2da1e2fc44bf2eca
<pre>
[JSC] Nested using blocks lose outer disposals
<a href="https://bugs.webkit.org/show_bug.cgi?id=310116">https://bugs.webkit.org/show_bug.cgi?id=310116</a>

Reviewed by Yusuke Suzuki.

emitUsingBodyScope holds a reference into m_usingScopeStack across the
emitBody call that may recursively append. Once nesting exceeds the
initial Vector capacity, the append reallocates and the stale reference
reads a moved-from UsingScope whose slots vector is empty, so the
finally emits no dispose calls for those outer blocks. ASAN catches the
freed read directly.

Test: JSTests/stress/nested-using-blocks.js

* JSTests/stress/nested-using-blocks.js: Added.
(shouldBe):
(eval.string_appeared_here.string_appeared_here.repeat.depth.1.string_appeared_here.string_appeared_here.repeat):
(shouldBe.async then):
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h:

Canonical link: <a href="https://commits.webkit.org/309457@main">https://commits.webkit.org/309457@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0eb25a17b3beac2409cee78225375c75ba7d75d6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150705 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23463 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17034 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159427 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/104139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23895 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23665 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116312 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/104139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153665 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18426 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135207 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97040 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17523 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15469 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7275 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/142688 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127137 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13131 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161901 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/11503 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5022 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14686 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124310 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23265 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19516 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124509 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33798 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23253 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134926 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79642 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19589 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11688 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/182187 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22867 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86667 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46569 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22579 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22731 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22633 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->