### PR TITLE
Make PushPullRequestBranch non-fatal (warn on failure)

### DIFF
--- a/Tools/CISupport/ews-build/factories.py
+++ b/Tools/CISupport/ews-build/factories.py
@@ -418,7 +418,6 @@ class MergeQueueFactory(MergeQueueFactoryBase):
         self.addStep(ValidateChange(verifyMergeQueue=True, verifyNoDraftForMergeQueue=True, enableSkipEWSLabel=False))
         self.addStep(Canonicalize())
         self.addStep(PushPullRequestBranch())
-        self.addStep(UpdatePullRequest())
         self.addStep(PushCommitToWebKitRepo())
         self.addStep(SetBuildSummary())
 
@@ -430,7 +429,6 @@ class UnsafeMergeQueueFactory(MergeQueueFactoryBase):
         self.addStep(Canonicalize())
         self.addStep(ValidateChange(verifyMergeQueue=True, verifyNoDraftForMergeQueue=True, enableSkipEWSLabel=False))
         self.addStep(PushPullRequestBranch())
-        self.addStep(UpdatePullRequest())
         self.addStep(PushCommitToWebKitRepo())
         self.addStep(SetBuildSummary())
 

--- a/Tools/CISupport/ews-build/factories_unittest.py
+++ b/Tools/CISupport/ews-build/factories_unittest.py
@@ -904,7 +904,6 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'validate-change',
             'canonicalize-commit',
             'push-pull-request-branch',
-            'update-pull-request',
             'push-commit-to-webkit-repo',
             'set-build-summary'
         ],
@@ -930,7 +929,6 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'canonicalize-commit',
             'validate-change',
             'push-pull-request-branch',
-            'update-pull-request',
             'push-commit-to-webkit-repo',
             'set-build-summary'
         ],

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -6835,7 +6835,6 @@ class PushCommitToWebKitRepo(shell.ShellCommand):
                         Canonicalize(),
                         ValidateChange(verifyMergeQueue=True, verifyNoDraftForMergeQueue=True, verifyObsolete=False, enableSkipEWSLabel=False),
                         PushPullRequestBranch(),
-                        UpdatePullRequest(),
                         PushCommitToWebKitRepo(),
                     ])
                 else:
@@ -7512,11 +7511,12 @@ class Canonicalize(steps.ShellSequence, ShellMixin, AddToLogMixin):
 
 class PushPullRequestBranch(shell.ShellCommand):
     name = 'push-pull-request-branch'
-    haltOnFailure = True
+    warnOnFailure = True
 
     def __init__(self, **kwargs):
         super().__init__(logEnviron=False, timeout=300, **kwargs)
 
+    @defer.inlineCallbacks
     def run(self, BufferLogObserverClass=logobserver.BufferLogObserver):
         remote, repo_name = self.getProperty('github.head.repo.full_name', DEFAULT_REMOTE).split('/', 1)
         if '-' in repo_name:
@@ -7528,13 +7528,17 @@ class PushPullRequestBranch(shell.ShellCommand):
         self.env['GIT_USER'] = username
         self.env['GIT_PASSWORD'] = access_token
 
-        return super().run()
+        rc = yield super().run()
+        if rc == SUCCESS:
+            self.build.addStepsAfterCurrentStep([UpdatePullRequest()])
+        elif rc == FAILURE:
+            rc = WARNINGS
+        defer.returnValue(rc)
 
     def getResultSummary(self):
         if self.results == SUCCESS:
             return {'step': 'Pushed to pull request branch'}
-        if self.results == FAILURE:
-            self.setProperty('build_summary', '')
+        if self.results == WARNINGS:
             return {'step': 'Failed to push to pull request branch'}
         return super().getResultSummary()
 

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -9199,6 +9199,8 @@ class TestPushPullRequestBranch(BuildStepMixinAdditions, unittest.TestCase):
         self.setProperty('github.number', '1234')
         self.setProperty('github.head.repo.full_name', 'Contributor/WebKit')
         self.setProperty('github.head.ref', 'eng/pull-request-branch')
+        next_steps = []
+        self.patch(self.build, 'addStepsAfterCurrentStep', lambda s: next_steps.extend(s))
         self.expectRemoteCommands(
             ExpectShell(workdir='wkdir',
                         log_environ=False,
@@ -9210,7 +9212,14 @@ class TestPushPullRequestBranch(BuildStepMixinAdditions, unittest.TestCase):
         )
         self.expect_outcome(result=SUCCESS, state_string='Pushed to pull request branch')
         with current_hostname(EWS_BUILD_HOSTNAMES[0]):
-            return self.run_step()
+            rc = self.run_step()
+
+        def check_injected_update_pull_request(result):
+            self.assertTrue(any(isinstance(step, UpdatePullRequest) for step in next_steps))
+            return result
+
+        rc.addCallback(check_injected_update_pull_request)
+        return rc
 
     def test_success_apple(self):
         GitHub.credentials = lambda user=None: ('webkit-commit-queue', 'password')
@@ -9219,6 +9228,8 @@ class TestPushPullRequestBranch(BuildStepMixinAdditions, unittest.TestCase):
         self.setProperty('github.head.repo.full_name', 'Contributor/WebKit-apple')
         self.setProperty('remote', 'apple')
         self.setProperty('github.head.ref', 'eng/pull-request-branch')
+        next_steps = []
+        self.patch(self.build, 'addStepsAfterCurrentStep', lambda s: next_steps.extend(s))
         self.expectRemoteCommands(
             ExpectShell(workdir='wkdir',
                         log_environ=False,
@@ -9230,7 +9241,14 @@ class TestPushPullRequestBranch(BuildStepMixinAdditions, unittest.TestCase):
         )
         self.expect_outcome(result=SUCCESS, state_string='Pushed to pull request branch')
         with current_hostname(EWS_BUILD_HOSTNAMES[0]):
-            return self.run_step()
+            rc = self.run_step()
+
+        def check_injected_update_pull_request(result):
+            self.assertTrue(any(isinstance(step, UpdatePullRequest) for step in next_steps))
+            return result
+
+        rc.addCallback(check_injected_update_pull_request)
+        return rc
 
     def test_success_integration(self):
         GitHub.credentials = lambda user=None: ('webkit-commit-queue', 'password')
@@ -9239,6 +9257,8 @@ class TestPushPullRequestBranch(BuildStepMixinAdditions, unittest.TestCase):
         self.setProperty('github.head.repo.full_name', 'WebKit/WebKit-integration')
         self.setProperty('remote', 'origin')
         self.setProperty('github.head.ref', 'integration/ci/1234')
+        next_steps = []
+        self.patch(self.build, 'addStepsAfterCurrentStep', lambda s: next_steps.extend(s))
         self.expectRemoteCommands(
             ExpectShell(workdir='wkdir',
                         log_environ=False,
@@ -9250,15 +9270,25 @@ class TestPushPullRequestBranch(BuildStepMixinAdditions, unittest.TestCase):
         )
         self.expect_outcome(result=SUCCESS, state_string='Pushed to pull request branch')
         with current_hostname(EWS_BUILD_HOSTNAMES[0]):
-            return self.run_step()
+            rc = self.run_step()
+
+        def check_injected_update_pull_request(result):
+            self.assertTrue(any(isinstance(step, UpdatePullRequest) for step in next_steps))
+            return result
+
+        rc.addCallback(check_injected_update_pull_request)
+        return rc
 
     def test_failure(self):
         GitHub.credentials = lambda user=None: ('webkit-commit-queue', 'password')
         self.setup_step(PushPullRequestBranch())
+        self.assertEqual(PushPullRequestBranch.haltOnFailure, False)
         self.setProperty('github.number', '1234')
         self.setProperty('github.head.repo.full_name', 'Contributor/WebKit')
         self.setProperty('github.head.ref', 'eng/pull-request-branch')
         self.setProperty('build_summary', 'Test summary.')
+        next_steps = []
+        self.patch(self.build, 'addStepsAfterCurrentStep', lambda s: next_steps.extend(s))
         self.expectRemoteCommands(
             ExpectShell(workdir='wkdir',
                         log_environ=False,
@@ -9268,10 +9298,16 @@ class TestPushPullRequestBranch(BuildStepMixinAdditions, unittest.TestCase):
             .exit(1)
             .log('stdio', stdout="fatal: could not read Username for 'https://github.com': Device not configured\n"),
         )
-        self.expect_outcome(result=FAILURE, state_string='Failed to push to pull request branch')
+        self.expect_outcome(result=WARNINGS, state_string='Failed to push to pull request branch')
         with current_hostname(EWS_BUILD_HOSTNAMES[0]):
-            return self.run_step()
-        self.expect_property('build_summary', '')
+            rc = self.run_step()
+
+        def check_no_update_pull_request(result):
+            self.assertFalse(any(isinstance(step, UpdatePullRequest) for step in next_steps))
+            return result
+
+        rc.addCallback(check_no_update_pull_request)
+        return rc
 
 
 class TestUpdatePullRequest(BuildStepMixinAdditions, unittest.TestCase):


### PR DESCRIPTION
#### 0bf571c83c94
<pre>
Make PushPullRequestBranch non-fatal (warn on failure)
<a href="https://bugs.webkit.org/show_bug.cgi?id=310291">https://bugs.webkit.org/show_bug.cgi?id=310291</a>
<a href="https://rdar.apple.com/172928720">rdar://172928720</a>

Reviewed by NOBODY (OOPS!).

Convert PushPullRequestBranch to use warnOnFailure=True so that push
failures produce a warning instead of halting the build. This allows
PushCommitToWebKitRepo to run even when pushing to the PR branch
fails.

Pushing to a pull request branch can fail for legitimate reasons when
the head repository is owned by an org, the PR creator hasn&apos;t granted
permission, or branch restrictions apply.

UpdatePullRequest is now injected dynamically on success via
addStepsAfterCurrentStep, and removed from all factories.

* Tools/CISupport/ews-build/steps.py:
* Tools/CISupport/ews-build/factories.py:
* Tools/CISupport/ews-build/steps_unittest.py:
* Tools/CISupport/ews-build/factories_unittest.py:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0bf571c83c942b8fc2326fcb53422fb1b3dae444

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151075 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23837 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17407 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159803 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104511 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3d6add21-20fb-4900-b549-2454a8938ead) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152948 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24268 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24061 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116636 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82795 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cbab7344-ab11-4041-8e81-ca314c487cfe) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154035 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18765 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135551 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97357 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17858 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15801 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7649 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127476 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13468 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162276 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15039 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124641 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/150475 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23639 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19851 "Found 1 new test failure: http/tests/webgpu/webgpu/api/validation/gpu_external_texture_expiration.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124829 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23629 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135265 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80073 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19899 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12030 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23239 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22951 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23103 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23005 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->