### PR TITLE
[GLIB] Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE from WTF

### DIFF
--- a/Source/WTF/wtf/glib/ChassisType.cpp
+++ b/Source/WTF/wtf/glib/ChassisType.cpp
@@ -28,7 +28,10 @@
 
 #include <mutex>
 #include <optional>
+#include <wtf/glib/GSpanExtras.h>
 #include <wtf/glib/GUniquePtr.h>
+#include <wtf/text/CStringView.h>
+#include <wtf/text/StringCommon.h>
 
 namespace WTF {
 
@@ -43,22 +46,22 @@ static std::optional<ChassisType> readMachineInfoChassisType()
     }
 
     GUniquePtr<char*> split(g_strsplit(buffer.get(), "\n", -1));
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port.
-    for (int i = 0; split.get()[i]; ++i) {
-        if (g_str_has_prefix(split.get()[i], "CHASSIS=")) {
-            char* chassis = split.get()[i] + 8;
+    for (const auto* line : span(split)) {
+        auto lineView = CStringView::unsafeFromUTF8(line);
+        if (startsWith(lineView.span(), "CHASSIS="_s)) {
+            const auto chassis = CStringView::fromUTF8(lineView.spanIncludingNullTerminator().subspan(8));
 
-            GUniquePtr<char> unquoted(g_shell_unquote(chassis, &error.outPtr()));
+            GUniquePtr<char> unquoted(g_shell_unquote(chassis.utf8(), &error.outPtr()));
             if (error)
-                g_warning("Could not unquote chassis type %s: %s", chassis, error->message);
+                g_warning("Could not unquote chassis type %s: %s", chassis.utf8(), error->message);
 
-            if (!strcmp(unquoted.get(), "tablet") || !strcmp(unquoted.get(), "handset"))
+            auto unquotedView = CStringView::unsafeFromUTF8(unquoted.get());
+            if (unquotedView == "tablet"_s || unquotedView == "handset"_s)
                 return ChassisType::Mobile;
 
             return ChassisType::Desktop;
         }
     }
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     return std::nullopt;
 }

--- a/Source/WTF/wtf/glib/FileSystemGlib.cpp
+++ b/Source/WTF/wtf/glib/FileSystemGlib.cpp
@@ -63,13 +63,11 @@ String filenameForDisplay(const String& string)
 #if OS(LINUX)
 CString currentExecutablePath()
 {
-    static char readLinkBuffer[PATH_MAX];
-    ssize_t result = readlink("/proc/self/exe", readLinkBuffer, PATH_MAX);
+    static std::array<char, PATH_MAX> readLinkBuffer;
+    ssize_t result = readlink("/proc/self/exe", readLinkBuffer.data(), readLinkBuffer.size());
     if (result == -1)
         return { };
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // Linux port
-    return CString(std::span { readLinkBuffer, static_cast<size_t>(result) });
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    return CString(unsafeMakeSpan(readLinkBuffer.data(), static_cast<size_t>(result)));
 }
 #elif OS(HURD)
 CString currentExecutablePath()


### PR DESCRIPTION
#### c4eee62c0277fdbb22836c98c6668631dd548ff9
<pre>
[GLIB] Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE from WTF
<a href="https://bugs.webkit.org/show_bug.cgi?id=310203">https://bugs.webkit.org/show_bug.cgi?id=310203</a>

Reviewed by Adrian Perez de Castro.

No more unsafe buffer usages in the GLib dirs of WTF.

* Source/WTF/wtf/glib/ChassisType.cpp:
(WTF::readMachineInfoChassisType):
* Source/WTF/wtf/glib/FileSystemGlib.cpp:
(WTF::FileSystemImpl::currentExecutablePath):

Canonical link: <a href="https://commits.webkit.org/309522@main">https://commits.webkit.org/309522@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07f9e5d633bfca181cc645f3be0a0811db3c64b1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150901 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23663 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17233 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159628 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104337 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24094 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23876 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116487 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82710 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153861 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18602 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135382 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97207 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17697 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15648 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7475 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/142885 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127315 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13299 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162102 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/11700 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5227 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14867 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124492 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23465 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19698 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124679 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33841 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23455 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135096 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79862 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19743 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11861 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/182426 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23065 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87175 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46596 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22777 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22929 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22831 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->