### PR TITLE
[JSC] Add fast path for MicrotaskCall in callMicrotask

### DIFF
--- a/Source/JavaScriptCore/interpreter/MicrotaskCall.h
+++ b/Source/JavaScriptCore/interpreter/MicrotaskCall.h
@@ -55,6 +55,18 @@ public:
     template<typename... Args> requires (std::is_convertible_v<Args, JSValue> && ...)
     JSValue tryCallWithArguments(VM&, JSFunction*, JSValue thisValue, JSCell* context, Args...);
 
+    ALWAYS_INLINE bool canUseCall(JSValue functionObject) const
+    {
+        if (!m_functionExecutable) [[unlikely]]
+            return false;
+        if (!functionObject.isCell()) [[unlikely]]
+            return false;
+        auto* cell = functionObject.asCell();
+        if (cell->type() != JSFunctionType) [[unlikely]]
+            return false;
+        return m_functionExecutable == jsCast<JSFunction*>(cell)->executable();
+    }
+
     bool isInitializedFor(FunctionExecutable* executable) const
     {
         return m_functionExecutable == executable;

--- a/Source/JavaScriptCore/runtime/JSMicrotask.cpp
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.cpp
@@ -77,6 +77,17 @@ static JSValue callMicrotask(JSGlobalObject* globalObject, JSValue functionObjec
     auto scope = DECLARE_THROW_SCOPE(vm);
     static_assert(sizeof...(args) <= MicrotaskCall::maxCallArguments);
 
+    if (microtaskCall && microtaskCall->canUseCall(functionObject)) [[likely]] {
+        if (!vm.isSafeToRecurseSoft()) [[unlikely]]
+            return throwStackOverflowError(globalObject, scope);
+        auto* jsFunction = jsCast<JSFunction*>(functionObject.asCell());
+        if (auto result = microtaskCall->tryCallWithArguments(vm, jsFunction, thisValue, context, args...)) [[likely]] {
+            scope.release();
+            return result;
+        }
+        RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, scope.exception());
+    }
+
     auto callData = JSC::getCallDataInline(functionObject);
     if (callData.type == CallData::Type::None)
         return throwTypeError(globalObject, scope, message);
@@ -102,19 +113,6 @@ static JSValue callMicrotask(JSGlobalObject* globalObject, JSValue functionObjec
         if (!vm.isSafeToRecurseSoft()) [[unlikely]]
             return throwStackOverflowError(functionScope->globalObject(), scope);
 
-        if (microtaskCall) [[likely]] {
-            auto* jsFunction = jsCast<JSFunction*>(functionObject.asCell());
-            if (!microtaskCall->isInitializedFor(functionExecutable)) {
-                microtaskCall->initialize(vm, jsFunction);
-                RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, scope.exception());
-            }
-            if (auto result = microtaskCall->tryCallWithArguments(vm, jsFunction, thisValue, context, args...)) [[likely]] {
-                scope.release();
-                return result;
-            }
-            RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, scope.exception());
-        }
-
         {
             DeferTraps deferTraps(vm); // We can't jettison this code if we're about to run it.
 
@@ -124,6 +122,19 @@ static JSValue callMicrotask(JSGlobalObject* globalObject, JSValue functionObjec
             ASSERT(newCodeBlock);
             newCodeBlock->m_shouldAlwaysBeInlined = false;
         }
+
+        if (microtaskCall) {
+            auto* jsFunction = jsCast<JSFunction*>(functionObject.asCell());
+            microtaskCall->initialize(vm, jsFunction);
+            RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, scope.exception());
+
+            if (auto result = microtaskCall->tryCallWithArguments(vm, jsFunction, thisValue, context, args...)) [[likely]] {
+                scope.release();
+                return result;
+            }
+            RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, scope.exception());
+        }
+
 #if (CPU(ARM64) || CPU(X86_64)) && CPU(ADDRESS64) && !ENABLE(C_LOOP)
         if ((sizeof...(args) + 1) >= newCodeBlock->numParameters()) [[likely]] {
             auto* entry = functionExecutable->generatedJITCodeAddressForCall();


### PR DESCRIPTION
#### 40f8432a95e21f322a95dd9ce37514604339546e
<pre>
[JSC] Add fast path for MicrotaskCall in callMicrotask
<a href="https://bugs.webkit.org/show_bug.cgi?id=310237">https://bugs.webkit.org/show_bug.cgi?id=310237</a>
<a href="https://rdar.apple.com/172882199">rdar://172882199</a>

Reviewed by Mark Lam.

Add extreme fast path via MicrotaskCall in callMicrotask.
Avoid touching FunctionExecutable&apos;s fields, just checking pointer value
and dispatch a call.

* Source/JavaScriptCore/interpreter/MicrotaskCall.h:
* Source/JavaScriptCore/runtime/JSMicrotask.cpp:
(JSC::callMicrotask):

Canonical link: <a href="https://commits.webkit.org/309582@main">https://commits.webkit.org/309582@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8447af71c127117144eab76e78acbc6f746bd49

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150968 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23730 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17300 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159696 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104404 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/01a3fb13-f0da-4bf6-8698-de56c9b8f027) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24161 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23948 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116544 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82737 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/38738fb8-37d6-4d56-9198-c6ebad471045) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153928 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18658 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135446 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97264 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1c24e5fc-0aa1-4fcd-a875-278c530bb33e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17752 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15704 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7542 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/142952 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127370 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13363 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162169 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/11767 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5294 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14934 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/api/crashtests/huge-fetch.any.sharedworker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124551 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23532 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19754 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124738 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23522 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135160 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79929 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23220 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19800 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11925 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/182493 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23132 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87386 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46609 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22844 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22996 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22898 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->