### PR TITLE
naturalWidth and naturalHeight should always return EXIF-oriented dimensions regardless of CSS image-orientation

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -794,7 +794,6 @@ imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/t
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-embed-element/embed-change-src.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_navigate_history_go_forward.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/srcdoc_change_hash.html [ Skip ]
-imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/natural-size-orientation.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-submit-remove-children.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/popovers/popover-anchor-inset-rule-display.tentative.html [ ImageOnlyFailure ]
 webkit.org/b/250171 imported/w3c/web-platform-tests/html/semantics/popovers/popover-anchor-change-display.tentative.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/natural-size-orientation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/natural-size-orientation-expected.txt
@@ -1,8 +1,5 @@
 
-
-Harness Error (TIMEOUT), message = null
-
 PASS naturalWidth and naturalHeight return correct values for an image without orientation metadata
-TIMEOUT naturalWidth and naturalHeight return re-oriented values for an image with orientation metadata Test timed out
-TIMEOUT naturalWidth and naturalHeight return re-oriented values for an image with orientation metadata even with image-orientation:none Test timed out
+PASS naturalWidth and naturalHeight return re-oriented values for an image with orientation metadata
+PASS naturalWidth and naturalHeight return re-oriented values for an image with orientation metadata even with image-orientation:none
 

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -692,13 +692,19 @@ float HTMLImageElement::effectiveImageDevicePixelRatio() const
 unsigned HTMLImageElement::naturalWidth() const
 {
     RefPtr image = m_imageLoader->image();
-    return image ? image->unclampedImageSizeForRenderer(protect(renderer()).get(), effectiveImageDevicePixelRatio()).width().toUnsigned() : 0;
+    if (!image)
+        return 0;
+    CheckedPtr renderer = this->renderer();
+    return image->unclampedImageSizeForRenderer(renderer.get(), effectiveImageDevicePixelRatio(), CachedImage::UsedSize, ImageOrientation::Orientation::FromImage).width().toUnsigned();
 }
 
 unsigned HTMLImageElement::naturalHeight() const
 {
     RefPtr image = m_imageLoader->image();
-    return image ? image->unclampedImageSizeForRenderer(protect(renderer()).get(), effectiveImageDevicePixelRatio()).height().toUnsigned() : 0;
+    if (!image)
+        return 0;
+    CheckedPtr renderer = this->renderer();
+    return image->unclampedImageSizeForRenderer(renderer.get(), effectiveImageDevicePixelRatio(), CachedImage::UsedSize, ImageOrientation::Orientation::FromImage).height().toUnsigned();
 }
 
 bool HTMLImageElement::isURLAttribute(const Attribute& attribute) const

--- a/Source/WebCore/loader/cache/CachedImage.cpp
+++ b/Source/WebCore/loader/cache/CachedImage.cpp
@@ -308,7 +308,7 @@ void CachedImage::setContainerContextForClient(const CachedImageClient& client, 
     m_svgImageCache->setContainerContextForClient(client, containerSize, containerZoom, imageURL);
 }
 
-FloatSize CachedImage::imageSizeForRenderer(const RenderElement* renderer, SizeType sizeType) const
+FloatSize CachedImage::imageSizeForRenderer(const RenderElement* renderer, SizeType sizeType, std::optional<ImageOrientation> orientationOverride) const
 {
     RefPtr image = m_image;
     if (!image)
@@ -322,13 +322,14 @@ FloatSize CachedImage::imageSizeForRenderer(const RenderElement* renderer, SizeT
     if (image->drawsSVGImage() && sizeType == UsedSize)
         return m_svgImageCache->imageSizeForRenderer(renderer);
 
-    return image->size(renderer ? renderer->imageOrientation() : ImageOrientation(ImageOrientation::Orientation::FromImage));
+    auto orientation = orientationOverride.value_or(renderer ? renderer->imageOrientation() : ImageOrientation(ImageOrientation::Orientation::FromImage));
+    return image->size(orientation);
 }
 
 
-LayoutSize CachedImage::unclampedImageSizeForRenderer(const RenderElement* renderer, float multiplier, SizeType sizeType) const
+LayoutSize CachedImage::unclampedImageSizeForRenderer(const RenderElement* renderer, float multiplier, SizeType sizeType, std::optional<ImageOrientation> orientationOverride) const
 {
-    LayoutSize imageSize = LayoutSize(imageSizeForRenderer(renderer, sizeType));
+    LayoutSize imageSize = LayoutSize(imageSizeForRenderer(renderer, sizeType, orientationOverride));
     if (imageSize.isEmpty() || multiplier == 1.0f)
         return imageSize;
 

--- a/Source/WebCore/loader/cache/CachedImage.h
+++ b/Source/WebCore/loader/cache/CachedImage.h
@@ -78,10 +78,10 @@ public:
         UsedSize,
         IntrinsicSize
     };
-    WEBCORE_EXPORT FloatSize imageSizeForRenderer(const RenderElement* renderer, SizeType = UsedSize) const;
+    WEBCORE_EXPORT FloatSize imageSizeForRenderer(const RenderElement* renderer, SizeType = UsedSize, std::optional<ImageOrientation> = std::nullopt) const;
     // This method takes a zoom multiplier that can be used to increase the natural size of the image by the zoom.
     LayoutSize imageSizeForRenderer(const RenderElement*, float multiplier, SizeType = UsedSize) const; // returns the size of the complete image.
-    LayoutSize unclampedImageSizeForRenderer(const RenderElement* renderer, float multiplier, SizeType = UsedSize) const;
+    LayoutSize unclampedImageSizeForRenderer(const RenderElement* renderer, float multiplier, SizeType = UsedSize, std::optional<ImageOrientation> = std::nullopt) const;
     void computeIntrinsicDimensions(float& intrinsicWidth, float& intrinsicHeight, FloatSize& intrinsicRatio);
 
     bool hasHDRContent() const;


### PR DESCRIPTION
#### 0a9668b237caef9da12548c5eb16f8a82aa23d25
<pre>
naturalWidth and naturalHeight should always return EXIF-oriented dimensions regardless of CSS image-orientation
<a href="https://bugs.webkit.org/show_bug.cgi?id=310252">https://bugs.webkit.org/show_bug.cgi?id=310252</a>
<a href="https://rdar.apple.com/172895058">rdar://172895058</a>

Reviewed by NOBODY (OOPS!).

The density-corrected natural width and height of an image take into
account any orientation specified in its metadata. naturalWidth and
naturalHeight must reflect the dimensions after applying any rotation
needed to correctly orient the image, regardless of the value of the
image-orientation property.

Reference: <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a>

Add an optional ImageOrientation override parameter to
CachedImage::imageSizeForRenderer and unclampedImageSizeForRenderer,
allowing callers to force a specific orientation while still passing
the renderer (needed for SVG container size computation).

HTMLImageElement::naturalWidth/naturalHeight now pass
ImageOrientation::FromImage as the override, so EXIF orientation is
always applied regardless of CSS image-orientation.

* LayoutTests/TestExpectations: Unskip Test
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/natural-size-orientation-expected.txt: Progression (last subtest)
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::naturalWidth const):
(WebCore::HTMLImageElement::naturalHeight const):
* Source/WebCore/loader/cache/CachedImage.cpp:
(WebCore::CachedImage::imageSizeForRenderer const):
(WebCore::CachedImage::unclampedImageSizeForRenderer const):
* Source/WebCore/loader/cache/CachedImage.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a9668b237caef9da12548c5eb16f8a82aa23d25

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150999 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23761 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17331 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159727 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104435 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/46738727-cc95-457e-9186-70e72993c118) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152872 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24192 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23981 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116572 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82751 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/03352ce8-a281-4d5d-8484-fd31848dfb92) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153959 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18689 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135479 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97293 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/366e8f3b-c269-489b-84d6-fd329a02bccd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17782 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15737 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7573 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127400 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13396 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162200 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5325 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14967 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124579 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23563 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19787 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124766 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23553 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135193 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79962 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19830 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11958 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23163 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87423 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22875 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23027 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22929 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->