### PR TITLE
nba.com: Unable to scrub volume slider using gaze and pinch [visionOS] and touch [iPadOS]

### DIFF
--- a/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/range-sliders.html
+++ b/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/range-sliders.html
@@ -14,6 +14,15 @@
     <input type="range">
     <input type="range" disabled>
     <input type="range" style="transform: scale(2); transform-origin: top left;">
+    <style>
+        #small-thumb::-webkit-slider-thumb {
+            appearance: none;
+            width: 6px;
+            height: 6px;
+            background: blue;
+        }
+    </style>
+    <input id="small-thumb" type="range">
 
 </body>
 </html>

--- a/LayoutTests/fast/forms/ios/drag-range-track-expected.txt
+++ b/LayoutTests/fast/forms/ios/drag-range-track-expected.txt
@@ -1,0 +1,10 @@
+
+Tests that dragging a range input with a small custom thumb fires input events
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS inputFired is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/ios/drag-range-track.html
+++ b/LayoutTests/fast/forms/ios/drag-range-track.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta name="viewport" content="width=device-width">
+    <script src="../../../resources/js-test.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+    <style>
+        input[type="range"] {
+            width: 300px;
+            height: 6px;
+            background: black;
+        }
+
+        input[type="range"]::-webkit-slider-thumb {
+            appearance: none;
+            background: blue;
+            width: 6px;
+            height: 6px;
+        }
+    </style>
+    <script>
+        jsTestIsAsync = true;
+        var inputFired = false;
+
+        addEventListener("load", async () => {
+            description("Tests that dragging a range input with a small custom thumb fires input events");
+
+            if (!window.testRunner || !testRunner.runUIScript) {
+                debug("This test requires WebKitTestRunner.");
+                finishJSTest();
+                return;
+            }
+
+            const slider = document.getElementById("slider");
+            const rect = slider.getBoundingClientRect();
+
+            const startX = rect.left + rect.width / 2;
+            const startY = rect.top + rect.height / 2;
+            const endX = startX + 100;
+
+            slider.addEventListener("input", () => { inputFired = true; }, { once: true });
+
+            await UIHelper.dragFromPointToPoint(startX, startY, endX, startY, 0.5);
+
+            shouldBeTrue("inputFired");
+            finishJSTest();
+        });
+    </script>
+</head>
+<body>
+<input id="slider" type="range" min="0" max="100" value="50">
+<div id="description"></div>
+<div id="console"></div>
+</body>
+</html>

--- a/LayoutTests/interaction-region/form-control-refresh/slider-thumb-native-interaction-region-expected.txt
+++ b/LayoutTests/interaction-region/form-control-refresh/slider-thumb-native-interaction-region-expected.txt
@@ -11,15 +11,15 @@
         (rect (0,0) width=1600 height=2094)
 
       (interaction regions [
-        (interaction (54.50,2) width=24 height=16)
+        (interaction (42,-10.50) width=49 height=41)
         (cornerRadius 8.00)
         (useContinuousCorners 1),
         (interaction (163.50,42) width=72 height=48)
         (cornerRadius 24.00)
         (useContinuousCorners 1),
-        (interaction (54.50,20) width=24 height=16)
+        (interaction (42,7.50) width=49 height=41)
         (cornerRadius 8.00)
-        (clipPath move to (24,8), add line to (3.72,14.76), add curve to (2.29,13.88) (1.18,12.54) (0.57,10.96), add curve to (0.19,10.02) (0,9.01) (0,8), add curve to (0,6.99) (0.19,5.98) (0.57,5.04), add curve to (1.20,3.45) (2.31,2.13) (3.74,1.25), close subpath),
+        (clipPath move to (36.50,20.50), add line to (16.22,27.26), add curve to (14.79,26.38) (13.68,25.04) (13.07,23.46), add curve to (12.69,22.52) (12.50,21.51) (12.50,20.50), add curve to (12.50,19.49) (12.69,18.48) (13.07,17.54), add curve to (13.70,15.95) (14.81,14.63) (16.24,13.75), close subpath),
         (interaction (163.50,96) width=72 height=48)
         (cornerRadius 24.00)
         (clipPath move to (72,24), add line to (11.17,44.28), add curve to (6.87,41.65) (3.53,37.62) (1.70,32.88), add curve to (0.58,30.06) (0,27.04) (0,24), add curve to (0,20.96) (0.58,17.94) (1.70,15.12), add curve to (3.60,10.36) (6.92,6.38) (11.22,3.74), close subpath)])

--- a/LayoutTests/interaction-region/input-type-range-region-expected.txt
+++ b/LayoutTests/interaction-region/input-type-range-region-expected.txt
@@ -12,8 +12,7 @@
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (guard (54.50,-8) width=24 height=36),
-        (interaction (54.50,2) width=24 height=16)
+        (interaction (42,-10.50) width=49 height=41)
         (cornerRadius 8.00)
         (useContinuousCorners 1)])
       )

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -59,7 +59,7 @@ webkit.org/b/296095 fast/forms/switch/click-animation-disabled.html [ Pass Timeo
 fast/forms/ios/inputmode-none-with-hardware-keyboard.html [ Pass Failure ]
 
 fast/forms/ios/dismiss-picker-using-keyboard.html [ Pass Timeout ]
-fast/forms/ios/drag-range-thumb.html [ Pass Timeout Timeout ]
+fast/forms/ios/drag-range-thumb.html [ Pass Timeout ]
 fast/forms/ios/inputmode-change-update-keyboard.html [ Pass Timeout ]
 
 fast/css/appearance-apple-pay-button.html [ Pass ]

--- a/Source/WebCore/html/shadow/SliderThumbElement.cpp
+++ b/Source/WebCore/html/shadow/SliderThumbElement.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2010 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -439,9 +439,14 @@ void SliderThumbElement::handleTouchStart(TouchEvent& touchEvent)
     RefPtr<Touch> touch = targetTouches->item(0);
     if (!renderer())
         return;
-    IntRect boundingBox = renderer()->absoluteBoundingBoxRect();
-    // Ignore the touch if it is not really inside the thumb.
-    if (!boundingBox.contains(touch->pageX(), touch->pageY()))
+
+    FloatRect thumbBoundingBox = renderer()->absoluteBoundingBoxRect();
+    // These values were chosen to match UIKit.
+    static constexpr float thumbMinDimension = 48;
+    static constexpr float thumbHitAreaExpansion = 12.5;
+    if (thumbBoundingBox.width() < thumbMinDimension || thumbBoundingBox.height() < thumbMinDimension)
+        thumbBoundingBox.inflate(thumbHitAreaExpansion);
+    if (!thumbBoundingBox.contains(touch->pageX(), touch->pageY()))
         return;
 
     setExclusiveTouchIdentifier(touch->identifier());

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -4755,6 +4755,17 @@ FloatSize RenderThemeCocoa::inflateRectForInteractionRegion(const RenderElement&
         return { cssBorderWidth, cssBorderWidth };
     }
 
+    // These values were chosen to match UIKit.
+    auto appearance = box.style().usedAppearance();
+    if (appearance == StyleAppearance::SliderThumbHorizontal || appearance == StyleAppearance::SliderThumbVertical) {
+        static constexpr float thumbMinDimension = 48;
+        static constexpr float thumbHitAreaExpansion = 12.5;
+        if (rect.width() < thumbMinDimension || rect.height() < thumbMinDimension) {
+            rect.inflate(thumbHitAreaExpansion);
+            return { thumbHitAreaExpansion, thumbHitAreaExpansion };
+        }
+    }
+
     return { 0, 0 };
 }
 


### PR DESCRIPTION
#### 11d18b9d064f2f939ee6aecfedfc33c64908ff48
<pre>
nba.com: Unable to scrub volume slider using gaze and pinch [visionOS] and touch [iPadOS]
<a href="https://bugs.webkit.org/show_bug.cgi?id=310228">https://bugs.webkit.org/show_bug.cgi?id=310228</a>
<a href="https://rdar.apple.com/147428926">rdar://147428926</a>

Reviewed by Aditya Keerthi.

The problem was that when the user touches a &lt;input type=&quot;range&quot;&gt;,
the touch had to land precisely on the thumb point of the slider
for it to work (very hard to achieve).
The fix matches UIKit&apos;s UISlider behaviour,
it expands the thumb&apos;s touch hit area by 12.5pt if the
thumb is smaller than 48pt in either dimension.

Test generated with assistance from Claude.

Test: fast/forms/ios/drag-range-track.html

* LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/range-sliders.html:
* LayoutTests/fast/forms/ios/drag-range-track-expected.txt: Added.
* LayoutTests/fast/forms/ios/drag-range-track.html: Added.
* LayoutTests/interaction-region/form-control-refresh/slider-thumb-native-interaction-region-expected.txt:
* LayoutTests/interaction-region/input-type-range-region-expected.txt:
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/html/shadow/SliderThumbElement.cpp:
(WebCore::SliderThumbElement::handleTouchStart):
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::RenderThemeCocoa::inflateRectForInteractionRegion):

Canonical link: <a href="https://commits.webkit.org/310265@main">https://commits.webkit.org/310265@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7b199d13a81cfaf074e0551f044ce5216ec9b4c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153296 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26080 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19678 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162041 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155169 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26606 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26400 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118511 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156255 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/20756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137626 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99224 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/19833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9876 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/129480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15496 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164515 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7651 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17090 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126570 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/25876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/21811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126728 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34368 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25879 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137292 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/82546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21673 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14070 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25496 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89782 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25187 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/25346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/25247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->