### PR TITLE
[Cocoa] Gate network tasks on nw_path_monitor after process resume to handle stale nw_path

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -2512,6 +2512,10 @@ void NetworkProcess::prepareToSuspend(bool isSuspensionImminent, MonotonicTime e
     RELEASE_LOG(ProcessSuspension, "%p - NetworkProcess::prepareToSuspend(), isSuspensionImminent=%d, remainingRunTime=%fs", this, isSuspensionImminent, remainingRunTime);
 
     m_isSuspended = true;
+
+#if PLATFORM(COCOA)
+    stopNetworkPathMonitor();
+#endif
     lowMemoryHandler(Critical::Yes);
 
     RefPtr callbackAggregator = CallbackAggregator::create([weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler)]() mutable {
@@ -2546,6 +2550,10 @@ void NetworkProcess::processDidResume(bool forForegroundActivity)
     RELEASE_LOG(ProcessSuspension, "%p - NetworkProcess::processDidResume() forForegroundActivity=%d", this, forForegroundActivity);
 
     m_isSuspended = false;
+
+#if PLATFORM(COCOA)
+    startNetworkPathMonitor();
+#endif
 
     WebResourceLoadStatisticsStore::resume();
     PCM::PersistentStore::processDidResume();

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -213,6 +213,11 @@ public:
     void prepareToSuspend(bool isSuspensionImminent, MonotonicTime estimatedSuspendTime, CompletionHandler<void()>&&);
     void processDidResume(bool forForegroundActivity);
 
+#if PLATFORM(COCOA)
+    bool isWaitingForNetworkPathUpdate() const { return m_waitingForNetworkPathUpdate; }
+    void whenNetworkPathIsReady(Function<void()>&&);
+#endif
+
     CacheModel cacheModel() const { return m_cacheModel; }
 
     const HashSet<String>& localhostAliasesForTesting() const LIFETIME_BOUND { return m_localhostAliasesForTesting; }
@@ -589,7 +594,13 @@ private:
     void terminateRemoteWorkerContextConnectionWhenPossible(RemoteWorkerType, PAL::SessionID, const WebCore::RegistrableDomain&, WebCore::ProcessIdentifier);
     void runningOrTerminatingServiceWorkerCountForTesting(PAL::SessionID, CompletionHandler<void(unsigned)>&&) const;
     void platformFlushCookies(PAL::SessionID, CompletionHandler<void()>&&);
-    
+
+#if PLATFORM(COCOA)
+    void startNetworkPathMonitor();
+    void stopNetworkPathMonitor();
+    void networkPathDidUpdate();
+#endif
+
     void registerURLSchemeAsSecure(const String&) const;
     void registerURLSchemeAsBypassingContentSecurityPolicy(const String&) const;
     void registerURLSchemeAsLocal(const String&) const;
@@ -672,6 +683,10 @@ private:
     bool m_isSuspended { false };
     bool m_didSyncCookiesForClose { false };
 #if PLATFORM(COCOA)
+    RetainPtr<id> m_nwPathMonitor;
+    bool m_waitingForNetworkPathUpdate { false };
+    unsigned m_networkPathMonitorSerial { 0 };
+    Vector<Function<void()>> m_pendingTaskResumes;
     int m_mediaStreamingActivitityToken { NOTIFY_TOKEN_INVALID };
     bool m_isParentProcessFullWebBrowserOrRunningTest { false };
 #endif

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -606,6 +606,15 @@ void NetworkDataTaskCocoa::resume()
     if (!m_session || m_session->isInvalidated())
         return;
 
+    if (m_session->networkProcess().isWaitingForNetworkPathUpdate()) {
+        RELEASE_LOG(NetworkSession, "%p - NetworkDataTaskCocoa::resume: waiting for network path update after process resume", this);
+        m_session->networkProcess().whenNetworkPathIsReady([weakThis = ThreadSafeWeakPtr { *this }] {
+            if (auto protectedThis = weakThis.get())
+                protectedThis->resume();
+        });
+        return;
+    }
+
     {
         CheckedRef session = *m_session;
         CheckedPtr storageSession = session->networkStorageSession();

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
@@ -293,4 +293,69 @@ void NetworkProcess::setProxyConfigData(PAL::SessionID sessionID, Vector<std::pa
 }
 #endif // HAVE(NW_PROXY_CONFIG)
 
+void NetworkProcess::startNetworkPathMonitor()
+{
+    stopNetworkPathMonitor();
+
+    RELEASE_LOG(ProcessSuspension, "%p - NetworkProcess::startNetworkPathMonitor()", this);
+    m_waitingForNetworkPathUpdate = true;
+    unsigned serial = ++m_networkPathMonitorSerial;
+
+    RetainPtr monitor = adoptNS(nw_path_monitor_create());
+    nw_path_monitor_set_queue(monitor.get(), mainDispatchQueueSingleton());
+    nw_path_monitor_set_update_handler(monitor.get(), makeBlockPtr([weakThis = WeakPtr { *this }](nw_path_t) {
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->networkPathDidUpdate();
+    }).get());
+    nw_path_monitor_start(monitor.get());
+    m_nwPathMonitor = WTF::move(monitor);
+
+    // Safety timeout: release queued tasks even if the monitor callback does not arrive.
+    RunLoop::currentSingleton().dispatchAfter(1_s, [weakThis = WeakPtr { *this }, serial] {
+        if (RefPtr protectedThis = weakThis.get()) {
+            if (protectedThis->m_networkPathMonitorSerial == serial) {
+                RELEASE_LOG_ERROR(ProcessSuspension, "%p - NetworkProcess::startNetworkPathMonitor safety timeout fired — nw_path_monitor did not deliver initial update within 1s", protectedThis.get());
+                protectedThis->networkPathDidUpdate();
+            } else
+                RELEASE_LOG(ProcessSuspension, "%p - NetworkProcess::startNetworkPathMonitor stale timeout ignored (serial %u vs current %u)", protectedThis.get(), serial, protectedThis->m_networkPathMonitorSerial);
+        }
+    });
+}
+
+void NetworkProcess::stopNetworkPathMonitor()
+{
+    if (m_nwPathMonitor) {
+        nw_path_monitor_cancel(static_cast<nw_path_monitor_t>(m_nwPathMonitor.get()));
+        m_nwPathMonitor = nullptr;
+    }
+    networkPathDidUpdate();
+}
+
+void NetworkProcess::networkPathDidUpdate()
+{
+    if (!m_waitingForNetworkPathUpdate)
+        return;
+
+    RELEASE_LOG(ProcessSuspension, "%p - NetworkProcess::networkPathDidUpdate() releasing %zu pending task(s)", this, m_pendingTaskResumes.size());
+    m_waitingForNetworkPathUpdate = false;
+
+    if (m_nwPathMonitor) {
+        nw_path_monitor_cancel(static_cast<nw_path_monitor_t>(m_nwPathMonitor.get()));
+        m_nwPathMonitor = nullptr;
+    }
+
+    auto pendingResumes = std::exchange(m_pendingTaskResumes, { });
+    for (auto& resumeCallback : pendingResumes)
+        resumeCallback();
+}
+
+void NetworkProcess::whenNetworkPathIsReady(Function<void()>&& callback)
+{
+    if (!m_waitingForNetworkPathUpdate) {
+        callback();
+        return;
+    }
+    m_pendingTaskResumes.append(WTF::move(callback));
+}
+
 } // namespace WebKit


### PR DESCRIPTION
#### 978163ec68e68f93f331ad2fd64d4ecda47515ec
<pre>
[Cocoa] Gate network tasks on nw_path_monitor after process resume to handle stale nw_path
<a href="https://bugs.webkit.org/show_bug.cgi?id=310245">https://bugs.webkit.org/show_bug.cgi?id=310245</a>
<a href="https://rdar.apple.com/172676951">rdar://172676951</a>

Reviewed by NOBODY (OOPS!).

After the WebKit.Networking process resumes from suspension, NSURLSession&apos;s
internal nw_path may still reflect a stale state (e.g., cellular-only) even
though WiFi is available system-wide. When allowsCellularAccess is NO, this
causes NSURLSession to fail immediately with NSURLErrorNotConnectedToInternet
instead of using the WiFi path that is already available at the system level.

This patch adds an nw_path_monitor to NetworkProcess. It is cancelled in
prepareToSuspend and started fresh in processDidResume. Until the monitor
delivers its first callback (confirming the process-local nw_path is
up to date), all new NSURLSession data tasks are held in a queue. Once the
callback fires, all queued tasks are resumed and the monitor is cancelled.

nw_path_monitor normally delivers its initial update handler callback
shortly after nw_path_monitor_start(), so the gate is typically released
quickly. A 1-second timeout acts as a safety net for cases where the
callback does not arrive. A serial number ensures stale timeouts from prior
resume cycles are ignored.

* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::prepareToSuspend):
(WebKit::NetworkProcess::processDidResume):
(WebKit::NetworkProcess::networkPathDidUpdate):
(WebKit::NetworkProcess::whenNetworkPathIsReady):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::resume):
* Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm:
(WebKit::NetworkProcess::startNetworkPathMonitor):
(WebKit::NetworkProcess::stopNetworkPathMonitor):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/978163ec68e68f93f331ad2fd64d4ecda47515ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154207 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27464 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20625 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162961 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107675 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ba85bf95-68a4-499a-937e-5483502efdc5) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27597 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27315 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119261 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84307 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2d20e194-4b6b-46b0-a2c8-a76330b32c11) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157166 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21520 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138488 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99957 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ef505d91-1460-4b83-838c-bacc5091081c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20608 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18610 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10793 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130270 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165433 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8642 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17942 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127356 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27011 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22652 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127501 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34591 "Found 1 new test failure: fast/block/transparent-outline-with-and-without-border-radius.html (failure)") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26935 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138126 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83528 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22390 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14918 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26625 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90728 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26206 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26437 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26278 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->