### PR TITLE
A remote webrtc track should get unmuted when first packet is received

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-getStats.https_interop-2026-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-getStats.https_interop-2026-expected.txt
@@ -5,6 +5,6 @@ PASS getStats() track without stream returns peer-connection and outbound-rtp st
 PASS getStats() audio contains outbound-rtp stats
 PASS getStats() video contains outbound-rtp stats
 PASS getStats() on track associated with RTCRtpSender should return stats report containing outbound-rtp stats
-FAIL getStats() on track associated with RTCRtpReceiver should return stats report containing inbound-rtp stats assert_true: expected true got false
+PASS getStats() on track associated with RTCRtpReceiver should return stats report containing inbound-rtp stats
 PASS getStats() audio contains candidate-pair stats
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-getStats.https_rest-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-getStats.https_rest-expected.txt
@@ -5,7 +5,7 @@ PASS getStats() with track not added to connection should reject with InvalidAcc
 PASS getStats() with track added via addTrack should succeed
 PASS getStats() with track added via addTransceiver should succeed
 FAIL getStats() with track associated with both sender and receiver should reject with InvalidAccessError assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL getStats() audio contains inbound-rtp stats assert_true: expected true got false
+PASS getStats() audio contains inbound-rtp stats
 FAIL getStats(track) should not work if multiple senders have the same track assert_unreached: Should have rejected: undefined Reached unreachable code
 PASS RTCStats.timestamp increases with time passing
 PASS getStats succeeds on a closed peerconnection

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-getStats.https_interop-2026-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-getStats.https_interop-2026-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL receiver.getStats() via addTransceiver should return stats report containing inbound-rtp stats assert_true: expected true got false
-FAIL receiver.getStats() via addTrack should return stats report containing inbound-rtp stats assert_true: expected true got false
-FAIL receiver.getStats() should work with a closed PeerConnection but not have inbound-rtp objects assert_true: expected true got false
-FAIL receiver.getStats() should return stats report containing ICE candidate stats assert_true: expected true got false
+PASS receiver.getStats() via addTransceiver should return stats report containing inbound-rtp stats
+PASS receiver.getStats() via addTrack should return stats report containing inbound-rtp stats
+PASS receiver.getStats() should work with a closed PeerConnection but not have inbound-rtp objects
+PASS receiver.getStats() should return stats report containing ICE candidate stats
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-getStats.https_rest-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-getStats.https_rest-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL receiver.getStats() should work on a stopped transceiver but not have inbound-rtp objects assert_true: expected true got false
+FAIL receiver.getStats() should work on a stopped transceiver but not have inbound-rtp objects assert_false: expected false got true
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpTransceiver.https_interop-2026-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpTransceiver.https_interop-2026-expected.txt
@@ -9,5 +9,5 @@ PASS checkStopAfterCreateOffer
 PASS checkStopAfterSetLocalAnswer
 PASS checkStopAfterSetLocalOffer
 PASS checkStopAfterSetRemoteOffer
-FAIL track with audio stays muted when setting the transceiver direction to 'sendrecv' after 'inactive' but no packets flow assert_true: track remains muted expected true got false
+PASS track with audio stays muted when setting the transceiver direction to 'sendrecv' after 'inactive' but no packets flow
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpTransceiver.https_rest-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpTransceiver.https_rest-expected.txt
@@ -33,5 +33,5 @@ PASS track with video is muted after SRD
 PASS track with video gets unmuted when packets flow.
 PASS track with video gets muted when setting the transceiver direction to 'inactive'
 PASS track with video gets unmuted when setting the transceiver direction to 'sendrecv' after 'inactive'
-FAIL track with video stays muted when setting the transceiver direction to 'sendrecv' after 'inactive' but no packets flow assert_true: track remains muted expected true got false
+PASS track with video stays muted when setting the transceiver direction to 'sendrecv' after 'inactive' but no packets flow
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3216,6 +3216,8 @@ webkit.org/b/191707 imported/w3c/web-platform-tests/webrtc/simplecall-no-ssrcs.h
 webkit.org/b/191707 imported/w3c/web-platform-tests/webrtc/simplecall.https.html [ Skip ]
 imported/w3c/web-platform-tests/webrtc-encoded-transform/script-metadata-transform.https.html [ Skip ]
 
+imported/w3c/web-platform-tests/webrtc/RTCRtpTransceiver.https.html?rest [ Pass Failure ]
+
 webkit.org/b/197473 imported/w3c/web-platform-tests/resource-timing/resource-timing-level1.sub.html [ Pass Failure ]
 
 # These tests depend on the implementation of "modern compatibility mode" in WebKitAdditions.

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
@@ -565,8 +565,6 @@ void PeerConnectionBackend::setRemoteDescriptionSucceeded(std::optional<Descript
                     DEBUG_LOG(LOGIDENTIFIER, "PeerConnection closed while dispatching track events");
                     return;
                 }
-
-                protect(track->source())->setMuted(false);
             }
         }
 

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.cpp
@@ -53,7 +53,10 @@ LibWebRTCRtpReceiverBackend::LibWebRTCRtpReceiverBackend(Ref<webrtc::RtpReceiver
 {
 }
 
-LibWebRTCRtpReceiverBackend::~LibWebRTCRtpReceiverBackend() = default;
+LibWebRTCRtpReceiverBackend::~LibWebRTCRtpReceiverBackend()
+{
+    m_rtcReceiver->SetObserver(nullptr);
+}
 
 RTCRtpParameters LibWebRTCRtpReceiverBackend::getParameters()
 {
@@ -117,32 +120,41 @@ Vector<RTCRtpSynchronizationSource> LibWebRTCRtpReceiverBackend::getSynchronizat
 
 Ref<RealtimeMediaSource> LibWebRTCRtpReceiverBackend::createSource(Document& document)
 {
-    auto rtcTrack = m_rtcReceiver->track();
-    switch (m_rtcReceiver->media_type()) {
-    case webrtc::MediaType::ANY:
-    case webrtc::MediaType::DATA:
-    case webrtc::MediaType::UNSUPPORTED:
-        break;
-    case webrtc::MediaType::AUDIO: {
-        // This is a cast from a webrtc type, not much we can do to make it safe.
-        SUPPRESS_MEMORY_UNSAFE_CAST webrtc::scoped_refptr<webrtc::AudioTrackInterface> audioTrack { static_cast<webrtc::AudioTrackInterface*>(rtcTrack.get()) };
-        Ref source = RealtimeIncomingAudioSource::create(toRef(WTF::move(audioTrack)), fromStdString(rtcTrack->id()));
-        if (document.page()) {
-            auto& webRTCProvider = downcast<LibWebRTCProvider>(document.page()->webRTCProvider());
-            source->setAudioModule(webRTCProvider.audioModule());
+    RefPtr source = [&] -> RefPtr<RealtimeMediaSource> {
+        auto rtcTrack = m_rtcReceiver->track();
+        switch (m_rtcReceiver->media_type()) {
+        case webrtc::MediaType::ANY:
+        case webrtc::MediaType::DATA:
+        case webrtc::MediaType::UNSUPPORTED:
+            break;
+        case webrtc::MediaType::AUDIO: {
+            // This is a cast from a webrtc type, not much we can do to make it safe.
+            SUPPRESS_MEMORY_UNSAFE_CAST webrtc::scoped_refptr<webrtc::AudioTrackInterface> audioTrack { static_cast<webrtc::AudioTrackInterface*>(rtcTrack.get()) };
+            Ref source = RealtimeIncomingAudioSource::create(toRef(WTF::move(audioTrack)), fromStdString(rtcTrack->id()));
+            if (document.page()) {
+                auto& webRTCProvider = downcast<LibWebRTCProvider>(document.page()->webRTCProvider());
+                source->setAudioModule(webRTCProvider.audioModule());
+            }
+            return source;
         }
-        return source;
-    }
-    case webrtc::MediaType::VIDEO: {
-        // This is a cast from a webrtc type, not much we can do to make it safe.
-        SUPPRESS_MEMORY_UNSAFE_CAST webrtc::scoped_refptr<webrtc::VideoTrackInterface> videoTrack { static_cast<webrtc::VideoTrackInterface*>(rtcTrack.get()) };
-        Ref source = RealtimeIncomingVideoSource::create(toRef(WTF::move(videoTrack)), fromStdString(rtcTrack->id()));
-        if (document.settings().webRTCMediaPipelineAdditionalLoggingEnabled())
-            source->enableFrameRatedMonitoring();
-        return source;
-    }
-    }
-    RELEASE_ASSERT_NOT_REACHED();
+        case webrtc::MediaType::VIDEO: {
+            // This is a cast from a webrtc type, not much we can do to make it safe.
+            SUPPRESS_MEMORY_UNSAFE_CAST webrtc::scoped_refptr<webrtc::VideoTrackInterface> videoTrack { static_cast<webrtc::VideoTrackInterface*>(rtcTrack.get()) };
+            Ref source = RealtimeIncomingVideoSource::create(toRef(WTF::move(videoTrack)), fromStdString(rtcTrack->id()));
+            if (document.settings().webRTCMediaPipelineAdditionalLoggingEnabled())
+                source->enableFrameRatedMonitoring();
+            return source;
+        }
+        }
+        return nullptr;
+    }();
+
+    RELEASE_ASSERT(source);
+
+    m_source = *source;
+    m_rtcReceiver->SetObserver(this);
+
+    return source.releaseNonNull();
 }
 
 Ref<RTCRtpTransformBackend> LibWebRTCRtpReceiverBackend::rtcRtpTransformBackend()
@@ -156,6 +168,14 @@ std::unique_ptr<RTCDtlsTransportBackend> LibWebRTCRtpReceiverBackend::dtlsTransp
 {
     RefPtr backend = toRefPtr(m_rtcReceiver->dtls_transport());
     return backend ? makeUnique<LibWebRTCDtlsTransportBackend>(backend.releaseNonNull()) : nullptr;
+}
+
+void LibWebRTCRtpReceiverBackend::OnFirstPacketReceivedAfterReceptiveChange(webrtc::MediaType)
+{
+    callOnMainThread([source = m_source] {
+        if (RefPtr protectedSource = source.get())
+            protectedSource->setMuted(false);
+    });
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.h
@@ -29,6 +29,7 @@
 #include "LibWebRTCMacros.h"
 #include "LibWebRTCRefWrappers.h"
 #include "RTCRtpReceiverBackend.h"
+#include "RealtimeMediaSource.h"
 #include <webrtc/api/scoped_refptr.h>
 #include <wtf/TZoneMalloc.h>
 
@@ -36,7 +37,7 @@ namespace WebCore {
 class Document;
 class RealtimeMediaSource;
 
-class LibWebRTCRtpReceiverBackend final : public RTCRtpReceiverBackend {
+class LibWebRTCRtpReceiverBackend final : public RTCRtpReceiverBackend, public webrtc::RtpReceiverObserverInterface {
     WTF_MAKE_TZONE_ALLOCATED(LibWebRTCRtpReceiverBackend);
 public:
     explicit LibWebRTCRtpReceiverBackend(Ref<webrtc::RtpReceiverInterface>&&);
@@ -47,6 +48,7 @@ public:
     Ref<RealtimeMediaSource> createSource(Document&);
 
 private:
+    // RTCRtpReceiverBackend
     bool isLibWebRTCRtpReceiverBackend() const final { return true; }
 
     RTCRtpParameters getParameters() final;
@@ -55,11 +57,16 @@ private:
     Ref<RTCRtpTransformBackend> rtcRtpTransformBackend() final;
     std::unique_ptr<RTCDtlsTransportBackend> dtlsTransportBackend() final;
 
+    // webrtc::RtpReceiverObserverInterface
+    void OnFirstPacketReceived(webrtc::MediaType) final { }
+    void OnFirstPacketReceivedAfterReceptiveChange(webrtc::MediaType) final;
+
     double webrtcToWallTimeOffset() const;
 
     const Ref<webrtc::RtpReceiverInterface> m_rtcReceiver;
     const RefPtr<RTCRtpTransformBackend> m_transformBackend;
     mutable std::optional<double> m_webrtcToWallTimeOffset;
+    ThreadSafeWeakPtr<RealtimeMediaSource> m_source;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 23e860752045b99081b432e3054b653eb829c57a
<pre>
A remote webrtc track should get unmuted when first packet is received
<a href="https://rdar.apple.com/172904930">rdar://172904930</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=310267">https://bugs.webkit.org/show_bug.cgi?id=310267</a>

Reviewed by Jean-Yves Avenard.

We use the new callback OnFirstPacketReceivedAfterReceptiveChange to unmute tracks as per spec.
We remove the unmuting that was previously used in PeerConnectionBackend::setRemoteDescriptionSucceeded.

Covered by rebased WPT tests.

Canonical link: <a href="https://commits.webkit.org/309987@main">https://commits.webkit.org/309987@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42bd5433411f8c5359547ab4703b6d725db68c13

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152087 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24869 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18454 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160830 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105544 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153961 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25361 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25175 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117487 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83330 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155047 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19674 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136506 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98200 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18751 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16699 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8664 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128397 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14392 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163296 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6442 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15984 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125514 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24667 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20746 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125690 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34163 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24668 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136188 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81261 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20699 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12965 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24285 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88570 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23976 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24136 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24037 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->