### PR TITLE
[WPE][GTK] Ensure that jhbuild or flatpak is only used if set explicitly via WEBKIT_JHBUILD=1 or WEBKIT_FLATPAK=1

### DIFF
--- a/Tools/Scripts/clean-webkit
+++ b/Tools/Scripts/clean-webkit
@@ -35,9 +35,6 @@ from webkitpy.common.checkout.scm.detection import SCMDetector
 from webkitpy.common.host import Host
 from webkitpy.common.system.filesystem import FileSystem
 
-def usesFlatpak():
-    return not os.environ.get('WEBKIT_JHBUILD') or os.environ.get('WEBKIT_JHBUILD') == '0'
-
 def listWebKitBuildFiles(fs):
     ret = []
     if fs.isdir("WebKitBuild"):
@@ -74,6 +71,14 @@ def removeDerivedSources(fs):
         if fs.isfile(each):
             fs.remove(each)
 
+def getKeepDirs():
+    if os.environ.get('WEBKIT_FLATPAK') == '1':
+        return ["Toolchains", "UserFlatpak"]
+    if os.environ.get('WEBKIT_JHBUILD') == '1':
+        return ["DependenciesGTK", "DependenciesWPE"]
+    return []
+
+
 def main(args):
     fs = FileSystem()
     host = Host()
@@ -92,7 +97,7 @@ def main(args):
         scm.discard_untracked_files(discard_ignored_files=True, keep_webkitbuild_directory=True)
         if fs.isdir("WebKitBuild"):
             files = listWebKitBuildFiles(fs)
-            keepDirs = usesFlatpak() and ["Toolchains", "UserFlatpak"] or ["DependenciesGTK", "DependenciesWPE"]
+            keepDirs = getKeepDirs()
             files = [path for path in files if path[len("WebKitBuild/"):] not in keepDirs]
             removeFiles(fs, files)
     else:

--- a/Tools/Scripts/run-gtk-tests
+++ b/Tools/Scripts/run-gtk-tests
@@ -28,16 +28,8 @@ top_level_directory = os.path.normpath(os.path.join(os.path.dirname(__file__), "
 sys.path.insert(0, os.path.join(top_level_directory, "Tools", "jhbuild"))
 sys.path.insert(0, os.path.join(top_level_directory, "Tools", "glib"))
 import common
-import jhbuildutils
-from api_test_runner import TestRunner, create_option_parser, get_runner_args
-
-
-try:
-    from gi.repository import Gio, GLib
-except ImportError:
-    # We don't require gi to be installed outside the sandbox
-    if jhbuildutils.enter_jhbuild_environment_if_available("gtk"):
-        raise
+from api_test_runner import TestRunner, check_environment, create_option_parser, get_runner_args
+from gi.repository import Gio, GLib
 
 class GtkTestRunner(TestRunner):
     TestRunner.TEST_TARGETS = [ "WebKitGTK", "TestWebKit", "TestJSC", "TestWTF", "TestWebCore", "TestJavaScriptCore" ]
@@ -94,12 +86,7 @@ class GtkTestRunner(TestRunner):
 
 if __name__ == "__main__":
     runner_args = get_runner_args(sys.argv)
-    if not jhbuildutils.enter_jhbuild_environment_if_available("gtk") and os.environ.get('WEBKIT_BUILD_USE_SYSTEM_LIBRARIES') != '1':
-        print('***')
-        print('*** Warning: jhbuild environment not present.')
-        print('*** Run update-webkitgtk-libs before build-webkit to ensure proper testing.')
-        print('***')
-
+    check_environment("gtk")
     option_parser = create_option_parser()
     option_parser.add_option('--display-server', choices=['xvfb', 'xorg', 'weston', 'wayland'], default='xvfb',
                              help='"xvfb": Use a virtualized X11 server. "xorg": Use the current X11 session. '

--- a/Tools/Scripts/run-wpe-tests
+++ b/Tools/Scripts/run-wpe-tests
@@ -28,8 +28,7 @@ top_level_directory = os.path.normpath(os.path.join(os.path.dirname(__file__), "
 sys.path.insert(0, os.path.join(top_level_directory, "Tools", "jhbuild"))
 sys.path.insert(0, os.path.join(top_level_directory, "Tools", "glib"))
 import common
-import jhbuildutils
-from api_test_runner import TestRunner, create_option_parser, get_runner_args
+from api_test_runner import TestRunner, check_environment, create_option_parser, get_runner_args
 
 class WPETestRunner(TestRunner):
     TestRunner.TEST_TARGETS = [ "WPE", "WPEPlatform", "WPEQt", "TestWebKit", "TestJSC", "TestWTF", "TestWebCore", "TestJavaScriptCore" ]
@@ -54,12 +53,7 @@ class WPETestRunner(TestRunner):
 
 if __name__ == "__main__":
     runner_args = get_runner_args(sys.argv)
-    if not jhbuildutils.enter_jhbuild_environment_if_available("wpe") and os.environ.get('WEBKIT_BUILD_USE_SYSTEM_LIBRARIES') != '1':
-        print('***')
-        print('*** Warning: jhbuild environment not present.')
-        print('*** Run update-webkitwpe-libs before build-webkit to ensure proper testing.')
-        print('***')
-
+    check_environment("wpe")
     option_parser = create_option_parser()
     option_parser.add_option('--display-server', choices=['headless', 'wayland'], default='headless',
                              help='"headless": Use headless view backend. "wayland": Use the current wayland session.')

--- a/Tools/Scripts/update-webkitgtk-libs
+++ b/Tools/Scripts/update-webkitgtk-libs
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2011 Igalia S.L.
+# Copyright (C) 2011, 2026 Igalia S.L.
 # Copyright (C) 2012 Intel Corporation
 #
 # This library is free software; you can redistribute it and/or
@@ -16,16 +16,8 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-use warnings;
 use FindBin;
 use lib $FindBin::Bin;
 use webkitdirs;
 
-my $scriptsDir = relativeScriptsDir();
-if (defined $ENV{'WEBKIT_JHBUILD'} and $ENV{'WEBKIT_JHBUILD'}) {
-    system("perl", "$scriptsDir/update-webkit-libs-jhbuild", "--gtk", @ARGV) == 0 or die $!;
-} elsif (defined $ENV{'WEBKIT_CROSS_TARGET'} or grep(/^--cross-target/, @ARGV)) {
-    system("$scriptsDir/cross-toolchain-helper", "--build-toolchain", @ARGV) == 0 or die $!;
-} elsif (!(defined $ENV{'WEBKIT_BUILD_USE_SYSTEM_LIBRARIES'} && $ENV{'WEBKIT_BUILD_USE_SYSTEM_LIBRARIES'})) {
-    system("$scriptsDir/update-webkit-flatpak", @ARGV) == 0 or die $!;
-}
+updateGtkOrWpeLibs("gtk")

--- a/Tools/Scripts/update-webkitwpe-libs
+++ b/Tools/Scripts/update-webkitwpe-libs
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2011 Igalia S.L.
+# Copyright (C) 2011, 2026 Igalia S.L.
 # Copyright (C) 2012 Intel Corporation
 #
 # This library is free software; you can redistribute it and/or
@@ -16,16 +16,8 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-use warnings;
 use FindBin;
 use lib $FindBin::Bin;
 use webkitdirs;
 
-my $scriptsDir = relativeScriptsDir();
-if (defined $ENV{'WEBKIT_JHBUILD'} and $ENV{'WEBKIT_JHBUILD'}) {
-    system("perl", "$scriptsDir/update-webkit-libs-jhbuild", "--wpe", @ARGV) == 0 or die $!;
-} elsif (defined $ENV{'WEBKIT_CROSS_TARGET'} or grep(/^--cross-target/, @ARGV)) {
-    system("$scriptsDir/cross-toolchain-helper", "--build-toolchain", @ARGV) == 0 or die $!;
-} elsif (!(defined $ENV{'WEBKIT_BUILD_USE_SYSTEM_LIBRARIES'} && $ENV{'WEBKIT_BUILD_USE_SYSTEM_LIBRARIES'})) {
-    system("$scriptsDir/update-webkit-flatpak", @ARGV) == 0 or die $!;
-}
+updateGtkOrWpeLibs("wpe")

--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -196,6 +196,7 @@ BEGIN {
        &splitVersionString
        &tsanIsEnabled
        &ubsanIsEnabled
+       &updateGtkOrWpeLibs
        &usesCryptexPath
        &vcpkgArgsFromFeatures
        &willUseAppleTVDeviceSDK
@@ -2541,8 +2542,13 @@ sub maybeUseContainerSDKRootDir()
 {
     return if not isLinux();
     return if (shouldUseFlatpak() or shouldBuildForCrossTarget() or inCrossTargetEnvironment());
-    return if ($ENV{'WEBKIT_CONTAINER_SDK'} // '') ne '1';
     return if ($ENV{'WEBKIT_CONTAINER_SDK_INSIDE_MOUNT_NAMESPACE'} // '') eq '1';
+    return if ($ENV{'WEBKIT_FLATPAK'} // '') eq '1';
+    return if ($ENV{'WEBKIT_JHBUILD'} // '') eq '1';
+    if (($ENV{'WEBKIT_CONTAINER_SDK'} // '') ne '1') {
+        print STDERR "WARNING: Running outside wkdev-sdk container. For proper testing, use https://github.com/Igalia/webkit-container-sdk\n";
+        return;
+    }
 
     my $sourceDir = sourceDir();
     my @wrapperScript = (File::Spec->catfile($sourceDir, "Tools", "Scripts", "container-sdk-rootdir-wrapper"));
@@ -2644,41 +2650,27 @@ sub wrapperPrefixIfNeeded()
         return ();
     }
 
-    # Returning () here means either Flatpak or no wrapper will be used.
-    if (isGtk() or isWPE()) {
-        # Respect user's choice.
-        if (defined $ENV{'WEBKIT_JHBUILD'}) {
-            if ($ENV{'WEBKIT_JHBUILD'} and -e getJhbuildPath()) {
-                return jhbuildWrapperPrefix();
-            } else {
-                return ();
-            }
-            # or let Flatpak take precedence over JHBuild.
-        } elsif (-e getUserFlatpakPath()) {
-            return ();
-        } elsif (-e getJhbuildPath()) {
-            return jhbuildWrapperPrefix();
-        }
+    if ((isGtk() or isWPE()) and (defined $ENV{'WEBKIT_JHBUILD'} and $ENV{'WEBKIT_JHBUILD'} and -e getJhbuildPath())) {
+        return jhbuildWrapperPrefix();
     }
     return ();
 }
 
 sub shouldUseFlatpak()
 {
-    # TODO: Use flatpak for JSCOnly on Linux? Could be useful when the SDK
-    # supports cross-compilation for ARMv7 and Aarch64 for instance.
-
     if (!isGtk() and !isWPE()) {
         return 0;
     }
 
-    if ((defined $ENV{'WEBKIT_JHBUILD'} && $ENV{'WEBKIT_JHBUILD'}) or (defined $ENV{'WEBKIT_BUILD_USE_SYSTEM_LIBRARIES'} && $ENV{'WEBKIT_BUILD_USE_SYSTEM_LIBRARIES'})) {
+    if (defined $ENV{'WEBKIT_JHBUILD'} and $ENV{'WEBKIT_JHBUILD'}) {
         return 0;
     }
 
     if (shouldBuildForCrossTarget() or inCrossTargetEnvironment()) {
         return 0;
     }
+
+    return 0 unless (defined $ENV{'WEBKIT_FLATPAK'} and $ENV{'WEBKIT_FLATPAK'});
 
     my @prefix = wrapperPrefixIfNeeded();
     return ((! inFlatpakSandbox()) and (@prefix == 0) and -e getUserFlatpakPath());
@@ -2716,7 +2708,8 @@ sub shouldRemoveCMakeCache(@)
                              "PKG_CONFIG_LIBDIR", "PKG_CONFIG_PATH", # pkg-config
                              "CPATH", "LIBRARY_PATH", # GCC/Clang include/lib helpers
                              "CMAKE_MODULE_PATH", "CMAKE_PREFIX_PATH", # CMake-specific
-                             "WEBKIT_USE_SCCACHE"); # sccache
+                             # WebKit-tooling build modifiers
+                             "WEBKIT_CONTAINER_SDK", "WEBKIT_FLATPAK", "WEBKIT_JHBUILD", "WEBKIT_USE_SCCACHE");
     for my $envFlag (@relevantEnvFlags) {
         my $flagValue = $ENV{$envFlag} || "";
             $buildArgsEnv .= "\n" . $envFlag . "=" . $flagValue;
@@ -3771,5 +3764,28 @@ sub runGitUpdate()
     # almost certainly what we want.
     system("git", "pull", "--autostash") == 0 or die;
 }
+
+
+sub updateGtkOrWpeLibs
+{
+    my ($port) = @_;
+    my $scriptsDir = relativeScriptsDir();
+    if (defined $ENV{'WEBKIT_JHBUILD'} and $ENV{'WEBKIT_JHBUILD'}) {
+        system("perl", "$scriptsDir/update-webkit-libs-jhbuild", "--$port", @ARGV) == 0 or die $!;
+    } elsif (defined $ENV{'WEBKIT_CROSS_TARGET'} or grep(/^--cross-target/, @ARGV)) {
+        system("$scriptsDir/cross-toolchain-helper", "--build-toolchain", @ARGV) == 0 or die $!;
+    } elsif (defined $ENV{'WEBKIT_FLATPAK'} and $ENV{'WEBKIT_FLATPAK'}) {
+        system("$scriptsDir/update-webkit-flatpak", @ARGV) == 0 or die $!;
+    }
+
+    if (defined $ENV{'WEBKIT_CONTAINER_SDK'} and $ENV{'WEBKIT_CONTAINER_SDK'}) {
+        # FIXME: implement a way to check if the update is needed by calling some script at /wkdev-sdk and then print a different message.
+        print "Running inside wkdev-sdk: execute wkdev-update on the host to check for updates.\n";
+    } else {
+        warn "Please download and install wkdev-sdk from https://github.com/Igalia/webkit-container-sdk\n";
+        exit 1;
+    }
+}
+
 
 1;

--- a/Tools/Scripts/webkitpy/port/base.py
+++ b/Tools/Scripts/webkitpy/port/base.py
@@ -1296,6 +1296,8 @@ class Port(object):
         pass
 
     def _should_use_jhbuild(self):
+        if os.environ.get('WEBKIT_JHBUILD') != '1':
+            return False
         suffix = ""
         if self.port_name:
             suffix = self.port_name.upper()

--- a/Tools/Scripts/webkitpy/port/base_unittest.py
+++ b/Tools/Scripts/webkitpy/port/base_unittest.py
@@ -39,6 +39,7 @@ from webkitpy.common.system.systemhost_mock import MockSystemHost
 from webkitpy.common.host_mock import MockHost
 from webkitpy.port import Port
 from webkitpy.port.test import add_unit_tests_to_mock_filesystem, TestPort
+from webkitpy.thirdparty.mock import patch
 
 from webkitcorepy import OutputCapture
 from webkitscmpy import mocks
@@ -291,7 +292,10 @@ class PortTest(unittest.TestCase):
         self.assertFalse(port._should_use_jhbuild())
         port._filesystem.maybe_make_directory(jhbuild_path)
         self.assertTrue(port._filesystem.isdir(jhbuild_path))
-        self.assertTrue(port._should_use_jhbuild())
+        # false unless WEBKIT_JHBUILD=1 in env
+        self.assertFalse(port._should_use_jhbuild())
+        with patch('os.environ', {'WEBKIT_JHBUILD': '1'}):
+            self.assertTrue(port._should_use_jhbuild())
 
     def test_commits_for_upload(self):
         with mocks.local.Svn(path='/'), mocks.local.Git():

--- a/Tools/Scripts/webkitpy/port/linux_container_sdk_utils.py
+++ b/Tools/Scripts/webkitpy/port/linux_container_sdk_utils.py
@@ -29,10 +29,14 @@ def maybe_use_container_sdk_root_dir():
     if not sys.platform.startswith('linux'):
         return
 
-    if os.environ.get('WEBKIT_CONTAINER_SDK') != '1':
+    if os.environ.get('WEBKIT_CONTAINER_SDK_INSIDE_MOUNT_NAMESPACE') == '1':
         return
 
-    if os.environ.get('WEBKIT_CONTAINER_SDK_INSIDE_MOUNT_NAMESPACE') == '1':
+    if any(os.environ.get(e) == '1' for e in ('WEBKIT_FLATPAK', 'WEBKIT_JHBUILD')):
+        return
+
+    if os.environ.get('WEBKIT_CONTAINER_SDK') != '1':
+        print('WARNING: Running outside wkdev-sdk container. For proper testing, use https://github.com/Igalia/webkit-container-sdk', file=sys.stderr)
         return
 
     source_dir = os.path.normpath(os.path.join(os.path.dirname(__file__), '..', '..', '..', '..'))

--- a/Tools/Scripts/webkitpy/port/port_testcase.py
+++ b/Tools/Scripts/webkitpy/port/port_testcase.py
@@ -51,6 +51,7 @@ from webkitpy.port.server_process_mock import MockServerProcess
 from webkitpy.layout_tests.controllers.layout_test_runner import TestShard
 from webkitpy.layout_tests.servers import http_server_base
 from webkitpy.tool.mocktool import MockOptions
+from webkitpy.thirdparty.mock import patch
 
 from webkitpy.test.markers import slow, xfail
 
@@ -336,17 +337,18 @@ class PortTestCase(unittest.TestCase):
         self.assertEqual(self.proc.cmd, [port._path_to_image_diff(), "--difference"])
 
         # Now test the case of using JHBuild wrapper.
-        port._filesystem.maybe_make_directory(port.path_from_webkit_base('WebKitBuild', 'Dependencies%s' % port.port_name.upper()))
-        self.assertTrue(port._should_use_jhbuild())
+        with patch('os.environ', {'WEBKIT_JHBUILD': '1'}):
+            port._filesystem.maybe_make_directory(port.path_from_webkit_base('WebKitBuild', 'Dependencies%s' % port.port_name.upper()))
+            self.assertTrue(port._should_use_jhbuild())
 
-        self.assertEqual(port.diff_image(b'foo', b'bar'), ImageDiffResult(passed=False, diff_image=b'image1', difference=90.0, tolerance=0.1, fuzzy_data=result_fuzzy_data))
-        self.assertEqual(self.proc.cmd, port._jhbuild_wrapper + [port._path_to_image_diff(), "--difference"])
+            self.assertEqual(port.diff_image(b'foo', b'bar'), ImageDiffResult(passed=False, diff_image=b'image1', difference=90.0, tolerance=0.1, fuzzy_data=result_fuzzy_data))
+            self.assertEqual(self.proc.cmd, port._jhbuild_wrapper + [port._path_to_image_diff(), "--difference"])
 
-        self.assertEqual(port.diff_image(b'foo', b'bar', tolerance=None), ImageDiffResult(passed=False, diff_image=b'image1', difference=90.0, tolerance=0.1, fuzzy_data=result_fuzzy_data))
-        self.assertEqual(self.proc.cmd, port._jhbuild_wrapper + [port._path_to_image_diff(), "--difference"])
+            self.assertEqual(port.diff_image(b'foo', b'bar', tolerance=None), ImageDiffResult(passed=False, diff_image=b'image1', difference=90.0, tolerance=0.1, fuzzy_data=result_fuzzy_data))
+            self.assertEqual(self.proc.cmd, port._jhbuild_wrapper + [port._path_to_image_diff(), "--difference"])
 
-        self.assertEqual(port.diff_image(b'foo', b'bar', tolerance=0), ImageDiffResult(passed=False, diff_image=b'image1', difference=90.0, fuzzy_data=result_fuzzy_data))
-        self.assertEqual(self.proc.cmd, port._jhbuild_wrapper + [port._path_to_image_diff(), "--difference"])
+            self.assertEqual(port.diff_image(b'foo', b'bar', tolerance=0), ImageDiffResult(passed=False, diff_image=b'image1', difference=90.0, fuzzy_data=result_fuzzy_data))
+            self.assertEqual(self.proc.cmd, port._jhbuild_wrapper + [port._path_to_image_diff(), "--difference"])
 
         port.clean_up_test_run()
         self.assertTrue(self.proc.stopped)

--- a/Tools/Scripts/webkitpy/w3c/wpt_runner.py
+++ b/Tools/Scripts/webkitpy/w3c/wpt_runner.py
@@ -58,8 +58,8 @@ def main(script_name, argv):
         sys.path.insert(0, filesystem.join(top_level_directory, 'Tools', 'jhbuild'))
         import jhbuildutils
 
-        if not jhbuildutils.enter_jhbuild_environment_if_available(port.name()) and os.environ.get('WEBKIT_BUILD_USE_SYSTEM_LIBRARIES') != '1':
-            _log.warning('jhbuild environment not present. Run update-webkitgtk-libs before build-webkit to ensure proper testing.')
+        if jhbuildutils.should_use_jhbuild() and not jhbuildutils.enter_jhbuild_environment_if_available(port.name()):
+            _log.warning('jhbuild not present: run update-webkitgtk-libs before build-webkit to ensure proper testing.')
 
     # Create the Port-specific driver.
     display_driver = port.create_driver(worker_number=0, no_timeout=True)._make_driver(pixel_tests=False)

--- a/Tools/flatpak/flatpakutils.py
+++ b/Tools/flatpak/flatpakutils.py
@@ -1422,8 +1422,13 @@ def is_sandboxed():
     return os.path.exists("/.flatpak-info")
 
 
+def should_use_flatpak():
+    if os.environ.get('WEBKIT_JHBUILD') == '1':
+        return False
+    return os.environ.get('WEBKIT_FLATPAK') == '1'
+
 def run_in_sandbox_if_available(args):
-    if os.environ.get('WEBKIT_JHBUILD') == '1' or os.environ.get('WEBKIT_BUILD_USE_SYSTEM_LIBRARIES') == '1':
+    if not should_use_flatpak():
         return None
 
     os.environ["FLATPAK_USER_DIR"] = os.environ.get("WEBKIT_FLATPAK_USER_DIR", FLATPAK_USER_DIR_PATH)

--- a/Tools/glib/api_test_runner.py
+++ b/Tools/glib/api_test_runner.py
@@ -28,18 +28,18 @@ from glib_test_runner import GLibTestRunner
 
 top_level_directory = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", ".."))
 sys.path.insert(0, os.path.join(top_level_directory, "Tools", "glib"))
-import common
+
+
+import common  # noqa: E402
+import jhbuildutils  # noqa: E402
+import subprocess  # noqa: E402
 from webkitpy.common.host import Host
 from webkitpy.common.test_expectations import TestExpectations
 from webkitpy.port.monadodriver import MonadoDriver  # noqa: E402
 from webkitpy.port.westondriver import WestonDriver
 from webkitcorepy import Timeout
 
-import subprocess
-
-
 UNKNOWN_CRASH_STR = "CRASH_OR_PROBLEM_IN_TEST_EXECUTABLE"
-
 
 def port_options(options):
     port_options = optparse.Values()
@@ -482,6 +482,16 @@ class TestRunner(object):
         sys.stdout.flush()
 
         return number_of_failed_tests
+
+
+def check_environment(port):
+    if jhbuildutils.should_use_jhbuild():
+        # This not only checks, but also enters into the jhbuild environment if present
+        if not jhbuildutils.enter_jhbuild_environment_if_available(port):
+            print('***')
+            print('*** Warning: jhbuild environment not present.')
+            print('*** Run update-webkitgtk-libs before build-webkit to ensure proper testing.')
+            print('***')
 
 
 def create_option_parser():

--- a/Tools/jhbuild/jhbuildutils.py
+++ b/Tools/jhbuild/jhbuildutils.py
@@ -30,8 +30,12 @@ def get_config_file_for_platform(platform):
     return top_level_path('Tools', platform, 'jhbuildrc')
 
 
+def should_use_jhbuild():
+    return os.environ.get('WEBKIT_JHBUILD') == '1'
+
+
 def enter_jhbuild_environment_if_available(platform):
-    if not os.path.exists(get_dependencies_path(platform)):
+    if not should_use_jhbuild() or not os.path.exists(get_dependencies_path(platform)):
         return False
 
     # Sometimes jhbuild chooses to install in a way that reads the library from the source directory, so fall


### PR DESCRIPTION
#### 23deb26c39372d21db46026a123405a285816750
<pre>
[WPE][GTK] Ensure that jhbuild or flatpak is only used if set explicitly via WEBKIT_JHBUILD=1 or WEBKIT_FLATPAK=1
<a href="https://bugs.webkit.org/show_bug.cgi?id=310187">https://bugs.webkit.org/show_bug.cgi?id=310187</a>

Reviewed by Philippe Normand.

The current status of some scripts like the ones for updating the third-party libs,
were to default to using flatpak unless this was executed inside wkdev-sdk.

That is wrong, it will confuse new users.

This patch changes the logic so the tools behave like this:

 - if WEBKIT_JHBUILD=1 in environment then try to use jhbuild
 - if WEBKIT_FLATPAK=1 in environment then try to use flatpak
 - if WEBKIT_CONTAINER_SDK is not in the environment, then print a warning
   telling to download and use wkdev-sdk.

Using jhbuild or flatpak is something opt-in for advanced use cases, is not
something that should be used by default.

The checks on the environment variable WEBKIT_BUILD_USE_SYSTEM_LIBRARIES are
also removed, because wkdev-sdk now defines WEBKIT_CONTAINER_SDK=1 which is
more appropiate.

I intend to send another patch to wkdev-sdk to stop setting in the environment
WEBKIT_BUILD_USE_SYSTEM_LIBRARIES=1 after this lands.

* Tools/Scripts/clean-webkit:
(removeDerivedSources):
(getKeepDirs):
(main):
(usesFlatpak): Deleted.
* Tools/Scripts/run-gtk-tests:
* Tools/Scripts/run-wpe-tests:
* Tools/Scripts/update-webkitgtk-libs:
* Tools/Scripts/update-webkitwpe-libs:
* Tools/Scripts/webkitdirs.pm:
(maybeUseContainerSDKRootDir):
(wrapperPrefixIfNeeded):
(shouldUseFlatpak):
(shouldRemoveCMakeCache):
(updateGtkOrWpeLibs):
* Tools/Scripts/webkitpy/port/base.py:
(Port._should_use_jhbuild):
* Tools/Scripts/webkitpy/port/base_unittest.py:
(PortTest.test_jhbuild_wrapper):
* Tools/Scripts/webkitpy/port/linux_container_sdk_utils.py:
(maybe_use_container_sdk_root_dir):
* Tools/Scripts/webkitpy/port/port_testcase.py:
(PortTestCase.test_diff_image):
* Tools/Scripts/webkitpy/w3c/wpt_runner.py:
(main):
* Tools/flatpak/flatpakutils.py:
(should_use_flatpak):
(run_in_sandbox_if_available):
* Tools/glib/api_test_runner.py:
(check_environment):
* Tools/jhbuild/jhbuildutils.py:
(should_use_jhbuild):
(enter_jhbuild_environment_if_available):

Canonical link: <a href="https://commits.webkit.org/309557@main">https://commits.webkit.org/309557@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec09addaba2d5b8f721b3b9fd0b06219a11aba48

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151038 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23800 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17370 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159766 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104474 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152911 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24231 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24022 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116607 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82768 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153998 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18726 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135514 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97328 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/150359 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17819 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15772 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7612 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/143022 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127437 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13431 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162239 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/11837 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15002 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124614 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23602 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19822 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124802 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23592 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135228 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80013 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23209 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19865 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11993 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/182647 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23202 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46617 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22914 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23066 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22968 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->