### PR TITLE
[Site Isolation] Simplify logic in LocalDOMWindow::createWindow and DOMWindow::isInsecureScriptAccess

### DIFF
--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -1022,20 +1022,12 @@ bool DOMWindow::isInsecureScriptAccess(const LocalDOMWindow& activeWindow, const
         if (&activeWindow == this)
             return false;
 
-        // FIXME: The name canAccess seems to be a roundabout way to ask "can execute script".
-        // Can we name the SecurityOrigin function better to make this more clear?
-
-        RefPtr localDocument = documentIfLocal();
-        if (localDocument && protect(protect(activeWindow.document())->securityOrigin())->isSameOriginDomain(protect(localDocument->securityOrigin())))
-            return false;
-
-        // Although remote frames are defined to host cross origin sites with site isolation,
-        // this is an implementation decision and we should still check that origins match
-        // as the HTML navigation spec describes for navigation to javascript urls
-        // https://html.spec.whatwg.org/#the-javascript:-url-special-case
-        RefPtr remoteFrame = (m_type == DOMWindowType::Remote) ? dynamicDowncast<RemoteDOMWindow>(*this)->frame() : nullptr;
-        if (remoteFrame && protect(protect(activeWindow.document())->securityOrigin())->isSameOriginDomain(remoteFrame->frameDocumentSecurityOriginOrOpaque()))
-            return false;
+        if (RefPtr frame = this->frame()) {
+            if (RefPtr securityOrigin = frame->frameDocumentSecurityOrigin()) {
+                if (protect(protect(activeWindow.document())->securityOrigin())->isSameOriginDomain(*securityOrigin))
+                    return false;
+            }
+        }
     }
 
     activeWindow.printErrorMessage(crossDomainAccessErrorMessage(activeWindow, IncludeTargetOrigin::Yes));

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -120,7 +120,6 @@
 #include "PseudoElementUtilities.h"
 #include "PushManager.h"
 #include "PushStrategy.h"
-#include "RemoteDOMWindow.h"
 #include "RemoteFrame.h"
 #include "RequestAnimationFrameCallback.h"
 #include "ResourceLoadInfo.h"
@@ -2865,15 +2864,11 @@ ExceptionOr<RefPtr<Frame>> LocalDOMWindow::createWindow(const String& urlString,
         }
     }
 
+    RefPtr window = newFrame->window();
+    if (window && window->isInsecureScriptAccess(activeWindow, completedURL.string()))
+        return noopener ? RefPtr<Frame> { nullptr } : newFrame;
+
     RefPtr localNewFrame = dynamicDowncast<LocalFrame>(newFrame);
-    if (localNewFrame && protect(localNewFrame->document()->window())->isInsecureScriptAccess(activeWindow, completedURL.string()))
-        return noopener ? RefPtr<Frame> { nullptr } : newFrame;
-
-    // For when calling window.open and providing a target window which is already remote
-    RefPtr remoteNewFrame = dynamicDowncast<RemoteFrame>(newFrame);
-    if (remoteNewFrame && protect(remoteNewFrame->window())->isInsecureScriptAccess(activeWindow, completedURL.string()))
-        return noopener ? RefPtr<Frame> { nullptr } : newFrame;
-
     if (prepareDialogFunction && localNewFrame)
         prepareDialogFunction(*protect(localNewFrame->document()->window()));
 


### PR DESCRIPTION
#### 20a2ad9db16e05f244a0afb7f4d8c7dedc8b72ae
<pre>
[Site Isolation] Simplify logic in LocalDOMWindow::createWindow and DOMWindow::isInsecureScriptAccess
<a href="https://bugs.webkit.org/show_bug.cgi?id=310297">https://bugs.webkit.org/show_bug.cgi?id=310297</a>
<a href="https://rdar.apple.com/172931973">rdar://172931973</a>

Reviewed by NOBODY (OOPS!).

When LocalDOMWindow::createWindow() calls DOMWindow::isInsecureScriptAccess(),
it handles the local and remote cases separately. But that&apos;s not necessary
because we can call isInsecureScriptAccess from a DOMWindow regardless of if
it&apos;s local or remote.

Similarly, when DOMWindow::isInsecureScriptAccess() compares the active window&apos;s
securityOrigin with that of the target frame, it handles the local and remote
cases separately. But that&apos;s not necessary because we can obtain the securityOrigin
from a Frame regardless of if it&apos;s local or remote.

There is no behavior change. This is tested by the two tests that were fixed by
adding this logic initially in <a href="https://commits.webkit.org/308632@main">https://commits.webkit.org/308632@main</a>:
- http/tests/security/xss-DENIED-window-open-javascript-url-with-spaces.html
- http/tests/security/xss-DENIED-window-open-javascript-url.html

* Source/WebCore/page/DOMWindow.cpp:
(WebCore::DOMWindow::isInsecureScriptAccess):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::createWindow):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20a2ad9db16e05f244a0afb7f4d8c7dedc8b72ae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151106 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23868 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17438 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159834 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104542 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a7767324-8aee-48af-aa5f-9bb0e8bcd781) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152979 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24299 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24094 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116659 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82813 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154066 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18782 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135579 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97380 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/da73847d-fa70-4647-a436-6aa4c000b9d7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17875 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15824 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7680 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127493 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13496 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162307 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5432 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15067 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124665 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23670 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19874 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124853 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23660 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135293 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80104 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23237 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19922 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12058 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23270 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87564 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22982 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23134 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23036 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->