### PR TITLE
[Site Isolation] Fix WKNavigation.HTTPSFirstWithHTTPRedirect

### DIFF
--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -894,6 +894,12 @@ bool ProvisionalPageProxy::sendMessageWithAsyncReply(UniqueRef<IPC::Encoder>&& e
     return protect(process())->sendMessage(WTF::move(encoder), sendOptions, WTF::move(handler));
 }
 
+void ProvisionalPageProxy::updateFrameProcess()
+{
+    if (auto mainFrame = m_mainFrame)
+        m_frameProcess = mainFrame->frameProcess();
+}
+
 } // namespace WebKit
 
 #undef MESSAGE_CHECK

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.h
@@ -153,6 +153,7 @@ public:
     WebPageProxyMessageReceiverRegistration& messageReceiverRegistration() LIFETIME_BOUND { return m_messageReceiverRegistration; }
 
     bool needsMainFrameObserver() const { return m_needsMainFrameObserver; }
+    void updateFrameProcess();
 
 private:
     ProvisionalPageProxy(WebPageProxy&, Ref<FrameProcess>&&, BrowsingContextGroup&, RefPtr<SuspendedPageProxy>&&, API::Navigation&, bool isServerRedirect, const WebCore::ResourceRequest&, ProcessSwapRequestedByClient, bool isProcessSwappingOnNavigationResponse, API::WebsitePolicies*, WebsiteDataStore* replacedDataStoreForWebArchiveLoad = nullptr);
@@ -208,7 +209,7 @@ private:
 
     WeakPtr<WebPageProxy> m_page;
     WebCore::PageIdentifier m_webPageID;
-    const Ref<FrameProcess> m_frameProcess;
+    Ref<FrameProcess> m_frameProcess;
     const Ref<BrowsingContextGroup> m_browsingContextGroup;
     RefPtr<RemotePageProxy> m_takenRemotePage;
 

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -676,6 +676,8 @@ void WebFrameProxy::setProcess(FrameProcess& process)
 
     m_frameProcess->decrementFrameCount();
     m_frameProcess = process;
+    if (RefPtr provisionalPage = m_page ? m_page->provisionalPageProxy() : nullptr)
+        provisionalPage->updateFrameProcess();
     m_frameProcess->incrementFrameCount();
 }
 


### PR DESCRIPTION
#### 2a4f2cc364a987aafad3a99f3d7c8b033ea1bd9e
<pre>
[Site Isolation] Fix WKNavigation.HTTPSFirstWithHTTPRedirect
<a href="https://bugs.webkit.org/show_bug.cgi?id=310145">https://bugs.webkit.org/show_bug.cgi?id=310145</a>
<a href="https://rdar.apple.com/172786795">rdar://172786795</a>

Reviewed by Per Arne Vollan.

309232@main makes it possible to use uncommitted process for loading under Site Isolation, but some API tests (like
WKNavigation.HTTPSFirstWithHTTPRedirect) still fail because uncommitted process is not reused as expected. The direct
cause is `sourceProcess-&gt;frameProcessCount()` in `WebProcessPool::processForNavigationInternal` is 2 even though the
process is only used by the navigating frame (so there should be only one `FrameProcess` and the value should be 1). It
turns out besides `WebFrameProxy`, `ProvisionalPageProxy` also holds onto `FrameProcess` with `m_frameProcess`, and that
is not updated when we swap process for `WebFrameProxy` -- so `WebFrameProxy` could hold onto the new `FrameProcess`
with redirect site, while `ProvisionalPageProxy` holds onto the old `FrameProcess` with previous site, and both
`FrameProcess` objects point to the same `WebProcessProxy`, preventing the process from being reused in
`WebProcessPool::processForNavigationInternal`. To fix this, making sure `ProvisionalPageProxy` updates `m_frameProcess`
when its frame updates process.

* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::updateFrameProcess):
* Source/WebKit/UIProcess/ProvisionalPageProxy.h:
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::setProcess):

Canonical link: <a href="https://commits.webkit.org/309483@main">https://commits.webkit.org/309483@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30e2a1394f195aee6b3b8f9cff5b74b6617caabd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150710 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23468 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17039 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159432 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104144 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f46461b6-c781-437f-9bef-a76670cbd553) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23900 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23670 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116316 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82608 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a41c37d2-aa60-4f42-a11f-69438e28c93e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153670 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18425 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135205 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97044 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17522 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15473 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7280 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127136 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161906 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5027 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14714 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/api/crashtests/huge-fetch.any.sharedworker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124315 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23270 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19520 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124514 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33814 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23258 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134924 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79647 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19591 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11686 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22872 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86672 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22584 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22736 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22638 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->