### PR TITLE
SVG animation does not clear animated CSS property when attributeName is dynamically changed

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/set-dynamic-attributeName-css-property-cleanup-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/set-dynamic-attributeName-css-property-cleanup-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Changing attributeName on set element clears old animated CSS property
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/set-dynamic-attributeName-css-property-cleanup.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/set-dynamic-attributeName-css-property-cleanup.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<title>Changing attributeName on set element clears old animated CSS property</title>
+<link rel="help" href="https://svgwg.org/specs/animations/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<svg>
+  <rect id="rect" x="0" y="0" width="100" height="100" fill="green">
+    <set id="set" attributeType="CSS" attributeName="opacity" to="0.5"/>
+  </rect>
+</svg>
+<script>
+  async_test(t => {
+    let svg = document.querySelector('svg');
+    let rect = document.getElementById('rect');
+    let set = document.getElementById('set');
+
+    window.onload = t.step_func(() => {
+      window.requestAnimationFrame(t.step_func(() => {
+        assert_equals(getComputedStyle(rect).opacity, '0.5',
+          'opacity should be 0.5 while set animates opacity');
+
+        // Change attributeName from "opacity" to "x".
+        // The old animated CSS property (opacity) should be cleared.
+        set.setAttribute('attributeName', 'x');
+
+        window.requestAnimationFrame(t.step_func_done(() => {
+          assert_equals(getComputedStyle(rect).opacity, '1',
+            'opacity should revert to 1 after attributeName changed away from opacity');
+        }));
+      }));
+    });
+  });
+</script>

--- a/Source/WebCore/svg/properties/SVGAttributeAnimator.h
+++ b/Source/WebCore/svg/properties/SVGAttributeAnimator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -116,7 +116,7 @@ protected:
     void removeAnimatedStyleProperty(SVGElement&);
     void applyAnimatedPropertyChange(SVGElement&);
 
-    const QualifiedName& m_attributeName;
+    QualifiedName m_attributeName;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### f295098a858c1280a342b0d67bb95cf5a58ea583
<pre>
SVG animation does not clear animated CSS property when attributeName is dynamically changed
<a href="https://bugs.webkit.org/show_bug.cgi?id=98718">https://bugs.webkit.org/show_bug.cgi?id=98718</a>
<a href="https://rdar.apple.com/97097883">rdar://97097883</a>

Reviewed by Said Abou-Hallawa.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

When JavaScript dynamically changes the attributeName of a SMIL animation
element (e.g. from &quot;opacity&quot; to &quot;x&quot;), the old animated CSS property is never
removed from the target element&apos;s animated SMIL style properties.

The root cause is that SVGAttributeAnimator::m_attributeName was a const
reference aliasing the SMIL element&apos;s m_attributeName. When setAttributeName()
updated the SMIL element&apos;s m_attributeName before calling stopAnimation(),
the animator&apos;s stop() method would see the new attribute name (&quot;x&quot;) instead
of the old one (&quot;opacity&quot;), causing removeAnimatedStyleProperty() to fail.

Fix by making SVGAttributeAnimator::m_attributeName an owned copy instead
of a reference, so the animator retains the original attribute name
regardless of when the SMIL element updates its own.

Test: imported/w3c/web-platform-tests/svg/animations/set-dynamic-attributeName-css-property-cleanup.html

* LayoutTests/imported/w3c/web-platform-tests/svg/animations/set-dynamic-attributeName-css-property-cleanup-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/set-dynamic-attributeName-css-property-cleanup.html: Added.
* Source/WebCore/svg/properties/SVGAttributeAnimator.h:
(WebCore::SVGAttributeAnimator::m_attributeName):

Canonical link: <a href="https://commits.webkit.org/309621@main">https://commits.webkit.org/309621@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7f03445f1140150464b277ecfe75ae8c3914fe8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151176 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23939 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17509 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159905 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104612 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/74078293-1518-4a50-860a-4e557cfbd4aa) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153049 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24370 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24177 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116713 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82844 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154136 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18836 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135642 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97434 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ceff4fa9-efe7-4073-978b-405349158d8d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17929 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15881 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7750 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127547 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13559 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162377 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5502 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15130 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124722 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23740 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19931 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124910 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33896 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23730 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135356 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80174 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19974 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12121 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23340 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87634 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23052 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23204 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23106 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->