### PR TITLE
Adopt ASCIILIteral in ProcessExecutablePathGLib.cpp

### DIFF
--- a/Source/WebKit/Shared/glib/ProcessExecutablePathGLib.cpp
+++ b/Source/WebKit/Shared/glib/ProcessExecutablePathGLib.cpp
@@ -42,42 +42,42 @@ static String getExecutablePath()
 }
 #endif
 
-static String findWebKitProcess(const char* processName)
+static String findWebKitProcess(const ASCIILiteral processName)
 {
 #if ENABLE(DEVELOPER_MODE)
     static const char* execDirectory = g_getenv("WEBKIT_EXEC_PATH");
     if (execDirectory) {
-        String processPath = FileSystem::pathByAppendingComponent(FileSystem::stringFromFileSystemRepresentation(execDirectory), StringView::fromLatin1(processName));
+        String processPath = FileSystem::pathByAppendingComponent(FileSystem::stringFromFileSystemRepresentation(execDirectory), processName);
         if (FileSystem::fileExists(processPath))
             return processPath;
     }
 
     static String executablePath = getExecutablePath();
     if (!executablePath.isNull()) {
-        String processPath = FileSystem::pathByAppendingComponent(executablePath, StringView::fromLatin1(processName));
+        String processPath = FileSystem::pathByAppendingComponent(executablePath, processName);
         if (FileSystem::fileExists(processPath))
             return processPath;
     }
 #endif
 
-    return FileSystem::pathByAppendingComponent(FileSystem::stringFromFileSystemRepresentation(PKGLIBEXECDIR), StringView::fromLatin1(processName));
+    return FileSystem::pathByAppendingComponent(FileSystem::stringFromFileSystemRepresentation(PKGLIBEXECDIR), processName);
 }
 
 String executablePathOfWebProcess()
 {
 #if PLATFORM(WPE)
-    return findWebKitProcess("WPEWebProcess");
+    return findWebKitProcess("WPEWebProcess"_s);
 #else
-    return findWebKitProcess("WebKitWebProcess");
+    return findWebKitProcess("WebKitWebProcess"_s);
 #endif
 }
 
 String executablePathOfNetworkProcess()
 {
 #if PLATFORM(WPE)
-    return findWebKitProcess("WPENetworkProcess");
+    return findWebKitProcess("WPENetworkProcess"_s);
 #else
-    return findWebKitProcess("WebKitNetworkProcess");
+    return findWebKitProcess("WebKitNetworkProcess"_s);
 #endif
 }
 
@@ -85,9 +85,9 @@ String executablePathOfNetworkProcess()
 String executablePathOfGPUProcess()
 {
 #if PLATFORM(WPE)
-    return findWebKitProcess("WPEGPUProcess");
+    return findWebKitProcess("WPEGPUProcess"_s);
 #else
-    return findWebKitProcess("WebKitGPUProcess");
+    return findWebKitProcess("WebKitGPUProcess"_s);
 #endif
 }
 #endif


### PR DESCRIPTION
#### 8e6f0e6498f75eabe2fd9d46e87d7469ecad25f0
<pre>
Adopt ASCIILIteral in ProcessExecutablePathGLib.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=310180">https://bugs.webkit.org/show_bug.cgi?id=310180</a>

Reviewed by Fujii Hironori.

* Source/WebKit/Shared/glib/ProcessExecutablePathGLib.cpp:
(WebKit::findWebKitProcess):
(WebKit::executablePathOfWebProcess):
(WebKit::executablePathOfNetworkProcess):
(WebKit::executablePathOfGPUProcess):

Canonical link: <a href="https://commits.webkit.org/309531@main">https://commits.webkit.org/309531@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ca5479dafc0fa48bf77a42847a1a0d99837d301

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150819 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23577 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17148 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159542 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104255 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24009 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23786 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116411 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82658 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153779 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18521 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135302 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97139 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17618 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15569 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7389 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127232 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162016 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5136 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14783 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124413 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23381 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19616 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124609 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23370 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135021 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79762 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23192 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19678 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11783 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22981 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86781 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22693 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22845 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22747 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->