### PR TITLE
[Writing Tools] Add a way for clients to preserve specific DOM nodes when invoking writing tools

### DIFF
--- a/Source/WebCore/editing/cocoa/EditingHTMLConverter.h
+++ b/Source/WebCore/editing/cocoa/EditingHTMLConverter.h
@@ -25,8 +25,11 @@
 
 #import <WebCore/AttributedString.h>
 #import <WebCore/SimpleRange.h>
+#import <wtf/WeakHashSet.h>
 
 namespace WebCore {
+
+class Node;
 
 enum class TextIteratorBehavior : uint16_t;
 
@@ -43,7 +46,7 @@ enum class IncludedElement : uint8_t {
     TextLists = 1 << 4,
 };
 
-WEBCORE_EXPORT AttributedString editingAttributedString(const SimpleRange&, OptionSet<IncludedElement> = { IncludedElement::Images });
+WEBCORE_EXPORT AttributedString editingAttributedString(const SimpleRange&, OptionSet<IncludedElement> = { IncludedElement::Images }, const WeakHashSet<Node, WeakPtrImplWithEventTargetData>& clientPreservedNodes = { });
 WEBCORE_EXPORT AttributedString editingAttributedStringReplacingNoBreakSpace(const SimpleRange&, OptionSet<TextIteratorBehavior>, OptionSet<IncludedElement>);
 
 } // namespace WebCore

--- a/Source/WebCore/editing/cocoa/EditingHTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/EditingHTMLConverter.mm
@@ -39,6 +39,7 @@
 #import "ContainerNodeInlines.h"
 #import "Document.h"
 #import "DocumentLoader.h"
+#import "DocumentPage.h"
 #import "Editing.h"
 #import "ElementChildIteratorInlines.h"
 #import "ElementInlines.h"
@@ -57,6 +58,7 @@
 #import "LocalFrame.h"
 #import "LocalizedStrings.h"
 #import "NodeName.h"
+#import "Page.h"
 #import "RenderImage.h"
 #import "RenderObjectStyle.h"
 #import "RenderStyle+GettersInlines.h"
@@ -204,11 +206,20 @@ static RetainPtr<NSAttributedString> attributedStringWithAttachmentForElement(co
 }
 
 #if ENABLE(WRITING_TOOLS)
-static bool elementQualifiesForWritingToolsPreservation(Element* element)
+static bool elementQualifiesForWritingToolsPreservation(Element* element, const WeakHashSet<Node, WeakPtrImplWithEventTargetData>& clientPreservedNodes)
 {
+    if (clientPreservedNodes.contains(*element))
+        return true;
+
     // If the element is a mail blockquote, it should be preserved after a Writing Tools composition.
     if (isMailBlockquote(*element))
         return true;
+
+    if (element->getIdAttribute() == "AppleMailSignature"_s) [[unlikely]] {
+        // FIXME (310312): Remove this special case once Mail adopts `-_addWritingToolsPreservedNodes:`.
+        if (RefPtr page = element->document().page(); page && page->isEditable())
+            return true;
+    }
 
     // If the element is a tab span node, it is a tab character with `whitespace:pre`, and need not be preserved.
     if (tabSpanNode(element))
@@ -229,14 +240,14 @@ static bool elementQualifiesForWritingToolsPreservation(Element* element)
     return false;
 }
 
-static bool hasAncestorQualifyingForWritingToolsPreservation(Element* ancestor, ElementCache<bool>& cache)
+static bool hasAncestorQualifyingForWritingToolsPreservation(Element* ancestor, ElementCache<bool>& cache, const WeakHashSet<Node, WeakPtrImplWithEventTargetData>& clientPreservedNodes)
 {
     if (!ancestor)
         return false;
 
     auto entry = cache.find(*ancestor);
     if (entry == cache.end()) {
-        auto result = elementQualifiesForWritingToolsPreservation(ancestor) || hasAncestorQualifyingForWritingToolsPreservation(protect(ancestor->parentElement()).get(), cache);
+        auto result = elementQualifiesForWritingToolsPreservation(ancestor, clientPreservedNodes) || hasAncestorQualifyingForWritingToolsPreservation(protect(ancestor->parentElement()).get(), cache, clientPreservedNodes);
 
         cache.set(*ancestor, result);
         return result;
@@ -332,11 +343,11 @@ static void associateElementWithTextLists(Element* element, ElementCache<RefPtr<
 }
 
 // FIXME: Encapsulate all these parameters into a type for readability and maintainability.
-static void updateAttributes(const Node* node, const RenderStyle& style, OptionSet<IncludedElement> includedElements, ElementCache<bool>& elementQualifiesForWritingToolsPreservationCache, ElementCache<RefPtr<Element>>& enclosingLinkCache, ElementCache<RefPtr<Element>>& enclosingListCache, NSMutableDictionary<NSAttributedStringKey, id> *attributes, ElementCache<RetainPtr<NSArray<NSTextList *>>>& textListsForListElements)
+static void updateAttributes(const Node* node, const RenderStyle& style, OptionSet<IncludedElement> includedElements, ElementCache<bool>& elementQualifiesForWritingToolsPreservationCache, ElementCache<RefPtr<Element>>& enclosingLinkCache, ElementCache<RefPtr<Element>>& enclosingListCache, NSMutableDictionary<NSAttributedStringKey, id> *attributes, ElementCache<RetainPtr<NSArray<NSTextList *>>>& textListsForListElements, const WeakHashSet<Node, WeakPtrImplWithEventTargetData>& clientPreservedNodes)
 {
 #if ENABLE(WRITING_TOOLS)
     if (includedElements.contains(IncludedElement::PreservedContent)) {
-        if (hasAncestorQualifyingForWritingToolsPreservation(protect(node->parentElement()).get(), elementQualifiesForWritingToolsPreservationCache))
+        if (hasAncestorQualifyingForWritingToolsPreservation(protect(node->parentElement()).get(), elementQualifiesForWritingToolsPreservationCache, clientPreservedNodes))
             [attributes setObject:@(1) forKey:WTWritingToolsPreservedAttributeName];
         else
             [attributes removeObjectForKey:WTWritingToolsPreservedAttributeName];
@@ -345,6 +356,7 @@ static void updateAttributes(const Node* node, const RenderStyle& style, OptionS
     UNUSED_PARAM(node);
     UNUSED_PARAM(includedElements);
     UNUSED_PARAM(elementQualifiesForWritingToolsPreservationCache);
+    UNUSED_PARAM(clientPreservedNodes);
 #endif
 
     if (style.textDecorationLineInEffect().hasUnderline())
@@ -448,7 +460,7 @@ static void updateAttributes(const Node* node, const RenderStyle& style, OptionS
 
 // This function uses TextIterator, which makes offsets in its result compatible with HTML editing.
 enum class ReplaceAllNoBreakSpaces : bool { No, Yes };
-static AttributedString editingAttributedStringInternal(const SimpleRange& range, TextIteratorBehaviors behaviors, OptionSet<IncludedElement> includedElements, ReplaceAllNoBreakSpaces replaceAllNoBreakSpaces)
+static AttributedString editingAttributedStringInternal(const SimpleRange& range, TextIteratorBehaviors behaviors, OptionSet<IncludedElement> includedElements, ReplaceAllNoBreakSpaces replaceAllNoBreakSpaces, const WeakHashSet<Node, WeakPtrImplWithEventTargetData>& clientPreservedNodes = { })
 {
     ElementCache<RefPtr<Element>> enclosingLinkCache;
     ElementCache<RefPtr<Element>> enclosingListCache;
@@ -484,7 +496,7 @@ static AttributedString editingAttributedStringInternal(const SimpleRange& range
         CheckedPtr renderer = node->renderer();
 
         if (renderer)
-            updateAttributes(node.get(), protect(renderer->style()), includedElements, elementQualifiesForWritingToolsPreservationCache, enclosingLinkCache, enclosingListCache, attributes.get(), textListsForListElements);
+            updateAttributes(node.get(), protect(renderer->style()), includedElements, elementQualifiesForWritingToolsPreservationCache, enclosingLinkCache, enclosingListCache, attributes.get(), textListsForListElements, clientPreservedNodes);
         else if (!includedElements.contains(IncludedElement::NonRenderedContent))
             continue;
 
@@ -509,9 +521,9 @@ static AttributedString editingAttributedStringInternal(const SimpleRange& range
     return AttributedString::fromNSAttributedString(WTF::move(string));
 }
 
-AttributedString editingAttributedString(const SimpleRange& range, OptionSet<IncludedElement> includedElements)
+AttributedString editingAttributedString(const SimpleRange& range, OptionSet<IncludedElement> includedElements, const WeakHashSet<Node, WeakPtrImplWithEventTargetData>& clientPreservedNodes)
 {
-    return editingAttributedStringInternal(range, { }, includedElements, ReplaceAllNoBreakSpaces::No);
+    return editingAttributedStringInternal(range, { }, includedElements, ReplaceAllNoBreakSpaces::No, clientPreservedNodes);
 }
 
 AttributedString editingAttributedStringReplacingNoBreakSpace(const SimpleRange& range, TextIteratorBehaviors behaviors, OptionSet<IncludedElement> includedElements)

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -5558,9 +5558,9 @@ void Page::initializeGamepadAccessForPageLoad()
 #endif // ENABLE(GAMEPAD)
 
 #if ENABLE(WRITING_TOOLS)
-void Page::willBeginWritingToolsSession(const std::optional<WritingTools::Session>& session, CompletionHandler<void(const Vector<WritingTools::Context>&)>&& completionHandler)
+void Page::willBeginWritingToolsSession(const std::optional<WritingTools::Session>& session, WeakHashSet<Node, WeakPtrImplWithEventTargetData>&& preservedNodes, CompletionHandler<void(const Vector<WritingTools::Context>&)>&& completionHandler)
 {
-    m_writingToolsController->willBeginWritingToolsSession(session, WTF::move(completionHandler));
+    m_writingToolsController->willBeginWritingToolsSession(session, WTF::move(preservedNodes), WTF::move(completionHandler));
 }
 
 void Page::didBeginWritingToolsSession(const WritingTools::Session& session, const Vector<WritingTools::Context>& contexts)

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1270,7 +1270,7 @@ public:
 #endif
 
 #if ENABLE(WRITING_TOOLS)
-    WEBCORE_EXPORT void willBeginWritingToolsSession(const std::optional<WritingTools::Session>&, CompletionHandler<void(const Vector<WritingTools::Context>&)>&&);
+    WEBCORE_EXPORT void willBeginWritingToolsSession(const std::optional<WritingTools::Session>&, WeakHashSet<Node, WeakPtrImplWithEventTargetData>&&, CompletionHandler<void(const Vector<WritingTools::Context>&)>&&);
 
     WEBCORE_EXPORT void didBeginWritingToolsSession(const WritingTools::Session&, const Vector<WritingTools::Context>&);
 

--- a/Source/WebCore/page/writing-tools/WritingToolsController.h
+++ b/Source/WebCore/page/writing-tools/WritingToolsController.h
@@ -32,6 +32,7 @@
 #import "WritingToolsTypes.h"
 #import <wtf/CheckedPtr.h>
 #import <wtf/TZoneMalloc.h>
+#import <wtf/WeakHashSet.h>
 #import <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -56,7 +57,7 @@ class WritingToolsController final : public CanMakeWeakPtr<WritingToolsControlle
 public:
     explicit WritingToolsController(Page&);
 
-    void willBeginWritingToolsSession(const std::optional<WritingTools::Session>&, CompletionHandler<void(const Vector<WritingTools::Context>&)>&&);
+    void willBeginWritingToolsSession(const std::optional<WritingTools::Session>&, WeakHashSet<Node, WeakPtrImplWithEventTargetData>&&, CompletionHandler<void(const Vector<WritingTools::Context>&)>&&);
 
     void didBeginWritingToolsSession(const WritingTools::Session&, const Vector<WritingTools::Context>&);
 
@@ -223,6 +224,7 @@ private:
 
     WeakPtr<Page> m_page;
     std::unique_ptr<State> m_state;
+    WeakHashSet<Node, WeakPtrImplWithEventTargetData> m_clientPreservedNodes;
 };
 
 } // namespace WebKit

--- a/Source/WebCore/page/writing-tools/WritingToolsController.mm
+++ b/Source/WebCore/page/writing-tools/WritingToolsController.mm
@@ -216,9 +216,11 @@ WritingToolsController::WritingToolsController(Page& page)
 
 #pragma mark - Delegate methods.
 
-void WritingToolsController::willBeginWritingToolsSession(const std::optional<WritingTools::Session>& session, CompletionHandler<void(const Vector<WritingTools::Context>&)>&& completionHandler)
+void WritingToolsController::willBeginWritingToolsSession(const std::optional<WritingTools::Session>& session, WeakHashSet<Node, WeakPtrImplWithEventTargetData>&& preservedNodes, CompletionHandler<void(const Vector<WritingTools::Context>&)>&& completionHandler)
 {
     RELEASE_LOG(WritingTools, "WritingToolsController::willBeginWritingToolsSession (%s)", session ? session->identifier.toString().utf8().data() : "");
+
+    m_clientPreservedNodes = WTF::move(preservedNodes);
 
     RefPtr document = this->document();
     if (!document) {
@@ -260,7 +262,7 @@ void WritingToolsController::willBeginWritingToolsSession(const std::optional<Wr
 
     auto selectedTextRange = document->selection().selection().firstRange();
 
-    auto attributedStringFromRange = editingAttributedString(*contextRange, allIncludedElements);
+    auto attributedStringFromRange = editingAttributedString(*contextRange, allIncludedElements, m_clientPreservedNodes);
     auto selectedTextCharacterRange = selectedTextRange ? characterRange(*contextRange, *selectedTextRange) : CharacterRange { };
 
     if (attributedStringFromRange.string.isEmpty())
@@ -556,6 +558,7 @@ void WritingToolsController::removeCompositionClearStateDeferralReason()
 
     state = nullptr;
     m_state = nullptr;
+    m_clientPreservedNodes = { };
 }
 
 void WritingToolsController::intelligenceTextAnimationsDidComplete()
@@ -1003,6 +1006,7 @@ template<>
 void WritingToolsController::didEndWritingToolsSession<WritingTools::Session::Type::Proofreading>(bool)
 {
     m_state = nullptr;
+    m_clientPreservedNodes = { };
 }
 
 template<>
@@ -1055,6 +1059,7 @@ void WritingToolsController::didEndWritingToolsSession(const WritingTools::Sessi
     // FIXME: Remove this branch once all composition types use the new effects system.
     if (session.type == WritingTools::Session::Type::Composition && session.compositionType == WritingTools::Session::CompositionType::SmartReply) {
         m_state = nullptr;
+        m_clientPreservedNodes = { };
         return;
     }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -2510,6 +2510,13 @@ static _WKSelectionAttributes NODELETE selectionAttributes(const WebKit::EditorS
 #endif
 }
 
+- (void)_clearWritingToolsPreservedNodes
+{
+#if ENABLE(WRITING_TOOLS)
+    _writingToolsPreservedNodes = nil;
+#endif
+}
+
 #pragma mark - WTWritingToolsDelegate conformance
 
 - (CocoaWritingToolsResultOptions)allowedWritingToolsResultOptions
@@ -2526,6 +2533,20 @@ static _WKSelectionAttributes NODELETE selectionAttributes(const WebKit::EditorS
     return WebKit::convertToCocoaWritingToolsBehavior(_page->writingToolsBehavior());
 }
 
+static std::optional<WebCore::JSHandleIdentifier> jsHandleIdentifierInFrame(const WebKit::WebFrameProxy& frame, _WKJSHandle *nodeHandle)
+{
+    if (!nodeHandle)
+        return std::nullopt;
+
+    auto handleInfo = nodeHandle->_ref->info();
+    if (RefPtr handleFrame = WebKit::WebFrameProxy::webFrame(handleInfo.frameInfo.frameID)) {
+        if (handleFrame->process().coreProcessIdentifier() == frame.process().coreProcessIdentifier())
+            return handleInfo.identifier;
+    }
+
+    return std::nullopt;
+}
+
 - (void)willBeginWritingToolsSession:(WTSession *)session forProofreadingReview:(BOOL)proofreadingReview requestContexts:(void (^)(NSArray<WTContext *> *))completion
 {
     auto webSession = WebKit::convertToWebSession(session);
@@ -2539,7 +2560,15 @@ static _WKSelectionAttributes NODELETE selectionAttributes(const WebKit::EditorS
     if (proofreadingReview && webSession)
         webSession->isForProofreadingReview = WebCore::WritingTools::IsForProofreadingReview::Yes;
 
-    _page->willBeginWritingToolsSession(webSession, [completion = makeBlockPtr(completion)](const auto& contextData) {
+    Vector<WebCore::JSHandleIdentifier> preservedNodeIdentifiers;
+    if (RefPtr mainFrame = _page->mainFrame()) {
+        for (_WKJSHandle *handle in _writingToolsPreservedNodes.get()) {
+            if (auto identifier = jsHandleIdentifierInFrame(*mainFrame, handle))
+                preservedNodeIdentifiers.append(WTF::move(*identifier));
+        }
+    }
+
+    _page->willBeginWritingToolsSession(webSession, WTF::move(preservedNodeIdentifiers), [completion = makeBlockPtr(completion)](const auto& contextData) {
         auto contexts = [NSMutableArray arrayWithCapacity:contextData.size()];
         for (auto& context : contextData) {
             auto platformContext = WebKit::convertToPlatformContext(context);
@@ -7216,6 +7245,15 @@ static RetainPtr<_WKTextExtractionResult> createEmptyTextExtractionResult()
     });
 }
 
+- (void)_addWritingToolsPreservedNodes:(NSArray<_WKJSHandle *> *)nodes
+{
+#if ENABLE(WRITING_TOOLS)
+    if (!_writingToolsPreservedNodes)
+        _writingToolsPreservedNodes = adoptNS([[NSMutableArray alloc] initWithCapacity:nodes.count]);
+    [_writingToolsPreservedNodes addObjectsFromArray:nodes];
+#endif
+}
+
 @end
 
 @implementation WKWebView (WKDeprecated)
@@ -7244,20 +7282,6 @@ static RetainPtr<_WKTextExtractionResult> createEmptyTextExtractionResult()
 @implementation WKWebView (WKTextExtraction)
 
 #if USE(APPLE_INTERNAL_SDK) || (!PLATFORM(WATCHOS) && !PLATFORM(APPLETV))
-
-static std::optional<WebCore::JSHandleIdentifier> jsHandleIdentifierInFrame(const WebKit::WebFrameProxy& frame, _WKJSHandle *nodeHandle)
-{
-    if (!nodeHandle)
-        return std::nullopt;
-
-    auto handleInfo = nodeHandle->_ref->info();
-    if (RefPtr handleFrame = WebKit::WebFrameProxy::webFrame(handleInfo.frameInfo.frameID)) {
-        if (handleFrame->process().coreProcessIdentifier() == frame.process().coreProcessIdentifier())
-            return handleInfo.identifier;
-    }
-
-    return std::nullopt;
-}
 
 static Vector<WebCore::JSHandleIdentifier> extractHandleIdentifiersOfNodesToSkip(Ref<WebKit::WebFrameProxy>&& frame, _WKTextExtractionConfiguration *configuration)
 {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -189,6 +189,7 @@ enum class PreferSolidColorHardPocketReason : uint8_t {
 @class WKTextExtractionItem;
 @class WKWebViewContentProviderRegistry;
 @class _WKFrameHandle;
+@class _WKJSHandle;
 @class _WKWarningView;
 
 #if ENABLE(WEB_AUTHN)
@@ -353,6 +354,8 @@ struct PerWebProcessState {
     NSUInteger _partialIntelligenceTextAnimationCount;
     BOOL _writingToolsTextReplacementsFinished;
     BOOL _activeWritingToolsSessionIsForProofreadingReview;
+
+    RetainPtr<NSMutableArray<_WKJSHandle *>> _writingToolsPreservedNodes;
 #endif
 
 #if ENABLE(SCREEN_TIME)
@@ -600,6 +603,8 @@ struct PerWebProcessState {
 
 - (void)_addTextAnimationForAnimationID:(NSUUID *)uuid withData:(const WebCore::TextAnimationData&)styleData;
 - (void)_removeTextAnimationForAnimationID:(NSUUID *)uuid;
+
+- (void)_clearWritingToolsPreservedNodes;
 
 #endif
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -666,6 +666,8 @@ typedef NS_OPTIONS(NSUInteger, _WKWebViewDataType) {
 - (void)_extractDebugTextWithConfiguration:(_WKTextExtractionConfiguration *)configuration completionHandler:(WK_SWIFT_UI_ACTOR void(^)(_WKTextExtractionResult *))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) NS_SWIFT_NAME(_extractDebugText(with:completionHandler:));
 - (void)_performInteraction:(_WKTextExtractionInteraction *)interaction completionHandler:(WK_SWIFT_UI_ACTOR void(^)(_WKTextExtractionInteractionResult *))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) NS_SWIFT_NAME(_performInteraction(_:completionHandler:));
 
+- (void)_addWritingToolsPreservedNodes:(NSArray<_WKJSHandle *> *)nodes WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
 #if !TARGET_OS_TV && !TARGET_OS_WATCH
 @property (nonatomic, strong, setter=_setWebViewInformation:) id _webViewInformation WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 #endif

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -880,6 +880,10 @@ static WebCore::Color scrollViewBackgroundColor(WKWebView *webView, AllowPageBac
     [self _clearTextExtractionFilterCache];
 #endif
 
+#if ENABLE(WRITING_TOOLS)
+    [self _clearWritingToolsPreservedNodes];
+#endif
+
     if (_gestureController)
         protect(_gestureController)->disconnectFromProcess();
 

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -1436,9 +1436,9 @@ WebCore::WritingTools::Behavior WebPageProxy::writingToolsBehavior() const
     return WebCore::WritingTools::Behavior::Limited;
 }
 
-void WebPageProxy::willBeginWritingToolsSession(const std::optional<WebCore::WritingTools::Session>& session, CompletionHandler<void(const Vector<WebCore::WritingTools::Context>&)>&& completionHandler)
+void WebPageProxy::willBeginWritingToolsSession(const std::optional<WebCore::WritingTools::Session>& session, Vector<WebCore::JSHandleIdentifier>&& preservedNodeIdentifiers, CompletionHandler<void(const Vector<WebCore::WritingTools::Context>&)>&& completionHandler)
 {
-    protect(legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebPage::WillBeginWritingToolsSession(session), WTF::move(completionHandler), webPageIDInMainFrameProcess());
+    protect(legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebPage::WillBeginWritingToolsSession(session, WTF::move(preservedNodeIdentifiers)), WTF::move(completionHandler), webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::didBeginWritingToolsSession(const WebCore::WritingTools::Session& session, const Vector<WebCore::WritingTools::Context>& contexts)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -298,6 +298,7 @@ struct FrameIdentifierType;
 struct FrameTreeSyncSerializationData;
 struct GrammarDetail;
 struct HTMLModelElementCamera;
+struct JSHandleIdentifierType;
 struct ImageBufferParameters;
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
 struct InheritedFrameState;
@@ -416,6 +417,7 @@ using FloatBoxExtent = RectEdges<float>;
 using FrameIdentifier = ObjectIdentifier<FrameIdentifierType>;
 using IntDegrees = int32_t;
 using HTMLMediaElementIdentifier = ObjectIdentifier<MediaPlayerClientIdentifierType>;
+using JSHandleIdentifier = ProcessQualified<ObjectIdentifier<JSHandleIdentifierType>>;
 using LayerHostingContextIdentifier = ObjectIdentifier<LayerHostingContextIdentifierType>;
 using MediaControlsContextMenuItemID = uint64_t;
 using MediaKeySystemRequestIdentifier = ObjectIdentifier<MediaKeySystemRequestIdentifierType>;
@@ -2770,7 +2772,7 @@ public:
 
     WebCore::WritingTools::Behavior NODELETE writingToolsBehavior() const;
 
-    void willBeginWritingToolsSession(const std::optional<WebCore::WritingTools::Session>&, CompletionHandler<void(const Vector<WebCore::WritingTools::Context>&)>&&);
+    void willBeginWritingToolsSession(const std::optional<WebCore::WritingTools::Session>&, Vector<WebCore::JSHandleIdentifier>&& preservedNodeIdentifiers, CompletionHandler<void(const Vector<WebCore::WritingTools::Context>&)>&&);
 
     void didBeginWritingToolsSession(const WebCore::WritingTools::Session&, const Vector<WebCore::WritingTools::Context>&);
 

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -385,6 +385,10 @@ void PageClientImpl::didCommitLoadForMainFrame(const String& mimeType, bool useC
     [webView _clearTextExtractionFilterCache];
 #endif
 
+#if ENABLE(WRITING_TOOLS)
+    [webView _clearWritingToolsPreservedNodes];
+#endif
+
 #if ENABLE(SYSTEM_TEXT_EXTRACTION)
     if (protect(*[webView _page])->preferences().systemTextExtractionEnabled())
         [webView _addTextExtractionAnnotation];

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -323,6 +323,10 @@ void PageClientImpl::didCommitLoadForMainFrame(const String&, bool)
     [webView() _clearTextExtractionFilterCache];
 #endif
 
+#if ENABLE(WRITING_TOOLS)
+    [webView() _clearWritingToolsPreservedNodes];
+#endif
+
 #if ENABLE(SYSTEM_TEXT_EXTRACTION)
     if (impl->page().preferences().systemTextExtractionEnabled())
         [webView() _addTextExtractionAnnotation];

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -1470,6 +1470,10 @@ void WebViewImpl::handleProcessSwapOrExit()
     hideDOMPasteMenuWithResult(WebCore::DOMPasteAccessResponse::DeniedForGesture);
 
     [m_view.get() _updateFixedContainerEdges:FixedContainerEdges { }];
+
+#if ENABLE(WRITING_TOOLS)
+    [m_view.get() _clearWritingToolsPreservedNodes];
+#endif
 }
 
 void WebViewImpl::processWillSwap()

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -106,6 +106,7 @@
 #import <WebCore/HitTestResult.h>
 #import <WebCore/ImageOverlay.h>
 #import <WebCore/ImageUtilities.h>
+#import <WebCore/JSNode.h>
 #import <WebCore/LegacyWebArchive.h>
 #import <WebCore/LocalFrameInlines.h>
 #import <WebCore/LocalFrameView.h>
@@ -1276,9 +1277,19 @@ void WebPage::setDisplayCaptureEnvironment(const String& environment)
 #endif
 
 #if ENABLE(WRITING_TOOLS)
-void WebPage::willBeginWritingToolsSession(const std::optional<WebCore::WritingTools::Session>& session, CompletionHandler<void(const Vector<WebCore::WritingTools::Context>&)>&& completionHandler)
+void WebPage::willBeginWritingToolsSession(const std::optional<WebCore::WritingTools::Session>& session, Vector<WebCore::JSHandleIdentifier>&& preservedNodeIdentifiers, CompletionHandler<void(const Vector<WebCore::WritingTools::Context>&)>&& completionHandler)
 {
-    protect(corePage())->willBeginWritingToolsSession(session, WTF::move(completionHandler));
+    WeakHashSet<Node, WeakPtrImplWithEventTargetData> preservedNodes;
+    for (auto& identifier : preservedNodeIdentifiers) {
+        auto* object = WebKitJSHandle::objectForIdentifier(identifier);
+        if (!object)
+            continue;
+
+        if (auto* jsNode = JSC::jsDynamicCast<JSNode*>(object))
+            preservedNodes.add(protect(jsNode->wrapped()));
+    }
+
+    protect(corePage())->willBeginWritingToolsSession(session, WTF::move(preservedNodes), WTF::move(completionHandler));
 }
 
 void WebPage::didBeginWritingToolsSession(const WebCore::WritingTools::Session& session, const Vector<WebCore::WritingTools::Context>& contexts)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -66,6 +66,7 @@
 #include <WebCore/UserContentTypes.h>
 #include <WebCore/UserScriptTypes.h>
 #include <WebCore/WebCoreKeyboardUIMode.h>
+#include <WebCore/WebKitJSHandle.h>
 #include <memory>
 #include <pal/HysteresisActivity.h>
 #include <wtf/CallbackAggregator.h>
@@ -2680,7 +2681,7 @@ private:
     void frameWasFocusedInAnotherProcess(std::optional<WebCore::FrameIdentifier>&&);
 
 #if ENABLE(WRITING_TOOLS)
-    void willBeginWritingToolsSession(const std::optional<WebCore::WritingTools::Session>&, CompletionHandler<void(const Vector<WebCore::WritingTools::Context>&)>&&);
+    void willBeginWritingToolsSession(const std::optional<WebCore::WritingTools::Session>&, Vector<WebCore::JSHandleIdentifier>&& preservedNodeIdentifiers, CompletionHandler<void(const Vector<WebCore::WritingTools::Context>&)>&&);
 
     void didBeginWritingToolsSession(const WebCore::WritingTools::Session&, const Vector<WebCore::WritingTools::Context>&);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -878,7 +878,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
 #endif
 
 #if ENABLE(WRITING_TOOLS)
-    WillBeginWritingToolsSession(std::optional<WebCore::WritingTools::Session> session) -> (Vector<WebCore::WritingTools::Context> contexts)
+    WillBeginWritingToolsSession(std::optional<WebCore::WritingTools::Session> session, Vector<WebCore::JSHandleIdentifier> preservedNodeIdentifiers) -> (Vector<WebCore::WritingTools::Context> contexts)
 
     DidBeginWritingToolsSession(struct WebCore::WritingTools::Session session, Vector<WebCore::WritingTools::Context> contexts)
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
@@ -46,11 +46,15 @@
 #import <WebCore/ColorCocoa.h>
 #import <WebCore/FloatRect.h>
 #import <WebCore/IntRect.h>
+#import <WebKit/WKContentWorldPrivate.h>
+#import <WebKit/WKJSHandle.h>
 #import <WebKit/WKMenuItemIdentifiersPrivate.h>
 #import <WebKit/WKWebViewConfigurationPrivate.h>
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/WKWebViewPrivateForTesting.h>
 #import <WebKit/WebKit.h>
+#import <WebKit/_WKContentWorldConfiguration.h>
+#import <WebKit/_WKJSHandle.h>
 #import <WebKit/_WKProcessPoolConfiguration.h>
 #import <WebKit/_WKTextPreview.h>
 #import <pal/spi/cocoa/WritingToolsSPI.h>
@@ -4529,6 +4533,57 @@ TEST(WritingToolsContextGeneration, ContextWithStyledContentChildrenInList)
     } };
 
     runContextGenerationTest(html, expected);
+}
+
+TEST(WritingTools, WritingToolsPreservedNodesFromClient)
+{
+    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
+
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p>Hello world</p><div id='myPreservedNode'>Do not rewrite</div><p>Goodbye</p></body>"]);
+    [webView focusDocumentBodyAndSelectAll];
+
+    RetainPtr worldConfiguration = adoptNS([_WKContentWorldConfiguration new]);
+    [worldConfiguration setJSHandleCreationEnabled:YES];
+    RetainPtr world = [WKContentWorld _worldWithConfiguration:worldConfiguration.get()];
+
+    RetainPtr handle = [webView querySelector:@"#myPreservedNode" frame:nil world:world.get()];
+    EXPECT_NOT_NULL(handle);
+
+    [webView _addWritingToolsPreservedNodes:@[ handle.get() ]];
+
+    __block bool finished = false;
+    [[webView writingToolsDelegate] willBeginWritingToolsSession:session.get() requestContexts:^(NSArray<WTContext *> *contexts) {
+        EXPECT_EQ(1UL, contexts.count);
+
+        EXPECT_WK_STREQ(@"Hello world\n\nDo not rewrite\nGoodbye", contexts.firstObject.attributedText.string);
+
+        __block size_t i = 0;
+        [contexts.firstObject.attributedText enumerateAttribute:WTWritingToolsPreservedAttributeName inRange:NSMakeRange(0, [contexts.firstObject.attributedText length]) options:0 usingBlock:^(id value, NSRange attributeRange, BOOL *stop) {
+            switch (i) {
+            case 0: // "Hello world".
+                EXPECT_NULL(value);
+                break;
+
+            case 1: // "Do not rewrite".
+                EXPECT_EQ([value integerValue], 1);
+                break;
+
+            case 2: // "Goodbye".
+                EXPECT_NULL(value);
+                break;
+
+            default:
+                ASSERT_NOT_REACHED();
+                break;
+            }
+
+            ++i;
+        }];
+
+        finished = true;
+    }];
+
+    TestWebKitAPI::Util::run(&finished);
 }
 
 #endif


### PR DESCRIPTION
#### 5523209676791efe2f6d5b5ad4aa926063d6fc20
<pre>
[Writing Tools] Add a way for clients to preserve specific DOM nodes when invoking writing tools
<a href="https://bugs.webkit.org/show_bug.cgi?id=310232">https://bugs.webkit.org/show_bug.cgi?id=310232</a>
<a href="https://rdar.apple.com/166250361">rdar://166250361</a>

Reviewed by Abrar Rahman Protyasha and Aditya Keerthi.

Add a way for clients to add nodes that should be preserved when invoking Writing Tools, by
specifying a list of UI-side `_WKJSHandle`s. This list is plumbed through the UI process into
WebCore, where it&apos;s mapped to a set of `Node`s and then consulted in
`elementQualifiesForWritingToolsPreservation`.

Test: WritingTools.WritingToolsPreservedNodesFromClient

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
* Source/WebCore/editing/cocoa/EditingHTMLConverter.h:
* Source/WebCore/editing/cocoa/EditingHTMLConverter.mm:
(WebCore::elementQualifiesForWritingToolsPreservation):
(WebCore::hasAncestorQualifyingForWritingToolsPreservation):
(WebCore::updateAttributes):
(WebCore::editingAttributedStringInternal):
(WebCore::editingAttributedString):

Add a workaround to fix the actual bug for now without any client adoption (by checking for a node
with `id=&apos;AppleMailSignature&apos;`, only when the web view is made `_editable`), with a FIXME to undo
this hack once Mail adopts `-_addWritingToolsPreservedNodes:`.

* Source/WebCore/page/Page.cpp:
(WebCore::Page::willBeginWritingToolsSession):
* Source/WebCore/page/Page.h:
* Source/WebCore/page/writing-tools/WritingToolsController.h:
* Source/WebCore/page/writing-tools/WritingToolsController.mm:
(WebCore::WritingToolsController::willBeginWritingToolsSession):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _clearWritingToolsPreservedNodes]):
(jsHandleIdentifierInFrame):
(-[WKWebView willBeginWritingToolsSession:forProofreadingReview:requestContexts:]):
(-[WKWebView _addWritingToolsPreservedNodes:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _processWillSwapOrDidExit]):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::willBeginWritingToolsSession):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::didCommitLoadForMainFrame):
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::didCommitLoadForMainFrame):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::handleProcessSwapOrExit):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::willBeginWritingToolsSession):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm:
((WritingTools, WritingToolsPreservedNodesFromClient)):

Add an API test to exercise the new method.

Canonical link: <a href="https://commits.webkit.org/309595@main">https://commits.webkit.org/309595@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8d16cb60a80c9a69395595a9dd05c7feb85d28c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151157 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23919 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17490 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159886 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/104593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2d03e91d-337e-4c19-a04e-1ff6e25e75fd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153030 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24350 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24149 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116701 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/104593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5b4805b1-9520-493c-92a7-6c136617cf32) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154117 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18823 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135624 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97422 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a9d4df11-e11f-4656-b7dd-f18acdb59b05) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17916 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15865 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7731 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127534 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13541 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162358 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5483 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15112 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124711 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23721 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19915 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124899 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33877 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23711 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135338 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80155 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19960 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12103 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23321 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87615 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23033 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23185 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23087 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->