### PR TITLE
Unload resources for <model> tags which scroll off screen

### DIFF
--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -653,6 +653,7 @@ void HTMLModelElement::reloadModelPlayer()
     auto transformState = modelPlayer->currentTransformState();
     ASSERT(animationState && transformState);
 
+#if ENABLE(MODEL_PROCESS)
     if (!m_modelPlayerProvider)
         m_modelPlayerProvider = document().page()->modelPlayerProvider();
     if (RefPtr modelPlayerProvider = m_modelPlayerProvider.get()) {
@@ -663,6 +664,7 @@ void HTMLModelElement::reloadModelPlayer()
         RELEASE_LOG_ERROR(ModelElement, "%p - HTMLModelElement: Failed to create model player to reload with", this);
         return;
     }
+#endif
 
     RELEASE_LOG(ModelElement, "%p - HTMLModelElement: Reloading previous states to new model player: %p", this, modelPlayer.get());
     modelPlayer->reload(*model, contentSize(), *animationState, WTF::move(*transformState));

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayerTransformState.cpp
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayerTransformState.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "ModelProcessModelPlayerTransformState.h"
 
-#if ENABLE(MODEL_PROCESS)
+#if ENABLE(MODEL_PROCESS) || ENABLE(GPU_PROCESS_MODEL)
 
 #include "Logging.h"
 #include <CoreRE/CoreRE.h>
@@ -42,16 +42,26 @@ ModelProcessModelPlayerTransformState::ModelProcessModelPlayerTransformState(std
     : m_entityTransform(entityTransform)
     , m_boundingBoxCenter(boundingBoxCenter)
     , m_boundingBoxExtents(boundingBoxExtents)
+#if ENABLE(MODEL_ELEMENT_PORTAL)
     , m_hasPortal(hasPortal)
+#endif
     , m_stageModeOperation(stageModeOperation)
 {
+#if !ENABLE(MODEL_ELEMENT_PORTAL)
+    UNUSED_PARAM(hasPortal);
+#endif
 }
 
 std::unique_ptr<WebCore::ModelPlayerTransformState> ModelProcessModelPlayerTransformState::clone() const
 {
+#if ENABLE(MODEL_ELEMENT_PORTAL)
     return makeUnique<ModelProcessModelPlayerTransformState>(m_entityTransform, m_boundingBoxCenter, m_boundingBoxExtents, m_hasPortal, m_stageModeOperation);
+#else
+    return makeUnique<ModelProcessModelPlayerTransformState>(m_entityTransform, m_boundingBoxCenter, m_boundingBoxExtents, false, m_stageModeOperation);
+#endif
 }
 
+#if ENABLE(MODEL_PROCESS)
 static bool areSameSignAndAlmostEqual(float a, float b, float tolerance)
 {
     if (a * b < 0)
@@ -84,19 +94,29 @@ bool ModelProcessModelPlayerTransformState::transformSupported(const WebCore::Tr
 
     return true;
 }
+#endif
 
 void ModelProcessModelPlayerTransformState::setEntityTransform(WebCore::TransformationMatrix entityTransform)
 {
     ASSERT(m_stageModeOperation == WebCore::StageModeOperation::None);
+#if ENABLE(MODEL_PROCESS)
     if (transformSupported(entityTransform))
         m_entityTransform = entityTransform;
+#else
+    m_entityTransform = entityTransform;
+#endif
 }
 
 bool ModelProcessModelPlayerTransformState::isEntityTransformSupported(const WebCore::TransformationMatrix& transform) const
 {
+#if ENABLE(MODEL_PROCESS)
     return transformSupported(transform);
+#else
+    return true;
+#endif
 }
 
+#if ENABLE(MODEL_ELEMENT_PORTAL)
 void ModelProcessModelPlayerTransformState::setHasPortal(bool hasPortal)
 {
     if (m_hasPortal == hasPortal)
@@ -105,6 +125,7 @@ void ModelProcessModelPlayerTransformState::setHasPortal(bool hasPortal)
     m_hasPortal = hasPortal;
     invalidateTransform();
 }
+#endif
 
 void ModelProcessModelPlayerTransformState::setStageMode(WebCore::StageModeOperation stageModeOperation)
 {

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayerTransformState.h
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayerTransformState.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if ENABLE(MODEL_PROCESS)
+#if ENABLE(MODEL_PROCESS) || ENABLE(GPU_PROCESS_MODEL)
 
 #include <WebCore/FloatPoint3D.h>
 #include <WebCore/ModelPlayerTransformState.h>
@@ -42,7 +42,9 @@ public:
     ModelProcessModelPlayerTransformState(std::optional<WebCore::TransformationMatrix> entityTransform, std::optional<WebCore::FloatPoint3D> boundingBoxCenter, std::optional<WebCore::FloatPoint3D> boundingBoxExtents, bool hasPortal, WebCore::StageModeOperation);
     virtual ~ModelProcessModelPlayerTransformState() = default;
 
+#if ENABLE(MODEL_PROCESS)
     static bool transformSupported(const WebCore::TransformationMatrix&);
+#endif
 
 private:
     // ModelPlayerTransformState overrides
@@ -52,8 +54,10 @@ private:
     bool isEntityTransformSupported(const WebCore::TransformationMatrix&) const final;
     std::optional<WebCore::FloatPoint3D> boundingBoxCenter() const final { return m_boundingBoxCenter; }
     std::optional<WebCore::FloatPoint3D> boundingBoxExtents() const final { return m_boundingBoxExtents; }
+#if ENABLE(MODEL_ELEMENT_PORTAL)
     bool hasPortal() const final { return m_hasPortal; }
     void setHasPortal(bool) final;
+#endif
     WebCore::StageModeOperation stageMode() const final { return m_stageModeOperation; }
     void setStageMode(WebCore::StageModeOperation) final;
     void invalidateTransform() final;
@@ -61,7 +65,9 @@ private:
     std::optional<WebCore::TransformationMatrix> m_entityTransform;
     std::optional<WebCore::FloatPoint3D> m_boundingBoxCenter;
     std::optional<WebCore::FloatPoint3D> m_boundingBoxExtents;
+#if ENABLE(MODEL_ELEMENT_PORTAL)
     bool m_hasPortal { true };
+#endif
     WebCore::StageModeOperation m_stageModeOperation { WebCore::StageModeOperation::None };
 };
 

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.h
@@ -31,6 +31,7 @@
 #include "ModelTypes.h"
 #include <WebCore/Model.h>
 #include <WebCore/ModelPlayer.h>
+#include <WebCore/ModelPlayerAnimationState.h>
 #include <WebCore/ModelPlayerClient.h>
 #include <WebCore/StageModeOperations.h>
 #include <wtf/Forward.h>
@@ -63,6 +64,7 @@ public:
     virtual ~WebModelPlayer();
 
     WebCore::ModelPlayerIdentifier identifier() const final;
+    bool isPlaceholder() const final;
     void update();
 
 private:
@@ -97,6 +99,10 @@ private:
     void setEntityTransform(WebCore::TransformationMatrix) final;
     bool supportsTransform(WebCore::TransformationMatrix) final;
     bool supportsMouseInteraction() final;
+    void visibilityStateDidChange() final;
+    void reload(WebCore::Model&, WebCore::LayoutSize, WebCore::ModelPlayerAnimationState&, std::unique_ptr<WebCore::ModelPlayerTransformState>&&) final;
+    std::optional<WebCore::ModelPlayerAnimationState> currentAnimationState() const final;
+    std::optional<std::unique_ptr<WebCore::ModelPlayerTransformState>> currentTransformState() const final;
 
     const MachSendRight* displayBuffer() const;
     WebCore::GraphicsLayerContentsDisplayDelegate* contentsDisplayDelegate();
@@ -140,6 +146,8 @@ private:
     std::optional<Ref<WebCore::SharedBuffer>> m_environmentMap;
     RetainPtr<WKStageModeOrbitSimulator> m_orbitSimulator;
     MonotonicTime m_lastUpdateTime;
+    std::optional<WebCore::ModelPlayerAnimationState> m_cachedAnimationState;
+    std::optional<std::unique_ptr<WebCore::ModelPlayerTransformState>> m_cachedTransformState;
     float m_playbackRate { 1.0f };
     bool m_isLooping { false };
 };

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
@@ -31,22 +31,26 @@
 
 #import "Mesh.h"
 #import "ModelInlineConverters.h"
+#import "ModelProcessModelPlayerTransformState.h"
 #import "ModelTypes.h"
 #import "RemoteGPUProxy.h"
 #import "WKStageModeOrbitSimulator.h"
-#import "WebKitSwiftSoftLink.h"
 #import <WebCore/Document.h>
 #import <WebCore/FloatPoint3D.h>
 #import <WebCore/GPU.h>
 #import <WebCore/GraphicsLayer.h>
 #import <WebCore/GraphicsLayerContentsDisplayDelegate.h>
 #import <WebCore/HTMLModelElement.h>
+#import <WebCore/ModelPlayerAnimationState.h>
 #import <WebCore/ModelPlayerGraphicsLayerConfiguration.h>
+#import <WebCore/ModelPlayerTransformState.h>
 #import <WebCore/Navigator.h>
 #import <WebCore/Page.h>
 #import <WebCore/PlatformCALayer.h>
 #import <WebCore/PlatformCALayerDelegatedContents.h>
 #import <wtf/RetainPtr.h>
+
+#import "WebKitSwiftSoftLink.h"
 
 #if PLATFORM(COCOA)
 #import <Metal/Metal.h>
@@ -311,6 +315,9 @@ void WebModelPlayer::load(WebCore::Model& modelSource, WebCore::LayoutSize size)
 
             [protectedThis->m_modelLoader requestCompleted:updateRequest];
 
+            if (!model)
+                return;
+
             if (RefPtr client = protectedThis->m_client.get(); client && !protectedThis->m_didFinishLoading) {
                 protectedThis->m_didFinishLoading = true;
                 [protectedThis->m_modelLoader setLoop:protectedThis->m_isLooping];
@@ -321,7 +328,7 @@ void WebModelPlayer::load(WebCore::Model& modelSource, WebCore::LayoutSize size)
                 protectedThis->notifyEntityTransformUpdated();
 
                 auto environmentMap = protectedThis->m_environmentMap;
-                if (model && environmentMap) {
+                if (environmentMap) {
                     if (auto environmentMapImage = loadIBL(WTF::move(*environmentMap))) {
                         model->setEnvironmentMap(*environmentMapImage);
                         protectedThis->m_environmentMap = std::nullopt;
@@ -506,6 +513,11 @@ WebCore::ModelPlayerIdentifier WebModelPlayer::identifier() const
     return m_id;
 }
 
+bool WebModelPlayer::isPlaceholder() const
+{
+    return !m_currentModel;
+}
+
 void WebModelPlayer::configureGraphicsLayer(WebCore::GraphicsLayer& graphicsLayer, WebCore::ModelPlayerGraphicsLayerConfiguration&& configuration)
 {
     graphicsLayer.setContentsDisplayDelegate(contentsDisplayDelegate(), WebCore::GraphicsLayer::ContentsLayerPurpose::Canvas);
@@ -529,10 +541,10 @@ const MachSendRight* WebModelPlayer::displayBuffer() const
 
 WebCore::GraphicsLayerContentsDisplayDelegate* WebModelPlayer::contentsDisplayDelegate()
 {
-    if (!m_contentsDisplayDelegate) {
+    if (auto buffer = displayBuffer(); !m_contentsDisplayDelegate && buffer) {
         RefPtr modelDisplayDelegate = ModelDisplayBufferDisplayDelegate::create(*this);
         m_contentsDisplayDelegate = modelDisplayDelegate;
-        modelDisplayDelegate->setDisplayBuffer(*displayBuffer());
+        modelDisplayDelegate->setDisplayBuffer(*buffer);
     }
 
     return m_contentsDisplayDelegate.get();
@@ -693,6 +705,76 @@ void WebModelPlayer::setEnvironmentMap(Ref<WebCore::SharedBuffer>&& data)
 
     if (RefPtr client = m_client.get())
         client->didFinishEnvironmentMapLoading(*this, success);
+}
+
+void WebModelPlayer::visibilityStateDidChange()
+{
+    // When the model becomes invisible, release memory-intensive resources.
+    // When it becomes visible again, HTMLModelElement will trigger a reload through startLoadModelTimer().
+    RefPtr client = m_client.get();
+    if (!client)
+        return;
+
+    if (!client->isVisible()) {
+        m_cachedAnimationState = currentAnimationState();
+        m_cachedTransformState = currentTransformState();
+
+        // Model is no longer visible - release resources to save memory
+        m_currentModel = nullptr;
+        m_retainedData = nil;
+        m_didFinishLoading = false;
+        m_modelLoader = nil;
+        m_displayBuffers.clear();
+        m_environmentMap = std::nullopt;
+    }
+}
+
+void WebModelPlayer::reload(WebCore::Model& modelSource, WebCore::LayoutSize size, WebCore::ModelPlayerAnimationState& animationState, std::unique_ptr<WebCore::ModelPlayerTransformState>&& transformState)
+{
+    load(modelSource, size);
+    if (transformState) {
+        if (auto entityTransform = transformState->entityTransform())
+            setEntityTransform(*entityTransform);
+    }
+
+    setAutoplay(animationState.autoplay());
+    setLoop(animationState.loop());
+    setPaused(animationState.paused(), [] (bool) { });
+    if (auto playbackRate = animationState.effectivePlaybackRate())
+        setPlaybackRate(*playbackRate, [] (double) { });
+    setCurrentTime(animationState.currentTime(), [] { });
+}
+
+std::optional<WebCore::ModelPlayerAnimationState> WebModelPlayer::currentAnimationState() const
+{
+    if (!m_currentModel)
+        return m_cachedAnimationState;
+
+    bool paused = m_pauseState != PauseState::Playing;
+    bool autoplay = !paused;
+    Seconds animationDuration { duration() };
+    std::optional<double> effectivePlaybackRate = m_playbackRate;
+    std::optional<Seconds> lastCachedCurrentTime = currentTime();
+    std::optional<MonotonicTime> lastCachedClockTimestamp = MonotonicTime::now();
+
+    return WebCore::ModelPlayerAnimationState(autoplay, m_isLooping, paused, animationDuration, effectivePlaybackRate, lastCachedCurrentTime, lastCachedClockTimestamp);
+}
+
+std::optional<std::unique_ptr<WebCore::ModelPlayerTransformState>> WebModelPlayer::currentTransformState() const
+{
+    if (!m_currentModel) {
+        if (m_cachedTransformState)
+            return (*m_cachedTransformState)->clone();
+        return std::nullopt;
+    }
+
+    std::optional<WebCore::TransformationMatrix> transform = entityTransform();
+
+    auto [simdCenter, simdExtents] = m_currentModel->getCenterAndExtents();
+    std::optional<WebCore::FloatPoint3D> center = WebCore::FloatPoint3D(simdCenter.x, simdCenter.y, simdCenter.z);
+    std::optional<WebCore::FloatPoint3D> extents = WebCore::FloatPoint3D(simdExtents.x, simdExtents.y, simdExtents.z);
+
+    return ModelProcessModelPlayerTransformState::create(transform, center, extents, false, m_stageMode);
 }
 
 }


### PR DESCRIPTION
#### c5ac54a936fb7afff6d94e510a5d5173f0b5b4f9
<pre>
Unload resources for &lt;model&gt; tags which scroll off screen
<a href="https://rdar.apple.com/172763636">rdar://172763636</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=310123">https://bugs.webkit.org/show_bug.cgi?id=310123</a>

Reviewed by Etienne Segonzac.

&lt;model&gt; can take a large amount of memory at times so when the element
is offscreen, unload the respective resources.

* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::reloadModelPlayer):
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayerTransformState.cpp:
(WebKit::ModelProcessModelPlayerTransformState::ModelProcessModelPlayerTransformState):
(WebKit::ModelProcessModelPlayerTransformState::clone const):
(WebKit::ModelProcessModelPlayerTransformState::setEntityTransform):
(WebKit::ModelProcessModelPlayerTransformState::isEntityTransformSupported const):
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayerTransformState.h:
* Source/WebKit/WebProcess/Model/WebModelPlayer.h:
* Source/WebKit/WebProcess/Model/WebModelPlayer.mm:
(WebKit::WebModelPlayer::load):
(WebKit::WebModelPlayer::isPlaceholder const):
(WebKit::WebModelPlayer::contentsDisplayDelegate):
(WebKit::WebModelPlayer::visibilityStateDidChange):
(WebKit::WebModelPlayer::reload):
(WebKit::WebModelPlayer::currentAnimationState const):
(WebKit::WebModelPlayer::currentTransformState const):

Canonical link: <a href="https://commits.webkit.org/310387@main">https://commits.webkit.org/310387@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d628de776053a0420a2fe7b82a08bf632136271d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153670 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26454 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20071 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162420 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107128 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155543 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26982 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26776 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118812 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84044 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156629 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21066 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137974 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99523 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20145 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18096 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10253 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129794 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15833 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164891 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8025 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17427 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126887 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26251 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22128 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127053 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34465 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26253 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137628 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82931 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21966 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14410 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25870 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90158 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25561 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25721 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25621 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->