### PR TITLE
[Navigation API] navigation.currentEntry.id doesn't change in private windows after history.replaceState

### DIFF
--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -1113,16 +1113,17 @@ void HistoryController::replaceState(RefPtr<SerializedScriptValue>&& stateObject
     Ref frame = m_frame.get();
     RefPtr page = frame->page();
     ASSERT(page);
-    if (!canRecordHistoryForFrame(frame))
-        return;
-
-    addVisitedLink(*page, URL({ }, urlString));
-    protect(frame->loader().client())->updateGlobalHistory();
 
     if (RefPtr document = frame->document(); document && document->settings().navigationAPIEnabled()) {
         currentItem->setNavigationAPIStateObject(nullptr);
         protect(protect(document->window())->navigation())->updateForNavigation(*currentItem, NavigationNavigationType::Replace);
     }
+
+    if (!canRecordHistoryForFrame(frame))
+        return;
+
+    addVisitedLink(*page, URL({ }, urlString));
+    protect(frame->loader().client())->updateGlobalHistory();
 }
 
 void HistoryController::replaceCurrentItem(RefPtr<HistoryItem>&& item)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/NavigationAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/NavigationAPI.mm
@@ -59,4 +59,30 @@ TEST(NavigationAPI, PushStateUpdatesCurrentEntryKeyWithoutAllowPrivacySensitiveO
     EXPECT_FALSE([keyBefore isEqualToString:keyAfter]);
 }
 
+TEST(NavigationAPI, ReplaceStateUpdatesCurrentEntryIDWithoutAllowPrivacySensitiveOperationsInNonPersistentDataStores)
+{
+    HTTPServer server({
+        { "/example"_s, { "example"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    [configuration setWebsiteDataStore:[WKWebsiteDataStore nonPersistentDataStore]];
+    [configuration preferences]._allowPrivacySensitiveOperationsInNonPersistentDataStores = NO;
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 300, 300) configuration:configuration.get()]);
+
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate allowAnyTLSCertificate];
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    NSString *idBefore = [webView stringByEvaluatingJavaScript:@"navigation.currentEntry.id"];
+    [webView stringByEvaluatingJavaScript:@"history.replaceState(null, '', '/foo')"];
+    NSString *idAfter = [webView stringByEvaluatingJavaScript:@"navigation.currentEntry.id"];
+
+    EXPECT_FALSE([idBefore isEqualToString:idAfter]);
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 2234866e77d326892e39c0f2c50d250d214a68e4
<pre>
[Navigation API] navigation.currentEntry.id doesn&apos;t change in private windows after history.replaceState
<a href="https://bugs.webkit.org/show_bug.cgi?id=310256">https://bugs.webkit.org/show_bug.cgi?id=310256</a>
<a href="https://rdar.apple.com/172897962">rdar://172897962</a>

Reviewed by Basuke Suzuki.

When history.replaceState() is called, we call HistoryController::replaceState(),
which updates the current entry held by the Navigation object by calling
Navigation::updateForNavigation().

For private windows, replaceState returns early before calling updateForNavigation()
because canRecordHistoryForFrame() returns false. Private windows use an ephemeral
data store and set allowPrivacySensitiveOperationsInNonPersistentDataStores to false.

To ensure that updateForNavigation() is called and the current entry is updated,
we now call updateForNavigation() before canRecordHistoryForFrame().

This is identical to <a href="https://commits.webkit.org/309489@main">https://commits.webkit.org/309489@main</a> with once caveat:
Unlike with pushState, replaceState does not cause the navigation.currentEntry.key
to change. That&apos;s because we aren&apos;t making a new HistoryItem with replaceState.
(NavigationHistoryEntry&apos;s key is tied to HistoryItem&apos;s UUID). replaceState simply
changes some properties of the existing HistoryItem. But we are making a new
NavigationHistoryEntry, so it will have a new id. We use the id to check if the
current entry is updated.

This is tested by a new API test:
TEST(NavigationAPI, ReplaceStateUpdatesCurrentEntryIDWithoutAllowPrivacySensitiveOperationsInNonPersistentDataStores)

* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::replaceState):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/NavigationAPI.mm:
(TestWebKitAPI::TEST(NavigationAPI, ReplaceStateUpdatesCurrentEntryIDWithoutAllowPrivacySensitiveOperationsInNonPersistentDataStores)):

Canonical link: <a href="https://commits.webkit.org/309560@main">https://commits.webkit.org/309560@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b7f0430099dc1baadbcc47b84756cb1039050eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151014 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23776 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17346 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159742 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104450 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7bca96ba-bf2e-41e7-8a92-e68a257e563f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152887 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24207 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23997 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116583 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82758 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153974 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18702 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135489 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97304 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f2fab2c5-4620-43b8-984a-c68afb99a418) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17795 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15749 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7588 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127413 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13406 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162215 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5340 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14977 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124590 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23578 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19799 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124778 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23568 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135203 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79985 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23210 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19841 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11968 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23178 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87443 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22890 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23042 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22944 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->