### PR TITLE
Handle subframe-only back/forward navigation when UseUIProcessForBackForwardItemLoading is enabled

### DIFF
--- a/LayoutTests/http/tests/navigation/back-iframe-no-bf-cache.html
+++ b/LayoutTests/http/tests/navigation/back-iframe-no-bf-cache.html
@@ -1,4 +1,4 @@
-<!-- webkit-test-runner [ UsesBackForwardCache=false dumpJSConsoleLogInStdErr=true ] -->
+<!-- webkit-test-runner [ UsesBackForwardCache=false UseUIProcessForBackForwardItemLoading=true dumpJSConsoleLogInStdErr=true ] -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -4711,6 +4711,14 @@ bool FrameLoader::shouldProceedWithAsyncBackForwardNavigation()
 void FrameLoader::loadRequestedHistoryItem(FrameLoadType loadType, PolicyAlreadyDecided policyAlreadyDecided)
 {
     ASSERT(m_requestedHistoryItem);
+
+    RefPtr currentItem = history().currentItem();
+    if (currentItem && m_requestedHistoryItem->shouldDoSameDocumentNavigationTo(*currentItem)) {
+        m_loadType = loadType;
+        loadSameDocumentItem(*m_requestedHistoryItem);
+        return;
+    }
+
     loadDifferentDocumentItem(protect(*m_requestedHistoryItem), nullptr, loadType, MayAttemptCacheOnlyLoadForFormSubmissionItem, ShouldTreatAsContinuingLoad::No, policyAlreadyDecided);
 }
 

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -962,6 +962,25 @@ void HistoryController::recursiveGoToItem(HistoryItem& item, HistoryItem* fromIt
     if (!itemsAreClones(item, fromItem))
         return m_frame->loader().loadItem(item, fromItem, type, shouldTreatAsContinuingLoad);
 
+    // When UseUIProcessForBackForwardItemLoading is enabled, the target HistoryItem
+    // has no children. Use fromItem's children to find child frames that may need
+    // navigation, and dispatch each to UIProcess for back/forward resolution.
+    if (item.children().isEmpty() && fromItem && !fromItem->children().isEmpty()
+        && m_frame->page() && m_frame->page()->settings().useUIProcessForBackForwardItemLoading()) {
+        for (Ref fromChildItem : fromItem->children()) {
+            auto frameID = fromChildItem->frameID();
+            if (!frameID)
+                continue;
+
+            RefPtr childFrame = dynamicDowncast<LocalFrame>(m_frame->tree().descendantByFrameID(*frameID));
+            if (!childFrame)
+                continue;
+
+            m_frame->loader().client().dispatchBackForwardSubframeNavigation(*childFrame, item.itemID(), type);
+        }
+        return;
+    }
+
     // Just iterate over the rest, looking for frames to navigate.
     for (Ref childItem : item.children()) {
         auto frameID = childItem->frameID();

--- a/Source/WebCore/loader/LocalFrameLoaderClient.cpp
+++ b/Source/WebCore/loader/LocalFrameLoaderClient.cpp
@@ -70,4 +70,8 @@ void LocalFrameLoaderClient::dispatchBackForwardItemLoading(const URL& url, cons
     loader->continueLoadURLIntoChildFrame(url, referer, childFrame);
 }
 
+void LocalFrameLoaderClient::dispatchBackForwardSubframeNavigation(LocalFrame&, BackForwardItemIdentifier, FrameLoadType)
+{
+}
+
 } // namespace WebCore

--- a/Source/WebCore/loader/LocalFrameLoaderClient.h
+++ b/Source/WebCore/loader/LocalFrameLoaderClient.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include <WebCore/BackForwardItemIdentifier.h>
 #include <WebCore/FrameLoaderClient.h>
 #include <WebCore/IntPoint.h>
 #include <WebCore/LayoutMilestone.h>
@@ -207,6 +208,7 @@ public:
     virtual void dispatchWillSubmitForm(FormState&, URL&& requestURL, String&& method, CompletionHandler<void()>&&) = 0;
 
     virtual void dispatchBackForwardItemLoading(const URL&, const String& referer, LocalFrame& childFrame);
+    virtual void dispatchBackForwardSubframeNavigation(LocalFrame& childFrame, BackForwardItemIdentifier targetItemID, FrameLoadType);
 
     virtual void revertToProvisionalState(DocumentLoader*) = 0;
     virtual void setMainDocumentError(DocumentLoader*, const ResourceError&) = 0;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -1169,6 +1169,19 @@ void WebLocalFrameLoaderClient::dispatchBackForwardItemLoading(const URL& url, c
     childClient->dispatchDecidePolicyForBackForwardNavigationAction(WTF::move(frameLoadRequest), referer, loader->loadType());
 }
 
+void WebLocalFrameLoaderClient::dispatchBackForwardSubframeNavigation(LocalFrame& childFrame, BackForwardItemIdentifier targetItemID, FrameLoadType loadType)
+{
+    auto* childClient = dynamicDowncast<WebLocalFrameLoaderClient>(childFrame.loader().client());
+    ASSERT(childClient);
+
+    URL childURL = childFrame.document() ? protect(childFrame.document())->url() : URL();
+    auto frameLoadRequest = childFrame.loader().createFrameLoadRequest(URL { childURL });
+    frameLoadRequest.setTargetBackForwardItemIdentifier(targetItemID);
+
+    String referer = m_localFrame->document() ? protect(m_localFrame->document())->url().string() : String();
+    childClient->dispatchDecidePolicyForBackForwardNavigationAction(WTF::move(frameLoadRequest), referer, loadType);
+}
+
 void WebLocalFrameLoaderClient::dispatchDecidePolicyForBackForwardNavigationAction(WebCore::FrameLoadRequest&& frameLoadRequest, const String& referer, WebCore::FrameLoadType loadType)
 {
     Ref localFrame = m_localFrame.get();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
@@ -153,6 +153,7 @@ private:
     void dispatchWillSubmitForm(WebCore::FormState&, URL&& requestURL, String&& method, CompletionHandler<void()>&&) final;
     
     void dispatchBackForwardItemLoading(const URL&, const String& referer, WebCore::LocalFrame& childFrame) final;
+    void dispatchBackForwardSubframeNavigation(WebCore::LocalFrame& childFrame, WebCore::BackForwardItemIdentifier targetItemID, WebCore::FrameLoadType) final;
 
     void revertToProvisionalState(WebCore::DocumentLoader*) final;
     void setMainDocumentError(WebCore::DocumentLoader*, const WebCore::ResourceError&) final;


### PR DESCRIPTION
#### d376594d869acfa8be3f4845ba1d7439a7c8553a
<pre>
Handle subframe-only back/forward navigation when UseUIProcessForBackForwardItemLoading is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=310242">https://bugs.webkit.org/show_bug.cgi?id=310242</a>
<a href="https://rdar.apple.com/172886286">rdar://172886286</a>

Reviewed by NOBODY (OOPS!).

When UseUIProcessForBackForwardItemLoading is enabled and site isolation is not enabled,
back/forward navigation that only affects subframes (where the main frame document is a
clone) fails because the target HistoryItem sent from UIProcess has no children.

In HistoryController::recursiveGoToItem, the loop over item.children() is empty, so no
child frame navigation is triggered, causing a timeout.

This patch adds a fallback path: when the target item has no children but fromItem does,
iterate fromItem-&gt;children() to identify child frames and dispatch each to UIProcess
via a new dispatchBackForwardSubframeNavigation method on LocalFrameLoaderClient. This
reuses the existing dispatchDecidePolicyForBackForwardNavigationAction async path that
UIProcess uses to look up FrameState for child frames.

Additionally, FrameLoader::loadRequestedHistoryItem is updated to check shouldDoSameDocumentNavigationTo
before unconditionally calling loadDifferentDocumentItem, so that hash-only navigations
within subframes are handled correctly as same-document navigations.

Tests: http/tests/navigation/back-iframe-no-bf-cache.html

* LayoutTests/http/tests/navigation/back-iframe-no-bf-cache.html:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::loadRequestedHistoryItem):
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::recursiveGoToItem):
* Source/WebCore/loader/LocalFrameLoaderClient.cpp:
(WebCore::LocalFrameLoaderClient::dispatchBackForwardSubframeNavigation):
* Source/WebCore/loader/LocalFrameLoaderClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::dispatchBackForwardSubframeNavigation):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d376594d869acfa8be3f4845ba1d7439a7c8553a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150998 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23760 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17330 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159726 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104434 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152871 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24191 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23979 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116570 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82749 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6e5eaadd-49ef-40de-8bc1-322de4827a7e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153958 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18688 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135477 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97291 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a106b3d1-84df-498a-8b15-88f8ea57a077) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17781 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15735 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7572 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127399 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13394 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162199 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5324 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14965 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124577 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23562 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19785 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124764 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23552 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135191 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79961 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19828 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11956 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23162 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87421 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22874 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23026 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22928 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->