### PR TITLE
Replace handcrafted StringTypeAdapters for types with a span() accessor with a partial template specialization

### DIFF
--- a/Source/WTF/wtf/HexNumber.h
+++ b/Source/WTF/wtf/HexNumber.h
@@ -64,21 +64,6 @@ template<typename NumberType> HexNumberBuffer hex(NumberType number, HexConversi
     return hex(number, 0, mode);
 }
 
-template<> class StringTypeAdapter<HexNumberBuffer> {
-public:
-    explicit StringTypeAdapter(const HexNumberBuffer& buffer)
-        : m_buffer { buffer }
-    {
-    }
-
-    unsigned length() const { return m_buffer.length; }
-    bool is8Bit() const { return true; }
-    template<typename CharacterType> void writeTo(std::span<CharacterType> destination) const { StringImpl::copyCharacters(destination, m_buffer.span()); }
-
-private:
-    const HexNumberBuffer& m_buffer;
-};
-
 WTF_EXPORT_PRIVATE CString toHexCString(std::span<const uint8_t>);
 WTF_EXPORT_PRIVATE String toHexString(std::span<const uint8_t>);
 

--- a/Source/WTF/wtf/text/StringConcatenate.h
+++ b/Source/WTF/wtf/text/StringConcatenate.h
@@ -159,14 +159,6 @@ private:
     std::span<const CharacterType> m_characters;
 };
 
-template<> class StringTypeAdapter<CString> : public StringTypeAdapter<std::span<const char>> {
-public:
-    StringTypeAdapter(const CString& string)
-        : StringTypeAdapter<std::span<const char>> { spanReinterpretCast<const char>(string.span()) }
-    {
-    }
-};
-
 template<> class StringTypeAdapter<ASCIILiteral> : public StringTypeAdapter<std::span<const Latin1Character>> {
 public:
     StringTypeAdapter(ASCIILiteral characters)
@@ -175,10 +167,19 @@ public:
     }
 };
 
-template<typename CharacterType, size_t InlineCapacity> class StringTypeAdapter<Vector<CharacterType, InlineCapacity>> : public StringTypeAdapter<std::span<const CharacterType>> {
+template<typename ClassType>
+using SpanMemberFunctionReturnTypeElementType = typename decltype(std::declval<ClassType>().span())::element_type;
+
+template<typename ClassType> concept HasAdaptableSpanMemberFunction = requires {
+    requires StringTypeAdaptable<SpanMemberFunctionReturnTypeElementType<ClassType>>;
+};
+
+template<typename ClassType>
+    requires HasAdaptableSpanMemberFunction<ClassType>
+class StringTypeAdapter<ClassType> : public StringTypeAdapter<std::span<SpanMemberFunctionReturnTypeElementType<ClassType>>> {
 public:
-    StringTypeAdapter(const Vector<CharacterType, InlineCapacity>& vector)
-        : StringTypeAdapter<std::span<const CharacterType>> { vector.span() }
+    StringTypeAdapter(const ClassType& characters)
+        : StringTypeAdapter<std::span<SpanMemberFunctionReturnTypeElementType<ClassType>>> { characters.span() }
     {
     }
 };

--- a/Source/WTF/wtf/text/StringConcatenateNumbers.h
+++ b/Source/WTF/wtf/text/StringConcatenateNumbers.h
@@ -116,21 +116,6 @@ private:
     unsigned m_length;
 };
 
-template<> class StringTypeAdapter<FormattedNumber> {
-public:
-    StringTypeAdapter(const FormattedNumber& number)
-        : m_number { number }
-    {
-    }
-
-    unsigned length() const { return m_number.length(); }
-    bool is8Bit() const { return true; }
-    template<typename CharacterType> void writeTo(std::span<CharacterType> destination) const { StringImpl::copyCharacters(destination, m_number.span()); }
-
-private:
-    const FormattedNumber& m_number;
-};
-
 class FormattedCSSNumber {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(FormattedCSSNumber);
 public:
@@ -148,21 +133,6 @@ public:
 private:
     NumberToCSSStringBuffer m_buffer;
     unsigned m_length;
-};
-
-template<> class StringTypeAdapter<FormattedCSSNumber> {
-public:
-    StringTypeAdapter(const FormattedCSSNumber& number)
-        : m_number { number }
-    {
-    }
-
-    unsigned length() const { return m_number.length(); }
-    bool is8Bit() const { return true; }
-    template<typename CharacterType> void writeTo(std::span<CharacterType> destination) const { StringImpl::copyCharacters(destination, m_number.span()); }
-
-private:
-    const FormattedCSSNumber& m_number;
 };
 
 }

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpReceiverBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpReceiverBackend.cpp
@@ -76,7 +76,7 @@ RTCRtpParameters GStreamerRtpReceiverBackend::getParameters()
         auto media = gstStructureGetString(structure, "media"_s);
         auto encodingName = gstStructureGetString(structure, "encoding-name"_s);
         if (!media.isEmpty() && !encodingName.isEmpty())
-            codec.mimeType = makeString(media.span(), '/', String(encodingName.span()).convertToASCIILowercase());
+            codec.mimeType = makeString(media, '/', String(encodingName.span()).convertToASCIILowercase());
 
         if (auto clockRate = gstStructureGet<uint64_t>(structure, "clock-rate"_s))
             codec.clockRate = *clockRate;

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
@@ -876,13 +876,13 @@ SDPStringBuilder::SDPStringBuilder(const GstSDPMessage* sdp)
     }
 
     if (auto name = CStringView::unsafeFromUTF8(gst_sdp_message_get_session_name(sdp)))
-        m_stringBuilder.append("s="_s, name.span(), CRLF);
+        m_stringBuilder.append("s="_s, name, CRLF);
 
     if (auto info = CStringView::unsafeFromUTF8(gst_sdp_message_get_information(sdp)))
-        m_stringBuilder.append("i="_s, info.span(), CRLF);
+        m_stringBuilder.append("i="_s, info, CRLF);
 
     if (auto uri = CStringView::unsafeFromUTF8(gst_sdp_message_get_uri(sdp)))
-        m_stringBuilder.append("u="_s, uri.span(), CRLF);
+        m_stringBuilder.append("u="_s, uri, CRLF);
 
     unsigned totalEmails = gst_sdp_message_emails_len(sdp);
     for (unsigned i = 0; i < totalEmails; i++)

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp
@@ -229,7 +229,7 @@ std::optional<GStreamerCaptureDevice> GStreamerCaptureDeviceManager::captureDevi
     if (nodeName.isEmpty())
         identifier = makeString(deviceName.span(), ", "_s, deviceClass.span(), ", "_s, deviceClass.span());
     else
-        identifier = makeString(nodeName.span(), ", "_s, deviceClass.span(), ", "_s, deviceClass.span());
+        identifier = makeString(nodeName, ", "_s, deviceClass.span(), ", "_s, deviceClass.span());
 
     bool isMock = false;
     if (auto persistentId = gstStructureGetString(properties.get(), "persistent-id"_s)) {

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoRTPPacketizer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoRTPPacketizer.cpp
@@ -87,7 +87,7 @@ RefPtr<GStreamerVideoRTPPacketizer> GStreamerVideoRTPPacketizer::create(RefPtr<U
 
         auto profileLevelID = gstStructureGetString(codecParameters.get(), "profile-level-id"_s);
         if (!profileLevelID.isEmpty()) {
-            codec = makeString("avc1."_s, profileLevelID.span());
+            codec = makeString("avc1."_s, profileLevelID);
             gst_structure_remove_field(codecParameters.get(), "profile-level-id");
         } else {
             auto profileValue = gstStructureGetString(codecParameters.get(), "profile"_s);

--- a/Source/WebKit/UIProcess/gtk/ValidationBubbleGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/ValidationBubbleGtk.cpp
@@ -46,7 +46,7 @@ ValidationBubbleGtk::ValidationBubbleGtk(GtkWidget* webView, String&& message, c
     // https://docs.gtk.org/Pango/pango_markup.html
     auto messageUTF8 = m_message.utf8();
     GUniquePtr<char> escapedMessage(g_markup_escape_text(messageUTF8.data(), messageUTF8.length()));
-    String markup = makeString("<span font='"_s, m_fontSize, "'>"_s, CStringView::unsafeFromUTF8(escapedMessage.get()).span(), "</span>"_s);
+    String markup = makeString("<span font='"_s, m_fontSize, "'>"_s, CStringView::unsafeFromUTF8(escapedMessage.get()), "</span>"_s);
     gtk_label_set_markup(GTK_LABEL(label), markup.utf8().data());
 
     gtk_widget_set_halign(label, GTK_ALIGN_START);


### PR DESCRIPTION
#### b124e9d9b52251286a71419da71c56d6a4ca627e
<pre>
Replace handcrafted StringTypeAdapters for types with a span() accessor with a partial template specialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=310300">https://bugs.webkit.org/show_bug.cgi?id=310300</a>

Reviewed by Xabier Rodriguez-Calvar and Darin Adler.

This takes advantage of concepts and metaprogramming to
introduce a StringTypeAdapter that will match types that
have a ::span() accessor whose element type is StringTypeAdaptable.
This way we can remove several StringTypeAdaptor specializations
that match and are now redundant.

As a bonus, also CStringView becomes StringTypeAdaptable.

* Source/WTF/wtf/HexNumber.h:
(WTF::StringTypeAdapter&lt;HexNumberBuffer&gt;::StringTypeAdapter): Deleted.
(WTF::StringTypeAdapter&lt;HexNumberBuffer&gt;::length const): Deleted.
(WTF::StringTypeAdapter&lt;HexNumberBuffer&gt;::is8Bit const): Deleted.
(WTF::StringTypeAdapter&lt;HexNumberBuffer&gt;::writeTo const): Deleted.
* Source/WTF/wtf/text/StringConcatenate.h:
(WTF::StringTypeAdapter&lt;ClassType&gt;::StringTypeAdapter):
(WTF::StringTypeAdapter&lt;CString&gt;::StringTypeAdapter): Deleted.
* Source/WTF/wtf/text/StringConcatenateNumbers.h:
(WTF::StringTypeAdapter&lt;FormattedNumber&gt;::StringTypeAdapter): Deleted.
(WTF::StringTypeAdapter&lt;FormattedNumber&gt;::length const): Deleted.
(WTF::StringTypeAdapter&lt;FormattedNumber&gt;::is8Bit const): Deleted.
(WTF::StringTypeAdapter&lt;FormattedNumber&gt;::writeTo const): Deleted.
(WTF::StringTypeAdapter&lt;FormattedCSSNumber&gt;::StringTypeAdapter): Deleted.
(WTF::StringTypeAdapter&lt;FormattedCSSNumber&gt;::length const): Deleted.
(WTF::StringTypeAdapter&lt;FormattedCSSNumber&gt;::is8Bit const): Deleted.
(WTF::StringTypeAdapter&lt;FormattedCSSNumber&gt;::writeTo const): Deleted.
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpReceiverBackend.cpp:
(WebCore::GStreamerRtpReceiverBackend::getParameters):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp:
(WebCore::SDPStringBuilder::SDPStringBuilder):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp:
(WebCore::GStreamerCaptureDeviceManager::captureDeviceFromGstDevice):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoRTPPacketizer.cpp:
(WebCore::GStreamerVideoRTPPacketizer::create):
* Source/WebKit/UIProcess/gtk/ValidationBubbleGtk.cpp:
(WebKit::ValidationBubbleGtk::ValidationBubbleGtk):

Canonical link: <a href="https://commits.webkit.org/310127@main">https://commits.webkit.org/310127@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5f2c6fcdde11a0ae2249033b52ecff9da6c5bd1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152693 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25474 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19073 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161437 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106149 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154566 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26002 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25780 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117993 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155652 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20220 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137078 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98706 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19295 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17236 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9273 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144704 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128946 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14952 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163909 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13500 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7047 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16546 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126053 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25272 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21275 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126211 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34266 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25274 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136748 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81878 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21175 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13527 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184325 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24890 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89176 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47052 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24582 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24741 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24642 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->