### PR TITLE
Take 2: [iOS] Captions do not render when using AVExperienceController

### DIFF
--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceAVKit.h
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceAVKit.h
@@ -75,7 +75,6 @@ private:
     bool isExternalPlaybackActive() const final { return false; }
     bool willRenderToLayer() const final { return false; }
     AVPlayerViewController *avPlayerViewController() const final { return nullptr; }
-    void setupCaptionsLayer(CALayer *, const WebCore::FloatSize&) final;
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     WKSPlayableViewControllerHost *playableViewController() final { return nullptr; }
 #endif

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceAVKit.mm
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceAVKit.mm
@@ -159,7 +159,6 @@ void VideoPresentationInterfaceAVKit::setupPlayerViewController()
 
     RetainPtr contentSource = playbackSessionInterface().contentSource();
     [contentSource setVideoLayer:fullscreenPlayerLayer()];
-    [contentSource setCaptionLayer:captionsLayer()];
 
     RetainPtr platformContentSource = [allocAVPlayerViewControllerContentSourceInstance() initWithVideoPlaybackControllable:contentSource.get()];
     m_experienceController = [allocWKSExperienceControllerInstance() initWithContentSource:platformContentSource.get()];
@@ -173,16 +172,6 @@ void VideoPresentationInterfaceAVKit::invalidatePlayerViewController()
     m_fullscreenPlayerLayerView = nil;
     [m_experienceController setDelegate:nil];
     m_experienceController = nil;
-}
-
-void VideoPresentationInterfaceAVKit::setupCaptionsLayer(CALayer *, const WebCore::FloatSize&)
-{
-    [CATransaction begin];
-    [CATransaction setDisableActions:YES];
-    [captionsLayer() removeFromSuperlayer];
-    [fullscreenPlayerLayer() setCaptionsLayer:captionsLayer()];
-    [fullscreenPlayerLayer() layoutSublayers];
-    [CATransaction commit];
 }
 
 void VideoPresentationInterfaceAVKit::presentFullscreen(bool animated, Function<void(BOOL, NSError *)>&& completionHandler)


### PR DESCRIPTION
#### 4d3344f625e0b7cf97ec55cd1c7b97f7410a83c1
<pre>
Take 2: [iOS] Captions do not render when using AVExperienceController
<a href="https://bugs.webkit.org/show_bug.cgi?id=310161">https://bugs.webkit.org/show_bug.cgi?id=310161</a>
<a href="https://rdar.apple.com/172805095">rdar://172805095</a>

Reviewed by Eric Carlson.

Two mistakes prevented captions from rendering in AVExperienceController even after 309302@main:
1. VideoPresentationInterfaceAVKit unnecessarily (and incorrectly) overrode
   VideoFullscreenCaptions::setupCaptionsLayer, even though the base class implementation is
   correct for this use case.
2. VideoPresentationInterfaceAVKit set a captions layer on WKAVContentSource, but this is
   unnecessary since the caption layer is already a sublayer of the WebAVPlayerLayer already
   provided to WKAVContentSource.

* Source/WebKit/Platform/ios/VideoPresentationInterfaceAVKit.h:
* Source/WebKit/Platform/ios/VideoPresentationInterfaceAVKit.mm:
(WebKit::VideoPresentationInterfaceAVKit::setupPlayerViewController):
(WebKit::VideoPresentationInterfaceAVKit::setupCaptionsLayer): Deleted.

Canonical link: <a href="https://commits.webkit.org/309487@main">https://commits.webkit.org/309487@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54b82077c7ba5b45e915894d4a0791db53a41f19

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150758 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23516 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17087 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159480 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104192 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3893e4c3-b7de-43a6-9053-8c233a853e38) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23948 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23721 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116360 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82629 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0b7452e2-024f-4db9-86c3-e2792fea4f2a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153718 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18471 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135251 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97088 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9f7a7bd4-1374-43fd-8969-855d57e2bd57) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17568 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15515 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7328 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127182 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161954 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5075 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14732 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124360 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23320 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19562 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124558 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33817 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23309 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134970 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79695 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19630 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11732 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22920 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86720 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22632 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22784 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22686 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->