### PR TITLE
[JSC] Flush ProfilerSupport queue at jsc shell exit

### DIFF
--- a/Source/JavaScriptCore/assembler/PerfLog.cpp
+++ b/Source/JavaScriptCore/assembler/PerfLog.cpp
@@ -215,11 +215,11 @@ void PerfLog::flush(const AbstractLocker&)
     m_file.flush();
 }
 
-void PerfLog::log(const CString& name, MacroAssemblerCodeRef<LinkBufferPtrTag> code, std::unique_ptr<IRDumpDebugInfo>&& debugInfo, std::unique_ptr<SourceCodeDumpDebugInfo>&& sourceCodeDebugInfo)
+void PerfLog::log(const CString& name, MacroAssemblerCodeRef<LinkBufferPtrTag> code, std::unique_ptr<IRDumpDebugInfo>&& irDebugInfo, std::unique_ptr<SourceCodeDumpDebugInfo>&& sourceCodeDebugInfo)
 {
     auto timestamp = ProfilerSupport::generateTimestamp();
     auto tid = ProfilerSupport::getCurrentThreadID();
-    ProfilerSupport::singleton().queue().dispatch([name = name, code, tid, timestamp, debugInfo = WTF::move(debugInfo), sourceCodeDebugInfo = WTF::move(sourceCodeDebugInfo)] {
+    ProfilerSupport::singleton().queue().dispatch([name = name, code, tid, timestamp, irDebugInfo = WTF::move(irDebugInfo), sourceCodeDebugInfo = WTF::move(sourceCodeDebugInfo)] {
         PerfLog& logger = singleton();
         size_t size = code.size();
         auto* executableAddress = code.code().untaggedPtr<const uint8_t*>();
@@ -230,8 +230,16 @@ void PerfLog::log(const CString& name, MacroAssemblerCodeRef<LinkBufferPtrTag> c
 
         CString irFilePath;
         Vector<std::pair<uint32_t, uint32_t>> lineEntries;
-        if (debugInfo) {
-            auto baseName = makeString("irdump-"_s, String::fromUTF8(debugInfo->functionName.span()), "-"_s, WTF::getCurrentProcessID(), "-"_s, timestamp);
+        struct SourceEntry {
+            uint32_t codeOffset;
+            uint32_t line;
+            uint32_t column;
+            CString filePath;
+        };
+        Vector<SourceEntry> sourceEntries;
+
+        if (irDebugInfo) {
+            auto baseName = makeString("irdump-"_s, String::fromUTF8(irDebugInfo->functionName.span()), "-"_s, WTF::getCurrentProcessID(), "-"_s, timestamp);
 
             String filePath;
             FileSystem::FileHandle handle;
@@ -247,7 +255,7 @@ void PerfLog::log(const CString& name, MacroAssemblerCodeRef<LinkBufferPtrTag> c
 
             if (handle) {
                 // Write sequential IR dump file from irLines.
-                for (auto& irLine : debugInfo->irLines) {
+                for (auto& irLine : irDebugInfo->irLines) {
                     CString line;
                     if (irLine.opName)
                         line = toCString("  ", irLine.opName, "\n");
@@ -259,8 +267,17 @@ void PerfLog::log(const CString& name, MacroAssemblerCodeRef<LinkBufferPtrTag> c
                 irFilePath = FileSystem::fileSystemRepresentation(filePath);
 
                 // Convert code entries to (codeOffset, 1-based lineNumber) pairs.
-                for (auto& codeEntry : debugInfo->codeEntries)
+                for (auto& codeEntry : irDebugInfo->codeEntries)
                     lineEntries.append({ codeEntry.codeOffset, codeEntry.irLineIndex + 1 });
+            }
+        }
+
+        if (sourceCodeDebugInfo) {
+            const CString& sourceCodeDumpDir = logger.m_sourceCodeDumpDirectory;
+            for (auto& entry : sourceCodeDebugInfo->codeEntries) {
+                CString filePath = protect(entry.sourceProvider)->sourceCodeDumpFilePath(sourceCodeDumpDir);
+                if (!filePath.isNull())
+                    sourceEntries.append({ entry.codeOffset, entry.lineColumn.line, entry.lineColumn.column, WTF::move(filePath) });
             }
         }
 
@@ -289,42 +306,26 @@ void PerfLog::log(const CString& name, MacroAssemblerCodeRef<LinkBufferPtrTag> c
             }
         }
 
-        if (sourceCodeDebugInfo && !sourceCodeDebugInfo->codeEntries.isEmpty()) {
-            struct SourceEntry {
-                uint32_t codeOffset;
-                uint32_t line;
-                uint32_t column;
-                CString filePath;
-            };
-            Vector<SourceEntry> sourceEntries;
-            const CString& sourceCodeDumpDir = logger.m_sourceCodeDumpDirectory;
-            for (auto& entry : sourceCodeDebugInfo->codeEntries) {
-                CString filePath = protect(entry.sourceProvider)->sourceCodeDumpFilePath(sourceCodeDumpDir);
-                if (!filePath.isNull())
-                    sourceEntries.append({ entry.codeOffset, entry.lineColumn.line, entry.lineColumn.column, WTF::move(filePath) });
-            }
+        if (!sourceEntries.isEmpty()) {
+            JITDump::DebugInfoRecord debugRecord;
+            debugRecord.header.timestamp = timestamp;
+            debugRecord.codeAddress = std::bit_cast<uintptr_t>(executableAddress);
+            debugRecord.nrEntry = sourceEntries.size();
 
-            if (!sourceEntries.isEmpty()) {
-                JITDump::DebugInfoRecord debugRecord;
-                debugRecord.header.timestamp = timestamp;
-                debugRecord.codeAddress = std::bit_cast<uintptr_t>(executableAddress);
-                debugRecord.nrEntry = sourceEntries.size();
+            uint32_t totalSize = sizeof(JITDump::DebugInfoRecord);
+            for (auto& sourceEntry : sourceEntries)
+                totalSize += sizeof(JITDump::DebugEntry) + (sourceEntry.filePath.length() + 1);
+            debugRecord.header.totalSize = totalSize;
 
-                uint32_t totalSize = sizeof(JITDump::DebugInfoRecord);
-                for (auto& sourceEntry : sourceEntries)
-                    totalSize += sizeof(JITDump::DebugEntry) + (sourceEntry.filePath.length() + 1);
-                debugRecord.header.totalSize = totalSize;
+            logger.write(locker, unsafeMakeSpan(std::bit_cast<char*>(&debugRecord), sizeof(JITDump::DebugInfoRecord)));
 
-                logger.write(locker, unsafeMakeSpan(std::bit_cast<char*>(&debugRecord), sizeof(JITDump::DebugInfoRecord)));
-
-                for (auto& sourceEntry : sourceEntries) {
-                    JITDump::DebugEntry debugEntry;
-                    debugEntry.codeAddress = std::bit_cast<uintptr_t>(executableAddress) + sourceEntry.codeOffset;
-                    debugEntry.line = sourceEntry.line;
-                    debugEntry.discrim = sourceEntry.column;
-                    logger.write(locker, unsafeMakeSpan(std::bit_cast<char*>(&debugEntry), sizeof(JITDump::DebugEntry)));
-                    logger.write(locker, sourceEntry.filePath.spanIncludingNullTerminator());
-                }
+            for (auto& sourceEntry : sourceEntries) {
+                JITDump::DebugEntry debugEntry;
+                debugEntry.codeAddress = std::bit_cast<uintptr_t>(executableAddress) + sourceEntry.codeOffset;
+                debugEntry.line = sourceEntry.line;
+                debugEntry.discrim = sourceEntry.column;
+                logger.write(locker, unsafeMakeSpan(std::bit_cast<char*>(&debugEntry), sizeof(JITDump::DebugEntry)));
+                logger.write(locker, sourceEntry.filePath.spanIncludingNullTerminator());
             }
         }
 

--- a/Source/JavaScriptCore/runtime/ProfilerSupport.cpp
+++ b/Source/JavaScriptCore/runtime/ProfilerSupport.cpp
@@ -37,6 +37,7 @@
 #include <wtf/StringPrintStream.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
+#include <wtf/threads/BinarySemaphore.h>
 
 #if OS(LINUX)
 #include <sys/mman.h>
@@ -91,6 +92,10 @@ ProfilerSupport::ProfilerSupport()
         RELEASE_ASSERT(marker != MAP_FAILED);
 #endif
     }
+
+    std::atexit([] {
+        ProfilerSupport::barrierSync();
+    });
 }
 
 uint32_t ProfilerSupport::getCurrentThreadID()
@@ -212,6 +217,15 @@ void ProfilerSupport::dumpIonGraphFunction(const String& functionName, Ref<JSON:
     RELEASE_ASSERT(handle);
     handle.write(WTF::asByteSpan(string.utf8().span()));
     handle.flush();
+}
+
+void ProfilerSupport::barrierSync()
+{
+    BinarySemaphore semaphore;
+    singleton().queue().dispatch([&semaphore] {
+        semaphore.signal();
+    });
+    semaphore.wait();
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/ProfilerSupport.h
+++ b/Source/JavaScriptCore/runtime/ProfilerSupport.h
@@ -70,6 +70,8 @@ public:
 
     static void dumpIonGraphFunction(const String& functionName, Ref<JSON::Object>&&);
 
+    static void barrierSync();
+
     static uint32_t getCurrentThreadID();
 
 private:


### PR DESCRIPTION
#### c0b0c8d82e2292c1a26d0a23878473ffefaf8028
<pre>
[JSC] Flush ProfilerSupport queue at jsc shell exit
<a href="https://bugs.webkit.org/show_bug.cgi?id=310227">https://bugs.webkit.org/show_bug.cgi?id=310227</a>
<a href="https://rdar.apple.com/172869612">rdar://172869612</a>

Reviewed by Keith Miller.

This adds ProfilerSupport::barrierSync to flush all tasks, and in JSC shell,
we use this with std::atexit to ensure that all of Profiler tasks are
flushed before exiting. This is necessary when your JITDump has large
size and taking long time to flush for example.

* Source/JavaScriptCore/assembler/PerfLog.cpp:
(JSC::PerfLog::log):
* Source/JavaScriptCore/runtime/ProfilerSupport.cpp:
(JSC::ProfilerSupport::ProfilerSupport):
(JSC::ProfilerSupport::barrierSync):
* Source/JavaScriptCore/runtime/ProfilerSupport.h:

Canonical link: <a href="https://commits.webkit.org/309521@main">https://commits.webkit.org/309521@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/436d1a6a5aa6bd4da1ef96e575091e5c2675f2ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150956 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23718 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17288 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159684 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/104392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2b391fcc-921c-4e1a-a514-d9801ba524dd) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24149 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23935 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116533 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/104392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1063d621-deb0-4dc6-8528-842e0eb818c5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153916 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18645 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/135441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97253 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e3481348-eac7-4344-a4bc-d2db363bd834) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/17739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/15694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7530 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/142940 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/127357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13358 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162157 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/11755 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5282 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14929 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124540 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23520 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/19744 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124727 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23510 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135155 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79917 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23187 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19788 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11920 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/182481 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23120 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87275 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46607 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22832 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22984 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22886 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->