### PR TITLE
CSS text-transform should not affect plain text copy

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/editing/other/paste_text_with_text_transform-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/editing/other/paste_text_with_text_transform-expected.txt
@@ -1,12 +1,11 @@
-This Should Not Be Capitalized
-This should be copied as plain text
+this should not be capitalized
+this should be copied as plain text
 
-This Should Be Copied As Plain Text
+this should be copied as plain text
 •••••••
-•••••••This Should Be Copied As Plain TextThis should be copied as plain textThis Should Not Be Capitalized
 
-FAIL text-transform should not affect plain text copy assert_equals: HTML content matches the expected structure after copy expected "this should not be capitalized" but got "This Should Not Be Capitalized"
-FAIL text-transform of first letter should not affect plain text copy assert_equals: HTML content matches the expected structure after copy expected "this should be copied as plain text" but got "This should be copied as plain textThis Should Not Be Capitalized"
-FAIL white space collapsing should be preserved assert_equals: HTML content matches the expected structure after copy expected "this should be copied as plain text" but got "This Should Be Copied As Plain TextThis should be copied as plain textThis Should Not Be Capitalized"
-FAIL secured string should be masked assert_equals: HTML content matches the expected structure after copy expected "•••••••" but got "•••••••This Should Be Copied As Plain TextThis should be copied as plain textThis Should Not Be Capitalized"
+PASS text-transform should not affect plain text copy
+PASS text-transform of first letter should not affect plain text copy
+PASS white space collapsing should be preserved
+PASS secured string should be masked
 

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2070,6 +2070,20 @@ CookieStoreManagerEnabled:
   sharedPreferenceForWebProcess: true
   richJavaScript: true
 
+CopyPlainTextWithoutTextTransformEnabled:
+  type: bool
+  status: stable
+  category: css
+  humanReadableName: "Strip text-transform when copying"
+  humanReadableDescription: "When copying text to the clipboard, strip CSS text-transform so the pasted text reflects the original DOM content"
+  defaultValue:
+    WebKitLegacy:
+      default: true
+    WebKit:
+      default: true
+    WebCore:
+      default: true
+
 CoreMathMLEnabled:
   type: bool
   status: unstable

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -1194,11 +1194,21 @@ void TextIterator::emitText(Text& textNode, RenderText& renderer, int textStartO
 
     bool shouldIgnoreFullSizeKana = m_behaviors.contains(TextIteratorBehavior::IgnoresFullSizeKana) && renderer.style().textTransform().contains(Style::TextTransformValue::FullSizeKana);
 
-    // FIXME: This probably yields the wrong offsets when text-transform: lowercase turns a single character into two characters.
-    String string = m_behaviors.contains(TextIteratorBehavior::EmitsOriginalText) || shouldIgnoreFullSizeKana ? renderer.originalText()
+    // FIXME: This probably yields the wrong offsets when text-transform changes the string length (e.g. lowercase ß → uppercase SS).
+    auto shouldUseOriginalText = [&] {
+        if (m_behaviors.contains(TextIteratorBehavior::EmitsOriginalText) || shouldIgnoreFullSizeKana)
+            return true;
+        if (m_behaviors.contains(TextIteratorBehavior::EmitsTextsWithoutTranscoding)
+            && renderer.style().textSecurity() == TextSecurity::None
+            && textNode.document().settings().copyPlainTextWithoutTextTransformEnabled())
+            return true;
+        return false;
+    }();
+
+    auto string = shouldUseOriginalText ? renderer.originalText()
         : (m_behaviors.contains(TextIteratorBehavior::EmitsTextsWithoutTranscoding) ? renderer.textWithoutConvertingBackslashToYenSymbol() : renderer.text());
 
-    ASSERT(m_behaviors.contains(TextIteratorBehavior::EmitsOriginalText) || string.length() >= static_cast<unsigned>(textEndOffset));
+    ASSERT(shouldUseOriginalText || string.length() >= static_cast<unsigned>(textEndOffset));
 
     textEndOffset = std::min(string.length(), static_cast<unsigned>(textEndOffset));
 


### PR DESCRIPTION
#### ef56b4b6d09fd8b8c0447dca8ed1c6874522a2ba
<pre>
CSS text-transform should not affect plain text copy
<a href="https://bugs.webkit.org/show_bug.cgi?id=43202">https://bugs.webkit.org/show_bug.cgi?id=43202</a>
<a href="https://rdar.apple.com/27247825">rdar://27247825</a>

Reviewed by NOBODY (OOPS!).

When copying text to the clipboard, use the original DOM text instead of the
transformed text so that CSS text-transform does not leak into the pasted
result. This is guarded by the CopyPlainTextWithoutTextTransformEnabled
setting and avoids text-security content to prevent leaking secured text.

* LayoutTests/imported/w3c/web-platform-tests/editing/other/paste_text_with_text_transform-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::TextIterator::emitText):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef56b4b6d09fd8b8c0447dca8ed1c6874522a2ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150736 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23494 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17065 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159458 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104170 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5e511882-5a48-40c7-8b47-30e0b44c60c8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152609 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23926 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23698 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116340 "Found 40 new test failures: accessibility/crash-while-adding-text-child-with-transform.html accessibility/element-line-rects-and-text.html accessibility/first-letter-text-transform-causes-crash.html accessibility/list-item-with-pseudo-element-crash.html accessibility/svg-labelledby.html fast/css/case-transform.html fast/css/content/content-quotes-crash.html fast/css/first-letter-capitalized-edit-select-crash.html fast/dom/inner-text-first-letter.html fast/harness/results.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82617 "8 flakes 11 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6b94b122-ce7b-4b60-9299-9d33707b6597) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153696 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18458 "Found 25 new test failures: accessibility/element-line-rects-and-text.html editing/pasteboard/paste-text-019.html fast/css/case-transform.html fast/css/content/content-quotes-crash.html fast/css/first-letter-capitalized-edit-select-crash.html fast/dom/inner-text-first-letter.html fast/harness/results.html fast/inline/inline-content-with-intrusive-float-partial-layout-crash.html fast/svg/assert-when-trying-to-construct-multiple-lines.html fast/svg/svg-text-segment-crash.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135231 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97068 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4c26f699-6e30-437f-b84d-da5b659c04b4) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17555 "Found 14 new test failures: imported/w3c/web-platform-tests/accname/name/comp_name_from_content.html imported/w3c/web-platform-tests/content-security-policy/svg/svg-inline.sub.html imported/w3c/web-platform-tests/css/css-forms/input-text-base-appearance-computed-style.html imported/w3c/web-platform-tests/css/css-text/text-transform/math/text-transform-math-auto-003.html imported/w3c/web-platform-tests/css/css-text/text-transform/text-transform-upperlower-107.html imported/w3c/web-platform-tests/css/cssom-view/cssom-getBoxQuads-002.html imported/w3c/web-platform-tests/editing/other/paste_text_with_text_transform.html imported/w3c/web-platform-tests/html/dom/elements/the-innertext-and-outertext-properties/dynamic-getter.html imported/w3c/web-platform-tests/html/dom/elements/the-innertext-and-outertext-properties/getter.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-summary-element/anchor-with-inline-element.html ... (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15501 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7306 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/142719 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127169 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13155 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161932 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/11534 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5053 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14710 "Found 45 new test failures: accessibility/crash-while-adding-text-child-with-transform.html accessibility/element-line-rects-and-text.html accessibility/first-letter-single-character.html accessibility/first-letter-text-transform-causes-crash.html accessibility/full-size-kana-untransformed.html accessibility/list-item-with-pseudo-element-crash.html accessibility/svg-labelledby.html editing/pasteboard/copy-backslash-with-euc.html editing/pasteboard/paste-text-019.html fast/css/case-transform.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124339 "Found 42 new test failures: accessibility/crash-while-adding-text-child-with-transform.html accessibility/element-line-rects-and-text.html accessibility/first-letter-text-transform-causes-crash.html accessibility/list-item-with-pseudo-element-crash.html accessibility/svg-labelledby.html editing/pasteboard/copy-backslash-with-euc.html editing/pasteboard/paste-text-019.html fast/css/case-transform.html fast/css/content/content-quotes-crash.html fast/css/first-letter-capitalized-edit-select-crash.html ... (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23297 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19548 "Found 45 new test failures: accessibility/crash-while-adding-text-child-with-transform.html accessibility/element-line-rects-and-text.html accessibility/first-letter-single-character.html accessibility/first-letter-text-transform-causes-crash.html accessibility/full-size-kana-untransformed.html accessibility/list-item-with-pseudo-element-crash.html accessibility/svg-labelledby.html editing/pasteboard/copy-backslash-with-euc.html editing/pasteboard/paste-text-019.html fast/css/case-transform.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124537 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23285 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134950 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79673 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19618 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11712 "Found 45 new test failures: accessibility/crash-while-adding-text-child-with-transform.html accessibility/element-line-rects-and-text.html accessibility/first-letter-single-character.html accessibility/first-letter-text-transform-causes-crash.html accessibility/full-size-kana-untransformed.html accessibility/list-item-with-pseudo-element-crash.html accessibility/svg-labelledby.html editing/pasteboard/copy-backslash-with-euc.html editing/pasteboard/paste-text-019.html fast/css/case-transform.html ... (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/182218 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22898 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86698 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46573 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22610 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22762 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22664 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->