### PR TITLE
[GTK] Too many useless MPRIS notifications

### DIFF
--- a/Source/WebCore/platform/audio/glib/MediaSessionGLib.cpp
+++ b/Source/WebCore/platform/audio/glib/MediaSessionGLib.cpp
@@ -220,6 +220,10 @@ bool MediaSessionGLib::ensureMprisSessionRegistered()
     if (!m_connection || mprisRegistrationEligibility() == MediaSessionGLibMprisRegistrationEligiblilty::NotEligible)
         return false;
 
+    const auto& info = nowPlayingInfo();
+    if (!info || info->metadata.title.isEmpty())
+        return false;
+
     if (m_ownerId)
         return true;
 


### PR DESCRIPTION
#### d7414b3bdd976db00dbd1369426905c41c19469c
<pre>
[GTK] Too many useless MPRIS notifications
<a href="https://bugs.webkit.org/show_bug.cgi?id=278721">https://bugs.webkit.org/show_bug.cgi?id=278721</a>

Reviewed by Philippe Normand.

We are currently spamming users which huge numbers of useless MPRIS
controls. It&apos;s not unusual to see one MPRIS notification with &quot;Unknown
Title&quot; and &quot;Unknown Artist&quot; per web process.

This commit adds a last-minute sanity check: drop any MPRIS registration
that does not have a title.

Although this check is good to have regardless, it has the feel of a
workaround rather than a proper solution. E.g. let&apos;s say a page has 5
media elements, 4 of which are hidden or otherwise not obvious to the
user, and 1 of which is a prominent video. Ideally we would display
MPRIS controls for the prominent video. Instead, we&apos;ll likely choose
badly and wind up dropping the MPRIS registration altogether. So further
improvement would certainly be useful.

Canonical link: <a href="https://commits.webkit.org/309615@main">https://commits.webkit.org/309615@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b3c4fa93994dcc8cc8f885302dfc1af50c14efb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151093 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23855 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17425 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159821 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104529 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152966 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24286 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24080 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116651 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82805 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154053 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18774 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135568 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97372 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17867 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15816 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7667 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127485 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13485 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162294 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5419 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15056 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124658 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23657 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19866 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124846 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33891 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23647 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135282 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80091 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19909 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12047 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23257 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87551 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22969 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23121 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23023 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->