### PR TITLE
[AutoFill Debugging] Skip invalid URLs when extracting links and images

### DIFF
--- a/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
@@ -724,7 +724,10 @@ private:
 
     String stringForURL(const String& shortenedString, const URL& url, ExtractedURLType type)
     {
-        auto string = [&] {
+        auto string = [&] -> String {
+            if (!url.isValid())
+                return { };
+
             if (!shortenURLs())
                 return url.string();
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm
@@ -1139,4 +1139,51 @@ TEST(TextExtractionTests, DelayedSafeBrowsingWarningBlocksTextExtraction)
 
 #endif // HAVE(SAFE_BROWSING)
 
+TEST(TextExtractionTests, InvalidURLsAreSkipped)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:^{
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        [[configuration preferences] _setTextExtractionEnabled:YES];
+        return configuration.autorelease();
+    }()]);
+
+    constexpr auto markupString = R"HTML(<!DOCTYPE html>
+        <html>
+        <body>
+            <a href="https://example.com/valid">Valid link</a>
+            <a href="   https://not a valid url   ">Link with spaces</a>
+            <a href="https://example
+        .com/newline">Link with newline</a>
+            <a href="">Empty href</a>
+            <img src="https://example.com/valid.png" alt="Valid image">
+            <img src="   not a valid src   " alt="Image with spaces">
+            <img src="https://example
+        .com/broken.png" alt="Image with newline">
+            <img src="" alt="Empty src">
+        </body>
+        </html>)HTML";
+    [webView synchronouslyLoadHTMLString:@(markupString)];
+
+    for (auto format : { _WKTextExtractionOutputFormatTextTree, _WKTextExtractionOutputFormatMarkdown }) {
+        RetainPtr debugText = [webView synchronouslyGetDebugText:^{
+            RetainPtr configuration = adoptNS([_WKTextExtractionConfiguration new]);
+            [configuration setIncludeURLs:YES];
+            [configuration setShortenURLs:YES];
+            [configuration setOutputFormat:format];
+            return configuration.autorelease();
+        }()];
+
+        EXPECT_TRUE([debugText containsString:@"Valid link"]);
+        EXPECT_TRUE([debugText containsString:@"example.com"]);
+        EXPECT_TRUE([debugText containsString:@"Valid image"]);
+
+        EXPECT_TRUE([debugText containsString:@"Link with spaces"]);
+        EXPECT_TRUE([debugText containsString:@"Link with newline"]);
+        EXPECT_TRUE([debugText containsString:@"Image with spaces"]);
+        EXPECT_TRUE([debugText containsString:@"Image with newline"]);
+
+        EXPECT_FALSE([debugText containsString:@"not a valid"]);
+    }
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### f86e3dba3c42fe1792d69c3108218c33ca412226
<pre>
[AutoFill Debugging] Skip invalid URLs when extracting links and images
<a href="https://bugs.webkit.org/show_bug.cgi?id=310150">https://bugs.webkit.org/show_bug.cgi?id=310150</a>
<a href="https://rdar.apple.com/172706501">rdar://172706501</a>

Reviewed by Abrar Rahman Protyasha.

Avoid including invalid URLs in text extraction output.

Test: TextExtractionTests.InvalidURLsAreSkipped

* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::TextExtractionAggregator::stringForURL):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm:
(TestWebKitAPI::InvalidURLsAreSkipped)):

Canonical link: <a href="https://commits.webkit.org/309452@main">https://commits.webkit.org/309452@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1dc955fc570a318cfa35250d55473f3c42116595

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150720 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23478 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17049 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159442 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/104154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152593 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23910 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23681 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116326 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/104154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153680 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18432 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135208 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97054 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/17529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/15481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7290 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127143 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13132 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161916 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5037 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14687 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124324 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23280 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19528 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124522 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33796 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23268 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134927 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79657 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19607 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11689 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22882 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86682 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22594 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22746 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22648 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->