### PR TITLE
Fix Thread Sanitizer builds of TestWebKitAPI: ld: Too many personality routines for compact unwind to encode

### DIFF
--- a/Configurations/Sanitizers.xcconfig
+++ b/Configurations/Sanitizers.xcconfig
@@ -88,6 +88,8 @@ WK_WORKAROUND_RDAR_145268301_ASAN_STACK_USE_AFTER_SCOPE_YES = -DWK_WORKAROUND_RD
 
 // Disable compact unwind to work around "Too many personality routines" linker error with TSan builds.
 WK_THREAD_SANITIZER_OTHER_LDFLAGS_YES = $(WK_THREAD_SANITIZER_OTHER_LDFLAGS_$(PRODUCT_NAME));
+WK_THREAD_SANITIZER_OTHER_LDFLAGS_TestWebKitAPI = -Wl,-no_compact_unwind;
+WK_THREAD_SANITIZER_OTHER_LDFLAGS_TestWebKitAPIBundle = -Wl,-no_compact_unwind;
 WK_THREAD_SANITIZER_OTHER_LDFLAGS_WebCore = -Wl,-no_compact_unwind;
 WK_THREAD_SANITIZER_OTHER_LDFLAGS_WebKit = -Wl,-no_compact_unwind;
 


### PR DESCRIPTION
#### 7ac0919ca48b15918a56471ec19510a486942860
<pre>
Fix Thread Sanitizer builds of TestWebKitAPI: ld: Too many personality routines for compact unwind to encode
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=310288">https://bugs.webkit.org/show_bug.cgi?id=310288</a>&gt;
&lt;<a href="https://rdar.apple.com/172926718">rdar://172926718</a>&gt;

Reviewed by Elliott Williams.

Extend the fix from Bug 299224 (300615@main) to cover
`TestWebKitAPI` and `TestWebKitAPIBundle`.  These targets now link
Swift source files, which introduces `__swift_exceptionPersonality`
as a fourth exception handling personality routine, exceeding the
compact unwind encoding limit.

Tested by building WebKit for Thread Sanitizer.

* Configurations/Sanitizers.xcconfig:
(WK_THREAD_SANITIZER_OTHER_LDFLAGS_TestWebKitAPI): Add.
(WK_THREAD_SANITIZER_OTHER_LDFLAGS_TestWebKitAPIBundle): Add.
- Add `-Wl,-no_compact_unwind` to OTHER_LDFLAGS when linking
  TestWebKitAPI and TestWebKitAPIBundle to work around the error.

Canonical link: <a href="https://commits.webkit.org/309575@main">https://commits.webkit.org/309575@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f06c0a9d42842a79ef87fa1358ead8c2157a499b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151063 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23825 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17395 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159791 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104499 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24256 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24049 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116626 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82788 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154023 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18751 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135540 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97347 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6063a0e7-f443-4fed-bbdf-076b611dac06) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17844 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15790 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7637 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127462 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162264 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15028 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124634 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23627 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19840 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124822 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23617 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135254 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80061 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23215 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19891 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12019 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23227 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22939 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23091 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22993 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->