### PR TITLE
[macOS] imported/w3c/web-platform-tests/pointerevents/pointerevent_pointer_boundary_events_after_removing_last_over_element.html is a flaky text failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_pointer_boundary_events_after_removing_last_over_element-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_pointer_boundary_events_after_removing_last_over_element-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL After removing the last over element, redundant pointerenter events should not be fired on the ancestors assert_equals: expected "pointerover@div#parent, pointerout@div#parent, pointerleave@div#parent, pointerleave@div#grandparent, pointerover@body, pointermove@body" but got "pointerover@body, pointermove@body"
-FAIL After removing the root element in the shadow under the cursor, pointerleave events should be targeted outside the shadow, but redundant pointerenter events should not be fired assert_equals: expected "pointerover@div#shadowHost, pointerout@div#shadowHost, pointerleave@div#shadowHost, pointerleave@div#containerOfShadowHost, pointerover@body, pointermove@body" but got "pointerover@body, pointermove@body"
+PASS After removing the last over element, redundant pointerenter events should not be fired on the ancestors
+PASS After removing the root element in the shadow under the cursor, pointerleave events should be targeted outside the shadow, but redundant pointerenter events should not be fired
 

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_pointer_boundary_events_after_removing_last_over_element.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_pointer_boundary_events_after_removing_last_over_element.html
@@ -73,6 +73,7 @@ addEventListener("load", () => {
       .pointerMove(div3Rect.x + 10, div3Rect.y + 10, {})
       .pointerDown()
       .pointerUp() // The clicked in the child, then it's removed from the DOM tree
+      .pause(250) // Allow the click handler to remove the element before moving
       .pointerMove(bodyRect.x + 10, bodyRect.y + 10, {}) // Then, move onto the <body>
       .send();
     // FYI: Comparing `pointerenter`s before `click` requires additional
@@ -127,6 +128,7 @@ addEventListener("load", () => {
       .pointerMove(rootElementInShadowRect.x + 10, rootElementInShadowRect.y + 10, {})
       .pointerDown()
       .pointerUp() // The clicked root element in the shadow is removed here.
+      .pause(250) // Allow the click handler to remove the element before moving
       .pointerMove(bodyRect.x + 10, bodyRect.y + 10, {}) // Then, move onto the <body>
       .send();
     // FYI: Comparing `pointerenter`s before `click` requires additional

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2431,8 +2431,6 @@ webkit.org/b/306301 [ x86_64 ] http/tests/webgpu/webgpu/api/validation/state/dev
 
 webkit.org/b/306663 [ Debug arm64 ] webaudio/silent-audio-interrupted-in-background.html [ Pass Failure ]
 
-webkit.org/b/310217 imported/w3c/web-platform-tests/pointerevents/pointerevent_pointer_boundary_events_after_removing_last_over_element.html [ Pass Failure ]
-
 webkit.org/b/306670 [ Debug arm64 ] http/tests/webgpu/webgpu/api/validation/render_pipeline/resource_compatibility.html [ Pass Failure Timeout ]
 
 webkit.org/b/306785 imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-insecure.sub.window.html [ Pass Failure ]


### PR DESCRIPTION
#### dde7276dc38f1ea088daa630d29ec03ba7ecfc36
<pre>
[macOS] imported/w3c/web-platform-tests/pointerevents/pointerevent_pointer_boundary_events_after_removing_last_over_element.html is a flaky text failure
<a href="https://rdar.apple.com/172861599">rdar://172861599</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=310217">https://bugs.webkit.org/show_bug.cgi?id=310217</a>

Reviewed by NOBODY (OOPS!).

This test currently has expectations marked as FAIL for both subtests,
this is due to timing race with pointer clicks on lines 75-76 and 130-131.
There needs to be a pause to allow for elements to be removed from DOM.

Fix in pointerevent_pointer_boundary_events_after_removing_last_over_element.html
— Added .pause(250) between .pointerUp() and .pointerMove() in both test action sequences.
  This gives the click handler time to remove the element from the DOM before the pointer moves,
  ensuring boundary events fire correctly and consistently.
Fix in pointerevent_pointer_boundary_events_after_removing_last_over_element-expected.txt
- Updated from FAIL/FAIL to PASS/PASS, since WebKit correctly fires the expected boundary
  events when given proper timing. The previous FAIL expectations were an artifact of the
  same timing issue.

* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_pointer_boundary_events_after_removing_last_over_element-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_pointer_boundary_events_after_removing_last_over_element.html:
* LayoutTests/platform/mac-wk2/TestExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dde7276dc38f1ea088daa630d29ec03ba7ecfc36

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150951 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23713 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17283 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159679 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104387 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24144 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23930 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116527 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82729 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153911 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18640 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139483 "") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97247 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17734 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15691 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7525 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127352 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13348 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162152 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14919 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124534 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23515 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19741 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124721 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23505 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135145 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79912 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19783 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11910 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23115 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22827 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22979 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22881 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->