### PR TITLE
Hide _WKElementActionTypeSaveImage for images hosted or displayed on managed domains

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.h
+++ b/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.h
@@ -67,6 +67,7 @@ typedef NS_ENUM(NSInteger, _WKElementActionType);
 - (BOOL)actionSheetAssistant:(WKActionSheetAssistant *)assistant shouldIncludeAppLinkActionsForElement:(_WKActivatedElementInfo *)element;
 #endif
 - (RetainPtr<NSArray>)actionSheetAssistant:(WKActionSheetAssistant *)assistant decideActionsForElement:(_WKActivatedElementInfo *)element defaultActions:(RetainPtr<NSArray>)defaultActions;
+- (NSURL *)currentPageURLForActionSheetAssistant:(WKActionSheetAssistant *)assistant;
 
 @optional
 - (BOOL)actionSheetAssistant:(WKActionSheetAssistant *)assistant showCustomSheetForElement:(_WKActivatedElementInfo *)element;

--- a/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm
+++ b/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm
@@ -47,6 +47,7 @@
 #import <WebCore/PathUtilities.h>
 #import <WebCore/ResolvedCaptionDisplaySettingsOptions.h>
 #import <WebCore/UIViewControllerUtilities.h>
+#import <pal/spi/ios/ManagedConfigurationSPI.h>
 #import <wtf/CompletionHandler.h>
 #import <wtf/Markable.h>
 #import <wtf/SoftLinking.h>
@@ -69,6 +70,7 @@ SOFT_LINK_CLASS(SafariServices, SSReadingList)
 #endif
 
 #import "TCCSoftLink.h"
+#import <pal/ios/ManagedConfigurationSoftLink.h>
 #import <pal/spi/ios/DataDetectorsUISoftLink.h>
 
 OBJC_CLASS DDAction;
@@ -586,7 +588,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #endif
 
     if ([elementInfo imageURL]) {
-        if (TCCAccessPreflight(WebKit::get_TCC_kTCCServicePhotosSingleton(), NULL) != kTCCAccessPreflightDenied)
+        if ([self _canShowSaveImageActionForImageURL:elementInfo.imageURL])
             [defaultActions addObject:[_WKElementAction _elementActionWithType:_WKElementActionTypeSaveImage info:elementInfo assistant:self]];
     }
 
@@ -613,6 +615,28 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     return defaultActions;
 }
 
+// Extracted to a method so tests can swizzle the TCC check
+- (BOOL)_isPhotoLibraryAccessDenied
+{
+    return TCCAccessPreflight(WebKit::get_TCC_kTCCServicePhotosSingleton(), NULL) == kTCCAccessPreflightDenied;
+}
+
+- (BOOL)_canShowSaveImageActionForImageURL:(NSURL *)imageURL
+{
+    if ([self _isPhotoLibraryAccessDenied])
+        return NO;
+
+#if !PLATFORM(MACCATALYST)
+    RetainPtr pageURL = [_delegate.get() currentPageURLForActionSheetAssistant:self];
+    RetainPtr profileConnection = [PAL::getMCProfileConnectionClassSingleton() sharedConnection];
+
+    if ((pageURL && [profileConnection isURLManaged:pageURL]) || (imageURL && [profileConnection isURLManaged:imageURL]))
+        return NO;
+#endif
+
+    return YES;
+}
+
 - (RetainPtr<NSArray<_WKElementAction *>>)defaultActionsForImageSheet:(_WKActivatedElementInfo *)elementInfo
 {
     NSURL *targetURL = [elementInfo URL];
@@ -628,7 +652,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if ([getSSReadingListClassSingleton() supportsURL:targetURL])
         [defaultActions addObject:[_WKElementAction _elementActionWithType:_WKElementActionTypeAddToReadingList info:elementInfo assistant:self]];
 #endif
-    if (TCCAccessPreflight(WebKit::get_TCC_kTCCServicePhotosSingleton(), NULL) != kTCCAccessPreflightDenied)
+    if ([self _canShowSaveImageActionForImageURL:elementInfo.imageURL])
         [defaultActions addObject:[_WKElementAction _elementActionWithType:_WKElementActionTypeSaveImage info:elementInfo assistant:self]];
 
     [defaultActions addObject:[_WKElementAction _elementActionWithType:_WKElementActionTypeCopy info:elementInfo assistant:self]];

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -10114,6 +10114,13 @@ static String fallbackLabelTextForUnlabeledInputFieldInZoomedFormControls(WebCor
 }
 #endif
 
+- (NSURL *)currentPageURLForActionSheetAssistant:(WKActionSheetAssistant *)assistant
+{
+    if (!_page)
+        return nil;
+    return URL { protect(_page)->currentURL() }.createNSURL().autorelease();
+}
+
 - (BOOL)actionSheetAssistant:(WKActionSheetAssistant *)assistant showCustomSheetForElement:(_WKActivatedElementInfo *)element
 {
     RetainPtr uiDelegate = static_cast<id <WKUIDelegatePrivate>>([_webView.get() UIDelegate]);

--- a/Tools/TestWebKitAPI/Tests/ios/ActionSheetTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/ActionSheetTests.mm
@@ -27,6 +27,7 @@
 
 #if PLATFORM(IOS_FAMILY) && !PLATFORM(MACCATALYST)
 
+#import "InstanceMethodSwizzler.h"
 #import "PlatformUtilities.h"
 #import "Test.h"
 #import "TestCocoa.h"
@@ -43,10 +44,12 @@
 #import <WebKit/WKWebViewPrivateForTesting.h>
 #import <WebKit/_WKActivatedElementInfo.h>
 #import <WebKit/_WKElementAction.h>
+#import <pal/spi/ios/ManagedConfigurationSPI.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/SoftLinking.h>
 #import <wtf/darwin/DispatchExtras.h>
+#import <pal/ios/ManagedConfigurationSoftLink.h>
 
 @interface ActionSheetObserver : NSObject<WKUIDelegatePrivate>
 @property (nonatomic) BlockPtr<NSArray *(_WKActivatedElementInfo *, NSArray *)> presentationHandler;
@@ -65,6 +68,47 @@
     return _dataDetectionContextHandler ? _dataDetectionContextHandler() : @{ };
 }
 
+@end
+
+@interface MockManagedPageURL : NSObject
+@end
+
+@implementation MockManagedPageURL
+- (BOOL)isURLManaged:(NSURL *)url
+{
+    return [url.lastPathComponent isEqualToString:@"image-and-contenteditable.html"]
+        || [url.lastPathComponent isEqualToString:@"image-in-link-and-input.html"];
+}
+@end
+
+@interface MockManagedImageURL : NSObject
+@end
+
+@implementation MockManagedImageURL
+- (BOOL)isURLManaged:(NSURL *)url
+{
+    return [url.lastPathComponent isEqualToString:@"icon.png"];
+}
+@end
+
+@interface MockTCCGranted : NSObject
+@end
+
+@implementation MockTCCGranted
+- (BOOL)_isPhotoLibraryAccessDenied
+{
+    return NO;
+}
+@end
+
+@interface MockTCCDenied : NSObject
+@end
+
+@implementation MockTCCDenied
+- (BOOL)_isPhotoLibraryAccessDenied
+{
+    return YES;
+}
 @end
 
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
@@ -470,6 +514,90 @@ TEST(ActionSheetTests, PlayPauseAnimationSheetActionsNotPresentByDefault)
     TestWebKitAPI::Util::run(&done);
 }
 #endif // ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
+
+static bool defaultActionsContainSaveImage(TestWKWebView *webView, ActionSheetObserver *observer, CGPoint location)
+{
+    __block bool done = false;
+    __block bool containsSaveImage = false;
+    [observer setPresentationHandler:^(_WKActivatedElementInfo *element, NSArray *actions) {
+        for (_WKElementAction *action in actions) {
+            if (action.type == _WKElementActionTypeSaveImage) {
+                containsSaveImage = true;
+                break;
+            }
+        }
+        done = true;
+        return @[ ];
+    }];
+    [webView _simulateLongPressActionAtLocation:location];
+    TestWebKitAPI::Util::run(&done);
+    return containsSaveImage;
+}
+
+static bool saveImageActionIsPresent(NSString *testPageName, CGPoint longPressLocation, Class managedURLMockClass = nil, Class tccResultMockClass = MockTCCGranted.class)
+{
+    auto tccSwizzler = InstanceMethodSwizzler {
+        NSClassFromString(@"WKActionSheetAssistant"),
+        @selector(_isPhotoLibraryAccessDenied),
+        [tccResultMockClass instanceMethodForSelector:@selector(_isPhotoLibraryAccessDenied)]
+    };
+
+    std::optional<InstanceMethodSwizzler> managedConfigSwizzler;
+    if (managedURLMockClass) {
+        managedConfigSwizzler.emplace(
+            PAL::getMCProfileConnectionClassSingleton(),
+            @selector(isURLManaged:),
+            [managedURLMockClass instanceMethodForSelector:@selector(isURLManaged:)]
+        );
+    }
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr observer = adoptNS([[ActionSheetObserver alloc] init]);
+    [webView setUIDelegate:observer.get()];
+    [webView synchronouslyLoadTestPageNamed:testPageName];
+
+    return defaultActionsContainSaveImage(webView.get(), observer.get(), longPressLocation);
+}
+
+TEST(ActionSheetTests, SaveImageActionIsPresent)
+{
+    EXPECT_TRUE(saveImageActionIsPresent(@"image-and-contenteditable", CGPointMake(100, 100)));
+}
+
+TEST(ActionSheetTests, SaveImageActionIsExcludedWhenTCCIsDenied)
+{
+    EXPECT_FALSE(saveImageActionIsPresent(@"image-and-contenteditable", CGPointMake(100, 100), nil, MockTCCDenied.class));
+}
+
+TEST(ActionSheetTests, SaveImageActionIsExcludedWhenPageURLIsManaged)
+{
+    EXPECT_FALSE(saveImageActionIsPresent(@"image-and-contenteditable", CGPointMake(100, 100), MockManagedPageURL.class));
+}
+
+TEST(ActionSheetTests, SaveImageActionIsExcludedWhenImageURLIsManaged)
+{
+    EXPECT_FALSE(saveImageActionIsPresent(@"image-and-contenteditable", CGPointMake(100, 100), MockManagedImageURL.class));
+}
+
+TEST(ActionSheetTests, LinkedImageSaveImageActionIsPresent)
+{
+    EXPECT_TRUE(saveImageActionIsPresent(@"image-in-link-and-input", CGPointMake(100, 50)));
+}
+
+TEST(ActionSheetTests, LinkedImageSaveImageActionIsExcludedWhenTCCIsDenied)
+{
+    EXPECT_FALSE(saveImageActionIsPresent(@"image-in-link-and-input", CGPointMake(100, 50), nil, MockTCCDenied.class));
+}
+
+TEST(ActionSheetTests, LinkedImageSaveImageActionIsExcludedWhenPageURLIsManaged)
+{
+    EXPECT_FALSE(saveImageActionIsPresent(@"image-in-link-and-input", CGPointMake(100, 50), MockManagedPageURL.class));
+}
+
+TEST(ActionSheetTests, LinkedImageSaveImageActionIsExcludedWhenImageURLIsManaged)
+{
+    EXPECT_FALSE(saveImageActionIsPresent(@"image-in-link-and-input", CGPointMake(100, 50), MockManagedImageURL.class));
+}
 
 } // namespace TestWebKitAPI
 


### PR DESCRIPTION
#### 919dd36c27d2d5e4825d68c5f6750e993183aa69
<pre>
Hide _WKElementActionTypeSaveImage for images hosted or displayed on managed domains
<a href="https://rdar.apple.com/37031149">rdar://37031149</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=310229">https://bugs.webkit.org/show_bug.cgi?id=310229</a>

Reviewed by Abrar Rahman Protyasha.

When the page URL or image URL is managed by MDM (MCProfileConnection) on iOS, hide the Save Image
action from both image and linked-image action sheets. The delegate (WKContentViewInteraction)
provides the page URL via a new required delegate method, currentPageURLForActionSheetAssistant:.
Also add several tests which verify the contents of the action sheet when there is no management and
when either the page or image URL is managed, for both plain images and linked images.

Test: Tools/TestWebKitAPI/Tests/ios/ActionSheetTests.mm

* Source/WebKit/UIProcess/ios/WKActionSheetAssistant.h:
* Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm:
(-[WKActionSheetAssistant defaultActionsForLinkSheet:]):
(-[WKActionSheetAssistant _isPhotoLibraryAccessDenied]):
(-[WKActionSheetAssistant _canShowSaveImageActionForImageURL:]):
(-[WKActionSheetAssistant defaultActionsForImageSheet:]):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView currentPageURLForActionSheetAssistant:]):
* Tools/TestWebKitAPI/Tests/ios/ActionSheetTests.mm:
(-[MockManagedPageURL isURLManaged:]):
(-[MockManagedImageURL isURLManaged:]):
(-[MockTCCGranted _isPhotoLibraryAccessDenied]):
(-[MockTCCDenied _isPhotoLibraryAccessDenied]):
(TestWebKitAPI::defaultActionsContainSaveImage):
(TestWebKitAPI::saveImageActionIsPresent):
(TestWebKitAPI::TEST(ActionSheetTests, SaveImageActionIsPresent)):
(TestWebKitAPI::TEST(ActionSheetTests, SaveImageActionIsExcludedWhenTCCIsDenied)):
(TestWebKitAPI::TEST(ActionSheetTests, SaveImageActionIsExcludedWhenPageURLIsManaged)):
(TestWebKitAPI::TEST(ActionSheetTests, SaveImageActionIsExcludedWhenImageURLIsManaged)):
(TestWebKitAPI::TEST(ActionSheetTests, LinkedImageSaveImageActionIsPresent)):
(TestWebKitAPI::TEST(ActionSheetTests, LinkedImageSaveImageActionIsExcludedWhenTCCIsDenied)):
(TestWebKitAPI::TEST(ActionSheetTests, LinkedImageSaveImageActionIsExcludedWhenPageURLIsManaged)):
(TestWebKitAPI::TEST(ActionSheetTests, LinkedImageSaveImageActionIsExcludedWhenImageURLIsManaged)):

Canonical link: <a href="https://commits.webkit.org/309628@main">https://commits.webkit.org/309628@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b23a896d479c7b79b2b4c0bd1d2af607dbce4490

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151088 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23850 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17420 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159816 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104524 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152961 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24281 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24075 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116645 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82802 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154048 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18770 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135562 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97366 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17863 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15812 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7662 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127481 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13479 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162289 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5414 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15050 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124654 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23652 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19862 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124842 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33901 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23642 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135276 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/80086 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19910 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12041 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23252 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87546 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22964 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23116 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23018 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->