### PR TITLE
[GLIB] Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE from WebKit layer

### DIFF
--- a/Source/WebKit/UIProcess/API/gtk/DropTargetGtk3.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/DropTargetGtk3.cpp
@@ -184,11 +184,12 @@ void DropTarget::dataReceived(IntPoint&& position, GtkSelectionData* data, unsig
         gint length;
         const auto* markupData = gtk_selection_data_get_data_with_length(data, &length);
         if (length > 0) {
+            const auto span = unsafeMakeSpan(markupData, length);
             // If data starts with UTF-16 BOM assume it's UTF-16, otherwise assume UTF-8.
             if (length >= 2 && reinterpret_cast<const char16_t*>(markupData)[0] == 0xFEFF)
-                m_selectionData->setMarkup(String(unsafeMakeSpan(reinterpret_cast<const char16_t*>(markupData),  (length / 2) - 1).subspan(1)));
+                m_selectionData->setMarkup(String(spanReinterpretCast<const char16_t>(span).subspan(1)));
             else
-                m_selectionData->setMarkup(String(unsafeMakeSpan(markupData, length)));
+                m_selectionData->setMarkup(String(span));
         }
         break;
     }

--- a/Source/WebKit/UIProcess/API/gtk/DropTargetGtk4.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/DropTargetGtk4.cpp
@@ -190,13 +190,12 @@ void DropTarget::accept(GdkDrop* drop, std::optional<WebCore::IntPoint> position
                 gsize length;
                 const auto* markupData = g_bytes_get_data(data.get(), &length);
                 if (length) {
-                    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GTK port
+                    auto spanData = span(data);
                     // If data starts with UTF-16 BOM assume it's UTF-16, otherwise assume UTF-8.
                     if (length >= 2 && reinterpret_cast<const char16_t*>(markupData)[0] == 0xFEFF)
-                        m_selectionData->setMarkup(String({ reinterpret_cast<const char16_t*>(markupData) + 1, (length / 2) - 1 }));
+                        m_selectionData->setMarkup(String(spanReinterpretCast<const char16_t>(spanData).subspan(1)));
                     else
-                        m_selectionData->setMarkup(String::fromUTF8(std::span(static_cast<const char*>(markupData), length)));
-                    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+                        m_selectionData->setMarkup(String(spanData));
                 }
             } else if (mimeType == "_NETSCAPE_URL"_s) {
                 auto urlData = span(data);

--- a/Source/WebKit/UIProcess/API/gtk/WebKitInputMethodContextImplGtk.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitInputMethodContextImplGtk.cpp
@@ -22,6 +22,7 @@
 
 #include <gtk/gtk.h>
 #include <wtf/MathExtras.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/WTFGType.h>
 #include <wtf/text/CString.h>
@@ -202,9 +203,7 @@ static void webkitInputMethodContextImplGtkNotifyCursorArea(WebKitInputMethodCon
 static void webkitInputMethodContextImplGtkNotifySurrounding(WebKitInputMethodContext* context, const gchar* text, unsigned length, unsigned cursorIndex, unsigned)
 {
     auto* priv = WEBKIT_INPUT_METHOD_CONTEXT_IMPL_GTK(context)->priv;
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GTK port
-    priv->surroundingText = std::span { text, length };
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    priv->surroundingText = unsafeMakeSpan(text, length);
     priv->surroundingCursorIndex = cursorIndex;
 }
 

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -1116,10 +1116,8 @@ static bool shouldForwardWheelEvent(WebKitWebViewBase* webViewBase, GdkEvent* ev
             // The last entry in the history is the current event time, so ignore that.
             if (length > 0)
                 length--;
-            for (unsigned i = 0; i < length; i++) {
-                WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GTK port
-                auto oldTime = history.get()[i].time;
-                WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+            for (const auto& item : unsafeMakeSpan(history.get(), length)) {
+                auto oldTime = item.time;
                 webViewBase->priv->wheelEventsToPropagate.removeAllMatching([&oldTime] (GRefPtr<GdkEvent>& current) {
                     return gdk_event_get_time(current.get()) == oldTime;
                 });


### PR DESCRIPTION
#### c680a9fd4e1d4ef7e7c8efaa2ab8370eb9f2decf
<pre>
[GLIB] Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE from WebKit layer
<a href="https://bugs.webkit.org/show_bug.cgi?id=310201">https://bugs.webkit.org/show_bug.cgi?id=310201</a>

Reviewed by Fujii Hironori.

These are the last bits from the WebKit/ dir that are practical
to remove. Other uses are probably unavoidable without changes
that are probably not worth it.

* Source/WebKit/UIProcess/API/gtk/DropTargetGtk3.cpp:
(WebKit::DropTarget::dataReceived):
* Source/WebKit/UIProcess/API/gtk/DropTargetGtk4.cpp:
(WebKit::DropTarget::accept):
* Source/WebKit/UIProcess/API/gtk/WebKitInputMethodContextImplGtk.cpp:
(webkitInputMethodContextImplGtkNotifySurrounding):
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
(shouldForwardWheelEvent):

Canonical link: <a href="https://commits.webkit.org/309542@main">https://commits.webkit.org/309542@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c4deeae4a18fae09ad5720396ad4f8b601ae323

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151008 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23770 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17340 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159736 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/104444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24201 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23990 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116580 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/104444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153968 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18699 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135486 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97301 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/17792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/15744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7582 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/127410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162209 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5334 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14974 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124588 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23572 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19794 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124775 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23562 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135200 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79973 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23199 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19836 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11965 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23172 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87434 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22884 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23036 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22938 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->