### PR TITLE
Rename insertedIntoAncestor, didFinishInsertingNode, and removedFromAncestor to match DOM spec

### DIFF
--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -1697,9 +1697,9 @@ bool HTMLModelElement::isURLAttribute(const Attribute& attribute) const
         || HTMLElement::isURLAttribute(attribute);
 }
 
-Node::InsertedIntoAncestorResult HTMLModelElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps HTMLModelElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    auto insertResult = HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    auto insertResult = HTMLElement::insertionSteps(insertionType, parentOfInsertedTree);
 
     if (insertionType.connectedToDocument) {
         Ref document = this->document();
@@ -1714,9 +1714,9 @@ Node::InsertedIntoAncestorResult HTMLModelElement::insertedIntoAncestor(Insertio
     return insertResult;
 }
 
-void HTMLModelElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void HTMLModelElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
-    HTMLElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    HTMLElement::removingSteps(removalType, oldParentOfRemovedTree);
 
     if (removalType.disconnectedFromDocument) {
         Ref document = this->document();

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -265,8 +265,8 @@ private:
     bool isVisible() const final;
     void logWarning(ModelPlayer&, const String&) final;
 
-    Node::InsertedIntoAncestorResult insertedIntoAncestor(InsertionType , ContainerNode& parentOfInsertedTree) override;
-    void removedFromAncestor(RemovalType, ContainerNode& oldParentOfRemovedTree) override;
+    Node::NeedsPostConnectionSteps insertionSteps(InsertionType , ContainerNode& parentOfInsertedTree) override;
+    void removingSteps(RemovalType, ContainerNode& oldParentOfRemovedTree) override;
 
     void defaultEventHandler(Event&) final;
     void dragDidStart(WebCore::MouseRelatedEvent&);

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -381,7 +381,7 @@ static ALWAYS_INLINE void executeNodeInsertionWithScriptAssertion(ContainerNode&
 
     ASSERT(ScriptDisallowedScope::InMainThread::isEventDispatchAllowedInSubtree(child));
     for (auto& target : postInsertionNotificationTargets)
-        target->didFinishInsertingNode();
+        target->postConnectionSteps();
 
     if (source == ContainerNode::ChildChange::Source::API)
         dispatchChildInsertionEvents(child);
@@ -419,7 +419,7 @@ static ALWAYS_INLINE void executeNodeInsertionWithScriptAssertion(ContainerNode&
 
     ASSERT(ScriptDisallowedScope::InMainThread::isEventDispatchAllowedInSubtree(containerNode));
     for (auto& target : postInsertionNotificationTargets)
-        target->didFinishInsertingNode();
+        target->postConnectionSteps();
 
     if (source == ContainerNode::ChildChange::Source::API) {
         for (auto& child : children)
@@ -1188,7 +1188,7 @@ void ContainerNode::cloneChildNodes(Document& document, CustomElementRegistry* f
     clone.childrenChanged(makeChildChangeForCloneInsertion(hadElement ? ClonedChildIncludesElements::Yes : ClonedChildIncludesElements::No));
 
     for (auto& target : postInsertionNotificationTargets)
-        target->didFinishInsertingNode();
+        target->postConnectionSteps();
 }
 
 Vector<SerializedNode> ContainerNode::serializeChildNodes(size_t currentDepth) const

--- a/Source/WebCore/dom/ContainerNodeAlgorithms.cpp
+++ b/Source/WebCore/dom/ContainerNodeAlgorithms.cpp
@@ -51,8 +51,8 @@ static void notifyNodeInsertedIntoDocument(ContainerNode& parentOfInsertedTree, 
     ASSERT(!node.isConnected());
 
     for (RefPtr currentNode = node; currentNode; currentNode = NodeTraversal::next(*currentNode, &node)) {
-        auto result = currentNode->insertedIntoAncestor(Node::InsertionType { /* connectedToDocument */ true, treeScopeChange == TreeScopeChange::Changed }, parentOfInsertedTree);
-        if (result == Node::InsertedIntoAncestorResult::NeedsPostInsertionCallback)
+        auto result = currentNode->insertionSteps(Node::InsertionType { /* connectedToDocument */ true, treeScopeChange == TreeScopeChange::Changed }, parentOfInsertedTree);
+        if (result == Node::NeedsPostConnectionSteps::Yes)
             postInsertionNotificationTargets.append(*currentNode);
         if (RefPtr root = currentNode->shadowRoot())
             notifyNodeInsertedIntoDocument(parentOfInsertedTree, *root, TreeScopeChange::DidNotChange, postInsertionNotificationTargets);
@@ -65,7 +65,7 @@ static void notifyNodeInsertedIntoTree(ContainerNode& parentOfInsertedTree, Node
     ASSERT(!node.isConnected());
 
     for (RefPtr currentNode = node; currentNode; currentNode = NodeTraversal::next(*currentNode, &node)) {
-        auto result = currentNode->insertedIntoAncestor(Node::InsertionType { /* connectedToDocument */ false, treeScopeChange == TreeScopeChange::Changed }, parentOfInsertedTree);
+        auto result = currentNode->insertionSteps(Node::InsertionType { /* connectedToDocument */ false, treeScopeChange == TreeScopeChange::Changed }, parentOfInsertedTree);
         UNUSED_PARAM(result);
         if (RefPtr root = currentNode->shadowRoot())
             notifyNodeInsertedIntoTree(parentOfInsertedTree, *root, TreeScopeChange::DidNotChange);
@@ -114,7 +114,7 @@ static RemovedSubtreeResult notifyNodeRemovedFromDocument(ContainerNode& oldPare
     unsigned subTreeSize = 0;
     for (RefPtr currentNode = node; currentNode; currentNode = NodeTraversal::next(*currentNode)) {
         ++subTreeSize;
-        currentNode->removedFromAncestor(Node::RemovalType { /* disconnectedFromDocument */ true, treeScopeChange == TreeScopeChange::Changed }, oldParentOfRemovedTree);
+        currentNode->removingSteps(Node::RemovalType { /* disconnectedFromDocument */ true, treeScopeChange == TreeScopeChange::Changed }, oldParentOfRemovedTree);
         updateCanDelayNodeDeletion(canDelayNodeDeletion, AsyncNodeDeletionQueue::canNodeBeDeletedAsync(node));
         updateObservability(observability, observabilityOfRemovedNode(*currentNode));
         if (RefPtr root = currentNode->shadowRoot()) {
@@ -136,7 +136,7 @@ static RemovedSubtreeResult notifyNodeRemovedFromTree(ContainerNode& oldParentOf
     RemovedSubtreeObservability observability = RemovedSubtreeObservability::NotObservable;
     for (RefPtr currentNode = node; currentNode; currentNode = NodeTraversal::next(*currentNode)) {
         ++subTreeSize;
-        currentNode->removedFromAncestor(Node::RemovalType { /* disconnectedFromDocument */ false, treeScopeChange == TreeScopeChange::Changed }, oldParentOfRemovedTree);
+        currentNode->removingSteps(Node::RemovalType { /* disconnectedFromDocument */ false, treeScopeChange == TreeScopeChange::Changed }, oldParentOfRemovedTree);
         updateCanDelayNodeDeletion(canDelayNodeDeletion, AsyncNodeDeletionQueue::canNodeBeDeletedAsync(node));
         updateObservability(observability, observabilityOfRemovedNode(*currentNode));
         if (RefPtr root = currentNode->shadowRoot()) {

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -699,7 +699,7 @@ void Element::cloneShadowTreeIfPossible(Element& newHost) const
         return downcast<ShadowRoot>(WTF::move(clone));
     }();
     if (oldShadowRoot->usesNullCustomElementRegistry())
-        clonedShadowRoot->setUsesNullCustomElementRegistry(); // Set this flag for Element::insertedIntoAncestor.
+        clonedShadowRoot->setUsesNullCustomElementRegistry(); // Set this flag for Element::insertionSteps.
     else {
         clonedShadowRoot->clearUsesNullCustomElementRegistry(); // Unset flag potentially set by DocumentFragment constructor
         if (RefPtr registry = oldShadowRoot->customElementRegistry()) {
@@ -3063,9 +3063,9 @@ RenderPtr<RenderElement> Element::createElementRenderer(RenderStyle&& style, con
     return RenderElement::createFor(*this, WTF::move(style));
 }
 
-Node::InsertedIntoAncestorResult Element::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps Element::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    ContainerNode::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    ContainerNode::insertionSteps(insertionType, parentOfInsertedTree);
 
     if (insertionType.treeScopeChanged) {
         RefPtr<HTMLDocument> newHTMLDocument = insertionType.connectedToDocument && parentOfInsertedTree.isInDocumentTree()
@@ -3128,7 +3128,7 @@ Node::InsertedIntoAncestorResult Element::insertedIntoAncestor(InsertionType ins
     if (!is<HTMLSlotElement>(*this))
         updateEffectiveTextDirectionIfNeeded();
 
-    return InsertedIntoAncestorResult::Done;
+    return NeedsPostConnectionSteps::No;
 }
 
 void Element::clearEffectiveLangStateOnNewDocumentElement()
@@ -3163,9 +3163,9 @@ bool Element::hasEffectiveLangState() const
     return false;
 }
 
-void Element::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void Element::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
-    ContainerNode::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    ContainerNode::removingSteps(removalType, oldParentOfRemovedTree);
 
     if (RefPtr<Page> page = document().page()) {
 #if ENABLE(POINTER_LOCK)
@@ -3435,7 +3435,7 @@ ExceptionOr<ShadowRoot&> Element::attachShadow(const ShadowRootInit& init, std::
         isPrecustomizedOrDefinedCustomElement() ? ShadowRootAvailableToElementInternals::Yes : ShadowRootAvailableToElementInternals::No,
         WTF::move(registry), scopedRegistry);
     if (registryKind == CustomElementRegistryKind::Null)
-        shadow->setUsesNullCustomElementRegistry(); // Set this flag for Element::insertedIntoAncestor.
+        shadow->setUsesNullCustomElementRegistry(); // Set this flag for Element::insertionSteps.
     shadow->setReferenceTarget(AtomString(init.referenceTarget));
     addShadowRoot(shadow.copyRef());
     return shadow.get();
@@ -3650,7 +3650,7 @@ void Element::childrenChanged(const ChildChange& change)
         switch (change.type) {
         case ChildChange::Type::ElementInserted:
         case ChildChange::Type::ElementRemoved:
-            // For elements, we notify shadowRoot in Element::insertedIntoAncestor and Element::removedFromAncestor.
+            // For elements, we notify shadowRoot in Element::insertionSteps and Element::removingSteps.
             break;
         case ChildChange::Type::AllChildrenRemoved:
         case ChildChange::Type::AllChildrenReplaced:

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -922,8 +922,8 @@ public:
 protected:
     Element(const QualifiedName&, Document&, OptionSet<TypeFlag>);
 
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) override;
-    void removedFromAncestor(RemovalType, ContainerNode&) override;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) override;
+    void removingSteps(RemovalType, ContainerNode&) override;
     void childrenChanged(const ChildChange&) override;
     void removeAllEventListeners() override;
 

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -1486,7 +1486,7 @@ void Node::queueTaskToDispatchEvent(TaskSource source, Ref<Event>&& event)
     });
 }
 
-Node::InsertedIntoAncestorResult Node::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps Node::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
     ASSERT(!containsSelectionEndPoint());
     if (insertionType.connectedToDocument)
@@ -1496,10 +1496,10 @@ Node::InsertedIntoAncestorResult Node::insertedIntoAncestor(InsertionType insert
 
     invalidateStyle(Style::Validity::SubtreeInvalid, Style::InvalidationMode::InsertedIntoAncestor);
 
-    return InsertedIntoAncestorResult::Done;
+    return NeedsPostConnectionSteps::No;
 }
 
-void Node::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void Node::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
     ASSERT(!containsSelectionEndPoint());
     if (removalType.disconnectedFromDocument)

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -496,24 +496,25 @@ public:
     WEBCORE_EXPORT const RenderStyle* computedStyle();
     virtual const RenderStyle* computedStyle(const std::optional<Style::PseudoElementIdentifier>&);
 
-    enum class InsertedIntoAncestorResult {
-        Done,
-        NeedsPostInsertionCallback,
-    };
+    enum class NeedsPostConnectionSteps : bool { No, Yes };
     struct InsertionType {
         bool connectedToDocument { false };
         bool treeScopeChanged { false };
     };
+    // https://dom.spec.whatwg.org/#concept-node-insert-ext
     // Called *after* this node or its ancestor is inserted into a new parent (may or may not be a part of document) by scripts or parser.
-    // insertedInto **MUST NOT** invoke scripts. Return NeedsPostInsertionCallback and implement didFinishInsertingNode instead to run scripts.
-    virtual InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode& parentOfInsertedTree);
-    virtual void didFinishInsertingNode() { }
+    // insertionSteps **MUST NOT** invoke scripts. Return NeedsPostConnectionSteps and implement postConnectionSteps instead to run scripts.
+    virtual NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode& parentOfInsertedTree);
+
+    // https://dom.spec.whatwg.org/#concept-node-post-connection-ext
+    virtual void postConnectionSteps() { }
 
     struct RemovalType {
         bool disconnectedFromDocument { false };
         bool treeScopeChanged { false };
     };
-    virtual void removedFromAncestor(RemovalType, ContainerNode& oldParentOfRemovedTree);
+    // https://dom.spec.whatwg.org/#concept-node-remove-ext
+    virtual void removingSteps(RemovalType, ContainerNode& oldParentOfRemovedTree);
 
     virtual String description() const;
     virtual String debugDescription() const;

--- a/Source/WebCore/dom/ProcessingInstruction.cpp
+++ b/Source/WebCore/dom/ProcessingInstruction.cpp
@@ -267,23 +267,23 @@ void ProcessingInstruction::addSubresourceAttributeURLs(ListHashSet<URL>& urls) 
     addSubresourceURL(urls, sheet()->baseURL());
 }
 
-Node::InsertedIntoAncestorResult ProcessingInstruction::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps ProcessingInstruction::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    CharacterData::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    CharacterData::insertionSteps(insertionType, parentOfInsertedTree);
     if (!insertionType.connectedToDocument)
-        return InsertedIntoAncestorResult::Done;
+        return NeedsPostConnectionSteps::No;
     document().styleScope().addStyleSheetCandidateNode(*this, m_createdByParser);
-    return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
+    return NeedsPostConnectionSteps::Yes;
 }
 
-void ProcessingInstruction::didFinishInsertingNode()
+void ProcessingInstruction::postConnectionSteps()
 {
     checkStyleSheet();
 }
 
-void ProcessingInstruction::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void ProcessingInstruction::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
-    CharacterData::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    CharacterData::removingSteps(removalType, oldParentOfRemovedTree);
     if (!removalType.disconnectedFromDocument)
         return;
     

--- a/Source/WebCore/dom/ProcessingInstruction.h
+++ b/Source/WebCore/dom/ProcessingInstruction.h
@@ -64,9 +64,9 @@ private:
     Ref<Node> cloneNodeInternal(Document&, CloningOperation, CustomElementRegistry*) const override;
     SerializedNode serializeNode(CloningOperation) const override;
 
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) override;
-    void didFinishInsertingNode() override;
-    void removedFromAncestor(RemovalType, ContainerNode&) override;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) override;
+    void postConnectionSteps() override;
+    void removingSteps(RemovalType, ContainerNode&) override;
 
     void checkStyleSheet();
     void setCSSStyleSheet(const String& href, const URL& baseURL, ASCIILiteral charset, const CachedCSSStyleSheet*) override;

--- a/Source/WebCore/dom/RadioButtonGroups.cpp
+++ b/Source/WebCore/dom/RadioButtonGroups.cpp
@@ -269,7 +269,7 @@ bool RadioButtonGroups::hasCheckedButton(const HTMLInputElement& element) const
     if (name.isEmpty())
         return element.checked();
     auto* group = m_nameToGroupMap.get(name.impl());
-    // FIXME: Update the radio button group before author script had a chance to run in didFinishInsertingNode().
+    // FIXME: Update the radio button group before author script had a chance to run in postConnectionSteps().
     return group && group->checkedButton();
 }
 

--- a/Source/WebCore/dom/ScriptElement.cpp
+++ b/Source/WebCore/dom/ScriptElement.cpp
@@ -99,7 +99,7 @@ ScriptElement::ScriptElement(Element& element, bool parserInserted, bool already
     }
 }
 
-void ScriptElement::didFinishInsertingNode()
+void ScriptElement::postConnectionSteps()
 {
     if (m_parserInserted == ParserInserted::No)
         prepareScript(); // FIXME: Provide a real starting line number here.

--- a/Source/WebCore/dom/ScriptElement.h
+++ b/Source/WebCore/dom/ScriptElement.h
@@ -101,14 +101,14 @@ protected:
     void setHasRelevantLoadEventsListener(bool hasListener) { m_hasRelevantLoadEventsListener = hasListener; }
 
     // Helper functions used by our parent classes.
-    Node::InsertedIntoAncestorResult insertedIntoAncestor(Node::InsertionType insertionType, ContainerNode&) const
+    Node::NeedsPostConnectionSteps insertionSteps(Node::InsertionType insertionType, ContainerNode&) const
     {
         if (insertionType.connectedToDocument && m_parserInserted == ParserInserted::No)
-            return Node::InsertedIntoAncestorResult::NeedsPostInsertionCallback;
-        return Node::InsertedIntoAncestorResult::Done;
+            return Node::NeedsPostConnectionSteps::Yes;
+        return Node::NeedsPostConnectionSteps::No;
     }
 
-    void didFinishInsertingNode();
+    void postConnectionSteps();
     void childrenChanged(const ContainerNode::ChildChange&);
     void finishParsingChildren();
     void handleSourceAttribute(const String& sourceURL);

--- a/Source/WebCore/dom/ShadowRoot.cpp
+++ b/Source/WebCore/dom/ShadowRoot.cpp
@@ -128,9 +128,9 @@ ShadowRoot::~ShadowRoot()
     removeDetachedChildren();
 }
 
-Node::InsertedIntoAncestorResult ShadowRoot::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps ShadowRoot::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    DocumentFragment::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    DocumentFragment::insertionSteps(insertionType, parentOfInsertedTree);
     if (!m_hasScopedCustomElementRegistry && usesNullCustomElementRegistry() && !parentOfInsertedTree.usesNullCustomElementRegistry()) {
         if (RefPtr registry = CustomElementRegistry::registryForElement(*host())) {
             clearUsesNullCustomElementRegistry();
@@ -146,12 +146,12 @@ Node::InsertedIntoAncestorResult ShadowRoot::insertedIntoAncestor(InsertionType 
     }
     if (!adoptedStyleSheets().empty() && document().frame())
         protect(styleScope())->didChangeActiveStyleSheetCandidates();
-    return InsertedIntoAncestorResult::Done;
+    return NeedsPostConnectionSteps::No;
 }
 
-void ShadowRoot::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void ShadowRoot::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
-    DocumentFragment::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    DocumentFragment::removingSteps(removalType, oldParentOfRemovedTree);
     if (removalType.disconnectedFromDocument)
         protect(document())->didRemoveInDocumentShadowRoot(*this);
 }

--- a/Source/WebCore/dom/ShadowRoot.h
+++ b/Source/WebCore/dom/ShadowRoot.h
@@ -158,8 +158,8 @@ private:
     ShadowRoot(Document&, ShadowRootMode, SlotAssignmentMode, ShadowRootDelegatesFocus, Clonable, ShadowRootSerializable, ShadowRootAvailableToElementInternals, RefPtr<CustomElementRegistry>&&, ShadowRootScopedCustomElementRegistry, const AtomString& referenceTarget);
     ShadowRoot(Document&, std::unique_ptr<SlotAssignment>&&);
 
-    Node::InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) override;
-    void removedFromAncestor(RemovalType, ContainerNode& insertionPoint) override;
+    Node::NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) override;
+    void removingSteps(RemovalType, ContainerNode& insertionPoint) override;
 
     void childrenChanged(const ChildChange&) override;
 

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -715,18 +715,18 @@ ReferrerPolicy HTMLAnchorElement::referrerPolicy() const
     return parseReferrerPolicy(attributeWithoutSynchronization(referrerpolicyAttr), ReferrerPolicySource::ReferrerPolicyAttribute).value_or(ReferrerPolicy::EmptyString);
 }
 
-Node::InsertedIntoAncestorResult HTMLAnchorElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps HTMLAnchorElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    HTMLElement::insertionSteps(insertionType, parentOfInsertedTree);
     protect(document())->processInternalResourceLinks(this);
     if (insertionType.connectedToDocument && document().settings().speculationRulesPrefetchEnabled())
-        return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
-    return InsertedIntoAncestorResult::Done;
+        return NeedsPostConnectionSteps::Yes;
+    return NeedsPostConnectionSteps::No;
 }
 
-void HTMLAnchorElement::didFinishInsertingNode()
+void HTMLAnchorElement::postConnectionSteps()
 {
-    HTMLElement::didFinishInsertingNode();
+    HTMLElement::postConnectionSteps();
     checkForSpeculationRules();
 }
 

--- a/Source/WebCore/html/HTMLAnchorElement.h
+++ b/Source/WebCore/html/HTMLAnchorElement.h
@@ -82,8 +82,8 @@ public:
     String referrerPolicyForBindings() const;
     ReferrerPolicy referrerPolicy() const;
 
-    Node::InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode& parentOfInsertedTree) override;
-    void didFinishInsertingNode() override;
+    Node::NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode& parentOfInsertedTree) override;
+    void postConnectionSteps() override;
 
     AtomString target() const override;
 

--- a/Source/WebCore/html/HTMLArticleElement.cpp
+++ b/Source/WebCore/html/HTMLArticleElement.cpp
@@ -47,9 +47,9 @@ HTMLArticleElement::HTMLArticleElement(const QualifiedName& tagName, Document& d
     ASSERT(tagName == HTMLNames::articleTag);
 }
 
-auto HTMLArticleElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree) -> InsertedIntoAncestorResult
+auto HTMLArticleElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree) -> NeedsPostConnectionSteps
 {
-    auto result = HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    auto result = HTMLElement::insertionSteps(insertionType, parentOfInsertedTree);
 
     if (insertionType.connectedToDocument) {
         if (RefPtr newDocument = dynamicDowncast<HTMLDocument>(parentOfInsertedTree.document()))
@@ -59,12 +59,12 @@ auto HTMLArticleElement::insertedIntoAncestor(InsertionType insertionType, Conta
     return result;
 }
 
-void HTMLArticleElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void HTMLArticleElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
     if (removalType.disconnectedFromDocument)
         protect(oldParentOfRemovedTree.document())->unregisterArticleElement(*this);
 
-    HTMLElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    HTMLElement::removingSteps(removalType, oldParentOfRemovedTree);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLArticleElement.h
+++ b/Source/WebCore/html/HTMLArticleElement.h
@@ -36,8 +36,8 @@ public:
     static Ref<HTMLArticleElement> create(const QualifiedName&, Document&);
 
 private:
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
-    void removedFromAncestor(RemovalType, ContainerNode& oldParentOfRemovedTree) final;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) final;
+    void removingSteps(RemovalType, ContainerNode& oldParentOfRemovedTree) final;
 
     HTMLArticleElement(const QualifiedName&, Document&);
 };

--- a/Source/WebCore/html/HTMLAttachmentElement.cpp
+++ b/Source/WebCore/html/HTMLAttachmentElement.cpp
@@ -648,9 +648,9 @@ static bool shouldMonitorDocumentTraffic(Document& document)
 }
 #endif // ATTACHMENT_LOG_DOCUMENT_TRAFFIC
 
-Node::InsertedIntoAncestorResult HTMLAttachmentElement::insertedIntoAncestor(InsertionType type, ContainerNode& ancestor)
+Node::NeedsPostConnectionSteps HTMLAttachmentElement::insertionSteps(InsertionType type, ContainerNode& ancestor)
 {
-    auto result = HTMLElement::insertedIntoAncestor(type, ancestor);
+    auto result = HTMLElement::insertionSteps(type, ancestor);
     if (isWideLayout()) {
         setInlineStyleProperty(CSSPropertyMarginLeft, 1, CSSUnitType::CSS_PX);
         setInlineStyleProperty(CSSPropertyMarginRight, 1, CSSUnitType::CSS_PX);
@@ -684,9 +684,9 @@ Node::InsertedIntoAncestorResult HTMLAttachmentElement::insertedIntoAncestor(Ins
     return result;
 }
 
-void HTMLAttachmentElement::removedFromAncestor(RemovalType type, ContainerNode& ancestor)
+void HTMLAttachmentElement::removingSteps(RemovalType type, ContainerNode& ancestor)
 {
-    HTMLElement::removedFromAncestor(type, ancestor);
+    HTMLElement::removingSteps(type, ancestor);
 
     Ref document = this->document();
 #if ATTACHMENT_LOG_DOCUMENT_TRAFFIC

--- a/Source/WebCore/html/HTMLAttachmentElement.h
+++ b/Source/WebCore/html/HTMLAttachmentElement.h
@@ -67,8 +67,8 @@ public:
     WEBCORE_EXPORT void updateIconForNarrowLayout(const RefPtr<Image>& icon, const WebCore::FloatSize&);
     WEBCORE_EXPORT void updateIconForWideLayout(Vector<uint8_t>&&);
 
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
-    void removedFromAncestor(RemovalType, ContainerNode&) final;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) final;
+    void removingSteps(RemovalType, ContainerNode&) final;
 
     String ensureUniqueIdentifier();
     AttachmentAssociatedElement* associatedElement() const;

--- a/Source/WebCore/html/HTMLBaseElement.cpp
+++ b/Source/WebCore/html/HTMLBaseElement.cpp
@@ -55,17 +55,17 @@ void HTMLBaseElement::attributeChanged(const QualifiedName& name, const AtomStri
         HTMLElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 
-Node::InsertedIntoAncestorResult HTMLBaseElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps HTMLBaseElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    HTMLElement::insertionSteps(insertionType, parentOfInsertedTree);
     if (insertionType.connectedToDocument)
         protect(document())->processBaseElement();
-    return InsertedIntoAncestorResult::Done;
+    return NeedsPostConnectionSteps::No;
 }
 
-void HTMLBaseElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void HTMLBaseElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
-    HTMLElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    HTMLElement::removingSteps(removalType, oldParentOfRemovedTree);
     if (removalType.disconnectedFromDocument)
         protect(document())->processBaseElement();
 }

--- a/Source/WebCore/html/HTMLBaseElement.h
+++ b/Source/WebCore/html/HTMLBaseElement.h
@@ -40,8 +40,8 @@ private:
     AtomString target() const final;
     bool NODELETE isURLAttribute(const Attribute&) const final;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
-    void removedFromAncestor(RemovalType, ContainerNode&) final;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) final;
+    void removingSteps(RemovalType, ContainerNode&) final;
 };
 
 } // namespace

--- a/Source/WebCore/html/HTMLBodyElement.cpp
+++ b/Source/WebCore/html/HTMLBodyElement.cpp
@@ -175,20 +175,20 @@ void HTMLBodyElement::attributeChanged(const QualifiedName& name, const AtomStri
     HTMLElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 
-Node::InsertedIntoAncestorResult HTMLBodyElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps HTMLBodyElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    HTMLElement::insertionSteps(insertionType, parentOfInsertedTree);
     if (!insertionType.connectedToDocument)
-        return InsertedIntoAncestorResult::Done;
+        return NeedsPostConnectionSteps::No;
     if (!is<HTMLFrameElementBase>(document().ownerElement()))
-        return InsertedIntoAncestorResult::Done;
-    return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
+        return NeedsPostConnectionSteps::No;
+    return NeedsPostConnectionSteps::Yes;
 }
 
-void HTMLBodyElement::didFinishInsertingNode()
+void HTMLBodyElement::postConnectionSteps()
 {
-    // A DOM mutation could have happened in between the call to insertedIntoAncestor() and the
-    // call to didFinishInsertingNode().
+    // A DOM mutation could have happened in between the call to insertionSteps() and the
+    // call to postConnectionSteps().
     Ref document = this->document();
     if (!is<HTMLFrameElementBase>(document->ownerElement()))
         return;

--- a/Source/WebCore/html/HTMLBodyElement.h
+++ b/Source/WebCore/html/HTMLBodyElement.h
@@ -44,8 +44,8 @@ private:
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) final;
 
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
-    void didFinishInsertingNode() final;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) final;
+    void postConnectionSteps() final;
 
     bool NODELETE isURLAttribute(const Attribute&) const final;
     

--- a/Source/WebCore/html/HTMLButtonElement.cpp
+++ b/Source/WebCore/html/HTMLButtonElement.cpp
@@ -74,16 +74,16 @@ Ref<HTMLButtonElement> HTMLButtonElement::create(Document& document)
     return adoptRef(*new HTMLButtonElement(buttonTag, document, nullptr));
 }
 
-Node::InsertedIntoAncestorResult HTMLButtonElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps HTMLButtonElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    auto result = HTMLFormControlElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    auto result = HTMLFormControlElement::insertionSteps(insertionType, parentOfInsertedTree);
     computeType(attributeWithoutSynchronization(HTMLNames::typeAttr));
     return result;
 }
 
-void HTMLButtonElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void HTMLButtonElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
-    HTMLFormControlElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    HTMLFormControlElement::removingSteps(removalType, oldParentOfRemovedTree);
     computeType(attributeWithoutSynchronization(HTMLNames::typeAttr));
 }
 

--- a/Source/WebCore/html/HTMLButtonElement.h
+++ b/Source/WebCore/html/HTMLButtonElement.h
@@ -62,8 +62,8 @@ private:
     int defaultTabIndex() const final;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode& parentOfInsertedTree) final;
-    void removedFromAncestor(RemovalType, ContainerNode& oldParentOfRemovedTree) final;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode& parentOfInsertedTree) final;
+    void removingSteps(RemovalType, ContainerNode& oldParentOfRemovedTree) final;
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;
     void defaultEventHandler(Event&) final;
 

--- a/Source/WebCore/html/HTMLDetailsElement.cpp
+++ b/Source/WebCore/html/HTMLDetailsElement.cpp
@@ -191,21 +191,21 @@ void HTMLDetailsElement::attributeChanged(const QualifiedName& name, const AtomS
         ensureDetailsExclusivityAfterMutation();
 }
 
-Node::InsertedIntoAncestorResult HTMLDetailsElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps HTMLDetailsElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    HTMLElement::insertionSteps(insertionType, parentOfInsertedTree);
 
     m_shouldCloseElementAfterInsertion = shouldClose();
 
     if (!insertionType.connectedToDocument)
-        return InsertedIntoAncestorResult::Done;
-    return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
+        return NeedsPostConnectionSteps::No;
+    return NeedsPostConnectionSteps::Yes;
 }
 
-void HTMLDetailsElement::didFinishInsertingNode()
+void HTMLDetailsElement::postConnectionSteps()
 {
     // FIXME: Spec makes this DOM mutation synchronously in "insertion steps"
-    // but our current model of insertedIntoAncestor is not compatible with that.
+    // but our current model of insertionSteps is not compatible with that.
     if (hasAttributeWithoutSynchronization(openAttr) && m_shouldCloseElementAfterInsertion) {
         ShouldNotFireMutationEventsScope scope(document());
         toggleOpen();

--- a/Source/WebCore/html/HTMLDetailsElement.h
+++ b/Source/WebCore/html/HTMLDetailsElement.h
@@ -46,8 +46,8 @@ public:
 private:
     HTMLDetailsElement(const QualifiedName&, Document&);
 
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
-    void didFinishInsertingNode() final;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) final;
+    void postConnectionSteps() final;
 
     Vector<Ref<HTMLDetailsElement>> otherElementsInNameGroup() const;
     void ensureDetailsExclusivityAfterMutation();

--- a/Source/WebCore/html/HTMLDialogElement.cpp
+++ b/Source/WebCore/html/HTMLDialogElement.cpp
@@ -289,9 +289,9 @@ bool HTMLDialogElement::supportsFocus() const
     return true;
 }
 
-void HTMLDialogElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void HTMLDialogElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
-    HTMLElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    HTMLElement::removingSteps(removalType, oldParentOfRemovedTree);
     setIsModal(false);
 }
 

--- a/Source/WebCore/html/HTMLDialogElement.h
+++ b/Source/WebCore/html/HTMLDialogElement.h
@@ -60,7 +60,7 @@ public:
 private:
     HTMLDialogElement(const QualifiedName&, Document&);
 
-    void removedFromAncestor(RemovalType, ContainerNode& oldParentOfRemovedTree) final;
+    void removingSteps(RemovalType, ContainerNode& oldParentOfRemovedTree) final;
     void setIsModal(bool newValue);
     bool supportsFocus() const final;
 

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -409,19 +409,19 @@ void HTMLElement::attributeChanged(const QualifiedName& name, const AtomString& 
         setAttributeEventListener(eventName, name, newValue);
 }
 
-Node::InsertedIntoAncestorResult HTMLElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps HTMLElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    auto result = StyledElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    auto result = StyledElement::insertionSteps(insertionType, parentOfInsertedTree);
     hideNonce();
     return result;
 }
 
-void HTMLElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void HTMLElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
     if (popoverData())
         hidePopoverInternal(FocusPreviousElement::No, FireEvents::No);
 
-    StyledElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    StyledElement::removingSteps(removalType, oldParentOfRemovedTree);
 }
 
 static Ref<DocumentFragment> textToFragment(Document& document, const String& text)

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -189,8 +189,8 @@ protected:
 
     bool matchesReadWritePseudoClass() const override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
-    Node::InsertedIntoAncestorResult insertedIntoAncestor(InsertionType , ContainerNode& parentOfInsertedTree) override;
-    void removedFromAncestor(RemovalType, ContainerNode& oldParentOfRemovedTree) override;
+    Node::NeedsPostConnectionSteps insertionSteps(InsertionType , ContainerNode& parentOfInsertedTree) override;
+    void removingSteps(RemovalType, ContainerNode& oldParentOfRemovedTree) override;
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const override;
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) override;
     unsigned parseBorderWidthAttribute(const AtomString&) const;

--- a/Source/WebCore/html/HTMLFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLFormControlElement.cpp
@@ -105,20 +105,20 @@ String HTMLFormControlElement::formAction() const
     return document->completeURL(value).string();
 }
 
-Node::InsertedIntoAncestorResult HTMLFormControlElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps HTMLFormControlElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
-    ValidatedFormListedElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    HTMLElement::insertionSteps(insertionType, parentOfInsertedTree);
+    ValidatedFormListedElement::insertionSteps(insertionType, parentOfInsertedTree);
 
     if (!insertionType.connectedToDocument)
-        return InsertedIntoAncestorResult::Done;
-    return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
+        return NeedsPostConnectionSteps::No;
+    return NeedsPostConnectionSteps::Yes;
 }
 
-void HTMLFormControlElement::didFinishInsertingNode()
+void HTMLFormControlElement::postConnectionSteps()
 {
-    HTMLElement::didFinishInsertingNode();
-    ValidatedFormListedElement::didFinishInsertingNode();
+    HTMLElement::postConnectionSteps();
+    ValidatedFormListedElement::postConnectionSteps();
 }
 
 void HTMLFormControlElement::didMoveToNewDocument(Document& oldDocument, Document& newDocument)
@@ -127,10 +127,10 @@ void HTMLFormControlElement::didMoveToNewDocument(Document& oldDocument, Documen
     ValidatedFormListedElement::didMoveToNewDocument();
 }
 
-void HTMLFormControlElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void HTMLFormControlElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
-    HTMLElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
-    ValidatedFormListedElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    HTMLElement::removingSteps(removalType, oldParentOfRemovedTree);
+    ValidatedFormListedElement::removingSteps(removalType, oldParentOfRemovedTree);
 }
 
 void HTMLFormControlElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/html/HTMLFormControlElement.h
+++ b/Source/WebCore/html/HTMLFormControlElement.h
@@ -109,11 +109,11 @@ public:
 protected:
     HTMLFormControlElement(const QualifiedName& tagName, Document&, HTMLFormElement*);
 
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) override;
-    void didFinishInsertingNode() override;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) override;
+    void postConnectionSteps() override;
     void didAttachRenderers() override;
     void didMoveToNewDocument(Document& oldDocument, Document& newDocument) override;
-    void removedFromAncestor(RemovalType, ContainerNode&) override;
+    void removingSteps(RemovalType, ContainerNode&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
 
     void disabledStateChanged() override;

--- a/Source/WebCore/html/HTMLFormElement.cpp
+++ b/Source/WebCore/html/HTMLFormElement.cpp
@@ -129,15 +129,15 @@ HTMLFormElement::~HTMLFormElement()
         imageElement->formWillBeDestroyed();
 }
 
-Node::InsertedIntoAncestorResult HTMLFormElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps HTMLFormElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    HTMLElement::insertionSteps(insertionType, parentOfInsertedTree);
     if (insertionType.connectedToDocument)
         document().didAssociateFormControl(*this);
-    return InsertedIntoAncestorResult::Done;
+    return NeedsPostConnectionSteps::No;
 }
 
-void HTMLFormElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void HTMLFormElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
     Ref root = traverseToRootNode(); // Do not rely on rootNode() because our IsInTreeScope is outdated.
     auto listedElements = copyListedElementsVector();
@@ -148,7 +148,7 @@ void HTMLFormElement::removedFromAncestor(RemovalType removalType, ContainerNode
     });
     for (auto& imageElement : imageElements)
         imageElement->formOwnerRemovedFromTree(root);
-    HTMLElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    HTMLElement::removingSteps(removalType, oldParentOfRemovedTree);
     if (removalType.disconnectedFromDocument)
       m_controlsCollection = nullptr; // Avoid leaks since HTMLCollection has a back Ref to this element.
 }

--- a/Source/WebCore/html/HTMLFormElement.h
+++ b/Source/WebCore/html/HTMLFormElement.h
@@ -126,8 +126,8 @@ public:
 private:
     HTMLFormElement(const QualifiedName&, Document&);
 
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
-    void removedFromAncestor(RemovalType, ContainerNode&) final;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) final;
+    void removingSteps(RemovalType, ContainerNode&) final;
     void finishParsingChildren() final;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;

--- a/Source/WebCore/html/HTMLFrameElementBase.cpp
+++ b/Source/WebCore/html/HTMLFrameElementBase.cpp
@@ -149,15 +149,15 @@ void HTMLFrameElementBase::attributeChanged(const QualifiedName& name, const Ato
         HTMLFrameOwnerElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 
-Node::InsertedIntoAncestorResult HTMLFrameElementBase::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps HTMLFrameElementBase::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    HTMLFrameOwnerElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    HTMLFrameOwnerElement::insertionSteps(insertionType, parentOfInsertedTree);
     if (insertionType.connectedToDocument)
-        return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
-    return InsertedIntoAncestorResult::Done;
+        return NeedsPostConnectionSteps::Yes;
+    return NeedsPostConnectionSteps::No;
 }
 
-void HTMLFrameElementBase::didFinishInsertingNode()
+void HTMLFrameElementBase::postConnectionSteps()
 {
     if (!isConnected())
         return;

--- a/Source/WebCore/html/HTMLFrameElementBase.h
+++ b/Source/WebCore/html/HTMLFrameElementBase.h
@@ -44,8 +44,8 @@ protected:
     bool canLoad() const;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
-    void didFinishInsertingNode() final;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) final;
+    void postConnectionSteps() final;
     void didAttachRenderers() override;
 
     WEBCORE_EXPORT void setLocation(const String&);

--- a/Source/WebCore/html/HTMLFrameSetElement.cpp
+++ b/Source/WebCore/html/HTMLFrameSetElement.cpp
@@ -200,15 +200,15 @@ void HTMLFrameSetElement::willRecalcStyle(OptionSet<Style::Change>)
         renderer->setNeedsLayout();
 }
 
-Node::InsertedIntoAncestorResult HTMLFrameSetElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps HTMLFrameSetElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
-    return InsertedIntoAncestorResult::Done;
+    HTMLElement::insertionSteps(insertionType, parentOfInsertedTree);
+    return NeedsPostConnectionSteps::No;
 }
 
-void HTMLFrameSetElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void HTMLFrameSetElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
-    HTMLElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    HTMLElement::removingSteps(removalType, oldParentOfRemovedTree);
 }
 
 WindowProxy* HTMLFrameSetElement::namedItem(const AtomString& name)

--- a/Source/WebCore/html/HTMLFrameSetElement.h
+++ b/Source/WebCore/html/HTMLFrameSetElement.h
@@ -71,8 +71,8 @@ private:
 
     void willRecalcStyle(OptionSet<Style::Change>) final;
 
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
-    void removedFromAncestor(RemovalType, ContainerNode&) final;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) final;
+    void removingSteps(RemovalType, ContainerNode&) final;
 
     FixedVector<HTMLDimensionsListValue> m_rowDimensions;
     FixedVector<HTMLDimensionsListValue> m_colDimensions;

--- a/Source/WebCore/html/HTMLHRElement.cpp
+++ b/Source/WebCore/html/HTMLHRElement.cpp
@@ -55,9 +55,9 @@ Ref<HTMLHRElement> HTMLHRElement::create(const QualifiedName& tagName, Document&
     return adoptRef(*new HTMLHRElement(tagName, document));
 }
 
-auto HTMLHRElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree) -> InsertedIntoAncestorResult
+auto HTMLHRElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree) -> NeedsPostConnectionSteps
 {
-    auto result = HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    auto result = HTMLElement::insertionSteps(insertionType, parentOfInsertedTree);
 
     if (!document().settings().htmlEnhancedSelectParsingEnabled() || m_ownerSelect)
         return result;
@@ -70,9 +70,9 @@ auto HTMLHRElement::insertedIntoAncestor(InsertionType insertionType, ContainerN
     return result;
 }
 
-void HTMLHRElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void HTMLHRElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
-    HTMLElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    HTMLElement::removingSteps(removalType, oldParentOfRemovedTree);
 
     if (!document().settings().htmlEnhancedSelectParsingEnabled() || !m_ownerSelect)
         return;

--- a/Source/WebCore/html/HTMLHRElement.h
+++ b/Source/WebCore/html/HTMLHRElement.h
@@ -36,8 +36,8 @@ public:
 private:
     HTMLHRElement(const QualifiedName&, Document&);
 
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
-    void removedFromAncestor(RemovalType, ContainerNode& oldParentOfRemovedTree) final;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) final;
+    void removingSteps(RemovalType, ContainerNode& oldParentOfRemovedTree) final;
 
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) final;

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -576,7 +576,7 @@ void HTMLImageElement::didAttachRenderers()
         renderImage->setImageSizeForAltText();
 }
 
-Node::InsertedIntoAncestorResult HTMLImageElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps HTMLImageElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
     FormAssociatedElement::elementInsertedIntoAncestor(*this, insertionType);
     if (!form())
@@ -584,7 +584,7 @@ Node::InsertedIntoAncestorResult HTMLImageElement::insertedIntoAncestor(Insertio
 
     // Insert needs to complete first, before we start updating the loader. Loader dispatches events which could result
     // in callbacks back to this node.
-    Node::InsertedIntoAncestorResult insertNotificationRequest = HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    Node::NeedsPostConnectionSteps insertNotificationRequest = HTMLElement::insertionSteps(insertionType, parentOfInsertedTree);
 
     if (insertionType.treeScopeChanged && !m_parsedUsemap.isNull())
         protect(treeScope())->addImageElementByUsemap(m_parsedUsemap, *this);
@@ -605,7 +605,7 @@ Node::InsertedIntoAncestorResult HTMLImageElement::insertedIntoAncestor(Insertio
     return insertNotificationRequest;
 }
 
-void HTMLImageElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void HTMLImageElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
     if (removalType.treeScopeChanged && !m_parsedUsemap.isNull())
         protect(oldParentOfRemovedTree.treeScope())->removeImageElementByUsemap(m_parsedUsemap, *this);
@@ -616,7 +616,7 @@ void HTMLImageElement::removedFromAncestor(RemovalType removalType, ContainerNod
         selectImageSource(RelevantMutation::Yes);
     }
 
-    HTMLElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    HTMLElement::removingSteps(removalType, oldParentOfRemovedTree);
     FormAssociatedElement::elementRemovedFromAncestor(*this, removalType);
 }
 

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -214,8 +214,8 @@ private:
     void addSubresourceAttributeURLs(ListHashSet<URL>&) const override;
     void addCandidateSubresourceURLs(ListHashSet<URL>&) const override;
 
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) override;
-    void removedFromAncestor(RemovalType, ContainerNode&) override;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) override;
+    void removingSteps(RemovalType, ContainerNode&) override;
 
     bool NODELETE isFormListedElement() const final { return false; }
     FormAssociatedElement* NODELETE asFormAssociatedElement() final { return this; }

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -1758,9 +1758,9 @@ void HTMLInputElement::didChangeForm()
     addToRadioButtonGroup();
 }
 
-Node::InsertedIntoAncestorResult HTMLInputElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps HTMLInputElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    auto result = HTMLTextFormControlElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    auto result = HTMLTextFormControlElement::insertionSteps(insertionType, parentOfInsertedTree);
     resetListAttributeTargetObserver();
     if (isRadioButton())
         updateValidity();
@@ -1772,7 +1772,7 @@ Node::InsertedIntoAncestorResult HTMLInputElement::insertedIntoAncestor(Insertio
         addToRadioButtonGroup();
         return result;
     }
-    return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
+    return NeedsPostConnectionSteps::Yes;
 }
 
 void HTMLInputElement::updateUserAgentShadowTree()
@@ -1783,16 +1783,16 @@ void HTMLInputElement::updateUserAgentShadowTree()
     m_inputType->createShadowSubtreeIfNeeded();
 }
 
-void HTMLInputElement::didFinishInsertingNode()
+void HTMLInputElement::postConnectionSteps()
 {
-    HTMLTextFormControlElement::didFinishInsertingNode();
+    HTMLTextFormControlElement::postConnectionSteps();
     if (isInTreeScope() && !form())
         addToRadioButtonGroup();
 }
 
-void HTMLInputElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void HTMLInputElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
-    HTMLTextFormControlElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    HTMLTextFormControlElement::removingSteps(removalType, oldParentOfRemovedTree);
     if (removalType.treeScopeChanged && isRadioButton())
         oldParentOfRemovedTree.treeScope().radioButtonGroups().removeButton(*this);
     if (removalType.disconnectedFromDocument && !form())

--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -374,9 +374,9 @@ private:
 
     void willChangeForm() final;
     void didChangeForm() final;
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
-    void didFinishInsertingNode() final;
-    void removedFromAncestor(RemovalType, ContainerNode&) final;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) final;
+    void postConnectionSteps() final;
+    void removingSteps(RemovalType, ContainerNode&) final;
     void didMoveToNewDocument(Document& oldDocument, Document& newDocument) final;
 
     int defaultTabIndex() const final;

--- a/Source/WebCore/html/HTMLLabelElement.cpp
+++ b/Source/WebCore/html/HTMLLabelElement.cpp
@@ -222,9 +222,9 @@ bool HTMLLabelElement::accessKeyAction(bool sendMouseEvents)
     return HTMLElement::accessKeyAction(sendMouseEvents);
 }
 
-auto HTMLLabelElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree) -> InsertedIntoAncestorResult
+auto HTMLLabelElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree) -> NeedsPostConnectionSteps
 {
-    auto result = HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    auto result = HTMLElement::insertionSteps(insertionType, parentOfInsertedTree);
 
     if (parentOfInsertedTree.isInTreeScope() && insertionType.treeScopeChanged) {
         Ref newScope = parentOfInsertedTree.treeScope();
@@ -249,7 +249,7 @@ void HTMLLabelElement::updateLabel(TreeScope& scope, const AtomString& oldForAtt
         scope.addLabel(newForAttributeValue, *this);
 }
 
-void HTMLLabelElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void HTMLLabelElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
     if (oldParentOfRemovedTree.isInTreeScope() && removalType.treeScopeChanged) {
         Ref oldScope = oldParentOfRemovedTree.treeScope();
@@ -257,7 +257,7 @@ void HTMLLabelElement::removedFromAncestor(RemovalType removalType, ContainerNod
             updateLabel(oldScope, attributeWithoutSynchronization(forAttr), nullAtom());
     }
 
-    HTMLElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    HTMLElement::removingSteps(removalType, oldParentOfRemovedTree);
 }
 
 } // namespace

--- a/Source/WebCore/html/HTMLLabelElement.h
+++ b/Source/WebCore/html/HTMLLabelElement.h
@@ -46,8 +46,8 @@ public:
 private:
     HTMLLabelElement(const QualifiedName&, Document&);
 
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode& parentOfInsertedTree) final;
-    void removedFromAncestor(RemovalType, ContainerNode& oldParentOfRemovedTree) final;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode& parentOfInsertedTree) final;
+    void removingSteps(RemovalType, ContainerNode& oldParentOfRemovedTree) final;
 
     bool isEventTargetedAtInteractiveDescendants(Event&) const;
 

--- a/Source/WebCore/html/HTMLLegendElement.cpp
+++ b/Source/WebCore/html/HTMLLegendElement.cpp
@@ -63,9 +63,9 @@ RefPtr<HTMLFormElement> HTMLLegendElement::formForBindings() const
     return dynamicDowncast<HTMLFormElement>(retargetReferenceTargetForBindings(form()));
 }
 
-auto HTMLLegendElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree) -> InsertedIntoAncestorResult
+auto HTMLLegendElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree) -> NeedsPostConnectionSteps
 {
-    auto result = HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    auto result = HTMLElement::insertionSteps(insertionType, parentOfInsertedTree);
 
     if (parentNode() != &parentOfInsertedTree)
         return result;
@@ -76,9 +76,9 @@ auto HTMLLegendElement::insertedIntoAncestor(InsertionType insertionType, Contai
     return result;
 }
 
-void HTMLLegendElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void HTMLLegendElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
-    HTMLElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    HTMLElement::removingSteps(removalType, oldParentOfRemovedTree);
 
     if (parentNode())
         return;

--- a/Source/WebCore/html/HTMLLegendElement.h
+++ b/Source/WebCore/html/HTMLLegendElement.h
@@ -40,8 +40,8 @@ public:
 private:
     HTMLLegendElement(const QualifiedName&, Document&);
 
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
-    void removedFromAncestor(RemovalType, ContainerNode& oldParentOfRemovedTree) final;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) final;
+    void removingSteps(RemovalType, ContainerNode& oldParentOfRemovedTree) final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLLinkElement.cpp
+++ b/Source/WebCore/html/HTMLLinkElement.cpp
@@ -516,27 +516,27 @@ bool HTMLLinkElement::isImplicitlyPotentiallyRenderBlocking() const
     return m_relAttribute.isStyleSheet && m_createdByParser;
 }
 
-Node::InsertedIntoAncestorResult HTMLLinkElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps HTMLLinkElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    HTMLElement::insertionSteps(insertionType, parentOfInsertedTree);
     if (!insertionType.connectedToDocument)
-        return InsertedIntoAncestorResult::Done;
+        return NeedsPostConnectionSteps::No;
 
     m_styleScope = &Style::Scope::forNode(*this);
     protect(m_styleScope)->addStyleSheetCandidateNode(*this, m_createdByParser);
 
-    return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
+    return NeedsPostConnectionSteps::Yes;
 }
 
-void HTMLLinkElement::didFinishInsertingNode()
+void HTMLLinkElement::postConnectionSteps()
 {
     m_url = getNonEmptyURLAttribute(hrefAttr);
     process();
 }
 
-void HTMLLinkElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void HTMLLinkElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
-    HTMLElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    HTMLElement::removingSteps(removalType, oldParentOfRemovedTree);
     if (!removalType.disconnectedFromDocument)
         return;
 

--- a/Source/WebCore/html/HTMLLinkElement.h
+++ b/Source/WebCore/html/HTMLLinkElement.h
@@ -120,9 +120,9 @@ private:
     void unblockRendering();
     bool NODELETE isImplicitlyPotentiallyRenderBlocking() const;
 
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
-    void didFinishInsertingNode() final;
-    void removedFromAncestor(RemovalType, ContainerNode&) final;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) final;
+    void postConnectionSteps() final;
+    void removingSteps(RemovalType, ContainerNode&) final;
 
     void initializeStyleSheet(Ref<StyleSheetContents>&&, const CachedCSSStyleSheet&, MediaQueryParserContext);
 

--- a/Source/WebCore/html/HTMLMapElement.cpp
+++ b/Source/WebCore/html/HTMLMapElement.cpp
@@ -112,19 +112,19 @@ Ref<HTMLCollection> HTMLMapElement::areas()
     return ensureRareData().ensureNodeLists().addCachedCollection<HTMLMapAreasCollection>(*this);
 }
 
-Node::InsertedIntoAncestorResult HTMLMapElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps HTMLMapElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    Node::InsertedIntoAncestorResult request = HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    Node::NeedsPostConnectionSteps request = HTMLElement::insertionSteps(insertionType, parentOfInsertedTree);
     if (insertionType.treeScopeChanged)
         treeScope().addImageMap(*this, m_name, getIdAttribute());
     return request;
 }
 
-void HTMLMapElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void HTMLMapElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
     if (removalType.treeScopeChanged)
         oldParentOfRemovedTree.treeScope().removeImageMap(*this, m_name, getIdAttribute());
-    HTMLElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    HTMLElement::removingSteps(removalType, oldParentOfRemovedTree);
 }
 
 }

--- a/Source/WebCore/html/HTMLMapElement.h
+++ b/Source/WebCore/html/HTMLMapElement.h
@@ -51,8 +51,8 @@ private:
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
 
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
-    void removedFromAncestor(RemovalType, ContainerNode&) final;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) final;
+    void removingSteps(RemovalType, ContainerNode&) final;
 
     AtomString m_name;
 };

--- a/Source/WebCore/html/HTMLMaybeFormAssociatedCustomElement.cpp
+++ b/Source/WebCore/html/HTMLMaybeFormAssociatedCustomElement.cpp
@@ -120,21 +120,21 @@ bool HTMLMaybeFormAssociatedCustomElement::isDisabledFormControl() const
     return isFormAssociatedCustomElement() && formAssociatedCustomElementUnsafe().isDisabled();
 }
 
-Node::InsertedIntoAncestorResult HTMLMaybeFormAssociatedCustomElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps HTMLMaybeFormAssociatedCustomElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    HTMLElement::insertionSteps(insertionType, parentOfInsertedTree);
     if (isFormAssociatedCustomElement())
-        formAssociatedCustomElementUnsafe().insertedIntoAncestor(insertionType, parentOfInsertedTree);
+        formAssociatedCustomElementUnsafe().insertionSteps(insertionType, parentOfInsertedTree);
     if (!insertionType.connectedToDocument)
-        return InsertedIntoAncestorResult::Done;
-    return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
+        return NeedsPostConnectionSteps::No;
+    return NeedsPostConnectionSteps::Yes;
 }
 
-void HTMLMaybeFormAssociatedCustomElement::didFinishInsertingNode()
+void HTMLMaybeFormAssociatedCustomElement::postConnectionSteps()
 {
-    HTMLElement::didFinishInsertingNode();
+    HTMLElement::postConnectionSteps();
     if (isFormAssociatedCustomElement())
-        formAssociatedCustomElementUnsafe().didFinishInsertingNode();
+        formAssociatedCustomElementUnsafe().postConnectionSteps();
 }
 
 void HTMLMaybeFormAssociatedCustomElement::didMoveToNewDocument(Document& oldDocument, Document& newDocument)
@@ -144,11 +144,11 @@ void HTMLMaybeFormAssociatedCustomElement::didMoveToNewDocument(Document& oldDoc
         formAssociatedCustomElementUnsafe().didMoveToNewDocument();
 }
 
-void HTMLMaybeFormAssociatedCustomElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void HTMLMaybeFormAssociatedCustomElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
-    HTMLElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    HTMLElement::removingSteps(removalType, oldParentOfRemovedTree);
     if (isFormAssociatedCustomElement())
-        formAssociatedCustomElementUnsafe().removedFromAncestor(removalType, oldParentOfRemovedTree);
+        formAssociatedCustomElementUnsafe().removingSteps(removalType, oldParentOfRemovedTree);
 }
 
 void HTMLMaybeFormAssociatedCustomElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/html/HTMLMaybeFormAssociatedCustomElement.h
+++ b/Source/WebCore/html/HTMLMaybeFormAssociatedCustomElement.h
@@ -66,10 +66,10 @@ private:
     HTMLMaybeFormAssociatedCustomElement(const QualifiedName& tagName, Document&);
     virtual ~HTMLMaybeFormAssociatedCustomElement();
 
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
-    void didFinishInsertingNode() final;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) final;
+    void postConnectionSteps() final;
     void didMoveToNewDocument(Document&, Document&) final;
-    void removedFromAncestor(RemovalType, ContainerNode&) final;
+    void removingSteps(RemovalType, ContainerNode&) final;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void finishParsingChildren() final;
 };

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -1104,20 +1104,20 @@ bool HTMLMediaElement::childShouldCreateRenderer(const Node& child) const
     return hasShadowRootParent(child) && HTMLElement::childShouldCreateRenderer(child);
 }
 
-Node::InsertedIntoAncestorResult HTMLMediaElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps HTMLMediaElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
     HTMLMEDIAELEMENT_RELEASE_LOG(INSERTEDINTOANCESTOR);
 
-    HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    HTMLElement::insertionSteps(insertionType, parentOfInsertedTree);
     if (insertionType.connectedToDocument)
         setInActiveDocument(true);
 
     if (!insertionType.connectedToDocument)
-        return InsertedIntoAncestorResult::Done;
-    return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
+        return NeedsPostConnectionSteps::No;
+    return NeedsPostConnectionSteps::Yes;
 }
 
-void HTMLMediaElement::didFinishInsertingNode()
+void HTMLMediaElement::postConnectionSteps()
 {
     Ref protectedThis { *this }; // prepareForLoad may result in a 'beforeload' event, which can make arbitrary DOM mutations.
 
@@ -1199,7 +1199,7 @@ void HTMLMediaElement::pauseAfterDetachedTask()
     }
 }
 
-void HTMLMediaElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void HTMLMediaElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
     HTMLMEDIAELEMENT_RELEASE_LOG(REMOVEDFROMANCESTOR);
 
@@ -1215,7 +1215,7 @@ void HTMLMediaElement::removedFromAncestor(RemovalType removalType, ContainerNod
     if (RefPtr mediaSession = m_mediaSession)
         mediaSession->clientCharacteristicsChanged(false);
 
-    HTMLElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    HTMLElement::removingSteps(removalType, oldParentOfRemovedTree);
 
     visibilityAdjustmentStateDidChange();
 }

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -815,9 +815,9 @@ private:
     bool supportsFocus() const override;
     bool rendererIsNeeded(const RenderStyle&) override;
     bool childShouldCreateRenderer(const Node&) const override;
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) override;
-    void didFinishInsertingNode() override;
-    void removedFromAncestor(RemovalType, ContainerNode&) override;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) override;
+    void postConnectionSteps() override;
+    void removingSteps(RemovalType, ContainerNode&) override;
     void didRecalcStyle(OptionSet<Style::Change>) override;
     bool canStartSelection() const override { return false; } 
     bool isInteractiveContent() const override;

--- a/Source/WebCore/html/HTMLMetaElement.cpp
+++ b/Source/WebCore/html/HTMLMetaElement.cpp
@@ -131,22 +131,22 @@ void HTMLMetaElement::attributeChanged(const QualifiedName& name, const AtomStri
     }
 }
 
-Node::InsertedIntoAncestorResult HTMLMetaElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps HTMLMetaElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    HTMLElement::insertionSteps(insertionType, parentOfInsertedTree);
     if (insertionType.connectedToDocument)
-        return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
-    return InsertedIntoAncestorResult::Done;
+        return NeedsPostConnectionSteps::Yes;
+    return NeedsPostConnectionSteps::No;
 }
 
-void HTMLMetaElement::didFinishInsertingNode()
+void HTMLMetaElement::postConnectionSteps()
 {
     process();
 }
 
-void HTMLMetaElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void HTMLMetaElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
-    HTMLElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    HTMLElement::removingSteps(removalType, oldParentOfRemovedTree);
 
     if (removalType.disconnectedFromDocument && equalLettersIgnoringASCIICase(name(), "theme-color"_s))
         protect(oldParentOfRemovedTree.document())->metaElementThemeColorChanged(*this);

--- a/Source/WebCore/html/HTMLMetaElement.h
+++ b/Source/WebCore/html/HTMLMetaElement.h
@@ -47,9 +47,9 @@ private:
     HTMLMetaElement(const QualifiedName&, Document&);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason = AttributeModificationReason::Directly) final;
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
-    void didFinishInsertingNode();
-    void removedFromAncestor(RemovalType, ContainerNode&) final;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) final;
+    void postConnectionSteps();
+    void removingSteps(RemovalType, ContainerNode&) final;
 
     void process(const AtomString& oldValue = nullAtom());
 

--- a/Source/WebCore/html/HTMLObjectElement.cpp
+++ b/Source/WebCore/html/HTMLObjectElement.cpp
@@ -237,23 +237,23 @@ void HTMLObjectElement::updateWidget(CreatePlugins createPlugins)
         renderFallbackContent();
 }
 
-Node::InsertedIntoAncestorResult HTMLObjectElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps HTMLObjectElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    HTMLPlugInElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    HTMLPlugInElement::insertionSteps(insertionType, parentOfInsertedTree);
     FormListedElement::elementInsertedIntoAncestor(*this, insertionType);
     if (!insertionType.connectedToDocument)
-        return InsertedIntoAncestorResult::Done;
-    return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
+        return NeedsPostConnectionSteps::No;
+    return NeedsPostConnectionSteps::Yes;
 }
 
-void HTMLObjectElement::didFinishInsertingNode()
+void HTMLObjectElement::postConnectionSteps()
 {
     resetFormOwner();
 }
 
-void HTMLObjectElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void HTMLObjectElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
-    HTMLPlugInElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    HTMLPlugInElement::removingSteps(removalType, oldParentOfRemovedTree);
     FormListedElement::elementRemovedFromAncestor(*this, removalType);
 }
 

--- a/Source/WebCore/html/HTMLObjectElement.h
+++ b/Source/WebCore/html/HTMLObjectElement.h
@@ -63,9 +63,9 @@ private:
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) final;
 
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
-    void didFinishInsertingNode() final;
-    void removedFromAncestor(RemovalType, ContainerNode&) final;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) final;
+    void postConnectionSteps() final;
+    void removingSteps(RemovalType, ContainerNode&) final;
 
     void didMoveToNewDocument(Document& oldDocument, Document& newDocument) final;
 

--- a/Source/WebCore/html/HTMLOptGroupElement.cpp
+++ b/Source/WebCore/html/HTMLOptGroupElement.cpp
@@ -120,9 +120,9 @@ void HTMLOptGroupElement::didAddUserAgentShadowRoot(ShadowRoot& root)
     root.appendChild(HTMLSlotElement::create(slotTag, document));
 }
 
-auto HTMLOptGroupElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree) -> InsertedIntoAncestorResult
+auto HTMLOptGroupElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree) -> NeedsPostConnectionSteps
 {
-    auto result = HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    auto result = HTMLElement::insertionSteps(insertionType, parentOfInsertedTree);
 
     if (!document().settings().htmlEnhancedSelectParsingEnabled())
         return result;
@@ -140,9 +140,9 @@ auto HTMLOptGroupElement::insertedIntoAncestor(InsertionType insertionType, Cont
     return result;
 }
 
-void HTMLOptGroupElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void HTMLOptGroupElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
-    HTMLElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    HTMLElement::removingSteps(removalType, oldParentOfRemovedTree);
 
     if (removalType.disconnectedFromDocument && m_shadowTreeNeedsUpdate)
         protect(document())->removeElementWithPendingUserAgentShadowTreeUpdate(*this);

--- a/Source/WebCore/html/HTMLOptGroupElement.h
+++ b/Source/WebCore/html/HTMLOptGroupElement.h
@@ -49,8 +49,8 @@ public:
 private:
     HTMLOptGroupElement(const QualifiedName&, Document&);
 
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
-    void removedFromAncestor(RemovalType, ContainerNode& oldParentOfRemovedTree) final;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) final;
+    void removingSteps(RemovalType, ContainerNode& oldParentOfRemovedTree) final;
 
     const AtomString& formControlType() const;
     bool isFocusable() const final;

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -159,9 +159,9 @@ void HTMLOptionElement::updateUserAgentShadowTree()
     }
 }
 
-auto HTMLOptionElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree) -> InsertedIntoAncestorResult
+auto HTMLOptionElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree) -> NeedsPostConnectionSteps
 {
-    auto result = HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    auto result = HTMLElement::insertionSteps(insertionType, parentOfInsertedTree);
 
     if (!document().settings().htmlEnhancedSelectParsingEnabled() || m_ownerSelect)
         return result;
@@ -177,9 +177,9 @@ auto HTMLOptionElement::insertedIntoAncestor(InsertionType insertionType, Contai
     return result;
 }
 
-void HTMLOptionElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void HTMLOptionElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
-    HTMLElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    HTMLElement::removingSteps(removalType, oldParentOfRemovedTree);
 
     if (removalType.disconnectedFromDocument && m_shadowTreeNeedsUpdate)
         protect(document())->removeElementWithPendingUserAgentShadowTreeUpdate(*this);

--- a/Source/WebCore/html/HTMLOptionElement.h
+++ b/Source/WebCore/html/HTMLOptionElement.h
@@ -78,8 +78,8 @@ public:
 private:
     HTMLOptionElement(const QualifiedName&, Document&);
 
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
-    void removedFromAncestor(RemovalType, ContainerNode& oldParentOfRemovedTree) final;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) final;
+    void removingSteps(RemovalType, ContainerNode& oldParentOfRemovedTree) final;
 
     bool supportsFocus() const final;
     bool isFocusable() const final;

--- a/Source/WebCore/html/HTMLPlugInElement.cpp
+++ b/Source/WebCore/html/HTMLPlugInElement.cpp
@@ -222,17 +222,17 @@ void HTMLPlugInElement::collectPresentationalHintsForAttribute(const QualifiedNa
     }
 }
 
-Node::InsertedIntoAncestorResult HTMLPlugInElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps HTMLPlugInElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    auto result = HTMLFrameOwnerElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    auto result = HTMLFrameOwnerElement::insertionSteps(insertionType, parentOfInsertedTree);
     if (insertionType.connectedToDocument)
         document().didConnectPluginElement();
     return result;
 }
 
-void HTMLPlugInElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void HTMLPlugInElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
-    HTMLFrameOwnerElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    HTMLFrameOwnerElement::removingSteps(removalType, oldParentOfRemovedTree);
     if (removalType.disconnectedFromDocument)
         document().didDisconnectPluginElement();
 }

--- a/Source/WebCore/html/HTMLPlugInElement.h
+++ b/Source/WebCore/html/HTMLPlugInElement.h
@@ -98,8 +98,8 @@ protected:
 
     virtual bool useFallbackContent() const { return false; }
 
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode& parentOfInsertedTree) override;
-    void removedFromAncestor(RemovalType, ContainerNode& oldParentOfRemovedTree) override;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode& parentOfInsertedTree) override;
+    void removingSteps(RemovalType, ContainerNode& oldParentOfRemovedTree) override;
 
     void defaultEventHandler(Event&) final;
 

--- a/Source/WebCore/html/HTMLScriptElement.cpp
+++ b/Source/WebCore/html/HTMLScriptElement.cpp
@@ -76,9 +76,9 @@ void HTMLScriptElement::finishParsingChildren()
     ScriptElement::finishParsingChildren();
 }
 
-void HTMLScriptElement::removedFromAncestor(RemovalType type, ContainerNode& container)
+void HTMLScriptElement::removingSteps(RemovalType type, ContainerNode& container)
 {
-    HTMLElement::removedFromAncestor(type, container);
+    HTMLElement::removingSteps(type, container);
     unblockRendering();
     unregisterSpeculationRules();
 }
@@ -98,15 +98,15 @@ void HTMLScriptElement::attributeChanged(const QualifiedName& name, const AtomSt
         HTMLElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 
-Node::InsertedIntoAncestorResult HTMLScriptElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps HTMLScriptElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
-    return ScriptElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    HTMLElement::insertionSteps(insertionType, parentOfInsertedTree);
+    return ScriptElement::insertionSteps(insertionType, parentOfInsertedTree);
 }
 
-void HTMLScriptElement::didFinishInsertingNode()
+void HTMLScriptElement::postConnectionSteps()
 {
-    ScriptElement::didFinishInsertingNode();
+    ScriptElement::postConnectionSteps();
 }
 
 void HTMLScriptElement::setText(String&& value)

--- a/Source/WebCore/html/HTMLScriptElement.h
+++ b/Source/WebCore/html/HTMLScriptElement.h
@@ -76,11 +76,11 @@ private:
     HTMLScriptElement(const QualifiedName&, Document&, bool wasInsertedByParser, bool alreadyStarted);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
-    void didFinishInsertingNode() final;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) final;
+    void postConnectionSteps() final;
     void childrenChanged(const ChildChange&) final;
     void finishParsingChildren() final;
-    void removedFromAncestor(RemovalType, ContainerNode&) final;
+    void removingSteps(RemovalType, ContainerNode&) final;
     void didMoveToNewDocument(Document& oldDocument, Document& newDocument) final;
 
     void potentiallyBlockRendering() final;

--- a/Source/WebCore/html/HTMLSelectedContentElement.cpp
+++ b/Source/WebCore/html/HTMLSelectedContentElement.cpp
@@ -50,20 +50,20 @@ Ref<HTMLSelectedContentElement> HTMLSelectedContentElement::create(const Qualifi
     return adoptRef(*new HTMLSelectedContentElement(document));
 }
 
-auto HTMLSelectedContentElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree) -> InsertedIntoAncestorResult
+auto HTMLSelectedContentElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree) -> NeedsPostConnectionSteps
 {
-    HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    HTMLElement::insertionSteps(insertionType, parentOfInsertedTree);
 
     ASSERT(document().settings().htmlEnhancedSelectParsingEnabled());
     ASSERT(document().settings().htmlEnhancedSelectEnabled());
     ASSERT(!document().settings().mutationEventsEnabled());
 
     if (insertionType.connectedToDocument)
-        return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
-    return InsertedIntoAncestorResult::Done;
+        return NeedsPostConnectionSteps::Yes;
+    return NeedsPostConnectionSteps::No;
 }
 
-void HTMLSelectedContentElement::didFinishInsertingNode()
+void HTMLSelectedContentElement::postConnectionSteps()
 {
     RefPtr<HTMLSelectElement> nearestAncestorSelect;
     m_isDisabled = false;
@@ -93,9 +93,9 @@ void HTMLSelectedContentElement::didFinishInsertingNode()
     nearestAncestorSelect->updateSelectedContent();
 }
 
-void HTMLSelectedContentElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void HTMLSelectedContentElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
-    HTMLElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    HTMLElement::removingSteps(removalType, oldParentOfRemovedTree);
 
     if (RefPtr select = m_owningSelect; select && !isInclusiveDescendantOf(*select)) {
         select->unregisterSelectedContentElement();

--- a/Source/WebCore/html/HTMLSelectedContentElement.h
+++ b/Source/WebCore/html/HTMLSelectedContentElement.h
@@ -42,9 +42,9 @@ public:
 private:
     explicit HTMLSelectedContentElement(Document&);
 
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
-    void didFinishInsertingNode() final;
-    void removedFromAncestor(RemovalType, ContainerNode&) final;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) final;
+    void postConnectionSteps() final;
+    void removingSteps(RemovalType, ContainerNode&) final;
 
     bool m_isDisabled { false };
     WeakPtr<HTMLSelectElement, WeakPtrImplWithEventTargetData> m_owningSelect;

--- a/Source/WebCore/html/HTMLSlotElement.cpp
+++ b/Source/WebCore/html/HTMLSlotElement.cpp
@@ -58,12 +58,12 @@ HTMLSlotElement::HTMLSlotElement(const QualifiedName& tagName, Document& documen
     ASSERT(hasTagName(slotTag));
 }
 
-HTMLSlotElement::InsertedIntoAncestorResult HTMLSlotElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+HTMLSlotElement::NeedsPostConnectionSteps HTMLSlotElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
     SetForScope isInInsertedIntoAncestor { m_isInInsertedIntoAncestor, true };
 
-    auto insertionResult = HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
-    ASSERT_UNUSED(insertionResult, insertionResult == InsertedIntoAncestorResult::Done);
+    auto insertionResult = HTMLElement::insertionSteps(insertionType, parentOfInsertedTree);
+    ASSERT_UNUSED(insertionResult, insertionResult == NeedsPostConnectionSteps::No);
 
     if (insertionType.treeScopeChanged && isInShadowTree()) {
         if (RefPtr shadowRoot = containingShadowRoot())
@@ -71,11 +71,11 @@ HTMLSlotElement::InsertedIntoAncestorResult HTMLSlotElement::insertedIntoAncesto
     }
 
     if (!insertionType.connectedToDocument)
-        return InsertedIntoAncestorResult::Done;
-    return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
+        return NeedsPostConnectionSteps::No;
+    return NeedsPostConnectionSteps::Yes;
 }
 
-void HTMLSlotElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void HTMLSlotElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
     if (removalType.treeScopeChanged && oldParentOfRemovedTree.isInShadowTree()) {
         RefPtr oldShadowRoot = oldParentOfRemovedTree.containingShadowRoot();
@@ -83,7 +83,7 @@ void HTMLSlotElement::removedFromAncestor(RemovalType removalType, ContainerNode
         oldShadowRoot->removeSlotElementByName(attributeWithoutSynchronization(nameAttr), *this, oldParentOfRemovedTree);
     }
 
-    HTMLElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    HTMLElement::removingSteps(removalType, oldParentOfRemovedTree);
 }
 
 void HTMLSlotElement::childrenChanged(const ChildChange& childChange)
@@ -106,9 +106,9 @@ void HTMLSlotElement::attributeChanged(const QualifiedName& name, const AtomStri
     }
 }
 
-void HTMLSlotElement::didFinishInsertingNode()
+void HTMLSlotElement::postConnectionSteps()
 {
-    HTMLElement::didFinishInsertingNode();
+    HTMLElement::postConnectionSteps();
     if (selfOrPrecedingNodesAffectDirAuto())
         updateEffectiveTextDirection();
 }

--- a/Source/WebCore/html/HTMLSlotElement.h
+++ b/Source/WebCore/html/HTMLSlotElement.h
@@ -59,11 +59,11 @@ public:
 private:
     HTMLSlotElement(const QualifiedName&, Document&);
 
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
-    void removedFromAncestor(RemovalType, ContainerNode&) final;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) final;
+    void removingSteps(RemovalType, ContainerNode&) final;
     void childrenChanged(const ChildChange&) final;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
-    void didFinishInsertingNode() final;
+    void postConnectionSteps() final;
 
     bool m_inSignalSlotList { false };
     bool m_isInInsertedIntoAncestor { false };

--- a/Source/WebCore/html/HTMLSourceElement.cpp
+++ b/Source/WebCore/html/HTMLSourceElement.cpp
@@ -74,9 +74,9 @@ Ref<HTMLSourceElement> HTMLSourceElement::create(Document& document)
     return create(sourceTag, document);
 }
 
-Node::InsertedIntoAncestorResult HTMLSourceElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps HTMLSourceElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    HTMLElement::insertionSteps(insertionType, parentOfInsertedTree);
     RefPtr<Element> parent = parentElement();
     if (parent == &parentOfInsertedTree) {
 #if ENABLE(VIDEO)
@@ -100,12 +100,12 @@ Node::InsertedIntoAncestorResult HTMLSourceElement::insertedIntoAncestor(Inserti
                 pictureElement->sourcesChanged();
         }
     }
-    return InsertedIntoAncestorResult::Done;
+    return NeedsPostConnectionSteps::No;
 }
 
-void HTMLSourceElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void HTMLSourceElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {        
-    HTMLElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    HTMLElement::removingSteps(removalType, oldParentOfRemovedTree);
     if (!parentNode() && is<Element>(oldParentOfRemovedTree)) {
 #if ENABLE(VIDEO)
         if (RefPtr medialElement = dynamicDowncast<HTMLMediaElement>(oldParentOfRemovedTree))

--- a/Source/WebCore/html/HTMLSourceElement.h
+++ b/Source/WebCore/html/HTMLSourceElement.h
@@ -58,8 +58,8 @@ public:
 private:
     HTMLSourceElement(const QualifiedName&, Document&);
     
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
-    void removedFromAncestor(RemovalType, ContainerNode&) final;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) final;
+    void removingSteps(RemovalType, ContainerNode&) final;
     void didMoveToNewDocument(Document& oldDocument, Document& newDocument) final;
 
     bool NODELETE isURLAttribute(const Attribute&) const final;

--- a/Source/WebCore/html/HTMLStyleElement.cpp
+++ b/Source/WebCore/html/HTMLStyleElement.cpp
@@ -134,17 +134,17 @@ void HTMLStyleElement::finishParsingChildren()
     HTMLElement::finishParsingChildren();
 }
 
-Node::InsertedIntoAncestorResult HTMLStyleElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps HTMLStyleElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    auto result = HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    auto result = HTMLElement::insertionSteps(insertionType, parentOfInsertedTree);
     if (insertionType.connectedToDocument)
         m_styleSheetOwner.insertedIntoDocument(*this);
     return result;
 }
 
-void HTMLStyleElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void HTMLStyleElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
-    HTMLElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    HTMLElement::removingSteps(removalType, oldParentOfRemovedTree);
     if (removalType.disconnectedFromDocument)
         m_styleSheetOwner.removedFromDocument(*this);
 }

--- a/Source/WebCore/html/HTMLStyleElement.h
+++ b/Source/WebCore/html/HTMLStyleElement.h
@@ -59,8 +59,8 @@ private:
     HTMLStyleElement(const QualifiedName&, Document&, bool createdByParser);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
-    void removedFromAncestor(RemovalType, ContainerNode&) final;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) final;
+    void removingSteps(RemovalType, ContainerNode&) final;
     void childrenChanged(const ChildChange&) final;
 
     bool isLoading() const { return m_styleSheetOwner.isLoading(); }

--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -97,14 +97,14 @@ bool HTMLTextFormControlElement::childShouldCreateRenderer(const Node& child) co
     return hasShadowRootParent(child) && HTMLFormControlElement::childShouldCreateRenderer(child);
 }
 
-Node::InsertedIntoAncestorResult HTMLTextFormControlElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps HTMLTextFormControlElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    InsertedIntoAncestorResult InsertedIntoAncestorResult = HTMLFormControlElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    NeedsPostConnectionSteps NeedsPostConnectionSteps = HTMLFormControlElement::insertionSteps(insertionType, parentOfInsertedTree);
     if (insertionType.connectedToDocument) {
         String initialValue = value();
         setTextAsOfLastFormControlChangeEvent(initialValue.isNull() ? String(emptyString()) : WTF::move(initialValue));
     }
-    return InsertedIntoAncestorResult;
+    return NeedsPostConnectionSteps;
 }
 
 static String pointerTypeFromHitTestRequest(HitTestRequest request)

--- a/Source/WebCore/html/HTMLTextFormControlElement.h
+++ b/Source/WebCore/html/HTMLTextFormControlElement.h
@@ -60,7 +60,7 @@ public:
     int minLength() const { return m_minLength; }
     ExceptionOr<void> setMinLength(int);
 
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) override;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) override;
 
     // The derived class should return true if placeholder processing is needed.
     bool isPlaceholderVisible() const { return m_isPlaceholderVisible; }

--- a/Source/WebCore/html/HTMLTitleElement.cpp
+++ b/Source/WebCore/html/HTMLTitleElement.cpp
@@ -55,27 +55,27 @@ Ref<HTMLTitleElement> HTMLTitleElement::create(const QualifiedName& tagName, Doc
     return adoptRef(*new HTMLTitleElement(tagName, document));
 }
 
-Node::InsertedIntoAncestorResult HTMLTitleElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps HTMLTitleElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    HTMLElement::insertionSteps(insertionType, parentOfInsertedTree);
 
     if (insertionType.connectedToDocument)
-        return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
+        return NeedsPostConnectionSteps::Yes;
 
-    return InsertedIntoAncestorResult::Done;
+    return NeedsPostConnectionSteps::No;
 }
 
-void HTMLTitleElement::didFinishInsertingNode()
+void HTMLTitleElement::postConnectionSteps()
 {
-    HTMLElement::didFinishInsertingNode();
+    HTMLElement::postConnectionSteps();
 
     m_title = computedTextWithDirection();
     protect(document())->titleElementAdded(*this);
 }
 
-void HTMLTitleElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void HTMLTitleElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
-    HTMLElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    HTMLElement::removingSteps(removalType, oldParentOfRemovedTree);
 
     if (removalType.disconnectedFromDocument)
         protect(document())->titleElementRemoved(*this);

--- a/Source/WebCore/html/HTMLTitleElement.h
+++ b/Source/WebCore/html/HTMLTitleElement.h
@@ -38,13 +38,13 @@ public:
 
     const StringWithDirection& textWithDirection() const LIFETIME_BOUND { return m_title; }
 
-    void didFinishInsertingNode() final;
+    void postConnectionSteps() final;
 
 private:
     HTMLTitleElement(const QualifiedName&, Document&);
 
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
-    void removedFromAncestor(RemovalType, ContainerNode&) final;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) final;
+    void removingSteps(RemovalType, ContainerNode&) final;
     void childrenChanged(const ChildChange&) final;
 
     StringWithDirection computedTextWithDirection();

--- a/Source/WebCore/html/HTMLTrackElement.cpp
+++ b/Source/WebCore/html/HTMLTrackElement.cpp
@@ -85,9 +85,9 @@ Ref<HTMLTrackElement> HTMLTrackElement::create(const QualifiedName& tagName, Doc
     return trackElement;
 }
 
-Node::InsertedIntoAncestorResult HTMLTrackElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps HTMLTrackElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    HTMLElement::insertionSteps(insertionType, parentOfInsertedTree);
 
     if (parentNode() == &parentOfInsertedTree) {
         if (auto* mediaElement = dynamicDowncast<HTMLMediaElement>(parentOfInsertedTree)) {
@@ -96,12 +96,12 @@ Node::InsertedIntoAncestorResult HTMLTrackElement::insertedIntoAncestor(Insertio
         }
     }
 
-    return InsertedIntoAncestorResult::Done;
+    return NeedsPostConnectionSteps::No;
 }
 
-void HTMLTrackElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void HTMLTrackElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
-    HTMLElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    HTMLElement::removingSteps(removalType, oldParentOfRemovedTree);
 
     if (!parentNode()) {
         if (auto* mediaElement = dynamicDowncast<HTMLMediaElement>(oldParentOfRemovedTree))

--- a/Source/WebCore/html/HTMLTrackElement.h
+++ b/Source/WebCore/html/HTMLTrackElement.h
@@ -79,8 +79,8 @@ private:
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
 
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
-    void removedFromAncestor(RemovalType, ContainerNode&) final;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) final;
+    void removingSteps(RemovalType, ContainerNode&) final;
     void didMoveToNewDocument(Document& oldDocument, Document& newDocument) final;
 
     bool NODELETE isURLAttribute(const Attribute&) const final;

--- a/Source/WebCore/html/ValidatedFormListedElement.cpp
+++ b/Source/WebCore/html/ValidatedFormListedElement.cpp
@@ -326,7 +326,7 @@ void ValidatedFormListedElement::parseReadOnlyAttribute(const AtomString& value)
     }
 }
 
-void ValidatedFormListedElement::insertedIntoAncestor(Node::InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+void ValidatedFormListedElement::insertionSteps(Node::InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
     m_isInsideDataList = TriState::Indeterminate;
     updateWillValidateAndValidity();
@@ -336,7 +336,7 @@ void ValidatedFormListedElement::insertedIntoAncestor(Node::InsertionType insert
 
     if (!insertionType.connectedToDocument)
         resetFormOwner();
-    // Need to wait for didFinishInsertingNode to reset form when this element is inserted into a document
+    // Need to wait for postConnectionSteps to reset form when this element is inserted into a document
     // because we rely on TreeScope::getElementById to return the right element.
 }
 
@@ -354,7 +354,7 @@ void ValidatedFormListedElement::syncWithFieldsetAncestors(ContainerNode* insert
         setDisabledInternal(m_disabled, computeIsDisabledByFieldsetAncestor());
 }
 
-void ValidatedFormListedElement::removedFromAncestor(Node::RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void ValidatedFormListedElement::removingSteps(Node::RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
     Ref element = asHTMLElement();
     bool wasMatchingInvalidPseudoClass = matchesInvalidPseudoClass();
@@ -451,7 +451,7 @@ void ValidatedFormListedElement::updateWillValidateAndValidity()
         hideVisibleValidationMessage();
 }
 
-void ValidatedFormListedElement::didFinishInsertingNode()
+void ValidatedFormListedElement::postConnectionSteps()
 {
     resetFormOwner();
 }

--- a/Source/WebCore/html/ValidatedFormListedElement.h
+++ b/Source/WebCore/html/ValidatedFormListedElement.h
@@ -101,9 +101,9 @@ protected:
 
     bool NODELETE validationMessageShadowTreeContains(const Node&) const;
 
-    void insertedIntoAncestor(Node::InsertionType, ContainerNode&);
-    void didFinishInsertingNode();
-    void removedFromAncestor(Node::RemovalType, ContainerNode&);
+    void insertionSteps(Node::InsertionType, ContainerNode&);
+    void postConnectionSteps();
+    void removingSteps(Node::RemovalType, ContainerNode&);
     void parseAttribute(const QualifiedName&, const AtomString&);
     void parseDisabledAttribute(const AtomString&);
     void parseReadOnlyAttribute(const AtomString&);

--- a/Source/WebCore/html/parser/HTMLConstructionSite.cpp
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.cpp
@@ -867,7 +867,7 @@ std::tuple<RefPtr<HTMLElement>, RefPtr<JSCustomElementInterface>, RefPtr<CustomE
     // FIXME: This is a hack to connect images to pictures before the image has
     // been inserted into the document. It can be removed once asynchronous image
     // loading is working. When this hack is removed, the assertion just before
-    // the setPictureElement() call in HTMLImageElement::insertedIntoAncestor
+    // the setPictureElement() call in HTMLImageElement::insertionSteps
     // can be simplified.
     if (RefPtr currentPictureElement = dynamicDowncast<HTMLPictureElement>(currentNode())) {
         if (auto* imageElement = dynamicDowncast<HTMLImageElement>(*element))

--- a/Source/WebCore/html/shadow/TextPlaceholderElement.cpp
+++ b/Source/WebCore/html/shadow/TextPlaceholderElement.cpp
@@ -54,22 +54,22 @@ TextPlaceholderElement::TextPlaceholderElement(Document& document, const LayoutS
     setInlineStyleProperty(CSSPropertyHeight, size.height(), CSSUnitType::CSS_PX);
 }
 
-auto TextPlaceholderElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree) -> InsertedIntoAncestorResult
+auto TextPlaceholderElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree) -> NeedsPostConnectionSteps
 {
     if (insertionType.treeScopeChanged) {
         if (RefPtr shadowHost = dynamicDowncast<HTMLTextFormControlElement>(parentOfInsertedTree.shadowHost()))
             shadowHost->setCanShowPlaceholder(false);
     }
-    return HTMLDivElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    return HTMLDivElement::insertionSteps(insertionType, parentOfInsertedTree);
 }
 
-void TextPlaceholderElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void TextPlaceholderElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
     if (removalType.treeScopeChanged) {
         if (RefPtr shadowHost = dynamicDowncast<HTMLTextFormControlElement>(oldParentOfRemovedTree.shadowHost()))
             shadowHost->setCanShowPlaceholder(true);
     }
-    HTMLDivElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    HTMLDivElement::removingSteps(removalType, oldParentOfRemovedTree);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/shadow/TextPlaceholderElement.h
+++ b/Source/WebCore/html/shadow/TextPlaceholderElement.h
@@ -42,8 +42,8 @@ private:
 
     bool NODELETE isTextPlaceholderElement() const final { return true; }
 
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode& parentOfInsertedTree) final;
-    void removedFromAncestor(RemovalType, ContainerNode& oldParentOfRemovedTree) final;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode& parentOfInsertedTree) final;
+    void removingSteps(RemovalType, ContainerNode& oldParentOfRemovedTree) final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/LogMessages.in
+++ b/Source/WebCore/platform/LogMessages.in
@@ -97,9 +97,9 @@ MEDIASESSIONMANAGERINTERFACE_MAYBEACTIVATEAUDIOSESSION_ACTIVE_SESSION_NOT_REQUIR
 HTMLMEDIAELEMENT_CONSTRUCTOR, "HTMLMediaElement::HTMLMediaElement(%" PRIX64 ")", (uint64_t), DEFAULT, Media
 HTMLMEDIAELEMENT_DESTRUCTOR, "HTMLMediaElement::~HTMLMediaElement(%" PRIX64 ")", (uint64_t), DEFAULT, Media
 HTMLMEDIAELEMENT_SETBUFFERINGPOLICY, "HTMLMediaElement::setBufferingPolicy(%" PRIX64 "): %" PRIu8, (uint64_t, uint8_t), DEFAULT, Media
-HTMLMEDIAELEMENT_INSERTEDINTOANCESTOR, "HTMLMediaElement::insertedIntoAncestor(%" PRIX64 ")", (uint64_t), DEFAULT, Media
-HTMLMEDIAELEMENT_REMOVEDFROMANCESTOR, "HTMLMediaElement::removedFromAncestor(%" PRIX64 ")", (uint64_t), DEFAULT, Media
-HTMLMEDIAELEMENT_DIDFINISHINSERTINGNODE, "HTMLMediaElement::didFinishInsertingNode(%" PRIX64 ")", (uint64_t), DEFAULT, Media
+HTMLMEDIAELEMENT_INSERTEDINTOANCESTOR, "HTMLMediaElement::insertionSteps(%" PRIX64 ")", (uint64_t), DEFAULT, Media
+HTMLMEDIAELEMENT_REMOVEDFROMANCESTOR, "HTMLMediaElement::removingSteps(%" PRIX64 ")", (uint64_t), DEFAULT, Media
+HTMLMEDIAELEMENT_DIDFINISHINSERTINGNODE, "HTMLMediaElement::postConnectionSteps(%" PRIX64 ")", (uint64_t), DEFAULT, Media
 HTMLMEDIAELEMENT_MEDIAPLAYERRATECHANGED, "HTMLMediaElement::mediaPlayerRateChanged(%" PRIX64 ") rate: %f", (uint64_t, double), DEFAULT, Media
 HTMLMEDIAELEMENT_MEDIAPLAYERTIMECHANGED, "HTMLMediaElement::mediaPlayerTimeChanged(%" PRIX64 ")", (uint64_t), DEFAULT, Media
 HTMLMEDIAELEMENT_MEDIAPLAYERTIMECHANGED_LOOPING, "HTMLMediaElement::mediaPlayerTimeChanged(%" PRIX64 ") current time (%f) is greater then duration (%f), looping", (uint64_t, double, double), DEFAULT, Media

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -183,9 +183,9 @@ void SVGElement::reportAttributeParsingError(SVGParsingError error, const Qualif
     ASSERT_NOT_REACHED();
 }
 
-void SVGElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void SVGElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
-    StyledElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    StyledElement::removingSteps(removalType, oldParentOfRemovedTree);
 
     if (!parentNode()) {
         m_hasRegisteredWithParentForRelativeLengths = false;
@@ -1056,9 +1056,9 @@ void SVGElement::svgAttributeChanged(const QualifiedName& attrName)
     }
 }
 
-Node::InsertedIntoAncestorResult SVGElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps SVGElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    StyledElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    StyledElement::insertionSteps(insertionType, parentOfInsertedTree);
 
     if (!m_hasInitializedRelativeLengthsState)
         updateRelativeLengthsInformation();
@@ -1069,13 +1069,13 @@ Node::InsertedIntoAncestorResult SVGElement::insertedIntoAncestor(InsertionType 
 
     if (needsPendingResourceHandling() && insertionType.connectedToDocument && !isInShadowTree()) {
         if (treeScopeForSVGReferences().isIdOfPendingSVGResource(getIdAttribute()))
-            return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
+            return NeedsPostConnectionSteps::Yes;
     }
 
-    return InsertedIntoAncestorResult::Done;
+    return NeedsPostConnectionSteps::No;
 }
 
-void SVGElement::didFinishInsertingNode()
+void SVGElement::postConnectionSteps()
 {
     buildPendingResourcesIfNeeded();
 }

--- a/Source/WebCore/svg/SVGElement.h
+++ b/Source/WebCore/svg/SVGElement.h
@@ -207,9 +207,9 @@ protected:
 
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const override;
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) override;
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) override;
-    void didFinishInsertingNode() override;
-    void removedFromAncestor(RemovalType, ContainerNode&) override;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) override;
+    void postConnectionSteps() override;
+    void removingSteps(RemovalType, ContainerNode&) override;
     void childrenChanged(const ChildChange&) override;
     virtual bool selfHasRelativeLengths() const { return false; }
     void updateRelativeLengthsInformation();

--- a/Source/WebCore/svg/SVGFEImageElement.cpp
+++ b/Source/WebCore/svg/SVGFEImageElement.cpp
@@ -144,23 +144,23 @@ void SVGFEImageElement::svgAttributeChanged(const QualifiedName& attrName)
     SVGFilterPrimitiveStandardAttributes::svgAttributeChanged(attrName);
 }
 
-Node::InsertedIntoAncestorResult SVGFEImageElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps SVGFEImageElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    SVGFilterPrimitiveStandardAttributes::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    SVGFilterPrimitiveStandardAttributes::insertionSteps(insertionType, parentOfInsertedTree);
     if (!insertionType.connectedToDocument)
-        return InsertedIntoAncestorResult::Done;
-    return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
+        return NeedsPostConnectionSteps::No;
+    return NeedsPostConnectionSteps::Yes;
 }
 
-void SVGFEImageElement::didFinishInsertingNode()
+void SVGFEImageElement::postConnectionSteps()
 {
-    SVGFilterPrimitiveStandardAttributes::didFinishInsertingNode();
+    SVGFilterPrimitiveStandardAttributes::postConnectionSteps();
     buildPendingResource();
 }
 
-void SVGFEImageElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void SVGFEImageElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
-    SVGFilterPrimitiveStandardAttributes::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    SVGFilterPrimitiveStandardAttributes::removingSteps(removalType, oldParentOfRemovedTree);
     if (removalType.disconnectedFromDocument)
         clearResourceReferences();
 }

--- a/Source/WebCore/svg/SVGFEImageElement.h
+++ b/Source/WebCore/svg/SVGFEImageElement.h
@@ -57,7 +57,7 @@ private:
     void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final;
     void addSubresourceAttributeURLs(ListHashSet<URL>&) const override;
 
-    void didFinishInsertingNode() override;
+    void postConnectionSteps() override;
 
     std::tuple<RefPtr<ImageBuffer>, FloatRect> imageBufferForEffect(const GraphicsContext& destinationContext) const;
 
@@ -67,8 +67,8 @@ private:
     void requestImageResource();
 
     void buildPendingResource() override;
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) override;
-    void removedFromAncestor(RemovalType, ContainerNode&) override;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) override;
+    void removingSteps(RemovalType, ContainerNode&) override;
 
     const Ref<SVGAnimatedPreserveAspectRatio> m_preserveAspectRatio { SVGAnimatedPreserveAspectRatio::create(this) };
     CachedResourceHandle<CachedImage> m_cachedImage;

--- a/Source/WebCore/svg/SVGFontFaceElement.cpp
+++ b/Source/WebCore/svg/SVGFontFaceElement.cpp
@@ -289,12 +289,12 @@ void SVGFontFaceElement::rebuildFontFace()
     document().styleScope().didChangeStyleSheetEnvironment();
 }
 
-Node::InsertedIntoAncestorResult SVGFontFaceElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps SVGFontFaceElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    auto result = SVGElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    auto result = SVGElement::insertionSteps(insertionType, parentOfInsertedTree);
     if (!insertionType.connectedToDocument) {
         ASSERT(!m_fontElement);
-        return InsertedIntoAncestorResult::Done;
+        return NeedsPostConnectionSteps::No;
     }
     protect(document())->svgExtensions().registerSVGFontFaceElement(*this);
 
@@ -302,9 +302,9 @@ Node::InsertedIntoAncestorResult SVGFontFaceElement::insertedIntoAncestor(Insert
     return result;
 }
 
-void SVGFontFaceElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void SVGFontFaceElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
-    SVGElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    SVGElement::removingSteps(removalType, oldParentOfRemovedTree);
 
     if (removalType.disconnectedFromDocument) {
         m_fontElement = nullptr;

--- a/Source/WebCore/svg/SVGFontFaceElement.h
+++ b/Source/WebCore/svg/SVGFontFaceElement.h
@@ -59,8 +59,8 @@ private:
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
 
     void childrenChanged(const ChildChange&) final;
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
-    void removedFromAncestor(RemovalType, ContainerNode&) final;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) final;
+    void removingSteps(RemovalType, ContainerNode&) final;
 
     bool rendererIsNeeded(const RenderStyle&) final { return false; }
 

--- a/Source/WebCore/svg/SVGFontFaceUriElement.cpp
+++ b/Source/WebCore/svg/SVGFontFaceUriElement.cpp
@@ -83,10 +83,10 @@ void SVGFontFaceUriElement::childrenChanged(const ChildChange& change)
         grandParent->rebuildFontFace();
 }
 
-Node::InsertedIntoAncestorResult SVGFontFaceUriElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps SVGFontFaceUriElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
     loadFont();
-    return SVGElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    return SVGElement::insertionSteps(insertionType, parentOfInsertedTree);
 }
 
 static bool isSVGFontTarget(const SVGFontFaceUriElement& element)

--- a/Source/WebCore/svg/SVGFontFaceUriElement.h
+++ b/Source/WebCore/svg/SVGFontFaceUriElement.h
@@ -46,7 +46,7 @@ private:
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void childrenChanged(const ChildChange&) final;
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) final;
     bool rendererIsNeeded(const RenderStyle&) final { return false; }
 
     void loadFont();

--- a/Source/WebCore/svg/SVGImageElement.cpp
+++ b/Source/WebCore/svg/SVGImageElement.cpp
@@ -186,11 +186,11 @@ void SVGImageElement::didAttachRenderers()
     }
 }
 
-Node::InsertedIntoAncestorResult SVGImageElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps SVGImageElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    auto result = SVGGraphicsElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    auto result = SVGGraphicsElement::insertionSteps(insertionType, parentOfInsertedTree);
     if (!insertionType.connectedToDocument)
-        return InsertedIntoAncestorResult::Done;
+        return NeedsPostConnectionSteps::No;
     // Update image loader, as soon as we're living in the tree.
     // We can only resolve base URIs properly, after that!
     m_imageLoader->updateFromElement();

--- a/Source/WebCore/svg/SVGImageElement.h
+++ b/Source/WebCore/svg/SVGImageElement.h
@@ -64,7 +64,7 @@ private:
     void svgAttributeChanged(const QualifiedName&) final;
 
     void didAttachRenderers() final;
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) final;
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
 
     void addSubresourceAttributeURLs(ListHashSet<URL>&) const final;

--- a/Source/WebCore/svg/SVGMPathElement.cpp
+++ b/Source/WebCore/svg/SVGMPathElement.cpp
@@ -78,23 +78,23 @@ void SVGMPathElement::clearResourceReferences()
     removeElementReference();
 }
 
-Node::InsertedIntoAncestorResult SVGMPathElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps SVGMPathElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    auto result = SVGElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    auto result = SVGElement::insertionSteps(insertionType, parentOfInsertedTree);
     if (insertionType.connectedToDocument)
-        return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
+        return NeedsPostConnectionSteps::Yes;
     return result;
 }
 
-void SVGMPathElement::didFinishInsertingNode()
+void SVGMPathElement::postConnectionSteps()
 {
-    SVGElement::didFinishInsertingNode();
+    SVGElement::postConnectionSteps();
     buildPendingResource();
 }
 
-void SVGMPathElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void SVGMPathElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
-    SVGElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    SVGElement::removingSteps(removalType, oldParentOfRemovedTree);
     if (removalType.disconnectedFromDocument)
         clearResourceReferences();
 }

--- a/Source/WebCore/svg/SVGMPathElement.h
+++ b/Source/WebCore/svg/SVGMPathElement.h
@@ -51,11 +51,11 @@ private:
 
     void buildPendingResource() final;
     void clearResourceReferences();
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
-    void removedFromAncestor(RemovalType, ContainerNode&) final;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) final;
+    void removingSteps(RemovalType, ContainerNode&) final;
 
     bool rendererIsNeeded(const RenderStyle&) final { return false; }
-    void didFinishInsertingNode() final;
+    void postConnectionSteps() final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGPathElement.cpp
+++ b/Source/WebCore/svg/SVGPathElement.cpp
@@ -168,16 +168,16 @@ void SVGPathElement::invalidateMPathDependencies()
     }
 }
 
-Node::InsertedIntoAncestorResult SVGPathElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps SVGPathElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    auto result = SVGGeometryElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    auto result = SVGGeometryElement::insertionSteps(insertionType, parentOfInsertedTree);
     invalidateMPathDependencies();
     return result;
 }
 
-void SVGPathElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void SVGPathElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
-    SVGGeometryElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    SVGGeometryElement::removingSteps(removalType, oldParentOfRemovedTree);
     invalidateMPathDependencies();
 }
 

--- a/Source/WebCore/svg/SVGPathElement.h
+++ b/Source/WebCore/svg/SVGPathElement.h
@@ -119,8 +119,8 @@ private:
 
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
 
-    Node::InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
-    void removedFromAncestor(RemovalType, ContainerNode&) final;
+    Node::NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) final;
+    void removingSteps(RemovalType, ContainerNode&) final;
 
     void invalidateMPathDependencies();
 

--- a/Source/WebCore/svg/SVGSVGElement.cpp
+++ b/Source/WebCore/svg/SVGSVGElement.cpp
@@ -520,7 +520,7 @@ bool SVGSVGElement::isReplaced(const RenderStyle*) const
     return isOutermostSVGSVGElement();
 }
 
-Node::InsertedIntoAncestorResult SVGSVGElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps SVGSVGElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
     if (insertionType.connectedToDocument) {
         Ref document = this->document();
@@ -535,17 +535,17 @@ Node::InsertedIntoAncestorResult SVGSVGElement::insertedIntoAncestor(InsertionTy
         if (!document->parsing() && !document->processingLoadEvent() && document->loadEventFinished())
             m_timeContainer->begin();
     }
-    return SVGGraphicsElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    return SVGGraphicsElement::insertionSteps(insertionType, parentOfInsertedTree);
 }
 
-void SVGSVGElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void SVGSVGElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
     if (removalType.disconnectedFromDocument) {
         Ref<Document> document = this->document();
         protect(document->svgExtensions())->removeTimeContainer(*this);
         pauseAnimations();
     }
-    SVGGraphicsElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    SVGGraphicsElement::removingSteps(removalType, oldParentOfRemovedTree);
 }
 
 void SVGSVGElement::pauseAnimations()

--- a/Source/WebCore/svg/SVGSVGElement.h
+++ b/Source/WebCore/svg/SVGSVGElement.h
@@ -137,8 +137,8 @@ private:
     bool rendererIsNeeded(const RenderStyle&) override;
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) override;
     bool isReplaced(const RenderStyle* = nullptr) const final;
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) override;
-    void removedFromAncestor(RemovalType, ContainerNode&) override;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) override;
+    void removingSteps(RemovalType, ContainerNode&) override;
     void prepareForDocumentSuspension() override;
     void resumeFromDocumentSuspension() override;
     void didMoveToNewDocument(Document& oldDocument, Document& newDocument) override;

--- a/Source/WebCore/svg/SVGScriptElement.cpp
+++ b/Source/WebCore/svg/SVGScriptElement.cpp
@@ -80,16 +80,16 @@ void SVGScriptElement::svgAttributeChanged(const QualifiedName& attrName)
     SVGElement::svgAttributeChanged(attrName);
 }
 
-Node::InsertedIntoAncestorResult SVGScriptElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps SVGScriptElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    auto result1 = SVGElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
-    auto result2 = ScriptElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
-    return result1 == InsertedIntoAncestorResult::NeedsPostInsertionCallback ? result1 : result2;
+    auto result1 = SVGElement::insertionSteps(insertionType, parentOfInsertedTree);
+    auto result2 = ScriptElement::insertionSteps(insertionType, parentOfInsertedTree);
+    return result1 == NeedsPostConnectionSteps::Yes ? result1 : result2;
 }
 
-void SVGScriptElement::didFinishInsertingNode()
+void SVGScriptElement::postConnectionSteps()
 {
-    ScriptElement::didFinishInsertingNode();
+    ScriptElement::postConnectionSteps();
 }
 
 void SVGScriptElement::childrenChanged(const ChildChange& change)

--- a/Source/WebCore/svg/SVGScriptElement.h
+++ b/Source/WebCore/svg/SVGScriptElement.h
@@ -49,8 +49,8 @@ private:
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;
 
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
-    void didFinishInsertingNode() final;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) final;
+    void postConnectionSteps() final;
     void childrenChanged(const ChildChange&) final;
     void finishParsingChildren() final;
     void didMoveToNewDocument(Document& oldDocument, Document& newDocument) final;

--- a/Source/WebCore/svg/SVGStyleElement.cpp
+++ b/Source/WebCore/svg/SVGStyleElement.cpp
@@ -96,17 +96,17 @@ void SVGStyleElement::finishParsingChildren()
     SVGElement::finishParsingChildren();
 }
 
-Node::InsertedIntoAncestorResult SVGStyleElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps SVGStyleElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    auto result = SVGElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    auto result = SVGElement::insertionSteps(insertionType, parentOfInsertedTree);
     if (insertionType.connectedToDocument)
         m_styleSheetOwner.insertedIntoDocument(*this);
     return result;
 }
 
-void SVGStyleElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void SVGStyleElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
-    SVGElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    SVGElement::removingSteps(removalType, oldParentOfRemovedTree);
     if (removalType.disconnectedFromDocument)
         m_styleSheetOwner.removedFromDocument(*this);
 }

--- a/Source/WebCore/svg/SVGStyleElement.h
+++ b/Source/WebCore/svg/SVGStyleElement.h
@@ -43,8 +43,8 @@ private:
     SVGStyleElement(const QualifiedName&, Document&, bool createdByParser);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
-    void removedFromAncestor(RemovalType, ContainerNode&) final;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) final;
+    void removingSteps(RemovalType, ContainerNode&) final;
     void childrenChanged(const ChildChange&) final;
 
     bool rendererIsNeeded(const RenderStyle&) final { return false; }

--- a/Source/WebCore/svg/SVGTRefElement.cpp
+++ b/Source/WebCore/svg/SVGTRefElement.cpp
@@ -215,7 +215,7 @@ void SVGTRefElement::buildPendingResource()
     // Remove any existing event listener.
     protect(m_targetListener)->detach();
 
-    // If we're not yet in a document, this function will be called again from insertedIntoAncestor().
+    // If we're not yet in a document, this function will be called again from insertionSteps().
     if (!isConnected())
         return;
 
@@ -239,23 +239,23 @@ void SVGTRefElement::buildPendingResource()
     updateReferencedText(target.element.get());
 }
 
-Node::InsertedIntoAncestorResult SVGTRefElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps SVGTRefElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    auto result = SVGElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    auto result = SVGElement::insertionSteps(insertionType, parentOfInsertedTree);
     if (insertionType.connectedToDocument)
-        return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
+        return NeedsPostConnectionSteps::Yes;
     return result;
 }
 
-void SVGTRefElement::didFinishInsertingNode()
+void SVGTRefElement::postConnectionSteps()
 {
-    SVGTextPositioningElement::didFinishInsertingNode();
+    SVGTextPositioningElement::postConnectionSteps();
     buildPendingResource();
 }
 
-void SVGTRefElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void SVGTRefElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
-    SVGElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    SVGElement::removingSteps(removalType, oldParentOfRemovedTree);
     if (removalType.disconnectedFromDocument)
         protect(m_targetListener)->detach();
 }

--- a/Source/WebCore/svg/SVGTRefElement.h
+++ b/Source/WebCore/svg/SVGTRefElement.h
@@ -50,9 +50,9 @@ private:
     bool childShouldCreateRenderer(const Node&) const override;
     bool rendererIsNeeded(const RenderStyle&) override;
 
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) override;
-    void removedFromAncestor(RemovalType, ContainerNode&) override;
-    void didFinishInsertingNode() override;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) override;
+    void removingSteps(RemovalType, ContainerNode&) override;
+    void postConnectionSteps() override;
 
     void clearTarget() override;
     void updateReferencedText(Element*);

--- a/Source/WebCore/svg/SVGTextPathElement.cpp
+++ b/Source/WebCore/svg/SVGTextPathElement.cpp
@@ -177,23 +177,23 @@ void SVGTextPathElement::buildPendingResource()
     LegacyRenderSVGResource::markForLayoutAndParentResourceInvalidation(*renderer);
 }
 
-Node::InsertedIntoAncestorResult SVGTextPathElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps SVGTextPathElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    SVGTextContentElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    SVGTextContentElement::insertionSteps(insertionType, parentOfInsertedTree);
     if (!insertionType.connectedToDocument)
-        return InsertedIntoAncestorResult::Done;
-    return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
+        return NeedsPostConnectionSteps::No;
+    return NeedsPostConnectionSteps::Yes;
 }
 
-void SVGTextPathElement::didFinishInsertingNode()
+void SVGTextPathElement::postConnectionSteps()
 {
     SVGTextContentElement::buildPendingResource();
     buildPendingResource();
 }
 
-void SVGTextPathElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void SVGTextPathElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
-    SVGTextContentElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    SVGTextContentElement::removingSteps(removalType, oldParentOfRemovedTree);
     if (removalType.disconnectedFromDocument)
         clearResourceReferences();
 }

--- a/Source/WebCore/svg/SVGTextPathElement.h
+++ b/Source/WebCore/svg/SVGTextPathElement.h
@@ -128,7 +128,7 @@ private:
     SVGTextPathElement(const QualifiedName&, Document&);
     virtual ~SVGTextPathElement();
 
-    void didFinishInsertingNode() override;
+    void postConnectionSteps() override;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
@@ -139,8 +139,8 @@ private:
 
     void clearResourceReferences();
     void buildPendingResource() override;
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) override;
-    void removedFromAncestor(RemovalType, ContainerNode&) override;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) override;
+    void removingSteps(RemovalType, ContainerNode&) override;
 
     bool selfHasRelativeLengths() const override;
 

--- a/Source/WebCore/svg/SVGTitleElement.cpp
+++ b/Source/WebCore/svg/SVGTitleElement.cpp
@@ -42,9 +42,9 @@ Ref<SVGTitleElement> SVGTitleElement::create(const QualifiedName& tagName, Docum
     return adoptRef(*new SVGTitleElement(tagName, document));
 }
 
-Node::InsertedIntoAncestorResult SVGTitleElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps SVGTitleElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    auto result = SVGElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    auto result = SVGElement::insertionSteps(insertionType, parentOfInsertedTree);
     if (insertionType.connectedToDocument && parentNode() == document().documentElement())
         protect(document())->titleElementAdded(*this);
     return result;
@@ -59,9 +59,9 @@ static bool NODELETE isTitleElementRemovedFromSVGSVGElement(SVGTitleElement& tit
     return false;
 }
 
-void SVGTitleElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void SVGTitleElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
-    SVGElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    SVGElement::removingSteps(removalType, oldParentOfRemovedTree);
     if (removalType.disconnectedFromDocument && isTitleElementRemovedFromSVGSVGElement(*this, oldParentOfRemovedTree)) {
         Ref<Document> document = this->document();
         document->titleElementRemoved(*this);

--- a/Source/WebCore/svg/SVGTitleElement.h
+++ b/Source/WebCore/svg/SVGTitleElement.h
@@ -35,8 +35,8 @@ public:
 private:
     SVGTitleElement(const QualifiedName&, Document&);
 
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
-    void removedFromAncestor(RemovalType, ContainerNode&) final;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) final;
+    void removingSteps(RemovalType, ContainerNode&) final;
     void childrenChanged(const ChildChange&) final;
 
     bool rendererIsNeeded(const RenderStyle&) final { return false; }

--- a/Source/WebCore/svg/SVGUseElement.cpp
+++ b/Source/WebCore/svg/SVGUseElement.cpp
@@ -113,28 +113,28 @@ void SVGUseElement::attributeChanged(const QualifiedName& name, const AtomString
     SVGGraphicsElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 
-Node::InsertedIntoAncestorResult SVGUseElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps SVGUseElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    auto result = SVGGraphicsElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    auto result = SVGGraphicsElement::insertionSteps(insertionType, parentOfInsertedTree);
     if (insertionType.connectedToDocument) {
         if (m_shadowTreeNeedsUpdate)
             protect(document())->addElementWithPendingUserAgentShadowTreeUpdate(*this);
         invalidateShadowTree();
         // FIXME: Move back the call to updateExternalDocument() here once notifyFinished is made always async.
-        return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
+        return NeedsPostConnectionSteps::Yes;
     }
     return result;
 }
 
-void SVGUseElement::didFinishInsertingNode()
+void SVGUseElement::postConnectionSteps()
 {
-    SVGGraphicsElement::didFinishInsertingNode();
+    SVGGraphicsElement::postConnectionSteps();
     updateExternalDocument();
 }
 
-void SVGUseElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void SVGUseElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
-    // Check m_shadowTreeNeedsUpdate before calling SVGElement::removedFromAncestor which calls SVGElement::invalidateInstances
+    // Check m_shadowTreeNeedsUpdate before calling SVGElement::removingSteps which calls SVGElement::invalidateInstances
     // and SVGUseElement::updateExternalDocument which calls invalidateShadowTree().
     if (removalType.disconnectedFromDocument) {
         if (m_shadowTreeNeedsUpdate) {
@@ -142,7 +142,7 @@ void SVGUseElement::removedFromAncestor(RemovalType removalType, ContainerNode& 
             document->removeElementWithPendingUserAgentShadowTreeUpdate(*this);
         }
     }
-    SVGGraphicsElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    SVGGraphicsElement::removingSteps(removalType, oldParentOfRemovedTree);
     if (removalType.disconnectedFromDocument) {
         clearShadowTree();
         updateExternalDocument();

--- a/Source/WebCore/svg/SVGUseElement.h
+++ b/Source/WebCore/svg/SVGUseElement.h
@@ -66,9 +66,9 @@ public:
 private:
     SVGUseElement(const QualifiedName&, Document&);
 
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) override;
-    void didFinishInsertingNode() final;
-    void removedFromAncestor(RemovalType, ContainerNode&) override;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) override;
+    void postConnectionSteps() final;
+    void removingSteps(RemovalType, ContainerNode&) override;
     void buildPendingResource() override;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;

--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -258,11 +258,11 @@ void SVGSMILElement::reset()
     resolveFirstInterval();
 }
 
-Node::InsertedIntoAncestorResult SVGSMILElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+Node::NeedsPostConnectionSteps SVGSMILElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    SVGElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    SVGElement::insertionSteps(insertionType, parentOfInsertedTree);
     if (!insertionType.connectedToDocument)
-        return InsertedIntoAncestorResult::Done;
+        return NeedsPostConnectionSteps::No;
 
     // Verify we are not in <use> instance tree.
     ASSERT(!isInShadowTree() || !is<SVGUseElement>(shadowHost()));
@@ -271,7 +271,7 @@ Node::InsertedIntoAncestorResult SVGSMILElement::insertedIntoAncestor(InsertionT
 
     RefPtr owner = ownerSVGElement();
     if (!owner)
-        return InsertedIntoAncestorResult::Done;
+        return NeedsPostConnectionSteps::No;
 
     m_timeContainer = owner->timeContainer();
     timeContainer()->setDocumentOrderIndexesDirty();
@@ -286,16 +286,16 @@ Node::InsertedIntoAncestorResult SVGSMILElement::insertedIntoAncestor(InsertionT
     if (RefPtr timeContainer = m_timeContainer)
         timeContainer->notifyIntervalsChanged();
 
-    return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
+    return NeedsPostConnectionSteps::Yes;
 }
 
-void SVGSMILElement::didFinishInsertingNode()
+void SVGSMILElement::postConnectionSteps()
 {
-    SVGElement::didFinishInsertingNode();
+    SVGElement::postConnectionSteps();
     buildPendingResource();
 }
 
-void SVGSMILElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void SVGSMILElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
     if (removalType.disconnectedFromDocument) {
         clearResourceReferences();
@@ -306,7 +306,7 @@ void SVGSMILElement::removedFromAncestor(RemovalType removalType, ContainerNode&
         m_timeContainer = nullptr;
     }
 
-    SVGElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    SVGElement::removingSteps(removalType, oldParentOfRemovedTree);
 }
 
 bool SVGSMILElement::hasValidAttributeName() const

--- a/Source/WebCore/svg/animation/SVGSMILElement.h
+++ b/Source/WebCore/svg/animation/SVGSMILElement.h
@@ -50,8 +50,8 @@ public:
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) override;
-    void removedFromAncestor(RemovalType, ContainerNode&) override;
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) override;
+    void removingSteps(RemovalType, ContainerNode&) override;
     
     virtual bool hasValidAttributeType() const = 0;
     virtual bool hasValidAttributeName() const;
@@ -118,7 +118,7 @@ protected:
     virtual void setTargetElement(SVGElement*);
     virtual void setAttributeName(const QualifiedName&);
 
-    void didFinishInsertingNode() override;
+    void postConnectionSteps() override;
 
     enum BeginOrEnd { Begin, End };
 


### PR DESCRIPTION
#### b51bb227d79ea4fd75c24f3f25c174110dc85a39
<pre>
Rename insertedIntoAncestor, didFinishInsertingNode, and removedFromAncestor to match DOM spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=310199">https://bugs.webkit.org/show_bug.cgi?id=310199</a>

Reviewed by Anne van Kesteren.

This PR does the following function renames to match the corresponding DOM concepts for clarity:
 - insertedIntoAncestor -&gt; insertionSteps / <a href="https://dom.spec.whatwg.org/#concept-node-insert-ext">https://dom.spec.whatwg.org/#concept-node-insert-ext</a>
 - didFinishInsertingNode -&gt; postConnectionSteps / <a href="https://dom.spec.whatwg.org/#concept-node-post-connection-ext">https://dom.spec.whatwg.org/#concept-node-post-connection-ext</a>
 - removedFromAncestor -&gt; removingSteps / <a href="https://dom.spec.whatwg.org/#concept-node-remove-ext">https://dom.spec.whatwg.org/#concept-node-remove-ext</a>

No new tests since there should be no behavioral changes.

* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::HTMLModelElement::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::executeNodeInsertionWithScriptAssertion):
(WebCore::ContainerNode::cloneChildNodes const):
* Source/WebCore/dom/ContainerNodeAlgorithms.cpp:
(WebCore::notifyNodeInsertedIntoDocument):
(WebCore::notifyNodeInsertedIntoTree):
(WebCore::notifyNodeRemovedFromDocument):
(WebCore::notifyNodeRemovedFromTree):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::cloneShadowTreeIfPossible const):
(WebCore::Element::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::Element::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::Node::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/dom/Node.h:
(WebCore::Node::postConnectionSteps): Renamed from didFinishInsertingNode.
* Source/WebCore/dom/ProcessingInstruction.cpp:
(WebCore::ProcessingInstruction::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::ProcessingInstruction::postConnectionSteps): Renamed from didFinishInsertingNode.
(WebCore::ProcessingInstruction::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/dom/ProcessingInstruction.h:
* Source/WebCore/dom/RadioButtonGroups.cpp:
(WebCore::RadioButtonGroups::hasCheckedButton const):
* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::ScriptElement::postConnectionSteps): Renamed from didFinishInsertingNode.
* Source/WebCore/dom/ScriptElement.h:
(WebCore::ScriptElement::insertionSteps const): Renamed from insertedIntoAncestor.
* Source/WebCore/dom/ShadowRoot.cpp:
(WebCore::ShadowRoot::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::ShadowRoot::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/dom/ShadowRoot.h:
* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::HTMLAnchorElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::HTMLAnchorElement::postConnectionSteps): Renamed from didFinishInsertingNode.
* Source/WebCore/html/HTMLAnchorElement.h:
* Source/WebCore/html/HTMLArticleElement.cpp:
(WebCore::HTMLArticleElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::HTMLArticleElement::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/html/HTMLArticleElement.h:
* Source/WebCore/html/HTMLAttachmentElement.cpp:
(WebCore::HTMLAttachmentElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::HTMLAttachmentElement::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/html/HTMLAttachmentElement.h:
* Source/WebCore/html/HTMLBaseElement.cpp:
(WebCore::HTMLBaseElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::HTMLBaseElement::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/html/HTMLBaseElement.h:
* Source/WebCore/html/HTMLBodyElement.cpp:
(WebCore::HTMLBodyElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::HTMLBodyElement::postConnectionSteps): Renamed from didFinishInsertingNode.
* Source/WebCore/html/HTMLBodyElement.h:
* Source/WebCore/html/HTMLButtonElement.cpp:
(WebCore::HTMLButtonElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::HTMLButtonElement::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/html/HTMLButtonElement.h:
* Source/WebCore/html/HTMLDetailsElement.cpp:
(WebCore::HTMLDetailsElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::HTMLDetailsElement::postConnectionSteps): Renamed from didFinishInsertingNode.
* Source/WebCore/html/HTMLDetailsElement.h:
* Source/WebCore/html/HTMLDialogElement.cpp:
(WebCore::HTMLDialogElement::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/html/HTMLDialogElement.h:
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::HTMLElement::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/html/HTMLElement.h:
* Source/WebCore/html/HTMLFormControlElement.cpp:
(WebCore::HTMLFormControlElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::HTMLFormControlElement::postConnectionSteps): Renamed from didFinishInsertingNode.
(WebCore::HTMLFormControlElement::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/html/HTMLFormControlElement.h:
* Source/WebCore/html/HTMLFormElement.cpp:
(WebCore::HTMLFormElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::HTMLFormElement::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/html/HTMLFormElement.h:
* Source/WebCore/html/HTMLFrameElementBase.cpp:
(WebCore::HTMLFrameElementBase::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::HTMLFrameElementBase::postConnectionSteps): Renamed from didFinishInsertingNode.
* Source/WebCore/html/HTMLFrameElementBase.h:
* Source/WebCore/html/HTMLFrameSetElement.cpp:
(WebCore::HTMLFrameSetElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::HTMLFrameSetElement::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/html/HTMLFrameSetElement.h:
* Source/WebCore/html/HTMLHRElement.cpp:
(WebCore::HTMLHRElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::HTMLHRElement::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/html/HTMLHRElement.h:
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::HTMLImageElement::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/html/HTMLImageElement.h:
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::HTMLInputElement::postConnectionSteps): Renamed from didFinishInsertingNode.
(WebCore::HTMLInputElement::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/html/HTMLInputElement.h:
* Source/WebCore/html/HTMLLabelElement.cpp:
(WebCore::HTMLLabelElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::HTMLLabelElement::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/html/HTMLLabelElement.h:
* Source/WebCore/html/HTMLLegendElement.cpp:
(WebCore::HTMLLegendElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::HTMLLegendElement::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/html/HTMLLegendElement.h:
* Source/WebCore/html/HTMLLinkElement.cpp:
(WebCore::HTMLLinkElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::HTMLLinkElement::postConnectionSteps): Renamed from didFinishInsertingNode.
(WebCore::HTMLLinkElement::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/html/HTMLLinkElement.h:
* Source/WebCore/html/HTMLMapElement.cpp:
(WebCore::HTMLMapElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::HTMLMapElement::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/html/HTMLMapElement.h:
* Source/WebCore/html/HTMLMaybeFormAssociatedCustomElement.cpp:
(WebCore::HTMLMaybeFormAssociatedCustomElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::HTMLMaybeFormAssociatedCustomElement::postConnectionSteps): Renamed from didFinishInsertingNode.
(WebCore::HTMLMaybeFormAssociatedCustomElement::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/html/HTMLMaybeFormAssociatedCustomElement.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::HTMLMediaElement::postConnectionSteps): Renamed from didFinishInsertingNode.
(WebCore::HTMLMediaElement::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/HTMLMetaElement.cpp:
(WebCore::HTMLMetaElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::HTMLMetaElement::postConnectionSteps): Renamed from didFinishInsertingNode.
(WebCore::HTMLMetaElement::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/html/HTMLMetaElement.h:
* Source/WebCore/html/HTMLObjectElement.cpp:
(WebCore::HTMLObjectElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::HTMLObjectElement::postConnectionSteps): Renamed from didFinishInsertingNode.
(WebCore::HTMLObjectElement::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/html/HTMLObjectElement.h:
* Source/WebCore/html/HTMLOptGroupElement.cpp:
(WebCore::HTMLOptGroupElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::HTMLOptGroupElement::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/html/HTMLOptGroupElement.h:
* Source/WebCore/html/HTMLOptionElement.cpp:
(WebCore::HTMLOptionElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::HTMLOptionElement::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/html/HTMLOptionElement.h:
* Source/WebCore/html/HTMLPlugInElement.cpp:
(WebCore::HTMLPlugInElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::HTMLPlugInElement::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/html/HTMLPlugInElement.h:
* Source/WebCore/html/HTMLScriptElement.cpp:
(WebCore::HTMLScriptElement::removingSteps): Renamed from removedFromAncestor.
(WebCore::HTMLScriptElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::HTMLScriptElement::postConnectionSteps): Renamed from didFinishInsertingNode.
* Source/WebCore/html/HTMLScriptElement.h:
* Source/WebCore/html/HTMLSelectedContentElement.cpp:
(WebCore::HTMLSelectedContentElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::HTMLSelectedContentElement::postConnectionSteps): Renamed from didFinishInsertingNode.
(WebCore::HTMLSelectedContentElement::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/html/HTMLSelectedContentElement.h:
* Source/WebCore/html/HTMLSlotElement.cpp:
(WebCore::HTMLSlotElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::HTMLSlotElement::removingSteps): Renamed from removedFromAncestor.
(WebCore::HTMLSlotElement::postConnectionSteps): Renamed from didFinishInsertingNode.
* Source/WebCore/html/HTMLSlotElement.h:
* Source/WebCore/html/HTMLSourceElement.cpp:
(WebCore::HTMLSourceElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::HTMLSourceElement::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/html/HTMLSourceElement.h:
* Source/WebCore/html/HTMLStyleElement.cpp:
(WebCore::HTMLStyleElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::HTMLStyleElement::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/html/HTMLStyleElement.h:
* Source/WebCore/html/HTMLTextFormControlElement.cpp:
(WebCore::HTMLTextFormControlElement::insertionSteps): Renamed from insertedIntoAncestor.
* Source/WebCore/html/HTMLTextFormControlElement.h:
* Source/WebCore/html/HTMLTitleElement.cpp:
(WebCore::HTMLTitleElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::HTMLTitleElement::postConnectionSteps): Renamed from didFinishInsertingNode.
(WebCore::HTMLTitleElement::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/html/HTMLTitleElement.h:
* Source/WebCore/html/HTMLTrackElement.cpp:
(WebCore::HTMLTrackElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::HTMLTrackElement::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/html/HTMLTrackElement.h:
* Source/WebCore/html/ValidatedFormListedElement.cpp:
(WebCore::ValidatedFormListedElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::ValidatedFormListedElement::removingSteps): Renamed from removedFromAncestor.
(WebCore::ValidatedFormListedElement::postConnectionSteps): Renamed from didFinishInsertingNode.
* Source/WebCore/html/ValidatedFormListedElement.h:
* Source/WebCore/html/parser/HTMLConstructionSite.cpp:
(WebCore::HTMLConstructionSite::createHTMLElementOrFindCustomElementInterface):
* Source/WebCore/html/shadow/TextPlaceholderElement.cpp:
(WebCore::TextPlaceholderElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::TextPlaceholderElement::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/html/shadow/TextPlaceholderElement.h:
* Source/WebCore/platform/LogMessages.in:
* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::removingSteps): Renamed from removedFromAncestor.
(WebCore::SVGElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::SVGElement::postConnectionSteps): Renamed from didFinishInsertingNode.
* Source/WebCore/svg/SVGElement.h:
* Source/WebCore/svg/SVGFEImageElement.cpp:
(WebCore::SVGFEImageElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::SVGFEImageElement::postConnectionSteps): Renamed from didFinishInsertingNode.
(WebCore::SVGFEImageElement::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/svg/SVGFEImageElement.h:
* Source/WebCore/svg/SVGFontFaceElement.cpp:
(WebCore::SVGFontFaceElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::SVGFontFaceElement::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/svg/SVGFontFaceElement.h:
* Source/WebCore/svg/SVGFontFaceUriElement.cpp:
(WebCore::SVGFontFaceUriElement::insertionSteps): Renamed from insertedIntoAncestor.
* Source/WebCore/svg/SVGFontFaceUriElement.h:
* Source/WebCore/svg/SVGImageElement.cpp:
(WebCore::SVGImageElement::insertionSteps): Renamed from insertedIntoAncestor.
* Source/WebCore/svg/SVGImageElement.h:
* Source/WebCore/svg/SVGMPathElement.cpp:
(WebCore::SVGMPathElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::SVGMPathElement::postConnectionSteps): Renamed from didFinishInsertingNode.
(WebCore::SVGMPathElement::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/svg/SVGMPathElement.h:
* Source/WebCore/svg/SVGPathElement.cpp:
(WebCore::SVGPathElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::SVGPathElement::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/svg/SVGPathElement.h:
* Source/WebCore/svg/SVGSVGElement.cpp:
(WebCore::SVGSVGElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::SVGSVGElement::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/svg/SVGSVGElement.h:
* Source/WebCore/svg/SVGScriptElement.cpp:
(WebCore::SVGScriptElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::SVGScriptElement::postConnectionSteps): Renamed from didFinishInsertingNode.
* Source/WebCore/svg/SVGScriptElement.h:
* Source/WebCore/svg/SVGStyleElement.cpp:
(WebCore::SVGStyleElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::SVGStyleElement::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/svg/SVGStyleElement.h:
* Source/WebCore/svg/SVGTRefElement.cpp:
(WebCore::SVGTRefElement::buildPendingResource):
(WebCore::SVGTRefElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::SVGTRefElement::postConnectionSteps): Renamed from didFinishInsertingNode.
(WebCore::SVGTRefElement::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/svg/SVGTRefElement.h:
* Source/WebCore/svg/SVGTextPathElement.cpp:
(WebCore::SVGTextPathElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::SVGTextPathElement::postConnectionSteps): Renamed from didFinishInsertingNode.
(WebCore::SVGTextPathElement::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/svg/SVGTextPathElement.h:
* Source/WebCore/svg/SVGTitleElement.cpp:
(WebCore::SVGTitleElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::SVGTitleElement::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/svg/SVGTitleElement.h:
* Source/WebCore/svg/SVGUseElement.cpp:
(WebCore::SVGUseElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::SVGUseElement::postConnectionSteps): Renamed from didFinishInsertingNode.
(WebCore::SVGUseElement::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/svg/SVGUseElement.h:
* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(WebCore::SVGSMILElement::insertionSteps): Renamed from insertedIntoAncestor.
(WebCore::SVGSMILElement::postConnectionSteps): Renamed from didFinishInsertingNode.
(WebCore::SVGSMILElement::removingSteps): Renamed from removedFromAncestor.
* Source/WebCore/svg/animation/SVGSMILElement.h:

Canonical link: <a href="https://commits.webkit.org/309518@main">https://commits.webkit.org/309518@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de35ab8682b9a7bc456560698ae42f108aec6dbc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150881 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23641 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17213 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159608 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104317 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152754 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24074 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23852 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116474 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82699 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2b7c0b68-d937-447b-ba4b-2b913616c77e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153841 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18601 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135369 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97194 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/17696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15632 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7455 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/127314 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13286 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162082 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5207 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14854 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124476 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23445 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19682 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124663 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23435 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135083 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79842 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23186 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19744 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11848 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23045 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87129 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22757 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22909 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22811 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->