### PR TITLE
[GStreamer] Respect video decoding limits in MediaCapabilites queries

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -1044,6 +1044,20 @@ GStreamerRegistryScanner::RegistryLookupResult GStreamerRegistryScanner::isConfi
             videoConfiguration.bitrate, videoConfiguration.framerate);
 #endif
 
+        if (configuration == Configuration::Decoding) {
+            if (auto* videoDecodingLimits = resolveVideoDecodingLimits()) {
+                if (videoConfiguration.width > videoDecodingLimits->mediaMaxWidth
+                    || videoConfiguration.height > videoDecodingLimits->mediaMaxHeight
+                    || videoConfiguration.framerate > videoDecodingLimits->mediaMaxFrameRate) {
+                    GST_DEBUG("Video configuration %ux%u@%f exceeds decoding limits %ux%u@%u",
+                        videoConfiguration.width, videoConfiguration.height, videoConfiguration.framerate,
+                        videoDecodingLimits->mediaMaxWidth, videoDecodingLimits->mediaMaxHeight,
+                        videoDecodingLimits->mediaMaxFrameRate);
+                    return { false, false, nullptr };
+                }
+            }
+        }
+
 #if ENABLE(WPE_PLATFORM)
         auto* scrData = screenData(primaryScreenDisplayID());
         if (!scrData || !scrData->screenSupportsHighDynamicRange) {


### PR DESCRIPTION
#### a8e8ac33b29802c9e5b8bac1f925425556e1f158
<pre>
[GStreamer] Respect video decoding limits in MediaCapabilites queries
<a href="https://bugs.webkit.org/show_bug.cgi?id=310192">https://bugs.webkit.org/show_bug.cgi?id=310192</a>

Reviewed by Xabier Rodriguez-Calvar.

The video decoding limits were only had into account in
supportsFeatures() so far. They should also be enforced by the
GStreamerRegistryScanner in isConfigurationSupported() as well.

See: <a href="https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1639">https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1639</a>

This change checks the limits from isConfigurationSupported(), so it&apos;s
enforced from MediaCapabilities queries.

Original author: Andrzej Surdej (<a href="https://github.com/asurdej-comcast)">https://github.com/asurdej-comcast)</a>

* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp:
(WebCore::GStreamerRegistryScanner::isConfigurationSupported const): Check the video decoding limits.

Canonical link: <a href="https://commits.webkit.org/309507@main">https://commits.webkit.org/309507@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f2cb6dad7c2140fb731a8d2b47f4bec5b59a8dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150855 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23615 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17187 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159582 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104291 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152728 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24048 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23824 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116450 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82682 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153815 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18560 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135344 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97170 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17657 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15608 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7429 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127275 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13261 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162056 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5181 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14829 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124452 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23419 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19658 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124640 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33832 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23409 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135058 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79815 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19707 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11823 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23019 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87099 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22731 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22883 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22785 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->