### PR TITLE
[css-values-5 attr()] Factor arbitrary substitution function resolution to a type

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3154,6 +3154,7 @@ style/StyleResolver.cpp
 style/StyleScope.cpp
 style/StyleScopeRuleSets.cpp
 style/StyleSheetContentsCache.cpp
+style/StyleSubstitutionResolver.cpp
 style/StyleTransformResolver.cpp
 style/StyleTreeResolver.cpp
 style/StyleUpdate.cpp

--- a/Source/WebCore/css/CSSPendingSubstitutionValue.cpp
+++ b/Source/WebCore/css/CSSPendingSubstitutionValue.cpp
@@ -26,29 +26,18 @@
 #include "config.h"
 #include "CSSPendingSubstitutionValue.h"
 
-#include "CSSProperty.h"
-#include "CSSPropertyParser.h"
-
 namespace WebCore {
 
-RefPtr<CSSValue> CSSPendingSubstitutionValue::resolveValue(Style::Builder& builder, CSSPropertyID propertyID) const
+Ref<CSSPendingSubstitutionValue> CSSPendingSubstitutionValue::create(CSSPropertyID shorthandPropertyId, Ref<CSSVariableReferenceValue>&& shorthandValue)
 {
-    if (!m_shorthandValue->resolveAndCacheValue(builder, [this](auto data) {
-        ParsedPropertyVector parsedProperties;
-        if (!CSSPropertyParser::parseValue(m_shorthandPropertyId, IsImportant::No, data->tokens(), data->context(), parsedProperties, StyleRuleType::Style)) {
-            m_cachedPropertyValues = { };
-            return;
-        }
-
-        m_cachedPropertyValues = parsedProperties; }))
-        return nullptr;
-
-    for (auto& property : m_cachedPropertyValues) {
-        if (property.id() == propertyID)
-            return property.value();
-    }
-
-    return nullptr;
+    return adoptRef(*new CSSPendingSubstitutionValue(shorthandPropertyId, WTF::move(shorthandValue)));
 }
 
+CSSPendingSubstitutionValue::CSSPendingSubstitutionValue(CSSPropertyID shorthandPropertyId, Ref<CSSVariableReferenceValue>&& shorthandValue)
+    : CSSValue(ClassType::PendingSubstitutionValue)
+    , m_shorthandPropertyId(shorthandPropertyId)
+    , m_shorthandValue(WTF::move(shorthandValue))
+{
 }
+
+} // namespace WebCore

--- a/Source/WebCore/css/CSSPendingSubstitutionValue.h
+++ b/Source/WebCore/css/CSSPendingSubstitutionValue.h
@@ -38,18 +38,13 @@ class CSSProperty;
 
 class CSSPendingSubstitutionValue final : public CSSValue {
 public:
-    static Ref<CSSPendingSubstitutionValue> create(CSSPropertyID shorthandPropertyId, Ref<CSSVariableReferenceValue>&& shorthandValue)
-    {
-        return adoptRef(*new CSSPendingSubstitutionValue(shorthandPropertyId, WTF::move(shorthandValue)));
-    }
+    static Ref<CSSPendingSubstitutionValue> create(CSSPropertyID shorthandPropertyId, Ref<CSSVariableReferenceValue>&&);
 
     CSSVariableReferenceValue& shorthandValue() const { return m_shorthandValue; }
     CSSPropertyID shorthandPropertyId() const { return m_shorthandPropertyId; }
 
     bool equals(const CSSPendingSubstitutionValue& other) const { return m_shorthandValue.ptr() == other.m_shorthandValue.ptr(); }
     static String customCSSText(const CSS::SerializationContext&) { return emptyString(); }
-
-    RefPtr<CSSValue> resolveValue(Style::Builder&, CSSPropertyID) const;
 
     IterationStatus customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>& func) const
     {
@@ -59,12 +54,9 @@ public:
     }
 
 private:
-    CSSPendingSubstitutionValue(CSSPropertyID shorthandPropertyId, Ref<CSSVariableReferenceValue>&& shorthandValue)
-        : CSSValue(ClassType::PendingSubstitutionValue)
-        , m_shorthandPropertyId(shorthandPropertyId)
-        , m_shorthandValue(WTF::move(shorthandValue))
-    {
-    }
+    friend class Style::SubstitutionResolver;
+
+    CSSPendingSubstitutionValue(CSSPropertyID shorthandPropertyId, Ref<CSSVariableReferenceValue>&&);
 
     const CSSPropertyID m_shorthandPropertyId;
     const Ref<CSSVariableReferenceValue> m_shorthandValue;

--- a/Source/WebCore/css/CSSVariableReferenceValue.cpp
+++ b/Source/WebCore/css/CSSVariableReferenceValue.cpp
@@ -30,19 +30,7 @@
 #include "config.h"
 #include "CSSVariableReferenceValue.h"
 
-#include "CSSCustomPropertyValue.h"
-#include "CSSParserTokenRange.h"
-#include "CSSPropertyParser.h"
-#include "CSSRegisteredCustomProperty.h"
 #include "CSSVariableData.h"
-#include "ConstantPropertyMap.h"
-#include "CustomFunctionRegistry.h"
-#include "Document.h"
-#include "RenderStyle+GettersInlines.h"
-#include "StyleBuilder.h"
-#include "StyleCustomPropertyRegistry.h"
-#include "StyleResolver.h"
-#include "StyleScope.h"
 
 namespace WebCore {
 
@@ -80,143 +68,6 @@ const CSSParserContext& CSSVariableReferenceValue::context() const
     return m_data->context();
 }
 
-auto CSSVariableReferenceValue::resolveVariableFallback(const AtomString& variableName, CSSParserTokenRange range, CSSValueID functionId, Style::Builder& builder) const -> std::pair<FallbackResult, Vector<CSSParserToken>>
-{
-    ASSERT(range.atEnd() || range.peek().type() == CommaToken);
-
-    if (range.atEnd())
-        return { FallbackResult::None, { } };
-
-    range.consumeIncludingWhitespace();
-
-    auto tokens = resolveTokenRange(range, builder);
-
-    if (functionId == CSSValueVar) {
-        auto* registered = builder.state().document().customPropertyRegistry().get(variableName);
-        if (registered && !registered->syntax.isUniversal()) {
-            // https://drafts.css-houdini.org/css-properties-values-api/#fallbacks-in-var-references
-            // The fallback value must match the syntax definition of the custom property being referenced,
-            // otherwise the declaration is invalid at computed-value time
-            if (!tokens || !CSSPropertyParser::isValidCustomPropertyValueForSyntax(registered->syntax, *tokens, context()))
-                return { FallbackResult::Invalid, { } };
-
-            return { FallbackResult::Valid, WTF::move(*tokens) };
-        }
-    }
-
-    if (!tokens)
-        return { FallbackResult::None, { } };
-
-    return { FallbackResult::Valid, WTF::move(*tokens) };
-}
-
-static const Style::CustomProperty* propertyValueForVariableName(const AtomString& variableName, CSSValueID functionId, Style::Builder& builder)
-{
-    if (functionId == CSSValueEnv)
-        return builder.state().document().constantProperties().values().get(variableName);
-
-    // Apply this variable first, in case it is still unresolved
-    builder.applyCustomProperty(variableName);
-
-    return protect(builder.state().style())->customPropertyValue(variableName);
-}
-
-bool CSSVariableReferenceValue::resolveVariableReference(CSSParserTokenRange range, CSSValueID functionId, Vector<CSSParserToken>& tokens, Style::Builder& builder) const
-{
-    ASSERT(functionId == CSSValueVar || functionId == CSSValueEnv);
-
-    range.consumeWhitespace();
-    ASSERT(range.peek().type() == IdentToken);
-    auto variableName = range.consumeIncludingWhitespace().value().toAtomString();
-
-    // Fallback has to be resolved even when not used to detect cycles and invalid syntax.
-    auto [fallbackResult, fallbackTokens] = resolveVariableFallback(variableName, range, functionId, builder);
-    if (fallbackResult == FallbackResult::Invalid)
-        return false;
-
-    RefPtr property = propertyValueForVariableName(variableName, functionId, builder);
-
-    if (!property || property->isGuaranteedInvalid()) {
-        if (fallbackTokens.size() > maxSubstitutionTokens)
-            return false;
-
-        if (fallbackResult == FallbackResult::Valid) {
-            tokens.appendVector(fallbackTokens);
-            return true;
-        }
-        return false;
-    }
-
-    if (property->tokens().size() > maxSubstitutionTokens)
-        return false;
-
-    tokens.appendVector(property->tokens());
-    return true;
-}
-
-bool CSSVariableReferenceValue::evaluateDashedFunction(StringView functionName, CSSParserTokenRange, Vector<CSSParserToken>& tokens, Style::Builder& builder) const
-{
-    // https://drafts.csswg.org/css-mixins/#evaluating-custom-functions
-
-    if (!builder.state().element())
-        return false;
-
-    auto scopedFunctionName = Style::ScopedName { functionName.toAtomString(), builder.state().styleScopeOrdinal() };
-
-    CheckedPtr element = builder.state().element();
-    auto customFunction = Style::Scope::resolveTreeScopedReference(*element, scopedFunctionName, [](const Style::Scope& scope, const AtomString& name) -> CheckedPtr<const Style::CustomFunction> {
-        auto* resolver = scope.resolverIfExists();
-        auto* registry = resolver ? resolver->customFunctionRegistry() : nullptr;
-        return registry ? registry->functionForName(name) : nullptr;
-    });
-
-    if (!customFunction)
-        return false;
-
-    // FIXME: Evaluate the function instead of just substituting.
-
-    auto properties = customFunction->properties;
-    auto resultValue = dynamicDowncast<CSSCustomPropertyValue>(properties->getPropertyCSSValue(CSSPropertyResult));
-    if (!resultValue)
-        return false;
-
-    auto data = resultValue->asVariableData();
-    tokens.appendVector(data->tokens());
-    return true;
-}
-
-std::optional<Vector<CSSParserToken>> CSSVariableReferenceValue::resolveTokenRange(CSSParserTokenRange range, Style::Builder& builder) const
-{
-    Vector<CSSParserToken> tokens;
-    bool success = true;
-    while (!range.atEnd()) {
-        auto token = range.peek();
-        if (token.type() == FunctionToken) {
-            auto functionId = token.functionId();
-            if (functionId == CSSValueVar || functionId == CSSValueEnv) {
-                if (!resolveVariableReference(range.consumeBlock(), functionId, tokens, builder))
-                    success = false;
-                continue;
-            }
-            if (functionId == CSSValueAttr) {
-                // attr() substitution function
-                // FIXME: Implement.
-            }
-            if (isCustomPropertyName(token.value())) {
-                // <dashed-function>
-                if (!evaluateDashedFunction(token.value(), range.consumeBlock(), tokens, builder))
-                    success = false;
-                continue;
-            }
-        }
-        tokens.append(range.consume());
-    }
-    if (!success)
-        return { };
-
-    return tokens;
-}
-
 void CSSVariableReferenceValue::cacheSimpleReference()
 {
     ASSERT(!m_simpleReference);
@@ -240,46 +91,6 @@ void CSSVariableReferenceValue::cacheSimpleReference()
         return;
 
     m_simpleReference = SimpleReference { variableName, functionId };
-}
-
-RefPtr<CSSVariableData> CSSVariableReferenceValue::tryResolveSimpleReference(Style::Builder& builder) const
-{
-    if (!m_simpleReference)
-        return nullptr;
-
-    // Shortcut for the simple common case of property:var(--foo)
-
-    RefPtr property = propertyValueForVariableName(m_simpleReference->name, m_simpleReference->functionId, builder);
-    if (!property || !std::holds_alternative<Ref<CSSVariableData>>(property->value()))
-        return nullptr;
-
-    return std::get<Ref<CSSVariableData>>(property->value()).ptr();
-}
-
-RefPtr<CSSVariableData> CSSVariableReferenceValue::resolveVariableReferences(Style::Builder& builder) const
-{
-    if (auto data = tryResolveSimpleReference(builder))
-        return data;
-
-    auto resolvedTokens = resolveTokenRange(m_data->tokenRange(), builder);
-    if (!resolvedTokens)
-        return nullptr;
-
-    return CSSVariableData::create(*resolvedTokens, context());
-}
-
-RefPtr<CSSValue> CSSVariableReferenceValue::resolveSingleValue(Style::Builder& builder, CSSPropertyID propertyID) const
-{
-    if (!resolveAndCacheValue(builder, [this, propertyID](auto data) {
-        m_cachedValue = CSSPropertyParser::parseStylePropertyLonghand(propertyID, data->tokens(), context());
-#if ASSERT_ENABLED
-        m_cachePropertyID = propertyID;
-#endif
-    }))
-        return nullptr;
-
-    ASSERT(m_cachePropertyID == propertyID);
-    return m_cachedValue;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSVariableReferenceValue.h
+++ b/Source/WebCore/css/CSSVariableReferenceValue.h
@@ -29,24 +29,21 @@
 
 #pragma once
 
-#include <WebCore/CSSParserTokenRange.h>
 #include <WebCore/CSSPropertyNames.h>
 #include <WebCore/CSSValue.h>
 #include <WebCore/CSSValueKeywords.h>
 #include <WebCore/CSSVariableData.h>
-#include <wtf/PointerComparison.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
 class CSSParserToken;
+class CSSParserTokenRange;
 struct CSSParserContext;
 
 namespace Style {
-class Builder;
+class SubstitutionResolver;
 }
-
-enum CSSPropertyID : uint16_t;
 
 class CSSVariableReferenceValue final : public CSSValue {
 public:
@@ -56,70 +53,36 @@ public:
     bool equals(const CSSVariableReferenceValue&) const;
     String customCSSText(const CSS::SerializationContext&) const;
 
-    RefPtr<CSSVariableData> resolveVariableReferences(Style::Builder&) const;
     const CSSParserContext& NODELETE context() const;
 
-    RefPtr<CSSValue> resolveSingleValue(Style::Builder&, CSSPropertyID) const;
-
-    // The maximum number of tokens that may be produced by a var() reference or var() fallback value.
-    // https://drafts.csswg.org/css-variables/#long-variables
-    static constexpr size_t maxSubstitutionTokens = 65536;
-    
     const CSSVariableData& data() const { return m_data.get(); }
 
-    template<typename CacheFunction> bool resolveAndCacheValue(Style::Builder&, NOESCAPE const CacheFunction&) const;
-
 private:
+    friend class Style::SubstitutionResolver;
+
     explicit CSSVariableReferenceValue(Ref<CSSVariableData>&&);
 
-    std::optional<Vector<CSSParserToken>> resolveTokenRange(CSSParserTokenRange, Style::Builder&) const;
-    bool resolveVariableReference(CSSParserTokenRange, CSSValueID, Vector<CSSParserToken>&, Style::Builder&) const;
-    bool evaluateDashedFunction(StringView functionName, CSSParserTokenRange, Vector<CSSParserToken>&, Style::Builder&) const;
-
-    enum class FallbackResult : uint8_t { None, Valid, Invalid };
-    std::pair<FallbackResult, Vector<CSSParserToken>> resolveVariableFallback(const AtomString& variableName, CSSParserTokenRange, CSSValueID functionId, Style::Builder&) const;
-
     void cacheSimpleReference();
-    RefPtr<CSSVariableData> tryResolveSimpleReference(Style::Builder&) const;
 
     const Ref<CSSVariableData> m_data;
     mutable String m_stringValue;
 
-    // For quicky resolving simple var(--foo) values.
+    // For quickly resolving simple var(--foo) values.
     struct SimpleReference {
         AtomString name;
         CSSValueID functionId;
     };
     std::optional<SimpleReference> m_simpleReference;
 
-    mutable RefPtr<CSSVariableData> m_cacheDependencyData;
-    mutable RefPtr<CSSValue> m_cachedValue;
+    struct Cache {
+        RefPtr<CSSVariableData> dependencyData;
+        RefPtr<CSSValue> value;
 #if ASSERT_ENABLED
-    mutable CSSPropertyID m_cachePropertyID { CSSPropertyInvalid };
+        CSSPropertyID propertyID { CSSPropertyInvalid };
 #endif
+    };
+    mutable Cache m_cache;
 };
-
-template<typename CacheFunction>
-bool CSSVariableReferenceValue::resolveAndCacheValue(Style::Builder& builder, NOESCAPE const CacheFunction& cacheFunction) const
-
-{
-    if (auto data = tryResolveSimpleReference(builder)) {
-        if (!arePointingToEqualData(m_cacheDependencyData, data))
-            cacheFunction(data);
-        m_cacheDependencyData = WTF::move(data);
-        return true;
-    }
-
-    auto resolvedTokens = resolveTokenRange(m_data->tokenRange(), builder);
-    if (!resolvedTokens)
-        return false;
-
-    if (!m_cacheDependencyData || m_cacheDependencyData->tokens() != *resolvedTokens) {
-        m_cacheDependencyData = CSSVariableData::create(*resolvedTokens, context());
-        cacheFunction(m_cacheDependencyData);
-    }
-    return true;
-}
 
 } // namespace WebCore
 

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -57,6 +57,7 @@
 #include "StyleCustomPropertyRegistry.h"
 #include "StyleFontSizeFunctions.h"
 #include "StylePropertyShorthand.h"
+#include "StyleSubstitutionResolver.h"
 #include <wtf/SetForScope.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -345,7 +346,7 @@ void Builder::applyProperty(CSSPropertyID id, CSSValue& value, SelectorChecker::
     ASSERT_WITH_MESSAGE(id != CSSPropertyCustom, "Custom property should be handled by applyCustomProperty");
 
     auto valueToApply = resolveInternalAutoBaseFunction(value);
-    valueToApply = resolveVariableReferences(id, valueToApply);
+    valueToApply = resolveSubstitutionFunctions(id, valueToApply);
     auto& style = m_state->style();
 
     if (CSSProperty::isDirectionAwareProperty(id)) {
@@ -603,17 +604,17 @@ Ref<CSSValue> Builder::resolveInternalAutoBaseFunction(CSSValue& value)
     return result.releaseNonNull();
 }
 
-Ref<CSSValue> Builder::resolveVariableReferences(CSSPropertyID propertyID, CSSValue& value)
+Ref<CSSValue> Builder::resolveSubstitutionFunctions(CSSPropertyID propertyID, CSSValue& value)
 {
     if (!value.hasVariableReferences())
         return value;
 
+    SubstitutionResolver substitutionResolver(*this);
+
     auto variableValue = [&]() -> RefPtr<CSSValue> {
         if (auto* substitution = dynamicDowncast<CSSPendingSubstitutionValue>(value))
-            return substitution->resolveValue(*this, propertyID);
-
-        auto& variableReferenceValue = downcast<CSSVariableReferenceValue>(value);
-        return variableReferenceValue.resolveSingleValue(*this, propertyID);
+            return substitutionResolver.substituteAndParseShorthand(*substitution, propertyID);
+        return substitutionResolver.substituteAndParse(downcast<CSSVariableReferenceValue>(value), propertyID);
     }();
 
     // https://drafts.csswg.org/css-variables-2/#invalid-variables
@@ -705,7 +706,8 @@ std::optional<Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>> Builder
 
     auto resolvedData = switchOn(value.value(),
         [&](const Ref<CSSVariableReferenceValue>& variableReferenceValue) -> RefPtr<CSSVariableData> {
-            return variableReferenceValue->resolveVariableReferences(*this);
+            SubstitutionResolver substitutionResolver(*this);
+            return substitutionResolver.substitute(variableReferenceValue.get());
         },
         [&](const Ref<CSSVariableData>& data) -> RefPtr<CSSVariableData> {
             return data.ptr();

--- a/Source/WebCore/style/StyleBuilder.h
+++ b/Source/WebCore/style/StyleBuilder.h
@@ -76,7 +76,7 @@ private:
     void applyCustomProperty(const AtomString& name, Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>&&);
 
     Ref<CSSValue> resolveInternalAutoBaseFunction(CSSValue&);
-    Ref<CSSValue> resolveVariableReferences(CSSPropertyID, CSSValue&);
+    Ref<CSSValue> resolveSubstitutionFunctions(CSSPropertyID, CSSValue&);
     std::optional<Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>> resolveCustomPropertyValue(CSSCustomPropertyValue&);
 
     void applyPageSizeDescriptor(CSSValue&);

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -1,0 +1,266 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleSubstitutionResolver.h"
+
+#include "CSSCustomPropertyValue.h"
+#include "CSSPendingSubstitutionValue.h"
+#include "CSSPropertyNames.h"
+#include "CSSPropertyParser.h"
+#include "CSSRegisteredCustomProperty.h"
+#include "CSSValueKeywords.h"
+#include "CSSVariableData.h"
+#include "CSSVariableReferenceValue.h"
+#include "ConstantPropertyMap.h"
+#include "CustomFunctionRegistry.h"
+#include "Document.h"
+#include "RenderStyle+GettersInlines.h"
+#include "StyleBuilder.h"
+#include "StyleCustomProperty.h"
+#include "StyleCustomPropertyRegistry.h"
+#include "StyleResolver.h"
+#include "StyleScope.h"
+
+namespace WebCore {
+namespace Style {
+
+SubstitutionResolver::SubstitutionResolver(Builder& builder)
+    : m_styleBuilder(builder)
+{
+}
+
+auto SubstitutionResolver::substituteVariableFallback(const AtomString& variableName, CSSParserTokenRange range, CSSValueID functionId, const CSSParserContext& context) const -> std::pair<FallbackResult, Vector<CSSParserToken>> {
+    ASSERT(range.atEnd() || range.peek().type() == CommaToken);
+
+    if (range.atEnd())
+        return { FallbackResult::None, { } };
+
+    range.consumeIncludingWhitespace();
+
+    auto tokens = substituteTokenRange(range, context);
+
+    if (functionId == CSSValueVar) {
+        auto* registered = m_styleBuilder.state().document().customPropertyRegistry().get(variableName);
+        if (registered && !registered->syntax.isUniversal()) {
+            // https://drafts.css-houdini.org/css-properties-values-api/#fallbacks-in-var-references
+            // The fallback value must match the syntax definition of the custom property being referenced,
+            // otherwise the declaration is invalid at computed-value time
+            if (!tokens || !CSSPropertyParser::isValidCustomPropertyValueForSyntax(registered->syntax, *tokens, context))
+                return { FallbackResult::Invalid, { } };
+
+            return { FallbackResult::Valid, WTF::move(*tokens) };
+        }
+    }
+
+    if (!tokens)
+        return { FallbackResult::None, { } };
+
+    return { FallbackResult::Valid, WTF::move(*tokens) };
+}
+
+RefPtr<const CustomProperty> SubstitutionResolver::propertyValueForVariableName(const AtomString& variableName, CSSValueID functionId) const
+{
+    if (functionId == CSSValueEnv)
+        return m_styleBuilder.state().document().constantProperties().values().get(variableName);
+
+    // Apply this variable first, in case it is still unresolved
+    m_styleBuilder.applyCustomProperty(variableName);
+
+    return protect(m_styleBuilder.state().style())->customPropertyValue(variableName);
+}
+
+bool SubstitutionResolver::substituteVariableFunction(CSSParserTokenRange range, CSSValueID functionId, Vector<CSSParserToken>& tokens, const CSSParserContext& context) const
+{
+    // The maximum number of tokens that may be produced by a substitution function reference or fallback value.
+    // https://drafts.csswg.org/css-variables/#long-variables
+    static constexpr size_t maxSubstitutionTokens = 65536;
+
+    ASSERT(functionId == CSSValueVar || functionId == CSSValueEnv);
+
+    range.consumeWhitespace();
+    ASSERT(range.peek().type() == IdentToken);
+    auto variableName = range.consumeIncludingWhitespace().value().toAtomString();
+
+    // Fallback has to be resolved even when not used to detect cycles and invalid syntax.
+    auto [fallbackResult, fallbackTokens] = substituteVariableFallback(variableName, range, functionId, context);
+    if (fallbackResult == FallbackResult::Invalid)
+        return false;
+
+    RefPtr property = propertyValueForVariableName(variableName, functionId);
+
+    if (!property || property->isGuaranteedInvalid()) {
+        if (fallbackTokens.size() > maxSubstitutionTokens)
+            return false;
+
+        if (fallbackResult == FallbackResult::Valid) {
+            tokens.appendVector(fallbackTokens);
+            return true;
+        }
+        return false;
+    }
+
+    if (property->tokens().size() > maxSubstitutionTokens)
+        return false;
+
+    tokens.appendVector(property->tokens());
+    return true;
+}
+
+bool SubstitutionResolver::substituteDashedFunction(StringView functionName, CSSParserTokenRange, Vector<CSSParserToken>& tokens) const
+{
+    // https://drafts.csswg.org/css-mixins/#evaluating-custom-functions
+
+    if (!m_styleBuilder.state().element())
+        return false;
+
+    auto scopedFunctionName = ScopedName { functionName.toAtomString(), m_styleBuilder.state().styleScopeOrdinal() };
+
+    CheckedPtr element = m_styleBuilder.state().element();
+    auto customFunction = Scope::resolveTreeScopedReference(*element, scopedFunctionName, [](const Scope& scope, const AtomString& name) -> CheckedPtr<const CustomFunction> {
+        RefPtr resolver = scope.resolverIfExists();
+        CheckedPtr registry = resolver ? resolver->customFunctionRegistry() : nullptr;
+        return registry ? registry->functionForName(name) : nullptr;
+    });
+
+    if (!customFunction)
+        return false;
+
+    // FIXME: Evaluate the function instead of just substituting.
+
+    auto properties = customFunction->properties;
+    auto resultValue = dynamicDowncast<CSSCustomPropertyValue>(properties->getPropertyCSSValue(CSSPropertyResult));
+    if (!resultValue)
+        return false;
+
+    auto data = resultValue->asVariableData();
+    tokens.appendVector(data->tokens());
+    return true;
+}
+
+std::optional<Vector<CSSParserToken>> SubstitutionResolver::substituteTokenRange(CSSParserTokenRange range, const CSSParserContext& context) const
+{
+    Vector<CSSParserToken> tokens;
+    bool success = true;
+    while (!range.atEnd()) {
+        auto token = range.peek();
+        if (token.type() == FunctionToken) {
+            auto functionId = token.functionId();
+            if (functionId == CSSValueVar || functionId == CSSValueEnv) {
+                if (!substituteVariableFunction(range.consumeBlock(), functionId, tokens, context))
+                    success = false;
+                continue;
+            }
+            if (functionId == CSSValueAttr) {
+                // attr()
+                // FIXME: Implement.
+            }
+            if (isCustomPropertyName(token.value())) {
+                // <dashed-function>
+                if (!substituteDashedFunction(token.value(), range.consumeBlock(), tokens))
+                    success = false;
+                continue;
+            }
+        }
+        tokens.append(range.consume());
+    }
+    if (!success)
+        return { };
+
+    return tokens;
+}
+
+RefPtr<CSSVariableData> SubstitutionResolver::trySimpleSubstitution(const CSSVariableReferenceValue& value) const
+{
+    if (!value.m_simpleReference)
+        return nullptr;
+
+    // Shortcut for the simple common case of property:var(--foo)
+
+    RefPtr property = propertyValueForVariableName(value.m_simpleReference->name, value.m_simpleReference->functionId);
+    if (!property || !std::holds_alternative<Ref<CSSVariableData>>(property->value()))
+        return nullptr;
+
+    return std::get<Ref<CSSVariableData>>(property->value()).ptr();
+}
+
+RefPtr<CSSVariableData> SubstitutionResolver::substitute(const CSSVariableReferenceValue& value) const
+{
+    if (auto data = trySimpleSubstitution(value))
+        return data;
+
+    auto& context = value.context();
+    auto substitutedTokens = substituteTokenRange(value.m_data->tokenRange(), context);
+    if (!substitutedTokens)
+        return nullptr;
+
+    return CSSVariableData::create(*substitutedTokens, context);
+}
+
+RefPtr<CSSValue> SubstitutionResolver::substituteAndParse(const CSSVariableReferenceValue& variableRef, CSSPropertyID propertyID) const
+{
+    auto data = substitute(variableRef);
+    if (!data)
+        return nullptr;
+
+    if (!arePointingToEqualData(variableRef.m_cache.dependencyData, data)) {
+        variableRef.m_cache.value = CSSPropertyParser::parseStylePropertyLonghand(propertyID, data->tokens(), variableRef.context());
+#if ASSERT_ENABLED
+        variableRef.m_cache.propertyID = propertyID;
+#endif
+    }
+    variableRef.m_cache.dependencyData = WTF::move(data);
+
+    ASSERT(variableRef.m_cache.propertyID == propertyID);
+    return variableRef.m_cache.value;
+}
+
+RefPtr<CSSValue> SubstitutionResolver::substituteAndParseShorthand(const CSSPendingSubstitutionValue& substitution, CSSPropertyID propertyID) const
+{
+    auto& variableRef = substitution.shorthandValue();
+
+    auto data = substitute(variableRef);
+    if (!data)
+        return nullptr;
+
+    if (!arePointingToEqualData(variableRef.m_cache.dependencyData, data)) {
+        ParsedPropertyVector parsedProperties;
+        if (!CSSPropertyParser::parseValue(substitution.m_shorthandPropertyId, IsImportant::No, data->tokens(), data->context(), parsedProperties, StyleRuleType::Style))
+            substitution.m_cachedPropertyValues = { };
+        else
+            substitution.m_cachedPropertyValues = parsedProperties;
+    }
+    variableRef.m_cache.dependencyData = WTF::move(data);
+
+    for (auto& property : substitution.m_cachedPropertyValues) {
+        if (property.id() == propertyID)
+            return property.value();
+    }
+
+    return nullptr;
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/StyleSubstitutionResolver.h
+++ b/Source/WebCore/style/StyleSubstitutionResolver.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSParserTokenRange.h"
+
+namespace WebCore {
+
+class CSSPendingSubstitutionValue;
+class CSSValue;
+class CSSVariableData;
+class CSSVariableReferenceValue;
+struct CSSParserContext;
+enum CSSPropertyID : uint16_t;
+enum CSSValueID : uint16_t;
+
+namespace Style {
+
+class Builder;
+class CustomProperty;
+
+// https://drafts.csswg.org/css-values-5/#arbitrary-substitution
+class SubstitutionResolver {
+public:
+    explicit SubstitutionResolver(Builder&);
+
+    RefPtr<CSSValue> substituteAndParse(const CSSVariableReferenceValue&, CSSPropertyID) const;
+    RefPtr<CSSValue> substituteAndParseShorthand(const CSSPendingSubstitutionValue&, CSSPropertyID) const;
+    RefPtr<CSSVariableData> substitute(const CSSVariableReferenceValue&) const;
+
+private:
+    std::optional<Vector<CSSParserToken>> substituteTokenRange(CSSParserTokenRange, const CSSParserContext&) const;
+    bool substituteVariableFunction(CSSParserTokenRange, CSSValueID, Vector<CSSParserToken>&, const CSSParserContext&) const;
+    bool substituteDashedFunction(StringView functionName, CSSParserTokenRange, Vector<CSSParserToken>&) const;
+
+    enum class FallbackResult : uint8_t { None, Valid, Invalid };
+    std::pair<FallbackResult, Vector<CSSParserToken>> substituteVariableFallback(const AtomString& variableName, CSSParserTokenRange, CSSValueID functionId, const CSSParserContext&) const;
+
+    RefPtr<const CustomProperty> propertyValueForVariableName(const AtomString&, CSSValueID) const;
+    RefPtr<CSSVariableData> trySimpleSubstitution(const CSSVariableReferenceValue&) const;
+
+    Builder& m_styleBuilder;
+};
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -46,6 +46,7 @@
 #include "HTMLProgressElement.h"
 #include "HTMLSelectElement.h"
 #include "HTMLSlotElement.h"
+#include "KeyframeEffectStack.h"
 #include "LoaderStrategy.h"
 #include "LocalFrame.h"
 #include "MatchResultCache.h"

--- a/Source/WebCore/style/values/filter-effects/StyleAppleColorFilter.h
+++ b/Source/WebCore/style/values/filter-effects/StyleAppleColorFilter.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <WebCore/Color.h>
 #include <WebCore/StyleAppleInvertLightnessFunction.h>
 #include <WebCore/StyleBrightnessFunction.h>
 #include <WebCore/StyleContrastFunction.h>


### PR DESCRIPTION
#### f2d4edab4efffff8b312388c7f52dc86279f260f
<pre>
[css-values-5 attr()] Factor arbitrary substitution function resolution to a type
<a href="https://bugs.webkit.org/show_bug.cgi?id=310292">https://bugs.webkit.org/show_bug.cgi?id=310292</a>
<a href="https://rdar.apple.com/172928726">rdar://172928726</a>

Reviewed by Alan Baradlay.

Add new SubstitutionResolver and match the terminology of

<a href="https://drafts.csswg.org/css-values-5/#arbitrary-substitution">https://drafts.csswg.org/css-values-5/#arbitrary-substitution</a>

better.

Factor the substitution functions out of CSSVariableReferenceValue/CSSPendingSubstitutionValue.
The cache fields remain in these types.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSPendingSubstitutionValue.cpp:
(WebCore::CSSPendingSubstitutionValue::create):
(WebCore::CSSPendingSubstitutionValue::CSSPendingSubstitutionValue):
(WebCore::CSSPendingSubstitutionValue::resolveValue const): Deleted.
* Source/WebCore/css/CSSPendingSubstitutionValue.h:
* Source/WebCore/css/CSSVariableReferenceValue.cpp:
(WebCore::CSSVariableReferenceValue::resolveVariableFallback const): Deleted.
(WebCore::propertyValueForVariableName): Deleted.
(WebCore::CSSVariableReferenceValue::resolveVariableReference const): Deleted.
(WebCore::CSSVariableReferenceValue::evaluateDashedFunction const): Deleted.
(WebCore::CSSVariableReferenceValue::resolveTokenRange const): Deleted.
(WebCore::CSSVariableReferenceValue::tryResolveSimpleReference const): Deleted.
(WebCore::CSSVariableReferenceValue::resolveVariableReferences const): Deleted.
(WebCore::CSSVariableReferenceValue::resolveSingleValue const): Deleted.
* Source/WebCore/css/CSSVariableReferenceValue.h:
(WebCore::CSSVariableReferenceValue::resolveAndCacheValue const): Deleted.
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::applyProperty):
(WebCore::Style::Builder::resolveSubstitutionFunctions):
(WebCore::Style::Builder::resolveCustomPropertyValue):
(WebCore::Style::Builder::resolveVariableReferences): Deleted.
* Source/WebCore/style/StyleBuilder.h:
* Source/WebCore/style/StyleSubstitutionResolver.cpp: Added.
(WebCore::Style::SubstitutionResolver::SubstitutionResolver):
(WebCore::Style::SubstitutionResolver::substituteVariableFallback const):
(WebCore::Style::SubstitutionResolver::propertyValueForVariableName const):
(WebCore::Style::SubstitutionResolver::substituteVariableFunction const):
(WebCore::Style::SubstitutionResolver::substituteDashedFunction const):
(WebCore::Style::SubstitutionResolver::substituteTokenRange const):
(WebCore::Style::SubstitutionResolver::trySimpleSubstitution const):
(WebCore::Style::SubstitutionResolver::substitute const):
(WebCore::Style::SubstitutionResolver::substituteAndParse const):
(WebCore::Style::SubstitutionResolver::substituteAndParseShorthand const):
* Source/WebCore/style/StyleSubstitutionResolver.h: Added.
* Source/WebCore/style/StyleTreeResolver.cpp:
* Source/WebCore/style/values/filter-effects/StyleAppleColorFilter.h:

Canonical link: <a href="https://commits.webkit.org/309612@main">https://commits.webkit.org/309612@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7964efaf53c44594c6d7c30c2d087722d28c978a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151202 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23965 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17535 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159931 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104638 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/520f4f2c-013e-42f8-9cc5-2638c44ff2ee) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153075 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24396 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24208 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116737 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82870 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154162 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/18865 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135668 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97458 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17958 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15904 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7776 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127576 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13585 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162403 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5528 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15156 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124746 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23766 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19954 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124934 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33889 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23756 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135382 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80216 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20000 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12147 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23366 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87660 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23078 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23230 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23132 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->