### PR TITLE
[JSC] Introduce better heuristics for rope resolution ordering

### DIFF
--- a/Source/JavaScriptCore/runtime/JSStringInlines.h
+++ b/Source/JavaScriptCore/runtime/JSStringInlines.h
@@ -407,29 +407,66 @@ inline void JSRopeString::resolveToBuffer(JSString* fiber0, JSString* fiber1, JS
 
                 auto* rope0 = static_cast<const JSRopeString*>(fiber0);
                 auto rope0Length = rope0->length();
-                if (rope0->isSubstring()) {
-                    StringView view0 = *rope0->substringBase()->valueInternal().impl();
-                    unsigned offset = rope0->substringOffset();
-                    view0.substring(offset, rope0Length).getCharacters(buffer);
-                } else
-                    resolveToBuffer(rope0->fiber0(), rope0->fiber1(), rope0->fiber2(), buffer.first(rope0Length), stackLimit);
-
-                // Both ropes are the same fibers! Then we can just copy the previously generated characters.
-                if (fiber0 == fiber1) {
-                    memcpySpan(buffer.subspan(rope0Length, rope0Length), buffer.first(rope0Length));
-                    return;
-                }
-                skip(buffer, rope0Length);
 
                 auto* rope1 = static_cast<const JSRopeString*>(fiber1);
                 auto rope1Length = rope1->length();
+
+                auto rope0Buffer = buffer.first(rope0Length);
+                auto rope1Buffer = buffer.subspan(rope0Length);
+
+                bool rope0Resolved = false;
+                if (rope0->isSubstring()) {
+                    {
+                        StringView view = *rope0->substringBase()->valueInternal().impl();
+                        unsigned offset = rope0->substringOffset();
+                        view.substring(offset, rope0Length).getCharacters(rope0Buffer);
+                    }
+                    if (rope0 == rope1) {
+                        memcpySpan(rope1Buffer, rope0Buffer);
+                        return;
+                    }
+                    rope0Resolved = true;
+                }
+
                 if (rope1->isSubstring()) {
-                    StringView view1 = *rope1->substringBase()->valueInternal().impl();
-                    unsigned offset = rope1->substringOffset();
-                    view1.substring(offset, rope1Length).getCharacters(buffer);
+                    {
+                        StringView view = *rope1->substringBase()->valueInternal().impl();
+                        unsigned offset = rope1->substringOffset();
+                        view.substring(offset, rope1Length).getCharacters(rope1Buffer);
+                    }
+                    if (rope0Resolved)
+                        return;
+                    MUST_TAIL_CALL return resolveToBuffer(rope0->fiber0(), rope0->fiber1(), rope0->fiber2(), rope0Buffer, stackLimit);
+                }
+
+                if (rope0Resolved)
+                    MUST_TAIL_CALL return resolveToBuffer(rope1->fiber0(), rope1->fiber1(), rope1->fiber2(), rope1Buffer, stackLimit);
+
+                // We resolve short rope first. Our heuristic is that longer rope can potentially have deeper nestings.
+                // Thus we would like to resolve that nestings in a tail-call form to avoid deeply nested call stacks.
+                const JSRopeString* shortRope;
+                const JSRopeString* longRope;
+                std::span<CharacterType> shortBuffer;
+                std::span<CharacterType> longBuffer;
+
+                if (rope0Length < rope1Length) {
+                    shortRope = rope0;
+                    longRope = rope1;
+                    shortBuffer = rope0Buffer;
+                    longBuffer = rope1Buffer;
+                } else {
+                    shortRope = rope1;
+                    longRope = rope0;
+                    shortBuffer = rope1Buffer;
+                    longBuffer = rope0Buffer;
+                }
+
+                resolveToBuffer(shortRope->fiber0(), shortRope->fiber1(), shortRope->fiber2(), shortBuffer, stackLimit);
+                if (rope0 == rope1) {
+                    memcpySpan(longBuffer, shortBuffer);
                     return;
                 }
-                MUST_TAIL_CALL return resolveToBuffer(rope1->fiber0(), rope1->fiber1(), rope1->fiber2(), buffer.first(rope1Length), stackLimit);
+                MUST_TAIL_CALL return resolveToBuffer(longRope->fiber0(), longRope->fiber1(), longRope->fiber2(), longBuffer, stackLimit);
             }
 
             auto* rope0 = static_cast<const JSRopeString*>(fiber0);


### PR DESCRIPTION
#### 313be2bb1cf5639434e48b7147e8e4d65e63cdb2
<pre>
[JSC] Introduce better heuristics for rope resolution ordering
<a href="https://bugs.webkit.org/show_bug.cgi?id=310170">https://bugs.webkit.org/show_bug.cgi?id=310170</a>
<a href="https://rdar.apple.com/172810886">rdar://172810886</a>

Reviewed by Dan Hecht.

It is common that we encounter a binary string rope and both sides have
ropes. In this case, ordering of resolution matters much for performance:
we can resolve one side in a nested recursion, and we can resolve the other
side in a self-tail-call, which gets converted to a loop. If we successfully
select deeper nesting rope for the tail-call side, we can reduce callstack
heights, making resolution faster.

While we cannot easily determine which side of rope is more deeply nesting,
we can use length of each rope as a heuristics: resolving shorter one first
and resolving longer one in a tail-call form.

* Source/JavaScriptCore/runtime/JSStringInlines.h:
(JSC::JSRopeString::resolveToBuffer):

Canonical link: <a href="https://commits.webkit.org/309484@main">https://commits.webkit.org/309484@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba12f99bfa8ff1b143bc3a5ed1e83ea569c24bca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150794 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23552 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17123 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159517 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104228 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/187a5b97-2038-455b-8174-a562f3a3fca3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23984 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23758 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116394 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 6 flakes 2 failures; Uploaded test results; 2 flakes; Passed layout tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82646 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5f837cb4-6c38-4cce-b774-d4be05779cdd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153754 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18501 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135282 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97122 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1b7ab3cb-e368-414c-a5ee-ac7b9f0cd147) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17598 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15548 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7364 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/142777 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127212 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13206 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161991 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/11592 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5111 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14763 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124397 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23356 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19595 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124593 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23345 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135001 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79731 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23174 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19659 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11763 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/182318 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22956 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86756 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46584 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22668 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22820 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22722 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->