### PR TITLE
Draw non-sRGB gradients via CGGradient using sampling

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8615,3 +8615,6 @@ webgl/2.0.y/conformance/textures/image_bitmap_from_image_bitmap/tex-2d-rgba-rgba
 webkit.org/b/311207 imported/w3c/web-platform-tests/workers/semantics/structured-clone/shared.html [ Pass Failure ]
 
 webkit.org/b/311222 [ Release ] imported/w3c/web-platform-tests/navigation-api/navigate-event/signal-abort-window-stop-after-intercept.html [ Skip ]
+
+# rdar://173890240 ([iOS] imported/w3c/web-platform-tests/css/css-images/gradient/gradient-analogous-missing-components-003.html has 2 component pixel difference)
+imported/w3c/web-platform-tests/css/css-images/gradient/gradient-analogous-missing-components-003.html [ Pass ImageOnlyFailure ]

--- a/Source/WebCore/Configurations/AllowedSPI-legacy.toml
+++ b/Source/WebCore/Configurations/AllowedSPI-legacy.toml
@@ -582,7 +582,6 @@ symbols = [
     "CGSNextRect",
     "CGSRegionEnumerator",
     "CGSReleaseRegionEnumerator",
-    "CGShadingCreateConic",
     "CGStyleCreateColorMatrix",
     "CGStyleCreateFocusRingWithColor",
     "CGStyleCreateGaussianBlur",

--- a/Source/WebCore/PAL/pal/spi/cg/CoreGraphicsSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cg/CoreGraphicsSPI.h
@@ -413,7 +413,6 @@ void CGContextSetStyle(CGContextRef, CGStyleRef);
 void CGContextDrawConicGradient(CGContextRef, CGGradientRef, CGPoint center, CGFloat angle);
 void CGPathAddUnevenCornersRoundedRect(CGMutablePathRef, const CGAffineTransform *, CGRect, const CGSize corners[4]);
 bool CGFontRenderingGetFontSmoothingDisabled(void);
-CGShadingRef CGShadingCreateConic(CGColorSpaceRef, CGPoint center, CGFloat angle, CGFunctionRef);
 
 CGGradientRef CGGradientCreateWithColorComponentsAndOptions(CGColorSpaceRef, const CGFloat*, const CGFloat*, size_t, CFDictionaryRef);
 CGGradientRef CGGradientCreateWithColorsAndOptions(CGColorSpaceRef, CFArrayRef, const CGFloat*, CFDictionaryRef);

--- a/Source/WebCore/platform/graphics/GradientColorStop.h
+++ b/Source/WebCore/platform/graphics/GradientColorStop.h
@@ -35,6 +35,8 @@ namespace WebCore {
 struct GradientColorStop {
     float offset { 0 };
     Color color;
+
+    friend bool operator==(const GradientColorStop&, const GradientColorStop&) = default;
 };
 
 inline void add(Hasher& hasher, const GradientColorStop& stop)

--- a/Source/WebCore/platform/graphics/SampledGradientBuilder.h
+++ b/Source/WebCore/platform/graphics/SampledGradientBuilder.h
@@ -1,0 +1,342 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ColorComponents.h"
+#include "ColorConversion.h"
+#include "ColorInterpolation.h"
+#include "ColorInterpolationMethod.h"
+#include "GradientColorStops.h"
+#include <wtf/Vector.h>
+
+namespace WebCore {
+
+struct SampledGradientStops {
+    Vector<float> locations;
+    Vector<float> colorComponents; // 4 components (RGBA) per location.
+};
+
+struct StopSample {
+    float offset;
+    ColorComponents<float, 4> color;
+};
+
+// Replace NaN ('none') components in `color` with the corresponding component
+// from `neighbor`, per CSS "missing component" replacement rules.
+static ColorComponents<float, 4> resolveNoneComponents(ColorComponents<float, 4> color, const ColorComponents<float, 4>& neighbor)
+{
+    return mapColorComponents([](float c, float n) {
+        return std::isnan(c) ? (std::isnan(n) ? 0.0f : n) : c;
+    }, color, neighbor);
+}
+
+struct SamplingData;
+
+using EvaluateCallback = ColorComponents<float, 4> (*)(const SamplingData&, float offset);
+
+struct SamplingData {
+    ColorInterpolationMethod colorInterpolationMethod;
+    bool firstStopIsSynthetic { false };
+    bool lastStopIsSynthetic { false };
+    Vector<StopSample> stopsIS; // stops in InterpolationSpace
+
+    void coarseSampleStops(EvaluateCallback evaluateIS);
+    template<typename OutputColorType>
+    ColorComponents<float, 4> toColorTypeResolvingNone(size_t index, size_t neighborIndex) const;
+};
+
+void SamplingData::coarseSampleStops(EvaluateCallback evaluateIS)
+{
+    // Coarse sampling density: equivalent of every 19 pixels of a 2048-wide LUT.
+    static constexpr float sampleStep = 19.0f / 2048.0f;
+
+    Vector<StopSample> coarseSamples;
+
+    // Iterate stop pairs and subdivide each segment. Hard stops (consecutive
+    // stops at the same offset) naturally produce zero interior samples, so the
+    // discontinuity is preserved as an exact boundary.
+    for (size_t i = 0; i + 1 < stopsIS.size(); ++i) {
+        float segStart = stopsIS[i].offset;
+        float segEnd = stopsIS[i + 1].offset;
+
+        coarseSamples.append({ segStart, resolveNoneComponents(stopsIS[i].color, stopsIS[i + 1].color) });
+
+        // Subdivide the segment interior.
+        float segLength = segEnd - segStart;
+        if (segLength <= 0)
+            continue;
+
+        int subdivisions = std::max(1, static_cast<int>(std::ceil(segLength / sampleStep)));
+        for (int j = 1; j < subdivisions; ++j) {
+            float offset = segStart + segLength * j / subdivisions;
+            coarseSamples.append({ offset, evaluateIS(*this, offset) });
+        }
+    }
+
+    // Emit the final endpoint.
+    if (stopsIS.size() >= 2)
+        coarseSamples.append({ stopsIS.last().offset, resolveNoneComponents(stopsIS.last().color, stopsIS[stopsIS.size() - 2].color) });
+    else if (!stopsIS.isEmpty())
+        coarseSamples.append({ stopsIS.last().offset, stopsIS.last().color });
+
+    stopsIS = WTF::move(coarseSamples);
+}
+
+template<typename OutputColorType>
+ColorComponents<float, 4> SamplingData::toColorTypeResolvingNone(size_t index, size_t neighborIndex) const
+{
+    auto resolved = resolveNoneComponents(stopsIS[index].color, stopsIS[neighborIndex].color);
+    return WTF::switchOn(colorInterpolationMethod.colorSpace,
+        [&]<typename MethodColorSpace>(const MethodColorSpace&)
+        {
+            return asColorComponents(WebCore::convertColor<OutputColorType>(
+            makeFromComponents<typename MethodColorSpace::ColorType>(resolved)).resolved());
+        });
+}
+
+// Interpolate between stops in the interpolation color space and return the result
+// still in that space (no conversion to the output color space).
+template<typename InterpolationSpace, AlphaPremultiplication alphaPremultiplication>
+static ColorComponents<float, 4> evaluateColorIS(const SamplingData& data, float offset)
+{
+    using InterpolationSpaceColorType = typename InterpolationSpace::ColorType;
+
+    // 1. Find stops that bound the requested offset.
+    auto [stop0, stop1] = [&] {
+        for (size_t stop = 1; stop < data.stopsIS.size(); ++stop) {
+            if (offset <= data.stopsIS[stop].offset)
+                return std::tie(data.stopsIS[stop - 1], data.stopsIS[stop]);
+        }
+        RELEASE_ASSERT_NOT_REACHED();
+    }();
+
+    // 2. Compute percentage offset between the two stops.
+    float t = (stop1.offset == stop0.offset) ? 0.0f : (offset - stop0.offset) / (stop1.offset - stop0.offset);
+
+    // 3. Interpolate the two stops' colors by the computed offset.
+    // Synthetic color stops are added to extend the author-provided gradient out to 0 and 1
+    // with a solid color, if necessary. These need special handling because `longer hue` gradients
+    // would otherwise rotate through 360° of hue in these segments.
+    auto interpolatedColor = [&]() {
+        if (stop0.offset == 0.0f && data.firstStopIsSynthetic)
+            return makeFromComponents<InterpolationSpaceColorType>(stop0.color);
+
+        if (stop1.offset == 1.0f && data.lastStopIsSynthetic)
+            return makeFromComponents<InterpolationSpaceColorType>(stop1.color);
+
+        return interpolateColorComponents<alphaPremultiplication>(
+            std::get<InterpolationSpace>(data.colorInterpolationMethod.colorSpace),
+            makeFromComponents<InterpolationSpaceColorType>(stop0.color), 1.0f - t,
+            makeFromComponents<InterpolationSpaceColorType>(stop1.color), t);
+    }();
+
+    return asColorComponents(interpolatedColor.unresolved());
+}
+
+// Linearly interpolate between stops in the interpolation color space (plain
+// component-wise lerp, no hue interpolation rules) and convert to the output
+// color space. Used by bisection after coarse sampling, where the hue
+// interpolation has already been baked into the coarse IS samples.
+template<typename OutputColorType, typename InterpolationSpace>
+static ColorComponents<float, 4> evaluateLinearOS(const SamplingData& data, float offset)
+{
+    using InterpolationSpaceColorType = typename InterpolationSpace::ColorType;
+
+    // 1. Find stops that bound the requested offset.
+    auto [stop0, stop1] = [&] {
+        for (size_t stop = 1; stop < data.stopsIS.size(); ++stop) {
+            if (offset <= data.stopsIS[stop].offset)
+                return std::tie(data.stopsIS[stop - 1], data.stopsIS[stop]);
+        }
+        RELEASE_ASSERT_NOT_REACHED();
+    }();
+
+    // 2. Compute percentage offset between the two stops.
+    float t = (stop1.offset == stop0.offset) ? 0.0f : (offset - stop0.offset) / (stop1.offset - stop0.offset);
+
+    // 3. Plain linear interpolation of IS components (hue already resolved).
+    // Handle NaN ('none') components: replace with the other stop's value per CSS spec.
+    auto lerped = mapColorComponents([t](float c0, float c1) {
+        if (std::isnan(c0))
+            return c1;
+        if (std::isnan(c1))
+            return c0;
+        return c0 + t * (c1 - c0);
+    }, stop0.color, stop1.color);
+
+    // 4. Convert to the output color space.
+    return asColorComponents(convertColor<OutputColorType>(makeFromComponents<InterpolationSpaceColorType>(lerped)).resolved());
+}
+
+static void bisectAndCollectStops(
+    EvaluateCallback evaluate, const SamplingData& data,
+    float offset0, ColorComponents<float, 4> color0,
+    float offset1, ColorComponents<float, 4> color1,
+    Vector<float>& locations, Vector<float>& components)
+{
+    // Stop recursing when the segment is narrower than one step of a 2048-wide LUT.
+    static constexpr float minimumSegmentWidth = 1.0f / 2048.0f;
+    if (offset1 - offset0 < minimumSegmentWidth)
+        return;
+
+    float midOffset = (offset0 + offset1) * 0.5f;
+    auto colorMid = evaluate(data, midOffset);
+
+    // Compute the linearly-interpolated color at the midpoint and measure the error.
+    auto colorLerp = mapColorComponents([](float c0, float c1) { return c0 + 0.5f * (c1 - c0); }, color0, color1); // NOLINT
+    auto absDiff = mapColorComponents([](float a, float b) { return std::abs(a - b); }, colorMid, colorLerp); // NOLINT
+    float maxDiff = std::max({ absDiff[0], absDiff[1], absDiff[2], absDiff[3] });
+
+    static constexpr float tolerance = 8.0f / 255.0f;
+    if (maxDiff <= tolerance)
+        return;
+
+    // The segment is not locally linear: recurse into both halves, then insert a stop
+    // at the midpoint so the consumer's linear interpolation passes through the correct color.
+    bisectAndCollectStops(evaluate, data, offset0, color0, midOffset, colorMid, locations, components);
+
+    locations.append(midOffset);
+    components.append(std::span(colorMid.components));
+
+    bisectAndCollectStops(evaluate, data, midOffset, colorMid, offset1, color1, locations, components);
+}
+
+// Build sampling data with stops converted to the interpolation color space.
+static SamplingData makeSamplingData(ColorInterpolationMethod colorInterpolationMethod, const GradientColorStops::StopVector& stops)
+{
+    auto convertColorToColorInterpolationSpace = [&](const Color& color) -> ColorComponents<float, 4> {
+        return WTF::switchOn(colorInterpolationMethod.colorSpace,
+            [&]<typename MethodColorSpace>(const MethodColorSpace&) -> ColorComponents<float, 4> {
+                using ColorType = typename MethodColorSpace::ColorType;
+                return asColorComponents(color.template toColorTypeLossyCarryingForwardMissing<ColorType>().unresolved());
+            });
+    };
+
+    auto totalNumberOfStops = stops.size();
+    bool hasZero = false;
+    bool hasOne = false;
+
+    for (const auto& stop : stops) {
+        if (stop.offset == 0) // NOLINT
+            hasZero = true;
+        else if (stop.offset == 1)
+            hasOne = true;
+    }
+
+    if (!hasZero)
+        totalNumberOfStops++;
+    if (!hasOne)
+        totalNumberOfStops++;
+
+    Vector<StopSample> stopsIS;
+    stopsIS.reserveInitialCapacity(totalNumberOfStops);
+
+    if (!hasZero)
+        stopsIS.append({ 0.0f, { 0.0f, 0.0f, 0.0f, 0.0f } });
+
+    // Clamp stop offsets to [0, 1], mapping NaN to 0. Stops with NaN or
+    // infinite offsets can arrive from CSS calc() expressions like
+    // calc(Infinity * -1%) and would otherwise cause infinite recursion
+    // in the adaptive bisection.
+    auto clampOffset = [](float offset) {
+        return std::isnan(offset) ? 0.0f : std::clamp(offset, 0.0f, 1.0f);
+    };
+
+    stopsIS.appendContainerWithMapping(stops, [&](const auto& stop) {
+        return StopSample { clampOffset(stop.offset), convertColorToColorInterpolationSpace(stop.color) };
+    });
+
+    if (!hasOne)
+        stopsIS.append({ 1.0f, stopsIS.last().color });
+
+    if (!hasZero)
+        stopsIS[0].color = stopsIS[1].color;
+
+    return SamplingData { colorInterpolationMethod, !hasZero, !hasOne, WTF::move(stopsIS) };
+}
+
+template<typename OutputColorType>
+SampledGradientStops sampleGradientStops(ColorInterpolationMethod colorInterpolationMethod, const GradientColorStops::StopVector& stops)
+{
+    SamplingData data = makeSamplingData(colorInterpolationMethod, stops);
+
+    bool needsCoarseSampling = WTF::switchOn(colorInterpolationMethod.colorSpace,
+        []<typename MethodColorSpace>(const MethodColorSpace&)
+        {
+            return hasHueInterpolationMethod<MethodColorSpace>;
+        });
+    if (needsCoarseSampling) {
+        auto evaluateIS = WTF::switchOn(colorInterpolationMethod.colorSpace,
+            [&]<typename MethodColorSpace>(const MethodColorSpace&)->EvaluateCallback
+            {
+                switch (colorInterpolationMethod.alphaPremultiplication) {
+                case AlphaPremultiplication::Unpremultiplied:
+                    return &evaluateColorIS<MethodColorSpace, AlphaPremultiplication::Unpremultiplied>;
+                case AlphaPremultiplication::Premultiplied:
+                    return &evaluateColorIS<MethodColorSpace, AlphaPremultiplication::Premultiplied>;
+                }
+            });
+        data.coarseSampleStops(evaluateIS);
+    }
+
+    auto evaluateOS = WTF::switchOn(colorInterpolationMethod.colorSpace,
+        [&]<typename MethodColorSpace>(const MethodColorSpace&) -> EvaluateCallback {
+            return &evaluateLinearOS<OutputColorType, MethodColorSpace>;
+        });
+
+    Vector<float> locations;
+    Vector<float> components;
+
+    auto stopCount = data.stopsIS.size();
+
+    // Append the first coarse sample, resolving 'none' against the next stop.
+    locations.append(data.stopsIS[0].offset);
+    size_t firstNeighbor = stopCount > 1 ? 1 : 0;
+    auto firstColor = data.toColorTypeResolvingNone<OutputColorType>(0, firstNeighbor);
+    components.append(std::span(firstColor.components));
+
+    // For each coarse interval, adaptively bisect to find non-linear sub-segments,
+    // then append the right endpoint of the interval. Each emitted endpoint resolves
+    // 'none' (NaN) components against its segment neighbor per CSS spec.
+    for (size_t i = 0; i + 1 < stopCount; ++i) {
+        auto leftColor = data.toColorTypeResolvingNone<OutputColorType>(i, i + 1);
+        auto rightColor = data.toColorTypeResolvingNone<OutputColorType>(i + 1, i);
+
+        bisectAndCollectStops(evaluateOS, data,
+            data.stopsIS[i].offset, leftColor,
+            data.stopsIS[i + 1].offset, rightColor,
+            locations, components);
+
+        locations.append(data.stopsIS[i + 1].offset);
+        components.append(std::span(rightColor.components));
+    }
+
+    ASSERT(locations.size() * 4 == components.size());
+
+    return { WTF::move(locations), WTF::move(components) };
+}
+
+}

--- a/Source/WebCore/platform/graphics/cg/GradientRendererCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GradientRendererCG.cpp
@@ -27,20 +27,46 @@
 #include "GradientRendererCG.h"
 
 #include "ColorHash.h"
-#include "ColorInterpolation.h"
 #include "ColorSpaceCG.h"
 #include "GradientColorStops.h"
-#include <pal/spi/cg/CoreGraphicsSPI.h>
+#include "SampledGradientBuilder.h"
 #include <wtf/HashMap.h>
+#include <wtf/TinyLRUCache.h>
+
+namespace WTF {
+using namespace WebCore;
+
+struct SampledGradientCacheKey {
+    ColorInterpolationMethod interpolationMethod;
+    GradientColorStops::StopVector colorStops;
+
+    friend bool operator==(const SampledGradientCacheKey&, const SampledGradientCacheKey&) = default;
+};
+
+template<>
+bool TinyLRUCachePolicy<SampledGradientCacheKey, RetainPtr<CGGradientRef>>::isKeyNull(const SampledGradientCacheKey& key)
+{
+    return key.colorStops.isEmpty();
+}
+
+template<>
+RetainPtr<CGGradientRef> TinyLRUCachePolicy<SampledGradientCacheKey, RetainPtr<CGGradientRef>>::createValueForKey(const SampledGradientCacheKey& params)
+{
+    return WebCore::GradientRendererCG::createGradientBySampling(params.interpolationMethod, params.colorStops);
+}
+
+} // namespace WTF
 
 namespace WebCore {
 
+// MARK: - Constructor.
+
 GradientRendererCG::GradientRendererCG(ColorInterpolationMethod colorInterpolationMethod, const GradientColorStops& stops)
-    : m_strategy { pickStrategy(colorInterpolationMethod, stops) }
+    : m_gradient { makeGradient(colorInterpolationMethod, stops) }
 {
 }
 
-// MARK: - Strategy selection.
+// MARK: - Direct CGGradient strategy (sRGB only).
 
 static bool anyComponentIsNone(const GradientColorStops& stops)
 {
@@ -48,31 +74,25 @@ static bool anyComponentIsNone(const GradientColorStops& stops)
         if (stop.color.anyComponentIsNone())
             return true;
     }
-    
+
     return false;
 }
 
-GradientRendererCG::Strategy GradientRendererCG::pickStrategy(ColorInterpolationMethod colorInterpolationMethod, const GradientColorStops& stops) const
+GradientRendererCG::Gradient GradientRendererCG::makeGradient(ColorInterpolationMethod colorInterpolationMethod, const GradientColorStops& stops) const
 {
-    return WTF::switchOn(colorInterpolationMethod.colorSpace,
-        [&] (const ColorInterpolationMethod::SRGB&) -> Strategy {
-            // FIXME: As an optimization we can precompute 'none' replacements and create a transformed stop list rather than falling back on CGShadingRef.
-            if (anyComponentIsNone(stops))
-                return makeShading(colorInterpolationMethod, stops);
-
-            return makeGradient(colorInterpolationMethod, stops);
+    // For non-sRGB color spaces, or sRGB with 'none' components, fall back to sampling.
+    bool needsSampling = WTF::switchOn(colorInterpolationMethod.colorSpace,
+        [&] (const ColorInterpolationMethod::SRGB&) {
+            // FIXME: As an optimization we can precompute 'none' replacements and create a transformed stop list rather than falling back on gradient sampling.
+            return anyComponentIsNone(stops);
         },
-        [&] (const auto&) -> Strategy {
-            return makeShading(colorInterpolationMethod, stops);
+        [&] (const auto&) {
+            return true;
         }
     );
-}
 
-// MARK: - Gradient strategy.
-
-GradientRendererCG::Strategy GradientRendererCG::makeGradient(ColorInterpolationMethod colorInterpolationMethod, const GradientColorStops& stops) const
-{
-    ASSERT_UNUSED(colorInterpolationMethod, std::holds_alternative<ColorInterpolationMethod::SRGB>(colorInterpolationMethod.colorSpace));
+    if (needsSampling)
+        return makeGradientBySampling(colorInterpolationMethod, stops);
 
     auto gradientInterpolatesPremultipliedOptionsDictionary = [] () -> CFDictionaryRef {
         static CFTypeRef keys[] = { kCGGradientInterpolatesPremultiplied };
@@ -159,203 +179,50 @@ GradientRendererCG::Strategy GradientRendererCG::makeGradient(ColorInterpolation
     return Gradient { adoptCF(CGGradientCreateWithColorComponentsAndOptions(cgColorSpace.get(), colorComponents.span().data(), locations.span().data(), numberOfStops, gradientOptionsDictionary(colorInterpolationMethod))) };
 }
 
-// MARK: - Shading strategy.
+// MARK: - Gradient-by-sampling strategy.
 
-template<typename InterpolationSpace, AlphaPremultiplication alphaPremultiplication>
-void GradientRendererCG::Shading::shadingFunction(void* info, const CGFloat* rawIn, CGFloat* rawOut)
+GradientRendererCG::Gradient GradientRendererCG::makeGradientBySampling(ColorInterpolationMethod colorInterpolationMethod, const GradientColorStops& stops) const
 {
-    using InterpolationSpaceColorType = typename InterpolationSpace::ColorType;
-    using OutputSpaceColorType = std::conditional_t<HasCGColorSpaceMapping<ColorSpace::ExtendedSRGB>, ExtendedSRGBA<float>, SRGBA<float>>;
-
-    auto* data = static_cast<GradientRendererCG::Shading::Data*>(info);
-
-    // Compute color at offset 'in[0]' and assign the components to out[0 -> 3].
-    auto in = unsafeMakeSpan(rawIn, 1);
-    auto out = unsafeMakeSpan(rawOut, 4);
-
-    float requestedOffset = in[0];
-
-    // 1. Find stops that bound the requested offset.
-    auto [stop0, stop1] = [&] {
-        for (size_t stop = 1; stop < data->stops().size(); ++stop) {
-            if (requestedOffset <= data->stops()[stop].offset)
-                return std::tie(data->stops()[stop - 1], data->stops()[stop]);
-        }
-        RELEASE_ASSERT_NOT_REACHED();
-    }();
-
-    // 2. Compute percentage offset between the two stops.
-    float offset = (stop1.offset == stop0.offset) ? 0.0f : (requestedOffset - stop0.offset) / (stop1.offset - stop0.offset);
-
-    // 3. Interpolate the two stops' colors by the computed offset.
-    // Synthetic color stops are added to extend the author-provided gradient out to 0 and 1
-    // with a solid color, if necessary. These need special handling because `longer hue` gradients
-    // would otherwise rotate through 360° of hue in these segments.
-    auto interpolatedColor = [&]() {
-        if (stop0.offset == 0.0f && data->firstStopIsSynthetic())
-            return makeFromComponents<InterpolationSpaceColorType>(stop0.colorComponents);
-
-        if (stop1.offset == 1.0f && data->lastStopIsSynthetic())
-            return makeFromComponents<InterpolationSpaceColorType>(stop1.colorComponents);
-
-        return interpolateColorComponents<alphaPremultiplication>(
-            std::get<InterpolationSpace>(data->colorInterpolationMethod().colorSpace),
-            makeFromComponents<InterpolationSpaceColorType>(stop0.colorComponents), 1.0f - offset,
-            makeFromComponents<InterpolationSpaceColorType>(stop1.colorComponents), offset);
-    }();
-
-    // 4. Convert to the output color space.
-    auto interpolatedColorConvertedToOutputSpace = asColorComponents(convertColor<OutputSpaceColorType>(interpolatedColor).resolved());
-
-    // 5. Write color components to 'out' pointer.
-    for (size_t componentIndex = 0; componentIndex < interpolatedColorConvertedToOutputSpace.size(); ++componentIndex)
-        out[componentIndex] = interpolatedColorConvertedToOutputSpace[componentIndex];
+    auto colorStops = stops.sorted().stops();
+    static NeverDestroyed<TinyLRUCache<WTF::SampledGradientCacheKey, RetainPtr<CGGradientRef>, 8>> cache;
+    RetainPtr gradient = cache.get().get({ colorInterpolationMethod, colorStops });
+    return Gradient { WTF::move(gradient) };
 }
 
-GradientRendererCG::Strategy GradientRendererCG::makeShading(ColorInterpolationMethod colorInterpolationMethod, const GradientColorStops& stops) const
+RetainPtr<CGGradientRef> GradientRendererCG::createGradientBySampling(ColorInterpolationMethod colorInterpolationMethod, const GradientColorStops::StopVector& stops)
 {
     using OutputSpaceColorType = std::conditional_t<HasCGColorSpaceMapping<ColorSpace::ExtendedSRGB>, ExtendedSRGBA<float>, SRGBA<float>>;
 
-    auto makeData = [&] (auto colorInterpolationMethod, auto& stops) {
-        auto convertColorToColorInterpolationSpace = [&] (const Color& color, auto colorInterpolationMethod) -> ColorComponents<float, 4> {
-            return WTF::switchOn(colorInterpolationMethod.colorSpace,
-                [&]<typename MethodColorSpace>(const MethodColorSpace&) -> ColorComponents<float, 4> {
-                    using ColorType = typename MethodColorSpace::ColorType;
-                    return asColorComponents(color.template toColorTypeLossyCarryingForwardMissing<ColorType>().unresolved());
-                }
-            );
-        };
+    auto sampled = sampleGradientStops<OutputSpaceColorType>(colorInterpolationMethod, stops);
 
-        auto totalNumberOfStops = stops.size();
-        bool hasZero = false;
-        bool hasOne = false;
+    auto cgColorSpace = cachedCGColorSpaceSingleton<ColorSpaceFor<OutputSpaceColorType>>();
 
-        for (const auto& stop : stops) {
-            auto offset = stop.offset;
-            ASSERT(offset >= 0);
-            ASSERT(offset <= 1);
-            
-            if (offset == 0)
-                hasZero = true;
-            else if (offset == 1)
-                hasOne = true;
-        }
+    Vector<CGFloat> locations(sampled.locations.size());
+    Vector<CGFloat> components(sampled.colorComponents.size());
+    for (size_t i = 0; i < sampled.locations.size(); ++i)
+        locations[i] = sampled.locations[i];
+    for (size_t i = 0; i < sampled.colorComponents.size(); ++i)
+        components[i] = sampled.colorComponents[i];
 
-        if (!hasZero)
-            totalNumberOfStops++;
-        if (!hasOne)
-            totalNumberOfStops++;
-
-        // FIXME: To avoid duplicate work in the shader function, we could precompute a few things:
-        //   - If we have a polar coordinate color space, we can pre-fixup the hues, inserting an extra stop at the same offset if both the fixup on the left and right require different results.
-        //   - If we have 'none' components, we can precompute 'none' replacements, inserting an extra stop at the same offset if the replacements on the left and right are different.
-
-        Vector<ColorConvertedToInterpolationColorSpaceStop> convertedStops;
-        convertedStops.reserveInitialCapacity(totalNumberOfStops);
-
-        if (!hasZero)
-            convertedStops.append({ 0.0f, { 0.0f, 0.0f, 0.0f, 0.0f } });
-
-        convertedStops.appendContainerWithMapping(stops, [&](auto& stop) {
-            return ColorConvertedToInterpolationColorSpaceStop { stop.offset, convertColorToColorInterpolationSpace(stop.color, colorInterpolationMethod) };
-        });
-
-        if (!hasOne)
-            convertedStops.append({ 1.0f, convertedStops.last().colorComponents });
-
-        if (!hasZero)
-            convertedStops[0].colorComponents = convertedStops[1].colorComponents;
-
-        return Shading::Data::create(colorInterpolationMethod, WTF::move(convertedStops), !hasZero, !hasOne);
-    };
-
-    auto makeFunction = [&] (auto colorInterpolationMethod, auto& data) {
-        auto makeEvaluateCallback = [&] (auto colorInterpolationMethod) -> CGFunctionEvaluateCallback {
-            return WTF::switchOn(colorInterpolationMethod.colorSpace,
-                [&]<typename MethodColorSpace> (const MethodColorSpace&) -> CGFunctionEvaluateCallback {
-                    switch (colorInterpolationMethod.alphaPremultiplication) {
-                    case AlphaPremultiplication::Unpremultiplied:
-                        return &Shading::shadingFunction<MethodColorSpace, AlphaPremultiplication::Unpremultiplied>;
-                    case AlphaPremultiplication::Premultiplied:
-                        return &Shading::shadingFunction<MethodColorSpace, AlphaPremultiplication::Premultiplied>;
-                    }
-                }
-            );
-        };
-
-        const CGFunctionCallbacks callbacks = {
-            0,
-            makeEvaluateCallback(colorInterpolationMethod),
-            [] (void* info) {
-                static_cast<GradientRendererCG::Shading::Data*>(info)->deref();
-            }
-        };
-
-        constexpr auto outputSpaceComponentInfo = OutputSpaceColorType::Model::componentInfo;
-
-        static constexpr std::array<CGFloat, 2> domain = { 0, 1 };
-        static constexpr std::array<CGFloat, 8> range = {
-            outputSpaceComponentInfo[0].min, outputSpaceComponentInfo[0].max,
-            outputSpaceComponentInfo[1].min, outputSpaceComponentInfo[1].max,
-            outputSpaceComponentInfo[2].min, outputSpaceComponentInfo[2].max,
-            0, 1
-        };
-
-        Ref dataRefCopy = data;
-        return adoptCF(CGFunctionCreate(&dataRefCopy.leakRef(), domain.size() / 2, domain.data(), range.size() / 2, range.data(), &callbacks));
-    };
-
-    auto data = makeData(colorInterpolationMethod, stops);
-    auto function = makeFunction(colorInterpolationMethod, data);
-
-    // FIXME: Investigate using bounded sRGB when the input stops are all bounded sRGB.
-    auto colorSpace = cachedCGColorSpaceSingleton<ColorSpaceFor<OutputSpaceColorType>>();
-
-    return Shading { WTF::move(data), WTF::move(function), colorSpace };
+    return adoptCF(CGGradientCreateWithColorComponentsAndOptions(cgColorSpace,
+        components.span().data(), locations.span().data(), locations.size(), nullptr));
 }
 
 // MARK: - Drawing functions.
 
 void GradientRendererCG::drawLinearGradient(CGContextRef platformContext, CGPoint startPoint, CGPoint endPoint, CGGradientDrawingOptions options)
 {
-    WTF::switchOn(m_strategy,
-        [&] (Gradient& gradient) {
-            CGContextDrawLinearGradient(platformContext, gradient.gradient.get(), startPoint, endPoint, options);
-        },
-        [&] (Shading& shading) {
-            bool startExtend = (options & kCGGradientDrawsBeforeStartLocation) != 0;
-            bool endExtend = (options & kCGGradientDrawsAfterEndLocation) != 0;
-
-            CGContextDrawShading(platformContext, adoptCF(CGShadingCreateAxial(shading.colorSpace.get(), startPoint, endPoint, shading.function.get(), startExtend, endExtend)).get());
-        }
-    );
+    CGContextDrawLinearGradient(platformContext, m_gradient.get(), startPoint, endPoint, options);
 }
 
 void GradientRendererCG::drawRadialGradient(CGContextRef platformContext, CGPoint startCenter, CGFloat startRadius, CGPoint endCenter, CGFloat endRadius, CGGradientDrawingOptions options)
 {
-    WTF::switchOn(m_strategy,
-        [&] (Gradient& gradient) {
-            CGContextDrawRadialGradient(platformContext, gradient.gradient.get(), startCenter, startRadius, endCenter, endRadius, options);
-        },
-        [&] (Shading& shading) {
-            bool startExtend = (options & kCGGradientDrawsBeforeStartLocation) != 0;
-            bool endExtend = (options & kCGGradientDrawsAfterEndLocation) != 0;
-
-            CGContextDrawShading(platformContext, adoptCF(CGShadingCreateRadial(shading.colorSpace.get(), startCenter, startRadius, endCenter, endRadius, shading.function.get(), startExtend, endExtend)).get());
-        }
-    );
+    CGContextDrawRadialGradient(platformContext, m_gradient.get(), startCenter, startRadius, endCenter, endRadius, options);
 }
 
 void GradientRendererCG::drawConicGradient(CGContextRef platformContext, CGPoint center, CGFloat angle)
 {
-    WTF::switchOn(m_strategy,
-        [&] (Gradient& gradient) {
-            CGContextDrawConicGradient(platformContext, gradient.gradient.get(), center, angle);
-        },
-        [&] (Shading& shading) {
-            CGContextDrawShading(platformContext, adoptCF(CGShadingCreateConic(shading.colorSpace.get(), center, angle, shading.function.get())).get());
-        }
-    );
+    CGContextDrawConicGradient(platformContext, m_gradient.get(), center, angle);
 }
 
 }

--- a/Source/WebCore/platform/graphics/cg/GradientRendererCG.h
+++ b/Source/WebCore/platform/graphics/cg/GradientRendererCG.h
@@ -26,21 +26,12 @@
 #pragma once
 
 #include <CoreGraphics/CoreGraphics.h>
-#include <WebCore/ColorComponents.h>
 #include <WebCore/ColorInterpolationMethod.h>
-#include <WebCore/DestinationColorSpace.h>
 #include <wtf/RetainPtr.h>
-#include <wtf/ThreadSafeRefCounted.h>
-#include <wtf/Vector.h>
 
 namespace WebCore {
 
 class GradientColorStops;
-
-struct ColorConvertedToInterpolationColorSpaceStop {
-    float offset;
-    ColorComponents<float, 4> colorComponents;
-};
 
 class GradientRendererCG {
 public:
@@ -50,54 +41,15 @@ public:
     void drawRadialGradient(CGContextRef, CGPoint startCenter, CGFloat startRadius, CGPoint endCenter, CGFloat endRadius, CGGradientDrawingOptions);
     void drawConicGradient(CGContextRef, CGPoint center, CGFloat angle);
 
+    static RetainPtr<CGGradientRef> createGradientBySampling(ColorInterpolationMethod, const GradientColorStops::StopVector&);
+
 private:
-    struct Gradient {
-        RetainPtr<CGGradientRef> gradient;
-    };
+    using Gradient = RetainPtr<CGGradientRef>;
 
-    struct Shading {
-        template<typename InterpolationSpace, AlphaPremultiplication> static void shadingFunction(void*, const CGFloat*, CGFloat*);
+    Gradient makeGradient(ColorInterpolationMethod, const GradientColorStops&) const;
+    Gradient makeGradientBySampling(ColorInterpolationMethod, const GradientColorStops&) const;
 
-        class Data : public ThreadSafeRefCounted<Data> {
-        public:
-            static Ref<Data> create(ColorInterpolationMethod colorInterpolationMethod, Vector<ColorConvertedToInterpolationColorSpaceStop> stops, bool firstStopIsSynthetic, bool lastStopIsSynthetic)
-            {
-                return adoptRef(*new Data(colorInterpolationMethod, WTF::move(stops), firstStopIsSynthetic, lastStopIsSynthetic));
-            }
-
-            ColorInterpolationMethod colorInterpolationMethod() const { return m_colorInterpolationMethod; }
-            const Vector<ColorConvertedToInterpolationColorSpaceStop>& stops() const LIFETIME_BOUND { return m_stops; }
-
-            bool firstStopIsSynthetic() const { return m_firstStopIsSynthetic; }
-            bool lastStopIsSynthetic() const { return m_lastStopIsSynthetic; }
-
-        private:
-            Data(ColorInterpolationMethod colorInterpolationMethod, Vector<ColorConvertedToInterpolationColorSpaceStop> stops, bool firstStopIsSynthetic, bool lastStopIsSynthetic)
-                : m_colorInterpolationMethod { colorInterpolationMethod }
-                , m_firstStopIsSynthetic(firstStopIsSynthetic)
-                , m_lastStopIsSynthetic(lastStopIsSynthetic)
-                , m_stops { WTF::move(stops) }
-            {
-            }
-
-            ColorInterpolationMethod m_colorInterpolationMethod;
-            bool m_firstStopIsSynthetic { false };
-            bool m_lastStopIsSynthetic { false };
-            Vector<ColorConvertedToInterpolationColorSpaceStop> m_stops;
-        };
-
-        Ref<Data> data;
-        RetainPtr<CGFunctionRef> function;
-        RetainPtr<CGColorSpaceRef> colorSpace;
-    };
-
-    using Strategy = Variant<Gradient, Shading>;
-
-    Strategy pickStrategy(ColorInterpolationMethod, const GradientColorStops&) const;
-    Strategy makeGradient(ColorInterpolationMethod, const GradientColorStops&) const;
-    Strategy makeShading(ColorInterpolationMethod, const GradientColorStops&) const;
-
-    Strategy m_strategy;
+    Gradient m_gradient;
 };
 
 }


### PR DESCRIPTION
#### 5e93c4d3d62c3acd9acff55d2af2f7cb946c466b
<pre>
Draw non-sRGB gradients via CGGradient using sampling
<a href="https://bugs.webkit.org/show_bug.cgi?id=310236">https://bugs.webkit.org/show_bug.cgi?id=310236</a>
<a href="https://rdar.apple.com/168525666">rdar://168525666</a>

Reviewed by Matt Woodrow.

The standard colorspace for interpolating colors in gradient on the web is now
OKLab, instead of sRGB. Because CoreGraphics doesn&apos;t support OKLab, gradients
are drawn via CGShading, not CGGradient. The overhead of performing colorstop
interpolation shows up in profiles of MotionMark 1.4 Chess subtest.

This change moves the interpolation for non-sRGB colorstops to an upfront
expense of sampling the gradient. Colorstop ranges are sub-divided into segments
that can be linearly interpolated by granularly dividing the stop ranges and
then bisecting the range til an acceptable tolerance is reached. The total
number of stops and tolerance was determined experimentally by comparing to
CoreGraphics.

The resulting colorstops are cached as CGGradient in an LRU cache to amortise
the overhead of the interpolation.

Canonical link: <a href="https://commits.webkit.org/310405@main">https://commits.webkit.org/310405@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5d9d51cdf05938948a66832b5a5e563564748af

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153770 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26554 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20171 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162521 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/107231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f23adcf6-21fc-46b6-9615-df29e27e0219) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155643 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27096 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26876 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/118889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/107231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156729 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/21162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/138080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/99599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fa9ed8f1-2c86-43da-bb6f-137441a6eb2a) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/20242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/18194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/10353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/129890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/15939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164991 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/8125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/17533 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/126977 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/26351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/22225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127144 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/34479 "The change is no longer eligible for processing.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26353 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137734 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/83031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23497 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/22046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/14517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25970 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/90258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/25661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/25821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/25721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->