### PR TITLE
[Gardening]: TestWebKitAPI.ContextMenuTests.ContextMenuElementInfoWithQRCodeDetectionCrash (api-tests) is a flaky failure

### DIFF
--- a/Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm
@@ -454,11 +454,7 @@ TEST(ContextMenuTests, ContextMenuElementInfoContainsQRCodePayloadStringSVGPageZ
 }
 
 // FIXME: Re-enable this test once webkit.org/b/266650 is resolved
-#if PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED > 140000 && !defined(NDEBUG)
 TEST(ContextMenuElementInfoWithQRCodeDetectionCrash, DISABLED_ContextMenuTests)
-#else
-TEST(ContextMenuTests, ContextMenuElementInfoWithQRCodeDetectionCrash)
-#endif
 {
     auto createWebView = [] {
         auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);


### PR DESCRIPTION
#### 5bb04c0655e6b93a8ea30d02e6548a4942bb17d1
<pre>
[Gardening]: TestWebKitAPI.ContextMenuTests.ContextMenuElementInfoWithQRCodeDetectionCrash (api-tests) is a flaky failure
<a href="https://rdar.apple.com/111706229">rdar://111706229</a>

Unreviewed test gardening

Skipping the test both in Debug and Release due to flaky failures.

* Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm:
(TestWebKitAPI::TEST(ContextMenuElementInfoWithQRCodeDetectionCrash, DISABLED_ContextMenuTests)):
(TestWebKitAPI::TEST(ContextMenuTests, ContextMenuElementInfoWithQRCodeDetectionCrash)): Deleted.

Canonical link: <a href="https://commits.webkit.org/309533@main">https://commits.webkit.org/309533@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef03fcdf78d97067703108bab2ad48704be486c5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150954 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23716 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17286 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159682 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/104390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a1ce4e62-5a2d-40bd-8861-d91a289876ff) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152827 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24147 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23933 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116531 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/104390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/28557dfc-2283-42d4-a28f-c97302470d9e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153914 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18647 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135437 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97251 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17741 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15692 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7528 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127359 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13354 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162155 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14925 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124538 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23518 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19742 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124725 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23508 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135151 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79915 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23194 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19785 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11916 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23118 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22830 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22982 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22884 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->