### PR TITLE
AX: When the page scale changes, FrameGeometry needs to be updated

### DIFF
--- a/LayoutTests/accessibility/mac/page-scale-factor-updates-frame-geometry-expected.txt
+++ b/LayoutTests/accessibility/mac/page-scale-factor-updates-frame-geometry-expected.txt
@@ -1,0 +1,8 @@
+This test ensures accessibility element screen positions update after a page scale factor change.
+
+PASS: deltaX was equal or approximately equal to 100.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Click me

--- a/LayoutTests/accessibility/mac/page-scale-factor-updates-frame-geometry.html
+++ b/LayoutTests/accessibility/mac/page-scale-factor-updates-frame-geometry.html
@@ -1,0 +1,45 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<button id="target" style="position: absolute; left: 100px; top: 50px; width: 80px; height: 30px;">Click me</button>
+
+<script>
+var output = "This test ensures accessibility element screen positions update after a page scale factor change.\n\n";
+
+var target, initialX, scaledX, deltaX;
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    (async function() {
+        await waitFor(() => {
+            var rootElement = accessibilityController.rootElement;
+            return rootElement && rootElement.x !== 0;
+        });
+
+        target = accessibilityController.accessibleElementById("target");
+        initialX = target.x;
+        await testRunner.setPageScaleFactor(2, 0, 0);
+
+        await waitFor(() => {
+            target = accessibilityController.accessibleElementById("target");
+            return target.x !== initialX;
+        });
+
+        scaledX = target.x;
+        deltaX = Math.abs(scaledX - initialX);
+
+        // At 2x scale, an element at left:100px should shift 100px in screen space.
+        output += expectNumber("deltaX", 100, /* allowedVariance */ 1);
+
+        debug(output);
+        finishJSTest();
+    })();
+}
+</script>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -6559,6 +6559,12 @@ void WebPageProxy::pageScaleFactorDidChange(IPC::Connection& connection, double 
             return;
         process.send(Messages::WebPage::DidScalePage(scaleFactor, { }), pageID);
     });
+
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    // If the page's scale factor changes, the UI process needs to send an updated AffineTransform to each frame.
+    for (RefPtr frame = m_mainFrame; frame; frame = frame->traverseNext().frame)
+        requestFrameScreenPosition(frame->frameID());
+#endif
 }
 
 void WebPageProxy::viewScaleFactorDidChange(IPC::Connection& connection, double scaleFactor)


### PR DESCRIPTION
#### 0d1bde91692585bf382dee6829002f2ebffa08bd
<pre>
AX: When the page scale changes, FrameGeometry needs to be updated
<a href="https://bugs.webkit.org/show_bug.cgi?id=310152">https://bugs.webkit.org/show_bug.cgi?id=310152</a>
<a href="https://rdar.apple.com/172792054">rdar://172792054</a>

Reviewed by Tyler Wilcock.

With ACCESSIBILITY_LOCAL_FRAME enabled, `m_frameGeometry` (stored in in the AXObjectCache)
is still after page scale changes (zoom, viewport scale, pinch zoom, etc.). We need to re-
compute the page scale for all frames whenever this changes. By hooking into
`pageScaleFactorDidChange`, we can do this all from the UI process to limit this to one-way
IPC (UI -&gt; web process), rather than a round trip from the web process.

Test: accessibility/mac/page-scale-factor-updates-frame-geometry.html

* LayoutTests/accessibility/mac/page-scale-factor-updates-frame-geometry-expected.txt: Added.
* LayoutTests/accessibility/mac/page-scale-factor-updates-frame-geometry.html: Added.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::pageScaleFactorDidChange):

Canonical link: <a href="https://commits.webkit.org/309478@main">https://commits.webkit.org/309478@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bda8f4e78d42d2d5147c2f86bb3da9dbf74d3113

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150760 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23518 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17089 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159482 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104194 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b0558a49-d9c7-4a51-9b45-2dc5b63afa63) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23950 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23723 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116362 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82632 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153720 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18468 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135250 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97090 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17565 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15517 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7330 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127179 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13174 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161956 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5077 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14731 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124361 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23322 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19564 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124559 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33813 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23311 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134969 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79697 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19635 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11731 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22922 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86722 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22634 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22786 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22688 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->