### PR TITLE
AX: WebKit computes an incorrect bounding box for math table row and cells

### DIFF
--- a/LayoutTests/accessibility/table-row-bounding-boxes-expected.txt
+++ b/LayoutTests/accessibility/table-row-bounding-boxes-expected.txt
@@ -1,0 +1,25 @@
+This test ensures MathML table rows and cells have distinct, correct bounding boxes.
+
+MathML table rows should have increasing Y positions:
+PASS: mtr1.height > 0 === true
+PASS: mtr2.height > 0 === true
+PASS: mtr3.height > 0 === true
+PASS: mtr2.pageY > mtr1.pageY === true
+PASS: mtr3.pageY > mtr2.pageY === true
+
+MathML table cells in first row should have increasing X positions:
+PASS: cell1.width > 0 === true
+PASS: cell2.width > 0 === true
+PASS: cell2.pageX > cell1.pageX === true
+
+First cell in second row should be below first cell in first row:
+PASS: cell3.pageX === cell1.pageX === true
+PASS: cell3.pageY > cell1.pageY === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+[
+1	2	3	4	5	6
+]
+

--- a/LayoutTests/accessibility/table-row-bounding-boxes.html
+++ b/LayoutTests/accessibility/table-row-bounding-boxes.html
@@ -1,0 +1,85 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ runSingly=true ] -->
+<!-- runSingly because of the usage of accessibilityController.setForceInitialFrameCaching, which sets a process-global static. -->
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<math id="math-table">
+<mrow>
+<mo>[</mo>
+<mtable>
+<mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd></mtr>
+<mtr><mtd><mn>3</mn></mtd><mtd><mn>4</mn></mtd></mtr>
+<mtr><mtd><mn>5</mn></mtd><mtd><mn>6</mn></mtd></mtr>
+</mtable>
+<mo>]</mo>
+</mrow>
+</math>
+
+<script>
+var output = "This test ensures MathML table rows and cells have distinct, correct bounding boxes.\n\n";
+
+var mtr1, mtr2, mtr3;
+var cell1, cell2, cell3;
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+    accessibilityController.setForceInitialFrameCaching(true);
+
+    var mathElement = accessibilityController.accessibleElementById("math-table");
+
+    setTimeout(async function() {
+        // Find the MathML table (mtable). It's nested: math > mrow > mtable.
+        var mrow = mathElement.childAtIndex(0);
+        var mtable;
+        for (var i = 0; i < mrow.childrenCount; i++) {
+            var child = mrow.childAtIndex(i);
+            if (child.subrole.includes("AXMathTable")) {
+                mtable = child;
+                break;
+            }
+        }
+
+        mtr1 = mtable.childAtIndex(0);
+        mtr2 = mtable.childAtIndex(1);
+        mtr3 = mtable.childAtIndex(2);
+
+        // Wait for paint-cached geometry to propagate to the isolated tree. The rows
+        // should have distinct Y positions once their bounds are properly cached.
+        await waitFor(() => {
+            return mtr1.height > 0 && mtr2.height > 0 && mtr3.height > 0
+                && mtr2.pageY > mtr1.pageY;
+        });
+
+        output += "MathML table rows should have increasing Y positions:\n";
+        output += expect("mtr1.height > 0", "true");
+        output += expect("mtr2.height > 0", "true");
+        output += expect("mtr3.height > 0", "true");
+        output += expect("mtr2.pageY > mtr1.pageY", "true");
+        output += expect("mtr3.pageY > mtr2.pageY", "true");
+
+        // Cells within the same row should have distinct X positions.
+        cell1 = mtr1.childAtIndex(0);
+        cell2 = mtr1.childAtIndex(1);
+        output += "\nMathML table cells in first row should have increasing X positions:\n";
+        output += expect("cell1.width > 0", "true");
+        output += expect("cell2.width > 0", "true");
+        output += expect("cell2.pageX > cell1.pageX", "true");
+
+        // Cells in corresponding positions of different rows should have the same X but different Y.
+        cell3 = mtr2.childAtIndex(0);
+        output += "\nFirst cell in second row should be below first cell in first row:\n";
+        output += expect("cell3.pageX === cell1.pageX", "true");
+        output += expect("cell3.pageY > cell1.pageY", "true");
+
+        accessibilityController.setForceInitialFrameCaching(false);
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -842,6 +842,9 @@ accessibility/dynamic-content-visibility.html [ Skip ]
 accessibility/dynamic-selected-radio-button.html [ Skip ]
 accessibility/password-notifications-timing.html [ Skip ]
 
+# Failing because the mtable cannot be found as an accessible element.
+accessibility/table-row-bounding-boxes.html [ Skip ]
+
 # AccessibilityTextStitchingEnabled feature is not implemented.
 accessibility/attributed-string-text-stitching.html [ Skip ]
 accessibility/aria-hidden-text-stitching.html [ Skip ]

--- a/Source/WebCore/rendering/RenderTableRow.cpp
+++ b/Source/WebCore/rendering/RenderTableRow.cpp
@@ -31,6 +31,7 @@
 #include "HTMLNames.h"
 #include "HitTestResult.h"
 #include "PaintInfo.h"
+#include "PaintInfoInlines.h"
 #include "RenderBoxInlines.h"
 #include "RenderBoxModelObjectInlines.h"
 #include "RenderElementInlines.h"
@@ -246,6 +247,11 @@ void RenderTableRow::paintOutlineForRowIfNeeded(PaintInfo& paintInfo, const Layo
 void RenderTableRow::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
 {
     ASSERT(hasSelfPaintingLayer());
+
+    if (paintInfo.phase == PaintPhase::Accessibility) {
+        if (auto* context = paintInfo.accessibilityRegionContext())
+            context->takeBounds(*this, paintOffset + location());
+    }
 
     paintOutlineForRowIfNeeded(paintInfo, paintOffset);
     for (RenderTableCell* cell = firstCell(); cell; cell = cell->nextCell()) {

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -34,6 +34,7 @@
 #include "HTMLNames.h"
 #include "HitTestResult.h"
 #include "PaintInfo.h"
+#include "PaintInfoInlines.h"
 #include "RenderBoxInlines.h"
 #include "RenderBoxModelObjectInlines.h"
 #include "RenderChildIterator.h"
@@ -1308,6 +1309,16 @@ static BoxSide NODELETE physicalBorderForDirection(const WritingMode writingMode
 
 void RenderTableSection::paintObject(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
 {
+    if (paintInfo.phase == PaintPhase::Accessibility) {
+        if (auto* context = paintInfo.accessibilityRegionContext()) {
+            context->takeBounds(*this, paintOffset);
+            for (auto& rowStruct : m_grid) {
+                if (auto* row = rowStruct.rowRenderer; row && !row->hasSelfPaintingLayer())
+                    context->takeBounds(*row, paintOffset + row->location());
+            }
+        }
+    }
+
     auto localRepaintRect = paintInfo.rect;
     localRepaintRect.moveBy(-paintOffset);
 


### PR DESCRIPTION
#### 03151c3c082658b798db77fd097db1c481a5f3bb
<pre>
AX: WebKit computes an incorrect bounding box for math table row and cells
<a href="https://bugs.webkit.org/show_bug.cgi?id=310200">https://bugs.webkit.org/show_bug.cgi?id=310200</a>
<a href="https://rdar.apple.com/172851295">rdar://172851295</a>

Reviewed by Joshua Hoffman.

RenderTableRow and RenderTableSection never reported their bounds to
the accessibility geometry cache during the PaintPhase::Accessibility
paint phase. This meant the AXGeometryManager never cached rects for
these elements.

In the isolated tree, when no paint-cached rect exists, the fallback
path uses InitialLocalRect for size but overwrites the position with
the nearest painted ancestor&apos;s position. For table rows, that ancestor
is the &lt;table&gt; itself, so every row gets the table&apos;s top-left corner
as its position. This is observable with VoiceOver: the cursor appears
on the first row regardless of which row is focused.

The fix adds takeBounds calls for RenderTableSection (and its child
rows) and RenderTableRow during the accessibility paint phase, matching
what RenderBlock and RenderTable already do. RenderTableCell was not
affected because it inherits from RenderBlockFlow which already calls
takeBounds.

* LayoutTests/accessibility/table-row-bounding-boxes-expected.txt: Added.
* LayoutTests/accessibility/table-row-bounding-boxes.html: Added.
* Source/WebCore/rendering/RenderTableRow.cpp:
(WebCore::RenderTableRow::paint):
* Source/WebCore/rendering/RenderTableSection.cpp:
(WebCore::RenderTableSection::paintObject):

Canonical link: <a href="https://commits.webkit.org/309640@main">https://commits.webkit.org/309640@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87f34c8e2e15215b95fbbf438faa5dce2992276b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151235 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23998 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17568 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159964 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104671 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153108 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24429 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24243 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116764 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82897 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154195 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18888 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135696 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97485 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17981 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15932 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7809 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127599 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13613 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162436 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5595 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15184 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124772 "Passed tests") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23799 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19982 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124960 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33911 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23789 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135410 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80269 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20026 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12175 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23399 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87693 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23111 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23263 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23165 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->