### PR TITLE
Revert: Absolutely positioned elements with intrinsic height incorrectly resolve percentage heights of children

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4480,6 +4480,10 @@ imported/w3c/web-platform-tests/css/css-values/viewport-units-scrollbars-dynamic
 imported/w3c/web-platform-tests/css/css-values/viewport-units-scrollbars-scroll-vw-002.html [ ImageOnlyFailure ]
 
 # wpt css-sizing failures
+webkit.org/b/308648 imported/w3c/web-platform-tests/css/css-sizing/abspos-auto-sizing-fit-content-percentage-005.html [ ImageOnlyFailure ]
+webkit.org/b/308648 imported/w3c/web-platform-tests/css/css-sizing/abspos-auto-sizing-fit-content-percentage-006.html [ ImageOnlyFailure ]
+webkit.org/b/308648 imported/w3c/web-platform-tests/css/css-sizing/abspos-auto-sizing-fit-content-percentage-007.html [ ImageOnlyFailure ]
+webkit.org/b/308648 imported/w3c/web-platform-tests/css/css-sizing/abspos-auto-sizing-fit-content-percentage-008.html [ ImageOnlyFailure ]
 webkit.org/b/203509 imported/w3c/web-platform-tests/css/css-sizing/auto-scrollbar-inside-stf-abspos.html [ ImageOnlyFailure ]
 webkit.org/b/203512 imported/w3c/web-platform-tests/css/css-sizing/intrinsic-percent-non-replaced-005.html [ ImageOnlyFailure ]
 webkit.org/b/203583 imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio-affects-container-width-when-height-changes.html [ Pass Failure ]

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -3078,13 +3078,7 @@ std::optional<LayoutUnit> RenderBlock::availableLogicalHeightForPercentageComput
         // A positioned element that specified both top/bottom or that specifies
         // height should be treated as though it has a height explicitly specified
         // that can be used for any percentage computations.
-        // However, intrinsic heights (fit-content, min-content, max-content) are
-        // content-dependent and should be treated as indefinite for percentage
-        // resolution of children, since the actual height is not yet determined.
-        auto heightIsIntrinsic = style.logicalHeight().isIntrinsic() || style.logicalHeight().isIntrinsicKeyword() || style.logicalHeight().isMinIntrinsic();
-        auto hasNonIntrinsicSpecifiedHeight = !style.logicalHeight().isAuto() && !heightIsIntrinsic;
-        auto hasDefiniteHeightFromInsets = !style.logicalTop().isAuto() && !style.logicalBottom().isAuto() && style.logicalHeight().isAuto();
-        auto isOutOfFlowPositionedWithSpecifiedHeight = isOutOfFlowPositioned() && (hasNonIntrinsicSpecifiedHeight || hasDefiniteHeightFromInsets);
+        auto isOutOfFlowPositionedWithSpecifiedHeight = isOutOfFlowPositioned() && (!style.logicalHeight().isAuto() || (!style.logicalTop().isAuto() && !style.logicalBottom().isAuto()));
         if (isOutOfFlowPositionedWithSpecifiedHeight) {
             // Don't allow this to affect the block' size() member variable, since this
             // can get called while the block is still laying out its kids.


### PR DESCRIPTION
#### 8e76c1932d393dd5b0c22b139721a079ff194705
<pre>
Revert: Absolutely positioned elements with intrinsic height incorrectly resolve percentage heights of children
<a href="https://bugs.webkit.org/show_bug.cgi?id=310197">https://bugs.webkit.org/show_bug.cgi?id=310197</a>
<a href="https://rdar.apple.com/172513516">rdar://172513516</a>

Reviewed by Brady Eidson.

Reverting the RenderBlock change from r308226 and marking the associated
WPT tests as failing while the correct fix is determined.

* LayoutTests/TestExpectations:
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::availableLogicalHeightForPercentageComputation const):

Canonical link: <a href="https://commits.webkit.org/309513@main">https://commits.webkit.org/309513@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6b4bc7c1f99a6effc12e23910e16ab9d4f9d2cd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150870 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23630 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17202 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159597 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104306 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/88a84e47-6beb-4185-a900-8795029522e2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152743 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24063 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23841 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116461 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82696 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9f5026af-382e-4ce3-bec5-828ef8e36cec) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153830 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18576 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135357 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97181 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4167eb4f-7626-427f-bee7-235fd9445857) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17672 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15620 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7444 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127290 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13274 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162071 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5196 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14842 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124462 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23434 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19670 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124650 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33838 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23424 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135071 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79831 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19724 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11836 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23034 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87118 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22746 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22898 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22800 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->