### PR TITLE
didFinishInsertingNode should only be called for connected nodes

### DIFF
--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -374,6 +374,7 @@ static ALWAYS_INLINE void executeNodeInsertionWithScriptAssertion(ContainerNode&
         ChildListMutationScope(containerNode).childAdded(child);
         notifyChildNodeInserted(containerNode, child, postInsertionNotificationTargets);
     }
+    ASSERT(postInsertionNotificationTargets.isEmpty() || child.isConnected());
 
     // FIXME: Move childrenChanged into ScriptDisallowedScope block.
     containerNode.childrenChanged(childChange);
@@ -411,6 +412,7 @@ static ALWAYS_INLINE void executeNodeInsertionWithScriptAssertion(ContainerNode&
             notifyChildNodeInserted(containerNode, child, postInsertionNotificationTargets);
         }
     }
+    ASSERT(postInsertionNotificationTargets.isEmpty() || children[0]->isConnected());
 
     // FIXME: Move childrenChanged into ScriptDisallowedScope block.
     containerNode.childrenChanged(childChange);

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -719,7 +719,7 @@ Node::InsertedIntoAncestorResult HTMLAnchorElement::insertedIntoAncestor(Inserti
 {
     HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
     protect(document())->processInternalResourceLinks(this);
-    if (document().settings().speculationRulesPrefetchEnabled())
+    if (insertionType.connectedToDocument && document().settings().speculationRulesPrefetchEnabled())
         return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
     return InsertedIntoAncestorResult::Done;
 }

--- a/Source/WebCore/html/HTMLSlotElement.cpp
+++ b/Source/WebCore/html/HTMLSlotElement.cpp
@@ -70,6 +70,8 @@ HTMLSlotElement::InsertedIntoAncestorResult HTMLSlotElement::insertedIntoAncesto
             shadowRoot->addSlotElementByName(attributeWithoutSynchronization(nameAttr), *this);
     }
 
+    if (!insertionType.connectedToDocument)
+        return InsertedIntoAncestorResult::Done;
     return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
 }
 


### PR DESCRIPTION
#### 8beb78405804b3d60c4a04c38ba550e3c73e8978
<pre>
didFinishInsertingNode should only be called for connected nodes
<a href="https://bugs.webkit.org/show_bug.cgi?id=310171">https://bugs.webkit.org/show_bug.cgi?id=310171</a>

Reviewed by Anne van Kesteren.

This PR aligns the semantics of didFinishInsertingNode with &quot;post-connection steps&quot; [1]
by avoid calling it on a disconnected node.

No new tests since there should be no behavioral changes.

[1] <a href="https://dom.spec.whatwg.org/#concept-node-post-connection-ext">https://dom.spec.whatwg.org/#concept-node-post-connection-ext</a>

* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::executeNodeInsertionWithScriptAssertion):
* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::HTMLAnchorElement::insertedIntoAncestor):
* Source/WebCore/html/HTMLSlotElement.cpp:
(WebCore::HTMLSlotElement::insertedIntoAncestor):

Canonical link: <a href="https://commits.webkit.org/309482@main">https://commits.webkit.org/309482@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2bfcdcfaa1c57d94a3846d17ff1c8ba835ce29a6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150786 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23544 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17115 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159508 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104220 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2293bdf1-2656-4ab4-9db7-4cff3063d15d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152659 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23976 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23750 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116381 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82639 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/994795a1-0a11-4fbc-a9ae-34b2e7b8c6c7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153746 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18491 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135269 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97109 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2d2967dc-a2a7-482c-970f-3e290cec7999) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17588 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15538 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7356 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127202 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13193 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161982 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5103 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14750 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124380 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23348 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19585 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124578 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23337 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134988 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79723 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23173 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19646 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11750 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22948 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86748 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22660 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22812 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22714 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->