### PR TITLE
[css-anchor-position-1] Chain of three or more anchor-positioned elements doesn't work

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-function-chain-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-function-chain-expected.txt
@@ -1,0 +1,10 @@
+You should see a row of five boxes in order.
+
+12345
+
+PASS .target 1
+PASS .target 2
+PASS .target 3
+PASS .target 4
+PASS .target 5
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-function-chain.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-function-chain.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+
+<title>Tests that chain of elements that anchor to each other using anchor() works.</title>
+
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#anchor-pos">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#determining">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<script src="support/test-common.js"></script>
+
+<style>
+  .containing-block {
+    border: 1px solid black;
+
+    position: relative;
+    width: 500px;
+    height: 200px;
+  }
+
+  .box {
+    position: absolute;
+    left: calc(anchor(--box right) + 10px);
+    anchor-name: --box;
+
+    width: 50px;
+    height: 50px;
+    background-color: green;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: white;
+  }
+</style>
+
+<body onload="checkLayoutForAnchorPos('.target')">
+  <p>You should see a row of five boxes in order.</p>
+
+  <div class="containing-block">
+    <div class="box target" data-offset-x="0" data-offset-y="0">1</div>
+    <div class="box target" data-offset-x="60" data-offset-y="0">2</div>
+    <div class="box target" data-offset-x="120" data-offset-y="0">3</div>
+    <div class="box target" data-offset-x="180" data-offset-y="0">4</div>
+    <div class="box target" data-offset-x="240" data-offset-y="0">5</div>
+  </div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-function-chain-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-function-chain-expected.txt
@@ -1,0 +1,10 @@
+You should see a row of five rectangles growing in size in order.
+
+12345
+
+PASS .target 1
+PASS .target 2
+PASS .target 3
+PASS .target 4
+PASS .target 5
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-function-chain.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-function-chain.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+
+<title>Tests that chain of elements that anchor to each other using anchor-size() works.</title>
+
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#anchor-size-fn">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#determining">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<script src="support/test-common.js"></script>
+
+<style>
+  .containing-block {
+    border: 1px solid black;
+
+    position: relative;
+    width: 500px;
+    height: 200px;
+  }
+
+  .box {
+    /* Can only use anchor-size() with position: absolute */
+    position: absolute;
+    background-color: green;
+    anchor-name: --box;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: white;
+  }
+
+  #box1 {
+    width: 50px;
+    height: 60px;
+  }
+
+  #box2, #box3, #box4, #box5 {
+    width: calc(anchor-size(--box width) + 10px);
+    height: calc(anchor-size(--box height) + 20px);
+  }
+
+  #box2 { left: 60px; }
+  #box3 { left: 130px; }
+  #box4 { left: 210px; }
+  #box5 { left: 300px; }
+</style>
+
+<body onload="checkLayoutForAnchorPos('.target')">
+  <p>You should see a row of five rectangles growing in size in order.</p>
+
+  <div class="containing-block">
+    <!--
+      The increasing size is to check that the boxes are anchoring to each other
+      in the correct order i.e box2 chains to box1, box3 chains to box2, ...
+    -->
+    <div class="box target" id="box1" data-expected-width="50" data-expected-height="60">1</div>
+    <div class="box target" id="box2" data-expected-width="60" data-expected-height="80">2</div>
+    <div class="box target" id="box3" data-expected-width="70" data-expected-height="100">3</div>
+    <div class="box target" id="box4" data-expected-width="80" data-expected-height="120">4</div>
+    <div class="box target" id="box5" data-expected-width="90" data-expected-height="140">5</div>
+  </div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-chain-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-chain-expected.txt
@@ -1,0 +1,10 @@
+You should see a row of five boxes in order.
+
+12345
+
+PASS .target 1
+PASS .target 2
+PASS .target 3
+PASS .target 4
+PASS .target 5
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-chain.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-chain.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+
+<title>Tests that chain of elements that anchor to each other using position-area works.</title>
+
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#position-area">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#determining">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<script src="support/test-common.js"></script>
+
+<style>
+  .containing-block {
+    border: 1px solid black;
+
+    position: relative;
+    width: 500px;
+    height: 200px;
+  }
+
+  .box {
+    position: absolute;
+    anchor-name: --box;
+    position-area: center right;
+    position-anchor: --box;
+
+    width: 50px;
+    height: 50px;
+    border-right: 10px white solid;
+    background-color: green;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: white;
+  }
+</style>
+
+<body onload="checkLayoutForAnchorPos('.target')">
+  <p>You should see a row of five boxes in order.</p>
+
+  <div class="containing-block">
+    <div class="box target" data-offset-x="0" data-offset-y="0">1</div>
+    <div class="box target" data-offset-x="60" data-offset-y="0">2</div>
+    <div class="box target" data-offset-x="120" data-offset-y="0">3</div>
+    <div class="box target" data-offset-x="180" data-offset-y="0">4</div>
+    <div class="box target" data-offset-x="240" data-offset-y="0">5</div>
+  </div>
+</body>

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -812,8 +812,10 @@ CheckedPtr<RenderBoxModelObject> AnchorPositionEvaluator::findAnchorForAnchorFun
 
     if (auto* state = anchorPositionedStates.get(keyForElementOrPseudoElement(*anchorElement))) {
         // Check if the anchor is itself anchor-positioned but hasn't been positioned yet.
-        if (state->stage < AnchorPositionResolutionStage::Positioned)
+        if (state->stage < AnchorPositionResolutionStage::Positioned) {
+            anchorPositionedState.stage = AnchorPositionResolutionStage::WaitingForAnchorToBePositioned;
             return { };
+        }
     }
 
     anchorPositionedState.stage = AnchorPositionResolutionStage::Resolved;
@@ -1298,11 +1300,13 @@ void AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayou
                     .anchors = WTF::move(anchors)
                 });
             }
-            state.stage = renderer && renderer->style().usesAnchorFunctions() ? AnchorPositionResolutionStage::ResolveAnchorFunctions : AnchorPositionResolutionStage::Resolved;
+            state.stage = AnchorPositionResolutionStage::Resolved;
             break;
         }
 
-        case AnchorPositionResolutionStage::ResolveAnchorFunctions:
+        case AnchorPositionResolutionStage::WaitingForAnchorToBePositioned:
+            break;
+
         case AnchorPositionResolutionStage::Resolved:
             if (CheckedPtr anchored = elementAndState.key.first->renderer()) {
                 if (auto anchoredBox = dynamicDowncast<RenderBox>(anchored.get()))

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -115,9 +115,23 @@ class BuilderState;
 struct BuilderPositionTryFallback;
 
 enum class AnchorPositionResolutionStage : uint8_t {
+    // Initial state, we've found which anchors the element uses, but we haven't
+    // resolved anchor names to the concrete elements.
     FindAnchors,
-    ResolveAnchorFunctions,
+
+    // State when an anchor-positioned element has resolved its anchors,
+    // but its anchor(s) is/are also anchor-positioned. The element waits
+    // here until the its anchor(s) is/are Positioned, in which case it'll
+    // transition to Resolved.
+    WaitingForAnchorToBePositioned,
+
+    // The anchor-positioned element has resolved the anchors it refers to.
+    // If we determine any anchor(s) in itself is/are anchor-positioned,
+    // we kick it back to WaitingForAnchorToBePositioned.
     Resolved,
+
+    // The anchor-positioned element has been laid out and its position determined.
+    // This occurs after a Resolved element went through the layout process.
     Positioned,
 };
 


### PR DESCRIPTION
#### 28a802021ac6e7310ff8b96dbebb14a0c9b7f624
<pre>
[css-anchor-position-1] Chain of three or more anchor-positioned elements doesn&apos;t work
<a href="https://rdar.apple.com/164468098">rdar://164468098</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=301919">https://bugs.webkit.org/show_bug.cgi?id=301919</a>

Reviewed by Antti Koivisto.

As it turns out, AnchorPositionResolutionStage::ResolveAnchorFunctions accidentally makes
chains of two anchor elements work by giving anchor-positioned elements using anchor
functions one extra style resolution:

Imagine three elements E, A1, A2. A1 anchor-positioned to E and A2 anchor-positioned to A1,
both using anchor functions.

After SR1 (first style resolution), A1 and A2 are at FindAnchors stage. After L1 (first layout),
they move to ResolveAnchorFunctions.

On SR2, A1 moved to Resolved, while A2 is still at ResolveAnchorFunctions because
AnchorPositionEvaluator::findAnchorForAnchorFunctionAndAttemptResolution sees that A2 anchors
to A1, and A1 is not Positioned. Then A2 gets invalidated because its stage is &lt; Resolved.
The fact that ResolveAnchorFunctions &lt; Resolved gives A2 another style-layout round,
otherwise we&apos;d normally stop here.

Thanks to the extra style-layout round, after L2, A1 moves to Positioned. Then on SR3,
A2 moves to Resolved because A1 is now Positioned.

Now this only (accidentally) works with a chain of two anchor-positioned elements using anchor
functions. This patch fixes that so it&apos;d work with a chain of any number of anchor elements.

ResolveAnchorFunctions is renamed (or repurposed) to be WaitingForDependentAnchorToBePositioned.
Then, in AnchorPositionEvaluator::findAnchorForAnchorFunctionAndAttemptResolution, if the anchor is
anchor-positioned and not Positioned yet, we kick the anchor-positioned element to
WaitingForDependentAnchorToBePositioned. Once in this stage, the anchor-positioned element still gets
invalidated for style resolution to run until its dependent anchor(s) are Positioned, in which case
it&apos;s Resolved and eventually Positioned.

Tests: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-function-chain.html
       imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-function-chain.html
       imported/w3c/web-platform-tests/css/css-anchor-position/position-area-chain.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-function-chain-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-function-chain.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-function-chain-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-function-chain.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-chain-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-chain.html: Added.
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::findAnchorForAnchorFunctionAndAttemptResolution):
(WebCore::Style::AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayout):
* Source/WebCore/style/AnchorPositionEvaluator.h:

Canonical link: <a href="https://commits.webkit.org/309845@main">https://commits.webkit.org/309845@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63443d927394f04ce1f562b45fb8f73ef36110a6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151758 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24539 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18109 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160500 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105215 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/95831354-3cfd-4d6e-b641-f56f635bc1a8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153632 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25032 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24832 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117217 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83189 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154718 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19376 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136179 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97932 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5f0f7fcc-76d1-4804-9a5f-782136b7563d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18462 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16396 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8335 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128092 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14083 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162964 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6113 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15674 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125236 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24338 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20455 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125417 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34065 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24339 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135879 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80914 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20447 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12654 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23955 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88241 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23647 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23807 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23707 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->