### PR TITLE
[JSC] Align OMG write-barrier code to FTL

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -2238,55 +2238,7 @@ auto OMGIRGenerator::setGlobal(uint32_t index, ExpressionType value) -> PartialR
             m_heaps.decorateMemory(&m_heaps.WasmGlobalValue_owner, cell);
             cell->setControlDependent(false);
 
-            Value* cellState = m_currentBlock->appendNew<MemoryValue>(m_proc, Load8Z, Int32, origin(), cell, safeCast<int32_t>(JSCell::cellStateOffset()));
-            m_heaps.decorateMemory(&m_heaps.JSCell_cellState, cellState);
-
-            auto* vm = vmValue();
-            Value* threshold = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, Int32, origin(), vm, safeCast<int32_t>(VM::offsetOfHeapBarrierThreshold()));
-            m_heaps.decorateMemory(&m_heaps.VM_heap_barrierThreshold, threshold);
-
-            BasicBlock* fenceCheckPath = m_proc.addBlock();
-            BasicBlock* fencePath = m_proc.addBlock();
-            BasicBlock* doSlowPath = m_proc.addBlock();
-            BasicBlock* continuation = m_proc.addBlock();
-
-            m_currentBlock->appendNewControlValue(m_proc, B3::Branch, origin(),
-                m_currentBlock->appendNew<Value>(m_proc, Above, origin(), cellState, threshold),
-                FrequentedBlock(continuation), FrequentedBlock(fenceCheckPath, FrequencyClass::Rare));
-            fenceCheckPath->addPredecessor(m_currentBlock);
-            continuation->addPredecessor(m_currentBlock);
-            m_currentBlock = fenceCheckPath;
-
-            Value* shouldFence = m_currentBlock->appendNew<MemoryValue>(m_proc, Load8Z, Int32, origin(), vm, safeCast<int32_t>(VM::offsetOfHeapMutatorShouldBeFenced()));
-            m_heaps.decorateMemory(&m_heaps.VM_heap_mutatorShouldBeFenced, shouldFence);
-
-            m_currentBlock->appendNewControlValue(m_proc, B3::Branch, origin(),
-                shouldFence,
-                FrequentedBlock(fencePath), FrequentedBlock(doSlowPath));
-            fencePath->addPredecessor(m_currentBlock);
-            doSlowPath->addPredecessor(m_currentBlock);
-            m_currentBlock = fencePath;
-
-            B3::PatchpointValue* doFence = m_currentBlock->appendNew<B3::PatchpointValue>(m_proc, B3::Void, origin());
-            doFence->setGenerator([] (CCallHelpers& jit, const B3::StackmapGenerationParams&) {
-                jit.memoryFence();
-            });
-
-            Value* cellStateLoadAfterFence = m_currentBlock->appendNew<MemoryValue>(m_proc, Load8Z, Int32, origin(), cell, safeCast<int32_t>(JSCell::cellStateOffset()));
-            m_heaps.decorateMemory(&m_heaps.JSCell_cellState, cellStateLoadAfterFence);
-
-            m_currentBlock->appendNewControlValue(m_proc, B3::Branch, origin(),
-                m_currentBlock->appendNew<Value>(m_proc, Above, origin(), cellStateLoadAfterFence, constant(Int32, blackThreshold)),
-                FrequentedBlock(continuation), FrequentedBlock(doSlowPath, FrequencyClass::Rare));
-            doSlowPath->addPredecessor(m_currentBlock);
-            continuation->addPredecessor(m_currentBlock);
-            m_currentBlock = doSlowPath;
-
-            callWasmOperation(m_currentBlock, B3::Void, operationWasmWriteBarrierSlowPath, cell, vm);
-            m_currentBlock->appendNewControlValue(m_proc, Jump, origin(), continuation);
-
-            continuation->addPredecessor(m_currentBlock);
-            m_currentBlock = continuation;
+            emitWriteBarrier(cell);
         }
         break;
     }
@@ -2308,32 +2260,20 @@ inline void OMGIRGenerator::emitWriteBarrier(Value* cell)
     Value* threshold = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, Int32, origin(), vm, safeCast<int32_t>(VM::offsetOfHeapBarrierThreshold()));
     m_heaps.decorateMemory(&m_heaps.VM_heap_barrierThreshold, threshold);
 
-    BasicBlock* fenceCheckPath = m_proc.addBlock();
-    BasicBlock* fencePath = m_proc.addBlock();
+    BasicBlock* recheckPath = m_proc.addBlock();
     BasicBlock* doSlowPath = m_proc.addBlock();
     BasicBlock* continuation = m_proc.addBlock();
 
     m_currentBlock->appendNewControlValue(m_proc, B3::Branch, origin(),
         m_currentBlock->appendNew<Value>(m_proc, Above, origin(), cellState, threshold),
-        FrequentedBlock(continuation), FrequentedBlock(fenceCheckPath, FrequencyClass::Rare));
-    fenceCheckPath->addPredecessor(m_currentBlock);
+        FrequentedBlock(continuation), FrequentedBlock(recheckPath, FrequencyClass::Rare));
+    recheckPath->addPredecessor(m_currentBlock);
     continuation->addPredecessor(m_currentBlock);
-    m_currentBlock = fenceCheckPath;
+    m_currentBlock = recheckPath;
 
-    Value* shouldFence = m_currentBlock->appendNew<MemoryValue>(m_proc, Load8Z, Int32, origin(), vm, safeCast<int32_t>(VM::offsetOfHeapMutatorShouldBeFenced()));
-    m_heaps.decorateMemory(&m_heaps.VM_heap_mutatorShouldBeFenced, shouldFence);
-
-    m_currentBlock->appendNewControlValue(m_proc, B3::Branch, origin(),
-        shouldFence,
-        FrequentedBlock(fencePath), FrequentedBlock(doSlowPath));
-    fencePath->addPredecessor(m_currentBlock);
-    doSlowPath->addPredecessor(m_currentBlock);
-    m_currentBlock = fencePath;
-
-    B3::PatchpointValue* doFence = m_currentBlock->appendNew<B3::PatchpointValue>(m_proc, B3::Void, origin());
-    doFence->setGenerator([] (CCallHelpers& jit, const B3::StackmapGenerationParams&) {
-        jit.memoryFence();
-    });
+    auto* fence = m_currentBlock->appendNew<FenceValue>(m_proc, origin());
+    m_heaps.decorateFenceRead(&m_heaps.root, fence);
+    m_heaps.decorateFenceWrite(&m_heaps.JSCell_cellState, fence);
 
     Value* cellStateLoadAfterFence = m_currentBlock->appendNew<MemoryValue>(m_proc, Load8Z, Int32, origin(), cell, safeCast<int32_t>(JSCell::cellStateOffset()));
     m_heaps.decorateMemory(&m_heaps.JSCell_cellState, cellStateLoadAfterFence);
@@ -2345,7 +2285,9 @@ inline void OMGIRGenerator::emitWriteBarrier(Value* cell)
     continuation->addPredecessor(m_currentBlock);
     m_currentBlock = doSlowPath;
 
-    callWasmOperation(m_currentBlock, B3::Void, operationWasmWriteBarrierSlowPath, cell, vm);
+    Value* call = callWasmOperation(m_currentBlock, B3::Void, operationWasmWriteBarrierSlowPath, cell, vm);
+    m_heaps.decorateCCallRead(&m_heaps.root, call);
+    m_heaps.decorateCCallWrite(&m_heaps.JSCell_cellState, call);
     m_currentBlock->appendNewControlValue(m_proc, Jump, origin(), continuation);
 
     continuation->addPredecessor(m_currentBlock);


### PR DESCRIPTION
#### 8b75d8f657337b629960924de5199ad4966a0309
<pre>
[JSC] Align OMG write-barrier code to FTL
<a href="https://bugs.webkit.org/show_bug.cgi?id=310248">https://bugs.webkit.org/show_bug.cgi?id=310248</a>
<a href="https://rdar.apple.com/172889778">rdar://172889778</a>

Reviewed by Yijia Huang.

This patch simplifies OMG write-barrier code, which should be now
aligned to what FTL is emitting. We also annotate slow path call / fence
with appropriate memory decoration.

* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::setGlobal):
(JSC::Wasm::OMGIRGenerator::emitWriteBarrier):

Canonical link: <a href="https://commits.webkit.org/309561@main">https://commits.webkit.org/309561@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a06c541f34735495e2a03a1e4ccd454c0ddb69e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150987 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23749 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17319 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159715 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104423 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24180 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23968 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116561 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82742 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/08148bdc-f362-45c4-a6db-cd4f2ac7d781) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153947 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18679 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135461 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97282 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17773 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15723 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7561 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/142971 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127391 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13378 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162188 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/11786 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5313 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14949 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124567 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23551 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19773 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124754 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23541 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135175 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79950 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23211 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19813 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11940 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/182512 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23151 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87404 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46611 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22863 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23015 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22917 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->