### PR TITLE
[JSC] Fix stack overflow in AsyncDisposableStack.prototype.disposeAsync

### DIFF
--- a/JSTests/stress/async-disposable-stack-dispose-async-many-sync-throws.js
+++ b/JSTests/stress/async-disposable-stack-dispose-async-many-sync-throws.js
@@ -1,0 +1,64 @@
+//@ requireOptions("--useExplicitResourceManagement=1")
+
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+async function test() {
+    {
+        let called = 0;
+        const stack = new AsyncDisposableStack();
+        for (let i = 0; i < 30000; i++)
+            stack.defer(() => { called++; throw 0; });
+
+        let syncThrew = false;
+        let p;
+        try {
+            p = stack.disposeAsync();
+        } catch {
+            syncThrew = true;
+        }
+        shouldBe(syncThrew, false);
+        shouldBe(p instanceof Promise, true);
+
+        let caught;
+        try { await p; } catch (e) { caught = e; }
+        shouldBe(caught instanceof SuppressedError, true);
+        shouldBe(called, 30000);
+    }
+
+    {
+        const stack = new AsyncDisposableStack();
+        stack.defer(() => { throw "A"; });
+        stack.defer(() => { throw "B"; });
+        stack.defer(() => { throw "C"; });
+
+        let caught;
+        try { await stack.disposeAsync(); } catch (e) { caught = e; }
+        shouldBe(caught.error, "A");
+        shouldBe(caught.suppressed.error, "B");
+        shouldBe(caught.suppressed.suppressed, "C");
+    }
+
+    {
+        let log = [];
+        const stack = new AsyncDisposableStack();
+        stack.defer(() => { log.push(1); throw "S1"; });
+        stack.defer(async () => { log.push(2); });
+        stack.defer(() => { log.push(3); throw "S2"; });
+        stack.defer(async () => { log.push(4); throw "AR"; });
+        stack.defer(() => { log.push(5); throw "S3"; });
+
+        let caught;
+        try { await stack.disposeAsync(); } catch (e) { caught = e; }
+        shouldBe(log.join(","), "5,4,3,2,1");
+        shouldBe(caught.error, "S1");
+        shouldBe(caught.suppressed.error, "S2");
+        shouldBe(caught.suppressed.suppressed.error, "AR");
+        shouldBe(caught.suppressed.suppressed.suppressed, "S3");
+    }
+}
+
+test().then(() => {}, e => { print("FAIL:", e); $vm.abort(); });
+drainMicrotasks();

--- a/Source/JavaScriptCore/builtins/AsyncDisposableStackPrototype.js
+++ b/Source/JavaScriptCore/builtins/AsyncDisposableStackPrototype.js
@@ -119,8 +119,13 @@ function disposeAsync()
             try {
                 result = resource.method.@call(resource.value);
             } catch (error) {
-                handleError(error);
-                return;
+                if (thrown)
+                    suppressed = new @SuppressedError(error, suppressed);
+                else {
+                    thrown = true;
+                    suppressed = error;
+                }
+                continue;
             }
             hasAwaited = true;
             @promiseResolve(@Promise, result).@then(loop, handleError);


### PR DESCRIPTION
#### 9a3b8c612a4930778e7e3be17a3ea95707435d76
<pre>
[JSC] Fix stack overflow in AsyncDisposableStack.prototype.disposeAsync
<a href="https://bugs.webkit.org/show_bug.cgi?id=310241">https://bugs.webkit.org/show_bug.cgi?id=310241</a>

Reviewed by Yusuke Suzuki.

The sync-throw path recursed loop -&gt; handleError -&gt; loop. At ~18000
consecutive sync-throwing resources the stack is exhausted and the
RangeError propagates out of disposeAsync synchronously, leaking the
remaining resources.

Inline the error accumulation into the catch block and continue the
while loop instead, matching the sync DisposableStack.prototype.dispose.
DisposeResources [1] step 3.e.ii only Awaits normal completions, so
staying synchronous on throw is correct. handleError is still used via
.@then where each invocation arrives on a fresh microtask frame.

[1]: <a href="https://tc39.es/proposal-explicit-resource-management/#sec-disposeresources">https://tc39.es/proposal-explicit-resource-management/#sec-disposeresources</a>

Test: JSTests/stress/async-disposable-stack-dispose-async-many-sync-throws.js

* JSTests/stress/async-disposable-stack-dispose-async-many-sync-throws.js: Added.
(shouldBe):
(async test.async stack):
(async test):
(test.then):
* Source/JavaScriptCore/builtins/AsyncDisposableStackPrototype.js:
(disposeAsync):

Canonical link: <a href="https://commits.webkit.org/309534@main">https://commits.webkit.org/309534@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6441ebde20fbf4e99bdb6aa2430bcac86d3f8907

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150972 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23734 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17304 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159700 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/104408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24165 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23952 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116548 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/104408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153932 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18665 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135451 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97268 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/17759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/15709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7546 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/142956 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/127377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13368 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162173 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/11771 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5298 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14939 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124555 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23536 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19759 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124742 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33847 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23526 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135165 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79933 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19806 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11930 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/182497 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23136 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87359 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46610 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22848 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23000 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22902 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->