### PR TITLE
Enhanced <select>: correct Page Up/Down and remove delayed scrolling

### DIFF
--- a/LayoutTests/fast/forms/select/base/select-pagedown-pageup-expected.txt
+++ b/LayoutTests/fast/forms/select/base/select-pagedown-pageup-expected.txt
@@ -1,0 +1,29 @@
+Tests Page Down and Page Up keyboard navigation in a base-select picker.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS focusedOptionNumber() is 50
+PASS isFocusedOptionVisible() is true
+PASS focusedOptionNumber() is 1
+PASS focusedOptionNumber() is >= 2
+PASS select.value is savedValue
+PASS focusedOptionNumber() is 100
+PASS focusedOptionNumber() < 100 is true
+PASS select.value is savedValue
+PASS secondPageDown is >= firstPageDown + 1
+PASS afterPageUp < secondPageDown is true
+PASS focusedOptionNumber() is 100
+PASS focusedOptionNumber() is 1
+PASS focusedOptionNumber() is 100
+PASS focusedOptionNumber() is 1
+PASS focusedOptionNumber() === pageDownTarget is true
+PASS focusedOptionNumber() === pageUpTarget is true
+PASS constrainedTarget > 1 is true
+PASS constrainedTarget < pageDownTarget is true
+PASS firstPartialItem !== null is true
+PASS isOptionVisible(firstPartialItem) is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/select/base/select-pagedown-pageup-vertical-expected.txt
+++ b/LayoutTests/fast/forms/select/base/select-pagedown-pageup-vertical-expected.txt
@@ -1,0 +1,35 @@
+Tests Page Down and Page Up keyboard navigation in a base-select picker with vertical writing modes.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+
+vertical-lr:
+
+PASS focusedOptionNumber() is 50
+PASS isFocusedOptionVisible() is true
+PASS focusedOptionNumber() is 1
+PASS focusedOptionNumber() is >= 2
+PASS focusedOptionNumber() is 100
+PASS focusedOptionNumber() < 100 is true
+PASS focusedOptionNumber() is 100
+PASS focusedOptionNumber() is 1
+PASS focusedOptionNumber() === pageDownTarget is true
+PASS focusedOptionNumber() === pageUpTarget is true
+
+vertical-rl:
+
+PASS focusedOptionNumber() is 50
+PASS isFocusedOptionVisible() is true
+PASS focusedOptionNumber() is 1
+PASS focusedOptionNumber() is >= 2
+PASS focusedOptionNumber() is 100
+PASS focusedOptionNumber() < 100 is true
+PASS focusedOptionNumber() is 100
+PASS focusedOptionNumber() is 1
+PASS focusedOptionNumber() === pageDownTarget is true
+PASS focusedOptionNumber() === pageUpTarget is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/select/base/select-pagedown-pageup-vertical.html
+++ b/LayoutTests/fast/forms/select/base/select-pagedown-pageup-vertical.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/js-test.js"></script>
+<script src="../../../../resources/ui-helper.js"></script>
+<style>
+select, ::picker(select) {
+  appearance: base-select;
+}
+</style>
+</head>
+<body>
+<select id="select-vlr" style="writing-mode: vertical-lr"></select>
+<select id="select-vrl" style="writing-mode: vertical-rl"></select>
+<script>
+description("Tests Page Down and Page Up keyboard navigation in a base-select picker with vertical writing modes.");
+
+function setup(select) {
+    const nOptions = 100;
+    for (let i = 1; i <= nOptions; i++) {
+        const option = document.createElement('option');
+        option.textContent = `Option ${i}`;
+        option.id = `${select.id}-opt${i}`;
+        select.appendChild(option);
+    }
+}
+
+const selectVLR = document.getElementById('select-vlr');
+const selectVRL = document.getElementById('select-vrl');
+setup(selectVLR);
+setup(selectVRL);
+
+let currentSelect;
+
+function getOption(n) {
+    return document.getElementById(`${currentSelect.id}-opt${n}`);
+}
+
+function focusedOptionNumber() {
+    const id = document.activeElement ? document.activeElement.id : '';
+    const prefix = `${currentSelect.id}-opt`;
+    return id.startsWith(prefix) ? parseInt(id.replace(prefix, '')) : null;
+}
+
+function isFocusedOptionVisible() {
+    const option = document.activeElement;
+    const prefix = `${currentSelect.id}-opt`;
+    if (!option || !option.id.startsWith(prefix))
+        return false;
+    const picker = internals.shadowRoot(currentSelect).querySelector('[popover]');
+    const pickerRect = picker.getBoundingClientRect();
+    const optionRect = option.getBoundingClientRect();
+    return optionRect.left >= pickerRect.left - 1 && optionRect.right <= pickerRect.right + 1;
+}
+
+async function openPickerAt(n) {
+    currentSelect.value = getOption(n).value;
+    await UIHelper.activateElement(currentSelect);
+    await UIHelper.animationFrame();
+}
+
+async function closePicker() {
+    if (currentSelect.matches(':open')) {
+        await UIHelper.activateElement(currentSelect);
+        await UIHelper.animationFrame();
+    }
+}
+
+const nOptions = 100;
+
+async function runTestsForSelect(select, label) {
+    currentSelect = select;
+
+    debug(`\n${label}:\n`);
+
+    // Test: Opening the picker at a middle option scrolls it into view.
+    await openPickerAt(50);
+    shouldBe('focusedOptionNumber()', '50');
+    shouldBeTrue('isFocusedOptionVisible()');
+    await closePicker();
+
+    // Test: Page Down from first option moves focus forward.
+    await openPickerAt(1);
+    shouldBe('focusedOptionNumber()', '1');
+    await UIHelper.keyDown("pageDown");
+    shouldBeGreaterThanOrEqual('focusedOptionNumber()', '2');
+    await closePicker();
+
+    // Test: Page Up from last option moves focus backward.
+    await openPickerAt(nOptions);
+    shouldBe('focusedOptionNumber()', String(nOptions));
+    await UIHelper.keyDown("pageUp");
+    shouldBeTrue(`focusedOptionNumber() < ${nOptions}`);
+    await closePicker();
+
+    // Test: Repeated Page Down eventually reaches the last option.
+    await openPickerAt(1);
+    previousOption = 1;
+    for (let i = 0; i < nOptions; i++) {
+        await UIHelper.keyDown("pageDown");
+        currentOption = focusedOptionNumber();
+        if (currentOption === nOptions)
+            break;
+        if (currentOption <= previousOption) {
+            testFailed(`Page Down did not make progress: was ${previousOption}, now ${currentOption}`);
+            break;
+        }
+        previousOption = currentOption;
+    }
+    shouldBe('focusedOptionNumber()', String(nOptions));
+    await closePicker();
+
+    // Test: Repeated Page Up eventually reaches the first option.
+    await openPickerAt(nOptions);
+    previousOption = nOptions;
+    for (let i = 0; i < nOptions; i++) {
+        await UIHelper.keyDown("pageUp");
+        currentOption = focusedOptionNumber();
+        if (currentOption === 1)
+            break;
+        if (currentOption >= previousOption) {
+            testFailed(`Page Up did not make progress: was ${previousOption}, now ${currentOption}`);
+            break;
+        }
+        previousOption = currentOption;
+    }
+    shouldBe('focusedOptionNumber()', '1');
+    await closePicker();
+
+    // Test: Page Down is viewport-based, not focused-item-based.
+    // Use the appropriate arrow key for the writing mode to move within the same page.
+    isVRL = select.style.writingMode === 'vertical-rl';
+    nextKey = isVRL ? 'ArrowLeft' : 'ArrowRight';
+    prevKey = isVRL ? 'ArrowRight' : 'ArrowLeft';
+    await openPickerAt(1);
+    await UIHelper.keyDown("pageDown");
+    pageDownTarget = focusedOptionNumber();
+    await closePicker();
+
+    await openPickerAt(1);
+    await UIHelper.keyDown(nextKey);
+    await UIHelper.keyDown(nextKey);
+    await UIHelper.keyDown("pageDown");
+    shouldBeTrue('focusedOptionNumber() === pageDownTarget');
+    await closePicker();
+
+    // Test: Page Up is viewport-based.
+    await openPickerAt(nOptions);
+    await UIHelper.keyDown("pageUp");
+    pageUpTarget = focusedOptionNumber();
+    await closePicker();
+
+    await openPickerAt(nOptions);
+    await UIHelper.keyDown(prevKey);
+    await UIHelper.keyDown(prevKey);
+    await UIHelper.keyDown("pageUp");
+    shouldBeTrue('focusedOptionNumber() === pageUpTarget');
+    await closePicker();
+}
+
+jsTestIsAsync = true;
+
+(async () => {
+    await runTestsForSelect(selectVLR, 'vertical-lr');
+    await runTestsForSelect(selectVRL, 'vertical-rl');
+    finishJSTest();
+})();
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/select/base/select-pagedown-pageup.html
+++ b/LayoutTests/fast/forms/select/base/select-pagedown-pageup.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/js-test.js"></script>
+<script src="../../../../resources/ui-helper.js"></script>
+<style id="pickerStyle">
+select, ::picker(select) {
+  appearance: base-select;
+}
+</style>
+</head>
+<body>
+<select id="select"></select>
+<script>
+description("Tests Page Down and Page Up keyboard navigation in a base-select picker.");
+
+const select = document.getElementById('select');
+const pickerStyle = document.getElementById('pickerStyle');
+const nOptions = 100;
+
+for (let i = 1; i <= nOptions; i++) {
+    const option = document.createElement('option');
+    option.textContent = `Option ${i}`;
+    option.id = `opt${i}`;
+    select.appendChild(option);
+}
+
+function getOption(n) {
+    return document.getElementById(`opt${n}`);
+}
+
+function focusedOptionNumber() {
+    const id = document.activeElement ? document.activeElement.id : '';
+    return id.startsWith('opt') ? parseInt(id.replace('opt', '')) : null;
+}
+
+function isFocusedOptionVisible() {
+    const option = document.activeElement;
+    if (!option || !option.id.startsWith('opt'))
+        return false;
+    const picker = internals.shadowRoot(select).querySelector('[popover]');
+    const pickerRect = picker.getBoundingClientRect();
+    const optionRect = option.getBoundingClientRect();
+    return optionRect.top >= pickerRect.top - 1 && optionRect.bottom <= pickerRect.bottom + 1;
+}
+
+function isOptionVisible(n) {
+    const option = getOption(n);
+    const picker = internals.shadowRoot(select).querySelector('[popover]');
+    const contentTop = picker.getBoundingClientRect().top + picker.clientTop;
+    const contentBottom = contentTop + picker.clientHeight;
+    const optionRect = option.getBoundingClientRect();
+    return optionRect.top >= contentTop - 1 && optionRect.bottom <= contentBottom + 1;
+}
+
+async function openPickerAt(n) {
+    select.value = getOption(n).value;
+    await UIHelper.activateElement(select);
+    await UIHelper.animationFrame();
+}
+
+async function closePicker() {
+    if (select.matches(':open')) {
+        await UIHelper.activateElement(select);
+        await UIHelper.animationFrame();
+    }
+}
+
+jsTestIsAsync = true;
+
+(async () => {
+
+    // Test: Opening the picker at a middle option scrolls it into view.
+    await openPickerAt(50);
+    shouldBe('focusedOptionNumber()', '50');
+    shouldBeTrue('isFocusedOptionVisible()');
+    await closePicker();
+
+    // Test: Page Down from first option moves focus forward.
+    await openPickerAt(1);
+    shouldBe('focusedOptionNumber()', '1');
+    await UIHelper.keyDown("pageDown");
+    shouldBeGreaterThanOrEqual('focusedOptionNumber()', '2');
+    savedValue = select.value;
+    shouldBe('select.value', 'savedValue');
+    await closePicker();
+
+    // Test: Page Up from last option moves focus backward.
+    await openPickerAt(nOptions);
+    shouldBe('focusedOptionNumber()', String(nOptions));
+    await UIHelper.keyDown("pageUp");
+    shouldBeTrue(`focusedOptionNumber() < ${nOptions}`);
+    savedValue = select.value;
+    shouldBe('select.value', 'savedValue');
+    await closePicker();
+
+    // Test: Repeated Page Down then Page Up.
+    await openPickerAt(1);
+    await UIHelper.keyDown("pageDown");
+    firstPageDown = focusedOptionNumber();
+    await UIHelper.keyDown("pageDown");
+    secondPageDown = focusedOptionNumber();
+    shouldBeGreaterThanOrEqual('secondPageDown', 'firstPageDown + 1');
+
+    await UIHelper.keyDown("pageUp");
+    afterPageUp = focusedOptionNumber();
+    shouldBeTrue('afterPageUp < secondPageDown');
+    await closePicker();
+
+    // Test: Page Down at the end stays on last option.
+    await openPickerAt(nOptions);
+    await UIHelper.keyDown("pageDown");
+    shouldBe('focusedOptionNumber()', String(nOptions));
+    await closePicker();
+
+    // Test: Page Up at the start stays on first option.
+    await openPickerAt(1);
+    await UIHelper.keyDown("pageUp");
+    shouldBe('focusedOptionNumber()', '1');
+    await closePicker();
+
+    // Test: Repeated Page Down eventually reaches the last option.
+    await openPickerAt(1);
+    previousOption = 1;
+    for (let i = 0; i < nOptions; i++) {
+        await UIHelper.keyDown("pageDown");
+        currentOption = focusedOptionNumber();
+        if (currentOption === nOptions)
+            break;
+        if (currentOption <= previousOption) {
+            testFailed(`Page Down did not make progress: was ${previousOption}, now ${currentOption}`);
+            break;
+        }
+        previousOption = currentOption;
+    }
+    shouldBe('focusedOptionNumber()', String(nOptions));
+    await closePicker();
+
+    // Test: Repeated Page Up eventually reaches the first option.
+    await openPickerAt(nOptions);
+    previousOption = nOptions;
+    for (let i = 0; i < nOptions; i++) {
+        await UIHelper.keyDown("pageUp");
+        currentOption = focusedOptionNumber();
+        if (currentOption === 1)
+            break;
+        if (currentOption >= previousOption) {
+            testFailed(`Page Up did not make progress: was ${previousOption}, now ${currentOption}`);
+            break;
+        }
+        previousOption = currentOption;
+    }
+    shouldBe('focusedOptionNumber()', '1');
+    await closePicker();
+
+    // Test: Page Down is viewport-based, not focused-item-based.
+    // Use arrow keys to move within the same page without changing the scroll position.
+    await openPickerAt(1);
+    await UIHelper.keyDown("pageDown");
+    pageDownTarget = focusedOptionNumber();
+    await closePicker();
+
+    await openPickerAt(1);
+    await UIHelper.keyDown("ArrowDown");
+    await UIHelper.keyDown("ArrowDown");
+    await UIHelper.keyDown("pageDown");
+    shouldBeTrue('focusedOptionNumber() === pageDownTarget');
+    await closePicker();
+
+    // Test: Page Up is viewport-based.
+    await openPickerAt(nOptions);
+    await UIHelper.keyDown("pageUp");
+    pageUpTarget = focusedOptionNumber();
+    await closePicker();
+
+    await openPickerAt(nOptions);
+    await UIHelper.keyDown("ArrowUp");
+    await UIHelper.keyDown("ArrowUp");
+    await UIHelper.keyDown("pageUp");
+    shouldBeTrue('focusedOptionNumber() === pageUpTarget');
+    await closePicker();
+
+    // Test: With a constrained picker height, Page Down jumps fewer items.
+    pickerStyle.textContent = `select, ::picker(select) { appearance: base-select; }\n::picker(select) { max-height: 150px; }`;
+
+    await openPickerAt(1);
+    await UIHelper.keyDown("pageDown");
+    constrainedTarget = focusedOptionNumber();
+    shouldBeTrue('constrainedTarget > 1');
+    shouldBeTrue('constrainedTarget < pageDownTarget');
+    await closePicker();
+
+    // Test: With a non-evenly-divisible picker height, the partially visible item from
+    // the current page remains visible after Page Down (overlap behavior).
+    pickerStyle.textContent = `select, ::picker(select) { appearance: base-select; }\n::picker(select) { max-height: 170px; }`;
+
+    await openPickerAt(1);
+    picker = internals.shadowRoot(select).querySelector('[popover]');
+    // Use content area edges (excluding border) to find partially visible items.
+    contentTop = picker.getBoundingClientRect().top + picker.clientTop;
+    contentBottom = contentTop + picker.clientHeight;
+    firstPartialItem = null;
+    for (let i = 1; i <= nOptions; i++) {
+        const optRect = getOption(i).getBoundingClientRect();
+        if (optRect.top < contentTop - 1 || optRect.bottom > contentBottom + 1) {
+            firstPartialItem = i;
+            break;
+        }
+    }
+    await UIHelper.keyDown("pageDown");
+    shouldBeTrue('firstPartialItem !== null');
+    shouldBeTrue('isOptionVisible(firstPartialItem)');
+    await closePicker();
+
+    finishJSTest();
+})();
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-home-end-pagedown-pageup-detailed.optional-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-home-end-pagedown-pageup-detailed.optional-expected.txt
@@ -1003,5 +1003,5 @@ Option #1000
 PASS Behavior of Home and End for customizable-<select>
 PASS Behavior of Home and End for customizable-<select>, starting at the top
 PASS Behavior of Home and End for customizable-<select>, starting at the bottom
-FAIL Behavior of PageUp and PageDown for customizable-<select> assert_not_equals: Second page down should scroll down by one page got disallowed value 305.390625
+FAIL Behavior of PageUp and PageDown for customizable-<select> assert_equals: First page down should not scroll expected 305.390625 but got -240.609375
 

--- a/LayoutTests/platform/ios/fast/forms/select/base/select-pagedown-pageup-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/select/base/select-pagedown-pageup-expected.txt
@@ -1,0 +1,32 @@
+Tests Page Down and Page Up keyboard navigation in a base-select picker.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS focusedOptionNumber() is 50
+PASS isFocusedOptionVisible() is true
+PASS focusedOptionNumber() is 1
+FAIL focusedOptionNumber() should be >= 2. Was 1 (of type number).
+PASS select.value is savedValue
+PASS focusedOptionNumber() is 100
+FAIL focusedOptionNumber() < 100 should be true. Was false.
+PASS select.value is savedValue
+FAIL secondPageDown should be >= firstPageDown + 1. Was 1 (of type number).
+FAIL afterPageUp < secondPageDown should be true. Was false.
+PASS focusedOptionNumber() is 100
+PASS focusedOptionNumber() is 1
+FAIL Page Down did not make progress: was 1, now 1
+FAIL focusedOptionNumber() should be 100. Was 1.
+FAIL Page Up did not make progress: was 100, now 100
+FAIL focusedOptionNumber() should be 1. Was 100.
+PASS focusedOptionNumber() === pageDownTarget is true
+PASS focusedOptionNumber() === pageUpTarget is true
+FAIL constrainedTarget > 1 should be true. Was false.
+FAIL constrainedTarget < pageDownTarget should be true. Was false.
+PASS firstPartialItem !== null is true
+FAIL isOptionVisible(firstPartialItem) should be true. Was false.
+PASS successfullyParsed is true
+Some tests failed.
+
+TEST COMPLETE
+

--- a/LayoutTests/platform/ios/fast/forms/select/base/select-pagedown-pageup-vertical-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/select/base/select-pagedown-pageup-vertical-expected.txt
@@ -1,0 +1,141 @@
+Tests Page Down and Page Up keyboard navigation in a base-select picker with vertical writing modes.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+
+vertical-lr:
+
+PASS focusedOptionNumber() is 50
+PASS isFocusedOptionVisible() is true
+PASS focusedOptionNumber() is 1
+FAIL focusedOptionNumber() should be >= 2. Was 1 (of type number).
+PASS focusedOptionNumber() is 100
+FAIL focusedOptionNumber() < 100 should be true. Was false.
+FAIL Page Down did not make progress: was 1, now 1
+FAIL focusedOptionNumber() should be 100. Was 1.
+FAIL Page Up did not make progress: was 100, now 100
+FAIL focusedOptionNumber() should be 1. Was 100.
+PASS focusedOptionNumber() === pageDownTarget is true
+PASS focusedOptionNumber() === pageUpTarget is true
+
+vertical-rl:
+
+PASS focusedOptionNumber() is 50
+PASS isFocusedOptionVisible() is true
+PASS focusedOptionNumber() is 1
+FAIL focusedOptionNumber() should be >= 2. Was 1 (of type number).
+PASS focusedOptionNumber() is 100
+FAIL focusedOptionNumber() < 100 should be true. Was false.
+FAIL Page Down did not make progress: was 1, now 1
+FAIL focusedOptionNumber() should be 100. Was 1.
+FAIL Page Up did not make progress: was 100, now 100
+FAIL focusedOptionNumber() should be 1. Was 100.
+PASS focusedOptionNumber() === pageDownTarget is true
+FAIL focusedOptionNumber() === pageUpTarget should be true. Was false.
+PASS successfullyParsed is true
+Some tests failed.
+
+TEST COMPLETE
+
+Option 1
+Option 2
+Option 3
+Option 4
+Option 5
+Option 6
+Option 7
+Option 8
+Option 9
+Option 10
+Option 11
+Option 12
+Option 13
+Option 14
+Option 15
+Option 16
+Option 17
+Option 18
+Option 19
+Option 20
+Option 21
+Option 22
+Option 23
+Option 24
+Option 25
+Option 26
+Option 27
+Option 28
+Option 29
+Option 30
+Option 31
+Option 32
+Option 33
+Option 34
+Option 35
+Option 36
+Option 37
+Option 38
+Option 39
+Option 40
+Option 41
+Option 42
+Option 43
+Option 44
+Option 45
+Option 46
+Option 47
+Option 48
+Option 49
+Option 50
+Option 51
+Option 52
+Option 53
+Option 54
+Option 55
+Option 56
+Option 57
+Option 58
+Option 59
+Option 60
+Option 61
+Option 62
+Option 63
+Option 64
+Option 65
+Option 66
+Option 67
+Option 68
+Option 69
+Option 70
+Option 71
+Option 72
+Option 73
+Option 74
+Option 75
+Option 76
+Option 77
+Option 78
+Option 79
+Option 80
+Option 81
+Option 82
+Option 83
+Option 84
+Option 85
+Option 86
+Option 87
+Option 88
+Option 89
+Option 90
+Option 91
+Option 92
+Option 93
+Option 94
+Option 95
+Option 96
+Option 97
+Option 98
+Option 99
+Option 100
+

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -291,7 +291,12 @@ void HTMLOptionElement::defaultEventHandler(Event& event)
         int currentIndex = select->optionToListIndex(index());
         int listIndex = select->computeNavigationIndex(keyIdentifier, currentIndex, select->pickerNavigationKeyIdentifiers());
         if (listIndex >= 0) {
-            select->focusOptionAtIndex(listIndex);
+            auto scrollMode = HTMLSelectElement::PickerScrollMode::Nearest;
+            if (keyIdentifier == "PageDown"_s)
+                scrollMode = HTMLSelectElement::PickerScrollMode::AlignBottom;
+            else if (keyIdentifier == "PageUp"_s)
+                scrollMode = HTMLSelectElement::PickerScrollMode::AlignTop;
+            select->focusOptionAtIndex(listIndex, std::nullopt, scrollMode);
             keyboardEvent->setDefaultHandled();
             return;
         }

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -71,6 +71,7 @@
 #include "RenderMenuList.h"
 #include "RenderTheme.h"
 #include "ScriptDisallowedScope.h"
+#include "ScrollIntoViewOptions.h"
 #include "SelectFallbackButtonElement.h"
 #include "SelectPopoverElement.h"
 #include "Settings.h"
@@ -386,36 +387,36 @@ void HTMLSelectElement::queuePickerCloseForAppearanceChange()
     });
 }
 
-static inline auto navigationKeyIdentifiersForWritingMode(const RenderElement* renderer) -> HTMLSelectElement::NavigationKeyIdentifiers
+static inline auto navigationKeyIdentifiersForWritingMode(WritingMode writingMode) -> HTMLSelectElement::NavigationKeyIdentifiers
 {
-    bool isHorizontalWritingMode = renderer ? renderer->writingMode().isHorizontal() : true;
-    bool isBlockFlipped = renderer ? renderer->writingMode().isBlockFlipped() : false;
+    bool isHorizontal = writingMode.isHorizontal();
 
-    auto next = isHorizontalWritingMode ? "Down"_s : "Right"_s;
-    auto previous = isHorizontalWritingMode ? "Up"_s : "Left"_s;
-    if (isBlockFlipped)
+    auto next = isHorizontal ? "Down"_s : "Right"_s;
+    auto previous = isHorizontal ? "Up"_s : "Left"_s;
+    if (writingMode.isBlockFlipped())
         std::swap(next, previous);
 
-    return { next, previous };
+    return { next, previous, writingMode };
 }
 
 auto HTMLSelectElement::pickerNavigationKeyIdentifiers() const -> NavigationKeyIdentifiers
 {
     RefPtr popover = m_popover;
     CheckedPtr renderer = popover ? popover->renderer() : nullptr;
-    return navigationKeyIdentifiersForWritingMode(renderer);
+    auto writingMode = renderer ? renderer->writingMode() : WritingMode { };
+    return navigationKeyIdentifiersForWritingMode(writingMode);
 }
 
-int HTMLSelectElement::computeNavigationIndex(const String& keyIdentifier, int currentListIndex, NavigationKeyIdentifiers navKeys) const
+int HTMLSelectElement::computeNavigationIndex(const String& keyIdentifier, int currentListIndex, NavigationKeyIdentifiers navigationKeys) const
 {
     // Primary axis (writing-mode aware block direction).
-    if (keyIdentifier == navKeys.next)
+    if (keyIdentifier == navigationKeys.next)
         return nextSelectableListIndex(currentListIndex);
-    if (keyIdentifier == navKeys.previous)
+    if (keyIdentifier == navigationKeys.previous)
         return previousSelectableListIndex(currentListIndex);
 
     // Secondary axis (the other pair of arrow keys, for convenience).
-    bool primaryIsVertical = (navKeys.next == "Down"_s || navKeys.next == "Up"_s);
+    bool primaryIsVertical = (navigationKeys.next == "Down"_s || navigationKeys.next == "Up"_s);
     if (primaryIsVertical) {
         // Primary is Down/Up, secondary is Right/Left.
         if (keyIdentifier == "Right"_s)
@@ -434,10 +435,16 @@ int HTMLSelectElement::computeNavigationIndex(const String& keyIdentifier, int c
         return firstSelectableListIndex();
     if (keyIdentifier == "End"_s)
         return lastSelectableListIndex();
-    if (keyIdentifier == "PageDown"_s)
+    if (keyIdentifier == "PageDown"_s) {
+        if (usesBaseAppearancePicker())
+            return nextSelectableListIndexForPickerPageMove(currentListIndex, SkipDirection::Forwards, navigationKeys.writingMode);
         return nextValidIndex(currentListIndex, SkipDirection::Forwards, 3);
-    if (keyIdentifier == "PageUp"_s)
+    }
+    if (keyIdentifier == "PageUp"_s) {
+        if (usesBaseAppearancePicker())
+            return nextSelectableListIndexForPickerPageMove(currentListIndex, SkipDirection::Backwards, navigationKeys.writingMode);
         return nextValidIndex(currentListIndex, SkipDirection::Backwards, 3);
+    }
 
     return -1;
 }
@@ -889,6 +896,50 @@ int HTMLSelectElement::nextSelectableListIndexPageAway(int startIndex, SkipDirec
     int edgeIndex = direction == SkipDirection::Forwards ? 0 : items.size() - 1;
     int skipAmount = pageSize + (direction == SkipDirection::Forwards ? startIndex : edgeIndex - startIndex);
     return nextValidIndex(edgeIndex, direction, skipAmount);
+}
+
+int HTMLSelectElement::nextSelectableListIndexForPickerPageMove(int startIndex, SkipDirection direction, WritingMode writingMode) const
+{
+    RefPtr popover = m_popover;
+    if (!popover)
+        return startIndex;
+
+    bool isHorizontal = writingMode.isHorizontal();
+    int pageSize = isHorizontal ? popover->clientHeight() : popover->clientWidth();
+    if (pageSize <= 0)
+        return startIndex;
+
+    auto& items = listItems();
+    int size = items.size();
+    if (startIndex < 0 || startIndex >= size)
+        return startIndex;
+
+    int scrollPos = isHorizontal ? popover->scrollTop() : popover->scrollLeft();
+    bool physicallyForward = (direction == SkipDirection::Forwards) != writingMode.isBlockFlipped();
+    int boundary = physicallyForward ? scrollPos + 2 * pageSize : scrollPos - pageSize;
+
+    int step = direction == SkipDirection::Forwards ? 1 : -1;
+    int lastGoodIndex = startIndex;
+
+    for (int i = startIndex + step; i >= 0 && i < size; i += step) {
+        RefPtr listItem = items[i].get();
+        if (!is<HTMLOptionElement>(*listItem) || listItem->isDisabledFormControl() || !listItem->isFocusable())
+            continue;
+
+        int itemStart = isHorizontal ? listItem->offsetTop() : listItem->offsetLeft();
+        int itemEnd = itemStart + (isHorizontal ? listItem->offsetHeight() : listItem->offsetWidth());
+
+        if (physicallyForward) {
+            if (itemEnd > boundary)
+                break;
+        } else {
+            if (itemStart < boundary)
+                break;
+        }
+        lastGoodIndex = i;
+    }
+
+    return lastGoodIndex;
 }
 
 void HTMLSelectElement::selectAll()
@@ -1773,7 +1824,8 @@ void HTMLSelectElement::listBoxDefaultEventHandler(Event& event)
             return;
 
         CheckedPtr renderer = this->renderer();
-        auto [nextKeyIdentifier, previousKeyIdentifier] = navigationKeyIdentifiersForWritingMode(renderer);
+        auto writingMode = renderer ? renderer->writingMode() : WritingMode { };
+        auto navigationKeys = navigationKeyIdentifiersForWritingMode(writingMode);
 
         const String& keyIdentifier = keyboardEvent->keyIdentifier();
 
@@ -1781,27 +1833,27 @@ void HTMLSelectElement::listBoxDefaultEventHandler(Event& event)
         int endIndex = 0;
         if (m_activeSelectionEndIndex < 0) {
             // Initialize the end index
-            if (keyIdentifier == nextKeyIdentifier || keyIdentifier == "PageDown"_s) {
+            if (keyIdentifier == navigationKeys.next || keyIdentifier == "PageDown"_s) {
                 int startIndex = lastSelectedListIndex();
                 handled = true;
-                if (keyIdentifier == nextKeyIdentifier)
+                if (keyIdentifier == navigationKeys.next)
                     endIndex = nextSelectableListIndex(startIndex);
                 else
                     endIndex = nextSelectableListIndexPageAway(startIndex, SkipDirection::Forwards);
-            } else if (keyIdentifier == previousKeyIdentifier || keyIdentifier == "PageUp"_s) {
+            } else if (keyIdentifier == navigationKeys.previous || keyIdentifier == "PageUp"_s) {
                 int startIndex = optionToListIndex(selectedIndex());
                 handled = true;
-                if (keyIdentifier == previousKeyIdentifier)
+                if (keyIdentifier == navigationKeys.previous)
                     endIndex = previousSelectableListIndex(startIndex);
                 else
                     endIndex = nextSelectableListIndexPageAway(startIndex, SkipDirection::Backwards);
             }
         } else {
             // Set the end index based on the current end index.
-            if (keyIdentifier == nextKeyIdentifier) {
+            if (keyIdentifier == navigationKeys.next) {
                 endIndex = nextSelectableListIndex(m_activeSelectionEndIndex);
                 handled = true;
-            } else if (keyIdentifier == previousKeyIdentifier) {
+            } else if (keyIdentifier == navigationKeys.previous) {
                 endIndex = previousSelectableListIndex(m_activeSelectionEndIndex);
                 handled = true;
             } else if (keyIdentifier == "PageDown"_s) {
@@ -2094,7 +2146,7 @@ void HTMLSelectElement::openPickerForUserInteraction(std::optional<bool> focusVi
     focusOptionAtIndex(listIndex, focusVisible);
 }
 
-void HTMLSelectElement::focusOptionAtIndex(int listIndex, std::optional<bool> focusVisible)
+void HTMLSelectElement::focusOptionAtIndex(int listIndex, std::optional<bool> focusVisible, PickerScrollMode scrollMode)
 {
     if (!usesBaseAppearancePicker())
         return;
@@ -2108,9 +2160,21 @@ void HTMLSelectElement::focusOptionAtIndex(int listIndex, std::optional<bool> fo
         return;
 
     FocusOptions focusOptions;
-    focusOptions.preventScroll = false;
+    focusOptions.preventScroll = true;
     focusOptions.focusVisible = focusVisible;
     option->focus(focusOptions);
+
+    switch (scrollMode) {
+    case PickerScrollMode::Nearest:
+        option->scrollIntoViewIfNeeded();
+        break;
+    case PickerScrollMode::AlignTop:
+        option->scrollIntoView(true);
+        break;
+    case PickerScrollMode::AlignBottom:
+        option->scrollIntoView(false);
+        break;
+    }
 }
 
 ExceptionOr<void> HTMLSelectElement::showPicker()

--- a/Source/WebCore/html/HTMLSelectElement.h
+++ b/Source/WebCore/html/HTMLSelectElement.h
@@ -63,6 +63,7 @@ public:
     ~HTMLSelectElement();
 
     enum class ExcludeOptGroup : bool { No, Yes };
+    enum class PickerScrollMode : uint8_t { Nearest, AlignTop, AlignBottom };
     static HTMLSelectElement* NODELETE findOwnerSelect(ContainerNode*, ExcludeOptGroup);
 
     WEBCORE_EXPORT int selectedIndex() const;
@@ -192,10 +193,11 @@ public:
     struct NavigationKeyIdentifiers {
         ASCIILiteral next;
         ASCIILiteral previous;
+        WritingMode writingMode { };
     };
     NavigationKeyIdentifiers pickerNavigationKeyIdentifiers() const;
     int computeNavigationIndex(const String& keyIdentifier, int currentListIndex, NavigationKeyIdentifiers) const;
-    void focusOptionAtIndex(int listIndex, std::optional<bool> focusVisible = std::nullopt);
+    void focusOptionAtIndex(int listIndex, std::optional<bool> focusVisible = std::nullopt, PickerScrollMode = PickerScrollMode::Nearest);
     int typeAheadMatchIndex(KeyboardEvent&);
 
 protected:
@@ -274,6 +276,7 @@ private:
     int firstSelectableListIndex() const;
     int lastSelectableListIndex() const;
     int nextSelectableListIndexPageAway(int startIndex, SkipDirection) const;
+    int nextSelectableListIndexForPickerPageMove(int startIndex, SkipDirection, WritingMode) const;
 
     void childrenChanged(const ChildChange&) final;
 


### PR DESCRIPTION
#### 7ec9768d8a063f439cb2a0265a016944b5699f6c
<pre>
Enhanced &lt;select&gt;: correct Page Up/Down and remove delayed scrolling
<a href="https://bugs.webkit.org/show_bug.cgi?id=310190">https://bugs.webkit.org/show_bug.cgi?id=310190</a>

Reviewed by Aditya Keerthi.

This makes Page Up/Down behave more like macOS where a new page of
options appears (if any) and either the first or last is focused
depending on the direction.

This also changes the way we do scrolling as

    focusOptions.preventScroll = false;

ends up scrolling in a subsequent task which is way too jank.

The iOS failures will be investigated in bug 310477.

Canonical link: <a href="https://commits.webkit.org/309769@main">https://commits.webkit.org/309769@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10abfe7b7912192484a630f351a976b011523d7b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151523 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24288 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17869 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160257 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104961 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/41a5d69f-68af-4910-ada6-91a79a0d99ee) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153397 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24719 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24590 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117013 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83081 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/249734c4-8c88-4fa5-899a-3582f7010da1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154483 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19158 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135966 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97729 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/852304b6-69a6-4cca-a161-14aaa5023d6d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18248 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16193 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8099 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127875 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13871 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162729 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5859 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15460 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125029 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24089 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20251 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125212 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24081 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135667 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80643 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23285 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20270 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12442 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23690 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88002 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23400 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23554 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23456 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->