### PR TITLE
[libpas] Force bmalloc's iso-heaps to use bitfit heaps in +MTE procs

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/bmalloc_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/bmalloc_heap.c
@@ -159,6 +159,7 @@ PAS_NEVER_INLINE void* bmalloc_allocate_array_by_size_with_alignment_casual(
     return (void*)bmalloc_iso_allocate_array_impl_casual_case(heap_ref, size, alignment, allocation_mode).begin;
 }
 
+#if !BMALLOC_ALLOW_ISO_HEAPED_BITFIT_ALLOCATIONS_UNDER_MTE
 void* bmalloc_try_iso_allocate_array_by_size(pas_heap_ref* heap_ref, size_t size, pas_allocation_mode allocation_mode)
 {
     return bmalloc_try_iso_allocate_array_by_size_inline(heap_ref, size, allocation_mode);
@@ -232,6 +233,7 @@ void* bmalloc_iso_reallocate_array_by_count(pas_heap_ref* heap_ref, void* ptr, s
 {
     return bmalloc_iso_reallocate_array_by_count_inline(heap_ref, ptr, count, allocation_mode);
 }
+#endif /* !PAS_ALLOW_ISO_HEAPED_BITFIT_ALLOCATIONS_UNDER_MTE */
 
 pas_heap* bmalloc_heap_ref_get_heap(pas_heap_ref* heap_ref)
 {

--- a/Source/bmalloc/libpas/src/libpas/bmalloc_heap.h
+++ b/Source/bmalloc/libpas/src/libpas/bmalloc_heap.h
@@ -33,6 +33,25 @@
 
 #if PAS_ENABLE_BMALLOC
 
+/* In principle, it is not generally kosher to allocate isoheaped objects out of bitfit heaps:
+ * plainly, they're not type-safe, and allow for intra- object type-confusion via UAFs on objects aligned
+ * at different offsets within a given bitfit page.
+ * At present, however, the particularities of our configuration allow for this to be done safely.
+ * Specifically, because we
+ *   1. Never use the array-alloc APIs for iso-heaped objects
+ *   2. Never use realloc for iso-heaped objects
+ *   3. Never use shrink for iso-heaped objects
+ *   4. Already size-segregate *before* calling into any pas_heap for
+ *      allocating an iso-heaped object -- thanks to TZoneMalloc.
+ * we can guarantee that in practice, the bitfit heap belonging to any given iso-heap will only ever see
+ * objects of a single size-class. When this option is enabled, bmalloc will check for MTE enablement at
+ * process launch time; if it is, then bmalloc will change its iso-heap runtime-config to allow bitfit
+ * allocations.
+ *
+ * As to why we'd want to do this, see 309573@main for details; in brief, this enables us to effectively
+ * get retag-on-free without slowing down the small-segregated free-path in the WebContent process. */
+#define BMALLOC_ALLOW_ISO_HEAPED_BITFIT_ALLOCATIONS_UNDER_MTE       1
+
 PAS_BEGIN_EXTERN_C;
 
 PAS_API void* bmalloc_try_allocate(size_t size, pas_allocation_mode allocation_mode);
@@ -66,6 +85,7 @@ PAS_API void* bmalloc_reallocate(void* old_ptr, size_t new_size,
 PAS_BAPI void* bmalloc_try_iso_allocate(pas_heap_ref* heap_ref, pas_allocation_mode allocation_mode);
 PAS_BAPI void* bmalloc_iso_allocate(pas_heap_ref* heap_ref, pas_allocation_mode allocation_mode);
 
+#if !BMALLOC_ALLOW_ISO_HEAPED_BITFIT_ALLOCATIONS_UNDER_MTE
 PAS_BAPI void* bmalloc_try_iso_allocate_array_by_size(pas_heap_ref* heap_ref, size_t size, pas_allocation_mode allocation_mode);
 PAS_BAPI void* bmalloc_iso_allocate_array_by_size(pas_heap_ref* heap_ref, size_t size, pas_allocation_mode allocation_mode);
 
@@ -90,6 +110,7 @@ PAS_API void* bmalloc_iso_allocate_array_by_count_with_alignment(
 
 PAS_API void* bmalloc_try_iso_reallocate_array_by_count(pas_heap_ref* heap_ref, void* ptr, size_t count, pas_allocation_mode allocation_mode);
 PAS_API void* bmalloc_iso_reallocate_array_by_count(pas_heap_ref* heap_ref, void* ptr, size_t count, pas_allocation_mode allocation_mode);
+#endif /* !PAS_ALLOW_ISO_HEAPED_BITFIT_ALLOCATIONS_UNDER_MTE */
 
 PAS_API pas_heap* bmalloc_heap_ref_get_heap(pas_heap_ref* heap_ref);
 

--- a/Source/bmalloc/libpas/src/libpas/pas_internal_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_internal_config.h
@@ -147,6 +147,25 @@
 #define PAS_SMALL_SHARED_PAGE_LOG_SHIFT     31
 #define PAS_MEDIUM_SHARED_PAGE_LOG_SHIFT    31
 
+/* In principle, it is not generally kosher to allocate isoheaped objects out of bitfit heaps:
+ * plainly, they're not type-safe, and allow for intra- object type-confusion via UAFs on objects aligned
+ * at different offsets within a given bitfit page.
+ * At present, however, the particularities of our configuration allow for this to be done safely.
+ * Specifically, because we
+ *   1. Never use the array-alloc APIs for iso-heaped objects
+ *   2. Never use realloc for iso-heaped objects
+ *   3. Never use shrink for iso-heaped objects
+ *   4. Already size-segregate *before* calling into any pas_heap for
+ *      allocating an iso-heaped object -- thanks to TZoneMalloc.
+ * we can guarantee that in practice, the bitfit heap belonging to any given iso-heap will only ever see
+ * objects of a single size-class. When this option is enabled, bmalloc will check for MTE enablement at
+ * process launch time; if it is, then bmalloc will change its iso-heap runtime-config to allow bitfit
+ * allocations.
+ *
+ * As to why we'd want to do this, see 309573@main for details; in brief, this enables us to effectively
+ * get retag-on-free without slowing down the small-segregated free-path in the WebContent process. */
+#define PAS_ALLOW_ISO_HEAPED_BITFIT_ALLOCATIONS_UNDER_MTE       1
+
 /* Must be zero; utility doesn't support partials right now (though it could if we hacked deallocation and
    added a shared page directory). */
 #define PAS_UTILITY_BOUND_FOR_PARTIAL_VIEWS                     0

--- a/Source/bmalloc/libpas/src/libpas/pas_mte_config.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_mte_config.c
@@ -48,6 +48,7 @@
 #include "pas_system_heap.h"
 #include "pas_utility_heap_config.h"
 #include "pas_utils.h"
+#include "bmalloc_heap.h"
 #include "pas_zero_memory.h"
 
 #if PAS_ENABLE_BMALLOC
@@ -106,13 +107,67 @@ static bool get_value_if_available(unsigned* valuePtr, const char* var)
     return false; // Not found.
 }
 
-static void pas_mte_do_initialization(void)
+static void pas_mte_set_configuration_for_webcontent(const char* procname)
+{
+    uint8_t* enabled_byte = &PAS_MTE_CONFIG_BYTE(PAS_MTE_ENABLE_FLAG);
+    uint8_t* medium_byte = &PAS_MTE_CONFIG_BYTE(PAS_MTE_MEDIUM_TAGGING_ENABLE_FLAG);
+    uint8_t* lockdown_mode_byte = &PAS_MTE_CONFIG_BYTE(PAS_MTE_LOCKDOWN_MODE_FLAG);
+    uint8_t* hardened_byte = &PAS_MTE_CONFIG_BYTE(PAS_MTE_HARDENED_FLAG);
+
+    // For a variety of reasons, a full MTE implementation in the WebContent process is not generally practical.
+    // As such, by default, we disable MTE in the WebContent process while leaving it on in the privileged
+    // processes. However, in certain "extra secure" contexts, this disablement is overridden such that we
+    // treat WebContent like any other process for the purposes of MTE.
+
+    bool wcp_is_hardened = false;
+    bool isEnhancedSecurityWebContentProcess = !strncmp(procname, "com.apple.WebKit.WebContent.EnhancedSecurity", 44);
+    if (*lockdown_mode_byte || isEnhancedSecurityWebContentProcess)
+        wcp_is_hardened = true;
+
+    if (wcp_is_hardened) {
+        *medium_byte = 1;
+        *enabled_byte = 1;
+        *hardened_byte = 1;
+    } else {
+        *medium_byte = 0;
+        *hardened_byte = 0;
+#if !PAS_USE_MTE_IN_WEBCONTENT
+        // Disable tagging in libpas by default in WebContent process
+        *enabled_byte = 0;
+#else
+        *enabled_byte = 1;
+#endif
+    }
+
+#ifndef NDEBUG
+    if (is_env_true("MTE_disableForWebContent")) {
+        PAS_ASSERT(!is_env_true("MTE_overrideEnablementForWebContent"));
+        *enabled_byte = 0;
+        *medium_byte = 0;
+    }
+#endif
+    if (is_env_true("MTE_overrideEnablementForWebContent")) {
+        *enabled_byte = 1;
+        *medium_byte = 1;
+    } else if (is_env_false("MTE_overrideEnablementForWebContent")) {
+        *enabled_byte = 0;
+        *medium_byte = 0;
+    }
+}
+
+static void pas_mte_set_configuration(void)
 {
     uint8_t* enabled_byte = &PAS_MTE_CONFIG_BYTE(PAS_MTE_ENABLE_FLAG);
     uint8_t* mode_byte = &PAS_MTE_CONFIG_BYTE(PAS_MTE_MODE_BITS);
     uint8_t* medium_byte = &PAS_MTE_CONFIG_BYTE(PAS_MTE_MEDIUM_TAGGING_ENABLE_FLAG);
     uint8_t* lockdown_mode_byte = &PAS_MTE_CONFIG_BYTE(PAS_MTE_LOCKDOWN_MODE_FLAG);
     uint8_t* hardened_byte = &PAS_MTE_CONFIG_BYTE(PAS_MTE_HARDENED_FLAG);
+
+    *enabled_byte = 0;
+    *mode_byte = 0;
+    *medium_byte = 0;
+    *lockdown_mode_byte = 0;
+    *hardened_byte = 0;
 
     struct proc_bsdinfo info;
     int rc = proc_pidinfo(getpid(), PROC_PIDTBSDINFO, 0, &info, sizeof(info));
@@ -144,53 +199,18 @@ static void pas_mte_do_initialization(void)
     bool isWebContentProcess = !strncmp(name, "com.apple.WebKit.WebContent", 27) || !strncmp(name, "jsc", 3);
 
     if (isWebContentProcess) {
-        // For a variety of reasons, a full MTE implementation in the WebContent process is not generally practical.
-        // As such, by default, we disable MTE in the WebContent process while leaving it on in the privileged
-        // processes. However, in certain "extra secure" contexts, this disablement is overridden such that we
-        // treat WebContent like any other process for the purposes of MTE.
-
-        bool wcp_is_hardened = false;
-        bool isEnhancedSecurityWebContentProcess = !strncmp(name, "com.apple.WebKit.WebContent.EnhancedSecurity", 44);
-        if (*lockdown_mode_byte || isEnhancedSecurityWebContentProcess)
-            wcp_is_hardened = true;
-
-        if (wcp_is_hardened) {
-            *medium_byte = 1;
-            *enabled_byte = 1;
-            *hardened_byte = 1;
-
-            pas_mte_force_nontaggable_user_allocations_into_large_heap();
-        } else {
-            *medium_byte = 0;
-            *hardened_byte = 0;
-#if !PAS_USE_MTE_IN_WEBCONTENT
-            // Disable tagging in libpas by default in WebContent process
-            *enabled_byte = 0;
-#else
-            *enabled_byte = 1;
-#endif
-        }
-
-#ifndef NDEBUG
-        if (is_env_true("MTE_disableForWebContent")) {
-            PAS_ASSERT(!is_env_true("MTE_overrideEnablementForWebContent"));
-            *enabled_byte = 0;
-            *medium_byte = 0;
-        }
-#endif
-        if (is_env_true("MTE_overrideEnablementForWebContent")) {
-            *enabled_byte = 1;
-            *medium_byte = 1;
-        } else if (is_env_false("MTE_overrideEnablementForWebContent")) {
-            *enabled_byte = 0;
-            *medium_byte = 0;
-        }
+        pas_mte_set_configuration_for_webcontent(name);
     } else {
         *medium_byte = 1; // Tag libpas medium objects in privileged processes
         *hardened_byte = 1;
     }
+}
 
-    PAS_IGNORE_WARNINGS_BEGIN("unreachable-code");
+static void pas_mte_do_initialization(void)
+{
+    pas_mte_set_configuration();
+    if (PAS_MTE_USE_LARGE_OBJECT_DELEGATION)
+        pas_mte_force_nontaggable_user_allocations_into_large_heap();
     // Retag-on-scavenge functionally supports both segregated and bitfit heaps.
     // However, true to the name, for segregated heaps the retag operation only
     // takes place on the scavenging path.
@@ -206,6 +226,7 @@ static void pas_mte_do_initialization(void)
     // mini-mode because a few stray allocations there won't hurt, but for a
     // security boundary those stray allocations are more of a problem. So we force
     // this here, prior to the creation of such segregated directories.
+    PAS_IGNORE_WARNINGS_BEGIN("unreachable-code");
     if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_RETAG_ON_SCAVENGE))
         pas_bmalloc_force_allocations_into_bitfit_heaps_where_available();
     PAS_IGNORE_WARNINGS_END;
@@ -372,6 +393,13 @@ void pas_bmalloc_force_allocations_into_bitfit_heaps_where_available(void)
     bmalloc_primitive_runtime_config.base.max_segregated_object_size = 0;
     bmalloc_intrinsic_runtime_config.base.max_bitfit_object_size = UINT_MAX;
     bmalloc_primitive_runtime_config.base.max_bitfit_object_size = UINT_MAX;
+
+    if (PAS_USE_MTE && BMALLOC_ALLOW_ISO_HEAPED_BITFIT_ALLOCATIONS_UNDER_MTE) {
+        bmalloc_typed_runtime_config.base.max_segregated_object_size = 0;
+        bmalloc_flex_runtime_config.base.max_segregated_object_size = 0;
+        bmalloc_typed_runtime_config.base.max_bitfit_object_size = UINT_MAX;
+        bmalloc_flex_runtime_config.base.max_bitfit_object_size = UINT_MAX;
+    }
 #endif
 
     // If large-object delegation is enabled, we don't want to override that
@@ -384,10 +412,8 @@ void pas_bmalloc_force_allocations_into_bitfit_heaps_where_available(void)
     // So we take the object-delegation path to be a special case and make
     // sure to re-apply after performing the above expansion.
     PAS_IGNORE_WARNINGS_BEGIN("unreachable-code");
-#if defined(PAS_MTE_USE_LARGE_OBJECT_DELEGATION)
     if (PAS_MTE_USE_LARGE_OBJECT_DELEGATION)
         pas_mte_force_nontaggable_user_allocations_into_large_heap();
-#endif // defined(PAS_MTE_USE_LARGE_OBJECT_DELEGATION)
     PAS_IGNORE_WARNINGS_END;
 }
 


### PR DESCRIPTION
#### d5c8f4f1b1b5d682598247d70533daf9596f7945
<pre>
[libpas] Force bmalloc&apos;s iso-heaps to use bitfit heaps in +MTE procs
<a href="https://bugs.webkit.org/show_bug.cgi?id=310126">https://bugs.webkit.org/show_bug.cgi?id=310126</a>
<a href="https://rdar.apple.com/172764727">rdar://172764727</a>

Reviewed by NOBODY (OOPS!).

This is the final patch in the series achieving retag-on-free for
+MTE processes. It does so by allowing TZoneMalloc, the last
pathway which would allocate segregated-and-MTE-tagged objects,
to instead exclusively use bitfit heaps when MTE is enabled.
For an understanding of why this is relevant to retag-on-free,
see the previous patch <a href="https://commits.webkit.org/309573@main">309573@main</a>.

In principle, it is not generally kosher to allocate isoheaped objects out of
bitfit heaps: plainly, they&apos;re not type-safe, and allow for intra- object
type-confusion via UAFs on objects aligned at different offsets within a given
bitfit page.
At present, however, the particularities of our configuration allow for this to
be done safely.
Specifically, because we
  1. Never use the array-alloc APIs for iso-heaped objects
  2. Never use realloc for iso-heaped objects
  3. Never use shrink for iso-heaped objects
  4. Already size-segregate *before* calling into any pas_heap for
     allocating an iso-heaped object -- thanks to TZoneMalloc.
we can guarantee that in practice, the bitfit heap belonging to any given
iso-heap will only ever see objects of a single size-class. When this option is
enabled, bmalloc will check for MTE enablement at process launch time; if it
is, then bmalloc will change its iso-heap runtime-config to allow bitfit
allocations.
Altogether, so long as these requirements are all maintained, then it is
possible to keep TZone enabled, effectively achieve retag-on-free, and avoid
any impact on perf.

What this patch actually does is:
  1. Reorganize the MTE initialization code to separate the determination
     of the MTE config bytes from the libpas-config manipulation
  2. Add a macro-flag, BMALLOC_ALLOW_ISO_HEAPED_BITFIT_ALLOCATIONS_UNDER_MTE,
     which enables the iso-bitfit behavior but disables certain bmalloc APIs
  3. When that flag is enabled, in +MTE processes, changes the bmalloc-heap&apos;s
     bmalloc_typed_runtime_config and bmalloc_flex_runtime_config to only
     allocate from bitfit heaps.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5c8f4f1b1b5d682598247d70533daf9596f7945

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151120 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23882 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17453 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159848 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104556 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eea33d04-3e7e-424b-bb63-9855f2c38086) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24313 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24108 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116672 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82819 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d37af194-513b-4b2d-b912-d3407b26702f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154080 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18792 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135588 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97393 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f47f625c-fe18-44a5-ae94-1b100604ed6c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17885 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15838 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7694 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/143104 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127503 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13505 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162321 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/11919 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15076 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124681 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23684 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19888 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124869 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23674 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135302 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80118 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19927 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12067 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/182729 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23284 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46633 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22996 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23148 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23050 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->