### PR TITLE
ScrollUpdateData should also additionally take layout viewport override rect

### DIFF
--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -704,7 +704,7 @@ void AsyncScrollingCoordinator::applyScrollPositionUpdate(ScrollUpdate&& update,
         auto& data = std::get<ScrollUpdateData>(update.data);
         switch (data.updateType) {
         case ScrollUpdateType::PositionUpdate:
-            updateScrollPositionAfterAsyncScroll(update.nodeID, update.scrollPosition, data.layoutViewportOrigin, data.updateLayerPositionAction, scrollType, viewportStability);
+            updateScrollPositionAfterAsyncScroll(update.nodeID, update.scrollPosition, data.layoutViewportOriginOrOverrideRect, data.updateLayerPositionAction, scrollType, viewportStability);
             break;
 
         case ScrollUpdateType::AnimatedScrollWillStart:
@@ -819,7 +819,7 @@ void AsyncScrollingCoordinator::notifyScrollableAreasForScrollEnd(ScrollingNodeI
         scrollableArea->scrollDidEnd();
 }
 
-void AsyncScrollingCoordinator::updateScrollPositionAfterAsyncScroll(ScrollingNodeID nodeID, FloatPoint scrollPosition, std::optional<FloatPoint> layoutViewportOrigin, ScrollingLayerPositionAction updateLayerPositionAction, ScrollType scrollType, ViewportRectStability viewportRectStability)
+void AsyncScrollingCoordinator::updateScrollPositionAfterAsyncScroll(ScrollingNodeID nodeID, FloatPoint scrollPosition, const std::optional<LayoutViewportOriginOrOverrideRect>& layoutViewportOriginOrOverrideRect, ScrollingLayerPositionAction updateLayerPositionAction, ScrollType scrollType, ViewportRectStability viewportRectStability)
 {
     ASSERT(isMainThread());
 
@@ -839,7 +839,7 @@ void AsyncScrollingCoordinator::updateScrollPositionAfterAsyncScroll(ScrollingNo
     }
 
     if (nodeID == frameView->scrollingNodeID()) {
-        reconcileScrollingState(*frameView, scrollPosition, layoutViewportOrigin, scrollType, viewportRectStability, updateLayerPositionAction);
+        reconcileScrollingState(*frameView, scrollPosition, layoutViewportOriginOrOverrideRect, scrollType, viewportRectStability, updateLayerPositionAction);
         return;
     }
 
@@ -855,7 +855,7 @@ void AsyncScrollingCoordinator::updateScrollPositionAfterAsyncScroll(ScrollingNo
     }
 }
 
-void AsyncScrollingCoordinator::reconcileScrollingState(LocalFrameView& frameView, const FloatPoint& scrollPosition, const LayoutViewportOriginOrOverrideRect& layoutViewportOriginOrOverrideRect, ScrollType scrollType, ViewportRectStability viewportRectStability, ScrollingLayerPositionAction scrollingLayerPositionAction)
+void AsyncScrollingCoordinator::reconcileScrollingState(LocalFrameView& frameView, const FloatPoint& scrollPosition, const std::optional<LayoutViewportOriginOrOverrideRect>& layoutViewportOriginOrOverrideRect, ScrollType scrollType, ViewportRectStability viewportRectStability, ScrollingLayerPositionAction scrollingLayerPositionAction)
 {
     LOG_WITH_STREAM(Scrolling, stream << getCurrentProcessID() << " AsyncScrollingCoordinator " << this << " reconcileScrollingState scrollPosition " << scrollPosition << " type " << scrollType << " stability " << viewportRectStability << " " << scrollingLayerPositionAction);
 
@@ -863,17 +863,15 @@ void AsyncScrollingCoordinator::reconcileScrollingState(LocalFrameView& frameVie
 
     std::optional<FloatRect> layoutViewportRect;
 
-    WTF::switchOn(layoutViewportOriginOrOverrideRect,
-        [&frameView](std::optional<FloatPoint> origin) {
-            if (origin)
-                frameView.setBaseLayoutViewportOrigin(LayoutPoint(origin.value()), LocalFrameView::TriggerLayoutOrNot::No);
-        }, [&layoutViewportRect](std::optional<FloatRect> overrideRect) {
-            if (!overrideRect)
-                return;
-
-            layoutViewportRect = overrideRect;
-        }
-    );
+    if (layoutViewportOriginOrOverrideRect) {
+        WTF::switchOn(*layoutViewportOriginOrOverrideRect,
+            [&frameView](FloatPoint origin) {
+                frameView.setBaseLayoutViewportOrigin(LayoutPoint(origin), LocalFrameView::TriggerLayoutOrNot::No);
+            }, [&layoutViewportRect](FloatRect overrideRect) {
+                layoutViewportRect = overrideRect;
+            }
+        );
+    }
 
     frameView.setScrollClamping(ScrollClamping::Unclamped);
     frameView.notifyScrollPositionChanged(roundedIntPoint(scrollPosition));

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h
@@ -158,8 +158,7 @@ private:
     WEBCORE_EXPORT void setPositionedNodeConstraints(ScrollingNodeID, const AbsolutePositionConstraints&) override;
     WEBCORE_EXPORT void setRelatedOverflowScrollingNodes(ScrollingNodeID, Vector<ScrollingNodeID>&&) override;
 
-    using LayoutViewportOriginOrOverrideRect = Variant<std::optional<FloatPoint>, std::optional<FloatRect>>;
-    WEBCORE_EXPORT void reconcileScrollingState(LocalFrameView&, const FloatPoint&, const LayoutViewportOriginOrOverrideRect&, ScrollType, ViewportRectStability, ScrollingLayerPositionAction) override;
+    void reconcileScrollingState(LocalFrameView&, const FloatPoint&, const std::optional<LayoutViewportOriginOrOverrideRect>&, ScrollType, ViewportRectStability, ScrollingLayerPositionAction);
     void reconcileScrollPosition(LocalFrameView&, ScrollingLayerPositionAction);
 
     WEBCORE_EXPORT void scrollBySimulatingWheelEventForTesting(ScrollingNodeID, FloatSize) final;
@@ -187,7 +186,7 @@ private:
     void updateEventTrackingRegions(FrameIdentifier rootFrameID);
     
     void applyScrollPositionUpdate(ScrollUpdate&&, ScrollType, ViewportRectStability);
-    void updateScrollPositionAfterAsyncScroll(ScrollingNodeID, FloatPoint, std::optional<FloatPoint> layoutViewportOrigin, ScrollingLayerPositionAction, ScrollType, ViewportRectStability);
+    void updateScrollPositionAfterAsyncScroll(ScrollingNodeID, FloatPoint, const std::optional<LayoutViewportOriginOrOverrideRect>&, ScrollingLayerPositionAction, ScrollType, ViewportRectStability);
     void animatedScrollWillStartForNode(ScrollingNodeID);
     void animatedScrollDidEndForNode(ScrollingNodeID);
     void wheelEventScrollWillStartForNode(ScrollingNodeID);

--- a/Source/WebCore/page/scrolling/ScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinator.h
@@ -89,9 +89,6 @@ public:
     // Should be called whenever the given frame view has been laid out.
     virtual void frameViewLayoutUpdated(LocalFrameView&) { }
 
-    using LayoutViewportOriginOrOverrideRect = Variant<std::optional<FloatPoint>, std::optional<FloatRect>>;
-    virtual void reconcileScrollingState(LocalFrameView&, const FloatPoint&, const LayoutViewportOriginOrOverrideRect&, ScrollType, ViewportRectStability, ScrollingLayerPositionAction) { }
-
     // Should be called whenever the set of fixed objects changes.
     void frameViewFixedObjectsDidChange(LocalFrameView&);
 

--- a/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp
@@ -76,7 +76,7 @@ void ScrollUpdate::merge(ScrollUpdate&& other)
         shouldFireScrollEnd = ShouldFireScrollEnd::Yes;
 
     if (std::holds_alternative<ScrollUpdateData>(data)) {
-        std::get<ScrollUpdateData>(data).layoutViewportOrigin = std::get<ScrollUpdateData>(other.data).layoutViewportOrigin;
+        std::get<ScrollUpdateData>(data).layoutViewportOriginOrOverrideRect = std::get<ScrollUpdateData>(other.data).layoutViewportOriginOrOverrideRect;
         return;
     }
 
@@ -263,8 +263,19 @@ TextStream& operator<<(TextStream& ts, const ScrollUpdate& update)
     if (std::holds_alternative<ScrollUpdateData>(update.data)) {
         auto updateData = std::get<ScrollUpdateData>(update.data);
         ts << "updateType: " << updateData.updateType << " nodeID: " << update.nodeID;
-        if (updateData.updateType == ScrollUpdateType::PositionUpdate)
-            ts << " scrollPosition: " << update.scrollPosition << " layoutViewportOrigin: " << updateData.layoutViewportOrigin << " updateLayerPositionAction: " << updateData.updateLayerPositionAction;
+        if (updateData.updateType == ScrollUpdateType::PositionUpdate) {
+            ts << " scrollPosition: " << update.scrollPosition;
+
+            if (updateData.layoutViewportOriginOrOverrideRect) {
+                WTF::switchOn(*updateData.layoutViewportOriginOrOverrideRect,
+                    [&ts](FloatPoint origin) { ts << " layoutViewportOrigin: " << origin; },
+                    [&ts](FloatRect overrideRect) { ts << " layoutViewportOverrideRect: " << overrideRect; }
+                );
+            } else
+                ts << " layoutViewportOriginOrOverrideRect: (none)";
+
+            ts << " updateLayerPositionAction: " << updateData.updateLayerPositionAction;
+        }
         return ts;
     }
 

--- a/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/FloatPoint.h>
+#include <WebCore/FloatRect.h>
 #include <WebCore/KeyboardScroll.h>
 #include <WebCore/ScrollTypes.h>
 #include <wtf/Markable.h>
@@ -174,10 +175,12 @@ enum class ScrollUpdateType : uint8_t {
 
 enum class ShouldFireScrollEnd : bool { No, Yes };
 
+using LayoutViewportOriginOrOverrideRect = Variant<FloatPoint, FloatRect>;
+
 struct ScrollUpdateData {
     ScrollUpdateType updateType { ScrollUpdateType::PositionUpdate };
     ScrollingLayerPositionAction updateLayerPositionAction { ScrollingLayerPositionAction::Sync };
-    std::optional<FloatPoint> layoutViewportOrigin { };
+    std::optional<LayoutViewportOriginOrOverrideRect> layoutViewportOriginOrOverrideRect { };
 };
 
 struct ScrollRequestResponseData {

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp
@@ -261,7 +261,7 @@ void ThreadedScrollingTree::scrollingTreeNodeDidScroll(ScrollingTreeScrollingNod
         .data = ScrollUpdateData {
             .updateType = ScrollUpdateType::PositionUpdate,
             .updateLayerPositionAction = scrollingLayerPositionAction,
-            .layoutViewportOrigin = layoutViewportOrigin,
+            .layoutViewportOriginOrOverrideRect = layoutViewportOrigin,
         },
     };
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2824,11 +2824,13 @@ header: <WebCore/ScrollingCoordinatorTypes.h>
 header: <WebCore/ScrollingCoordinatorTypes.h>
 [CustomHeader] enum class WebCore::ShouldFireScrollEnd : bool;
 
+using WebCore::LayoutViewportOriginOrOverrideRect = Variant<WebCore::FloatPoint, WebCore::FloatRect>;
+
 header: <WebCore/ScrollingCoordinatorTypes.h>
 [CustomHeader] struct WebCore::ScrollUpdateData {
     WebCore::ScrollUpdateType updateType;
     WebCore::ScrollingLayerPositionAction updateLayerPositionAction;
-    std::optional<WebCore::FloatPoint> layoutViewportOrigin;
+    std::optional<WebCore::LayoutViewportOriginOrOverrideRect> layoutViewportOriginOrOverrideRect;
 };
 
 header: <WebCore/ScrollingCoordinatorTypes.h>

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -242,10 +242,16 @@ void RemoteScrollingCoordinatorProxy::sendScrollingTreeNodeUpdate()
             if (updateData.updateType == ScrollUpdateType::PositionUpdate) {
                 webPageProxy->scrollingNodeScrollViewDidScroll(update.nodeID);
                 auto* scrollPerfData = webPageProxy->scrollingPerformanceData();
-                // update.layoutViewportOrigin is set for frame scrolls.
-                if (scrollPerfData && updateData.layoutViewportOrigin) {
+
+                if (scrollPerfData && updateData.layoutViewportOriginOrOverrideRect) {
+                    // updateData.layoutViewportOriginOrOverrideRect is set for frame scrolls and is an origin (point)
+                    if (!std::holds_alternative<FloatPoint>(*updateData.layoutViewportOriginOrOverrideRect)) {
+                        ASSERT_NOT_REACHED();
+                        continue;
+                    }
+
                     auto layoutViewport = m_scrollingTree->layoutViewport();
-                    layoutViewport.setLocation(*updateData.layoutViewportOrigin);
+                    layoutViewport.setLocation(std::get<FloatPoint>(*updateData.layoutViewportOriginOrOverrideRect));
                     scrollPerfData->didScroll(layoutViewport);
                 }
             }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
@@ -85,7 +85,7 @@ void RemoteScrollingTree::scrollingTreeNodeDidScroll(ScrollingTreeScrollingNode&
         .data = ScrollUpdateData {
             .updateType = ScrollUpdateType::PositionUpdate,
             .updateLayerPositionAction = scrollingLayerPositionAction,
-            .layoutViewportOrigin = layoutViewportOrigin,
+            .layoutViewportOriginOrOverrideRect = layoutViewportOrigin,
         }
     };
     addPendingScrollUpdate(WTF::move(scrollUpdate));

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
@@ -227,7 +227,7 @@ void RemoteScrollingTreeMac::scrollingTreeNodeDidScroll(ScrollingTreeScrollingNo
         .data = ScrollUpdateData {
             .updateType = ScrollUpdateType::PositionUpdate,
             .updateLayerPositionAction = action,
-            .layoutViewportOrigin = layoutViewportOrigin,
+            .layoutViewportOriginOrOverrideRect = layoutViewportOrigin,
         }
     };
     addPendingScrollUpdate(WTF::move(scrollUpdate));

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -3783,7 +3783,26 @@ void WebPage::updateVisibleContentRects(const VisibleContentRectUpdateInfo& visi
             viewportStability = ViewportRectStability::Unstable;
             layerAction = ScrollingLayerPositionAction::SetApproximate;
         }
-        scrollingCoordinator->reconcileScrollingState(*frameView, scrollPosition, visibleContentRectUpdateInfo.layoutViewportRect(), ScrollType::User, viewportStability, layerAction);
+
+        auto mainFrameScrollingNodeID = frameView->scrollingNodeID();
+        if (!mainFrameScrollingNodeID) {
+            ASSERT_NOT_REACHED();
+            return;
+        }
+
+        auto scrollUpdate = ScrollUpdate {
+            .nodeID = *mainFrameScrollingNodeID,
+            .scrollPosition = scrollPosition,
+            .data = ScrollUpdateData {
+                .updateType = ScrollUpdateType::PositionUpdate,
+                .updateLayerPositionAction = layerAction,
+                .layoutViewportOriginOrOverrideRect = visibleContentRectUpdateInfo.layoutViewportRect()
+            }
+        };
+
+        // We don't actually know that these are user scrolls; we get here for all kinds of state changes.
+        scrollingCoordinator->applyScrollUpdate(WTF::move(scrollUpdate), ScrollType::User, viewportStability);
+
         if (visibleContentRectUpdateInfo.needsScrollend() && frameView->scrollingNodeID()) {
             auto scrollUpdate = ScrollUpdate {
                 .nodeID = *frameView->scrollingNodeID(),


### PR DESCRIPTION
#### ce72c466dbf2f81d64060ad84d85a54f34e539a6
<pre>
ScrollUpdateData should also additionally take layout viewport override rect
<a href="https://rdar.apple.com/172851675">rdar://172851675</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=310202">https://bugs.webkit.org/show_bug.cgi?id=310202</a>

Reviewed by Simon Fraser.

This is a fix for the changes that got reverted in 309493@main.

307744@main refactors WebPage::updateVisibleContentRects() to use
AsyncScrollingCoordinator::applyScrollUpdate():

- scrollingCoordinator-&gt;reconcileScrollingState(*frameView, scrollPosition, visibleContentRectUpdateInfo.layoutViewportRect(), ScrollType::User, viewportStability, layerAction);
+ auto scrollUpdate = ScrollUpdate {
+     [...]
+     .data = ScrollUpdateData {
+         [...]
+         .updateType = ScrollUpdateType::PositionUpdate,
+         .layoutViewportOrigin = visibleContentRectUpdateInfo.layoutViewportRect().location()
+     }
+ };
+ scrollingCoordinator-&gt;applyScrollUpdate(WTF::move(scrollUpdate), ScrollType::User, viewportStability);

scrollUpdate.data.layoutViewportOrigin gets threaded from AsyncScrollingCoordinator::applyScrollUpdate
to AsyncScrollingCoordinator::reconcileScrollingState: applyScrollUpdate -&gt; applyScrollPositionUpdate -&gt;
updateScrollPositionAfterAsyncScroll (because updateType is PositionUpdate) -&gt; third parameter of
reconcileScrollingState.

But the two code are not equivalent: the above parameter of reconcileScrollingState
is a LayoutViewportOriginOrOverrideRect (aka Variant&lt;std::optional&lt;FloatPoint&gt;, std::optional&lt;FloatRect&gt;&gt;.)
The method does different thing whether the parameter is a layout viewport origin (as a FloatPoint),
or a layout viewport override rect (as a FloatRect.) The original code passes in a FloatRect
while the refactored code passes in a FloatPoint.

This patch changes ScrollUpdateData::layoutViewportOrigin to be LayoutViewportOriginOrOverrideRect,
and renames it to layoutViewportOriginOrOverrideRect. Then the override rect in
WebPage::updateVisibleContentRects can be supplied to AsyncScrollingCoordinator::applyScrollUpdate
and passed down to reconcileScrollingState. This fixes flickering issues when scrolling on e.g
<a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/attr">https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/attr</a>

This patch also changes LayoutViewportOriginOrOverrideRect to be
std::optional&lt;Variant&lt;FloatPoint, FloatRect&gt;&gt;.

* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::applyScrollPositionUpdate):
(WebCore::AsyncScrollingCoordinator::updateScrollPositionAfterAsyncScroll):
(WebCore::AsyncScrollingCoordinator::reconcileScrollingState):
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h:
* Source/WebCore/page/scrolling/ScrollingCoordinator.h:
(WebCore::ScrollingCoordinator::reconcileScrollingState): Deleted.
* Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp:
(WebCore::ScrollUpdate::merge):
(WebCore::operator&lt;&lt;):
* Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h:
* Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp:
(WebCore::ThreadedScrollingTree::scrollingTreeNodeDidScroll):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::sendScrollingTreeNodeUpdate):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp:
(WebKit::RemoteScrollingTree::scrollingTreeNodeDidScroll):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::scrollingTreeNodeDidScroll):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::updateVisibleContentRects):

Canonical link: <a href="https://commits.webkit.org/309856@main">https://commits.webkit.org/309856@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef24b7e260125e824e4c75b3be1e9969adae8807

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151756 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24537 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18107 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160498 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105213 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/83223280-a235-4d6e-953c-82e02d950740) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153630 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25030 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24830 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117216 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83187 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b4737407-98ac-44b4-973e-48169431e4a5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154716 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19373 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136177 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97931 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4af1de76-2981-4d2b-9370-a367b8bd23b4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18459 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16398 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8333 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128089 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14081 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162962 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6111 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15672 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125235 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24336 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20457 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125416 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34069 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24337 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135877 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80912 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20443 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12652 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23953 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88239 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23645 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23805 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23705 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->