### PR TITLE
[MediaCapabilities][GStreamer] Check audio codecs support isConfigurationSupported()

### DIFF
--- a/LayoutTests/platform/glib/media/mediacapabilities/audio-decoding-info-expected.txt
+++ b/LayoutTests/platform/glib/media/mediacapabilities/audio-decoding-info-expected.txt
@@ -1,0 +1,30 @@
+
+MP3 audio should be supported without hardware decoding
+RUN(promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', audio: { contentType: 'audio/mp3' } });)
+Promise resolved OK
+info.supported == true OK
+info.smooth == true OK
+info.powerEfficient == false OK
+
+MPEG audio should be supported without hardware decoding
+RUN(promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', audio: { contentType: 'audio/mpeg' } });)
+Promise resolved OK
+info.supported == true OK
+info.smooth == true OK
+info.powerEfficient == false OK
+
+MP4 container with mp4a.40.2 audio should be supported without hardware decoding
+RUN(promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', audio: { contentType: 'audio/mp4; codecs="mp4a.40.2"' } });)
+Promise resolved OK
+info.supported == true OK
+info.smooth == true OK
+info.powerEfficient == false OK
+
+MP4 container with a fictional codec should not be supported
+RUN(promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', audio: { contentType: 'audio/mp4; codecs="fictional"' } });)
+Promise resolved OK
+info.supported == false OK
+info.smooth == false OK
+info.powerEfficient == false OK
+END OF TEST
+

--- a/LayoutTests/platform/glib/media/mediacapabilities/audio-decoding-info.html
+++ b/LayoutTests/platform/glib/media/mediacapabilities/audio-decoding-info.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="../../../../media/video-test.js"></script>
+    <script type="text/javascript">
+    var promise;
+
+    function next()
+    {
+        if (!tests.length) {
+            endTest();
+            return;
+        }
+
+        var nextTest = tests.shift();
+        consoleWrite('');
+        nextTest();
+    }
+
+    // Prototype:
+    // checkMediaCapabilitiesInfo(info, expectedSupported, expectedSmooth, expectedPowerEfficient)
+
+    tests = [
+         function() {
+             consoleWrite('MP3 audio should be supported without hardware decoding');
+             run("promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', audio: { contentType: 'audio/mp3' } });");
+             shouldResolve(promise).then((info) => {
+                 checkMediaCapabilitiesInfo(info, true, true, false);
+                 next();
+             }, next);
+         },
+         function() {
+             consoleWrite('MPEG audio should be supported without hardware decoding');
+             run("promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', audio: { contentType: 'audio/mpeg' } });");
+             shouldResolve(promise).then((info) => {
+                 checkMediaCapabilitiesInfo(info, true, true, false);
+                 next();
+             }, next);
+         },
+         function() {
+             consoleWrite('MP4 container with mp4a.40.2 audio should be supported without hardware decoding');
+             run("promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', audio: { contentType: 'audio/mp4; codecs=\"mp4a.40.2\"' } });");
+             shouldResolve(promise).then((info) => {
+                 checkMediaCapabilitiesInfo(info, true, true, false);
+                 next();
+             }, next);
+         },
+         function() {
+             consoleWrite('MP4 container with a fictional codec should not be supported');
+             run("promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', audio: { contentType: 'audio/mp4; codecs=\"fictional\"' } });");
+             shouldResolve(promise).then((info) => {
+                 checkMediaCapabilitiesInfo(info, false, false, false);
+                 next();
+             }, next);
+         },
+    ];
+    </script>
+</head>
+<body onload="next()" />
+</html>

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -1030,10 +1030,12 @@ ASCIILiteral GStreamerRegistryScanner::configurationNameForLogging(Configuration
 
 GStreamerRegistryScanner::RegistryLookupResult GStreamerRegistryScanner::isConfigurationSupported(Configuration configuration, const PlatformMediaConfiguration& mediaConfiguration) const
 {
-    bool isUsingHardware = false;
 #ifndef GST_DISABLE_GST_DEBUG
     ASCIILiteral configLogString = configurationNameForLogging(configuration);
 #endif
+
+    Vector<String> allCodecs;
+    Vector<String> videoCodecs;
 
     if (mediaConfiguration.video) {
         auto& videoConfiguration = mediaConfiguration.video.value();
@@ -1079,11 +1081,8 @@ GStreamerRegistryScanner::RegistryLookupResult GStreamerRegistryScanner::isConfi
             return { false, false, nullptr };
 
         auto codecs = contentType.codecs();
-        if (!codecs.isEmpty()) {
-            if (!areAllCodecsSupported(configuration, codecs, false))
-                return { false, false, nullptr };
-            isUsingHardware = areAllCodecsSupported(configuration, codecs, true);
-        }
+        allCodecs.appendVector(codecs);
+        videoCodecs.appendVector(WTF::move(codecs));
     }
 
     if (mediaConfiguration.audio) {
@@ -1096,6 +1095,15 @@ GStreamerRegistryScanner::RegistryLookupResult GStreamerRegistryScanner::isConfi
         auto contentType = ContentType(audioConfiguration.contentType);
         if (!isContainerTypeSupported(configuration, contentType.containerType()))
             return { false, false, nullptr };
+
+        allCodecs.appendVector(contentType.codecs());
+    }
+
+    bool isUsingHardware = false;
+    if (!allCodecs.isEmpty()) {
+        if (!areAllCodecsSupported(configuration, allCodecs, false))
+            return { false, false, nullptr };
+        isUsingHardware = !videoCodecs.isEmpty() && areAllCodecsSupported(configuration, videoCodecs, true);
     }
 
     return { true, isUsingHardware, nullptr };


### PR DESCRIPTION
#### e89e1a0fa65d95a376af552f1ddc4e83795a4a11
<pre>
[MediaCapabilities][GStreamer] Check audio codecs support isConfigurationSupported()
<a href="https://bugs.webkit.org/show_bug.cgi?id=310195">https://bugs.webkit.org/show_bug.cgi?id=310195</a>

Reviewed by Xabier Rodriguez-Calvar.

Currently, isConfigurationSupported() only validates video codecs
against the registered decoder/encoder map. Audio codecs from the audio
configuration were never checked, so unsupported audio codecs could
incorrectly be reported as supported.

See: <a href="https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1640">https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1640</a>

Fix this by collecting codec strings from both the video and audio
ContentType objects into a single vector and running the software codec
support checks once on the combined list at the end of the function.

Audio hardware accelerated decoding doesn&apos;t save much CPU power compared
to video accelerated decoding, and we don&apos;t want to reject a video+audio
codec combination just because the audio part isn&apos;t accelerated. That&apos;s
why the hardware accelerated decoding support checks are only run on the
video codecs.

A new platform-specific layout test has been added to check that common
audio formats and codecs are properly detected (but without
power-efficient decoding, that is, without hardware decoding), while an
unexistent &quot;fictional&quot; codec is rejected.

Co-authored by: Andrzej Surdej (<a href="https://github.com/asurdej-comcast)">https://github.com/asurdej-comcast)</a>

* LayoutTests/platform/glib/media/mediacapabilities/audio-decoding-info-expected.txt: Added.
* LayoutTests/platform/glib/media/mediacapabilities/audio-decoding-info.html: Added.
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp:
(WebCore::GStreamerRegistryScanner::isConfigurationSupported const): Collect audio codecs and run the codec checks.

Canonical link: <a href="https://commits.webkit.org/309939@main">https://commits.webkit.org/309939@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7cfa03d7e509768ced1b411eec2076ad6feee81b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152222 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25004 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18599 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160965 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154096 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25496 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25310 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/117605 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155182 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/136649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98318 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/18868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/16825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8799 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14523 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163432 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/6577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/16115 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/125631 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24802 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/20864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125807 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34128 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24803 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136319 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/81402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20817 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/13096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24420 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88705 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/24111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24271 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/24172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->