### PR TITLE
[Site Isolation] Fix null dereference crash when focus navigates into

### DIFF
--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -812,6 +812,8 @@ FocusableElementSearchResult FocusController::findFocusableElementAcrossFocusSco
     }
 
     auto candidateInCurrentScope = findFocusableElementWithinScope(direction, scope, currentNode, focusEventData, shouldFocusElement);
+    if (candidateInCurrentScope.continuedSearchInRemoteFrame == ContinuedSearchInRemoteFrame::Yes)
+        return candidateInCurrentScope;
     if (candidateInCurrentScope.element) {
         if (direction == FocusDirection::Backward) {
             // Skip through invokers if they have popovers with focusable contents, and navigate through those contents instead.
@@ -860,15 +862,19 @@ FocusableElementSearchResult FocusController::findFocusableElementAcrossFocusSco
             },
             [&](const RefPtr<Frame>& frame) -> FocusableElementSearchResult {
                 switch (frame->frameType()) {
-                case Frame::FrameType::Remote:
-
+                case Frame::FrameType::Remote: {
+                    if (!currentNode)
+                        return { };
+                    RefPtr currentFrame = currentNode->document().frame();
+                    if (!currentFrame)
+                        return { };
                     if (shouldFocusElement == ShouldFocusElement::Yes) {
-                        RefPtr currentFrame = currentNode->document().frame();
                         clearSelectionIfNeeded(currentFrame.get(), nullptr, nullptr);
                         currentNode->document().setFocusedElement(nullptr);
                     }
-                    downcast<RemoteFrame>(*frame).client().findFocusableElementContinuingFromFrame(direction, currentNode->document().frame()->frameID(), focusEventData, shouldFocusElement);
+                    downcast<RemoteFrame>(*frame).client().findFocusableElementContinuingFromFrame(direction, currentFrame->frameID(), focusEventData, shouldFocusElement);
                     return { nullptr, ContinuedSearchInRemoteFrame::Yes };
+                }
                 case Frame::FrameType::Local:
                     if (RefPtr ownerElement = frame->ownerElement())
                         return handleElementOwner(*ownerElement);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FocusWebView.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FocusWebView.mm
@@ -233,6 +233,53 @@ TEST(FocusWebView, MultipleFrames)
     EXPECT_WK_STREQ([uiDelegate waitForAlert], "https://apple.com focused");
 }
 
+// Regression test for rdar://172564611 — site isolation crash when focus navigation enters a
+// cross-origin iframe (Process B) whose document itself begins with a nested cross-origin iframe
+// (another RemoteFrame from Process B's perspective). Previously, findFocusableElementAcrossFocusScope
+// found the nested RemoteFrame as the first candidate (returning { null, ContinuedSearchInRemoteFrame::Yes })
+// but did not return early, allowing a null dereference of currentNode in the Remote owner case.
+TEST(FocusWebView, FocusNavigationIntoFrameWithNestedRemoteFrame)
+{
+    auto mainHTML = "<body>"
+        "<input id='mainInput'>"
+        "<iframe id='outerFrame' src='https://webkit.org/outerframe'></iframe>"
+        "</body>"_s;
+
+    // This frame begins with a cross-origin nested iframe (a RemoteFrame from webkit.org's
+    // process perspective), followed by a local input. The crash triggers when focus navigation
+    // enters this frame and the first focusable candidate is the nested RemoteFrame.
+    auto outerFrameHTML = "<body>"
+        "<iframe src='https://apple.com/innerframe'></iframe>"
+        "<input id='outerInput'>"
+        "</body>"_s;
+
+    auto innerFrameHTML = "<body><input id='innerInput'></body>"_s;
+
+    HTTPServer server({
+        { "/main"_s, { mainHTML } },
+        { "/outerframe"_s, { outerFrameHTML } },
+        { "/innerframe"_s, { innerFrameHTML } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    [[configuration preferences] _setSiteIsolationEnabled:YES];
+
+    auto [webView, navigationDelegate, uiDelegate] = makeWebViewAndDelegates(WTF::move(configuration));
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/main"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    [webView evaluateJavaScript:@""
+        "document.getElementById('mainInput').addEventListener('focusin', () => alert('mainInput focused'));"
+        "document.getElementById('mainInput').focus();" completionHandler:nil];
+    EXPECT_WK_STREQ([uiDelegate waitForAlert], "mainInput focused");
+
+    // This tab press enters webkit.org's cross-origin process with currentNode = null and a nested
+    // RemoteFrame as the first candidate — previously this would crash.
+    [webView typeCharacter:'\t'];
+    Util::runFor(0.5_s);
+}
+
 TEST(FocusWebView, DoNotFocusWebViewWhenUnparented)
 {
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];


### PR DESCRIPTION
#### 731ac27ab1cffc450eaf03c0392cd82dcfa34dea
<pre>
[Site Isolation] Fix null dereference crash when focus navigates into  cross-origin iframe containing a nested remote frame
<a href="https://rdar.apple.com/172564611">rdar://172564611</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=310307">https://bugs.webkit.org/show_bug.cgi?id=310307</a>

Reviewed by Megan Gardner.

When findFocusableElementAcrossFocusScope found a candidate with ContinuedSearchInRemoteFrame::Yes,it did not return early, allowing execution to continue into the Remote frame owner case with anull currentNode, causing a crash. Also adds null checks for currentNode and currentFrame in the Remote frame handling path.

* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::findFocusableElementAcrossFocusScope):
</pre>
----------------------------------------------------------------------
#### 4b515f3982d80aedbd1c47246f9adeaff1557540
<pre>
[Site Isolation] Fix null dereference crash when focus navigates into cross-origin iframe containing a nested remote frame <a href="https://rdar.apple.com/172564611">rdar://172564611</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=310307">https://bugs.webkit.org/show_bug.cgi?id=310307</a>

Reviewed by Megan Gardner.

When findFocusableElementAcrossFocusScope found a candidate with ContinuedSearchInRemoteFrame::Yes,
it did not return early, allowing execution to continue into the Remote frame owner case with a
null currentNode, causing a crash. Also adds null checks for currentNode and currentFrame in the
Remote frame handling path.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bfbfdc0829823b20411543bbf6cac1c07bbf9d1d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151308 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/24071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17642 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160039 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/104746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153181 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24503 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24360 "Failed to checkout and rebase branch from PR 60956") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/116827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/104746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154268 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/18961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/135755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97545 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/18052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/24360 "Failed to checkout and rebase branch from PR 60956") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7884 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/127674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/13667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162511 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/5644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15244 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/124838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/23873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/24360 "Failed to checkout and rebase branch from PR 60956") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125022 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/33908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/23863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135463 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80359 "Built successfully") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/23863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/12233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/23472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/87776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/23184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/23337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/23238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->