### PR TITLE
[iOS] Top scroll stretch color should match top color extension when present

### DIFF
--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -137,6 +137,7 @@ enum class SDKAlignedBehavior {
     NoHTMLEnhancedSelectParsingQuirk,
     DataURLForPastedImages,
     SuppressKeypressForModifierShortcuts,
+    ScrollColorExtensionGrowsDuringRubberBanding,
     DocumentBackgroundColorFromCanvas,
 
     NumberOfBehaviors

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -3318,10 +3318,11 @@ WebCore::CocoaColor *sampledFixedPositionContentColor(const WebCore::FixedContai
         if (!topFixedColor.isVisible())
             return 0;
 
-        if (!WebCore::PageColorSampler::colorsAreSimilar(_page->sampledPageTopColor(), topFixedColor))
+        if (WebCore::PageColorSampler::colorsAreSimilar(_page->underPageBackgroundColor(), topFixedColor))
             return 0;
 
-        if (WebCore::PageColorSampler::colorsAreSimilar(_page->underPageBackgroundColor(), topFixedColor))
+        static const auto scrollColorExtensionGrowsDuringRubberBanding = linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::ScrollColorExtensionGrowsDuringRubberBanding);
+        if (!scrollColorExtensionGrowsDuringRubberBanding && !WebCore::PageColorSampler::colorsAreSimilar(_page->sampledPageTopColor(), topFixedColor))
             return 0;
 
         return std::max<CGFloat>(-obscuredInsets.top - [_scrollView contentOffset].y, 0);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SampledPageTopColor.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SampledPageTopColor.mm
@@ -518,6 +518,86 @@ TEST(SampledPageTopColor, TopColorExtensionWhenRubberBanding)
     EXPECT_EQ(colorExtensionViewHeight(), 100.f);
 }
 
+TEST(SampledPageTopColor, TopColorExtensionGrowsDuringRubberBandingWithoutSampledPageTopColor)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+
+    auto insets = UIEdgeInsetsMake(75, 0, 0, 0);
+    auto insetSize = UIEdgeInsetsInsetRect([webView bounds], insets).size;
+    [webView _setObscuredInsets:insets];
+    RetainPtr scrollView = [webView scrollView];
+    [scrollView setContentInsetAdjustmentBehavior:UIScrollViewContentInsetAdjustmentNever];
+    [scrollView setContentInset:insets];
+    [webView _overrideLayoutParametersWithMinimumLayoutSize:insetSize minimumUnobscuredSizeOverride:insetSize maximumUnobscuredSizeOverride:insetSize];
+
+    [webView synchronouslyLoadTestPageNamed:@"top-fixed-element"];
+    [webView waitForNextPresentationUpdate];
+
+    RetainPtr topColorExtension = [webView _colorExtensionViewForTesting:UIRectEdgeTop];
+    EXPECT_NOT_NULL(topColorExtension.get());
+
+    auto colorExtensionViewHeight = [topColorExtension] {
+        return CGRectGetHeight([topColorExtension bounds]);
+    };
+
+    EXPECT_EQ(colorExtensionViewHeight(), 75.f);
+
+    {
+        auto components = CGColorGetComponents([topColorExtension layer].backgroundColor);
+        EXPECT_IN_RANGE(components[0], 0.99, 1.01);
+        EXPECT_IN_RANGE(components[1], 0.38, 0.39);
+        EXPECT_IN_RANGE(components[2], 0.27, 0.28);
+    }
+
+    [scrollView setContentOffset:CGPointMake(0, -100) animated:NO];
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_EQ(colorExtensionViewHeight(), 100.f);
+
+    {
+        auto components = CGColorGetComponents([topColorExtension layer].backgroundColor);
+        EXPECT_IN_RANGE(components[0], 0.99, 1.01);
+        EXPECT_IN_RANGE(components[1], 0.38, 0.39);
+        EXPECT_IN_RANGE(components[2], 0.27, 0.28);
+    }
+}
+
+TEST(SampledPageTopColor, TopColorExtensionHeightIncreasesWithRubberBandAmount)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+
+    auto insets = UIEdgeInsetsMake(75, 0, 0, 0);
+    auto insetSize = UIEdgeInsetsInsetRect([webView bounds], insets).size;
+    [webView _setObscuredInsets:insets];
+    RetainPtr scrollView = [webView scrollView];
+    [scrollView setContentInsetAdjustmentBehavior:UIScrollViewContentInsetAdjustmentNever];
+    [scrollView setContentInset:insets];
+    [webView _overrideLayoutParametersWithMinimumLayoutSize:insetSize minimumUnobscuredSizeOverride:insetSize maximumUnobscuredSizeOverride:insetSize];
+
+    [webView synchronouslyLoadTestPageNamed:@"top-fixed-element"];
+    [webView waitForNextPresentationUpdate];
+
+    RetainPtr topColorExtension = [webView _colorExtensionViewForTesting:UIRectEdgeTop];
+
+    auto colorExtensionViewHeight = [topColorExtension] {
+        return CGRectGetHeight([topColorExtension bounds]);
+    };
+
+    EXPECT_EQ(colorExtensionViewHeight(), 75.f);
+
+    [scrollView setContentOffset:CGPointMake(0, -100) animated:NO];
+    [webView waitForNextPresentationUpdate];
+    EXPECT_EQ(colorExtensionViewHeight(), 100.f);
+
+    [scrollView setContentOffset:CGPointMake(0, -150) animated:NO];
+    [webView waitForNextPresentationUpdate];
+    EXPECT_EQ(colorExtensionViewHeight(), 150.f);
+
+    [scrollView setContentOffset:CGPointMake(0, -75) animated:NO];
+    [webView waitForNextPresentationUpdate];
+    EXPECT_EQ(colorExtensionViewHeight(), 75.f);
+}
+
 #endif // PLATFORM(IOS_FAMILY) && ENABLE(CONTENT_INSET_BACKGROUND_FILL)
 
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)


### PR DESCRIPTION
#### 847baf682a730be72f88a9a50bacf8fda60a6c52
<pre>
[iOS] Top scroll stretch color should match top color extension when present
<a href="https://bugs.webkit.org/show_bug.cgi?id=310151">https://bugs.webkit.org/show_bug.cgi?id=310151</a>
<a href="https://rdar.apple.com/172789935">rdar://172789935</a>

Reviewed by Abrar Rahman Protyasha.

The top scroll stretch color should always match the color
displayed behind the top obscured content inset. When a color
extension is present, it will be displayed in this region. To
ensure the colors match, we no longer compare the fixed header
color (used for the extension) to the sampled page top color
as we should behave the same regardless of how similar or
dissimilar the two are.

Tests: SampledPageTopColor.TopColorExtensionGrowsDuringRubberBandingWithoutSampledPageTopColor
       SampledPageTopColor.TopColorExtensionHeightIncreasesWithRubberBandAmount

* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _obscuredInsetsForFixedColorExtension]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SampledPageTopColor.mm:
(TestWebKitAPI::TEST(SampledPageTopColor, TopColorExtensionGrowsDuringRubberBandingWithoutSampledPageTopColor)):
(TestWebKitAPI::TEST(SampledPageTopColor, TopColorExtensionHeightIncreasesWithRubberBandAmount)):

Canonical link: <a href="https://commits.webkit.org/309491@main">https://commits.webkit.org/309491@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39778a021802d418cdd2b8fccbd0ae672cfddb32

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150743 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23501 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17072 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159465 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104177 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0e5394bf-3f9d-44a8-ab1c-bc4e627b748c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152616 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23933 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23705 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116346 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82622 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6171fb01-7ebd-4ce1-84e4-100434a5ffe1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153703 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18455 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135232 "Found 1 new API test failure: TestWebKitAPI.ContextMenuTests.ContextMenuElementInfoWithQRCodeDetectionCrash (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97074 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9d395802-4275-4e63-8878-d9074d22e82d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17552 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15503 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7313 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/142726 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127166 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13156 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161939 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/11541 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5060 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14711 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124346 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23305 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19550 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124544 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23293 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134951 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79680 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23177 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19620 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11713 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/182225 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22905 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86705 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46574 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22617 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22769 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22671 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->