### PR TITLE
[API Tests] Reduce run-api-tests startup overhead when running specific tests

### DIFF
--- a/Tools/Scripts/webkitpy/api_tests/manager.py
+++ b/Tools/Scripts/webkitpy/api_tests/manager.py
@@ -25,12 +25,11 @@ import logging
 import os
 import re
 import time
+from typing import Optional
 
 from webkitpy.api_tests.runner import Runner
 from webkitpy.common.iteration_compatibility import iteritems
 from webkitpy.common.system.executive import ScriptError
-from webkitpy.results.upload import Upload
-from webkitpy.xcode.simulated_device import DeviceRequest, SimulatedDeviceManager
 
 _log = logging.getLogger(__name__)
 
@@ -100,7 +99,54 @@ class Manager(object):
                     continue
         return result
 
-    def _collect_tests(self, args):
+    @classmethod
+    def _is_exact_test_name(cls, arg: str) -> bool:
+        """Returns True if arg looks like an exact fully-qualified test name (no globs)."""
+        if '*' in arg:
+            return False
+        parts = arg.split('.')
+        # Must be <Suite>.<Test> or <Binary>.<Suite>.<Test> (or with / for parameterized suites)
+        return len(parts) >= 2 and '' not in parts
+
+    def _try_collect_exact_tests(self, args: list[str]) -> Optional[list[str]]:
+        """Try to resolve test names without spawning the binary to list all tests.
+
+        Returns a list of fully-qualified test names (Binary.Suite.Test) if all args
+        can be resolved exactly, or None if we need to fall back to listing.
+        """
+        if not args:
+            return None
+
+        if not all(self._is_exact_test_name(arg) for arg in args):
+            return None
+
+        known_binaries: set[str] = set(self._port.path_to_api_test_binaries().keys())
+        result: list[str] = []
+
+        for arg in args:
+            parts = arg.split('.')
+            candidate_binary = parts[0]
+
+            if candidate_binary in known_binaries:
+                # First part is a binary name. Need at least 3 parts
+                # (Binary.Suite.Test) to be an exact test. With only 2 parts
+                # (Binary.Suite), it's a suite filter that requires listing.
+                if len(parts) < 3:
+                    return None
+                result.append(arg)
+            else:
+                # arg is <Suite>.<Test> — we don't know which binary contains it,
+                # so fall back to listing.
+                return None
+
+        return sorted(result) if result else None
+
+    def _collect_tests(self, args: list[str]) -> list[str]:
+        # Fast path: if all args are exact test names, skip listing
+        exact = self._try_collect_exact_tests(args)
+        if exact is not None:
+            return exact
+
         available_tests = []
         specified_binaries = self._binaries_for_arguments(args)
         for canonicalized_binary, path in self._port.path_to_api_test_binaries().items():
@@ -181,7 +227,6 @@ class Manager(object):
             return False
 
         self._update_worker_count()
-        self._port.reset_preferences()
 
         # Set up devices for the test run
         if 'simulator' in self._port.port_name:
@@ -207,14 +252,13 @@ class Manager(object):
         start_time = time.time()
 
         self._stream.write_update('Checking build ...')
-        if not self._port.check_api_test_build(self._binaries_for_arguments(args)):
-            _log.error('Build check failed')
-            return Manager.FAILED_BUILD_CHECK
+        if self._options.build:
+            if not self._port.check_api_test_build(self._binaries_for_arguments(args)):
+                _log.error('Build check failed')
+                return Manager.FAILED_BUILD_CHECK
 
         if not self._set_up_run():
             return Manager.FAILED_BUILD_CHECK
-
-        configuration_for_upload = self._port.configuration_for_upload(self._port.target_host(0))
 
         self._stream.write_update('Collecting tests ...')
         try:
@@ -331,8 +375,12 @@ class Manager(object):
                 self.host.filesystem.write_text_file(json_output, json.dumps(result_dictionary, indent=4))
 
         if self._options.report_urls:
+            from webkitpy.results.upload import Upload
+
             self._stream.writeln('\n')
             self._stream.write_update('Preparing upload data ...')
+
+            configuration_for_upload = self._port.configuration_for_upload(self._port.target_host(0))
 
             status_to_test_result = {
                 runner.STATUS_PASSED: None,

--- a/Tools/Scripts/webkitpy/api_tests/manager_unittest.py
+++ b/Tools/Scripts/webkitpy/api_tests/manager_unittest.py
@@ -51,3 +51,15 @@ A.
         ]
         got_tests = Manager._test_list_from_output(gtest_list_tests_output)
         self.assertEqual(expected_tests, got_tests)
+
+    def test_is_exact_test_name(self):
+        self.assertTrue(Manager._is_exact_test_name('WebKit.MouseMoveOverElementWithClosedWebView'))
+        self.assertTrue(Manager._is_exact_test_name('TestWebKitAPI.WebKit.MouseMoveOverElementWithClosedWebView'))
+        self.assertTrue(Manager._is_exact_test_name('Misc/ValueParametrizedTest.ValueParametrizedTestsSupported/CatRed'))
+        self.assertFalse(Manager._is_exact_test_name('WebKit.*'))
+        self.assertFalse(Manager._is_exact_test_name('WebKit'))
+        self.assertFalse(Manager._is_exact_test_name('*'))
+        self.assertFalse(Manager._is_exact_test_name(''))
+        # Binary.Suite (only 2 parts) still passes _is_exact_test_name;
+        # _try_collect_exact_tests handles the binary prefix check separately
+        self.assertTrue(Manager._is_exact_test_name('TestWebKitAPI.SmartLists'))

--- a/Tools/Scripts/webkitpy/port/base.py
+++ b/Tools/Scripts/webkitpy/port/base.py
@@ -60,7 +60,6 @@ import time
 
 from collections import OrderedDict
 from webkitcorepy import string_utils, decorators
-from webkitscmpy import local
 
 from webkitpy.common.memoized import memoized
 from webkitpy.common.prettypatch import PrettyPatch
@@ -301,12 +300,13 @@ class Port(object):
         return True
 
     def check_api_test_build(self, canonicalized_binaries=None):
+        binaries = self.path_to_api_test_binaries()
         if not canonicalized_binaries:
-            canonicalized_binaries = self.path_to_api_test_binaries().keys()
+            canonicalized_binaries = binaries.keys()
         if not self._root_was_set and self.get_option('build') and not self._build_api_tests(wtf_only=(canonicalized_binaries == ['TestWTF'])):
             return False
 
-        for binary, path in self.path_to_api_test_binaries().items():
+        for binary, path in binaries.items():
             if binary not in canonicalized_binaries:
                 continue
             if not self._filesystem.exists(path):
@@ -1427,6 +1427,7 @@ class Port(object):
     @memoized
     def commits_for_upload(self):
         from webkitpy.results.upload import Upload
+        from webkitscmpy import local
 
         repos = {}
         if port_config.apple_additions() and getattr(port_config.apple_additions(), 'repos', False):

--- a/Tools/Scripts/webkitpy/port/embedded_device.py
+++ b/Tools/Scripts/webkitpy/port/embedded_device.py
@@ -51,7 +51,7 @@ class EmbeddedDevicePort(EmbeddedPort, metaclass=ABCMeta):
     @classmethod
     def determine_full_port_name(cls, host, options, port_name):
         if port_name == cls.port_name:
-            sdk_version = host.platform.xcode_sdk_version(cls.SDK)
+            sdk_version = host.platform.xcode_sdk_version(cls._DEFAULT_SDK)
             if not sdk_version:
                 raise Exception("Please install the {} SDK.".format(cls.DEVICE_TYPE.software_variant))
             port_name = port_name + '-' + str(sdk_version.major)

--- a/Tools/Scripts/webkitpy/port/factory.py
+++ b/Tools/Scripts/webkitpy/port/factory.py
@@ -35,8 +35,6 @@ import optparse
 import re
 
 from webkitpy.port import config
-from webkitpy.common.system import executive
-from webkitpy.common.system import filesystem
 
 
 def platform_options(use_globs=False):
@@ -78,7 +76,7 @@ def platform_options(use_globs=False):
 
 def configuration_options():
     return [
-        optparse.make_option("-t", "--target", default=config.Config(executive.Executive(), filesystem.FileSystem()).default_configuration(), dest="configuration", help="(DEPRECATED) (default: %default)"),
+        optparse.make_option("-t", "--target", default=None, dest="configuration", help="(DEPRECATED)"),
         optparse.make_option('--debug', action='store_const', const='Debug', dest="configuration",
             help='Set the configuration to Debug'),
         optparse.make_option('--release', action='store_const', const='Release', dest="configuration",
@@ -132,28 +130,37 @@ class PortFactory(object):
             return 'win'
         raise NotImplementedError('unknown platform: %s' % platform)
 
+    @staticmethod
+    def _load_port_class(port_class):
+        """Import and return the class object for a PORT_CLASSES entry."""
+        module_name, class_name = port_class.rsplit('.', 1)
+        module = __import__('webkitpy.port.{}'.format(module_name), globals(), locals(), [], 0)
+        return module.__dict__.get('port').__dict__.get(module_name).__dict__.get(class_name)
+
     def get(self, port_name=None, options=None, **kwargs):
         """Returns an object implementing the Port interface. If
         port_name is None, this routine attempts to guess at the most
         appropriate port on this platform."""
         port_name = port_name or self._default_port()
-        classes = []
-        for port_class in self.PORT_CLASSES:
-            module_name, class_name = port_class.rsplit('.', 1)
-            module = __import__('webkitpy.port.{}'.format(module_name), globals(), locals(), [], 0)
-            cls = module.__dict__.get('port').__dict__.get(module_name).__dict__.get(class_name)
-            if cls:
-                classes.append(cls)
-        if config.apple_additions() and hasattr(config.apple_additions(), 'ports'):
-            classes += config.apple_additions().ports()
 
-        for cls in classes:
-            if port_name.startswith(cls.port_name):
-                port_name = cls.determine_full_port_name(self._host, options, port_name)
+        for port_class in self.PORT_CLASSES:
+            cls = self._load_port_class(port_class)
+            if cls and port_name.startswith(cls.port_name):
+                full_port_name = cls.determine_full_port_name(self._host, options, port_name)
                 try:
-                    return cls(self._host, port_name, options=options, **kwargs)
+                    return cls(self._host, full_port_name, options=options, **kwargs)
                 except ValueError:
                     continue
+
+        if config.apple_additions() and hasattr(config.apple_additions(), 'ports'):
+            for cls in config.apple_additions().ports():
+                if port_name.startswith(cls.port_name):
+                    full_port_name = cls.determine_full_port_name(self._host, options, port_name)
+                    try:
+                        return cls(self._host, full_port_name, options=options, **kwargs)
+                    except ValueError:
+                        continue
+
         raise NotImplementedError('unsupported platform: "%s"' % port_name)
 
     def all_port_names(self, platform=None):

--- a/Tools/Scripts/webkitpy/port/ios_device.py
+++ b/Tools/Scripts/webkitpy/port/ios_device.py
@@ -36,7 +36,11 @@ class IOSDevicePort(EmbeddedDevicePort, IOSPort):
     DEFAULT_ARCHITECTURE = 'arm64'
     VERSION_FALLBACK_ORDER = ['ios-7', 'ios-8', 'ios-9', 'ios-10']
 
-    SDK = apple_additions().get_sdk('iphoneos') if apple_additions() else 'iphoneos'
+    _DEFAULT_SDK = 'iphoneos'
+
+    @property
+    def SDK(self):
+        return apple_additions().get_sdk(self._DEFAULT_SDK) if apple_additions() else self._DEFAULT_SDK
 
     def _is_device_platform_match(self, device):
         return device.platform.is_ios()

--- a/Tools/Scripts/webkitpy/port/ios_simulator.py
+++ b/Tools/Scripts/webkitpy/port/ios_simulator.py
@@ -42,7 +42,11 @@ class IOSSimulatorPort(EmbeddedSimulatorPort, IOSPort):
         DeviceType(hardware_family='iPhone', hardware_type='12'),
         DeviceType(hardware_family='iPad', hardware_type='(9th generation)'),
     ]
-    SDK = apple_additions().get_sdk('iphonesimulator') if apple_additions() else 'iphonesimulator'
+    _DEFAULT_SDK = 'iphonesimulator'
+
+    @property
+    def SDK(self):
+        return apple_additions().get_sdk(self._DEFAULT_SDK) if apple_additions() else self._DEFAULT_SDK
 
     def architecture(self):
         result = self.get_option('architecture') or self.host.platform.architecture()

--- a/Tools/Scripts/webkitpy/port/port_testcase.py
+++ b/Tools/Scripts/webkitpy/port/port_testcase.py
@@ -86,6 +86,10 @@ def bind_mock_apple_additions():
     class MockAppleAdditions(object):
 
         @staticmethod
+        def get_sdk(sdk_name):
+            return sdk_name
+
+        @staticmethod
         def layout_tests_path():
             return '/additional_testing_path/'
 

--- a/Tools/Scripts/webkitpy/port/visionos_device.py
+++ b/Tools/Scripts/webkitpy/port/visionos_device.py
@@ -36,7 +36,11 @@ class VisionOSDevicePort(EmbeddedDevicePort, VisionOSPort):
     DEFAULT_ARCHITECTURE = 'arm64'
     VERSION_FALLBACK_ORDER = ['visionos-1', 'visionos-2']
 
-    SDK = apple_additions().get_sdk('xros') if apple_additions() else 'xros'
+    _DEFAULT_SDK = 'xros'
+
+    @property
+    def SDK(self):
+        return apple_additions().get_sdk(self._DEFAULT_SDK) if apple_additions() else self._DEFAULT_SDK
 
     def _is_device_platform_match(self, device):
         return device.platform.is_visionos()

--- a/Tools/Scripts/webkitpy/port/visionos_simulator.py
+++ b/Tools/Scripts/webkitpy/port/visionos_simulator.py
@@ -39,7 +39,11 @@ class VisionOSSimulatorPort(EmbeddedSimulatorPort, VisionOSPort):
     DEFAULT_DEVICE_TYPES = [
         DeviceType(software_variant='visionOS', hardware_family='Vision', hardware_type='Pro')
     ]
-    SDK = apple_additions().get_sdk('xrsimulator') if apple_additions() else 'xrsimulator'
+    _DEFAULT_SDK = 'xrsimulator'
+
+    @property
+    def SDK(self):
+        return apple_additions().get_sdk(self._DEFAULT_SDK) if apple_additions() else self._DEFAULT_SDK
 
     def architecture(self):
         result = self.get_option('architecture') or self.host.platform.architecture()

--- a/Tools/Scripts/webkitpy/port/watch_device.py
+++ b/Tools/Scripts/webkitpy/port/watch_device.py
@@ -35,7 +35,11 @@ class WatchDevicePort(EmbeddedDevicePort, WatchPort):
     ARCHITECTURES = ['armv7k', 'arm64e', 'arm64_32']
     DEFAULT_ARCHITECTURE = 'armv7k'
 
-    SDK = apple_additions().get_sdk('watchos') if apple_additions() else 'watchos'
+    _DEFAULT_SDK = 'watchos'
+
+    @property
+    def SDK(self):
+        return apple_additions().get_sdk(self._DEFAULT_SDK) if apple_additions() else self._DEFAULT_SDK
 
     def _is_device_platform_match(self, device):
         return device.platform.is_watchos()

--- a/Tools/Scripts/webkitpy/port/watch_simulator.py
+++ b/Tools/Scripts/webkitpy/port/watch_simulator.py
@@ -37,7 +37,11 @@ class WatchSimulatorPort(EmbeddedSimulatorPort, WatchPort):
     DEFAULT_ARCHITECTURE = 'i386'
 
     DEFAULT_DEVICE_TYPES = [DeviceType(hardware_family='Apple Watch', hardware_type='Series 9 - 45mm')]
-    SDK = apple_additions().get_sdk('watchsimulator') if apple_additions() else 'watchsimulator'
+    _DEFAULT_SDK = 'watchsimulator'
+
+    @property
+    def SDK(self):
+        return apple_additions().get_sdk(self._DEFAULT_SDK) if apple_additions() else self._DEFAULT_SDK
 
     def architecture(self):
         result = self.get_option('architecture') or self.host.platform.architecture()


### PR DESCRIPTION
#### a80da14addae7e5ec036c259da7b3f739b678a56
<pre>
[API Tests] Reduce run-api-tests startup overhead when running specific tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=310247">https://bugs.webkit.org/show_bug.cgi?id=310247</a>
<a href="https://rdar.apple.com/172887928">rdar://172887928</a>

Reviewed by Jonathan Bedard.

This patch reduces the startup overhead of run-api-tests by addressing
several bottlenecks in the Python script&apos;s initialization path.

1. Defer default_configuration() in configuration_options() (~500ms)

The -t/--target option eagerly created a Config object and called
default_configuration(), which spawns a Perl subprocess
(webkit-build-directory) to determine the build directory. This
happened unconditionally at option-parse time, even when --debug or
--release was explicitly passed. Changed the default to None; the
port base class (base.py:168-169) already has a lazy fallback that
calls default_configuration() only when no configuration was set.

2. Make SDK resolution lazy in embedded port modules (~1-1.5s)

Six embedded port modules (ios_simulator, ios_device,
watch_simulator, watch_device, visionos_simulator, visionos_device)
called apple_additions().get_sdk() at class-definition time, which
triggered xcodebuild -showsdks (~1s+) the moment any of these
modules was imported by PortFactory.get(). Fixed by converting SDK
from a class-level attribute to a lazy @property that defers the
lookup until first access. Each class now has a _DEFAULT_SDK class
attribute for the base SDK name and a @property SDK that calls
apple_additions().get_sdk() only when needed. This aligns with the
EmbeddedPort base class, which already declares SDK as
@property @abstractmethod. Also updated EmbeddedDevicePort&apos;s
determine_full_port_name() classmethod to use cls._DEFAULT_SDK
instead of cls.SDK, since properties don&apos;t work on class references.
Additionally, PORT_CLASSES is restored to alphabetical order and
the import logic is extracted into a _load_port_class() helper.

3. Defer configuration_for_upload until needed (~100-200ms)

configuration_for_upload was computed unconditionally before test
collection, but is only needed when --report-urls is specified.
Moved it into the upload block.

4. Skip test collection when exact test names are provided.

Previously, `_collect_tests` always copied the test binary to &quot;ToBeListed&quot; and
spawned it with --gtest_list_tests to enumerate every available test, even when
the user specified exact test names on the command line (~0.5-1s of overhead).

Fix by adding `_try_collect_exact_tests`, which detects when all arguments are
fully-qualified test names (no glob wildcards) and resolves them directly
without listing. For the `&lt;Binary&gt;.&lt;Suite&gt;.&lt;Test&gt;` form, the name is used as-is.
For the `&lt;Suite&gt;.&lt;Test&gt;` form, the appropriate binary prefix is added. The method
falls back to the full listing path for glob patterns, partial matches like
`&lt;Binary&gt;.&lt;Suite&gt;`, or when no arguments are given.

5. Remove unnecessary preference reset from API test runs.

`_set_up_run` unconditionally called `reset_preferences()`, which runs two
sequential `defaults delete` commands for the DumpRenderTree and
WebKitTestRunner preference domains (~0.1s). These are layout test runner
preference domains and are not used by the API test binaries.

6. Skip build check when --no-build is set.

`check_api_test_build` was called unconditionally, resolving binary paths and
checking filesystem existence even when --no-build (the default) was passed.
Now the entire build check is skipped when build=False, deferring the first
build-directory resolution to `_collect_tests` where it&apos;s actually needed.

7. Lazy-import webkitscmpy in port/base.py (~150-200ms)

`from webkitscmpy import local` was a module-level import that loaded the
entire webkitscmpy dependency graph (registering dozens of AutoInstall
packages) on every run. Moved it into `commits_for_upload()`, the only
method that uses it.

8. Cache path_to_api_test_binaries() in check_api_test_build.

`check_api_test_build` called `path_to_api_test_binaries()` twice: once to
get the key list and once to iterate. Stored the result in a local variable
to avoid the redundant dict reconstruction.

9. Lazy-import Upload and remove dead imports in manager.py.

Moved `from webkitpy.results.upload import Upload` into the upload codepath
where it&apos;s actually used. Removed completely unused `DeviceRequest` and
`SimulatedDeviceManager` imports.

* Tools/Scripts/webkitpy/api_tests/manager.py:
(Manager):
(Manager._is_exact_test_name):
(Manager._try_collect_exact_tests):
(Manager._collect_tests):
(Manager._set_up_run):
(Manager.run):
* Tools/Scripts/webkitpy/api_tests/manager_unittest.py:
(test_is_exact_test_name):
* Tools/Scripts/webkitpy/port/base.py:
(Port.check_api_test_build):
(Port.commits_for_upload):
* Tools/Scripts/webkitpy/port/embedded_device.py:
(EmbeddedDevicePort.determine_full_port_name):
* Tools/Scripts/webkitpy/port/factory.py:
(configuration_options):
(PortFactory):
(PortFactory._load_port_class):
(PortFactory.get):
(PortFactory.get.in):
* Tools/Scripts/webkitpy/port/ios_device.py:
(IOSDevicePort):
(IOSDevicePort.SDK):
* Tools/Scripts/webkitpy/port/ios_simulator.py:
(IOSSimulatorPort):
(IOSSimulatorPort.SDK):
* Tools/Scripts/webkitpy/port/port_testcase.py:
(bind_mock_apple_additions.MockAppleAdditions):
(bind_mock_apple_additions.MockAppleAdditions.get_sdk):
* Tools/Scripts/webkitpy/port/visionos_device.py:
(VisionOSDevicePort):
(VisionOSDevicePort.SDK):
* Tools/Scripts/webkitpy/port/visionos_simulator.py:
(VisionOSSimulatorPort):
(VisionOSSimulatorPort.SDK):
* Tools/Scripts/webkitpy/port/watch_device.py:
(WatchDevicePort):
(WatchDevicePort.SDK):
* Tools/Scripts/webkitpy/port/watch_simulator.py:
(WatchSimulatorPort):
(WatchSimulatorPort.SDK):

Canonical link: <a href="https://commits.webkit.org/309636@main">https://commits.webkit.org/309636@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e1cfbb565b776f0c533cbef2165e5de9b5390d7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151301 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24064 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17635 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160032 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/104739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153174 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24496 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24341 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116820 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/104739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1978d518-5848-4ca3-a565-2a75eca4795b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154261 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/18956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/135761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97538 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/18c66dc5-2947-46f4-bade-3ea0674eddb3) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/150622 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/18047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/15992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7877 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/127669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/13673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162504 "Built successfully") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/15250 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/124832 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23866 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/20046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125016 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/33905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23856 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135469 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80352 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23243 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20082 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/12239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23465 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23177 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23330 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23231 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->