### PR TITLE
[JSC] Avoid DUCET table-based comparison for common prefix

### DIFF
--- a/Source/JavaScriptCore/runtime/IntlObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/IntlObjectInlines.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2016 Yusuke Suzuki <yusuke.suzuki@sslab.ics.keio.ac.jp>
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2026 Apple Inc. All rights reserved.
+ * Copyright (C) 2019 the V8 project authors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -222,12 +223,12 @@ ALWAYS_INLINE bool followedByNonLatinCharacter(std::span<const Latin1Character>,
 }
 
 template<typename CharacterType1, typename CharacterType2>
-UCollationResult compareASCIIWithUCADUCETLevel3(std::span<const CharacterType1> characters1, std::span<const CharacterType2> characters2)
+UCollationResult compareASCIIWithUCADUCETLevel3(std::span<const CharacterType1> characters1, std::span<const CharacterType2> characters2, size_t startPosition)
 {
     auto* data1 = characters1.data();
     auto* data2 = characters2.data();
     ASSERT(characters1.size() == characters2.size());
-    for (size_t position = 0; position < characters1.size(); ++position) {
+    for (size_t position = startPosition; position < characters1.size(); ++position) {
         auto lhs = data1[position];
         auto rhs = data2[position];
         uint8_t leftWeight = ducetLevel3Weights[lhs];
@@ -242,15 +243,22 @@ UCollationResult compareASCIIWithUCADUCETLevel3(std::span<const CharacterType1> 
 template<typename CharacterType1, typename CharacterType2>
 inline std::optional<UCollationResult> compareASCIIWithUCADUCET(std::span<const CharacterType1> characters1, std::span<const CharacterType2> characters2)
 {
-    if (characters1.size() == characters2.size()) {
-        if (equal(characters1.data(), characters2))
-            return UCOL_EQUAL;
-    }
-
     auto* data1 = characters1.data();
     auto* data2 = characters2.data();
     size_t commonLength = std::min(characters1.size(), characters2.size());
-    for (unsigned position = 0; position < commonLength; ++position) {
+
+    size_t prefixSkip = 0;
+    while (prefixSkip < commonLength) {
+        auto lhs = data1[prefixSkip];
+        // Restrict fast prefix skipping to standard ASCII characters. We cannot
+        // skip non-ASCII characters because they could form a contraction with the
+        // following differing character.
+        if (lhs != data2[prefixSkip] || !isASCII(lhs))
+            break;
+        ++prefixSkip;
+    }
+
+    for (size_t position = prefixSkip; position < commonLength; ++position) {
         auto lhs = data1[position];
         auto rhs = data2[position];
 
@@ -270,7 +278,7 @@ inline std::optional<UCollationResult> compareASCIIWithUCADUCET(std::span<const 
     }
 
     if (characters1.size() == characters2.size())
-        return compareASCIIWithUCADUCETLevel3(characters1, characters2);
+        return compareASCIIWithUCADUCETLevel3(characters1, characters2, prefixSkip);
 
     // If the next character is valid, then we do not need to look into the rest of characters.
     if (characters1.size() > characters2.size()) {


### PR DESCRIPTION
#### 94e8cd3fac6929251c25ee1d09a23b621fba97b4
<pre>
[JSC] Avoid DUCET table-based comparison for common prefix
<a href="https://bugs.webkit.org/show_bug.cgi?id=310173">https://bugs.webkit.org/show_bug.cgi?id=310173</a>
<a href="https://rdar.apple.com/172815188">rdar://172815188</a>

Reviewed by NOBODY (OOPS!).

This patch integrates V8&apos;s recent optimization which skips DUCET
table-based comparison for the common prefix of the strings.

* Source/JavaScriptCore/runtime/IntlObjectInlines.h:
(JSC::compareASCIIWithUCADUCETLevel3):
(JSC::compareASCIIWithUCADUCET):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94e8cd3fac6929251c25ee1d09a23b621fba97b4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150800 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23558 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17129 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159523 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/104234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23990 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23764 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116396 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/104234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153760 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18506 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/135286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97124 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/17603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/15553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7370 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/142783 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/127217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13210 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161997 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/11598 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/5117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14767 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124398 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23362 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19600 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124594 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23351 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135005 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/79737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19662 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/11767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/182324 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22962 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/86762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/46586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22674 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22826 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22728 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->