### PR TITLE
[Site Isolation] Web Inspector: extract frame/loader ID tracking from InspectorPageAgent into IdentifierRegistry

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1692,11 +1692,14 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     inspector/InspectorFrontendClient.h
     inspector/InspectorFrontendClientLocal.h
     inspector/InspectorFrontendHost.h
+    inspector/InspectorIdentifierRegistry.h
     inspector/InspectorInstrumentationPublic.h
     inspector/InspectorInstrumentationWebKit.h
     inspector/InstrumentingAgents.h
     inspector/InspectorOverlay.h
     inspector/InspectorOverlayLabel.h
+    inspector/InspectorResourceType.h
+    inspector/InspectorResourceUtilities.h
     inspector/InspectorWebAgentBase.h
     inspector/LegacyWebSocketInspectorInstrumentation.h
     inspector/PageInspectorController.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -68,6 +68,7 @@ html/HTMLOptionElement.cpp
 html/OffscreenCanvas.cpp
 html/canvas/CanvasRenderingContext2DBase.cpp
 inspector/InspectorAuditAccessibilityObject.cpp
+inspector/InspectorIdentifierRegistry.cpp
 inspector/InspectorNodeFinder.cpp
 inspector/agents/InspectorAnimationAgent.cpp
 inspector/agents/InspectorCSSAgent.cpp

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1878,6 +1878,7 @@ inspector/InspectorFrontendAPIDispatcher.cpp
 inspector/InspectorFrontendClientLocal.cpp
 inspector/InspectorFrontendHost.cpp
 inspector/InspectorHistory.cpp
+inspector/InspectorIdentifierRegistry.cpp
 inspector/InspectorInstrumentation.cpp
 inspector/InspectorInstrumentationPublic.cpp
 inspector/InspectorInstrumentationWebKit.cpp

--- a/Source/WebCore/inspector/InspectorIdentifierRegistry.cpp
+++ b/Source/WebCore/inspector/InspectorIdentifierRegistry.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "InspectorIdentifierRegistry.h"
+
+#include <JavaScriptCore/IdentifiersFactory.h>
+#include <WebCore/DocumentLoader.h>
+#include <WebCore/LocalFrame.h>
+#include <wtf/TZoneMallocInlines.h>
+
+namespace Inspector {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(IdentifierRegistry);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LegacyIdentifierRegistry);
+
+LegacyIdentifierRegistry::LegacyIdentifierRegistry() = default;
+LegacyIdentifierRegistry::~LegacyIdentifierRegistry() = default;
+
+WebCore::Frame* LegacyIdentifierRegistry::frameForId(const Protocol::Network::FrameId& frameId)
+{
+    return frameId.isEmpty() ? nullptr : m_identifierToFrame.get(frameId);
+}
+
+Protocol::Network::FrameId LegacyIdentifierRegistry::frameId(const WebCore::Frame* frame)
+{
+    if (!frame)
+        return emptyString();
+    return m_frameToIdentifier.ensure(*frame, [this, frame] {
+        auto identifier = IdentifiersFactory::createIdentifier();
+        m_identifierToFrame.set(identifier, frame);
+        return identifier;
+    }).iterator->value;
+}
+
+Protocol::Network::LoaderId LegacyIdentifierRegistry::loaderId(WebCore::DocumentLoader* loader)
+{
+    if (!loader)
+        return emptyString();
+    return m_loaderToIdentifier.ensure(loader, [] {
+        return IdentifiersFactory::createIdentifier();
+    }).iterator->value;
+}
+
+WebCore::LocalFrame* LegacyIdentifierRegistry::assertFrame(Protocol::ErrorString& errorString, const Protocol::Network::FrameId& frameId)
+{
+    auto* frame = dynamicDowncast<WebCore::LocalFrame>(frameForId(frameId));
+    if (!frame)
+        errorString = "Missing frame for given frameId"_s;
+    return frame;
+}
+
+Protocol::Network::FrameId LegacyIdentifierRegistry::takeFrame(const WebCore::Frame& frame)
+{
+    auto identifier = m_frameToIdentifier.take(frame);
+    if (!identifier.isNull())
+        m_identifierToFrame.remove(identifier);
+    return identifier;
+}
+
+Protocol::Network::LoaderId LegacyIdentifierRegistry::takeLoader(WebCore::DocumentLoader& loader)
+{
+    return m_loaderToIdentifier.take(&loader);
+}
+
+} // namespace Inspector

--- a/Source/WebCore/inspector/InspectorIdentifierRegistry.h
+++ b/Source/WebCore/inspector/InspectorIdentifierRegistry.h
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <JavaScriptCore/InspectorProtocolObjects.h>
+#include <wtf/Forward.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
+#include <wtf/RobinHoodHashMap.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/WeakHashMap.h>
+#include <wtf/WeakPtr.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+class DocumentLoader;
+class Frame;
+class LocalFrame;
+}
+
+namespace Inspector {
+
+// Abstract interface for mapping WebCore objects to inspector protocol identifier strings.
+// InspectorPageAgent, NetworkAgent, and other agents use these to produce consistent
+// frameId/loaderId values. Under Site Isolation, the subclass can produce deterministic
+// IDs from FrameIdentifier so that UIProcess and WebProcess agree without syncing state.
+class IdentifierRegistry : public RefCountedAndCanMakeWeakPtr<IdentifierRegistry> {
+    WTF_MAKE_TZONE_ALLOCATED(IdentifierRegistry);
+public:
+    virtual ~IdentifierRegistry() = default;
+
+    virtual WebCore::Frame* frameForId(const Protocol::Network::FrameId&) = 0;
+    WEBCORE_EXPORT virtual Protocol::Network::FrameId frameId(const WebCore::Frame*) = 0;
+    virtual Protocol::Network::LoaderId loaderId(WebCore::DocumentLoader*) = 0;
+    virtual WebCore::LocalFrame* assertFrame(Protocol::ErrorString&, const Protocol::Network::FrameId&) = 0;
+
+    // Called when a frame is detached; returns the protocol ID that was assigned.
+    // Callers must ensure takeFrame is called via InspectorInstrumentation::frameDetached
+    // to clean up the identifier maps. The WeakHashMap handles frame destruction gracefully,
+    // but the reverse map (identifier-to-frame) would retain stale entries without this call.
+    virtual Protocol::Network::FrameId takeFrame(const WebCore::Frame&) = 0;
+    // Called when a document loader is detached; returns the protocol ID that was assigned.
+    virtual Protocol::Network::LoaderId takeLoader(WebCore::DocumentLoader&) = 0;
+};
+
+// Default implementation using IdentifiersFactory sequential counters.
+// This is the pre-Site-Isolation behavior where IDs are opaque strings
+// with no relationship to FrameIdentifier values.
+class LegacyIdentifierRegistry final : public IdentifierRegistry {
+    WTF_MAKE_TZONE_ALLOCATED(LegacyIdentifierRegistry);
+public:
+    static Ref<LegacyIdentifierRegistry> create() { return adoptRef(*new LegacyIdentifierRegistry()); }
+    ~LegacyIdentifierRegistry();
+
+    // IdentifierRegistry
+    WebCore::Frame* frameForId(const Protocol::Network::FrameId&) final;
+    WEBCORE_EXPORT Protocol::Network::FrameId frameId(const WebCore::Frame*) final;
+    Protocol::Network::LoaderId loaderId(WebCore::DocumentLoader*) final;
+    WebCore::LocalFrame* assertFrame(Protocol::ErrorString&, const Protocol::Network::FrameId&) final;
+    Protocol::Network::FrameId takeFrame(const WebCore::Frame&) final;
+    Protocol::Network::LoaderId takeLoader(WebCore::DocumentLoader&) final;
+
+private:
+    LegacyIdentifierRegistry();
+    WeakHashMap<WebCore::Frame, String> m_frameToIdentifier;
+    MemoryCompactRobinHoodHashMap<String, WeakPtr<WebCore::Frame>> m_identifierToFrame;
+    // FIXME: DocumentLoader should use a smart pointer key (CheckedPtr or RefPtr).
+    // It currently holds raw DocumentLoader* which prevents making loaderId/takeLoader
+    // parameters const. See webkit.org/b/310162 for follow-up.
+    HashMap<WebCore::DocumentLoader*, String> m_loaderToIdentifier;
+};
+
+// Deterministic implementation for Site Isolation. Produces type-prefixed IDs
+// derived from FrameIdentifier and ScriptExecutionContextIdentifier so that
+// UIProcess and WebContent processes independently compute matching protocol IDs.
+class BackendIdentifierRegistry final : public IdentifierRegistry {
+    WTF_MAKE_TZONE_ALLOCATED(BackendIdentifierRegistry);
+public:
+    static Ref<BackendIdentifierRegistry> create() { return adoptRef(*new BackendIdentifierRegistry()); }
+    ~BackendIdentifierRegistry();
+
+    // IdentifierRegistry
+    WebCore::Frame* frameForId(const Protocol::Network::FrameId&) final;
+    WEBCORE_EXPORT Protocol::Network::FrameId frameId(const WebCore::Frame*) final;
+    Protocol::Network::LoaderId loaderId(WebCore::DocumentLoader*) final;
+    WebCore::LocalFrame* assertFrame(Protocol::ErrorString&, const Protocol::Network::FrameId&) final;
+    Protocol::Network::FrameId takeFrame(const WebCore::Frame&) final;
+    Protocol::Network::LoaderId takeLoader(WebCore::DocumentLoader&) final;
+
+private:
+    BackendIdentifierRegistry();
+
+    // Reverse map for frameForId() lookups. Populated by frameId().
+    MemoryCompactRobinHoodHashMap<String, WeakPtr<WebCore::Frame>> m_identifierToFrame;
+    // FIXME: DocumentLoader should use a smart pointer key (CheckedPtr or RefPtr).
+    // See webkit.org/b/310162 for follow-up.
+    HashMap<WebCore::DocumentLoader*, String> m_loaderToIdentifier;
+};
+
+} // namespace Inspector

--- a/Source/WebCore/inspector/InspectorResourceUtilities.cpp
+++ b/Source/WebCore/inspector/InspectorResourceUtilities.cpp
@@ -42,6 +42,7 @@
 #include "Page.h"
 #include "SharedBuffer.h"
 #include <JavaScriptCore/ContentSearchUtilities.h>
+#include <JavaScriptCore/InspectorProtocolObjects.h>
 
 namespace Inspector {
 

--- a/Source/WebCore/inspector/InspectorResourceUtilities.h
+++ b/Source/WebCore/inspector/InspectorResourceUtilities.h
@@ -28,6 +28,7 @@
 #include "CachedResource.h" // for CachedResource::Type.
 #include <JavaScriptCore/InspectorProtocolObjects.h>
 #include <wtf/Forward.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 class DocumentLoader;
@@ -39,6 +40,10 @@ class TextResourceDecoder;
 
 namespace Inspector {
 namespace Protocol {
+typedef String ErrorString;
+namespace Page {
+enum class ResourceType : int;
+}
 }
 
 enum class ResourceType;

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -59,7 +59,7 @@
 #include "HTMLStyleElement.h"
 #include "InspectorCSSAgent.h"
 #include "InspectorDOMAgent.h"
-#include "InspectorPageAgent.h"
+#include "InspectorIdentifierRegistry.h"
 #include "InspectorResourceUtilities.h"
 #include "MediaList.h"
 #include "Node.h"
@@ -1026,9 +1026,9 @@ Vector<String> InspectorStyle::longhandProperties(const String& shorthandPropert
     return properties;
 }
 
-Ref<InspectorStyleSheet> InspectorStyleSheet::create(InspectorPageAgent* pageAgent, const String& id, RefPtr<CSSStyleSheet>&& pageStyleSheet, Inspector::Protocol::CSS::StyleSheetOrigin origin, const String& documentURL, Listener* listener)
+Ref<InspectorStyleSheet> InspectorStyleSheet::create(Inspector::IdentifierRegistry& identifierRegistry, const String& id, RefPtr<CSSStyleSheet>&& pageStyleSheet, Inspector::Protocol::CSS::StyleSheetOrigin origin, const String& documentURL, Listener* listener)
 {
-    return adoptRef(*new InspectorStyleSheet(pageAgent, id, WTF::move(pageStyleSheet), origin, documentURL, listener));
+    return adoptRef(*new InspectorStyleSheet(identifierRegistry, id, WTF::move(pageStyleSheet), origin, documentURL, listener));
 }
 
 String InspectorStyleSheet::styleSheetURL(CSSStyleSheet* pageStyleSheet)
@@ -1038,8 +1038,8 @@ String InspectorStyleSheet::styleSheetURL(CSSStyleSheet* pageStyleSheet)
     return emptyString();
 }
 
-InspectorStyleSheet::InspectorStyleSheet(InspectorPageAgent* pageAgent, const String& id, RefPtr<CSSStyleSheet>&& pageStyleSheet, Inspector::Protocol::CSS::StyleSheetOrigin origin, const String& documentURL, Listener* listener)
-    : m_pageAgent(pageAgent)
+InspectorStyleSheet::InspectorStyleSheet(Inspector::IdentifierRegistry& identifierRegistry, const String& id, RefPtr<CSSStyleSheet>&& pageStyleSheet, Inspector::Protocol::CSS::StyleSheetOrigin origin, const String& documentURL, Listener* listener)
+    : m_identifierRegistry(identifierRegistry)
     , m_id(id)
     , m_pageStyleSheet(WTF::move(pageStyleSheet))
     , m_origin(origin)
@@ -1279,7 +1279,7 @@ RefPtr<Inspector::Protocol::CSS::CSSStyleSheetHeader> InspectorStyleSheet::build
         .setDisabled(styleSheet->disabled())
         .setSourceURL(finalURL())
         .setTitle(styleSheet->title())
-        .setFrameId(m_pageAgent->frameId(frame.get()))
+        .setFrameId(m_identifierRegistry->frameId(frame.get()))
         .setIsInline(styleSheet->isInline() && styleSheet->startPosition() != TextPosition())
         .setStartLine(styleSheet->startPosition().m_line.zeroBasedInt())
         .setStartColumn(styleSheet->startPosition().m_column.zeroBasedInt())
@@ -1835,13 +1835,13 @@ void InspectorStyleSheet::collectFlatRules(RefPtr<CSSRuleList>&& ruleList, Vecto
     }
 }
 
-Ref<InspectorStyleSheetForInlineStyle> InspectorStyleSheetForInlineStyle::create(InspectorPageAgent* pageAgent, const String& id, Ref<StyledElement>&& element, Inspector::Protocol::CSS::StyleSheetOrigin origin, Listener* listener)
+Ref<InspectorStyleSheetForInlineStyle> InspectorStyleSheetForInlineStyle::create(Inspector::IdentifierRegistry& identifierRegistry, const String& id, Ref<StyledElement>&& element, Inspector::Protocol::CSS::StyleSheetOrigin origin, Listener* listener)
 {
-    return adoptRef(*new InspectorStyleSheetForInlineStyle(pageAgent, id, WTF::move(element), origin, listener));
+    return adoptRef(*new InspectorStyleSheetForInlineStyle(identifierRegistry, id, WTF::move(element), origin, listener));
 }
 
-InspectorStyleSheetForInlineStyle::InspectorStyleSheetForInlineStyle(InspectorPageAgent* pageAgent, const String& id, Ref<StyledElement>&& element, Inspector::Protocol::CSS::StyleSheetOrigin origin, Listener* listener)
-    : InspectorStyleSheet(pageAgent, id, nullptr, origin, String(), listener)
+InspectorStyleSheetForInlineStyle::InspectorStyleSheetForInlineStyle(Inspector::IdentifierRegistry& identifierRegistry, const String& id, Ref<StyledElement>&& element, Inspector::Protocol::CSS::StyleSheetOrigin origin, Listener* listener)
+    : InspectorStyleSheet(identifierRegistry, id, nullptr, origin, String(), listener)
     , m_element(WTF::move(element))
     , m_ruleSourceData(nullptr)
     , m_isStyleTextValid(false)

--- a/Source/WebCore/inspector/InspectorStyleSheet.h
+++ b/Source/WebCore/inspector/InspectorStyleSheet.h
@@ -30,10 +30,15 @@
 #include "Settings.h"
 #include <JavaScriptCore/InspectorProtocolObjects.h>
 #include <wtf/CheckedPtr.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/HashMap.h>
 #include <wtf/JSONValues.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Vector.h>
+
+namespace Inspector {
+class IdentifierRegistry;
+}
 
 namespace WebCore {
 
@@ -44,7 +49,6 @@ class CSSStyleRule;
 class CSSStyleSheet;
 class Document;
 class Element;
-class InspectorPageAgent;
 class InspectorStyleSheet;
 class ParsedStyleSheet;
 
@@ -161,7 +165,7 @@ public:
 
     using StyleDeclarationOrCSSRule = Variant<CSSStyleDeclaration*, CSSRule*>;
 
-    static Ref<InspectorStyleSheet> create(InspectorPageAgent*, const String& id, RefPtr<CSSStyleSheet>&& pageStyleSheet, Inspector::Protocol::CSS::StyleSheetOrigin, const String& documentURL, Listener*);
+    static Ref<InspectorStyleSheet> create(Inspector::IdentifierRegistry&, const String& id, RefPtr<CSSStyleSheet>&& pageStyleSheet, Inspector::Protocol::CSS::StyleSheetOrigin, const String& documentURL, Listener*);
     static String NODELETE styleSheetURL(CSSStyleSheet* pageStyleSheet);
 
     virtual ~InspectorStyleSheet();
@@ -191,7 +195,7 @@ public:
     InspectorCSSId ruleOrStyleId(StyleDeclarationOrCSSRule) const;
 
 protected:
-    InspectorStyleSheet(InspectorPageAgent*, const String& id, RefPtr<CSSStyleSheet>&& pageStyleSheet, Inspector::Protocol::CSS::StyleSheetOrigin, const String& documentURL, Listener*);
+    InspectorStyleSheet(Inspector::IdentifierRegistry&, const String& id, RefPtr<CSSStyleSheet>&& pageStyleSheet, Inspector::Protocol::CSS::StyleSheetOrigin, const String& documentURL, Listener*);
 
     bool canBind() const { return m_origin != Inspector::Protocol::CSS::StyleSheetOrigin::UserAgent && m_origin != Inspector::Protocol::CSS::StyleSheetOrigin::User; }
     virtual Document* ownerDocument() const;
@@ -225,7 +229,7 @@ private:
     Vector<Ref<CSSStyleRule>> cssStyleRulesSplitFromSameRule(CSSStyleRule&);
     Vector<const CSSSelector*> selectorsForCSSStyleRule(CSSStyleRule&);
 
-    CheckedPtr<InspectorPageAgent> m_pageAgent;
+    WeakRef<Inspector::IdentifierRegistry> m_identifierRegistry;
     String m_id;
     RefPtr<CSSStyleSheet> m_pageStyleSheet;
     Inspector::Protocol::CSS::StyleSheetOrigin m_origin;
@@ -237,7 +241,7 @@ private:
 
 class InspectorStyleSheetForInlineStyle final : public InspectorStyleSheet {
 public:
-    static Ref<InspectorStyleSheetForInlineStyle> create(InspectorPageAgent*, const String& id, Ref<StyledElement>&&, Inspector::Protocol::CSS::StyleSheetOrigin, Listener*);
+    static Ref<InspectorStyleSheetForInlineStyle> create(Inspector::IdentifierRegistry&, const String& id, Ref<StyledElement>&&, Inspector::Protocol::CSS::StyleSheetOrigin, Listener*);
 
     void didModifyElementAttribute();
     ExceptionOr<String> text() final;
@@ -245,7 +249,7 @@ public:
     ExceptionOr<void> setRuleStyleText(const InspectorCSSId&, const String& newStyleDeclarationText, String* outOldStyleDeclarationText, const String* newRuleText, String* outOldRuleText);
 
 private:
-    InspectorStyleSheetForInlineStyle(InspectorPageAgent*, const String& id, Ref<StyledElement>&&, Inspector::Protocol::CSS::StyleSheetOrigin, Listener*);
+    InspectorStyleSheetForInlineStyle(Inspector::IdentifierRegistry&, const String& id, Ref<StyledElement>&&, Inspector::Protocol::CSS::StyleSheetOrigin, Listener*);
 
     Document* ownerDocument() const final;
     RefPtr<CSSRuleSourceData> ruleSourceDataFor(CSSStyleDeclaration* style) const final { ASSERT_UNUSED(style, style == &inlineStyle()); return m_ruleSourceData; }

--- a/Source/WebCore/inspector/PageInspectorController.cpp
+++ b/Source/WebCore/inspector/PageInspectorController.cpp
@@ -44,6 +44,7 @@
 #include "InspectorDOMAgent.h"
 #include "InspectorDOMStorageAgent.h"
 #include "InspectorFrontendClient.h"
+#include "InspectorIdentifierRegistry.h"
 #include "InspectorIndexedDBAgent.h"
 #include "InspectorInstrumentation.h"
 #include "InspectorLayerTreeAgent.h"
@@ -99,6 +100,7 @@ PageInspectorController::PageInspectorController(Page& page, std::unique_ptr<Ins
     , m_overlay(makeUniqueRefWithoutRefCountedCheck<InspectorOverlay>(*this, inspectorBackendClient.get()))
     , m_executionStopwatch(Stopwatch::create())
     , m_inspectorBackendClient(WTF::move(inspectorBackendClient))
+    , m_identifierRegistry(Inspector::LegacyIdentifierRegistry::create())
 {
     ASSERT_ARG(inspectorBackendClient, m_inspectorBackendClient);
 

--- a/Source/WebCore/inspector/PageInspectorController.h
+++ b/Source/WebCore/inspector/PageInspectorController.h
@@ -37,6 +37,7 @@
 #include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/Ref.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
@@ -45,6 +46,7 @@ namespace Inspector {
 class BackendDispatcher;
 class FrontendChannel;
 class FrontendRouter;
+class IdentifierRegistry;
 class InspectorAgent;
 }
 
@@ -134,6 +136,8 @@ public:
     InspectorDOMAgent& ensureDOMAgent();
     WEBCORE_EXPORT InspectorPageAgent& ensurePageAgent();
 
+    Inspector::IdentifierRegistry& identifierRegistry() const { return m_identifierRegistry.get(); }
+
     // InspectorEnvironment
     bool developerExtrasEnabled() const override;
     bool canAccessInspectedScriptState(JSC::JSGlobalObject*) const override;
@@ -161,6 +165,7 @@ private:
     Inspector::AgentRegistry m_agents;
 
     std::unique_ptr<InspectorBackendClient> m_inspectorBackendClient;
+    Ref<Inspector::IdentifierRegistry> m_identifierRegistry;
     InspectorFrontendClient* m_inspectorFrontendClient { nullptr };
 
     // Lazy, but also on-demand agents.

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
@@ -57,12 +57,14 @@
 #include "HTMLStyleElement.h"
 #include "InspectorDOMAgent.h"
 #include "InspectorHistory.h"
+#include "InspectorIdentifierRegistry.h"
 #include "InspectorPageAgent.h"
 #include "InstrumentingAgents.h"
 #include "LocalDOMWindow.h"
 #include "LocalFrameInlines.h"
 #include "Node.h"
 #include "NodeList.h"
+#include "PageInspectorController.h"
 #include "PseudoElement.h"
 #include "RenderFlexibleBox.h"
 #include "RenderGrid.h"
@@ -806,11 +808,7 @@ Inspector::Protocol::ErrorStringOr<Inspector::Protocol::CSS::StyleSheetId> Inspe
 {
     Inspector::Protocol::ErrorString errorString;
 
-    CheckedPtr pageAgent = Ref { m_instrumentingAgents.get() }->enabledPageAgent();
-    if (!pageAgent)
-        return makeUnexpected("Page domain must be enabled"_s);
-
-    auto* frame = pageAgent->assertFrame(errorString, frameId);
+    auto* frame = m_inspectedPage->inspectorController().identifierRegistry().assertFrame(errorString, frameId);
     if (!frame)
         return makeUnexpected(errorString);
 
@@ -1262,12 +1260,15 @@ void InspectorCSSAgent::nodesWithPendingLayoutFlagsChangeDispatchTimerFired()
 
 InspectorStyleSheetForInlineStyle& InspectorCSSAgent::asInspectorStyleSheet(StyledElement& element)
 {
-    return m_nodeToInspectorStyleSheet.ensure(&element, [this, &element] {
-        String newStyleSheetId = String::number(m_lastStyleSheetId++);
-        auto inspectorStyleSheet = InspectorStyleSheetForInlineStyle::create(Ref { m_instrumentingAgents.get() }->enabledPageAgent(), newStyleSheetId, element, Inspector::Protocol::CSS::StyleSheetOrigin::Author, this);
-        m_idToInspectorStyleSheet.set(newStyleSheetId, inspectorStyleSheet.copyRef());
-        return inspectorStyleSheet;
-    }).iterator->value;
+    auto it = m_nodeToInspectorStyleSheet.find(&element);
+    if (it != m_nodeToInspectorStyleSheet.end())
+        return it->value;
+
+    String newStyleSheetId = String::number(m_lastStyleSheetId);
+    ++m_lastStyleSheetId;
+    auto inspectorStyleSheet = InspectorStyleSheetForInlineStyle::create(m_inspectedPage->inspectorController().identifierRegistry(), newStyleSheetId, element, Inspector::Protocol::CSS::StyleSheetOrigin::Author, this);
+    m_idToInspectorStyleSheet.set(newStyleSheetId, inspectorStyleSheet.copyRef());
+    return m_nodeToInspectorStyleSheet.set(&element, WTF::move(inspectorStyleSheet)).iterator->value;
 }
 
 Element* InspectorCSSAgent::elementForId(Inspector::Protocol::ErrorString& errorString, Inspector::Protocol::DOM::NodeId nodeId)
@@ -1305,15 +1306,17 @@ String InspectorCSSAgent::unbindStyleSheet(InspectorStyleSheet* inspectorStyleSh
 
 InspectorStyleSheet& InspectorCSSAgent::bindStyleSheet(CSSStyleSheet* styleSheet)
 {
-    return m_cssStyleSheetToInspectorStyleSheet.ensure(styleSheet, [&] {
-        auto id = String::number(m_lastStyleSheetId++);
-        RefPtr document = styleSheet->ownerDocument();
-        Ref inspectorStyleSheet = InspectorStyleSheet::create(protect(m_instrumentingAgents)->enabledPageAgent(), id, styleSheet, detectOrigin(styleSheet, document), InspectorDOMAgent::documentURLString(document), this);
-        m_idToInspectorStyleSheet.set(id, inspectorStyleSheet);
-        if (m_creatingViaInspectorStyleSheet && document)
-            m_documentToInspectorStyleSheet.add(document.releaseNonNull(), Vector<Ref<InspectorStyleSheet>>()).iterator->value.append(inspectorStyleSheet);
-        return inspectorStyleSheet;
-    }).iterator->value;
+    auto it = m_cssStyleSheetToInspectorStyleSheet.find(styleSheet);
+    if (it != m_cssStyleSheetToInspectorStyleSheet.end())
+        return it->value;
+
+    auto id = String::number(m_lastStyleSheetId++);
+    RefPtr document = styleSheet->ownerDocument();
+    Ref inspectorStyleSheet = InspectorStyleSheet::create(m_inspectedPage->inspectorController().identifierRegistry(), id, styleSheet, detectOrigin(styleSheet, document), InspectorDOMAgent::documentURLString(document), this);
+    m_idToInspectorStyleSheet.set(id, inspectorStyleSheet);
+    if (m_creatingViaInspectorStyleSheet && document)
+        m_documentToInspectorStyleSheet.add(document.releaseNonNull(), Vector<Ref<InspectorStyleSheet>>()).iterator->value.append(inspectorStyleSheet);
+    return m_cssStyleSheetToInspectorStyleSheet.set(styleSheet, WTF::move(inspectorStyleSheet)).iterator->value;
 }
 
 InspectorStyleSheet* InspectorCSSAgent::assertStyleSheetForId(Inspector::Protocol::ErrorString& errorString, const String& styleSheetId)

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -81,6 +81,7 @@
 #include "InspectorBackendClient.h"
 #include "InspectorCSSAgent.h"
 #include "InspectorHistory.h"
+#include "InspectorIdentifierRegistry.h"
 #include "InspectorNodeFinder.h"
 #include "InspectorPageAgent.h"
 #include "InstrumentingAgents.h"
@@ -1514,12 +1515,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightSelector(co
     RefPtr<Document> document;
 
     if (!!frameId) {
-        Ref agents = m_instrumentingAgents.get();
-        CheckedPtr pageAgent = agents->enabledPageAgent();
-        if (!pageAgent)
-            return makeUnexpected("Page domain must be enabled"_s);
-
-        RefPtr frame = pageAgent->assertFrame(errorString, frameId);
+        RefPtr frame = m_inspectedPage->inspectorController().identifierRegistry().assertFrame(errorString, frameId);
         if (!frame)
             return makeUnexpected(errorString);
 
@@ -1690,12 +1686,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightFrame(const
 {
     Inspector::Protocol::ErrorString errorString;
 
-    Ref agents = m_instrumentingAgents.get();
-    CheckedPtr pageAgent = agents->enabledPageAgent();
-    if (!pageAgent)
-        return makeUnexpected("Page domain must be enabled"_s);
-
-    RefPtr frame = pageAgent->assertFrame(errorString, frameId);
+    RefPtr frame = m_inspectedPage->inspectorController().identifierRegistry().assertFrame(errorString, frameId);
     if (!frame)
         return makeUnexpected(errorString);
 
@@ -2028,11 +2019,8 @@ Ref<Inspector::Protocol::DOM::Node> InspectorDOMAgent::buildObjectForNode(Node* 
             value->setLayoutFlags(layoutFlags.releaseNonNull());
     }
 
-    CheckedPtr pageAgent = agents->enabledPageAgent();
-    if (pageAgent) {
-        if (RefPtr frameView = node->document().view())
-            value->setFrameId(pageAgent->frameId(&frameView->frame()));
-    }
+    if (RefPtr frameView = node->document().view())
+        value->setFrameId(m_inspectedPage->inspectorController().identifierRegistry().frameId(&frameView->frame()));
 
     if (RefPtr element = dynamicDowncast<Element>(*node)) {
         value->setAttributes(buildArrayForElementAttributes(element.get()));
@@ -2066,8 +2054,7 @@ Ref<Inspector::Protocol::DOM::Node> InspectorDOMAgent::buildObjectForNode(Node* 
                 value->setPseudoElements(pseudoElements.releaseNonNull());
         }
     } else if (RefPtr document = dynamicDowncast<Document>(*node)) {
-        if (pageAgent)
-            value->setFrameId(pageAgent->frameId(document->frame()));
+        value->setFrameId(m_inspectedPage->inspectorController().identifierRegistry().frameId(document->frame()));
         value->setDocumentURL(documentURLString(document.get()));
         value->setBaseURL(documentBaseURLString(document.get()));
         value->setXmlVersion(document->xmlVersion());

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
@@ -52,6 +52,7 @@
 #include "ImageUtilities.h"
 #include "InspectorBackendClient.h"
 #include "InspectorDOMAgent.h"
+#include "InspectorIdentifierRegistry.h"
 #include "InspectorNetworkAgent.h"
 #include "InspectorOverlay.h"
 #include "InspectorResourceUtilities.h"
@@ -61,6 +62,7 @@
 #include "MIMETypeRegistry.h"
 #include "MemoryCache.h"
 #include "Page.h"
+#include "PageInspectorController.h"
 #include "RenderObjectInlines.h"
 #include "RenderTheme.h"
 #include "ScriptController.h"
@@ -686,49 +688,35 @@ void InspectorPageAgent::frameNavigated(LocalFrame& frame)
 
 void InspectorPageAgent::frameDetached(LocalFrame& frame)
 {
-    auto identifier = m_frameToIdentifier.take(frame);
+    auto identifier = m_inspectedPage->inspectorController().identifierRegistry().takeFrame(frame);
     if (identifier.isNull())
         return;
     m_frontendDispatcher->frameDetached(identifier);
-    m_identifierToFrame.remove(identifier);
 }
 
 Frame* InspectorPageAgent::frameForId(const Inspector::Protocol::Network::FrameId& frameId)
 {
-    return frameId.isEmpty() ? nullptr : m_identifierToFrame.get(frameId);
+    return m_inspectedPage->inspectorController().identifierRegistry().frameForId(frameId);
 }
 
 String InspectorPageAgent::frameId(Frame* frame)
 {
-    if (!frame)
-        return emptyString();
-    return m_frameToIdentifier.ensure(*frame, [this, frame] {
-        auto identifier = IdentifiersFactory::createIdentifier();
-        m_identifierToFrame.set(identifier, frame);
-        return identifier;
-    }).iterator->value;
+    return m_inspectedPage->inspectorController().identifierRegistry().frameId(frame);
 }
 
 String InspectorPageAgent::loaderId(DocumentLoader* loader)
 {
-    if (!loader)
-        return emptyString();
-    return m_loaderToIdentifier.ensure(loader, [] {
-        return IdentifiersFactory::createIdentifier();
-    }).iterator->value;
+    return m_inspectedPage->inspectorController().identifierRegistry().loaderId(loader);
 }
 
 LocalFrame* InspectorPageAgent::assertFrame(Inspector::Protocol::ErrorString& errorString, const Inspector::Protocol::Network::FrameId& frameId)
 {
-    auto* frame = dynamicDowncast<LocalFrame>(frameForId(frameId));
-    if (!frame)
-        errorString = "Missing frame for given frameId"_s;
-    return frame;
+    return m_inspectedPage->inspectorController().identifierRegistry().assertFrame(errorString, frameId);
 }
 
 void InspectorPageAgent::loaderDetachedFromFrame(DocumentLoader& loader)
 {
-    m_loaderToIdentifier.remove(&loader);
+    m_inspectedPage->inspectorController().identifierRegistry().takeLoader(loader);
 }
 
 void InspectorPageAgent::accessibilitySettingsDidChange()

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.h
@@ -39,7 +39,6 @@
 #include <WebCore/LayoutRect.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/Platform.h>
-#include <wtf/RobinHoodHashMap.h>
 #include <wtf/Seconds.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRef.h>
@@ -145,9 +144,6 @@ private:
     InspectorBackendClient* m_client { nullptr };
     WeakRef<InspectorOverlay> m_overlay;
 
-    WeakHashMap<Frame, String> m_frameToIdentifier;
-    MemoryCompactRobinHoodHashMap<String, WeakPtr<Frame>> m_identifierToFrame;
-    HashMap<DocumentLoader*, String> m_loaderToIdentifier;
     String m_userAgentOverride;
     AtomString m_emulatedMedia;
     String m_bootstrapScript;

--- a/Source/WebCore/inspector/agents/page/PageNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageNetworkAgent.cpp
@@ -31,9 +31,11 @@
 #include "FrameConsoleClient.h"
 #include "FrameDestructionObserverInlines.h"
 #include "InspectorBackendClient.h"
+#include "InspectorIdentifierRegistry.h"
 #include "InstrumentingAgents.h"
 #include "LocalFrameInlines.h"
 #include "Page.h"
+#include "PageInspectorController.h"
 #include "Settings.h"
 #include "ThreadableWebSocketChannel.h"
 #include "WebSocket.h"
@@ -61,19 +63,15 @@ PageNetworkAgent::~PageNetworkAgent() = default;
 
 Inspector::Protocol::Network::LoaderId PageNetworkAgent::loaderIdentifier(DocumentLoader* loader)
 {
-    if (loader) {
-        if (CheckedPtr pageAgent = Ref { m_instrumentingAgents.get() }->enabledPageAgent())
-            return pageAgent->loaderId(loader);
-    }
+    if (loader)
+        return m_inspectedPage->inspectorController().identifierRegistry().loaderId(loader);
     return { };
 }
 
 Inspector::Protocol::Network::FrameId PageNetworkAgent::frameIdentifier(DocumentLoader* loader)
 {
-    if (loader) {
-        if (CheckedPtr pageAgent = Ref { m_instrumentingAgents.get() }->enabledPageAgent())
-            return pageAgent->frameId(loader->frame());
-    }
+    if (loader)
+        return m_inspectedPage->inspectorController().identifierRegistry().frameId(loader->frame());
     return { };
 }
 
@@ -119,13 +117,7 @@ bool PageNetworkAgent::setEmulatedConditionsInternal(std::optional<int>&& bytesP
 
 ScriptExecutionContext* PageNetworkAgent::scriptExecutionContext(Inspector::Protocol::ErrorString& errorString, const Inspector::Protocol::Network::FrameId& frameId)
 {
-    CheckedPtr pageAgent = Ref { m_instrumentingAgents.get() }->enabledPageAgent();
-    if (!pageAgent) {
-        errorString = "Page domain must be enabled"_s;
-        return nullptr;
-    }
-
-    auto* frame = pageAgent->assertFrame(errorString, frameId);
+    auto* frame = m_inspectedPage->inspectorController().identifierRegistry().assertFrame(errorString, frameId);
     if (!frame)
         return nullptr;
 

--- a/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp
@@ -35,19 +35,19 @@
 #include "DOMWrapperWorld.h"
 #include "Document.h"
 #include "FrameConsoleClient.h"
-#include "InspectorPageAgent.h"
+#include "InspectorIdentifierRegistry.h"
 #include "InstrumentingAgents.h"
 #include "JSDOMWindowCustom.h"
 #include "JSExecState.h"
 #include "LocalFrame.h"
 #include "Page.h"
+#include "PageInspectorController.h"
 #include "ScriptController.h"
 #include "SecurityOrigin.h"
 #include "UserGestureEmulationScope.h"
 #include <JavaScriptCore/InjectedScript.h>
 #include <JavaScriptCore/InjectedScriptManager.h>
 #include <JavaScriptCore/InspectorProtocolObjects.h>
-#include <wtf/CheckedPtr.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -101,11 +101,11 @@ void PageRuntimeAgent::frameNavigated(LocalFrame& frame)
 
 void PageRuntimeAgent::didClearWindowObjectInWorld(LocalFrame& frame, DOMWrapperWorld& world)
 {
-    CheckedPtr pageAgent = Ref { m_instrumentingAgents.get() }->enabledPageAgent();
-    if (!pageAgent)
+    auto frameId = m_inspectedPage->inspectorController().identifierRegistry().frameId(&frame);
+    if (frameId.isEmpty())
         return;
 
-    notifyContextCreated(pageAgent->frameId(&frame), frame.script().globalObject(world), world);
+    notifyContextCreated(frameId, frame.script().globalObject(world), world);
 }
 
 InjectedScript PageRuntimeAgent::injectedScriptForEval(Inspector::Protocol::ErrorString& errorString, std::optional<Inspector::Protocol::Runtime::ExecutionContextId>&& executionContextId)
@@ -139,15 +139,13 @@ void PageRuntimeAgent::unmuteConsole()
 
 void PageRuntimeAgent::reportExecutionContextCreation()
 {
-    CheckedPtr pageAgent = Ref { m_instrumentingAgents.get() }->enabledPageAgent();
-    if (!pageAgent)
-        return;
+    Ref identifierRegistry = m_inspectedPage->inspectorController().identifierRegistry();
 
     m_inspectedPage->forEachLocalFrame([&](LocalFrame& frame) {
         if (!frame.script().canExecuteScripts(ReasonForCallingCanExecuteScripts::NotAboutToExecuteScript))
             return;
 
-        auto frameId = pageAgent->frameId(&frame);
+        auto frameId = identifierRegistry->frameId(&frame);
 
         // Always send the main world first.
         auto& mainGlobalObject = mainWorldGlobalObject(frame);


### PR DESCRIPTION
#### 50fdc88f3dde36d88bcdd1776e70014ad9bdc3b0
<pre>
[Site Isolation] Web Inspector: extract frame/loader ID tracking from InspectorPageAgent into IdentifierRegistry
<a href="https://bugs.webkit.org/show_bug.cgi?id=310162">https://bugs.webkit.org/show_bug.cgi?id=310162</a>

Reviewed by Qianlang Chen.

Introduce an abstract IdentifierRegistry interface and LegacyIdentifierRegistry
implementation to own the frame-to-identifier and loader-to-identifier maps that
were previously private to InspectorPageAgent. PageInspectorController creates
and owns the registry (Ref&lt;&gt;); agents that need frame lookups hold a WeakRef&lt;&gt;.

This is a pure refactoring with no behavioral change for non-SI configurations.
LegacyIdentifierRegistry preserves the existing IdentifiersFactory sequential
counter behavior (&quot;0.1&quot;, &quot;0.2&quot;, ...) identically. Under Site Isolation, a
BackendIdentifierRegistry subclass (added in a follow-up) produces deterministic
type-prefixed IDs derived from FrameIdentifier so UIProcess and WebContent
processes can independently compute matching IDs.

The frontend treats all protocol frameId and loaderId values as opaque strings.
They flow through NetworkManager._frameIdentifierMap (keyed by frameId),
Frame.loaderIdentifier, and are passed to backend commands like
Page.getResourceTree and Network.getResponseBody. No frontend changes are
needed because the string format is never parsed by the frontend -- only
compared for equality and used as map keys.

Agents that previously required InspectorPageAgent (and thus the Page domain to
be enabled) now access frame/loader IDs through the always-available registry
on PageInspectorController. This means PageRuntimeAgent::didClearWindowObjectInWorld
can now resolve frameIds even when the Page domain is disabled. This is safe
because the Runtime agent only dispatches executionContextCreated if its own
domain is enabled and a frontend dispatcher is connected. The frameId lookup
is a prerequisite for the notification, not a trigger.

No new tests: this is a mechanical extraction. All existing inspector/ layout
tests validate that the refactored ID paths produce identical behavior.

* Source/WebCore/inspector/InspectorIdentifierRegistry.h: Added.
(Inspector::IdentifierRegistry): Abstract base with frameId/loaderId/
  frameForId/assertFrame/takeFrame/takeLoader virtual interface.
(Inspector::LegacyIdentifierRegistry): Concrete impl using
  IdentifiersFactory sequential counters and bidirectional hash maps.
* Source/WebCore/inspector/InspectorIdentifierRegistry.cpp: Added.
* Source/WebCore/inspector/PageInspectorController.h:
(WebCore::PageInspectorController::identifierRegistry): Added.
* Source/WebCore/inspector/PageInspectorController.cpp:
  Create LegacyIdentifierRegistry in constructor.
* Source/WebCore/inspector/agents/InspectorPageAgent.h:
* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
  Delegate frameId/loaderId/frameForId/assertFrame/takeFrame/takeLoader
  to identifierRegistry(). Remove private hash maps.
* Source/WebCore/inspector/InspectorStyleSheet.h:
  Change from CheckedPtr&lt;InspectorPageAgent&gt; to WeakRef&lt;IdentifierRegistry&gt;
  for frame lookups (decouples from Page agent lifecycle).
* Source/WebCore/inspector/InspectorShaderProgram.h:
  Add missing #include &lt;wtf/WeakRef.h&gt;.
* Source/WebCore/Sources.txt:

Canonical link: <a href="https://commits.webkit.org/311409@main">https://commits.webkit.org/311409@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/304d93ee1179e73c9628a3d5c0243f2d94d9aab8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156780 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30116 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23299 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165603 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110862 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158651 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30252 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30119 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121436 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85290 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159738 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23656 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140785 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102104 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22712 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20923 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13375 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132391 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18614 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168086 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12247 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20234 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129551 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29718 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25001 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129660 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35141 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29641 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140408 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87445 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24483 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17212 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29350 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93366 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28874 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29104 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29000 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->