### PR TITLE
Reduce unnecessary protected local variables in no-delete context in WebCore

### DIFF
--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -733,7 +733,7 @@ RefPtr<AXIsolatedObject> AXIsolatedObject::approximateHitTest(const IntPoint& po
 
     if (result) {
         if (std::optional stitchedIntoID = result->stitchedIntoID()) {
-            if (RefPtr stitchRepresentative = tree().objectForID(*stitchedIntoID))
+            if (auto* stitchRepresentative = tree().objectForID(*stitchedIntoID))
                 return stitchRepresentative;
         }
     }

--- a/Source/WebCore/animation/AnimationEffect.cpp
+++ b/Source/WebCore/animation/AnimationEffect.cpp
@@ -152,7 +152,7 @@ ExceptionOr<void> AnimationEffect::bindingsUpdateTiming(Document& document, cons
 {
     auto retVal = updateTiming(document, timing);
     if (!retVal.hasException()) {
-        if (RefPtr cssAnimation = dynamicDowncast<CSSAnimation>(animation()))
+        if (auto* cssAnimation = dynamicDowncast<CSSAnimation>(animation()))
             cssAnimation->effectTimingWasUpdatedUsingBindings(timing);
     }
     return retVal;

--- a/Source/WebCore/animation/StyleOriginatedAnimation.cpp
+++ b/Source/WebCore/animation/StyleOriginatedAnimation.cpp
@@ -393,7 +393,7 @@ void StyleOriginatedAnimation::enqueueDOMEvent(const AtomString& eventType, WebA
         return;
 
     auto scheduledTimelineTime = [&]() -> std::optional<Seconds> {
-        if (RefPtr documentTimeline = dynamicDowncast<DocumentTimeline>(timeline())) {
+        if (auto* documentTimeline = dynamicDowncast<DocumentTimeline>(timeline())) {
             ASSERT(scheduledEffectTime.time());
             if (auto scheduledAnimationTime = convertAnimationTimeToTimelineTime(*scheduledEffectTime.time()))
                 return documentTimeline->convertTimelineTimeToOriginRelativeTime(*scheduledAnimationTime);

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -916,8 +916,8 @@ void WebAnimation::enqueueAnimationEvent(Ref<AnimationEventBase>&& event)
             if (RefPtr source = scrollTimeline->source())
                 return source->document().existingTimeline();
         }
-        if (RefPtr keyframeEffect = this->keyframeEffect()) {
-            if (RefPtr target = keyframeEffect->target())
+        if (auto* keyframeEffect = this->keyframeEffect()) {
+            if (auto* target = keyframeEffect->target())
                 return target->document().existingTimeline();
         }
         return nullptr;
@@ -1811,7 +1811,7 @@ ExceptionOr<void> WebAnimation::commitStyles()
 
     auto unanimatedStyle = [&]() {
         if (auto styleable = Styleable::fromRenderer(*renderer)) {
-            if (CheckedPtr lastStyleChangeEventStyle = styleable->lastStyleChangeEventStyle())
+            if (auto* lastStyleChangeEventStyle = styleable->lastStyleChangeEventStyle())
                 return RenderStyle::clone(*lastStyleChangeEventStyle);
         }
         // If we don't have a style for the last style change event, then the

--- a/Source/WebCore/css/CSSImportRule.cpp
+++ b/Source/WebCore/css/CSSImportRule.cpp
@@ -124,7 +124,7 @@ CSSStyleSheet* CSSImportRule::styleSheet() const
         return nullptr;
 
     std::optional<bool> isOriginClean;
-    if (RefPtr cachedSheet = m_importRule->cachedCSSStyleSheet())
+    if (auto* cachedSheet = m_importRule->cachedCSSStyleSheet())
         isOriginClean = cachedSheet->isCORSSameOrigin();
 
     if (!m_styleSheetCSSOMWrapper)

--- a/Source/WebCore/css/CSSVariableReferenceValue.cpp
+++ b/Source/WebCore/css/CSSVariableReferenceValue.cpp
@@ -165,8 +165,8 @@ bool CSSVariableReferenceValue::evaluateDashedFunction(StringView functionName, 
 
     CheckedPtr element = builder.state().element();
     auto customFunction = Style::Scope::resolveTreeScopedReference(*element, scopedFunctionName, [](const Style::Scope& scope, const AtomString& name) -> CheckedPtr<const Style::CustomFunction> {
-        RefPtr resolver = scope.resolverIfExists();
-        CheckedPtr registry = resolver ? resolver->customFunctionRegistry() : nullptr;
+        auto* resolver = scope.resolverIfExists();
+        auto* registry = resolver ? resolver->customFunctionRegistry() : nullptr;
         return registry ? registry->functionForName(name) : nullptr;
     });
 

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -349,7 +349,7 @@ SelectorChecker::MatchResult SelectorChecker::matchRecursively(CheckingContext& 
                 matchType = MatchType::VirtualPseudoElementOnly;
                 break;
             }
-            if (CheckedPtr root = context.element->containingShadowRoot()) {
+            if (auto* root = context.element->containingShadowRoot()) {
                 if (root->mode() != ShadowRootMode::UserAgent)
                     return MatchResult::fails(Match::SelectorFailsLocally);
 

--- a/Source/WebCore/css/ShorthandSerializer.cpp
+++ b/Source/WebCore/css/ShorthandSerializer.cpp
@@ -268,7 +268,7 @@ bool ShorthandSerializer::commonSerializationChecks(const StyleProperties& prope
             return true;
 
         // Don't serialize if any longhand was set to -internal-auto-base().
-        if (RefPtr functionValue = dynamicDowncast<CSSFunctionValue>(value); functionValue && functionValue->name() == CSSValueInternalAutoBase)
+        if (auto* functionValue = dynamicDowncast<CSSFunctionValue>(*value); functionValue && functionValue->name() == CSSValueInternalAutoBase)
             return true;
 
         // Don't serialize if any longhand was set by a different shorthand.

--- a/Source/WebCore/dom/CustomElementDefaultARIA.cpp
+++ b/Source/WebCore/dom/CustomElementDefaultARIA.cpp
@@ -60,7 +60,7 @@ const AtomString& CustomElementDefaultARIA::valueForAttribute(const Element& thi
     return WTF::visit(WTF::makeVisitor([&](const AtomString& stringValue) -> const AtomString& {
         return stringValue;
     }, [&](const WeakPtr<Element, WeakPtrImplWithEventTargetData>& weakElementValue) -> const AtomString& {
-        RefPtr elementValue = weakElementValue.get();
+        auto* elementValue = weakElementValue.get();
         if (elementValue && isElementVisible(*elementValue, thisElement))
             return elementValue->attributeWithoutSynchronization(HTMLNames::idAttr);
         return nullAtom();

--- a/Source/WebCore/dom/DocumentFullscreen.cpp
+++ b/Source/WebCore/dom/DocumentFullscreen.cpp
@@ -363,7 +363,7 @@ ExceptionOr<void> DocumentFullscreen::willEnterFullscreen(Element& element, HTML
     for (auto ancestor : ancestors | std::views::reverse)
         elementEnterFullscreen(ancestor);
 
-    if (RefPtr iframe = dynamicDowncast<HTMLIFrameElement>(element); iframe && !elementWasFullscreen)
+    if (auto* iframe = dynamicDowncast<HTMLIFrameElement>(element); iframe && !elementWasFullscreen)
         iframe->setIFrameFullscreenFlag(true);
 
     return { };
@@ -457,7 +457,7 @@ static Vector<Ref<Document>> documentsToUnfullscreen(Frame& firstFrame)
         ASSERT(protect(document->fullscreen())->fullscreenElement());
         if (!protect(document->fullscreen())->isSimpleFullscreenDocument())
             break;
-        if (RefPtr iframe = dynamicDowncast<HTMLIFrameElement>(document->ownerElement()); iframe && iframe->hasIFrameFullscreenFlag())
+        if (auto* iframe = dynamicDowncast<HTMLIFrameElement>(document->ownerElement()); iframe && iframe->hasIFrameFullscreenFlag())
             break;
     }
     return documents;

--- a/Source/WebCore/dom/ElementInternals.cpp
+++ b/Source/WebCore/dom/ElementInternals.cpp
@@ -123,7 +123,7 @@ ExceptionOr<RefPtr<NodeList>> ElementInternals::labels()
 
 FormAssociatedCustomElement* ElementInternals::elementAsFormAssociatedCustom() const
 {
-    if (RefPtr element = dynamicDowncast<HTMLMaybeFormAssociatedCustomElement>(m_element.get()))
+    if (auto* element = dynamicDowncast<HTMLMaybeFormAssociatedCustomElement>(m_element.get()))
         return element->formAssociatedCustomElementForElementInternals();
     return nullptr;
 }

--- a/Source/WebCore/dom/ScriptedAnimationController.cpp
+++ b/Source/WebCore/dom/ScriptedAnimationController.cpp
@@ -74,7 +74,7 @@ Seconds ScriptedAnimationController::interval() const
 
 Seconds ScriptedAnimationController::preferredScriptedAnimationInterval() const
 {
-    RefPtr page = this->page();
+    auto* page = this->page();
     if (!page)
         return FullSpeedAnimationInterval;
 


### PR DESCRIPTION
#### cea8379e03023a4c6b1881993187221fb6689b72
<pre>
Reduce unnecessary protected local variables in no-delete context in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=310154">https://bugs.webkit.org/show_bug.cgi?id=310154</a>
<a href="https://rdar.apple.com/172795714">rdar://172795714</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/accessibility/AXImageMapHelpers.cpp:
(WebCore::AXImageMapHelpers::rendererFromAreaElement):
* Source/WebCore/accessibility/AccessibilityScrollView.cpp:
(WebCore::AccessibilityScrollView::parentObject const):
* Source/WebCore/contentextensions/ContentExtensionsBackend.cpp:
(WebCore::ContentExtensions::ContentExtensionsBackend::processContentRuleListsForLoad const):
* Source/WebCore/dom/DocumentFullscreen.cpp:
(WebCore::DocumentFullscreen::fullyExitFullscreen):
* Source/WebCore/dom/NodeIterator.cpp:
(WebCore::NodeIterator::NodePointer::moveToNext):
* Source/WebCore/dom/SelectorQuery.cpp:
(WebCore::elementsForLocalName):
* Source/WebCore/dom/TreeScope.cpp:
(WebCore::TreeScope::pointerLockElement const):
* Source/WebCore/dom/UserTypingGestureIndicator.cpp:
(WebCore::UserTypingGestureIndicator::UserTypingGestureIndicator):
* Source/WebCore/html/HTMLStyleElement.cpp:
(WebCore::HTMLStyleElement::attributeChanged):

Canonical link: <a href="https://commits.webkit.org/309580@main">https://commits.webkit.org/309580@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ccb511deacd37fcbdbbcde23c658b1600491485

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150853 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23613 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17185 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159580 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104289 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152726 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24046 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23822 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116448 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82683 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153813 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18558 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135343 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97168 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17655 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15609 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7427 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127273 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13260 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162054 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5179 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14828 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124450 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23417 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19659 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124638 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33871 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23407 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135057 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79813 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19711 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11822 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23017 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87094 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22729 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22881 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22783 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->