### PR TITLE
[css-values-5 attr] Modernize CSSAttrValue type

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1062,7 +1062,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     crypto/parameters/CryptoAlgorithmRsaPssParamsInit.h
     crypto/parameters/CryptoAlgorithmX25519ParamsInit.h
 
-    css/CSSAttrValue.h
+    css/CSSAttrFunctionValue.h
     css/CSSColorValue.h
     css/CSSComputedStyleDeclaration.h
     css/CSSConditionRule.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -872,7 +872,7 @@ crypto/keys/CryptoKeyRSA.cpp
 crypto/keys/CryptoKeyRSAComponents.cpp
 crypto/keys/CryptoKeyRaw.cpp
 css/CSSAppleColorFilterValue.cpp
-css/CSSAttrValue.cpp
+css/CSSAttrFunctionValue.cpp
 css/CSSBackgroundRepeatValue.cpp
 css/CSSBasicShapeValue.cpp
 css/CSSBorderImage.cpp

--- a/Source/WebCore/css/CSSAttrFunctionValue.cpp
+++ b/Source/WebCore/css/CSSAttrFunctionValue.cpp
@@ -24,40 +24,64 @@
  */
 
 #include "config.h"
-#include "CSSAttrValue.h"
+#include "CSSAttrFunctionValue.h"
 
-#include <wtf/text/MakeString.h>
 #include "CSSPrimitiveValue.h"
+#include <wtf/text/MakeString.h>
 
 namespace WebCore {
 
-Ref<CSSAttrValue> CSSAttrValue::create(String attributeName, RefPtr<CSSValue>&& fallback)
-{
-    return adoptRef(*new CSSAttrValue(WTF::move(attributeName), WTF::move(fallback)));
-}
+// MARK: - CSS::AttrFunction
 
-bool CSSAttrValue::equals(const CSSAttrValue& other) const
-{
-    RefPtr fallback = dynamicDowncast<CSSPrimitiveValue>(m_fallback);
-    RefPtr otherFallback = dynamicDowncast<CSSPrimitiveValue>(other.m_fallback);
+namespace CSS {
 
-    if (fallback && otherFallback)
-        return m_attributeName == other.m_attributeName && fallback->stringValue() == otherFallback->stringValue();
-    if (fallback || otherFallback)
+bool AttrFunction::operator==(const AttrFunction& other) const
+{
+    RefPtr fallbackValue = dynamicDowncast<CSSPrimitiveValue>(fallback);
+    RefPtr otherFallback = dynamicDowncast<CSSPrimitiveValue>(other.fallback);
+
+    if (fallbackValue && otherFallback)
+        return attributeName == other.attributeName && fallbackValue->stringValue() == otherFallback->stringValue();
+    if (fallbackValue || otherFallback)
         return false;
-    return m_attributeName == other.m_attributeName;
+    return attributeName == other.attributeName;
 }
 
-String CSSAttrValue::customCSSText(const CSS::SerializationContext& context) const
+String AttrFunction::cssText(const SerializationContext& context) const
 {
-    RefPtr fallback = dynamicDowncast<CSSPrimitiveValue>(m_fallback);
+    RefPtr fallbackValue = dynamicDowncast<CSSPrimitiveValue>(fallback);
     return makeString(
         "attr("_s,
-        m_attributeName.impl(),
-        fallback && !fallback->stringValue().isEmpty() ? ", "_s : ""_s,
-        fallback && !fallback->stringValue().isEmpty() ? fallback->cssText(context) : ""_s,
+        attributeName.impl(),
+        fallbackValue && !fallbackValue->stringValue().isEmpty() ? ", "_s : ""_s,
+        fallbackValue && !fallbackValue->stringValue().isEmpty() ? fallbackValue->cssText(context) : ""_s,
         ')'
     );
+}
+
+} // namespace CSS
+
+// MARK: - CSSAttrFunctionValue
+
+Ref<CSSAttrFunctionValue> CSSAttrFunctionValue::create(CSS::AttrFunction attr)
+{
+    return adoptRef(*new CSSAttrFunctionValue(WTF::move(attr)));
+}
+
+CSSAttrFunctionValue::CSSAttrFunctionValue(CSS::AttrFunction attr)
+    : CSSValue(ClassType::AttrFunction)
+    , m_attr(WTF::move(attr))
+{
+}
+
+String CSSAttrFunctionValue::customCSSText(const CSS::SerializationContext& context) const
+{
+    return m_attr.cssText(context);
+}
+
+bool CSSAttrFunctionValue::equals(const CSSAttrFunctionValue& other) const
+{
+    return m_attr == other.m_attr;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSAttrFunctionValue.h
+++ b/Source/WebCore/css/CSSAttrFunctionValue.h
@@ -26,33 +26,39 @@
 #pragma once
 
 #include <WebCore/CSSValue.h>
-
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
-class Element;
+namespace CSS {
 
-class CSSAttrValue final : public CSSValue {
+struct SerializationContext;
+
+struct AttrFunction {
+    String attributeName;
+    RefPtr<CSSValue> fallback;
+
+    bool operator==(const AttrFunction&) const;
+    String cssText(const SerializationContext&) const;
+};
+
+} // namespace CSS
+
+class CSSAttrFunctionValue final : public CSSValue {
 public:
-    static Ref<CSSAttrValue> create(String attributeName, RefPtr<CSSValue>&& fallback = nullptr);
-    const String attributeName() const { return m_attributeName; }
-    const CSSValue* fallback() const { return m_fallback.get(); }
-    bool equals(const CSSAttrValue& other) const;
+    static Ref<CSSAttrFunctionValue> create(CSS::AttrFunction);
+
+    const CSS::AttrFunction& attrFunction() const LIFETIME_BOUND { return m_attr; }
+
     String customCSSText(const CSS::SerializationContext&) const;
+    bool equals(const CSSAttrFunctionValue&) const;
 
 private:
-    explicit CSSAttrValue(String&& attributeName, RefPtr<CSSValue>&& fallback)
-        : CSSValue(ClassType::Attr)
-        , m_attributeName(WTF::move(attributeName))
-        , m_fallback(WTF::move(fallback))
-    {
-    }
+    CSSAttrFunctionValue(CSS::AttrFunction);
 
-    String m_attributeName;
-    const RefPtr<CSSValue> m_fallback;
+    CSS::AttrFunction m_attr;
 };
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_CSS_VALUE(CSSAttrValue, isAttrValue())
+SPECIALIZE_TYPE_TRAITS_CSS_VALUE(CSSAttrFunctionValue, isAttrFunctionValue())

--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -126,7 +126,6 @@ static inline bool NODELETE isValidCSSUnitTypeForDoubleConversion(CSSUnitType un
     case CSSUnitType::CSS_CQMIN:
     case CSSUnitType::CSS_CQMAX:
         return true;
-    case CSSUnitType::CSS_ATTR:
     case CSSUnitType::CSS_FONT_FAMILY:
     case CSSUnitType::CustomIdent:
     case CSSUnitType::CSS_PROPERTY_ID:
@@ -149,7 +148,6 @@ static inline bool isStringType(CSSUnitType type)
     switch (type) {
     case CSSUnitType::CSS_STRING:
     case CSSUnitType::CustomIdent:
-    case CSSUnitType::CSS_ATTR:
     case CSSUnitType::CSS_FONT_FAMILY:
         return true;
     case CSSUnitType::CSS_CALC:
@@ -178,7 +176,9 @@ static inline bool isStringType(CSSUnitType type)
     case CSSUnitType::CSS_HZ:
     case CSSUnitType::CSS_IDENT:
     case CSSUnitType::CSS_IN:
+    case CSSUnitType::CSS_INTEGER:
     case CSSUnitType::CSS_KHZ:
+    case CSSUnitType::CSS_LH:
     case CSSUnitType::CSS_LVB:
     case CSSUnitType::CSS_LVH:
     case CSSUnitType::CSS_LVI:
@@ -188,15 +188,12 @@ static inline bool isStringType(CSSUnitType type)
     case CSSUnitType::CSS_MM:
     case CSSUnitType::CSS_MS:
     case CSSUnitType::CSS_NUMBER:
-    case CSSUnitType::CSS_INTEGER:
     case CSSUnitType::CSS_PC:
     case CSSUnitType::CSS_PERCENTAGE:
     case CSSUnitType::CSS_PROPERTY_ID:
     case CSSUnitType::CSS_PT:
     case CSSUnitType::CSS_PX:
     case CSSUnitType::CSS_Q:
-    case CSSUnitType::CSS_LH:
-    case CSSUnitType::CSS_RLH:
     case CSSUnitType::CSS_QUIRKY_EM:
     case CSSUnitType::CSS_RAD:
     case CSSUnitType::CSS_RCAP:
@@ -204,6 +201,7 @@ static inline bool isStringType(CSSUnitType type)
     case CSSUnitType::CSS_REM:
     case CSSUnitType::CSS_REX:
     case CSSUnitType::CSS_RIC:
+    case CSSUnitType::CSS_RLH:
     case CSSUnitType::CSS_S:
     case CSSUnitType::CSS_SVB:
     case CSSUnitType::CSS_SVH:
@@ -311,13 +309,6 @@ CSSPrimitiveValue::CSSPrimitiveValue(Ref<CSSCalc::Value> value)
     m_value.calc = &value.leakRef();
 }
 
-CSSPrimitiveValue::CSSPrimitiveValue(Ref<CSSAttrValue> value)
-    : CSSValue(ClassType::Primitive)
-{
-    setPrimitiveUnitType(CSSUnitType::CSS_ATTR);
-    m_value.attr = &value.leakRef();
-}
-
 CSSPrimitiveValue::~CSSPrimitiveValue()
 {
     auto type = primitiveUnitType();
@@ -327,9 +318,6 @@ CSSPrimitiveValue::~CSSPrimitiveValue()
     case CSSUnitType::CSS_FONT_FAMILY:
         if (m_value.string)
             m_value.string->deref();
-        break;
-    case CSSUnitType::CSS_ATTR:
-        m_value.attr->deref();
         break;
     case CSSUnitType::CSS_CALC:
         m_value.calc->deref();
@@ -472,10 +460,6 @@ Ref<CSSPrimitiveValue> CSSPrimitiveValue::create(Ref<CSSCalc::Value> value)
     return adoptRef(*new CSSPrimitiveValue(WTF::move(value)));
 }
 
-Ref<CSSPrimitiveValue> CSSPrimitiveValue::create(Ref<CSSAttrValue> value)
-{
-    return adoptRef(*new CSSPrimitiveValue(WTF::move(value)));
-}
 
 Ref<CSSPrimitiveValue> CSSPrimitiveValue::createCustomIdent(String value)
 {
@@ -832,8 +816,6 @@ String CSSPrimitiveValue::stringValue() const
         return nameString(m_value.valueID);
     case CSSUnitType::CSS_PROPERTY_ID:
         return nameString(m_value.propertyID);
-    case CSSUnitType::CSS_ATTR:
-        return protect(cssAttrValue())->cssText(CSS::defaultSerializationContext());
     default:
         return String();
     }
@@ -918,7 +900,6 @@ ASCIILiteral CSSPrimitiveValue::unitTypeString(CSSUnitType unitType)
     case CSSUnitType::CSS_VW: return "vw"_s;
     case CSSUnitType::CSS_X: return "x"_s;
 
-    case CSSUnitType::CSS_ATTR:
     case CSSUnitType::CSS_CALC:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_ANGLE:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_LENGTH:
@@ -1008,8 +989,6 @@ ALWAYS_INLINE String CSSPrimitiveValue::serializeInternal(const CSS::Serializati
     case CSSUnitType::CSS_VW:
     case CSSUnitType::CSS_X:
         return formatNumberValue(unitTypeString(type));
-    case CSSUnitType::CSS_ATTR:
-        return protect(cssAttrValue())->cssText(context);
     case CSSUnitType::CSS_CALC:
         return protect(cssCalcValue())->cssText(context);
     case CSSUnitType::CSS_DIMENSION:
@@ -1146,8 +1125,6 @@ bool CSSPrimitiveValue::equals(const CSSPrimitiveValue& other) const
     case CSSUnitType::CustomIdent:
     case CSSUnitType::CSS_FONT_FAMILY:
         return equal(m_value.string, other.m_value.string);
-    case CSSUnitType::CSS_ATTR:
-        return protect(cssAttrValue())->equals(*protect(other.cssAttrValue()));
     case CSSUnitType::CSS_CALC:
         return protect(cssCalcValue())->equals(*protect(other.cssCalcValue()));
     case CSSUnitType::CSS_IDENT:
@@ -1246,9 +1223,6 @@ bool CSSPrimitiveValue::addDerivedHash(Hasher& hasher) const
     case CSSUnitType::CustomIdent:
     case CSSUnitType::CSS_FONT_FAMILY:
         add(hasher, String { m_value.string });
-        break;
-    case CSSUnitType::CSS_ATTR:
-        add(hasher, m_value.attr);
         break;
     case CSSUnitType::CSS_CALC:
         add(hasher, m_value.calc);

--- a/Source/WebCore/css/CSSPrimitiveValue.h
+++ b/Source/WebCore/css/CSSPrimitiveValue.h
@@ -21,7 +21,6 @@
 
 #pragma once
 
-#include <WebCore/CSSAttrValue.h>
 #include <WebCore/CSSCalcValue.h>
 #include <WebCore/CSSPrimitiveNumericUnits.h>
 #include <WebCore/CSSPropertyNames.h>
@@ -57,7 +56,6 @@ public:
 
     // FIXME: Some of these use primitiveUnitType() and some use primitiveType(). Many that use primitiveUnitType() are likely broken with calc().
     bool isAngle() const { return unitCategory(primitiveType()) == CSSUnitCategory::Angle; }
-    bool isAttr() const { return primitiveUnitType() == CSSUnitType::CSS_ATTR; }
     bool isFontIndependentLength() const { return isFontIndependentLength(primitiveUnitType()); }
     bool isFontRelativeLength() const { return isFontRelativeLength(primitiveUnitType()); }
     bool isParentFontRelativeLength() const { return isPercentage() || (isFontRelativeLength() && !isRootFontRelativeLength()); }
@@ -88,7 +86,6 @@ public:
     static Ref<CSSPrimitiveValue> create(double, CSSUnitType);
     static Ref<CSSPrimitiveValue> NODELETE createInteger(double);
     static Ref<CSSPrimitiveValue> create(Ref<CSSCalc::Value>);
-    static Ref<CSSPrimitiveValue> NODELETE create(Ref<CSSAttrValue>);
 
     static inline Ref<CSSPrimitiveValue> create(CSSValueID);
     bool isValueID() const { return primitiveUnitType() == CSSUnitType::CSS_VALUE_ID; }
@@ -176,7 +173,6 @@ public:
 
     WEBCORE_EXPORT String stringValue() const;
     const CSSCalc::Value* cssCalcValue() const { return isCalculated() ? m_value.calc : nullptr; }
-    const CSSAttrValue* cssAttrValue() const { return isAttr() ? m_value.attr : nullptr; }
 
     String customCSSText(const CSS::SerializationContext&) const;
 
@@ -196,7 +192,6 @@ private:
     CSSPrimitiveValue(const String&, CSSUnitType);
     CSSPrimitiveValue(double, CSSUnitType);
     explicit CSSPrimitiveValue(Ref<CSSCalc::Value>);
-    explicit CSSPrimitiveValue(Ref<CSSAttrValue>);
 
     CSSPrimitiveValue(StaticCSSValueTag, CSSValueID);
     CSSPrimitiveValue(StaticCSSValueTag, double, CSSUnitType);
@@ -249,7 +244,6 @@ private:
         double number;
         StringImpl* string;
         const CSSCalc::Value* calc;
-        const CSSAttrValue* attr;
     } m_value;
 };
 

--- a/Source/WebCore/css/CSSUnits.cpp
+++ b/Source/WebCore/css/CSSUnits.cpp
@@ -110,7 +110,6 @@ CSSUnitCategory unitCategory(CSSUnitType type)
     case CSSUnitType::CSS_CQB:
     case CSSUnitType::CSS_CQMIN:
     case CSSUnitType::CSS_CQMAX:
-    case CSSUnitType::CSS_ATTR:
     case CSSUnitType::CSS_CALC:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_ANGLE:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_LENGTH:
@@ -206,7 +205,6 @@ TextStream& operator<<(TextStream& ts, CSSUnitType unitType)
     case CSSUnitType::CSS_STRING: ts << "string"_s; break;
     case CSSUnitType::CSS_IDENT: ts << "ident"_s; break;
     case CSSUnitType::CustomIdent: ts << "custom-ident"_s; break;
-    case CSSUnitType::CSS_ATTR: ts << "attr"_s; break;
     case CSSUnitType::CSS_VW: ts << "vw"_s; break;
     case CSSUnitType::CSS_VH: ts << "vh"_s; break;
     case CSSUnitType::CSS_VMIN: ts << "vmin"_s; break;
@@ -369,7 +367,6 @@ bool conversionToCanonicalUnitRequiresConversionData(CSSUnitType unit)
     case CSSUnitType::CSS_DPI:
     case CSSUnitType::CSS_DPCM:
     case CSSUnitType::CSS_FR:
-    case CSSUnitType::CSS_ATTR:
     case CSSUnitType::CSS_CALC:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_ANGLE:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_LENGTH:

--- a/Source/WebCore/css/CSSUnits.h
+++ b/Source/WebCore/css/CSSUnits.h
@@ -77,7 +77,6 @@ enum class CSSUnitType : uint8_t {
     CSS_DIMENSION,
     CSS_STRING,
     CSS_IDENT,
-    CSS_ATTR,
 
     CSS_VW,
     CSS_VH,

--- a/Source/WebCore/css/CSSValue.cpp
+++ b/Source/WebCore/css/CSSValue.cpp
@@ -30,7 +30,7 @@
 #include "CSSValue.h"
 
 #include "CSSAppleColorFilterValue.h"
-#include "CSSAttrValue.h"
+#include "CSSAttrFunctionValue.h"
 #include "CSSBackgroundRepeatValue.h"
 #include "CSSBasicShapeValue.h"
 #include "CSSBorderImageSliceValue.h"
@@ -111,8 +111,8 @@ template<typename Visitor> constexpr decltype(auto) CSSValue::visitDerived(Visit
     switch (m_classType) {
     case AppleColorFilter:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSAppleColorFilterValue>(*this));
-    case Attr:
-        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSAttrValue>(*this));
+    case AttrFunction:
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSAttrFunctionValue>(*this));
     case BackgroundRepeat:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSBackgroundRepeatValue>(*this));
     case BasicShape:

--- a/Source/WebCore/css/CSSValue.h
+++ b/Source/WebCore/css/CSSValue.h
@@ -70,7 +70,7 @@ public:
     WEBCORE_EXPORT String cssText(const CSS::SerializationContext&) const;
 
     bool isAppleColorFilterValue() const { return m_classType == ClassType::AppleColorFilter; }
-    bool isAttrValue() const { return m_classType == ClassType::Attr; }
+    bool isAttrFunctionValue() const { return m_classType == ClassType::AttrFunction; }
     bool isBackgroundRepeatValue() const { return m_classType == ClassType::BackgroundRepeat; }
     bool isBasicShape() const { return m_classType == ClassType::BasicShape; }
     bool isBorderImageSliceValue() const { return m_classType == ClassType::BorderImageSlice; }
@@ -215,7 +215,7 @@ protected:
 
         // Other non-list classes.
         AppleColorFilter,
-        Attr,
+        AttrFunction,
         BackgroundRepeat,
         BasicShape,
         BorderImageSlice,

--- a/Source/WebCore/css/DeprecatedCSSOMPrimitiveValue.cpp
+++ b/Source/WebCore/css/DeprecatedCSSOMPrimitiveValue.cpp
@@ -58,7 +58,6 @@ unsigned short DeprecatedCSSOMPrimitiveValue::primitiveType() const
         return CSS_UNKNOWN;
 
     switch (primitiveValue->primitiveType()) {
-    case CSSUnitType::CSS_ATTR:                         return CSS_ATTR;
     case CSSUnitType::CSS_CM:                           return CSS_CM;
     case CSSUnitType::CSS_DEG:                          return CSS_DEG;
     case CSSUnitType::CSS_DIMENSION:                    return CSS_DIMENSION;
@@ -125,7 +124,6 @@ ExceptionOr<float> DeprecatedCSSOMPrimitiveValue::getFloatValue(unsigned short u
 ExceptionOr<String> DeprecatedCSSOMPrimitiveValue::getStringValue() const
 {
     switch (primitiveType()) {
-    case CSS_ATTR:      return downcast<CSSPrimitiveValue>(m_value.get()).stringValue();
     case CSS_IDENT:     return downcast<CSSPrimitiveValue>(m_value.get()).stringValue();
     case CSS_STRING:    return downcast<CSSPrimitiveValue>(m_value.get()).stringValue();
     case CSS_URI:       return downcast<CSSURLValue>(m_value.get()).stringValue();

--- a/Source/WebCore/css/calc/CSSCalcTree+NumericIdentity.h
+++ b/Source/WebCore/css/calc/CSSCalcTree+NumericIdentity.h
@@ -200,7 +200,6 @@ constexpr NumericIdentity toNumericIdentity(const NonCanonicalDimension& dimensi
     case CSSUnitType::CSS_HZ:
     case CSSUnitType::CSS_DPPX:
     case CSSUnitType::CSS_FR:
-    case CSSUnitType::CSS_ATTR:
     case CSSUnitType::CSS_CALC:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_ANGLE:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_LENGTH:

--- a/Source/WebCore/css/calc/CSSCalcTree+Serialization.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Serialization.cpp
@@ -189,7 +189,6 @@ static unsigned NODELETE sortPriority(CSSUnitType unit)
     case CSSUnitType::CSS_X:            return 63;
 
     // Non-numeric types are not supported.
-    case CSSUnitType::CSS_ATTR:
     case CSSUnitType::CSS_CALC:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_ANGLE:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_LENGTH:

--- a/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
@@ -273,7 +273,6 @@ std::optional<CanonicalDimension> canonicalize(NonCanonicalDimension root, const
     case CSSUnitType::CSS_INTEGER:
     case CSSUnitType::CSS_PERCENTAGE:
     // Non-numeric types should never be stored in a NonCanonicalDimension.
-    case CSSUnitType::CSS_ATTR:
     case CSSUnitType::CSS_CALC:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_ANGLE:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_LENGTH:

--- a/Source/WebCore/css/calc/CSSCalcTree.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree.cpp
@@ -157,7 +157,6 @@ Child makeNumeric(double value, CSSUnitType unit)
         return makeChild(NonCanonicalDimension { .value = value, .unit = unit });
 
     // Non-numeric types are not supported.
-    case CSSUnitType::CSS_ATTR:
     case CSSUnitType::CSS_CALC:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_ANGLE:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_LENGTH:

--- a/Source/WebCore/css/calc/CSSCalcType.cpp
+++ b/Source/WebCore/css/calc/CSSCalcType.cpp
@@ -293,7 +293,6 @@ Type Type::determineType(CSSUnitType unitType)
         // the type is «[ "percent" → 1 ]».
         return Type { .percent = 1 };
 
-    case CSSUnitType::CSS_ATTR:
     case CSSUnitType::CSS_CALC:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_ANGLE:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_LENGTH:

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Attr.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Attr.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "CSSPropertyParserConsumer+Attr.h"
 
-#include "CSSAttrValue.h"
+#include "CSSAttrFunctionValue.h"
 #include "CSSParserContext.h"
 #include "CSSParserTokenRange.h"
 #include "CSSPrimitiveValue.h"
@@ -72,10 +72,7 @@ RefPtr<CSSValue> consumeAttr(CSSParserTokenRange args, CSS::PropertyParserState&
     if (!args.atEnd())
         return nullptr;
 
-    auto attr = CSSAttrValue::create(WTF::move(attrName), WTF::move(fallback));
-    // FIXME: Consider moving to a CSSFunctionValue with a custom-ident rather than a special CSS_ATTR primitive value.
-
-    return CSSPrimitiveValue::create(WTF::move(attr));
+    return CSSAttrFunctionValue::create(CSS::AttrFunction { String { attrName.string() }, WTF::move(fallback) });
 }
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/editing/cocoa/NodeHTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/NodeHTMLConverter.mm
@@ -478,7 +478,7 @@ static bool stringFromCSSValue(CSSValue& value, String& result)
     if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
         // FIXME: Use isStringType(CSSUnitType)?
         auto primitiveType = primitiveValue->primitiveType();
-        if (primitiveType == CSSUnitType::CSS_STRING || primitiveType == CSSUnitType::CSS_IDENT || primitiveType == CSSUnitType::CSS_ATTR) {
+        if (primitiveType == CSSUnitType::CSS_STRING || primitiveType == CSSUnitType::CSS_IDENT) {
             auto stringValue = value.cssText(CSS::defaultSerializationContext());
             if (stringValue.length()) {
                 result = stringValue;

--- a/Source/WebCore/style/values/content/StyleContent.cpp
+++ b/Source/WebCore/style/values/content/StyleContent.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "StyleContent.h"
 
-#include "CSSAttrValue.h"
+#include "CSSAttrFunctionValue.h"
 #include "CSSCounterValue.h"
 #include "CSSPrimitiveValue.h"
 #include "CSSValueList.h"
@@ -68,13 +68,13 @@ auto CSSValueConversion<Content>::operator()(BuilderState& state, const CSSValue
         return CSS::Keyword::Normal { };
 
     // FIXME: Replace with support for CSS Values 5 attr() substitution function.
-    auto processAttrContent = [&](const CSSAttrValue& value) -> AtomString {
+    auto processAttrContent = [&](const CSS::AttrFunction& value) -> AtomString {
         if (!state.style().pseudoElementType())
             state.style().setHasAttrContent();
         else
             const_cast<ComputedStyle&>(state.parentStyle()).setHasAttrContent();
 
-        QualifiedName attr(nullAtom(), value.attributeName().impl(), nullAtom());
+        QualifiedName attr(nullAtom(), value.attributeName.impl(), nullAtom());
         RefPtr element = state.element();
         const AtomString& attributeValue = element ? element->getAttribute(attr) : nullAtom();
 
@@ -82,7 +82,7 @@ auto CSSValueConversion<Content>::operator()(BuilderState& state, const CSSValue
         state.registerContentAttribute(attr.localName());
 
         if (attributeValue.isNull()) {
-            RefPtr fallback = dynamicDowncast<CSSPrimitiveValue>(value.fallback());
+            RefPtr fallback = dynamicDowncast<CSSPrimitiveValue>(value.fallback);
             return fallback && fallback->isString() ? fallback->stringValue().impl() : emptyAtom();
         }
         return attributeValue.impl();
@@ -113,12 +113,13 @@ auto CSSValueConversion<Content>::operator()(BuilderState& state, const CSSValue
                 }
                 if (primitive->isString())
                     return Content::Text { primitive->stringValue() };
-                if (RefPtr attr = primitive->cssAttrValue())
-                    return Content::Text { processAttrContent(*attr) };
 
                 state.setCurrentPropertyInvalidAtComputedValueTime();
                 return Content::Text { emptyString() };
             }
+
+            if (auto* attrValue = dynamicDowncast<CSSAttrFunctionValue>(item))
+                return Content::Text { processAttrContent(attrValue->attrFunction()) };
 
             if (RefPtr counter = dynamicDowncast<CSSCounterValue>(item))
                 return Content::Counter { counter->identifier(), counter->separator(), toStyleFromCSSValue<CounterStyle>(state, counter->counterStyle()) };
@@ -132,16 +133,17 @@ auto CSSValueConversion<Content>::operator()(BuilderState& state, const CSSValue
         if (!contentListAltTextPair)
             return { };
 
-        auto altTextList = requiredListDowncast<CSSValueList, CSSPrimitiveValue>(state, contentListAltTextPair->second());
+        RefPtr altTextList = requiredDowncast<CSSValueList>(state, contentListAltTextPair->second());
         if (!altTextList)
             return { };
 
         StringBuilder altTextBuilder;
-        for (Ref item : *altTextList) {
-            if (item->isString())
-                altTextBuilder.append(item->stringValue());
-            else if (RefPtr attr = item->cssAttrValue())
-                altTextBuilder.append(processAttrContent(*attr));
+        for (auto& item : *altTextList) {
+            if (RefPtr primitive = dynamicDowncast<CSSPrimitiveValue>(item)) {
+                if (primitive->isString())
+                    altTextBuilder.append(primitive->stringValue());
+            } else if (RefPtr attrValue = dynamicDowncast<CSSAttrFunctionValue>(item))
+                altTextBuilder.append(processAttrContent(attrValue->attrFunction()));
         }
         return altTextBuilder.toString();
     };


### PR DESCRIPTION
#### c9049094e928462b0a30139e308c1e9aed1872b0
<pre>
[css-values-5 attr] Modernize CSSAttrValue type
<a href="https://bugs.webkit.org/show_bug.cgi?id=310179">https://bugs.webkit.org/show_bug.cgi?id=310179</a>
<a href="https://rdar.apple.com/172826170">rdar://172826170</a>

Reviewed by NOBODY (OOPS\!).

Cleanups for the CSS attr() function value type to move it towards a more modern setup.

- Rename CSSAttrValue to CSSAttrFunctionValue
- CSSAttrFunctionValue is now a proper CSSValue subclass instead of being a union member of CSSPrimitiveValue
- It contains CSS::AttrFunction that carries the actual data
- Remove unnecessary CSSUnitType::CSS_ATTR enum value

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSAttrFunctionValue.cpp: Renamed from Source/WebCore/css/CSSAttrValue.cpp.
(WebCore::CSS::AttrFunction::operator== const):
(WebCore::CSS::AttrFunction::cssText const):
(WebCore::CSSAttrFunctionValue::create):
(WebCore::CSSAttrFunctionValue::CSSAttrFunctionValue):
(WebCore::CSSAttrFunctionValue::customCSSText const):
(WebCore::CSSAttrFunctionValue::equals const):
* Source/WebCore/css/CSSAttrFunctionValue.h: Renamed from Source/WebCore/css/CSSAttrValue.h.
* Source/WebCore/css/CSSPrimitiveValue.cpp:
(WebCore::isValidCSSUnitTypeForDoubleConversion):
(WebCore::isStringType):
(WebCore::CSSPrimitiveValue::~CSSPrimitiveValue):
(WebCore::CSSPrimitiveValue::stringValue const):
(WebCore::CSSPrimitiveValue::unitTypeString):
(WebCore::CSSPrimitiveValue::serializeInternal const):
(WebCore::CSSPrimitiveValue::equals const):
(WebCore::CSSPrimitiveValue::addDerivedHash const):
* Source/WebCore/css/CSSPrimitiveValue.h:
* Source/WebCore/css/CSSUnits.cpp:
(WebCore::unitCategory):
(WebCore::operator&lt;&lt;):
(WebCore::conversionToCanonicalUnitRequiresConversionData):
* Source/WebCore/css/CSSUnits.h:
* Source/WebCore/css/CSSValue.cpp:
(WebCore::CSSValue::visitDerived):
* Source/WebCore/css/CSSValue.h:
* Source/WebCore/css/DeprecatedCSSOMPrimitiveValue.cpp:
(WebCore::DeprecatedCSSOMPrimitiveValue::primitiveType const):
(WebCore::DeprecatedCSSOMPrimitiveValue::getStringValue const):
* Source/WebCore/css/calc/CSSCalcTree+NumericIdentity.h:
(WebCore::CSSCalc::toNumericIdentity):
* Source/WebCore/css/calc/CSSCalcTree+Serialization.cpp:
(WebCore::CSSCalc::sortPriority):
* Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp:
(WebCore::CSSCalc::canonicalize):
* Source/WebCore/css/calc/CSSCalcTree.cpp:
(WebCore::CSSCalc::makeNumeric):
* Source/WebCore/css/calc/CSSCalcType.cpp:
(WebCore::CSSCalc::Type::determineType):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Attr.cpp:
(WebCore::CSSPropertyParserHelpers::consumeAttr):
* Source/WebCore/editing/cocoa/NodeHTMLConverter.mm:
(stringFromCSSValue):
* Source/WebCore/style/values/content/StyleContent.cpp:
(WebCore::Style::CSSValueConversion&lt;Content&gt;::operator):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9049094e928462b0a30139e308c1e9aed1872b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150847 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23607 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17179 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/159574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/104283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f3620381-5a0e-498c-a1ed-5996fa33e7ca) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152720 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24040 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23816 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/116447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/104283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a6ad328b-abd2-4839-baf9-8a7e9a4e1ed6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153807 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/18561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/135339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/97167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/96a4ff93-fbca-4096-a1ef-fe58ab9aa246) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/17658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/15602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/7421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/127276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/13256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/162048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/5173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/14824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/124448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23411 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/19652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/124636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/23401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/135053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79807 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/19702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/11818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/23011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/86828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/22723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22875 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/22777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->