### PR TITLE
[LBSE] Move SVG-specific data out of RenderLayer into a lazily-allocated SVGData struct

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2954,6 +2954,7 @@ rendering/RenderLayerBacking.cpp
 rendering/RenderLayerCompositor.cpp
 rendering/RenderLayerFilters.cpp
 rendering/RenderLayerModelObject.cpp
+rendering/RenderLayerSVGAdditions.cpp
 rendering/RenderLayerScrollableArea.cpp
 rendering/RenderLayoutState.cpp
 rendering/RenderLineBoxList.cpp

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -76,6 +76,7 @@
 #include "RenderLayer.h"
 #include "RenderLayerCompositor.h"
 #include "RenderLayerInlines.h"
+#include "RenderLayerSVGAdditionsInlines.h"
 #include "RenderLayerScrollableArea.h"
 #include "RenderLineBreak.h"
 #include "RenderListItem.h"
@@ -1701,7 +1702,7 @@ bool RenderElement::isVisibleInDocumentRect(const IntRect& documentRect) const
 
 bool RenderElement::isInsideEntirelyHiddenLayer() const
 {
-    if (isSVGLayerAwareRenderer() && document().settings().layerBasedSVGEngineEnabled() && enclosingLayer()->enclosingSVGHiddenOrResourceContainer())
+    if (isSVGLayerAwareRenderer() && document().settings().layerBasedSVGEngineEnabled() && enclosingLayer()->enclosingHiddenOrResourceContainerForSVG())
         return true;
     return style().usedVisibility() != Visibility::Visible && !enclosingLayer()->hasVisibleContent();
 }

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 2006-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2013-2014 Google Inc. All rights reserved.
  * Copyright (C) 2019 Adobe. All rights reserved.
- * Copyright (c) 2020, 2021, 2022 Igalia S.L.
+ * Copyright (c) 2020, 2021, 2022, 2026 Igalia S.L.
  *
  * Portions are Copyright (C) 1998 Netscape Communications Corporation.
  *
@@ -114,6 +114,7 @@
 #include "RenderLayerFilters.h"
 #include "RenderLayerInlines.h"
 #include "RenderLayerModelObjectInlines.h"
+#include "RenderLayerSVGAdditionsInlines.h"
 #include "RenderLayerScrollableArea.h"
 #include "RenderMarquee.h"
 #include "RenderMultiColumnFlow.h"
@@ -124,6 +125,7 @@
 #include "RenderSVGInline.h"
 #include "RenderSVGModelObject.h"
 #include "RenderSVGResourceClipper.h"
+#include "RenderSVGResourceContainer.h"
 #include "RenderSVGRoot.h"
 #include "RenderSVGText.h"
 #include "RenderSVGViewportContainer.h"
@@ -363,6 +365,9 @@ RenderLayer::RenderLayer(RenderLayerModelObject& renderer)
     , m_hasNotIsolatedBlendingDescendantsStatusDirty(false)
     , m_renderer(renderer)
 {
+    if (renderer.isSVGLayerAwareRenderer() && renderer.document().settings().layerBasedSVGEngineEnabled())
+        m_svgData = makeUnique<SVGData>();
+
     setIsNormalFlowOnly(shouldBeNormalFlowOnly());
     setIsCSSStackingContext(shouldBeCSSStackingContext());
     setCanBeBackdropRoot(computeCanBeBackdropRoot());
@@ -380,7 +385,7 @@ RenderLayer::RenderLayer(RenderLayerModelObject& renderer)
         // Leave m_visibleContentStatusDirty = true in any case. The associated renderer needs to be inserted into the
         // render tree, before we can determine the visible content status. The visible content status of a SVG renderer
         // depends on its ancestors (all children of RenderSVGHiddenContainer are recursively invisible, no matter what).
-        if (renderer.isSVGLayerAwareRenderer() && renderer.document().settings().layerBasedSVGEngineEnabled())
+        if (m_svgData)
             return false;
 
         //  We need the parent to know if we have skipped content or content-visibility root.
@@ -1291,7 +1296,7 @@ void RenderLayer::recursiveUpdateLayerPositions(OptionSet<UpdateLayerPositionsFl
         m_enclosingPaginationLayer = nullptr;
     }
 
-    if (renderer().isSVGLayerAwareRenderer() && renderer().document().settings().layerBasedSVGEngineEnabled()) {
+    if (m_svgData) {
         if (!is<RenderSVGRoot>(renderer())) {
             ASSERT(!renderer().isFixedPositioned());
             if (mode == Write)
@@ -1681,12 +1686,7 @@ void RenderLayer::dirtyAncestorChainHasAlwaysIncludedInZOrderListsDescendants()
 
 FloatRect RenderLayer::referenceBoxRectForClipPath(CSSBoxType boxType, const LayoutSize& offsetFromRoot, const LayoutRect& rootRelativeBounds) const
 {
-    bool isReferenceBox = false;
-
-    if (renderer().document().settings().layerBasedSVGEngineEnabled() && renderer().isSVGLayerAwareRenderer())
-        isReferenceBox = true;
-    else
-        isReferenceBox = renderer().isRenderBox();
+    bool isReferenceBox = m_svgData ? true : renderer().isRenderBox();
 
     // FIXME: Support different reference boxes for inline content.
     // https://bugs.webkit.org/show_bug.cgi?id=129047
@@ -1946,23 +1946,14 @@ void RenderLayer::dirtyAncestorChainVisibleDescendantStatus()
 
 void RenderLayer::updateAncestorDependentState()
 {
-    m_enclosingSVGHiddenOrResourceContainer = nullptr;
-    auto determineSVGAncestors = [&] (const RenderElement& renderer) {
-        for (auto* ancestor = renderer.parent(); ancestor; ancestor = ancestor->parent()) {
-            if (auto* container = dynamicDowncast<RenderSVGHiddenContainer>(ancestor)) {
-                m_enclosingSVGHiddenOrResourceContainer = container;
-                return;
-            }
-        }
-    };
-    if (renderer().document().settings().layerBasedSVGEngineEnabled())
-        determineSVGAncestors(renderer());
+    if (m_svgData)
+        updateAncestorDependentStateForSVG();
 
     bool insideSVGForeignObject = false;
     if (renderer().document().mayHaveRenderedSVGForeignObjects()) {
         if (ancestorsOfType<LegacyRenderSVGForeignObject>(renderer()).first())
             insideSVGForeignObject = true;
-        else if (renderer().document().settings().layerBasedSVGEngineEnabled() && ancestorsOfType<RenderSVGForeignObject>(renderer()).first())
+        else if (m_svgData && ancestorsOfType<RenderSVGForeignObject>(renderer()).first())
             insideSVGForeignObject = true;
     }
 
@@ -2047,7 +2038,7 @@ bool RenderLayer::computeHasVisibleContent() const
     if (renderer().style().usedVisibility() == Visibility::Visible)
         return true;
 
-    if (!renderer().style().filter().isNone() && renderer().isSVGLayerAwareRenderer())
+    if (m_svgData && !renderer().style().filter().isNone())
         return true;
 
     // Layer's renderer has visibility:hidden, but some non-layer child may have visibility:visible.
@@ -2407,11 +2398,7 @@ RenderLayer* RenderLayer::enclosingTransformedAncestor() const
 
 bool RenderLayer::shouldRepaintAfterLayout() const
 {
-    // The SVG containers themselves never trigger repaints, only their contents are allowed to.
-    // SVG container sizes/positions are only ever determined by their children, so they will
-    // change as a reaction on a re-position/re-sizing of the children - which already properly
-    // trigger repaints.
-    if (is<RenderSVGContainer>(renderer()) && !shouldPaintWithFilters())
+    if (m_svgData && shouldSkipRepaintAfterLayoutForSVG())
         return false;
 
     if (m_repaintStatus == RepaintStatus::NeedsNormalRepaint || m_repaintStatus == RepaintStatus::NeedsFullRepaint)
@@ -2926,7 +2913,7 @@ LayoutPoint RenderLayer::convertToLayerCoords(const RenderLayer* ancestorLayer, 
         currLayer = accumulateOffsetTowardsAncestor(currLayer, ancestorLayer, locationInLayerCoords, adjustForColumns);
 
     // Pixel snap the whole SVG subtree as one "block" -- not individual layers down the SVG render tree.
-    if (renderer().isRenderSVGRoot())
+    if (m_svgData && renderer().isRenderSVGRoot())
         return LayoutPoint(roundPointToDevicePixels(locationInLayerCoords, renderer().document().deviceScaleFactor()));
 
     return locationInLayerCoords;
@@ -3302,33 +3289,6 @@ static inline bool NODELETE shouldSuppressPaintingLayer(RenderLayer* layer)
     return false;
 }
 
-void RenderLayer::paintSVGResourceLayer(GraphicsContext& context, const AffineTransform& layerContentTransform)
-{
-    bool wasPaintingSVGResourceLayer = m_isPaintingSVGResourceLayer;
-    m_isPaintingSVGResourceLayer = true;
-    context.concatCTM(layerContentTransform);
-
-    auto localPaintDirtyRect = LayoutRect::infiniteRect();
-
-    auto* rootPaintingLayer = [&] () {
-        auto* curr = parent();
-        while (curr && !(curr->renderer().isAnonymous() && is<RenderSVGViewportContainer>(curr->renderer())))
-            curr = curr->parent();
-        return curr;
-    }();
-    ASSERT(rootPaintingLayer);
-
-    LayerPaintingInfo paintingInfo(rootPaintingLayer, localPaintDirtyRect, PaintBehavior::Normal, LayoutSize());
-
-    OptionSet<PaintLayerFlag> flags { PaintLayerFlag::TemporaryClipRects };
-    if (!renderer().hasNonVisibleOverflow())
-        flags.add({ PaintLayerFlag::PaintingOverflowContents, PaintLayerFlag::PaintingOverflowContentsRoot });
-
-    paintLayer(context, paintingInfo, flags);
-
-    m_isPaintingSVGResourceLayer = wasPaintingSVGResourceLayer;
-}
-
 static inline bool NODELETE paintForFixedRootBackground(const RenderLayer* layer, OptionSet<RenderLayer::PaintLayerFlag> paintFlags)
 {
     return layer->renderer().isDocumentElementRenderer() && (paintFlags & RenderLayer::PaintLayerFlag::PaintingRootBackgroundOnly);
@@ -3539,14 +3499,8 @@ void RenderLayer::setupClipPath(GraphicsContext& context, GraphicsContextStateSa
     if (!renderer().hasClipPath() || (context.paintingDisabled() && !isCollectingEventRegion) || paintingInfo.paintDirtyRect.isEmpty())
         return;
 
-    // Applying clip-path on <clipPath> enforces us to use mask based clipping, so return false here to disable path based clipping.
-    // Furthermore if we're the child of a resource container (<clipPath> / <mask> / ...) disabled path based clipping.
-    if (is<RenderSVGResourceClipper>(m_enclosingSVGHiddenOrResourceContainer)) {
-        // If m_isPaintingSVGResourceLayer is true, this function was invoked via paintSVGResourceLayer() -- clipping on <clipPath> is already
-        // handled in RenderSVGResourceClipper::applyMaskClipping(), so do not set paintSVGClippingMask to true here.
-        paintFlags.set(PaintLayerFlag::PaintingSVGClippingMask, !m_isPaintingSVGResourceLayer);
+    if (m_svgData && setupClipPathIfNeededForSVG(paintFlags))
         return;
-    }
 
     auto clippedContentBounds = calculateLayerBounds(paintingInfo.rootLayer, offsetFromRoot, { UseLocalClipRectIfPossible });
 
@@ -3705,25 +3659,6 @@ void RenderLayer::paintLayerContents(GraphicsContext& context, const LayerPainti
     bool isSelfPaintingLayer = this->isSelfPaintingLayer();
     bool isInsideSkippedSubtree = renderer().isSkippedContent();
 
-    auto hasVisibleContent = [&]() -> bool {
-        if (isInsideSkippedSubtree)
-            return false;
-
-        if (!m_hasVisibleContent)
-            return false;
-
-        if (!m_enclosingSVGHiddenOrResourceContainer)
-            return true;
-
-        // Hidden SVG containers (<defs> / <symbol> ...) and their children are never painted directly.
-        if (!is<RenderSVGResourceContainer>(m_enclosingSVGHiddenOrResourceContainer))
-            return false;
-
-        // SVG resource layers and their children are only painted indirectly, via paintSVGResourceLayer().
-        ASSERT(m_enclosingSVGHiddenOrResourceContainer->hasLayer());
-        return m_enclosingSVGHiddenOrResourceContainer->layer()->isPaintingSVGResourceLayer();
-    };
-
     auto shouldSkipNonFixedTopDocumentContent = [&] {
         if (!paintingInfo.paintBehavior.contains(PaintBehavior::FixedAndStickyLayersOnly))
             return false;
@@ -3740,7 +3675,8 @@ void RenderLayer::paintLayerContents(GraphicsContext& context, const LayerPainti
         return true;
     };
 
-    bool shouldPaintContent = hasVisibleContent()
+    bool shouldPaintContent = !isInsideSkippedSubtree
+        && hasVisibleContentForPainting()
         && isSelfPaintingLayer
         && !isPaintingOverlayScrollbars
         && !isCollectingEventRegion
@@ -3892,7 +3828,7 @@ void RenderLayer::paintLayerContents(GraphicsContext& context, const LayerPainti
 
         if (filterContext)
             localPaintingInfo.paintBehavior.add(PaintBehavior::DontShowVisitedLinks);
-        else if (hasFailedFilterForSVGRenderer()) {
+        else if (m_svgData && hasFailedFilterForSVG()) {
             shouldPaintContent = false;
             isPaintingCompositedForeground = false;
         }
@@ -4348,16 +4284,8 @@ void RenderLayer::paintForegroundForFragments(const LayerFragments& layerFragmen
     bool selectionOnly = localPaintingInfo.paintBehavior.contains(PaintBehavior::SelectionOnly);
     bool selectionAndBackgroundsOnly = localPaintingInfo.paintBehavior.contains(PaintBehavior::SelectionAndBackgroundsOnly);
 
-    if (is<RenderSVGModelObject>(renderer()) && !is<RenderSVGContainer>(renderer())) {
-        // SVG containers need to propagate paint phases. This could be saved if we remember somewhere if a SVG subtree
-        // contains e.g. LegacyRenderSVGForeignObject objects that do need the individual paint phases. For SVG shapes & SVG images
-        // we can avoid the multiple paintForegroundForFragmentsWithPhase() calls.
-        if (selectionOnly || selectionAndBackgroundsOnly)
-            return;
-
-        paintForegroundForFragmentsWithPhase(PaintPhase::Foreground, layerFragments, context, localPaintingInfo, localPaintBehavior, subtreePaintRootForRenderer);
+    if (m_svgData && paintForegroundForFragmentsForSVG(layerFragments, context, localPaintingInfo, localPaintBehavior, subtreePaintRootForRenderer))
         return;
-    }
 
     if (!selectionOnly)
         paintForegroundForFragmentsWithPhase(PaintPhase::ChildBlockBackgrounds, layerFragments, context, localPaintingInfo, localPaintBehavior, subtreePaintRootForRenderer);
@@ -4734,15 +4662,8 @@ RenderLayer::HitLayer RenderLayer::hitTestLayer(RenderLayer* rootLayer, RenderLa
         return { };
 
     // If we're hit testing 'SVG clip content' (aka. RenderSVGResourceClipper) do not early exit.
-    if (!request.svgClipContent()) {
-        // SVG resource layers and their children are never hit tested.
-        if (is<RenderSVGResourceContainer>(m_enclosingSVGHiddenOrResourceContainer))
-            return { };
-
-        // Hidden SVG containers (<defs> / <symbol> ...) are never hit tested directly.
-        if (is<RenderSVGHiddenContainer>(renderer()))
-            return { };
-    }
+    if (m_svgData && !request.svgClipContent() && shouldSkipHitTestForSVG())
+        return { };
 
     bool skipLayerForFixedContainerSampling = [&] {
         if (!request.isForFixedContainerSampling())
@@ -6640,23 +6561,6 @@ bool RenderLayer::invalidateEventRegion(EventRegionInvalidationReason reason)
     UNUSED_PARAM(reason);
     return false;
 #endif
-}
-
-bool RenderLayer::hasFailedFilterForSVGRenderer() const
-{
-    // Per the SVG spec, if a filter is referenced but cannot be applied (non-existent
-    // reference, empty filter, etc.), the element must not be rendered — the filter
-    // produces transparent black, making the element invisible. The CSS Filter Effects
-    // spec differs — a failed filter means "no effect" (painted normally). Therefore
-    // treat SVG renderers differently, obeying to the SVG rules.
-    if (!m_filters || m_filters->filter() || !renderer().isSVGLayerAwareRenderer() || !renderer().style().filter().isReferenceFilter())
-        return false;
-    return WTF::switchOn(renderer().style().filter().first(),
-        [&](const Style::FilterReference& reference) {
-            return ReferencedSVGResources::referencedFilterElement(renderer().treeScopeForSVGReferences(), reference) != nullptr;
-        },
-        [&](const auto&) { return false; }
-    );
 }
 
 TextStream& operator<<(WTF::TextStream& ts, ClipRectsType clipRectsType)

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -274,11 +274,20 @@ private:
 
     OptionSet<LayerPositionUpdates> m_layerPositionDirtyBits;
 
-protected:
+private:
     explicit RenderLayer(RenderLayerModelObject&);
     void destroy();
 
-private:
+    bool hasVisibleContentForPainting() const
+    {
+        if (!hasVisibleContent())
+            return false;
+        if (!m_svgData) [[likely]]
+            return true;
+        return hasVisibleContentForPaintingForSVG();
+    }
+    bool hasVisibleContentForPaintingForSVG() const; // Defined in RenderLayerSVGAdditions.cpp.
+
     // These flags propagate in paint order (z-order tree).
     enum class Compositing {
         HasDescendantNeedingRequirementsTraversal           = 1 << 0, // Need to do the overlap-testing tree walk because hierarchy or geometry changed.
@@ -455,9 +464,14 @@ public:
             || m_hasAlwaysIncludedInZOrderListsDescendantsStatusDirty;
     }
 
-    bool isPaintingSVGResourceLayer() const { return m_isPaintingSVGResourceLayer; }
-
-    inline RenderSVGHiddenContainer* enclosingSVGHiddenOrResourceContainer() const;
+    // SVG-specific methods -- defined in RenderLayerSVGAdditionsInlines.h / RenderLayerSVGAdditions.cpp.
+    inline bool isPaintingResourceLayerForSVG() const;
+    inline RenderSVGHiddenContainer* enclosingHiddenOrResourceContainerForSVG() const;
+    void paintResourceLayerForSVG(GraphicsContext&, const AffineTransform&);
+    bool shouldSkipRepaintAfterLayoutForSVG() const;
+    bool hasFailedFilterForSVG() const;
+    bool shouldSkipHitTestForSVG() const;
+    void updateAncestorDependentStateForSVG();
 
     void repaintIncludingDescendants();
 
@@ -979,8 +993,6 @@ public:
 
     void setIsHiddenByOverflowTruncation(bool);
 
-    void paintSVGResourceLayer(GraphicsContext&, const AffineTransform& contentTransform);
-
     bool ancestorLayerIsDOMParent(const RenderLayer* ancestor) const;
 
     struct LayerPaintingInfo {
@@ -1012,6 +1024,10 @@ private:
     void setLastChild(RenderLayer* last) { m_last = last; }
 
     void updateAncestorDependentState();
+
+    // SVG-specific methods -- defined in RenderLayerSVGAdditions.cpp.
+    bool setupClipPathIfNeededForSVG(OptionSet<PaintLayerFlag>&);
+    bool paintForegroundForFragmentsForSVG(const LayerFragments&, GraphicsContext&, const LayerPaintingInfo&, OptionSet<PaintBehavior>, RenderObject*);
 
     void dirtyPaintOrderListsOnChildChange(RenderLayer&);
 
@@ -1319,8 +1335,6 @@ private:
 
     void removeClipperClientIfNeeded() const;
 
-    bool hasFailedFilterForSVGRenderer() const;
-
     struct OverflowControlRects {
         IntRect horizontalScrollbar;
         IntRect verticalScrollbar;
@@ -1404,7 +1418,6 @@ private:
 
     bool m_insideSVGForeignObject : 1;
     bool m_isHiddenByOverflowTruncation : 1 { false };
-    bool m_isPaintingSVGResourceLayer : 1 { false };
 
     bool m_hasDescendantNeedingEventRegionUpdate : 1 { false };
 
@@ -1481,14 +1494,18 @@ private:
     // Pointer to the enclosing RenderLayer that caused us to be paginated. It is 0 if we are not paginated.
     InlineWeakPtr<RenderLayer> m_enclosingPaginationLayer;
 
-    // Pointer to the enclosing RenderSVGHiddenContainer or RenderSVGResourceContainer, if present.
-    SingleThreadWeakPtr<RenderSVGHiddenContainer> m_enclosingSVGHiddenOrResourceContainer;
-
     IntRect m_blockSelectionGapsBounds;
 
     RefPtr<RenderLayerFilters> m_filters;
     std::unique_ptr<RenderLayerBacking> m_backing;
     std::unique_ptr<RenderLayerScrollableArea> m_scrollableArea;
+
+    struct SVGData {
+        WTF_MAKE_STRUCT_TZONE_ALLOCATED(SVGData);
+        bool isPaintingResourceLayer { false };
+        SingleThreadWeakPtr<RenderSVGHiddenContainer> enclosingHiddenOrResourceContainer;
+    };
+    std::unique_ptr<SVGData> m_svgData;
 
     PaintFrequencyTracker m_paintFrequencyTracker;
 };

--- a/Source/WebCore/rendering/RenderLayerInlines.h
+++ b/Source/WebCore/rendering/RenderLayerInlines.h
@@ -90,11 +90,6 @@ inline bool RenderLayer::hasNonOpacityTransparency() const
     return false;
 }
 
-inline RenderSVGHiddenContainer* RenderLayer::enclosingSVGHiddenOrResourceContainer() const
-{
-    return m_enclosingSVGHiddenOrResourceContainer.get();
-}
-
 inline const LayoutPoint& RenderLayer::location() const LIFETIME_BOUND
 {
     ASSERT(!renderer().layerAccessPreventedSlow());

--- a/Source/WebCore/rendering/RenderLayerSVGAdditions.cpp
+++ b/Source/WebCore/rendering/RenderLayerSVGAdditions.cpp
@@ -1,0 +1,179 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "config.h"
+#include "RenderLayer.h"
+
+#include "CSSFilterRenderer.h"
+#include "ReferencedSVGResources.h"
+#include "RenderAncestorIterator.h"
+#include "RenderLayerFilters.h"
+#include "RenderLayerInlines.h"
+#include "RenderLayerModelObject.h"
+#include "RenderLayerSVGAdditionsInlines.h"
+#include "RenderSVGContainer.h"
+#include "RenderSVGHiddenContainer.h"
+#include "RenderSVGModelObject.h"
+#include "RenderSVGResourceClipper.h"
+#include "RenderSVGResourceContainer.h"
+#include "RenderSVGRoot.h"
+#include "RenderSVGViewportContainer.h"
+#include "SVGFilterElement.h"
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(RenderLayer::SVGData);
+
+bool RenderLayer::hasVisibleContentForPaintingForSVG() const
+{
+    ASSERT(m_svgData);
+    ASSERT(renderer().document().settings().layerBasedSVGEngineEnabled());
+    if (!m_svgData->enclosingHiddenOrResourceContainer)
+        return true;
+
+    // Hidden SVG containers (<defs> / <symbol> ...) and their children are never painted directly.
+    CheckedPtr container = m_svgData->enclosingHiddenOrResourceContainer.get();
+    if (!is<RenderSVGResourceContainer>(container.get()))
+        return false;
+
+    // SVG resource layers and their children are only painted indirectly, via paintResourceLayerForSVG().
+    ASSERT(container->hasLayer());
+    CheckedPtr containerLayer = container->layer();
+    return containerLayer->isPaintingResourceLayerForSVG();
+}
+
+void RenderLayer::paintResourceLayerForSVG(GraphicsContext& context, const AffineTransform& layerContentTransform)
+{
+    ASSERT(m_svgData);
+    ASSERT(renderer().document().settings().layerBasedSVGEngineEnabled());
+
+    bool wasPaintingSVGResourceLayer = m_svgData->isPaintingResourceLayer;
+    m_svgData->isPaintingResourceLayer = true;
+    context.concatCTM(layerContentTransform);
+
+    auto localPaintDirtyRect = LayoutRect::infiniteRect();
+
+    CheckedPtr rootPaintingLayer = [&] () -> RenderLayer* {
+        auto* curr = parent();
+        while (curr && !(curr->renderer().isAnonymous() && is<RenderSVGViewportContainer>(curr->renderer())))
+            curr = curr->parent();
+        return curr;
+    }();
+    ASSERT(rootPaintingLayer);
+
+    LayerPaintingInfo paintingInfo(rootPaintingLayer, localPaintDirtyRect, PaintBehavior::Normal, LayoutSize());
+
+    OptionSet<PaintLayerFlag> flags { PaintLayerFlag::TemporaryClipRects };
+    if (!renderer().hasNonVisibleOverflow())
+        flags.add({ PaintLayerFlag::PaintingOverflowContents, PaintLayerFlag::PaintingOverflowContentsRoot });
+
+    paintLayer(context, paintingInfo, flags);
+
+    m_svgData->isPaintingResourceLayer = wasPaintingSVGResourceLayer;
+}
+
+bool RenderLayer::setupClipPathIfNeededForSVG(OptionSet<PaintLayerFlag>& paintFlags)
+{
+    ASSERT(m_svgData);
+    ASSERT(renderer().document().settings().layerBasedSVGEngineEnabled());
+
+    // Applying clip-path on <clipPath> enforces us to use mask based clipping, so disable path based clipping.
+    // If isPaintingResourceLayerForSVG() is true, this function was invoked via paintResourceLayerForSVG() -- clipping on <clipPath> is already
+    // handled in RenderSVGResourceClipper::applyMaskClipping(), so do not set paintSVGClippingMask to true here.
+    if (!is<RenderSVGResourceClipper>(m_svgData->enclosingHiddenOrResourceContainer.get()))
+        return false;
+
+    paintFlags.set(PaintLayerFlag::PaintingSVGClippingMask, !m_svgData->isPaintingResourceLayer);
+    return true;
+}
+
+bool RenderLayer::paintForegroundForFragmentsForSVG(const LayerFragments& layerFragments, GraphicsContext& context, const LayerPaintingInfo& localPaintingInfo, OptionSet<PaintBehavior> localPaintBehavior, RenderObject* subtreePaintRootForRenderer)
+{
+    ASSERT(m_svgData);
+    ASSERT(renderer().document().settings().layerBasedSVGEngineEnabled());
+
+    if (!is<RenderSVGModelObject>(renderer()) || is<RenderSVGContainer>(renderer()))
+        return false;
+
+    // SVG containers need to propagate paint phases. This could be saved if we remember somewhere if a SVG subtree
+    // contains e.g. LegacyRenderSVGForeignObject objects that do need the individual paint phases. For SVG shapes & SVG images
+    // we can avoid the multiple paintForegroundForFragmentsWithPhase() calls.
+    if (localPaintingInfo.paintBehavior.containsAny({ PaintBehavior::SelectionOnly, PaintBehavior::SelectionAndBackgroundsOnly }))
+        return true;
+
+    paintForegroundForFragmentsWithPhase(PaintPhase::Foreground, layerFragments, context, localPaintingInfo, localPaintBehavior, subtreePaintRootForRenderer);
+    return true;
+}
+
+bool RenderLayer::shouldSkipRepaintAfterLayoutForSVG() const
+{
+    ASSERT(m_svgData);
+    ASSERT(renderer().document().settings().layerBasedSVGEngineEnabled());
+
+    // The SVG containers themselves never trigger repaints, only their contents are allowed to.
+    // SVG container sizes/positions are only ever determined by their children, so they will
+    // change as a reaction on a re-position/re-sizing of the children - which already properly
+    // trigger repaints.
+    return is<RenderSVGContainer>(renderer()) && !shouldPaintWithFilters();
+}
+
+bool RenderLayer::shouldSkipHitTestForSVG() const
+{
+    ASSERT(m_svgData);
+    ASSERT(renderer().document().settings().layerBasedSVGEngineEnabled());
+
+    // SVG resource layers and their children are never hit tested.
+    if (is<RenderSVGResourceContainer>(m_svgData->enclosingHiddenOrResourceContainer.get()))
+        return true;
+
+    // Hidden SVG containers (<defs> / <symbol> ...) are never hit tested directly.
+    if (is<RenderSVGHiddenContainer>(renderer()))
+        return true;
+
+    return false;
+}
+
+bool RenderLayer::hasFailedFilterForSVG() const
+{
+    ASSERT(m_svgData);
+    ASSERT(renderer().document().settings().layerBasedSVGEngineEnabled());
+
+    // Per the SVG spec, if a filter is referenced but cannot be applied (non-existent
+    // reference, empty filter, etc.), the element must not be rendered — the filter
+    // produces transparent black, making the element invisible. The CSS Filter Effects
+    // spec differs — a failed filter means "no effect" (painted normally). Therefore
+    // treat SVG renderers differently, obeying to the SVG rules.
+    if (!m_filters || m_filters->filter() || !renderer().style().filter().isReferenceFilter())
+        return false;
+    return WTF::switchOn(renderer().style().filter().first(),
+        [&](const Style::FilterReference& reference) {
+            return ReferencedSVGResources::referencedFilterElement(protect(renderer().treeScopeForSVGReferences()), reference) != nullptr;
+        },
+        [&](const auto&) { return false; }
+    );
+}
+
+void RenderLayer::updateAncestorDependentStateForSVG()
+{
+    ASSERT(m_svgData);
+    ASSERT(renderer().document().settings().layerBasedSVGEngineEnabled());
+    m_svgData->enclosingHiddenOrResourceContainer = ancestorsOfType<RenderSVGHiddenContainer>(renderer()).first();
+}
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/RenderLayerSVGAdditionsInlines.h
+++ b/Source/WebCore/rendering/RenderLayerSVGAdditionsInlines.h
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#pragma once
+
+#include "RenderLayer.h"
+#include "RenderSVGHiddenContainer.h"
+
+namespace WebCore {
+
+inline bool RenderLayer::isPaintingResourceLayerForSVG() const
+{
+    return m_svgData && m_svgData->isPaintingResourceLayer;
+}
+
+inline RenderSVGHiddenContainer* RenderLayer::enclosingHiddenOrResourceContainerForSVG() const
+{
+    return m_svgData ? m_svgData->enclosingHiddenOrResourceContainer.get() : nullptr;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -59,6 +59,7 @@
 #include "FocusController.h"
 #include "FrameInlines.h"
 #include "FrameSelection.h"
+#include "GraphicsLayer.h"
 #include "HTMLBodyElement.h"
 #include "HTMLHtmlElement.h"
 #include "HitTestResult.h"

--- a/Source/WebCore/rendering/RenderSearchField.h
+++ b/Source/WebCore/rendering/RenderSearchField.h
@@ -27,7 +27,9 @@
 
 namespace WebCore {
 
+class FontSelector;
 class HTMLInputElement;
+class HostWindow;
 
 class RenderSearchField final : public RenderTextControlSingleLine {
     WTF_MAKE_TZONE_ALLOCATED(RenderSearchField);

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -95,6 +95,9 @@
 #include <wtf/FileSystem.h>
 #include <wtf/Language.h>
 #include <wtf/NeverDestroyed.h>
+#if PLATFORM(COCOA)
+#include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
+#endif
 
 #if PLATFORM(COCOA)
 #include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>

--- a/Source/WebCore/rendering/shapes/LayoutShape.cpp
+++ b/Source/WebCore/rendering/shapes/LayoutShape.cpp
@@ -39,7 +39,6 @@
 #include "RectangleLayoutShape.h"
 #include "StyleBasicShape.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
-#include "WindRule.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/rendering/svg/RenderSVGBlock.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGBlock.cpp
@@ -24,6 +24,7 @@
 
 #include "LegacyRenderSVGResource.h"
 #include "RenderBoxModelObjectInlines.h"
+#include "RenderElementInlines.h"
 #include "RenderObjectInlines.h"
 #include "RenderSVGBlockInlines.h"
 #include "RenderView.h"

--- a/Source/WebCore/rendering/svg/RenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGPath.cpp
@@ -240,7 +240,7 @@ void RenderSVGPath::drawMarkers(PaintInfo& paintInfo)
 
             context.setLineDash(DashArray(), 0);
             auto contentTransform = marker->markerTransformation(markerPosition.origin, markerPosition.angle, strokeWidth);
-            protect(marker->layer())->paintSVGResourceLayer(context, contentTransform);
+            protect(marker->layer())->paintResourceLayerForSVG(context, contentTransform);
         }
     }
 }

--- a/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
@@ -178,7 +178,7 @@ void RenderSVGResourceClipper::applyMaskClipping(PaintInfo& paintInfo, const Ren
         context.setCompositeOperation(CompositeOperator::SourceOver);
     }
 
-    protect(layer())->paintSVGResourceLayer(context, contentTransform);
+    protect(layer())->paintResourceLayerForSVG(context, contentTransform);
 
     if (pushTransparencyLayer)
         context.endTransparencyLayer();

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp
@@ -189,7 +189,7 @@ bool RenderSVGResourceMasker::drawContentIntoContext(GraphicsContext& context, c
     }
 
     // Draw the content into the ImageBuffer.
-    protect(layer())->paintSVGResourceLayer(context, maskContentTransformation);
+    protect(layer())->paintResourceLayerForSVG(context, maskContentTransformation);
     return true;
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp
@@ -205,7 +205,7 @@ RefPtr<ImageBuffer> RenderSVGResourcePattern::createTileImage(GraphicsContext& c
     GraphicsContextStateSaver stateSaver(tileImageContext);
 
     // Draw the content into the ImageBuffer.
-    protect(patternRenderer->layer())->paintSVGResourceLayer(tileImageContext, tileImageTransform);
+    protect(patternRenderer->layer())->paintResourceLayerForSVG(tileImageContext, tileImageTransform);
     return tileImage;
 }
 

--- a/Source/WebCore/rendering/svg/SVGTextQuery.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextQuery.cpp
@@ -20,9 +20,9 @@
 
 #include "config.h"
 #include "SVGTextQuery.h"
-#include "FontCascadeInlines.h"
 
 #include "FloatConversion.h"
+#include "FontCascadeInlines.h"
 #include "LegacyInlineFlowBox.h"
 #include "RenderBlockFlow.h"
 #include "RenderElementInlines.h"

--- a/Source/WebCore/svg/SVGGraphicsElement.cpp
+++ b/Source/WebCore/svg/SVGGraphicsElement.cpp
@@ -32,6 +32,7 @@
 #include "RenderElementStyleInlines.h"
 #include "RenderLayer.h"
 #include "RenderLayerInlines.h"
+#include "RenderLayerSVGAdditionsInlines.h"
 #include "RenderObjectDocument.h"
 #include "RenderSVGHiddenContainer.h"
 #include "RenderSVGPath.h"
@@ -288,7 +289,10 @@ void SVGGraphicsElement::invalidateResourceImageBuffersIfNeeded()
     if (!document().settings().layerBasedSVGEngineEnabled())
         return;
     if (CheckedPtr svgRenderer = dynamicDowncast<RenderLayerModelObject>(renderer())) {
-        if (CheckedPtr container = svgRenderer->enclosingLayer()->enclosingSVGHiddenOrResourceContainer()) {
+        CheckedPtr layer = svgRenderer->enclosingLayer();
+        if (!layer)
+            return;
+        if (CheckedPtr container = layer->enclosingHiddenOrResourceContainerForSVG()) {
             if (auto* maskRenderer = dynamicDowncast<RenderSVGResourceMasker>(container.get()))
                 maskRenderer->invalidateMask();
             if (auto* patternRenderer = dynamicDowncast<RenderSVGResourcePattern>(container.get()))


### PR DESCRIPTION
#### 967dba77d23fa5c99511879e4f6b9b520789cc05
<pre>
[LBSE] Move SVG-specific data out of RenderLayer into a lazily-allocated SVGData struct
<a href="https://bugs.webkit.org/show_bug.cgi?id=310224">https://bugs.webkit.org/show_bug.cgi?id=310224</a>

Reviewed by Simon Fraser.

Move SVG-specific state into a lazily-allocated SVGData struct, keeping RenderLayer
final with no virtual dispatch. SVG logic lives in RenderLayerSVGAdditions.cpp and
RenderLayerSVGAdditionsInlines.h, called from RenderLayer.

We chose not to introduce a RenderLayerSVG subclass because making RenderLayer
non-final would prevent the compiler from devirtualizing calls, adding vtable
pointer overhead to every layer and indirect dispatch on hot paths like
hasVisibleContentForPainting() and setupClipPath(), which is a 0.25 - 0.7%
regression on SpeedoMeter 3 -- avoid that.

Covered by existing tests.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::isInsideEntirelyHiddenLayer const):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::RenderLayer):
(WebCore::RenderLayer::recursiveUpdateLayerPositions):
(WebCore::RenderLayer::referenceBoxRectForClipPath const):
(WebCore::RenderLayer::updateAncestorDependentState):
(WebCore::RenderLayer::computeHasVisibleContent const):
(WebCore::RenderLayer::shouldRepaintAfterLayout const):
(WebCore::RenderLayer::convertToLayerCoords const):
(WebCore::RenderLayer::setupClipPath):
(WebCore::RenderLayer::paintLayerContents):
(WebCore::RenderLayer::paintForegroundForFragments):
(WebCore::RenderLayer::hitTestLayer):
(WebCore::RenderLayer::calculateClipRects const):
(WebCore::RenderLayer::paintSVGResourceLayer): Deleted.
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerInlines.h:
(WebCore::RenderLayer::enclosingSVGHiddenOrResourceContainer const): Deleted.
* Source/WebCore/rendering/RenderLayerSVGAdditions.cpp: Added.
(WebCore::RenderLayer::hasVisibleContentForPaintingForSVG const):
(WebCore::RenderLayer::paintResourceLayerForSVG):
(WebCore::RenderLayer::setupClipPathIfNeededForSVG):
(WebCore::RenderLayer::paintForegroundForFragmentsForSVG):
(WebCore::RenderLayer::shouldSkipRepaintAfterLayoutForSVG const):
(WebCore::RenderLayer::shouldSkipHitTestForSVG const):
(WebCore::RenderLayer::hasFailedFilterForSVG const):
(WebCore::RenderLayer::updateAncestorDependentStateForSVG):
* Source/WebCore/rendering/RenderLayerSVGAdditionsInlines.h: Added.
(WebCore::RenderLayer::isPaintingResourceLayerForSVG const):
(WebCore::RenderLayer::enclosingHiddenOrResourceContainerForSVG const):
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
* Source/WebCore/rendering/RenderSearchField.h:
* Source/WebCore/rendering/RenderTheme.cpp:
* Source/WebCore/rendering/shapes/LayoutShape.cpp:
* Source/WebCore/rendering/svg/RenderSVGBlock.cpp:
* Source/WebCore/rendering/svg/RenderSVGPath.cpp:
(WebCore::RenderSVGPath::drawMarkers):
* Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp:
(WebCore::RenderSVGResourceClipper::applyMaskClipping):
* Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp:
(WebCore::RenderSVGResourceMasker::drawContentIntoContext):
* Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp:
(WebCore::RenderSVGResourcePattern::createTileImage const):
* Source/WebCore/rendering/svg/SVGTextQuery.cpp:
* Source/WebCore/svg/SVGGraphicsElement.cpp:
(WebCore::SVGGraphicsElement::invalidateResourceImageBuffersIfNeeded):

Canonical link: <a href="https://commits.webkit.org/311493@main">https://commits.webkit.org/311493@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a82c710cea5efd758b9d97631186abf79879c9be

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157139 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30475 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23666 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165962 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/111221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159010 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/30611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30478 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121691 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/111221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160097 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/30611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141099 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102359 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/30611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/21228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13734 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/30611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18927 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168447 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/12606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20547 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129822 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/30077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25306 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129930 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35196 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30000 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140721 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/87821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/24754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17525 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29711 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/93725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/29233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/29463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/29360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->