### PR TITLE
[Claude Code] Add wk-debug-log plugin for temporary WTFLogAlways instrumentation

### DIFF
--- a/.claude/plugins/.claude-plugin/marketplace.json
+++ b/.claude/plugins/.claude-plugin/marketplace.json
@@ -8,6 +8,11 @@
       "name": "git-webkit",
       "source": "./git-webkit",
       "description": "Teaches Claude to use git-webkit tools for working with the WebKit repository"
+    },
+    {
+      "name": "wk-debug-log",
+      "source": "./wk-debug-log",
+      "description": "Add or remove WTFLogAlways debug logging in WebKit repository"
     }
   ]
 }

--- a/.claude/plugins/wk-debug-log/.claude-plugin/plugin.json
+++ b/.claude/plugins/wk-debug-log/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "wk-debug-log",
+  "description": "Add or remove WTFLogAlways debug logging in WebKit repository",
+  "version": "1.0.0"
+}

--- a/.claude/plugins/wk-debug-log/skills/wk-debug-log-add/SKILL.md
+++ b/.claude/plugins/wk-debug-log/skills/wk-debug-log-add/SKILL.md
@@ -1,0 +1,115 @@
+---
+description: Add WTFLogAlways debug logging to WebKit source files
+argument-hint: <description of what to trace>
+allowed-tools: Bash(git diff:*), Bash(git log:*)
+---
+
+# WebKit Debug Log — Add
+
+Add temporary `WTFLogAlways` debug logging to trace the execution flow described by the user.
+
+User argument: $ARGUMENTS
+
+---
+
+## Use WTFLogAlways only
+
+- Use `WTFLogAlways("::DEBUG:: ...")` for all debug output.
+- **DO NOT** use `RELEASE_LOG`, `LOG`, `printf`, `fprintf`, `NSLog`, or any other logging mechanism. These depend on channel settings or build configuration and may not produce output.
+- `WTFLogAlways` works in all processes: UIProcess, WebProcess, NetworkProcess, and GPUProcess.
+
+## Prefix every message with `::DEBUG::`
+
+This allows easy grep-based search and bulk removal:
+```cpp
+WTFLogAlways("::DEBUG:: functionName: description key=%s", value);
+```
+
+## Include function name in every message
+
+```cpp
+WTFLogAlways("::DEBUG:: loadDifferentDocumentItem: POST formData found url=%s", url.string().utf8().data());
+```
+
+## Output values that identify which code path was taken
+
+- bool results: `"canContinue=%d", canContinue`
+- enum values: `"state=%d", static_cast<int>(state)`
+- pointer null/non-null: `"item=%p", item.get()`
+- URL: `"url=%s", url.string().utf8().data()`
+- isMainFrame: `"isMainFrame=%d", frame->isMainFrame()`
+
+## ObjectIdentifier output
+
+```cpp
+// Simple identifiers (FrameIdentifier, PageIdentifier, ProcessIdentifier, etc.)
+WTFLogAlways("::DEBUG:: frameID=%" PRIu64, frameID.toUInt64());
+// or
+WTFLogAlways("::DEBUG:: frameID=%s", frameID.loggingString().utf8().data());
+
+// Compound identifiers (BackForwardItemIdentifier, etc.)
+WTFLogAlways("::DEBUG:: itemID=%s", itemID.toString().utf8().data());
+```
+
+## Handling std::optional and nullable types
+
+Many WebKit getters return `std::optional<T>` or pointer types. **Always check before dereferencing.**
+
+```cpp
+// std::optional<FrameIdentifier> — use -> or * after checking
+WTFLogAlways("::DEBUG:: frameID=%s", frameID ? frameID->loggingString().utf8().data() : "none");
+
+// Pointer types — guard with ternary
+WTFLogAlways("::DEBUG:: url=%s", item ? item->url().string().utf8().data() : "<null>");
+```
+
+**IMPORTANT**: Before formatting any value for logging, check the actual return type of the getter. If it returns `std::optional<T>`, use `->` after a truthiness check. Do NOT call `.member()` directly on an `std::optional`.
+
+## Place logs at every branch of a conditional
+
+```cpp
+if (condition) {
+    WTFLogAlways("::DEBUG:: functionName: condition=true ...");
+    // ...
+} else {
+    WTFLogAlways("::DEBUG:: functionName: condition=false ...");
+    // ...
+}
+```
+
+## Log before AND after calls with side effects
+
+```cpp
+WTFLogAlways("::DEBUG:: before stopAllLoaders");
+stopAllLoaders(ClearProvisionalItem::No);
+WTFLogAlways("::DEBUG:: after stopAllLoaders");
+```
+
+## Log at IPC boundaries
+
+Add logs on both the sending side and receiving side of IPC messages.
+
+## Sensitive data
+
+Do not log values that may contain user credentials, authentication tokens, cookie contents, passwords, or user-entered form data. When logging URLs, be aware they may contain sensitive query parameters. Prefer logging the *existence* or *type* of data rather than its full contents when security-sensitive data may be involved.
+
+## NEVER add debug logs to header files
+
+- **Only add `WTFLogAlways` calls to `.cpp` or `.mm` implementation files** in `Source/` and `Tools/`.
+- **NEVER add debug logs to `.h` header files.** Header files are included by many translation units — modifying a header triggers recompilation of every file that includes it (directly or transitively), dramatically increasing build time.
+- If the code you want to trace is in a header (e.g., an inline function or template), find the call site in a `.cpp` file and log there instead.
+
+## Scope control
+
+- Start narrow — prefer instrumenting a single function or file first, then expand if needed.
+- If the trace request would result in more than ~15 log insertions, confirm with the user before proceeding. Show the list of functions/files you plan to instrument and let the user decide the scope.
+
+## Code safety rules
+
+- **Prefer inserting new lines** — add `WTFLogAlways(...)` lines between existing lines whenever possible.
+- **Modifying existing lines is allowed when necessary** — e.g., converting a single-statement `if` to a block `{ ... }` to insert a log inside the branch is acceptable.
+- **NEVER delete or alter control flow logic** — do not change conditions, remove `return` statements, or restructure code. Only add braces to accommodate log insertion.
+- **NEVER introduce new variables** — use only expressions already in scope.
+- **Keep `old_string` in Edit minimal** — match only 2-3 lines of context to avoid accidentally deleting code.
+- **Verify braces and function boundaries** — ensure closing `}` is not merged with the next function declaration. Always check that a blank line separates the end of one function from the start of the next.
+- **NEVER commit changes** — debug logging is temporary instrumentation. Do not run `git commit` or suggest committing the changes. The user will commit when ready.

--- a/.claude/plugins/wk-debug-log/skills/wk-debug-log-remove/SKILL.md
+++ b/.claude/plugins/wk-debug-log/skills/wk-debug-log-remove/SKILL.md
@@ -1,0 +1,49 @@
+---
+description: Remove all ::DEBUG:: WTFLogAlways debug logging from WebKit source files
+argument-hint: <description of target scope>
+allowed-tools: Bash(git diff:*), Bash(git log:*)
+---
+
+# WebKit Debug Log — Remove
+
+Find and remove all lines containing `::DEBUG::` from the codebase.
+
+## Scope
+
+Hint: $ARGUMENTS
+
+If no hint is given, use `git diff` to identify files you have modified, and search those files for `::DEBUG::` lines. This focuses removal on your own changes rather than scanning the entire tree.
+
+If the user provided a hint, interpret it flexibly:
+- A project name like "WebCore" or "WebKit" → search `Source/WebCore/` or `Source/WebKit/`
+- A subdirectory path like "WebCore/loader" or "Tools/TestWebKitAPI" → search that path
+- A feature area like "navigation" or "back-forward" → find files containing `::DEBUG::` and filter to those whose path or content relates to the described area
+- A filename or glob pattern like "FrameLoader*" → search matching files only
+
+## Steps
+
+1. Search for all files containing `::DEBUG::` within the scope:
+   ```
+   Grep for "::DEBUG::" across the target directory
+   ```
+2. For each file, remove every line that contains `WTFLogAlways("::DEBUG::` — remove the entire line including the trailing semicolon and newline.
+3. After removing debug log lines, clean up braces to match WebKit style (single-statement bodies must not have braces):
+   - Scan each `if`, `else`, `else if`, `for`, and `while` block in the modified file.
+   - If a block `{ ... }` now contains exactly one statement, revert it to brace-less form.
+   - This is a purely structural check — count the statements inside the block regardless of how the braces got there.
+   - Example — before removal:
+     ```cpp
+     if (!parentItem || !parentItem->children().size()) {
+         WTFLogAlways("::DEBUG:: ...");
+         return false;
+     }
+     ```
+     After removal, revert to:
+     ```cpp
+     if (!parentItem || !parentItem->children().size())
+         return false;
+     ```
+   - **Do NOT remove braces from blocks that still contain multiple statements.** Double-check the statement count before removing any braces.
+4. Collapse any resulting double-blank-lines into a single blank line.
+5. Do NOT remove or modify any other lines.
+6. Report how many lines were removed from how many files.


### PR DESCRIPTION
#### 21006db59e35ebd813a5ce21f9643b34c6e34bb6
<pre>
[Claude Code] Add wk-debug-log plugin for temporary WTFLogAlways instrumentation
<a href="https://bugs.webkit.org/show_bug.cgi?id=310296">https://bugs.webkit.org/show_bug.cgi?id=310296</a>

Reviewed by NOBODY (OOPS!).

Add a Claude Code plugin that provides two skills for managing temporary debug logging
in WebKit source files.

When debugging WebKit, it&apos;s common to scatter `WTFLogAlways` calls across the codebase
to trace execution flow. This is tedious and error-prone — you need to know the right
format strings for WebKit types (`ObjectIdentifier`, `std::optional`, URLs, etc.),
avoid header files to prevent rebuild cascades, and remember to clean everything up
afterward.

This plugin automates both sides of that workflow:
- `/wk-debug-log:wk-debug-log-add &lt;what to trace&gt;` — Inserts `WTFLogAlways(&quot;::DEBUG:: ...&quot;)` calls at
  the appropriate locations. The skill knows WebKit conventions: how to format
  `FrameIdentifier`, `URL`, `std::optional`, pointer types, etc. It logs at conditional
  branches, before/after side-effecting calls, and at IPC boundaries. It avoids header
  files and never alters control flow.
- `/wk-debug-log:wk-debug-log-remove [scope]` — Finds and removes all lines containing `::DEBUG::`
  marker. Optionally scoped to a project (&quot;WebCore&quot;), subdirectory (&quot;WebCore/loader&quot;),
  feature area, or file pattern. Also cleans up braces that were added solely for log
  insertion.

The `::DEBUG::` prefix in every message enables easy grep-based identification and
guaranteed clean removal.

Both skills declare allowed-tools for git diff/log to avoid permission prompts.
The add skill includes a guardrail to never commit debug logging changes.
The remove skill defaults to git-diff changed files instead of scanning the full tree.

* .claude/plugins/wk-debug-log/.claude-plugin/plugin.json: Added.
* .claude/plugins/wk-debug-log/skills/wk-debug-log-add/SKILL.md: Added.
* .claude/plugins/wk-debug-log/skills/wk-debug-log-remove/SKILL.md: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21006db59e35ebd813a5ce21f9643b34c6e34bb6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152710 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25491 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19090 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161454 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106166 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26019 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25797 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118004 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83599 "2 flakes 2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155669 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20225 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137095 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98717 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ff332b6d-1d7e-46cb-8fd7-cfe74672a8e2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19300 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17251 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9290 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128952 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163926 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16563 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126063 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25289 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21290 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126221 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25291 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136765 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81895 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21187 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13544 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24907 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24599 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24758 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24659 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->