### PR TITLE
Fix outstanding safer C++ warnings in Source/WebKit

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/NoDeleteCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/NoDeleteCheckerExpectations
@@ -1,2 +1,0 @@
-[ macOS ] Shared/Cocoa/WebPreferencesDefaultValuesCocoa.mm
-[ macOS ] UIProcess/mac/WebViewImpl.mm

--- a/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -1,1 +1,0 @@
-[ macOS ] UIProcess/mac/PageClientImplMac.mm

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1,3 +1,0 @@
-[ macOS ] UIProcess/API/mac/WKWebViewMac.mm
-[ macOS ] UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
-[ macOS ] UIProcess/mac/WebViewImpl.mm

--- a/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -1,1 +1,0 @@
-[ macOS ] UIProcess/mac/WebViewImpl.mm

--- a/Source/WebKit/Shared/Cocoa/WebPreferencesDefaultValuesCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/WebPreferencesDefaultValuesCocoa.mm
@@ -189,7 +189,7 @@ bool defaultHostedBlurMaterialInMediaControlsEnabled()
 }
 #endif
 
-bool NODELETE defaultIOSurfaceLosslessCompressionEnabled()
+bool defaultIOSurfaceLosslessCompressionEnabled()
 {
 #if HAVE(COREVIDEO_COMPRESSED_PIXEL_FORMAT_TYPES) && HAVE(LOSSLESS_COMPRESSED_IOSURFACE_CG_SUPPORT)
 #define WK_CA_FEATURE_CG_COMPRESSED_IOSURFACES 15

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -1205,7 +1205,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     if (!_page)
         return NO;
 
-    if (!_page->preferences().contentInsetBackgroundFillEnabled())
+    if (!protect(_page->preferences())->contentInsetBackgroundFillEnabled())
         return NO;
 
     return _page->obscuredContentInsets().top() > 0 || _page->overflowHeightForTopScrollEdgeEffect() > 0;

--- a/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
@@ -788,7 +788,7 @@ void WebInspectorUIProxy::inspectedViewFrameDidChange(CGFloat currentDimension)
 
     auto frameAdjustedForContentLayoutRect = [&](NSRect frameIgnoringContentLayoutRect) {
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
-        bool drawsScrollPocket = inspectedPage->preferences().contentInsetBackgroundFillEnabled() && inspectedPage->pendingOrActualObscuredContentInsets().top();
+        bool drawsScrollPocket = protect(inspectedPage->preferences())->contentInsetBackgroundFillEnabled() && inspectedPage->pendingOrActualObscuredContentInsets().top();
         if (drawsScrollPocket)
             return frameIgnoringContentLayoutRect;
 #endif

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -1207,7 +1207,7 @@ void PageClientImpl::cancelTextRecognitionForVideoInElementFullscreen()
 void PageClientImpl::didChangeLocalInspectorAttachment()
 {
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
-    m_impl->updateScrollPocket();
+    protect(m_impl)->updateScrollPocket();
 #endif
 }
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -351,7 +351,7 @@ public:
     void windowDidChangeOcclusionState();
     void windowWillClose();
     void NODELETE windowWillEnterOrExitFullScreen();
-    void NODELETE windowDidEnterOrExitFullScreen();
+    void windowDidEnterOrExitFullScreen();
     void screenDidChangeColorSpace();
     bool shouldDelayWindowOrderingForEvent(NSEvent *);
     bool windowResizeMouseLocationIsInVisibleScrollerThumb(CGPoint);

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -599,14 +599,14 @@ static void* keyValueObservingContext = &keyValueObservingContext;
 
 - (void)_windowDidEnterOrExitFullScreen:(NSNotification *)notification
 {
-    if (_impl)
-        _impl->windowDidEnterOrExitFullScreen();
+    if (CheckedPtr impl = _impl.get())
+        impl->windowDidEnterOrExitFullScreen();
 }
 
 - (void)_windowWillEnterOrExitFullScreen:(NSNotification *)notification
 {
-    if (_impl)
-        _impl->windowWillEnterOrExitFullScreen();
+    if (CheckedPtr impl = _impl.get())
+        impl->windowWillEnterOrExitFullScreen();
 }
 
 - (void)_activeSpaceDidChange:(NSNotification *)notification
@@ -7325,7 +7325,7 @@ void WebViewImpl::updateScrollPocket()
     RetainPtr view = m_view.get();
     CGFloat topContentInset = obscuredContentInsets().top();
     CGFloat additionalHeight = page->overflowHeightForTopScrollEdgeEffect();
-    bool needsTopView = page->preferences().contentInsetBackgroundFillEnabled()
+    bool needsTopView = protect(page->preferences())->contentInsetBackgroundFillEnabled()
         && view
         && !view->_reasonsToHideTopScrollPocket
         && (m_clientImplicitlyRequestedTopScrollPocket || automaticallyAdjustsContentInsets())
@@ -7368,7 +7368,7 @@ void WebViewImpl::updateScrollPocket()
 
     auto topInsetFrame = NSMakeRect(NSMinX(bounds), NSMinY(bounds) - additionalHeight, NSWidth(bounds), additionalHeight + std::min<CGFloat>(topContentInset, NSHeight(bounds)));
 
-    if ([m_view _usesAutomaticContentInsetBackgroundFill]) {
+    if ([protect(m_view) _usesAutomaticContentInsetBackgroundFill]) {
         for (NSView *pocketContainer in m_viewsAboveScrollPocket.get())
             topInsetFrame = NSUnionRect(topInsetFrame, [view convertRect:pocketContainer.bounds fromView:pocketContainer]);
     }
@@ -7385,7 +7385,7 @@ void WebViewImpl::updateScrollPocket()
 
 void WebViewImpl::updateTopScrollPocketStyle()
 {
-    [m_topScrollPocket setStyle:[m_view _usesAutomaticContentInsetBackgroundFill] ? NSScrollPocketStyleAutomatic : NSScrollPocketStyleHard];
+    [m_topScrollPocket setStyle:[protect(m_view) _usesAutomaticContentInsetBackgroundFill] ? NSScrollPocketStyleAutomatic : NSScrollPocketStyleHard];
 }
 
 void WebViewImpl::registerViewAboveScrollPocket(NSView *containerView)


### PR DESCRIPTION
#### 70fb5cbbac2a992051742d5da84768e04b66e5a7
<pre>
Fix outstanding safer C++ warnings in Source/WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=310214">https://bugs.webkit.org/show_bug.cgi?id=310214</a>

Reviewed by BJ Burg and Geoffrey Garen.

Deployed more smart pointers and removed incorrect NODELETE annotations in Source/WebKit
to fix new safer C++ static analysis warnings after migrating to macOS Tahoe.

No new tests since there should be any behavioral changes.

* Source/WebKit/SaferCPPExpectations/NoDeleteCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebKit/Shared/Cocoa/WebPreferencesDefaultValuesCocoa.mm:
(WebKit::defaultIOSurfaceLosslessCompressionEnabled):
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView scrollViewDrawsMagicPocket]):
* Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm:
(WebKit::WebInspectorUIProxy::inspectedViewFrameDidChange):
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::didChangeLocalInspectorAttachment):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(-[WKWindowVisibilityObserver _windowDidEnterOrExitFullScreen:]):
(-[WKWindowVisibilityObserver _windowWillEnterOrExitFullScreen:]):
(WebKit::WebViewImpl::updateScrollPocket):
(WebKit::WebViewImpl::updateTopScrollPocketStyle):

Canonical link: <a href="https://commits.webkit.org/309536@main">https://commits.webkit.org/309536@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e26396ef995da7e3ca7ef25980c228551b7baf59

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150978 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23740 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17310 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159706 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/104414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24171 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23959 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116553 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/104414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153938 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18667 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135457 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97273 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e6342e1f-d25a-4b10-9eee-aa0642dceaac) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/17761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/15713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7552 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127379 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162179 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5304 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14945 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124558 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23542 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19763 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124745 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23532 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135171 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79941 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23195 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19810 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11936 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23142 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87367 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22854 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23006 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22908 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->