### PR TITLE
Back button unexpectedly enabled in newly opened tab

### DIFF
--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -140,6 +140,7 @@ enum class SDKAlignedBehavior {
     ScrollColorExtensionGrowsDuringRubberBanding,
     ManagedRefreshControlAppearance,
     EnableUserScriptAndUserStyleInterning,
+    AllBackForwardItemsWithoutUserGestureInvisibleToUI,
 
     NumberOfBehaviors
 };

--- a/Source/WebCore/history/HistoryItem.cpp
+++ b/Source/WebCore/history/HistoryItem.cpp
@@ -409,6 +409,15 @@ void HistoryItem::notifyChanged()
     m_client->historyItemChanged(*this);
 }
 
+void HistoryItem::setWasCreatedByJSWithoutUserInteraction(bool wasCreatedByJSWithoutUserInteraction)
+{
+    if (m_wasCreatedByJSWithoutUserInteraction == wasCreatedByJSWithoutUserInteraction)
+        return;
+
+    m_wasCreatedByJSWithoutUserInteraction = wasCreatedByJSWithoutUserInteraction;
+    notifyChanged();
+}
+
 #ifndef NDEBUG
 
 int HistoryItem::showTree() const

--- a/Source/WebCore/history/HistoryItem.h
+++ b/Source/WebCore/history/HistoryItem.h
@@ -215,7 +215,7 @@ public:
     void setWasRestoredFromSession(bool wasRestoredFromSession) { m_wasRestoredFromSession = wasRestoredFromSession; }
     bool wasRestoredFromSession() const { return m_wasRestoredFromSession; }
 
-    void setWasCreatedByJSWithoutUserInteraction(bool wasCreatedByJSWithoutUserInteraction) { m_wasCreatedByJSWithoutUserInteraction = wasCreatedByJSWithoutUserInteraction; }
+    WEBCORE_EXPORT void setWasCreatedByJSWithoutUserInteraction(bool);
     bool wasCreatedByJSWithoutUserInteraction() const { return m_wasCreatedByJSWithoutUserInteraction; }
 
 #if !LOG_DISABLED

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1338,7 +1338,7 @@ void FrameLoader::loadInSameDocument(URL url, RefPtr<SerializedScriptValue> stat
             history().updateBackForwardListForFragmentScroll();
 
         if (!document->hasRecentUserInteractionForNavigationFromJS() && !documentLoader()->triggeringAction().isRequestFromClientOrUserInput()) {
-            if (auto* currentItem = history().currentItem())
+            if (RefPtr currentItem = history().currentItem())
                 currentItem->setWasCreatedByJSWithoutUserInteraction(true);
         }
     }

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -61,6 +61,10 @@
 #include "VisitedLinkStore.h"
 #include <wtf/text/CString.h>
 
+#if PLATFORM(COCOA)
+#import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
+#endif
+
 namespace WebCore {
 
 static inline void addVisitedLink(Page& page, const URL& url)
@@ -565,6 +569,14 @@ void HistoryController::updateForStandardLoad(HistoryUpdateType updateType)
         if (!historyURL.isEmpty()) {
             if (updateType != UpdateAllExceptBackForwardList)
                 updateBackForwardListClippedAtTarget(true);
+
+#if PLATFORM(COCOA)
+            if (linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::AllBackForwardItemsWithoutUserGestureInvisibleToUI)) {
+                if (m_currentItem && m_frame->isMainFrame() && !documentLoader->triggeringAction().processingUserGesture() && !documentLoader->isRequestFromClientOrUserInput())
+                    m_currentItem->setWasCreatedByJSWithoutUserInteraction(true);
+            }
+#endif
+
             if (canRecordHistory) {
                 protect(frameLoader->client())->updateGlobalHistory();
                 documentLoader->setDidCreateGlobalHistoryEntry(true);

--- a/Source/WebKit/Shared/LoadParameters.h
+++ b/Source/WebKit/Shared/LoadParameters.h
@@ -90,6 +90,7 @@ struct LoadParameters {
     std::optional<double> dataDetectionReferenceDate;
 #endif
     bool isRequestFromClientOrUserInput { false };
+    bool hadUserGesture { false };
     WebCore::NavigationUpgradeToHTTPSBehavior navigationUpgradeToHTTPSBehavior { WebCore::NavigationUpgradeToHTTPSBehavior::BasedOnPolicy };
     bool isHandledByAboutSchemeHandler { false };
 

--- a/Source/WebKit/Shared/LoadParameters.serialization.in
+++ b/Source/WebKit/Shared/LoadParameters.serialization.in
@@ -56,6 +56,7 @@ enum class WebCore::LockBackForwardList : bool;
     std::optional<double> dataDetectionReferenceDate;
 #endif
     bool isRequestFromClientOrUserInput;
+    bool hadUserGesture;
     WebCore::NavigationUpgradeToHTTPSBehavior navigationUpgradeToHTTPSBehavior;
     bool isHandledByAboutSchemeHandler;
 

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
@@ -197,6 +197,8 @@ String WebBackForwardListFrameItem::loggingStringAtIndent(size_t indent)
         builder.append("FrameItemID:"_s, frameItemIDString, ", URL:"_s, url(), ", FrameID:"_s, frameIDString);
         if (!m_frameState->target.isEmpty())
             builder.append(", FrameUniqueName:"_s, m_frameState->target);
+        if (m_frameState->wasCreatedByJSWithoutUserInteraction)
+            builder.append(" (no user gesture)"_s);
         builder.append('\n');
     }
 

--- a/Source/WebKit/UIProcess/API/C/WKBackForwardListRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKBackForwardListRef.cpp
@@ -45,12 +45,12 @@ WKBackForwardListItemRef WKBackForwardListGetCurrentItem(WKBackForwardListRef li
 
 WKBackForwardListItemRef WKBackForwardListGetBackItem(WKBackForwardListRef listRef)
 {
-    return toAPI(protect(toImpl(listRef)->backItem()).get());
+    return toAPI(protect(toImpl(listRef))->backItem().get());
 }
 
 WKBackForwardListItemRef WKBackForwardListGetForwardItem(WKBackForwardListRef listRef)
 {
-    return toAPI(protect(toImpl(listRef)->forwardItem()).get());
+    return toAPI(protect(toImpl(listRef))->forwardItem().get());
 }
 
 WKBackForwardListItemRef WKBackForwardListGetItemAtIndex(WKBackForwardListRef listRef, int index)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardList.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardList.mm
@@ -58,12 +58,12 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (WKBackForwardListItem *)backItem
 {
-    return WebKit::wrapper(protect((*_list).backItem()).get());
+    return WebKit::wrapper(protect(*_list)->backItem().get());
 }
 
 - (WKBackForwardListItem *)forwardItem
 {
-    return WebKit::wrapper(protect((*_list).forwardItem()).get());
+    return WebKit::wrapper(protect(*_list)->forwardItem().get());
 }
 
 - (WKBackForwardListItem *)itemAtIndex:(NSInteger)index

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -65,6 +65,14 @@ static inline void setBackForwardItemIdentifiers(FrameState& frameState, BackFor
 
 #if !ENABLE(BACK_FORWARD_LIST_SWIFT)
 
+static bool shouldSkipItemsWithoutUserGestureForWebKitAPI()
+{
+#if PLATFORM(COCOA)
+    return linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::AllBackForwardItemsWithoutUserGestureInvisibleToUI);
+#endif
+    return false;
+}
+
 static const unsigned DefaultCapacity = 100;
 
 WebBackForwardList::WebBackForwardList(WebPageProxy& page)
@@ -265,26 +273,53 @@ WebBackForwardListItem* WebBackForwardList::currentItem() const
     return m_page && m_currentIndex ? m_entries[*m_currentIndex].ptr() : nullptr;
 }
 
-WebBackForwardListItem* WebBackForwardList::backItem() const
+RefPtr<WebBackForwardListItem> WebBackForwardList::backItem() const
 {
     ASSERT(!m_currentIndex || *m_currentIndex < m_entries.size());
+    if (!m_page || !m_currentIndex)
+        return nullptr;
 
-    return m_page && m_currentIndex && *m_currentIndex ? m_entries[*m_currentIndex - 1].ptr() : nullptr;
+    if (shouldSkipItemsWithoutUserGestureForWebKitAPI())
+        return itemStartingAtIndexSkippingItemsAddedByJSWithoutUserGesture(NavigationDirection::Backward, *m_currentIndex).first;
+
+    return *m_currentIndex ? m_entries[*m_currentIndex - 1].ptr() : nullptr;
 }
 
-WebBackForwardListItem* WebBackForwardList::forwardItem() const
+RefPtr<WebBackForwardListItem> WebBackForwardList::forwardItem() const
 {
     ASSERT(!m_currentIndex || *m_currentIndex < m_entries.size());
+    if (!m_page || !m_currentIndex)
+        return nullptr;
 
-    return m_page && m_currentIndex && m_entries.size() && *m_currentIndex < m_entries.size() - 1 ? m_entries[*m_currentIndex + 1].ptr() : nullptr;
+    if (shouldSkipItemsWithoutUserGestureForWebKitAPI())
+        return itemStartingAtIndexSkippingItemsAddedByJSWithoutUserGesture(NavigationDirection::Forward, *m_currentIndex).first;
+
+    return m_entries.size() && *m_currentIndex < m_entries.size() - 1 ? m_entries[*m_currentIndex + 1].ptr() : nullptr;
 }
 
-RefPtr<WebBackForwardListItem> WebBackForwardList::itemAtDeltaFromCurrentIndex(int delta) const
+RefPtr<WebBackForwardListItem> WebBackForwardList::itemAtDeltaFromCurrentIndex(int delta, AllowSkippingBackForwardItems allowSkippingBackForwardItems) const
 {
     if (!m_currentIndex || (int)*m_currentIndex + delta < 0)
         return nullptr;
 
-    return itemAtIndexWithoutSkipping(*m_currentIndex + delta).first;
+    // API requests to get the current item will always get the current item without any skipping logic.
+    if (!delta)
+        return itemAtIndexWithoutSkipping(*m_currentIndex).first;
+
+    if (allowSkippingBackForwardItems == AllowSkippingBackForwardItems::No || !shouldSkipItemsWithoutUserGestureForWebKitAPI())
+        return itemAtIndexWithoutSkipping(*m_currentIndex + delta).first;
+
+    auto direction = delta < 0 ? NavigationDirection::Backward : NavigationDirection::Forward;
+    size_t stepsLeft = abs(delta);
+    size_t nextIndex = *m_currentIndex;
+    while (stepsLeft) {
+        auto item = itemStartingAtIndexSkippingItemsAddedByJSWithoutUserGesture(direction, nextIndex);
+        if (!item.first || !--stepsLeft)
+            return item.first;
+        nextIndex = item.second;
+    }
+
+    return nullptr;
 }
 
 std::pair<RefPtr<WebBackForwardListItem>, size_t> WebBackForwardList::itemAtIndexWithoutSkipping(size_t index) const
@@ -340,6 +375,25 @@ Ref<API::Array> WebBackForwardList::backListAsAPIArrayWithLimit(unsigned limit) 
         return API::Array::create();
 
     ASSERT(backListSize >= size);
+
+    if (shouldSkipItemsWithoutUserGestureForWebKitAPI()) {
+        Vector<RefPtr<API::Object>> vector;
+
+        size_t nextStartingIndex = *m_currentIndex;
+        while (backListSize) {
+            auto item = itemStartingAtIndexSkippingItemsAddedByJSWithoutUserGesture(NavigationDirection::Backward, nextStartingIndex);
+            if (item.first)
+                vector.append(item.first);
+
+            if (!item.first || !--backListSize || !item.second)
+                break;
+            nextStartingIndex = item.second;
+        }
+        vector.reverse();
+
+        return API::Array::create(WTF::move(vector));
+    }
+
     size_t startIndex = backListSize - size;
     Vector<RefPtr<API::Object>> vector(size, [&](size_t i) -> RefPtr<API::Object> {
         // FIXME: Remove SUPPRESS_UNCOUNTED_LAMBDA_CAPTURE when the false positive
@@ -360,6 +414,23 @@ Ref<API::Array> WebBackForwardList::forwardListAsAPIArrayWithLimit(unsigned limi
     unsigned size = std::min(static_cast<unsigned>(forwardListCount()), limit);
     if (!size)
         return API::Array::create();
+
+    if (shouldSkipItemsWithoutUserGestureForWebKitAPI()) {
+        Vector<RefPtr<API::Object>> vector;
+
+        size_t nextStartingIndex = *m_currentIndex;
+        while (size) {
+            auto item = itemStartingAtIndexSkippingItemsAddedByJSWithoutUserGesture(NavigationDirection::Forward, nextStartingIndex);
+            if (item.first)
+                vector.append(item.first);
+
+            if (!item.first || !--size || !item.second)
+                break;
+            nextStartingIndex = item.second;
+        }
+
+        return API::Array::create(WTF::move(vector));
+    }
 
     size_t startIndex = *m_currentIndex + 1;
     Vector<RefPtr<API::Object>> vector(size, [&](size_t i) -> RefPtr<API::Object> {
@@ -517,19 +588,44 @@ std::pair<RefPtr<WebBackForwardListItem>, size_t> WebBackForwardList::itemStarti
         return { nullptr, 0 };
 
     auto item = itemAtIndexWithoutSkipping(itemIndex);
-    ASSERT(item.first);
 
 #if PLATFORM(COCOA)
     if (!linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::UIBackForwardSkipsHistoryItemsWithoutUserGesture))
         return item;
 #endif
 
-    // For example:
-    // Yahoo -> Yahoo#a (no userInteraction) -> Google -> Google#a (no user interaction) -> Google#b (no user interaction)
-    // If we're on Google and navigate back, we don't want to skip anything and load Yahoo#a.
-    // However, if we're on Yahoo and navigate forward, we do want to skip items and end up on Google#b.
-    if (direction == NavigationDirection::Backward && !currentItem()->wasCreatedByJSWithoutUserInteraction())
+    if (!item.first)
         return item;
+
+    // For example:
+    // A -> A#a (no userInteraction) -> B -> B#a (no user interaction) -> B#b (no user interaction)
+    // If we're on B and navigate back, we don't want to skip anything and load A#a.
+    // However, if we're on A and navigate forward, we do want to skip items and end up on B#b.
+    if (direction == NavigationDirection::Backward && !currentItem()->wasCreatedByJSWithoutUserInteraction()) {
+        // The exception to the above is that if the entire list of back items is missing user interaction,
+        // they should all be ignored. For example:
+        // A (no userInteraction) -> B (no userInteraction) -> C*
+        // From the API perspective, C should be item 0, and going back is not an option.
+        // This happens e.g. with new windows that undergo a series of JS driven client redirects.
+        // See https://bugs.webkit.org/show_bug.cgi?id=310243
+
+        auto itemToReturn = item;
+        do {
+            if (item.first->wasCreatedByJSWithoutUserInteraction()) {
+                if (item.second)
+                    item = itemAtIndexWithoutSkipping(item.second - 1);
+                else {
+                    // We reached the beginning of the list and still didn't find an item with user interaction,
+                    // therefore we are returning nothing.
+                    itemToReturn = { };
+                    break;
+                }
+            } else
+                break;
+        } while (true);
+
+        return itemToReturn;
+    }
 
     // For example:
     // Yahoo -> Yahoo#a (no userInteraction) -> Google -> Google#a (no user interaction) -> Google#b (no user interaction)
@@ -540,8 +636,14 @@ std::pair<RefPtr<WebBackForwardListItem>, size_t> WebBackForwardList::itemStarti
     while (item.first->wasCreatedByJSWithoutUserInteraction()) {
         itemIndex += delta;
         item = itemAtIndexWithoutSkipping(itemIndex);
-        if (!item.first)
-            return originalitem;
+        if (!item.first) {
+            // If there are no more back items that ever had a user gesture, then we should not enable going back.
+            // This happens when e.g. a new window is created by JavaScript then client redirects occur that create
+            // a sequence of history items, each without user interaction.
+            RELEASE_LOG(Loading, "UI Navigation is disabling going back because no more WebBackForwardListItem items in the back list had user interaction");
+            return { };
+        }
+
         RELEASE_LOG(Loading, "UI Navigation is skipping a WebBackForwardListItem because it was added by JavaScript without user interaction");
     }
 
@@ -703,6 +805,8 @@ void WebBackForwardList::backForwardUpdateItem(IPC::Connection& connection, Ref<
 
         if (oldFrameID && newFrameID && oldFrameID != newFrameID)
             updateFrameIdentifier(*oldFrameID, *newFrameID);
+
+        webPageProxy->updateCanGoBackAndForward();
     }
 }
 
@@ -757,7 +861,7 @@ void WebBackForwardList::backForwardAllItems(FrameIdentifier frameID, Completion
 void WebBackForwardList::backForwardItemAtIndexForWebContent(int32_t delta, FrameIdentifier frameID, CompletionHandler<void(RefPtr<FrameState>&&)>&& completionHandler)
 {
     // FIXME: This should verify that the web process requesting the item hosts the specified frame.
-    if (RefPtr item = itemAtDeltaFromCurrentIndex(delta)) {
+    if (RefPtr item = itemAtDeltaFromCurrentIndex(delta, AllowSkippingBackForwardItems::No)) {
         if (RefPtr frameItem = item->mainFrameItem().childItemForFrameID(frameID))
             return completionHandler(frameItem->copyFrameStateWithChildren());
         completionHandler(item->copyMainFrameStateWithChildren());
@@ -824,18 +928,20 @@ WebBackForwardListItem* WebBackForwardListWrapper::currentItem() const
     return m_impl->currentItem();
 }
 
-WebBackForwardListItem* WebBackForwardListWrapper::backItem() const
+RefPtr<WebBackForwardListItem> WebBackForwardListWrapper::backItem() const
 {
     return m_impl->backItem();
 }
 
-WebBackForwardListItem* WebBackForwardListWrapper::forwardItem() const
+RefPtr<WebBackForwardListItem> WebBackForwardListWrapper::forwardItem() const
 {
     return m_impl->forwardItem();
 }
 
-RefPtr<WebBackForwardListItem> WebBackForwardListWrapper::itemAtDeltaFromCurrentIndex(int index) const
+RefPtr<WebBackForwardListItem> WebBackForwardListWrapper::itemAtDeltaFromCurrentIndex(int index, AllowSkippingBackForwardItems allowSkipping) const
 {
+    // FIXME: Update the Swift interface and pass this value through.
+    UNUSED_PARAM(allowSkipping);
     return m_impl->itemAtDeltaFromCurrentIndex(index);
 }
 

--- a/Source/WebKit/UIProcess/WebBackForwardList.h
+++ b/Source/WebKit/UIProcess/WebBackForwardList.h
@@ -47,6 +47,8 @@ class WebPageProxy;
 struct BackForwardListState;
 struct WebBackForwardListCounts;
 
+enum class AllowSkippingBackForwardItems : bool { No, Yes };
+
 #if !ENABLE(BACK_FORWARD_LIST_SWIFT)
 
 class WebBackForwardList : public API::ObjectImpl<API::Object::Type::BackForwardList>, public IPC::MessageReceiver {
@@ -70,9 +72,10 @@ public:
     void clear();
 
     WebBackForwardListItem* NODELETE currentItem() const;
-    WebBackForwardListItem* NODELETE backItem() const;
-    WebBackForwardListItem* NODELETE forwardItem() const;
-    RefPtr<WebBackForwardListItem> itemAtDeltaFromCurrentIndex(int) const;
+    RefPtr<WebBackForwardListItem> backItem() const;
+    RefPtr<WebBackForwardListItem> forwardItem() const;
+
+    RefPtr<WebBackForwardListItem> itemAtDeltaFromCurrentIndex(int, AllowSkippingBackForwardItems = AllowSkippingBackForwardItems::Yes) const;
 
     RefPtr<WebBackForwardListItem> goBackItemSkippingItemsWithoutUserGesture() const;
     RefPtr<WebBackForwardListItem> goForwardItemSkippingItemsWithoutUserGesture() const;
@@ -157,9 +160,10 @@ public:
     void clear();
 
     WebBackForwardListItem* WTF_NULLABLE currentItem() const;
-    RefPtr<WebBackForwardListItem> itemAtDeltaFromCurrentIndex(int) const;
-    WebBackForwardListItem* WTF_NULLABLE backItem() const;
-    WebBackForwardListItem* WTF_NULLABLE forwardItem() const;
+
+    RefPtr<WebBackForwardListItem> itemAtDeltaFromCurrentIndex(int, AllowSkippingBackForwardItems = AllowSkippingBackForwardItems::Yes) const;
+    RefPtr<WebBackForwardListItem> backItem() const;
+    RefPtr<WebBackForwardListItem> forwardItem() const;
 
     Ref<API::Array> backList() const;
     Ref<API::Array> forwardList() const;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2258,8 +2258,10 @@ void WebPageProxy::loadRequestWithNavigationShared(Ref<WebProcessProxy>&& proces
     loadParameters.isHandledByAboutSchemeHandler = m_aboutSchemeHandler->canHandleURL(url);
     loadParameters.requiredCookiesVersion = websiteDataStore().cookiesVersion();
     loadParameters.originatingFrame = navigation.lastNavigationAction() ? std::optional(navigation.lastNavigationAction()->originatingFrameInfoData) : std::nullopt;
-    if (auto& action = navigation.lastNavigationAction())
+    if (auto& action = navigation.lastNavigationAction()) {
+        loadParameters.hadUserGesture = action->userGestureTokenIdentifier.has_value();
         loadParameters.requester = action->requester;
+    }
     if (shouldTreatAsContinuingLoad == ShouldTreatAsContinuingLoad::YesAfterNavigationPolicyDecision)
         loadParameters.originalRequest = navigation.originalRequest();
 
@@ -2787,6 +2789,11 @@ void WebPageProxy::didChangeBackForwardList(WebBackForwardListItem* added, Vecto
     if (!m_navigationClient->didChangeBackForwardList(*this, added, removed) && m_loaderClient)
         m_loaderClient->didChangeBackForwardList(*this, added, WTF::move(removed));
 
+    updateCanGoBackAndForward();
+}
+
+void WebPageProxy::updateCanGoBackAndForward()
+{
     Ref pageLoadState = internals().pageLoadState;
     auto transaction = pageLoadState->transaction();
 
@@ -2819,7 +2826,7 @@ void WebPageProxy::goToBackForwardItemAtIndex(int32_t steps, FrameLoadType frame
 {
     WEBPAGEPROXY_RELEASE_LOG(Loading, "goToBackForwardItemAtIndex: steps=%d", steps);
 
-    RefPtr item = backForwardListWrapper().itemAtDeltaFromCurrentIndex(steps);
+    RefPtr item = backForwardListWrapper().itemAtDeltaFromCurrentIndex(steps, AllowSkippingBackForwardItems::No);
     if (!item)
         return;
 
@@ -5453,6 +5460,7 @@ void WebPageProxy::receivedNavigationActionPolicyDecision(WebProcessProxy& proce
             loadParameters.shouldTreatAsContinuingLoad = navigation->currentRequestIsRedirect() ? ShouldTreatAsContinuingLoad::YesAfterProvisionalLoadStarted : ShouldTreatAsContinuingLoad::YesAfterNavigationPolicyDecision;
             loadParameters.frameIdentifier = frame->frameID();
             loadParameters.isRequestFromClientOrUserInput = navigationAction->data().isRequestFromClientOrUserInput;
+            loadParameters.hadUserGesture = navigationAction->data().userGestureTokenIdentifier.has_value();
             loadParameters.navigationID = navigation->navigationID();
             loadParameters.ownerPermissionsPolicy = navigation->ownerPermissionsPolicy();
             loadParameters.navigationUpgradeToHTTPSBehavior = navigationAction->data().navigationUpgradeToHTTPSBehavior;
@@ -5787,8 +5795,10 @@ void WebPageProxy::continueNavigationInNewProcess(API::Navigation& navigation, W
         loadParameters.ownerPermissionsPolicy = navigation.ownerPermissionsPolicy();
         loadParameters.navigationUpgradeToHTTPSBehavior = navigationUpgradeToHTTPSBehavior;
         loadParameters.isHandledByAboutSchemeHandler = m_aboutSchemeHandler->canHandleURL(loadParameters.request.url());
-        if (auto& action = navigation.lastNavigationAction())
+        if (auto& action = navigation.lastNavigationAction()) {
             loadParameters.requester = action->requester;
+            loadParameters.hadUserGesture = action->userGestureTokenIdentifier.has_value();
+        }
 
         if (isPendingInitialHistoryItem)
             frame.setIsPendingInitialHistoryItem(true);

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1595,7 +1595,7 @@ public:
     WebCore::RectEdges<bool> NODELETE pinnedState() const;
     WebCore::RectEdges<bool> pinnedStateIncludingAncestorsAtPoint(WebCore::FloatPoint);
 
-    WebCore::RectEdges<bool> NODELETE rubberBandableEdgesRespectingHistorySwipe() const;
+    WebCore::RectEdges<bool> rubberBandableEdgesRespectingHistorySwipe() const;
     WebCore::RectEdges<bool> NODELETE rubberBandableEdges() const;
     void NODELETE setRubberBandableEdges(WebCore::RectEdges<bool>);
     void NODELETE setRubberBandsAtLeft(bool);
@@ -2972,6 +2972,8 @@ public:
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
     void exitImmersive(CompletionHandler<void()>&&);
 #endif
+
+    void updateCanGoBackAndForward();
 
 private:
     WebPageProxy(PageClient&, WebProcessProxy&, Ref<API::PageConfiguration>&&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2283,6 +2283,11 @@ void WebPage::loadRequest(LoadParameters&& loadParameters)
 
     localFrame->loader().setNavigationUpgradeToHTTPSBehavior(loadParameters.navigationUpgradeToHTTPSBehavior);
     localFrame->loader().setRequiredCookiesVersion(loadParameters.requiredCookiesVersion);
+
+    std::optional<UserGestureIndicator> userGestureIndicator;
+    if (loadParameters.hadUserGesture && loadParameters.shouldTreatAsContinuingLoad != ShouldTreatAsContinuingLoad::No)
+        userGestureIndicator.emplace(IsProcessingUserGesture::Yes);
+
     localFrame->loader().load(WTF::move(frameLoadRequest), WTF::move(loadParameters.requester));
 
     ASSERT(!m_pendingNavigationID);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ProcessSwapOnNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ProcessSwapOnNavigation.mm
@@ -2397,6 +2397,16 @@ TEST(ProcessSwap, NavigateBackAfterClientSideRedirect)
     EXPECT_FALSE(didPerformClientRedirect);
 }
 
+static constexpr auto webkitMainWithClickableLinkBytes = R"PSONRESOURCE(
+<script>
+window.addEventListener('pageshow', function(event) {
+    if (event.persisted)
+        window.webkit.messageHandlers.pson.postMessage("Was persisted");
+});
+</script>
+<a id="testLink" href="pson://www.apple.com/main.html">Navigate</a>
+)PSONRESOURCE"_s;
+
 static void runNavigationWithLockedHistoryTest(ShouldEnablePSON shouldEnablePSON)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
@@ -2406,7 +2416,7 @@ static void runNavigationWithLockedHistoryTest(ShouldEnablePSON shouldEnablePSON
     RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
     RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
-    [handler addMappingFromURLString:@"pson://www.webkit.org/main.html" toData:navigationWithLockedHistoryBytes];
+    [handler addMappingFromURLString:@"pson://www.webkit.org/main.html" toData:webkitMainWithClickableLinkBytes];
     [handler addMappingFromURLString:@"pson://www.apple.com/main.html" toData:pageCache1Bytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"pson"];
 
@@ -2431,7 +2441,8 @@ static void runNavigationWithLockedHistoryTest(ShouldEnablePSON shouldEnablePSON
 
     auto webkitPID = [webView _webProcessIdentifier];
 
-    // Page redirects to apple.com.
+    // Click the link with a user gesture to navigate to apple.com.
+    [webView evaluateJavaScript:@"testLink.click()" completionHandler:nil];
     TestWebKitAPI::Util::run(&done);
     done = false;
 
@@ -6828,7 +6839,6 @@ TEST(ProcessSwap, GoBackToSuspendedPageWithMainFrameIDThatIsNotOne)
     RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
     RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
-    [handler addMappingFromURLString:@"pson://www.webkit.org/main1.html" toData:targetBlankSameSiteNoOpenerTestBytes];
     [handler addMappingFromURLString:@"pson://www.webkit.org/main2.html" toData:linkToAppleTestBytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
@@ -6845,8 +6855,6 @@ TEST(ProcessSwap, GoBackToSuspendedPageWithMainFrameIDThatIsNotOne)
 
     RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView1 setNavigationDelegate:navigationDelegate.get()];
-    RetainPtr uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
-    [webView1 setUIDelegate:uiDelegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main1.html"]];
 
@@ -6857,9 +6865,14 @@ TEST(ProcessSwap, GoBackToSuspendedPageWithMainFrameIDThatIsNotOne)
     EXPECT_WK_STREQ(@"pson://www.webkit.org/main1.html", [[webView1 URL] absoluteString]);
     auto pid1 = [webView1 _webProcessIdentifier];
 
-    TestWebKitAPI::Util::run(&didCreateWebView);
-    didCreateWebView = false;
+    // Directly create a second web view that is related to the first.
+    // This makes it start out sharing a process with the first, and gives it a main frame ID that is not 1.
+    RetainPtr webView2Configuration = adoptNS([webViewConfiguration copy]);
+    [webView2Configuration _setRelatedWebView:webView1.get()];
+    RetainPtr createdWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webView2Configuration.get()]);
+    [createdWebView setNavigationDelegate:navigationDelegate.get()];
 
+    [createdWebView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main2.html"]]];
     TestWebKitAPI::Util::run(&done);
     done = false;
 
@@ -6867,7 +6880,7 @@ TEST(ProcessSwap, GoBackToSuspendedPageWithMainFrameIDThatIsNotOne)
     EXPECT_WK_STREQ(@"pson://www.webkit.org/main2.html", [[createdWebView URL] absoluteString]);
     auto pid2 = [createdWebView _webProcessIdentifier];
 
-    // Same-site navigations without opener still share the same process.
+    // Same-site navigations still share the same process.
     EXPECT_EQ(pid1, pid2);
 
     // Click link in new WKWebView so that it navigates cross-site to apple.com.
@@ -7579,11 +7592,7 @@ TEST(ProcessSwap, PassSandboxExtension)
 #if PLATFORM(MAC)
 
 static constexpr auto pageThatOpensBytes = R"PSONRESOURCE(
-<script>
-window.onload = function() {
-    window.open("pson://www.webkit.org/window.html", "_blank");
-}
-</script>
+<a id="testLink" target="_blank" href="pson://www.webkit.org/window.html">Open</a>
 )PSONRESOURCE"_s;
 
 static constexpr auto openedPage = "Hello World"_s;
@@ -7604,8 +7613,6 @@ TEST(ProcessSwap, SameSiteWindowWithOpenerNavigateToFile)
     RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
-    RetainPtr uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
-    [webView setUIDelegate:uiDelegate.get()];
 
     numberOfDecidePolicyCalls = 0;
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]];
@@ -7614,13 +7621,16 @@ TEST(ProcessSwap, SameSiteWindowWithOpenerNavigateToFile)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    TestWebKitAPI::Util::run(&didCreateWebView);
-    didCreateWebView = false;
+    // Directly create a second web view that is related to the first.
+    // This makes it start out sharing a process with the first.
+    RetainPtr webView2Configuration = adoptNS([webViewConfiguration copy]);
+    [webView2Configuration _setRelatedWebView:webView.get()];
+    RetainPtr createdWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webView2Configuration.get()]);
+    [createdWebView setNavigationDelegate:navigationDelegate.get()];
 
+    [createdWebView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/window.html"]]];
     TestWebKitAPI::Util::run(&done);
     done = false;
-
-    EXPECT_EQ(2, numberOfDecidePolicyCalls);
 
     auto pid1 = [webView _webProcessIdentifier];
     EXPECT_TRUE(!!pid1);
@@ -7637,7 +7647,6 @@ TEST(ProcessSwap, SameSiteWindowWithOpenerNavigateToFile)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    EXPECT_EQ(3, numberOfDecidePolicyCalls);
     auto pid3 = [createdWebView _webProcessIdentifier];
     EXPECT_TRUE(!!pid3);
     EXPECT_NE(pid2, pid3);
@@ -7655,7 +7664,6 @@ TEST(ProcessSwap, SameSiteWindowWithOpenerNavigateToFile)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    EXPECT_EQ(4, numberOfDecidePolicyCalls);
     auto pid4 = [createdWebView _webProcessIdentifier];
     EXPECT_NE(pid3, pid4);
 
@@ -7663,7 +7671,6 @@ TEST(ProcessSwap, SameSiteWindowWithOpenerNavigateToFile)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    EXPECT_EQ(5, numberOfDecidePolicyCalls);
     auto pid5 = [createdWebView _webProcessIdentifier];
     EXPECT_NE(pid4, pid5);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKBackForwardListTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKBackForwardListTests.mm
@@ -470,7 +470,8 @@ TEST(WKBackForwardList, BackSwipeNavigationSkipsItemsWithoutUserGesture)
     [webView _evaluateJavaScriptWithoutUserGesture:@"history.pushState(null, document.title, location.pathname + '#c');" completionHandler:nil];
     [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
 
-    EXPECT_EQ([webView backForwardList].backList.count, 4U);
+    // 4 items in the back list, but most should be invisible because of the user gesture flag.
+    EXPECT_EQ([webView backForwardList].backList.count, 1U);
     EXPECT_EQ([webView backForwardList].forwardList.count, 0U);
 
     // Navigating back via a swipe gesture should skip those back/forward list items without a user gesture.
@@ -480,8 +481,9 @@ TEST(WKBackForwardList, BackSwipeNavigationSkipsItemsWithoutUserGesture)
 
     EXPECT_STREQ([webView URL].absoluteString.UTF8String, [url1 absoluteString].UTF8String);
 
+    // 4 items in the forward list, but most should be invisible because of the user gesture flag.
+    EXPECT_EQ([webView backForwardList].forwardList.count, 1U);
     EXPECT_EQ([webView backForwardList].backList.count, 0U);
-    EXPECT_EQ([webView backForwardList].forwardList.count, 4U);
 }
 
 TEST(WKBackForwardList, BackSwipeNavigationDoesNotSkipItemsWithUserGesture)
@@ -576,7 +578,7 @@ static void runBackForwardNavigationSkipsItemsWithoutUserGestureTest(Function<vo
     // We should go back to url2#c.
     expectedURLString = makeString(String([url2 absoluteString]), "#c"_s).createNSString();
     EXPECT_STREQ([webView URL].absoluteString.UTF8String, expectedURLString.get().UTF8String);
-    EXPECT_EQ([webView backForwardList].backList.count, 4U);
+    EXPECT_EQ([webView backForwardList].backList.count, 1U);
     EXPECT_EQ([webView backForwardList].forwardList.count, 1U);
 
     // Let's go back again.
@@ -586,7 +588,7 @@ static void runBackForwardNavigationSkipsItemsWithoutUserGestureTest(Function<vo
     // We should have skipped over url2#b, url2#a and url2, to end up on url1.
     EXPECT_STREQ([webView URL].absoluteString.UTF8String, [url1 absoluteString].UTF8String);
     EXPECT_EQ([webView backForwardList].backList.count, 0U);
-    EXPECT_EQ([webView backForwardList].forwardList.count, 5U);
+    EXPECT_EQ([webView backForwardList].forwardList.count, 2U);
 
     // Now let's go forward.
     [webView goForward];
@@ -595,7 +597,7 @@ static void runBackForwardNavigationSkipsItemsWithoutUserGestureTest(Function<vo
     // We should get to the latest url2 URL, that is url2#c.
     expectedURLString = makeString(String([url2 absoluteString]), "#c"_s).createNSString();
     EXPECT_STREQ([webView URL].absoluteString.UTF8String, expectedURLString.get().UTF8String);
-    EXPECT_EQ([webView backForwardList].backList.count, 4U);
+    EXPECT_EQ([webView backForwardList].backList.count, 1U);
     EXPECT_EQ([webView backForwardList].forwardList.count, 1U);
 
     // Let's go forward again.
@@ -613,15 +615,15 @@ static void runBackForwardNavigationSkipsItemsWithoutUserGestureTest(Function<vo
 
     expectedURLString = makeString(String([url2 absoluteString]), "#c"_s).createNSString();
     EXPECT_STREQ([webView URL].absoluteString.UTF8String, expectedURLString.get().UTF8String);
-    EXPECT_EQ([webView backForwardList].backList.count, 4U);
+    EXPECT_EQ([webView backForwardList].backList.count, 1U);
     EXPECT_EQ([webView backForwardList].forwardList.count, 1U);
 
     [webView _evaluateJavaScriptWithoutUserGesture:@"history.back();" completionHandler:^(id, NSError *) { }];
     [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
     expectedURLString = makeString(String([url2 absoluteString]), "#b"_s).createNSString();
     EXPECT_STREQ([webView URL].absoluteString.UTF8String, expectedURLString.get().UTF8String);
-    EXPECT_EQ([webView backForwardList].backList.count, 3U);
-    EXPECT_EQ([webView backForwardList].forwardList.count, 2U);
+    EXPECT_EQ([webView backForwardList].backList.count, 1U);
+    EXPECT_EQ([webView backForwardList].forwardList.count, 1U);
 }
 
 TEST(WKBackForwardList, BackForwardNavigationSkipsItemsWithoutUserGesturePushState)
@@ -660,33 +662,51 @@ TEST(WKBackForwardList, BackForwardNavigationSkipsItemsWithoutUserGestureSubfram
         { "/iframe.html"_s, { "<script>onload = () => { setTimeout(() => { history.pushState(null, document.title, '#'); }, 0); };</script>"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] init]);
 
     RetainPtr navigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
     webView.get().navigationDelegate = navigationDelegate.get();
 
+    // After this load, the bf list is:
+    // (source)*
     [webView loadRequest:server.request("/source.html"_s)];
     [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
 
+    // After this load, the bf list is:
+    // (source) - (destination)*
     [webView loadRequest:server.request("/destination.html"_s)];
     [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
 
-    // Wait for the subframe to call pushState().
-    while ([webView backForwardList].backList.count != 2)
+    // Wait for the subframe to call pushState(). The API-visible backList is filtered
+    // so we poll history.length which reflects the unfiltered count.
+    while ([[webView objectByEvaluatingJavaScript:@"history.length"] integerValue] < 3)
         TestWebKitAPI::Util::spinRunLoop();
+
+    // After the push state without user gesture in the iframe, the bf list is:
+    // (source) - (destination) - [destination`]*
+    // Because the current item has no user gesture, going back would skip the previous item
+    // that *does* have a user gesture. So the back list count should be 1, not 2.
+    EXPECT_EQ([webView backForwardList].backList.count, 1U);
 
     [webView goBack];
     [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
 
     // We should be back to source.html since we would have ignored the history item
     // added by the subframe without user interaction.
+    // The bf list should look like:
+    // (source)* - (destination) - [destination`]
     EXPECT_EQ([webView backForwardList].backList.count, 0U);
     EXPECT_STREQ([webView URL].absoluteString.UTF8String, server.request("/source.html"_s).URL.absoluteString.UTF8String);
 
     [webView goForward];
     [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
 
-    EXPECT_EQ([webView backForwardList].backList.count, 2U);
+    // Going forward skips the middle item (which has a user gesture) to the final item.
+    // So the list is once again:
+    // (source) - (destination) - [destination`]*
+    // Like before, vecause the current item has no user gesture, going back would skip the previous item
+    // that *does* have a user gesture. So the back list count should be 1, not 2.
+    EXPECT_EQ([webView backForwardList].backList.count, 1U);
     EXPECT_EQ([webView backForwardList].forwardList.count, 0U);
     EXPECT_STREQ([webView URL].absoluteString.UTF8String, server.request("/destination.html"_s).URL.absoluteString.UTF8String);
 }
@@ -1280,21 +1300,21 @@ TEST(WKBackForwardList, BackwardSkipIteratesThroughConsecutiveJSItems)
     [webView _evaluateJavaScriptWithoutUserGesture:@"history.pushState(null, '', '#b');" completionHandler:nil];
     [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
 
-    EXPECT_EQ([webView backForwardList].backList.count, 3U);
+    EXPECT_EQ([webView backForwardList].backList.count, 1U);
 
     [webView goBack];
     [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
 
     EXPECT_STREQ([webView URL].absoluteString.UTF8String, [url1 absoluteString].UTF8String);
     EXPECT_EQ([webView backForwardList].backList.count, 0U);
-    EXPECT_EQ([webView backForwardList].forwardList.count, 3U);
+    EXPECT_EQ([webView backForwardList].forwardList.count, 1U);
 
     [webView goForward];
     [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
 
     RetainPtr expectedURL = makeString(String([url2 absoluteString]), "#b"_s).createNSString();
     EXPECT_STREQ([webView URL].absoluteString.UTF8String, expectedURL.get().UTF8String);
-    EXPECT_EQ([webView backForwardList].backList.count, 3U);
+    EXPECT_EQ([webView backForwardList].backList.count, 1U);
     EXPECT_EQ([webView backForwardList].forwardList.count, 0U);
 }
 
@@ -1373,19 +1393,15 @@ TEST(WKBackForwardList, BackwardSkipReturnsNonJSItemWhenNothingFurtherBack)
 
     EXPECT_STREQ([webView URL].absoluteString.UTF8String, [url1 absoluteString].UTF8String);
     EXPECT_EQ([webView backForwardList].backList.count, 0U);
-    EXPECT_EQ([webView backForwardList].forwardList.count, 1U);
+    EXPECT_EQ([webView backForwardList].forwardList.count, 0U);
 }
 
 TEST(WKBackForwardList, ForwardSkipReturnsFirstJSItemWhenAllForwardItemsAreJS)
 {
-    // Covers the guard in the main while-loop of
-    // itemSkippingBackForwardItemsAddedByJSWithoutUserGesture for the forward
-    // direction (line 643): runs out of items before finding a non-JS item.
+    // Create a back/forward list with the following state:
+    // url1 -> url1#a(JS) -> url1#b(JS) -> url1#c(JS)
     //
-    // State: url1 -> url1#a(JS) -> url1#b(JS) -> url1#c(JS)
-    //
-    // Navigate to url1, then goForward: all forward items are JS. The while loop
-    // iterates through them all and runs out, returning originalItem (url1#a).
+    // Navigate to url1's item, and verify the API visible forward list is empty.
 
     RetainPtr webView = adoptNS([[WKWebView alloc] init]);
     RetainPtr navigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
@@ -1405,20 +1421,14 @@ TEST(WKBackForwardList, ForwardSkipReturnsFirstJSItemWhenAllForwardItemsAreJS)
     [webView _evaluateJavaScriptWithoutUserGesture:@"history.pushState(null, '', '#c');" completionHandler:nil];
     [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
 
-    // backList is ordered oldest-first; firstObject is url1 (the original loadRequest item).
     WKBackForwardListItem *url1Item = [webView backForwardList].backList.firstObject;
     [webView goToBackForwardListItem:url1Item];
     [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
 
     EXPECT_STREQ([webView URL].absoluteString.UTF8String, [url1 absoluteString].UTF8String);
 
-    [webView goForward];
-    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
-
-    RetainPtr expectedURL = makeString(String([url1 absoluteString]), "#a"_s).createNSString();
-    EXPECT_STREQ([webView URL].absoluteString.UTF8String, expectedURL.get().UTF8String);
-    EXPECT_EQ([webView backForwardList].backList.count, 1U);
-    EXPECT_EQ([webView backForwardList].forwardList.count, 2U);
+    EXPECT_EQ([webView backForwardList].backList.count, 0U);
+    EXPECT_EQ([webView backForwardList].forwardList.count, 0U);
 }
 
 static void runGoBackAfterNavigatingSameSiteIframe2(ShouldEnablePageCache shouldEnablePageCache)
@@ -1509,4 +1519,113 @@ TEST(WKBackForwardList, PageCacheGoBackAfterNavigatingSameSiteIframe2)
 TEST(WKBackForwardList, NoPageCacheGoBackAfterNavigatingSameSiteIframe2)
 {
     runGoBackAfterNavigatingSameSiteIframe2(ShouldEnablePageCache::No);
+}
+
+TEST(WKBackForwardList, BackForwardNavigationSkipsPromiseRedirectWithoutUserInteraction)
+{
+    // When a web page asynchronously adds items to the session history after the load event,
+    // the JavaScript visible session history should see the new entries... But the browser-visible
+    // session history (like what the user sees when looking at the back/forward list buttons) now
+    // hides these entries.
+    //
+    // This test uses both JavaScript and the WKBackForwardList API to verify both views of the
+    // session history are as expected.
+
+    TestWebKitAPI::HTTPServer server({
+        { "/opener"_s, { "<a id='link' href='/pageA' target='_blank'>Open</a>"
+            "<script>function clickLink() { document.getElementById('link').click(); }</script>"_s } },
+        { "/pageA"_s, { "<script>"
+            "window.onload = function() {"
+            "  var data = new TextEncoder().encode('test data for hashing');"
+            "  crypto.subtle.digest('SHA-256', data).then(function(hash) {"
+            "    return crypto.subtle.importKey('raw', hash, { name: 'AES-CBC', length: 256 }, false, ['encrypt']);"
+            "  }).then(function(key) {"
+            "    var iv = new Uint8Array(16);"
+            "    return crypto.subtle.encrypt({ name: 'AES-CBC', iv: iv }, key, data);"
+            "  }).then(function(encrypted) {"
+            "    window.location.href = '/pageB';"
+            "  });"
+            "};"
+            "</script>"_s } },
+        { "/pageB"_s, { "Page B"_s } },
+        { "/pageC"_s, { "Page C"_s } },
+        { "/pageD"_s, { "Page D"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    RetainPtr openerWebView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero]);
+    [openerWebView configuration].preferences.javaScriptCanOpenWindowsAutomatically = YES;
+
+    __block RetainPtr<TestWKWebView> popupWebView;
+    __block bool popupCreated = false;
+    RetainPtr navigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
+
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
+    uiDelegate.get().createWebViewWithConfiguration = ^(WKWebViewConfiguration *configuration, WKNavigationAction *action, WKWindowFeatures *windowFeatures) {
+        popupWebView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+        [popupWebView setNavigationDelegate:navigationDelegate.get()];
+        popupCreated = true;
+        return popupWebView.get();
+    };
+    [openerWebView setUIDelegate:uiDelegate.get()];
+
+    RetainPtr openerNavigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
+    [openerWebView setNavigationDelegate:openerNavigationDelegate.get()];
+    [openerWebView loadRequest:server.request("/opener"_s)];
+    [openerNavigationDelegate waitForDidFinishNavigation];
+
+    [openerWebView evaluateJavaScript:@"clickLink()" completionHandler:nil];
+    TestWebKitAPI::Util::run(&popupCreated);
+
+    // Wait for two navigations to finish: To page A, then to Page B.
+    [navigationDelegate waitForDidFinishNavigation];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // Page A did some crypto operations in a promise chain.
+    // At the end of that promise chain it did a JS redirect to page B.
+    // So the session history looks like this:
+    // (A) -> (B)*
+    // Parenthesis indicates the page had no user interaction.
+    // Asterisk indicates the current item.
+    // JavaScript will always see the full session history, so the length there is 2.
+    EXPECT_STREQ([[popupWebView stringByEvaluatingJavaScript:@"history.length"] UTF8String], "2");
+
+    // But the API back/forward list ignores entries without user interaction.
+    // Therefore both the backList and forwardList should be empty.
+    EXPECT_EQ([popupWebView backForwardList].backList.count, 0U);
+    EXPECT_EQ([popupWebView backForwardList].forwardList.count, 0U);
+
+    [popupWebView loadRequest:server.request("/pageC"_s)];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // The history now looks like this:
+    // (A) -> (B) -> C*
+    // JavaScript sees all 3, but the API back/forward list ignores those first two entries.
+    EXPECT_STREQ([[popupWebView stringByEvaluatingJavaScript:@"history.length"] UTF8String], "3");
+    EXPECT_EQ([popupWebView backForwardList].backList.count, 0U);
+    EXPECT_EQ([popupWebView backForwardList].forwardList.count, 0U);
+    EXPECT_STREQ([popupWebView URL].absoluteString.UTF8String, server.request("/pageC"_s).URL.absoluteString.UTF8String);
+
+    [popupWebView loadRequest:server.request("/pageD"_s)];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // The history now looks like this:
+    // (A) -> (B) -> C -> D*
+    // JavaScript sees all 4, the API back/forward list should see only 2.
+    EXPECT_STREQ([[popupWebView stringByEvaluatingJavaScript:@"history.length"] UTF8String], "4");
+    EXPECT_EQ([popupWebView backForwardList].backList.count, 1U);
+    EXPECT_EQ([popupWebView backForwardList].forwardList.count, 0U);
+    EXPECT_STREQ([popupWebView URL].absoluteString.UTF8String, server.request("/pageD"_s).URL.absoluteString.UTF8String);
+
+    [popupWebView goBack];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // The history now looks like this:
+    // (A) -> (B) -> C* -> D
+    EXPECT_EQ([popupWebView backForwardList].backList.count, 0U);
+    EXPECT_EQ([popupWebView backForwardList].forwardList.count, 1U);
+    EXPECT_STREQ([popupWebView URL].absoluteString.UTF8String, server.request("/pageC"_s).URL.absoluteString.UTF8String);
+
+    // Attempting to goBack now should simply fail.
+    auto *navigation = [popupWebView goBack];
+    EXPECT_NULL(navigation);
 }


### PR DESCRIPTION
#### 16dc6bfd11c1dc99d785ada5b4b5f0af08dd63fb
<pre>
Back button unexpectedly enabled in newly opened tab
<a href="https://rdar.apple.com/174798415">rdar://174798415</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=310243">https://bugs.webkit.org/show_bug.cgi?id=310243</a>

Reviewed by Chris Dumez.

Normally, navigating a page to a new URL will push a new back/forward history entry.

Browsers detect client redirects that occur during the loading process (i.e. before the load event)
and update the existing back/forward item instead of creating new ones for the location change.

Some sites do something like this &quot;quick client redirect&quot; but subtly asynchronous. For example, via
a promise chain that sometimes can resolve synchronously, but often does not, even if it resolves
very shortly after the load event. This causes the location change to actually happen after the load
event, and therefore its treated as a new navigation that warrants creating a new back/forward item.

This leads to an annoying user experience for users when, for example, a new window or tab ends up
with multiple items in the back/forward list, leading to an enabled back button, confusing the user.

In <a href="https://commits.webkit.org/259437@main">https://commits.webkit.org/259437@main</a> we added logic that skips some items created by JS when
going back or forward. This was a fix to guard against malicious JS trying to hijack the list.
But the same logic can be applied here - Tracking items that are created without user interaction
and treating them differently.

The fix in 259437@main was incomplete as it only applied to &quot;goBack&quot; and &quot;goForward&quot; to protect
against hijacking swipe gestures. It did not apply to getting the items in the lists or to the
&quot;goToItem:&quot; API.

This change expands that fix to all API access of the back/forward list, presenting an entirely
different view of the list to the client application then JavaScript will see in the `history`
interface. Additionally, it sets the flag in one more case when one of these &quot;quick redirects&quot;
occurs but after the load event.

This type of &quot;presenting a different back/forward list to the app than what JavaScript sees&quot; has
precedent in other browser engines and is probably a good mechanism to have going forward.

Finally, it also tests the new behavior both via JavaScript and the WebKit API to make sure that
the back/forward list is represented differently to each.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKBackForwardListTests.mm

* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Source/WebCore/history/HistoryItem.cpp:
(WebCore::HistoryItem::setWasCreatedByJSWithoutUserInteraction):
* Source/WebCore/history/HistoryItem.h:
(WebCore::HistoryItem::setWasCreatedByJSWithoutUserInteraction): Deleted.
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::updateForStandardLoad):
* Source/WebKit/UIProcess/API/C/WKBackForwardListRef.cpp:
(WKBackForwardListGetBackItem):
(WKBackForwardListGetForwardItem):
* Source/WebKit/UIProcess/API/Cocoa/WKBackForwardList.mm:
(-[WKBackForwardList backItem]):
(-[WKBackForwardList forwardItem]):
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(shouldSkipItemsForWebKitAPI):
(WebKit::WebBackForwardList::backItem const):
(WebKit::WebBackForwardList::forwardItem const):
(WebKit::WebBackForwardList::itemAtDeltaFromCurrentIndex const):
(WebKit::WebBackForwardList::backListAsAPIArrayWithLimit const):
(WebKit::WebBackForwardList::forwardListAsAPIArrayWithLimit const):
(WebKit::WebBackForwardList::itemStartingAtIndexSkippingItemsAddedByJSWithoutUserGesture const):
(WebKit::WebBackForwardList::backForwardUpdateItem):
(WebKit::WebBackForwardList::backForwardItemAtIndexForWebContent):
(WebKit::WebBackForwardListWrapper::backItem const):
(WebKit::WebBackForwardListWrapper::forwardItem const):
(WebKit::WebBackForwardListWrapper::itemAtDeltaFromCurrentIndex const):
* Source/WebKit/UIProcess/WebBackForwardList.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didChangeBackForwardList):
(WebKit::WebPageProxy::updateCanGoBackAndForward):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKBackForwardListTests.mm:
(TEST(WKBackForwardList, BackForwardNavigationSkipsPromiseRedirectWithoutUserInteraction)):

Canonical link: <a href="https://commits.webkit.org/311615@main">https://commits.webkit.org/311615@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d994c8adb07d2da5c3387a20e88186024cb0acab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157343 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30680 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23873 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166167 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111425 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/48d3e7ba-bc7e-4564-b21c-15fc9668436c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159214 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30815 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30682 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121864 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85575 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c73d123e-0991-4ffc-b025-85211e194de7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160301 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24108 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141286 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102532 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d598e15d-a26a-412a-abee-7b99583e4ce7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23164 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21412 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13938 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149394 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132843 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19114 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168652 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/18178 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12810 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20734 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129998 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30281 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25490 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130105 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35271 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30204 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140908 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88132 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24928 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17713 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/189362 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29915 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93929 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48585 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29437 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29667 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29564 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->