### PR TITLE
[GStreamer] Drop unsafe buffer usage from GStreamerWebRTCUtils

### DIFF
--- a/Source/WTF/wtf/glib/GSpanExtras.h
+++ b/Source/WTF/wtf/glib/GSpanExtras.h
@@ -102,6 +102,21 @@ inline std::span<const uint8_t> span(const GRefPtr<GByteArray>& array LIFETIME_B
     return span(array.get());
 }
 
+template <typename T = uint8_t*, typename = std::enable_if_t<std::is_pointer_v<T>>>
+inline std::span<T>span(GArray* array LIFETIME_BOUND)
+{
+    if (!array)
+        return unsafeMakeSpan<T>(nullptr, 0);
+
+    return unsafeMakeSpan(static_cast<T*>(static_cast<void*>(array->data)), array->len);
+}
+
+template <typename T = uint8_t*, typename = std::enable_if_t<std::is_pointer_v<T>>>
+inline std::span<T>span(GRefPtr<GArray>& array LIFETIME_BOUND)
+{
+    return span<T>(array.get());
+}
+
 inline std::span<const uint8_t> span(GVariant* variant LIFETIME_BOUND)
 {
     const auto* ptr = static_cast<const uint8_t*>(g_variant_get_data(variant));

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
@@ -418,9 +418,8 @@ std::optional<Ref<RTCCertificate>> generateCertificate(Ref<SecurityOrigin>&& ori
 
     switch (info.type) {
     case PeerConnectionBackend::CertificateInformation::Type::ECDSAP256: {
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN;
-        privateKey.reset(EVP_EC_gen("prime256v1"));
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END;
+        char curveName[] = "prime256v1";
+        privateKey.reset(EVP_PKEY_Q_keygen(nullptr, nullptr, "EC", curveName));
         if (!privateKey)
             return { };
         break;
@@ -746,15 +745,8 @@ void forEachTransceiver(const GRefPtr<GstElement>& webrtcBin, Function<bool(GRef
     GRefPtr<GArray> transceivers;
     g_signal_emit_by_name(webrtcBin.get(), "get-transceivers", &transceivers.outPtr());
 
-    if (!transceivers || !transceivers->len)
-        return;
-
-    for (unsigned index = 0; index < transceivers->len; index++) {
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN; // GLib port
-        GRefPtr current = g_array_index(transceivers.get(), GstWebRTCRTPTransceiver*, index);
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END;
-
-        if (function(WTF::move(current)))
+    for (auto* transceiver : span<GstWebRTCRTPTransceiver*>(transceivers)) {
+        if (function(transceiver))
             break;
     }
 }
@@ -915,11 +907,10 @@ SDPStringBuilder::SDPStringBuilder(const GstSDPMessage* sdp)
 
             m_stringBuilder.append("t="_s, unsafeSpan(time->start), ' ', unsafeSpan(time->stop), CRLF);
             if (time->repeat) {
-                WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN; // GLib port
-                m_stringBuilder.append("r="_s, unsafeSpan(g_array_index(time->repeat, char*, 0)));
-                for (unsigned ii = 1; ii < time->repeat->len; ii++)
-                    m_stringBuilder.append(' ', unsafeSpan(g_array_index(time->repeat, char*, ii)));
-                WTF_ALLOW_UNSAFE_BUFFER_USAGE_END;
+                auto repeatSpan = span<char*>(time->repeat);
+                m_stringBuilder.append("r="_s, unsafeSpan(consume(repeatSpan)));
+                for (const auto* repeat : repeatSpan)
+                    m_stringBuilder.append(' ', unsafeSpan(repeat));
                 m_stringBuilder.append(CRLF);
             }
         }


### PR DESCRIPTION
#### 21f98a1bf7b8e1dc5837da7732ae467826cbf627
<pre>
[GStreamer] Drop unsafe buffer usage from GStreamerWebRTCUtils
<a href="https://bugs.webkit.org/show_bug.cgi?id=310282">https://bugs.webkit.org/show_bug.cgi?id=310282</a>

Reviewed by Philippe Normand.

Add a std::span constructor for GArray so that the GArray&apos;s provided
by GStreamer can be used instead of unsafe iteration through the GArray
API.

Replace EVP_EC_gen() macro usage with EVP_PKEY_Q_keygen() directly,
to avoid unnecessary call to strstr(), fixing this way:

error: function &apos;strstr&apos; is unsafe [-Werror,-Wunsafe-buffer-usage-in-libc-call]
   421 |         privateKey.reset(EVP_PKEY_Q_keygen(__null, __null, &quot;EC&quot;, (char *)(strstr(&quot;prime256v1&quot;, &quot;&quot;))));

* Source/WTF/wtf/glib/GSpanExtras.h:
(WTF::std::span&lt;T&gt;span):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp:
(WebCore::generateCertificate):
(WebCore::forEachTransceiver):
(WebCore::SDPStringBuilder::SDPStringBuilder):

Canonical link: <a href="https://commits.webkit.org/309611@main">https://commits.webkit.org/309611@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34082a7213cb19a41fddd20b25102b4ae773bd06

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151055 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23817 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17387 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159783 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104491 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152928 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24248 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24040 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116619 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82779 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154015 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18741 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135531 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97340 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17834 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15785 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7629 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/143039 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127452 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13448 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162256 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/11854 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5381 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15019 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124626 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23619 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19835 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124814 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23609 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135245 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80048 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23232 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19879 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12010 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/182664 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23219 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87513 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46620 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22931 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23083 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22985 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->