### PR TITLE
Remove try await unsafe compiler bug workaround

### DIFF
--- a/Tools/SwiftBrowser/Source/Views/BrowserView.swift
+++ b/Tools/SwiftBrowser/Source/Views/BrowserView.swift
@@ -45,8 +45,7 @@ struct BrowserView: View {
                 #endif
             }
             .task {
-                // Safety: this is actually safe; false positive is rdar://154775389
-                for await unsafe _ in NotificationCenter.default.messages(of: UserDefaults.self, for: .didChange) {
+                for await _ in NotificationCenter.default.messages(of: UserDefaults.self, for: .didChange) {
                     viewModel.updateWebPreferences()
                 }
             }

--- a/Tools/SwiftBrowser/Source/Views/ContentView.swift
+++ b/Tools/SwiftBrowser/Source/Views/ContentView.swift
@@ -121,16 +121,9 @@ struct ContentView: View {
                 .findNavigator(isPresented: $findNavigatorIsPresented)
                 .task {
                     do {
-                        #if compiler(>=6.2)
-                        // Safety: this is actually safe; false positive is rdar://154775389
-                        for try await unsafe event in viewModel.page.navigations {
-                            print(event)
-                        }
-                        #else
                         for try await event in viewModel.page.navigations {
                             print(event)
                         }
-                        #endif
                     } catch {
                         print(error)
                     }

--- a/Tools/TestWebKitAPI/Tests/WebKit Swift/Foundation+Extras.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit Swift/Foundation+Extras.swift
@@ -36,8 +36,7 @@ extension RangeReplaceableCollection {
     ) async throws(Failure) where Failure: Error {
         self.init()
 
-        // Safety: this is actually safe; false positive is rdar://154775389
-        for try await unsafe element in sequence {
+        for try await element in sequence {
             append(element)
         }
     }
@@ -46,8 +45,7 @@ extension RangeReplaceableCollection {
 @available(macOS 15.0, iOS 18.0, *)
 extension AsyncSequence {
     func wait(isolation: isolated (any Actor)? = #isolation) async throws(Failure) {
-        // Safety: this is actually safe; false positive is rdar://154775389
-        for try await unsafe _ in self {
+        for try await _ in self {
         }
     }
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit Swift/URLSchemeHandlerTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit Swift/URLSchemeHandlerTests.swift
@@ -150,14 +150,12 @@ struct URLSchemeHandlerTests {
         var secondEvents: [WebPage.NavigationEvent] = []
 
         do {
-            // Safety: this is actually safe; false positive is rdar://154775389
-            for try await unsafe firstEvent in page.load(URL(string: "testing://main")) {
+            for try await firstEvent in page.load(URL(string: "testing://main")) {
                 firstEvents.append(firstEvent)
 
                 if firstEvent == .startedProvisionalNavigation {
                     do {
-                        // Safety: this is actually safe; false positive is rdar://154775389
-                        for try await unsafe secondEvent in page.load(URL(string: "testing://main2")) {
+                        for try await secondEvent in page.load(URL(string: "testing://main2")) {
                             secondEvents.append(secondEvent)
                         }
                     } catch {

--- a/Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageNavigationTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageNavigationTests.swift
@@ -63,8 +63,7 @@ struct WebPageNavigationTests {
         let expected: [WebPage.NavigationEvent] = [.startedProvisionalNavigation]
 
         await #expect(throws: (any Error).self) {
-            // Safety: this is actually safe; false positive is rdar://154775389
-            for try await unsafe event in sequence {
+            for try await event in sequence {
                 actual.append(event)
             }
         }
@@ -82,8 +81,7 @@ struct WebPageNavigationTests {
 
         // FIXME: `#expect` should work here, but due to a Swift Testing issue causes the test to hang.
         do {
-            // Safety: this is actually safe; false positive is rdar://154775389
-            for try await unsafe event in sequence where event == .startedProvisionalNavigation {
+            for try await event in sequence where event == .startedProvisionalNavigation {
                 page.stopLoading()
             }
             Issue.record("Stopping page load should trigger an error and therefore the loop should never finish.")
@@ -105,8 +103,7 @@ struct WebPageNavigationTests {
 
         await withCheckedContinuation { continuation in
             task = Task {
-                // Safety: this is actually safe; false positive is rdar://154775389
-                for try await unsafe event in sequence {
+                for try await event in sequence {
                     if event == .startedProvisionalNavigation {
                         continuation.resume()
                     } else {
@@ -123,8 +120,7 @@ struct WebPageNavigationTests {
 
         // FIXME: `#expect` should work here, but due to a Swift Testing issue causes the test to hang.
         do {
-            // Safety: this is actually safe; false positive is rdar://154775389
-            for try await unsafe event in allNavigations {
+            for try await event in allNavigations {
                 actualEvents.append(event)
             }
             Issue.record("The stream is indefinite and therefore should never reach here.")
@@ -145,8 +141,7 @@ struct WebPageNavigationTests {
 
         // FIXME: `#expect` should work here, but a Swift Testing issue causes the test to hang.
         do {
-            // Safety: this is actually safe; false positive is rdar://154775389
-            for try await unsafe event in sequence where event == .startedProvisionalNavigation {
+            for try await event in sequence where event == .startedProvisionalNavigation {
                 page.terminateWebContentProcess()
             }
             Issue.record("Terminating the web content process should trigger an error and therefore the loop should never finish.")


### PR DESCRIPTION
#### 75924e52a170f1c65dd5068ee87c1fa0227c2af7
<pre>
Remove try await unsafe compiler bug workaround
<a href="https://bugs.webkit.org/show_bug.cgi?id=310277">https://bugs.webkit.org/show_bug.cgi?id=310277</a>
<a href="https://rdar.apple.com/172910403">rdar://172910403</a>

Reviewed by Richard Robinson.

This removes a workaround for an unsafety false positive which is fixed in more
recent versions of the Swift compiler (compiler bug reference

<a href="https://rdar.apple.com/154775389">rdar://154775389</a>).
Canonical link: <a href="https://commits.webkit.org/309605@main">https://commits.webkit.org/309605@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d072c0e0c55e96695b16b5541e21549dad1fd949

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151070 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23832 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17402 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159798 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104506 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e5828913-63e1-496f-8929-333fd3fae783) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152943 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24263 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24056 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116632 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82792 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c643c354-9037-4987-b428-6b3886fc59c1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154030 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18756 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135544 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97353 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bbf9d949-0167-4221-acd7-c2edee4e1e0e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17849 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15798 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7644 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127467 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13461 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162271 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15032 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124637 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23634 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19848 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124825 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33882 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23624 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135258 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80068 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19889 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12023 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23234 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22946 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23098 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23000 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->