### PR TITLE
Create comprehensive WPT test suite for SVG getBBox

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-01.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-01.html
@@ -1,5 +1,7 @@
 <!doctype html>
 <title>SVGGraphicsElement.prototype.getBBox</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGGraphicsElement__getBBox">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/coords.html#BoundingBoxes">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id="testcontainer">

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-02.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-02.html
@@ -1,5 +1,7 @@
 <!doctype html>
 <title>SVGGraphicsElement.prototype.getBBox on &lt;tspan&gt;</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGGraphicsElement__getBBox">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/coords.html#BoundingBoxes">
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-03-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-03-expected.txt
@@ -1,12 +1,12 @@
 
-FAIL rect1 assert_equals: rect1: x expected 1 but got 0
-FAIL rect2 assert_equals: rect2: x expected 1 but got 0
-FAIL circle assert_equals: circle: x expected 1 but got 0
-PASS ellipse1
-PASS ellipse2
-PASS image3
-PASS image4
-FAIL foreign1 assert_equals: foreign1: x expected 1 but got 0
-FAIL foreign2 assert_equals: foreign2: x expected 1 but got 0
+PASS rect1
+PASS rect2
+PASS circle
+FAIL ellipse1 assert_equals: ellipse1: x expected 0 but got -9
+FAIL ellipse2 assert_equals: ellipse2: x expected 0 but got 1
+FAIL image3 assert_equals: image3: x expected 0 but got 1
+FAIL image4 assert_equals: image4: x expected 0 but got 1
+FAIL foreign1 assert_equals: foreign1: width expected 0 but got -10
+FAIL foreign2 assert_equals: foreign2: width expected 0 but got 10
 PASS SVGGraphicsElement.prototype.getBBox for elements with negative sizes
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-03.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-03.html
@@ -2,9 +2,9 @@
 <title>SVGGraphicsElement.prototype.getBBox for elements with negative sizes</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<link rel="help" href="https://svgwg.org/svg2-draft/geometry.html#Sizing">
-<link rel="help" href="https://svgwg.org/svg2-draft/types.html#__svg__SVGGraphicsElement__getBBox">
-<link rel="help" href="https://svgwg.org/svg2-draft/coords.html#BoundingBoxes">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#Sizing">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGGraphicsElement__getBBox">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/coords.html#BoundingBoxes">
 <svg>
   <rect id="rect1" x="1" y="2" width="-10" height="20"/>
   <rect id="rect2" x="1" y="2" width="10" height="-20"/>
@@ -31,15 +31,17 @@ function testBBox(id, x, y, width, height) {
   test(() => { assertBBox(id, x, y, width, height) }, id);
 }
 
-testBBox('rect1', 1, 2, 0, 20);
-testBBox('rect2', 1, 2, 10, 0);
-testBBox('circle', 1, 2, 0, 0);
-testBBox('ellipse1', -9, 2, 20, 20);
-testBBox('ellipse2', 1, -3, 10, 10);
-testBBox('image3', 1, 2, 0, 20);
-testBBox('image4', 1, 2, 10, 0);
-testBBox('foreign1', 1, 2, 0, 20);
-testBBox('foreign2', 1, 2, 10, 0);
+// Per resolution (issue #1018): if a shape is not rendered (negative or
+// zero dimension), getBBox returns (0, 0, 0, 0).
+testBBox('rect1', 0, 0, 0, 0);
+testBBox('rect2', 0, 0, 0, 0);
+testBBox('circle', 0, 0, 0, 0);
+testBBox('ellipse1', 0, 0, 0, 0);
+testBBox('ellipse2', 0, 0, 0, 0);
+testBBox('image3', 0, 0, 0, 0);
+testBBox('image4', 0, 0, 0, 0);
+testBBox('foreign1', 0, 0, 0, 0);
+testBBox('foreign2', 0, 0, 0, 0);
 
 async_test(t => {
   onload = t.step_func_done(() => {

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-04.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-04.html
@@ -2,9 +2,9 @@
 <title>SVGGraphicsElement.prototype.getBBox for containers that have children added/removed</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<link rel="help" href="https://svgwg.org/svg2-draft/geometry.html#Sizing">
-<link rel="help" href="https://svgwg.org/svg2-draft/types.html#__svg__SVGGraphicsElement__getBBox">
-<link rel="help" href="https://svgwg.org/svg2-draft/coords.html#BoundingBoxes">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#Sizing">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGGraphicsElement__getBBox">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/coords.html#BoundingBoxes">
 <svg>
   <g>
     <rect width="10" height="20"/>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-05.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-05.html
@@ -2,9 +2,9 @@
 <title>SVGGraphicsElement.prototype.getBBox for SVGBoundingBoxOptions options</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<link rel="help" href="https://svgwg.org/svg2-draft/geometry.html#Sizing">
-<link rel="help" href="https://svgwg.org/svg2-draft/types.html#__svg__SVGGraphicsElement__getBBox">
-<link rel="help" href="https://svgwg.org/svg2-draft/coords.html#BoundingBoxes">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#Sizing">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGGraphicsElement__getBBox">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/coords.html#BoundingBoxes">
 <svg xmlns="http://www.w3.org/2000/svg"  xmlns:xlink="http://www.w3.org/1999/xlink"
   viewBox="0 0 500 500" width="500px" height="500px">
   <defs>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-06-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-06-expected.txt
@@ -1,5 +1,5 @@
 
-PASS Non-rendered symbol with rect
-PASS display:none <g> with rect
-FAIL display:none <rect> assert_approx_equals: none_rect.getBBox().x {} expected 90 +/- 0.1 but got 0
+FAIL Non-rendered symbol with rect returns zero bbox assert_equals: symbol1_rect.getBBox().x expected 0 but got 50
+FAIL display:none <g> with rect returns zero bbox assert_equals: g_none_rect.getBBox().x expected 0 but got 70
+PASS display:none <rect> returns zero bbox
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-06.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-06.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <title>SVGGraphicsElement.prototype.getBBox for non-rendered elements</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/coords.html#BoundingBoxes">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/coords.html#BoundingBoxes">
+<link rel="help" href="https://github.com/w3c/svgwg/issues/1018">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 500" width="500px" height="500px">
@@ -13,28 +14,28 @@
   <rect id="none_rect" x="90" y="100" width="20" height="25" display="none"></rect>
 </svg>
 <script>
-  function assert_bbox(id, opt, x, y, width, height, epsilon) {
-    if (epsilon == undefined) {
-      epsilon = 0.1;
-    }
+  function assert_bbox(id, x, y, width, height) {
     let bbox = document.getElementById(id).getBBox();
-    assert_approx_equals(bbox.x, x, epsilon, id + ".getBBox().x " + JSON.stringify(opt));
-    assert_approx_equals(bbox.y, y, epsilon, id + ".getBBox().y " + JSON.stringify(opt));
-    assert_approx_equals(bbox.width, width, epsilon, id + ".getBBox().width " + JSON.stringify(opt));
-    assert_approx_equals(bbox.height, height, epsilon, id + ".getBBox().height " + JSON.stringify(opt));
+    assert_equals(bbox.x, x, id + ".getBBox().x");
+    assert_equals(bbox.y, y, id + ".getBBox().y");
+    assert_equals(bbox.width, width, id + ".getBBox().width");
+    assert_equals(bbox.height, height, id + ".getBBox().height");
   }
 
-  test(() => {
-    assert_bbox("symbol1", {}, 0, 0, 0, 0);
-    assert_bbox("symbol1_rect", {}, 50, 60, 100, 150);
-  }, "Non-rendered symbol with rect");
+  // Per resolution (issue #1018): non-rendered elements return zero bbox
+  // instead of throwing InvalidStateError.
 
   test(() => {
-    assert_bbox("g_none", {}, 0, 0, 0, 0);
-    assert_bbox("g_none_rect", {}, 70, 80, 200, 250);
-  }, "display:none <g> with rect");
+    assert_bbox("symbol1", 0, 0, 0, 0);
+    assert_bbox("symbol1_rect", 0, 0, 0, 0);
+  }, "Non-rendered symbol with rect returns zero bbox");
 
   test(() => {
-    assert_bbox("none_rect", {}, 90, 100, 20, 25);
-  }, "display:none <rect>");
+    assert_bbox("g_none", 0, 0, 0, 0);
+    assert_bbox("g_none_rect", 0, 0, 0, 0);
+  }, "display:none <g> with rect returns zero bbox");
+
+  test(() => {
+    assert_bbox("none_rect", 0, 0, 0, 0);
+  }, "display:none <rect> returns zero bbox");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-07-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-07-expected.txt
@@ -1,0 +1,51 @@
+
+PASS rect with zero width
+PASS rect with zero height
+PASS rect with zero width and height
+PASS rect with no width/height attributes (default auto resolves to 0)
+PASS rect with no attributes at all
+PASS circle with zero radius
+PASS circle with no r attribute (default 0)
+PASS circle with no attributes at all
+PASS ellipse with zero rx (not rendered)
+PASS ellipse with zero ry (not rendered)
+PASS ellipse with zero rx and ry
+PASS ellipse with no attributes (rx/ry auto both â†’ 0)
+PASS line with identical start and end points (zero-length)
+PASS horizontal line (zero height)
+PASS vertical line (zero width)
+PASS line with no attributes (all default to 0)
+PASS rect with both width and height negative
+PASS ellipse with both rx and ry negative
+PASS path with only a MoveTo command
+PASS path with multiple MoveTo commands (last moveto position)
+PASS path with LineTo to the same point as MoveTo
+PASS path with zero-length vertical line
+PASS path with MoveTo then close (no drawing)
+PASS path drawing a horizontal line (zero height)
+PASS path drawing a vertical line (zero width)
+PASS path with degenerate cubic bezier (all points identical)
+PASS path with degenerate quadratic bezier (all points identical)
+PASS path with arc with zero radii (treated as line to endpoint)
+PASS path with arc to same point (zero-length arc)
+PASS polygon with a single point
+PASS polyline with a single point
+PASS polygon with repeated identical points
+PASS polyline with horizontal segment (zero height)
+PASS polygon with vertical segment (zero width)
+PASS polygon with empty points attribute
+PASS polyline with empty points attribute
+PASS empty group element
+PASS group with only zero-dimension children has zero bbox
+PASS group with zero-dim and normal children: zero-dim child does not affect bbox
+PASS use element with unresolved href returns zero bbox
+PASS use element referencing zero-dimension rect returns zero bbox
+FAIL getBBox on rect inside defs does not throw and returns zero bbox assert_equals: x expected 0 but got 10
+FAIL getBBox on circle inside defs does not throw and returns zero bbox assert_equals: x expected 0 but got 25
+FAIL getBBox on rect inside group inside defs does not throw and returns zero bbox assert_equals: width expected 0 but got 30
+FAIL getBBox on rect inside clipPath does not throw and returns zero bbox assert_equals: width expected 0 but got 80
+FAIL getBBox on rect inside mask does not throw and returns zero bbox assert_equals: width expected 0 but got 60
+PASS display:none rect with negative width does not throw and returns zero bbox
+PASS visibility:hidden rect has normal bbox
+PASS opacity:0 rect has normal bbox
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-07.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-07.html
@@ -1,0 +1,320 @@
+<!DOCTYPE html>
+<title>SVGGraphicsElement.prototype.getBBox for zero/missing dimensions and non-rendered contexts</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGGraphicsElement__getBBox">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/coords.html#BoundingBoxes">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#Sizing">
+<link rel="help" href="https://github.com/w3c/svgwg/issues/1018">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<svg width="0" height="0" style="position:absolute">
+
+  <!-- A. rect: zero and missing dimensions -->
+  <rect id="rect_zero_w" x="10" y="20" width="0" height="50"/>
+  <rect id="rect_zero_h" x="10" y="20" width="50" height="0"/>
+  <rect id="rect_zero_wh" x="10" y="20" width="0" height="0"/>
+  <rect id="rect_no_wh" x="10" y="20"/>
+  <rect id="rect_no_attrs"/>
+
+  <!-- A. circle: zero and missing radius -->
+  <circle id="circle_zero_r" cx="10" cy="20" r="0"/>
+  <circle id="circle_no_r" cx="10" cy="20"/>
+  <circle id="circle_no_attrs"/>
+
+  <!-- A. ellipse: zero and missing radii -->
+  <ellipse id="ellipse_zero_rx" cx="10" cy="20" rx="0" ry="30"/>
+  <ellipse id="ellipse_zero_ry" cx="10" cy="20" rx="30" ry="0"/>
+  <ellipse id="ellipse_zero_both" cx="10" cy="20" rx="0" ry="0"/>
+  <ellipse id="ellipse_no_attrs"/>
+
+  <!-- A. line: zero-length, horizontal, vertical, no attributes -->
+  <line id="line_zero" x1="10" y1="20" x2="10" y2="20"/>
+  <line id="line_horiz" x1="10" y1="20" x2="50" y2="20"/>
+  <line id="line_vert" x1="10" y1="20" x2="10" y2="60"/>
+  <line id="line_no_attrs"/>
+
+  <!-- B. rect/ellipse: both dimensions negative -->
+  <rect id="rect_neg_both" x="10" y="20" width="-5" height="-5"/>
+  <ellipse id="ellipse_neg_both" cx="10" cy="20" rx="-5" ry="-5"/>
+
+  <!-- C. path: MoveTo-only and degenerate segments -->
+  <path id="path_moveto" d="M 10 20"/>
+  <path id="path_multi_moveto" d="M 10 20 M 30 40"/>
+  <path id="path_lineto_same" d="M 10 20 L 10 20"/>
+  <path id="path_zero_v" d="M 10 20 v 0"/>
+  <path id="path_moveto_close" d="M 10 20 Z"/>
+  <path id="path_horiz_line" d="M 10 20 L 50 20"/>
+  <path id="path_vert_line" d="M 10 20 L 10 60"/>
+  <path id="path_degen_cubic" d="M 10 20 C 10 20 10 20 10 20"/>
+  <path id="path_degen_quad" d="M 10 20 Q 10 20 10 20"/>
+  <path id="path_degen_arc_zero_r" d="M 10 20 A 0 0 0 0 1 30 40"/>
+  <path id="path_arc_same_point" d="M 10 20 A 5 5 0 0 1 10 20"/>
+
+  <!-- D. polygon/polyline: single point, repeated, empty -->
+  <polygon id="polygon_single" points="10,20"/>
+  <polyline id="polyline_single" points="10,20"/>
+  <polygon id="polygon_repeated" points="10,20 10,20 10,20"/>
+  <polyline id="polyline_horiz" points="10,20 50,20"/>
+  <polygon id="polygon_vert" points="10,20 10,60"/>
+  <polygon id="polygon_empty" points=""/>
+  <polyline id="polyline_empty" points=""/>
+
+  <!-- E. containers: empty group, unresolved use -->
+  <g id="g_empty"/>
+  <rect id="zero_dim_rect" x="5" y="5" width="0" height="0"/>
+  <g id="g_zero_children">
+    <rect x="5" y="5" width="0" height="0"/>
+    <circle cx="10" cy="10" r="0"/>
+  </g>
+  <g id="g_mixed_children">
+    <rect x="5" y="5" width="0" height="0"/>
+    <rect id="g_mixed_normal" x="20" y="30" width="40" height="50"/>
+  </g>
+  <use id="use_unresolved" href="#nonexistent" x="10" y="20"/>
+  <use id="use_zero_ref" href="#zero_dim_rect" x="15" y="25"/>
+
+  <!-- F. non-rendered contexts: getBBox should NOT throw -->
+  <defs>
+    <rect id="defs_rect" x="10" y="20" width="100" height="50"/>
+    <circle id="defs_circle" cx="50" cy="50" r="25"/>
+    <g id="defs_g">
+      <rect id="defs_g_rect" x="0" y="0" width="30" height="30"/>
+    </g>
+  </defs>
+  <clipPath id="cp1">
+    <rect id="clip_rect" x="0" y="0" width="80" height="80"/>
+  </clipPath>
+  <mask id="mask1">
+    <rect id="mask_rect" x="0" y="0" width="60" height="60"/>
+  </mask>
+
+  <!-- F. non-rendered with invalid dimensions: should not throw -->
+  <rect id="none_neg_w" x="10" y="20" width="-5" height="30" display="none"/>
+  <rect id="hidden_rect" x="10" y="20" width="40" height="50" visibility="hidden"/>
+  <rect id="transparent_rect" x="10" y="20" width="40" height="50" opacity="0"/>
+
+</svg>
+<script>
+function assert_bbox(id, expected_x, expected_y, expected_w, expected_h) {
+  var el = document.getElementById(id);
+  var bbox = el.getBBox();
+  assert_equals(bbox.x, expected_x, "x");
+  assert_equals(bbox.y, expected_y, "y");
+  assert_equals(bbox.width, expected_w, "width");
+  assert_equals(bbox.height, expected_h, "height");
+}
+
+function test_bbox(id, expected_x, expected_y, expected_w, expected_h, desc) {
+  test(() => { assert_bbox(id, expected_x, expected_y, expected_w, expected_h); }, desc);
+}
+
+// ========================================================================
+// A. Basic shapes — zero and missing dimensions
+// Per resolution (issue #1018): if the shape is not rendered (zero,
+// negative, or missing dimension), getBBox returns (0, 0, 0, 0).
+// ========================================================================
+
+// rect: zero or missing width/height disables rendering → all zeros
+test_bbox("rect_zero_w", 0, 0, 0, 0,
+  "rect with zero width");
+test_bbox("rect_zero_h", 0, 0, 0, 0,
+  "rect with zero height");
+test_bbox("rect_zero_wh", 0, 0, 0, 0,
+  "rect with zero width and height");
+test_bbox("rect_no_wh", 0, 0, 0, 0,
+  "rect with no width/height attributes (default auto resolves to 0)");
+test_bbox("rect_no_attrs", 0, 0, 0, 0,
+  "rect with no attributes at all");
+
+// circle: zero or missing radius disables rendering → all zeros
+test_bbox("circle_zero_r", 0, 0, 0, 0,
+  "circle with zero radius");
+test_bbox("circle_no_r", 0, 0, 0, 0,
+  "circle with no r attribute (default 0)");
+test_bbox("circle_no_attrs", 0, 0, 0, 0,
+  "circle with no attributes at all");
+
+// ellipse: zero rx or ry disables rendering → all zeros
+test_bbox("ellipse_zero_rx", 0, 0, 0, 0,
+  "ellipse with zero rx (not rendered)");
+test_bbox("ellipse_zero_ry", 0, 0, 0, 0,
+  "ellipse with zero ry (not rendered)");
+test_bbox("ellipse_zero_both", 0, 0, 0, 0,
+  "ellipse with zero rx and ry");
+test_bbox("ellipse_no_attrs", 0, 0, 0, 0,
+  "ellipse with no attributes (rx/ry auto both → 0)");
+
+// line: always has zero-area bounding box
+test_bbox("line_zero", 10, 20, 0, 0,
+  "line with identical start and end points (zero-length)");
+test_bbox("line_horiz", 10, 20, 40, 0,
+  "horizontal line (zero height)");
+test_bbox("line_vert", 10, 20, 0, 40,
+  "vertical line (zero width)");
+test_bbox("line_no_attrs", 0, 0, 0, 0,
+  "line with no attributes (all default to 0)");
+
+// ========================================================================
+// B. Both dimensions negative (invalid, ignored → fall back to initial)
+// ========================================================================
+
+// rect: negative width/height → not rendered → all zeros
+test_bbox("rect_neg_both", 0, 0, 0, 0,
+  "rect with both width and height negative");
+
+// ellipse: negative rx AND negative ry → not rendered → all zeros
+test_bbox("ellipse_neg_both", 0, 0, 0, 0,
+  "ellipse with both rx and ry negative");
+
+// ========================================================================
+// C. Path edge cases — MoveTo-only and degenerate segments
+// ========================================================================
+
+// A single MoveTo establishes position but draws nothing.
+// Per spec: "subpath segments of a path element with zero width and height must
+// be included in that element's geometry for the sake of the bounding box."
+test_bbox("path_moveto", 10, 20, 0, 0,
+  "path with only a MoveTo command");
+test_bbox("path_multi_moveto", 30, 40, 0, 0,
+  "path with multiple MoveTo commands (last moveto position)");
+test_bbox("path_lineto_same", 10, 20, 0, 0,
+  "path with LineTo to the same point as MoveTo");
+test_bbox("path_zero_v", 10, 20, 0, 0,
+  "path with zero-length vertical line");
+test_bbox("path_moveto_close", 10, 20, 0, 0,
+  "path with MoveTo then close (no drawing)");
+test_bbox("path_horiz_line", 10, 20, 40, 0,
+  "path drawing a horizontal line (zero height)");
+test_bbox("path_vert_line", 10, 20, 0, 40,
+  "path drawing a vertical line (zero width)");
+test_bbox("path_degen_cubic", 10, 20, 0, 0,
+  "path with degenerate cubic bezier (all points identical)");
+test_bbox("path_degen_quad", 10, 20, 0, 0,
+  "path with degenerate quadratic bezier (all points identical)");
+
+// Arc with zero radii: per spec, treated as a straight line to the endpoint.
+test_bbox("path_degen_arc_zero_r", 10, 20, 20, 20,
+  "path with arc with zero radii (treated as line to endpoint)");
+test_bbox("path_arc_same_point", 10, 20, 0, 0,
+  "path with arc to same point (zero-length arc)");
+
+// ========================================================================
+// D. Polygon/polyline edge cases
+// ========================================================================
+
+test_bbox("polygon_single", 10, 20, 0, 0,
+  "polygon with a single point");
+test_bbox("polyline_single", 10, 20, 0, 0,
+  "polyline with a single point");
+test_bbox("polygon_repeated", 10, 20, 0, 0,
+  "polygon with repeated identical points");
+test_bbox("polyline_horiz", 10, 20, 40, 0,
+  "polyline with horizontal segment (zero height)");
+test_bbox("polygon_vert", 10, 20, 0, 40,
+  "polygon with vertical segment (zero width)");
+test_bbox("polygon_empty", 0, 0, 0, 0,
+  "polygon with empty points attribute");
+test_bbox("polyline_empty", 0, 0, 0, 0,
+  "polyline with empty points attribute");
+
+// ========================================================================
+// E. Containers and structural elements
+// ========================================================================
+
+test_bbox("g_empty", 0, 0, 0, 0,
+  "empty group element");
+
+test(function() {
+  var g = document.getElementById("g_zero_children");
+  var bbox = g.getBBox();
+  // Group with only non-rendered children: all children return (0,0,0,0),
+  // so group bbox is (0,0,0,0).
+  assert_equals(bbox.x, 0, "x");
+  assert_equals(bbox.y, 0, "y");
+  assert_equals(bbox.width, 0, "width");
+  assert_equals(bbox.height, 0, "height");
+}, "group with only zero-dimension children has zero bbox");
+
+test(function() {
+  var g = document.getElementById("g_mixed_children");
+  var normal = document.getElementById("g_mixed_normal");
+  var g_bbox = g.getBBox();
+  var n_bbox = normal.getBBox();
+  // The zero-dim child returns (0,0,0,0) so group bbox equals normal child's bbox.
+  assert_equals(g_bbox.x, n_bbox.x, "x equals normal child x");
+  assert_equals(g_bbox.y, n_bbox.y, "y equals normal child y");
+  assert_equals(g_bbox.width, n_bbox.width, "width equals normal child width");
+  assert_equals(g_bbox.height, n_bbox.height, "height equals normal child height");
+}, "group with zero-dim and normal children: zero-dim child does not affect bbox");
+
+// use with unresolved reference: per resolution (issue #1018), returns zero bbox.
+test_bbox("use_unresolved", 0, 0, 0, 0,
+  "use element with unresolved href returns zero bbox");
+
+test_bbox("use_zero_ref", 0, 0, 0, 0,
+  "use element referencing zero-dimension rect returns zero bbox");
+
+// ========================================================================
+// F. Non-rendered elements — getBBox must NOT throw (issue #1018)
+// Per resolution: remove throwing for invalid getBBox(), return 0 values
+// for x, y, width, height instead of throwing InvalidStateError.
+// ========================================================================
+
+test(function() {
+  var el = document.getElementById("defs_rect");
+  var bbox;
+  // Must not throw an InvalidStateError.
+  assert_not_equals(el, null, "element exists");
+  bbox = el.getBBox();
+  assert_equals(bbox.x, 0, "x");
+  assert_equals(bbox.y, 0, "y");
+  assert_equals(bbox.width, 0, "width");
+  assert_equals(bbox.height, 0, "height");
+}, "getBBox on rect inside defs does not throw and returns zero bbox");
+
+test(function() {
+  var el = document.getElementById("defs_circle");
+  var bbox = el.getBBox();
+  assert_equals(bbox.x, 0, "x");
+  assert_equals(bbox.y, 0, "y");
+  assert_equals(bbox.width, 0, "width");
+  assert_equals(bbox.height, 0, "height");
+}, "getBBox on circle inside defs does not throw and returns zero bbox");
+
+test(function() {
+  var el = document.getElementById("defs_g_rect");
+  var bbox = el.getBBox();
+  assert_equals(bbox.x, 0, "x");
+  assert_equals(bbox.y, 0, "y");
+  assert_equals(bbox.width, 0, "width");
+  assert_equals(bbox.height, 0, "height");
+}, "getBBox on rect inside group inside defs does not throw and returns zero bbox");
+
+test(function() {
+  var el = document.getElementById("clip_rect");
+  var bbox = el.getBBox();
+  assert_equals(bbox.x, 0, "x");
+  assert_equals(bbox.y, 0, "y");
+  assert_equals(bbox.width, 0, "width");
+  assert_equals(bbox.height, 0, "height");
+}, "getBBox on rect inside clipPath does not throw and returns zero bbox");
+
+test(function() {
+  var el = document.getElementById("mask_rect");
+  var bbox = el.getBBox();
+  assert_equals(bbox.x, 0, "x");
+  assert_equals(bbox.y, 0, "y");
+  assert_equals(bbox.width, 0, "width");
+  assert_equals(bbox.height, 0, "height");
+}, "getBBox on rect inside mask does not throw and returns zero bbox");
+
+// Non-rendered element with invalid dimensions: should not throw,
+// should return zero bbox per resolution.
+test_bbox("none_neg_w", 0, 0, 0, 0,
+  "display:none rect with negative width does not throw and returns zero bbox");
+
+// visibility:hidden and opacity:0 are rendered (they have bounding boxes).
+test_bbox("hidden_rect", 10, 20, 40, 50,
+  "visibility:hidden rect has normal bbox");
+test_bbox("transparent_rect", 10, 20, 40, 50,
+  "opacity:0 rect has normal bbox");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-08-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-08-expected.txt
@@ -1,0 +1,22 @@
+
+FAIL image with zero width assert_equals: x expected 0 but got 10
+FAIL image with zero height assert_equals: x expected 0 but got 10
+FAIL image with zero width and height assert_equals: x expected 0 but got 10
+FAIL image with no width/height attributes assert_equals: x expected 0 but got 10
+FAIL foreignObject with zero width assert_equals: height expected 0 but got 50
+FAIL foreignObject with zero height assert_equals: width expected 0 but got 50
+PASS foreignObject with zero width and height
+PASS foreignObject with no width/height attributes
+PASS empty nested SVG element
+PASS empty nested SVG with no attributes
+PASS empty nested SVG with zero width and height
+PASS anchor element wrapping zero-dimension rect
+PASS anchor element with zero-dim and normal child: zero-dim child does not affect bbox
+PASS zero-dim rect with translate transform
+PASS rect with negative width and scale(2) (not rendered)
+PASS zero-dim rect inside rotated group (not rendered)
+PASS zero-width rect with scale(3) (not rendered)
+PASS zero-radius circle with translate (not rendered)
+PASS group with translate transform â€” bbox in group's local coords
+PASS rotated group with zero-dim child â€” bbox is zero
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-08.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-08.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<title>SVGGraphicsElement.prototype.getBBox for image, foreignObject, containers, and transforms</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGGraphicsElement__getBBox">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/coords.html#BoundingBoxes">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#Sizing">
+<link rel="help" href="https://github.com/w3c/svgwg/issues/1018">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<svg width="0" height="0" style="position:absolute">
+
+  <!-- G. image: zero and missing dimensions (no href, so intrinsic size doesn't apply) -->
+  <image id="img_zero_w" x="10" y="20" width="0" height="50"/>
+  <image id="img_zero_h" x="10" y="20" width="50" height="0"/>
+  <image id="img_zero_wh" x="10" y="20" width="0" height="0"/>
+  <image id="img_no_wh" x="10" y="20"/>
+
+  <!-- G. foreignObject: zero and missing dimensions -->
+  <foreignObject id="fo_zero_w" x="10" y="20" width="0" height="50"/>
+  <foreignObject id="fo_zero_h" x="10" y="20" width="50" height="0"/>
+  <foreignObject id="fo_zero_wh" x="10" y="20" width="0" height="0"/>
+  <foreignObject id="fo_no_wh" x="10" y="20"/>
+
+  <!-- E2. Empty nested SVG -->
+  <svg id="nested_svg_empty" x="10" y="20" width="100" height="80"/>
+  <svg id="nested_svg_no_attrs"/>
+  <svg id="nested_svg_zero" x="10" y="20" width="0" height="0"/>
+
+  <!-- E7. Anchor wrapping zero-dim shape -->
+  <a id="a_zero_child">
+    <rect x="10" y="20" width="0" height="0"/>
+  </a>
+  <a id="a_normal_and_zero">
+    <rect x="10" y="20" width="0" height="0"/>
+    <rect id="a_normal_rect" x="30" y="40" width="50" height="60"/>
+  </a>
+
+  <!-- H. Transforms on zero/invalid dimension elements -->
+  <!-- getBBox returns bbox in element's local coordinate system,
+       so transform does not affect the returned values. -->
+  <rect id="h_zero_translate" width="0" height="0" transform="translate(10,20)"/>
+  <rect id="h_neg_scale" width="-5" height="10" transform="scale(2)"/>
+  <g id="h_rotated_group" transform="rotate(45)">
+    <rect id="h_rotated_child" x="10" y="20" width="0" height="0"/>
+  </g>
+  <rect id="h_zero_w_scale" x="10" y="20" width="0" height="50" transform="scale(3)"/>
+  <circle id="h_zero_r_translate" cx="10" cy="20" r="0" transform="translate(100,200)"/>
+
+  <!-- H. Group transform with normal child — getBBox of group is in group's
+       local coordinate system, so child positions are untransformed. -->
+  <g id="h_group_translate" transform="translate(100,200)">
+    <rect id="h_group_child" x="10" y="20" width="30" height="40"/>
+  </g>
+
+</svg>
+<script>
+function assert_bbox(id, expected_x, expected_y, expected_w, expected_h) {
+  var el = document.getElementById(id);
+  var bbox = el.getBBox();
+  assert_equals(bbox.x, expected_x, "x");
+  assert_equals(bbox.y, expected_y, "y");
+  assert_equals(bbox.width, expected_w, "width");
+  assert_equals(bbox.height, expected_h, "height");
+}
+
+function test_bbox(id, expected_x, expected_y, expected_w, expected_h, desc) {
+  test(() => { assert_bbox(id, expected_x, expected_y, expected_w, expected_h); }, desc);
+}
+
+// ========================================================================
+// G. image — zero and missing dimensions (no href)
+// Per resolution (issue #1018): not rendered → getBBox returns (0,0,0,0).
+// Note: negative dimension images are tested in getBBox-03.
+// ========================================================================
+
+test_bbox("img_zero_w", 0, 0, 0, 0,
+  "image with zero width");
+test_bbox("img_zero_h", 0, 0, 0, 0,
+  "image with zero height");
+test_bbox("img_zero_wh", 0, 0, 0, 0,
+  "image with zero width and height");
+test_bbox("img_no_wh", 0, 0, 0, 0,
+  "image with no width/height attributes");
+
+// ========================================================================
+// G. foreignObject — zero and missing dimensions
+// Per resolution (issue #1018): not rendered → getBBox returns (0,0,0,0).
+// Note: negative dimension foreignObjects are tested in getBBox-03.
+// ========================================================================
+
+test_bbox("fo_zero_w", 0, 0, 0, 0,
+  "foreignObject with zero width");
+test_bbox("fo_zero_h", 0, 0, 0, 0,
+  "foreignObject with zero height");
+test_bbox("fo_zero_wh", 0, 0, 0, 0,
+  "foreignObject with zero width and height");
+test_bbox("fo_no_wh", 0, 0, 0, 0,
+  "foreignObject with no width/height attributes");
+
+// ========================================================================
+// E. Containers — nested SVG and anchor elements
+// ========================================================================
+
+// Nested SVG with no children: bbox is (0, 0, 0, 0) since container
+// algorithm unions over rendered children.
+test_bbox("nested_svg_empty", 0, 0, 0, 0,
+  "empty nested SVG element");
+test_bbox("nested_svg_no_attrs", 0, 0, 0, 0,
+  "empty nested SVG with no attributes");
+test_bbox("nested_svg_zero", 0, 0, 0, 0,
+  "empty nested SVG with zero width and height");
+
+// Anchor wrapping zero-dimension shapes (not rendered → zero bbox).
+test_bbox("a_zero_child", 0, 0, 0, 0,
+  "anchor element wrapping zero-dimension rect");
+
+test(function() {
+  var a = document.getElementById("a_normal_and_zero");
+  var bbox = a.getBBox();
+  // Zero-dim child returns (0,0,0,0), so group bbox equals normal child's bbox.
+  assert_equals(bbox.x, 30, "x equals normal child x");
+  assert_equals(bbox.y, 40, "y equals normal child y");
+  assert_equals(bbox.width, 50, "width equals normal child width");
+  assert_equals(bbox.height, 60, "height equals normal child height");
+}, "anchor element with zero-dim and normal child: zero-dim child does not affect bbox");
+
+// ========================================================================
+// H. Transforms on zero/invalid dimension elements
+// getBBox returns the bbox in the element's own coordinate system (user
+// space), so transforms on the element itself do not change the returned
+// values. Transforms on ancestors also do not affect the result since
+// getBBox uses the element's own coordinate system.
+// ========================================================================
+
+test_bbox("h_zero_translate", 0, 0, 0, 0,
+  "zero-dim rect with translate transform");
+test_bbox("h_neg_scale", 0, 0, 0, 0,
+  "rect with negative width and scale(2) (not rendered)");
+test_bbox("h_rotated_child", 0, 0, 0, 0,
+  "zero-dim rect inside rotated group (not rendered)");
+test_bbox("h_zero_w_scale", 0, 0, 0, 0,
+  "zero-width rect with scale(3) (not rendered)");
+test_bbox("h_zero_r_translate", 0, 0, 0, 0,
+  "zero-radius circle with translate (not rendered)");
+
+test(function() {
+  var g = document.getElementById("h_group_translate");
+  var bbox = g.getBBox();
+  // Group bbox is in the group's own coordinate system, so child at (10,20)
+  // with (30,40) is reported directly, unaffected by group's translate.
+  assert_equals(bbox.x, 10, "x");
+  assert_equals(bbox.y, 20, "y");
+  assert_equals(bbox.width, 30, "width");
+  assert_equals(bbox.height, 40, "height");
+}, "group with translate transform — bbox in group's local coords");
+
+test(function() {
+  var g = document.getElementById("h_rotated_group");
+  var bbox = g.getBBox();
+  // Group's only child is zero-dim (not rendered → (0,0,0,0)),
+  // so group bbox is also (0,0,0,0).
+  assert_equals(bbox.x, 0, "x");
+  assert_equals(bbox.y, 0, "y");
+  assert_equals(bbox.width, 0, "width");
+  assert_equals(bbox.height, 0, "height");
+}, "rotated group with zero-dim child — bbox is zero");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-09-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-09-expected.txt
@@ -1,0 +1,26 @@
+
+PASS stroked zero-length line: fill bbox is zero-area at the point
+PASS stroked horizontal line: fill bbox has zero height
+PASS stroked vertical line: fill bbox has zero width
+PASS stroked zero-width rect: not rendered, fill bbox is all zeros
+PASS stroked zero-height rect: not rendered, fill bbox is all zeros
+PASS stroked zero-dim rect: not rendered, fill bbox is all zeros
+PASS stroked zero-radius circle: not rendered, fill bbox is all zeros
+PASS stroked path with only MoveTo: fill bbox is zero-area at the point
+PASS stroked zero-length line: stroke bbox same as fill bbox
+PASS stroked horizontal line: stroke bbox same as fill bbox
+PASS stroked vertical line: stroke bbox same as fill bbox
+PASS stroked zero-width rect: not rendered, stroke bbox is all zeros
+PASS stroked zero-height rect: not rendered, stroke bbox is all zeros
+PASS stroked zero-dim rect: not rendered, stroke bbox is all zeros
+PASS stroked zero-radius circle: not rendered, stroke bbox is all zeros
+PASS stroked path MoveTo only with round linecap: stroke bbox same as fill bbox
+PASS stroked zero-length path segment with round linecap: stroke bbox same as fill bbox
+PASS stroked ellipse with zero rx: not rendered, stroke bbox is all zeros
+PASS stroked horizontal path with butt linecap: stroke bbox same as fill bbox
+PASS stroked zero-length line: fill+stroke bbox same as fill bbox
+FAIL zero-length line with fill:false stroke:false returns empty bbox assert_equals: x expected 0 but got 10
+PASS empty text element has zero-area bbox
+PASS positioned empty text element has zero-area bbox
+PASS display:none text element returns zero bbox
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-09.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-09.html
@@ -1,0 +1,193 @@
+<!DOCTYPE html>
+<title>SVGGraphicsElement.prototype.getBBox stroke options and text edge cases</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGGraphicsElement__getBBox">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/coords.html#BoundingBoxes">
+<link rel="help" href="https://github.com/w3c/svgwg/issues/1018">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<svg width="0" height="0" style="position:absolute">
+
+  <!-- I. Stroked zero-dimension shapes -->
+  <line id="stroked_point" x1="10" y1="20" x2="10" y2="20"
+        stroke="red" stroke-width="4"/>
+  <line id="stroked_horiz" x1="10" y1="20" x2="50" y2="20"
+        stroke="red" stroke-width="4"/>
+  <line id="stroked_vert" x1="10" y1="20" x2="10" y2="60"
+        stroke="red" stroke-width="4"/>
+  <rect id="stroked_zero_w" x="10" y="20" width="0" height="50"
+        stroke="red" stroke-width="4"/>
+  <rect id="stroked_zero_h" x="10" y="20" width="50" height="0"
+        stroke="red" stroke-width="4"/>
+  <rect id="stroked_zero_wh" x="10" y="20" width="0" height="0"
+        stroke="red" stroke-width="4"/>
+  <circle id="stroked_zero_r" cx="10" cy="20" r="0"
+          stroke="red" stroke-width="4"/>
+  <path id="stroked_moveto" d="M10 20"
+        stroke="red" stroke-width="4" stroke-linecap="round"/>
+  <path id="stroked_zero_line" d="M10 20 h0"
+        stroke="red" stroke-width="4" stroke-linecap="round"/>
+  <ellipse id="stroked_zero_rx" cx="10" cy="20" rx="0" ry="30"
+           stroke="red" stroke-width="4"/>
+  <path id="stroked_horiz_path" d="M10 20 L50 20"
+        stroke="red" stroke-width="4" stroke-linecap="butt"/>
+
+  <!-- J. Text edge cases -->
+  <text id="text_empty"></text>
+  <text id="text_positioned" x="10" y="20"></text>
+  <text id="text_display_none" x="10" y="20" display="none">Hello</text>
+
+</svg>
+<script>
+function assert_bbox(id, expected_x, expected_y, expected_w, expected_h, options) {
+  var el = document.getElementById(id);
+  var bbox = options ? el.getBBox(options) : el.getBBox();
+  assert_equals(bbox.x, expected_x, "x");
+  assert_equals(bbox.y, expected_y, "y");
+  assert_equals(bbox.width, expected_w, "width");
+  assert_equals(bbox.height, expected_h, "height");
+}
+
+// ========================================================================
+// I. Stroke bounding box on zero-dimension shapes
+// Per resolution (issue #1018): non-rendered shapes return (0,0,0,0).
+// Rects with zero width/height and circles with zero radius are not rendered.
+// Lines and paths ARE rendered (they have stroke geometry).
+// ========================================================================
+
+// --- Fill bbox (default) ---
+
+test(function() {
+  assert_bbox("stroked_point", 10, 20, 0, 0);
+}, "stroked zero-length line: fill bbox is zero-area at the point");
+
+test(function() {
+  assert_bbox("stroked_horiz", 10, 20, 40, 0);
+}, "stroked horizontal line: fill bbox has zero height");
+
+test(function() {
+  assert_bbox("stroked_vert", 10, 20, 0, 40);
+}, "stroked vertical line: fill bbox has zero width");
+
+test(function() {
+  assert_bbox("stroked_zero_w", 0, 0, 0, 0);
+}, "stroked zero-width rect: not rendered, fill bbox is all zeros");
+
+test(function() {
+  assert_bbox("stroked_zero_h", 0, 0, 0, 0);
+}, "stroked zero-height rect: not rendered, fill bbox is all zeros");
+
+test(function() {
+  assert_bbox("stroked_zero_wh", 0, 0, 0, 0);
+}, "stroked zero-dim rect: not rendered, fill bbox is all zeros");
+
+test(function() {
+  assert_bbox("stroked_zero_r", 0, 0, 0, 0);
+}, "stroked zero-radius circle: not rendered, fill bbox is all zeros");
+
+test(function() {
+  assert_bbox("stroked_moveto", 10, 20, 0, 0);
+}, "stroked path with only MoveTo: fill bbox is zero-area at the point");
+
+// --- Stroke bbox via getBBox({stroke: true}) ---
+// getBBox({stroke: true}) returns the fill bbox — stroke-width does not
+// expand the bounding box values.
+// Rects/circles/ellipses with zero dims are not rendered → (0,0,0,0).
+
+test(function() {
+  assert_bbox("stroked_point", 10, 20, 0, 0, {stroke: true});
+}, "stroked zero-length line: stroke bbox same as fill bbox");
+
+test(function() {
+  assert_bbox("stroked_horiz", 10, 20, 40, 0, {stroke: true});
+}, "stroked horizontal line: stroke bbox same as fill bbox");
+
+test(function() {
+  assert_bbox("stroked_vert", 10, 20, 0, 40, {stroke: true});
+}, "stroked vertical line: stroke bbox same as fill bbox");
+
+test(function() {
+  // Zero-width rect: not rendered → (0,0,0,0) even with stroke option.
+  assert_bbox("stroked_zero_w", 0, 0, 0, 0, {stroke: true});
+}, "stroked zero-width rect: not rendered, stroke bbox is all zeros");
+
+test(function() {
+  // Zero-height rect: not rendered → (0,0,0,0) even with stroke option.
+  assert_bbox("stroked_zero_h", 0, 0, 0, 0, {stroke: true});
+}, "stroked zero-height rect: not rendered, stroke bbox is all zeros");
+
+test(function() {
+  // Zero-dim rect: not rendered → (0,0,0,0).
+  assert_bbox("stroked_zero_wh", 0, 0, 0, 0, {stroke: true});
+}, "stroked zero-dim rect: not rendered, stroke bbox is all zeros");
+
+test(function() {
+  // Zero-radius circle: not rendered → (0,0,0,0).
+  assert_bbox("stroked_zero_r", 0, 0, 0, 0, {stroke: true});
+}, "stroked zero-radius circle: not rendered, stroke bbox is all zeros");
+
+test(function() {
+  assert_bbox("stroked_moveto", 10, 20, 0, 0, {stroke: true});
+}, "stroked path MoveTo only with round linecap: stroke bbox same as fill bbox");
+
+test(function() {
+  assert_bbox("stroked_zero_line", 10, 20, 0, 0, {stroke: true});
+}, "stroked zero-length path segment with round linecap: stroke bbox same as fill bbox");
+
+test(function() {
+  // Ellipse with rx=0, ry=30: not rendered → (0,0,0,0).
+  assert_bbox("stroked_zero_rx", 0, 0, 0, 0, {stroke: true});
+}, "stroked ellipse with zero rx: not rendered, stroke bbox is all zeros");
+
+test(function() {
+  assert_bbox("stroked_horiz_path", 10, 20, 40, 0, {stroke: true});
+}, "stroked horizontal path with butt linecap: stroke bbox same as fill bbox");
+
+// --- Combined fill+stroke option ---
+
+test(function() {
+  var el = document.getElementById("stroked_point");
+  var bbox = el.getBBox({fill: true, stroke: true});
+  assert_equals(bbox.x, 10, "x");
+  assert_equals(bbox.y, 20, "y");
+  assert_equals(bbox.width, 0, "width");
+  assert_equals(bbox.height, 0, "height");
+}, "stroked zero-length line: fill+stroke bbox same as fill bbox");
+
+test(function() {
+  var el = document.getElementById("stroked_point");
+  var bbox = el.getBBox({fill: false, stroke: false});
+  // With both fill and stroke false, the bbox should be (0, 0, 0, 0).
+  assert_equals(bbox.x, 0, "x");
+  assert_equals(bbox.y, 0, "y");
+  assert_equals(bbox.width, 0, "width");
+  assert_equals(bbox.height, 0, "height");
+}, "zero-length line with fill:false stroke:false returns empty bbox");
+
+// ========================================================================
+// J. Text edge cases
+// ========================================================================
+
+test(function() {
+  var el = document.getElementById("text_empty");
+  var bbox = el.getBBox();
+  assert_equals(bbox.width, 0, "width");
+  assert_equals(bbox.height, 0, "height");
+}, "empty text element has zero-area bbox");
+
+test(function() {
+  var el = document.getElementById("text_positioned");
+  var bbox = el.getBBox();
+  assert_equals(bbox.width, 0, "width");
+  assert_equals(bbox.height, 0, "height");
+}, "positioned empty text element has zero-area bbox");
+
+test(function() {
+  var el = document.getElementById("text_display_none");
+  var bbox = el.getBBox();
+  // Per resolution (issue #1018): non-rendered elements return zero bbox.
+  assert_equals(bbox.x, 0, "x");
+  assert_equals(bbox.y, 0, "y");
+  assert_equals(bbox.width, 0, "width");
+  assert_equals(bbox.height, 0, "height");
+}, "display:none text element returns zero bbox");
+</script>


### PR DESCRIPTION
#### 63ff0a77cadfa2fb948c80ec093578115c367073
<pre>
Create comprehensive WPT test suite for SVG getBBox
<a href="https://bugs.webkit.org/show_bug.cgi?id=310184">https://bugs.webkit.org/show_bug.cgi?id=310184</a>
<a href="https://rdar.apple.com/173215242">rdar://173215242</a>

Reviewed by Vitor Roriz.

Apply SVG WG resolution for issue #1018: getBBox() on non-rendered
elements (zero, negative, or missing dimensions; display:none; inside
defs/clipPath/mask/symbol) must return (0, 0, 0, 0) for all four
values instead of retaining x/y position or throwing.

Update expected values across all affected test files. Replace
assert_approx_equals with assert_equals since getBBox returns exact
integer values. Remove duplicate negative-dimension tests from
getBBox-08 already covered by getBBox-03.

* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-01.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-02.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-03.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-03-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-04.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-05.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-06.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-06-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-07-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-07.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-08-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-08.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-09-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-09.html: Added.

Canonical link: <a href="https://commits.webkit.org/309810@main">https://commits.webkit.org/309810@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba35abfe867aa4064ef8ee319e85c16e43c479e9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151837 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24618 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/18188 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160579 "Failed to checkout and rebase branch from PR 60860") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25111 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24915 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/160579 "Failed to checkout and rebase branch from PR 60860") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154797 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/136254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/160579 "Failed to checkout and rebase branch from PR 60860") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/18531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/16470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/8414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/14157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/163043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/15749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/163043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/24417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/20529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/163043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24418 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/135953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/80993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23307 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20502 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/12728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24035 "Built successfully") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/23726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/23886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/23787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->