### PR TITLE
Simplify MediaStreamTrackDataHolder constructor

### DIFF
--- a/Source/WebCore/platform/mediastream/MediaStreamTrackDataHolder.cpp
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackDataHolder.cpp
@@ -26,6 +26,7 @@
 #include "MediaStreamTrackDataHolder.h"
 #include <wtf/CheckedRef.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/UUID.h>
 
 #if ENABLE(MEDIA_STREAM)
 
@@ -81,27 +82,32 @@ private:
     std::unique_ptr<PreventSourceFromEndingObserver> m_observer;
 };
 
-MediaStreamTrackDataHolder::MediaStreamTrackDataHolder(String&& trackId, String&& label, RealtimeMediaSource::Type type, CaptureDevice::DeviceType deviceType, bool isEnabled, bool isEnded, MediaStreamTrackHintValue contentHint, bool isProducingData, bool isMuted, bool isInterrupted, RealtimeMediaSourceSettings settings, RealtimeMediaSourceCapabilities capabilities, size_t settingsCapabilitiesUpdateCount, Ref<RealtimeMediaSource>&& source)
-    : trackId(WTF::move(trackId))
-    , label(WTF::move(label))
-    , type(type)
-    , deviceType(deviceType)
-    , isEnabled(isEnabled)
-    , isEnded(isEnded)
-    , contentHint(contentHint)
-    , isProducingData(isProducingData)
-    , isMuted(isMuted)
-    , isInterrupted(isInterrupted)
-    , settings(WTF::move(settings))
-    , capabilities(WTF::move(capabilities))
-    , settingsCapabilitiesUpdateCount(settingsCapabilitiesUpdateCount)
-    , source(source.get())
-    , preventSourceFromEndingObserverWrapper(PreventSourceFromEndingObserverWrapper::create(WTF::move(source)))
+MediaStreamTrackDataHolder::MediaStreamTrackDataHolder(MediaStreamTrackData&& data, Ref<RealtimeMediaSource>&& source)
+    : m_data(WTF::move(data))
+    , m_source(WTF::move(source))
+    , m_preventSourceFromEndingObserverWrapper(PreventSourceFromEndingObserverWrapper::create(m_source.get()))
 {
 }
 
-MediaStreamTrackDataHolder::~MediaStreamTrackDataHolder()
+MediaStreamTrackDataHolder::~MediaStreamTrackDataHolder() = default;
+
+MediaStreamTrackData MediaStreamTrackData::isolatedCopy(ShouldUpdateId shouldUpdateId) const
 {
+    return {
+        .trackId = shouldUpdateId == ShouldUpdateId::Yes ? createVersion4UUIDString() : trackId.isolatedCopy(),
+        .label = label.isolatedCopy(),
+        .type = type,
+        .deviceType = deviceType,
+        .isEnabled = isEnabled,
+        .isEnded = isEnded,
+        .contentHint = contentHint,
+        .isProducingData = isProducingData,
+        .isMuted = isMuted,
+        .isInterrupted = isInterrupted,
+        .settings = settings.isolatedCopy(),
+        .capabilities = capabilities.isolatedCopy(),
+        .settingsCapabilitiesUpdateCount = settingsCapabilitiesUpdateCount
+    };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackDataHolder.h
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackDataHolder.h
@@ -35,14 +35,8 @@ namespace WebCore {
 
 class PreventSourceFromEndingObserverWrapper;
 
-struct MediaStreamTrackDataHolder {
-    WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(MediaStreamTrackDataHolder);
-
-    WEBCORE_EXPORT MediaStreamTrackDataHolder(String&& trackId, String&& label, RealtimeMediaSource::Type, CaptureDevice::DeviceType, bool isEnabled, bool isEnded, MediaStreamTrackHintValue, bool isProducingData, bool isMuted, bool isInterrupted, RealtimeMediaSourceSettings, RealtimeMediaSourceCapabilities, size_t, Ref<RealtimeMediaSource>&&);
-    WEBCORE_EXPORT ~MediaStreamTrackDataHolder();
-
-    MediaStreamTrackDataHolder(const MediaStreamTrackDataHolder &) = delete;
-    MediaStreamTrackDataHolder &operator=(const MediaStreamTrackDataHolder &) = delete;
+struct MediaStreamTrackData {
+    WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(MediaStreamTrackData);
 
     String trackId;
     String label;
@@ -57,9 +51,27 @@ struct MediaStreamTrackDataHolder {
     RealtimeMediaSourceSettings settings;
     RealtimeMediaSourceCapabilities capabilities;
     size_t settingsCapabilitiesUpdateCount { 0 };
-    Ref<RealtimeMediaSource> source;
 
-    Ref<PreventSourceFromEndingObserverWrapper> preventSourceFromEndingObserverWrapper;
+    enum class ShouldUpdateId : bool { No, Yes };
+    MediaStreamTrackData isolatedCopy(ShouldUpdateId) const;
+};
+
+class MediaStreamTrackDataHolder {
+    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(MediaStreamTrackDataHolder);
+public:
+    WEBCORE_EXPORT MediaStreamTrackDataHolder(MediaStreamTrackData&&, Ref<RealtimeMediaSource>&&);
+    WEBCORE_EXPORT ~MediaStreamTrackDataHolder();
+
+    MediaStreamTrackDataHolder(const MediaStreamTrackDataHolder&) = delete;
+    MediaStreamTrackDataHolder& operator=(const MediaStreamTrackDataHolder&) = delete;
+
+    MediaStreamTrackData& data() { return m_data; }
+    Ref<RealtimeMediaSource>& source() { return m_source; }
+
+private:
+    MediaStreamTrackData m_data;
+    Ref<RealtimeMediaSource> m_source;
+    const Ref<PreventSourceFromEndingObserverWrapper> m_preventSourceFromEndingObserverWrapper;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
@@ -291,24 +291,34 @@ void MediaStreamTrackPrivateSourceObserver::applyConstraints(const MediaConstrai
     });
 }
 
+static MediaStreamTrackData fromIdAndSource(String&& id, RealtimeMediaSource& source)
+{
+    return  {
+        .trackId = WTF::move(id),
+        .label = source.name(),
+        .type = source.type(),
+        .deviceType = source.deviceType(),
+        .isEnabled = true,
+        .isEnded = false,
+        .contentHint = MediaStreamTrackHintValue::Empty,
+        .isProducingData = source.isProducingData(),
+        .isMuted = source.muted(),
+        .isInterrupted = source.interrupted(),
+        .settings = source.settings(),
+        .capabilities = source.capabilities(),
+        .settingsCapabilitiesUpdateCount = source.settingsCapabilitiesUpdateCount()
+    };
+}
+
 MediaStreamTrackPrivate::MediaStreamTrackPrivate(Ref<const Logger>&& trackLogger, Ref<RealtimeMediaSource>&& source, String&& id, std::function<void(Function<void()>&&)>&& postTask)
     : m_sourceObserver(MediaStreamTrackPrivateSourceObserver::create(WTF::move(source), WTF::move(postTask)))
-    , m_id(WTF::move(id))
-    , m_label(m_sourceObserver->source().name())
-    , m_type(m_sourceObserver->source().type())
-    , m_deviceType(m_sourceObserver->source().deviceType())
+    , m_data(fromIdAndSource(WTF::move(id), m_sourceObserver->source()))
     , m_isCaptureTrack(m_sourceObserver->source().isCaptureSource())
     , m_captureDidFail(m_sourceObserver->source().captureDidFail())
     , m_logger(WTF::move(trackLogger))
 #if !RELEASE_LOG_DISABLED
     , m_logIdentifier(uniqueLogIdentifier())
 #endif
-    , m_isProducingData(m_sourceObserver->source().isProducingData())
-    , m_isMuted(m_sourceObserver->source().muted())
-    , m_isInterrupted(m_sourceObserver->source().interrupted())
-    , m_settings(m_sourceObserver->source().settings())
-    , m_capabilities(m_sourceObserver->source().capabilities())
-    , m_settingsCapabilitiesUpdateCount(m_sourceObserver->source().settingsCapabilitiesUpdateCount())
 #if ASSERT_ENABLED
     , m_creationThreadId(isMainThread() ? 0 : Thread::currentSingleton().uid())
 #endif
@@ -324,26 +334,14 @@ MediaStreamTrackPrivate::MediaStreamTrackPrivate(Ref<const Logger>&& trackLogger
 }
 
 MediaStreamTrackPrivate::MediaStreamTrackPrivate(Ref<const Logger>&& logger, UniqueRef<MediaStreamTrackDataHolder>&& dataHolder, std::function<void(Function<void()>&&)>&& postTask)
-    : m_sourceObserver(MediaStreamTrackPrivateSourceObserver::create(WTF::move(dataHolder->source), WTF::move(postTask)))
-    , m_id(WTF::move(dataHolder->trackId))
-    , m_label(WTF::move(dataHolder->label))
-    , m_type(dataHolder->type)
-    , m_deviceType(dataHolder->deviceType)
+    : m_sourceObserver(MediaStreamTrackPrivateSourceObserver::create(WTF::move(dataHolder->source()), WTF::move(postTask)))
+    , m_data(WTF::move(dataHolder->data()))
     , m_isCaptureTrack(false)
-    , m_isEnabled(dataHolder->isEnabled)
-    , m_isEnded(dataHolder->isEnded)
     , m_captureDidFail(false)
-    , m_contentHint(dataHolder->contentHint)
     , m_logger(WTF::move(logger))
 #if !RELEASE_LOG_DISABLED
     , m_logIdentifier(uniqueLogIdentifier())
 #endif
-    , m_isProducingData(dataHolder->isProducingData)
-    , m_isMuted(dataHolder->isMuted)
-    , m_isInterrupted(dataHolder->isInterrupted)
-    , m_settings(WTF::move(dataHolder->settings))
-    , m_capabilities(WTF::move(dataHolder->capabilities))
-    , m_settingsCapabilitiesUpdateCount(dataHolder->settingsCapabilitiesUpdateCount)
 #if ASSERT_ENABLED
     , m_creationThreadId(isMainThread() ? 0 : Thread::currentSingleton().uid())
 #endif
@@ -376,7 +374,7 @@ void MediaStreamTrackPrivate::updateLabelIfRemoteTrack()
     if (!isMainThread() || !(protect(source())->isIncomingAudioSource() || protect(source())->isIncomingVideoSource()))
         return;
 
-    m_label = makeString(m_label, " - "_s, m_id);
+    m_data.label = makeString(m_data.label, " - "_s, m_data.trackId);
 }
 
 
@@ -402,7 +400,7 @@ void MediaStreamTrackPrivate::removeObserver(MediaStreamTrackPrivateObserver& ob
 
 void MediaStreamTrackPrivate::setContentHint(MediaStreamTrackHintValue hintValue)
 {
-    m_contentHint = hintValue;
+    m_data.contentHint = hintValue;
 }
 
 void MediaStreamTrackPrivate::startProducingData()
@@ -431,7 +429,7 @@ void MediaStreamTrackPrivate::setIsInBackground(bool value)
 void MediaStreamTrackPrivate::setMuted(bool muted)
 {
     ASSERT(isOnCreationThread());
-    m_isMuted = muted;
+    m_data.isMuted = muted;
 
     m_sourceObserver->setMuted(muted);
 }
@@ -439,13 +437,13 @@ void MediaStreamTrackPrivate::setMuted(bool muted)
 void MediaStreamTrackPrivate::setEnabled(bool enabled)
 {
     ASSERT(isOnCreationThread());
-    if (m_isEnabled == enabled)
+    if (m_data.isEnabled == enabled)
         return;
 
     ALWAYS_LOG(LOGIDENTIFIER, enabled);
 
     // Always update the enabled state regardless of the track being ended.
-    m_isEnabled = enabled;
+    m_data.isEnabled = enabled;
 
     forEachObserver([this](auto& observer) {
         observer.trackEnabledChanged(*this);
@@ -455,15 +453,15 @@ void MediaStreamTrackPrivate::setEnabled(bool enabled)
 void MediaStreamTrackPrivate::endTrack()
 {
     ASSERT(isOnCreationThread());
-    if (m_isEnded)
+    if (m_data.isEnded)
         return;
 
     ALWAYS_LOG(LOGIDENTIFIER);
 
-    // Set m_isEnded to true before telling the source it can stop, so if this is the
+    // Set m_data.isEnded to true before telling the source it can stop, so if this is the
     // only track using the source and it does stop, we will only call each observer's
     // trackEnded method once.
-    m_isEnded = true;
+    m_data.isEnded = true;
     updateReadyState();
 
     m_sourceObserver->requestToEnd();
@@ -486,7 +484,7 @@ Ref<MediaStreamTrackPrivate> MediaStreamTrackPrivate::clone()
     clonedMediaStreamTrackPrivate->m_captureDidFail = this->m_captureDidFail;
     clonedMediaStreamTrackPrivate->updateReadyState();
 
-    if (m_isProducingData && !m_isMuted && !m_isInterrupted)
+    if (m_data.isProducingData && !m_data.isMuted && !m_data.isInterrupted)
         clonedMediaStreamTrackPrivate->startProducingData();
 
     return clonedMediaStreamTrackPrivate;
@@ -538,8 +536,8 @@ void MediaStreamTrackPrivate::applyConstraints(const MediaConstraints& constrain
 {
     MediaStreamTrackPrivateSourceObserver::ApplyConstraintsHandler callback = [weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler)] (auto&& result, auto&& settings, auto&& capabilities) mutable {
         if (RefPtr protectedThis = weakThis.get()) {
-            protectedThis->m_settings = WTF::move(settings);
-            protectedThis->m_capabilities = WTF::move(capabilities);
+            protectedThis->m_data.settings = WTF::move(settings);
+            protectedThis->m_data.capabilities = WTF::move(capabilities);
         }
         completionHandler(WTF::move(result));
     };
@@ -567,7 +565,7 @@ void MediaStreamTrackPrivate::sourceStarted()
     ASSERT(isOnCreationThread());
     ALWAYS_LOG(LOGIDENTIFIER);
 
-    m_isProducingData = true;
+    m_data.isProducingData = true;
     forEachObserver([this](auto& observer) {
         observer.trackStarted(*this);
     });
@@ -576,14 +574,14 @@ void MediaStreamTrackPrivate::sourceStarted()
 void MediaStreamTrackPrivate::sourceStopped(bool captureDidFail)
 {
     ASSERT(isOnCreationThread());
-    m_isProducingData = false;
+    m_data.isProducingData = false;
 
-    if (m_isEnded)
+    if (m_data.isEnded)
         return;
 
     ALWAYS_LOG(LOGIDENTIFIER);
 
-    m_isEnded = true;
+    m_data.isEnded = true;
     m_captureDidFail = captureDidFail;
     updateReadyState();
 
@@ -597,8 +595,8 @@ void MediaStreamTrackPrivate::sourceMutedChanged(bool interrupted, bool muted)
     ASSERT(isOnCreationThread());
     ALWAYS_LOG(LOGIDENTIFIER);
 
-    m_isInterrupted = interrupted;
-    m_isMuted = muted;
+    m_data.isInterrupted = interrupted;
+    m_data.isMuted = muted;
     forEachObserver([this](auto& observer) {
         observer.trackMutedChanged(*this);
     });
@@ -609,9 +607,9 @@ void MediaStreamTrackPrivate::sourceSettingsChanged(RealtimeMediaSourceSettings&
     ASSERT(isOnCreationThread());
     ALWAYS_LOG(LOGIDENTIFIER);
 
-    m_settings = WTF::move(settings);
-    m_capabilities = WTF::move(capabilities);
-    m_settingsCapabilitiesUpdateCount = settingsCapabilitiesUpdateCount;
+    m_data.settings = WTF::move(settings);
+    m_data.capabilities = WTF::move(capabilities);
+    m_data.settingsCapabilitiesUpdateCount = settingsCapabilitiesUpdateCount;
     forEachObserver([this](auto& observer) {
         observer.trackSettingsChanged(*this);
     });
@@ -622,10 +620,10 @@ void MediaStreamTrackPrivate::sourceConfigurationChanged(String&& label, Realtim
     ASSERT(isOnCreationThread());
     ALWAYS_LOG(LOGIDENTIFIER);
 
-    m_label = WTF::move(label);
-    m_settings = WTF::move(settings);
-    m_capabilities = WTF::move(capabilities);
-    m_settingsCapabilitiesUpdateCount = settingsCapabilitiesUpdateCount;
+    m_data.label = WTF::move(label);
+    m_data.settings = WTF::move(settings);
+    m_data.capabilities = WTF::move(capabilities);
+    m_data.settingsCapabilitiesUpdateCount = settingsCapabilitiesUpdateCount;
     forEachObserver([this](auto& observer) {
         observer.trackConfigurationChanged(*this);
     });
@@ -646,7 +644,7 @@ void MediaStreamTrackPrivate::updateReadyState()
     ASSERT(isOnCreationThread());
     ReadyState state = ReadyState::None;
 
-    if (m_isEnded)
+    if (m_data.isEnded)
         state = ReadyState::Ended;
     else if (m_hasStartedProducingData)
         state = ReadyState::Live;
@@ -664,21 +662,7 @@ void MediaStreamTrackPrivate::updateReadyState()
 
 UniqueRef<MediaStreamTrackDataHolder> MediaStreamTrackPrivate::toDataHolder(ShouldClone shouldClone)
 {
-    return makeUniqueRef<MediaStreamTrackDataHolder>(
-        shouldClone == ShouldClone::Yes ? createVersion4UUIDString() : m_id.isolatedCopy(),
-        m_label.isolatedCopy(),
-        m_type,
-        m_deviceType,
-        m_isEnabled,
-        m_isEnded,
-        m_contentHint,
-        m_isProducingData,
-        m_isMuted,
-        m_isInterrupted,
-        m_settings.isolatedCopy(),
-        m_capabilities.isolatedCopy(),
-        m_settingsCapabilitiesUpdateCount,
-        shouldClone == ShouldClone::Yes ? m_sourceObserver->source().clone() : Ref { m_sourceObserver->source() });
+    return makeUniqueRef<MediaStreamTrackDataHolder>(m_data.isolatedCopy(shouldClone), shouldClone == ShouldClone::Yes ? m_sourceObserver->source().clone() : Ref { m_sourceObserver->source() });
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h
@@ -29,6 +29,7 @@
 
 #if ENABLE(MEDIA_STREAM)
 
+#include <WebCore/MediaStreamTrackDataHolder.h>
 #include <WebCore/MediaStreamTrackHintValue.h>
 #include <WebCore/RealtimeMediaSource.h>
 #include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
@@ -45,7 +46,7 @@ class MediaStreamTrackPrivateSourceObserver;
 class RealtimeMediaSourceCapabilities;
 class WebAudioSourceProvider;
 
-struct MediaStreamTrackDataHolder;
+class MediaStreamTrackDataHolder;
 
 class MediaStreamTrackPrivateObserver : public AbstractRefCountedAndCanMakeWeakPtr<MediaStreamTrackPrivateObserver> {
 public:
@@ -102,32 +103,32 @@ public:
 
     WEBCORE_EXPORT virtual ~MediaStreamTrackPrivate();
 
-    const String& id() const LIFETIME_BOUND { return m_id; }
-    const String& label() const LIFETIME_BOUND { return m_label; }
+    const String& id() const LIFETIME_BOUND { return m_data.trackId; }
+    const String& label() const LIFETIME_BOUND { return m_data.label; }
 
     bool isActive() const { return enabled() && !ended() && !muted(); }
 
-    bool ended() const { return m_isEnded; }
+    bool ended() const { return m_data.isEnded; }
 
-    MediaStreamTrackHintValue contentHint() const { return m_contentHint; }
+    MediaStreamTrackHintValue contentHint() const { return m_data.contentHint; }
     void NODELETE setContentHint(MediaStreamTrackHintValue);
     
     void startProducingData();
     void stopProducingData();
-    bool isProducingData() const { return m_isProducingData; }
+    bool isProducingData() const { return m_data.isProducingData; }
 
     void dataFlowStarted();
 
-    bool muted() const { return m_isMuted; }
+    bool muted() const { return m_data.isMuted; }
     void setMuted(bool);
-    bool interrupted() const { return m_isInterrupted; }
+    bool interrupted() const { return m_data.isInterrupted; }
     bool captureDidFail() const { return m_captureDidFail; }
 
     void setIsInBackground(bool);
 
     bool isCaptureTrack() const { return m_isCaptureTrack; }
 
-    bool enabled() const { return m_isEnabled; }
+    bool enabled() const { return m_data.isEnabled; }
     void setEnabled(bool);
 
     Ref<MediaStreamTrackPrivate> clone();
@@ -137,10 +138,10 @@ public:
     RealtimeMediaSource& NODELETE sourceForProcessor();
     bool NODELETE hasSource(const RealtimeMediaSource*) const;
 
-    RealtimeMediaSource::Type type() const { return m_type; }
-    CaptureDevice::DeviceType deviceType() const { return m_deviceType; }
-    bool isVideo() const { return m_type == RealtimeMediaSource::Type::Video; }
-    bool isAudio() const { return m_type == RealtimeMediaSource::Type::Audio; }
+    RealtimeMediaSource::Type type() const { return m_data.type; }
+    CaptureDevice::DeviceType deviceType() const { return m_data.deviceType; }
+    bool isVideo() const { return m_data.type == RealtimeMediaSource::Type::Video; }
+    bool isAudio() const { return m_data.type == RealtimeMediaSource::Type::Audio; }
 
     void endTrack();
 
@@ -148,8 +149,8 @@ public:
     void removeObserver(MediaStreamTrackPrivateObserver&);
     bool hasObserver(MediaStreamTrackPrivateObserver& observer) const { return m_observers.contains(observer); }
 
-    const RealtimeMediaSourceSettings& settings() const LIFETIME_BOUND { return m_settings; }
-    const RealtimeMediaSourceCapabilities& capabilities() const LIFETIME_BOUND { return m_capabilities; }
+    const RealtimeMediaSourceSettings& settings() const LIFETIME_BOUND { return m_data.settings; }
+    const RealtimeMediaSourceCapabilities& capabilities() const LIFETIME_BOUND { return m_data.capabilities; }
 
     Ref<RealtimeMediaSource::TakePhotoNativePromise> takePhoto(PhotoSettings&&);
     Ref<RealtimeMediaSource::PhotoCapabilitiesNativePromise> getPhotoCapabilities();
@@ -166,7 +167,7 @@ public:
     enum class ReadyState { None, Live, Ended };
     ReadyState readyState() const { return m_readyState; }
 
-    void setIdForTesting(String&& id) { m_id = WTF::move(id); }
+    void setIdForTesting(String&& id) { m_data.trackId = WTF::move(id); }
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger; }
@@ -176,16 +177,16 @@ public:
     friend class MediaStreamTrackPrivateSourceObserver;
     friend class MediaStreamTrackPrivateSourceObserverSourceProxy;
 
-    void initializeSettings(RealtimeMediaSourceSettings&& settings) { m_settings = WTF::move(settings); }
-    void initializeCapabilities(RealtimeMediaSourceCapabilities&& capabilities) { m_capabilities = WTF::move(capabilities); }
+    void initializeSettings(RealtimeMediaSourceSettings&& settings) { m_data.settings = WTF::move(settings); }
+    void initializeCapabilities(RealtimeMediaSourceCapabilities&& capabilities) { m_data.capabilities = WTF::move(capabilities); }
 
-    enum class ShouldClone : bool { No, Yes };
+    using ShouldClone = MediaStreamTrackData::ShouldUpdateId;
     UniqueRef<MediaStreamTrackDataHolder> toDataHolder(ShouldClone = ShouldClone::No);
 
     void updateLabelIfRemoteTrack();
 
     MediaStreamTrackPrivateSourceObserver& sourceObserver() { return m_sourceObserver; }
-    size_t settingsCapabilitiesUpdateCount() const { return m_settingsCapabilitiesUpdateCount; }
+    size_t settingsCapabilitiesUpdateCount() const { return m_data.settingsCapabilitiesUpdateCount; }
 
 private:
     MediaStreamTrackPrivate(Ref<const Logger>&&, Ref<RealtimeMediaSource>&&, String&& id, std::function<void(Function<void()>&&)>&&);
@@ -217,27 +218,15 @@ private:
     WeakHashSet<MediaStreamTrackPrivateObserver> m_observers;
     const Ref<MediaStreamTrackPrivateSourceObserver> m_sourceObserver;
 
-    String m_id;
-    String m_label;
-    RealtimeMediaSource::Type m_type;
-    CaptureDevice::DeviceType m_deviceType;
+    MediaStreamTrackData m_data;
     ReadyState m_readyState { ReadyState::None };
     bool m_isCaptureTrack { false };
-    bool m_isEnabled { true };
-    bool m_isEnded { false };
     bool m_captureDidFail { false };
     bool m_hasStartedProducingData { false };
-    MediaStreamTrackHintValue m_contentHint { MediaStreamTrackHintValue::Empty };
     const Ref<const Logger> m_logger;
 #if !RELEASE_LOG_DISABLED
     const uint64_t m_logIdentifier;
 #endif
-    bool m_isProducingData { false };
-    bool m_isMuted { false };
-    bool m_isInterrupted { false };
-    RealtimeMediaSourceSettings m_settings;
-    RealtimeMediaSourceCapabilities m_capabilities;
-    size_t m_settingsCapabilitiesUpdateCount { 0 };
 #if ASSERT_ENABLED
     uint32_t m_creationThreadId { 0 };
 #endif


### PR DESCRIPTION
#### d8261f2794114c8f77dc6831b4235594b622c382
<pre>
Simplify MediaStreamTrackDataHolder constructor
<a href="https://rdar.apple.com/172811901">rdar://172811901</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=310172">https://bugs.webkit.org/show_bug.cgi?id=310172</a>

Reviewed by Jean-Yves Avenard.

As a follow-up to <a href="https://commits.webkit.org/309458@main">https://commits.webkit.org/309458@main</a>, we introduce MediaStreamTrackData that is owned by MediaStreamTrackDataHolder.
This helps constructing MediaStreamTrackDataHolder by using default MediaStreamTrackData constructors.
We use MediaStreamTrackData in MediaStreamTrackPrivate as well.
MediaStreamTrackDataHolder holds a source directly as the source handling is different in MediaStreamTrackDataHolder and MediaStreamTrackPrivate.
This is a refactoring, no behavior change.

Covered by existing tests.

Canonical link: <a href="https://commits.webkit.org/309606@main">https://commits.webkit.org/309606@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/323a5a8da07dbf4d0c618e6e3745310063ee202d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150812 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23570 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17141 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159535 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104246 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/32f1378c-0658-4c8c-b1c5-39be374a1b00) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152685 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24002 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23777 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116405 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82651 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c03af78f-873f-4fbd-a929-ac78822c52b8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153772 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18517 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135296 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97133 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/48eaec18-de1d-4219-a956-c95e04f1d7e8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17614 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15563 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7382 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127228 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13220 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162009 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5129 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14777 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124407 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23374 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19610 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124603 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33884 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23363 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135015 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79751 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19673 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11777 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22974 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86774 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22686 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22838 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22740 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->