### PR TITLE
[Test Gardening] Disable some slow or failing Swift Tests in preparation for EWS bringup

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit Swift/URLSchemeHandlerTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit Swift/URLSchemeHandlerTests.swift
@@ -125,6 +125,7 @@ struct URLSchemeHandlerTests {
     }
 
     @Test(
+        .disabled("This test is too slow"),
         .bug("https://bugs.webkit.org/show_bug.cgi?id=295741"),
         arguments: [
             TestURLSchemeHandler.Delays(beforeYield: .seconds(2), beforeFinish: .zero),

--- a/Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageTransferableTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageTransferableTests.swift
@@ -106,7 +106,10 @@ struct WebPageTransferableTests {
         #expect(actualURL == URL(string: "about:blank"))
     }
 
-    @Test(arguments: [UTType.png, UTType.image])
+    @Test(
+        .disabled("Fails in EWS due to incorrect scaleFactor"),
+        arguments: [UTType.png, UTType.image]
+    )
     func exportToImage(type: UTType) async throws {
         let defaultFrame = CGRect(x: 0, y: 0, width: 1024, height: 768)
 


### PR DESCRIPTION
#### 965e7d66836a50f2d850ea6ce8185dc097157607
<pre>
[Test Gardening] Disable some slow or failing Swift Tests in preparation for EWS bringup
<a href="https://bugs.webkit.org/show_bug.cgi?id=310218">https://bugs.webkit.org/show_bug.cgi?id=310218</a>
<a href="https://rdar.apple.com/172864007">rdar://172864007</a>

Unreviewed test gardening.

* Tools/TestWebKitAPI/Tests/WebKit Swift/URLSchemeHandlerTests.swift:
* Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageTransferableTests.swift:

Canonical link: <a href="https://commits.webkit.org/309511@main">https://commits.webkit.org/309511@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/27e8300228f04187a9f278bfee1cea2c9d987397

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150923 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23685 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17255 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159651 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/104359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152796 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24116 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23899 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116505 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/104359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153883 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18618 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/135402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97225 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/17712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/15664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7497 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/127330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/13319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162124 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14889 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124510 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23487 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/19714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124697 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33834 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23477 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135116 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/79884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19761 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11881 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23087 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22799 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22951 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22853 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->