### PR TITLE
[Site Isolation] Fix flaky ColorInputTests by waiting for color picker before setting color

### DIFF
--- a/Tools/TestWebKitAPI/Tests/mac/ColorInputTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/ColorInputTests.mm
@@ -35,13 +35,24 @@
 
 namespace TestWebKitAPI {
 
+static bool isShowingColorPicker(TestWKWebView *webView)
+{
+    for (NSView *subview in [webView window].contentView.subviews) {
+        if ([subview isKindOfClass:NSClassFromString(@"WKPopoverColorWell")])
+            return true;
+    }
+    return false;
+}
+
 TEST(ColorInputTests, SetColorUsingColorPicker)
 {
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadHTMLString:@"<input type='color' id='color' style='width: 200px; height: 200px;'>"];
 
     [webView sendClickAtPoint:NSMakePoint(50, 350)];
-    [webView waitForNextPresentationUpdate];
+    Util::waitFor([&] {
+        return isShowingColorPicker(webView.get());
+    });
 
     [webView _setSelectedColorForColorPicker:NSColor.redColor];
     [webView waitForNextPresentationUpdate];
@@ -57,7 +68,9 @@ TEST(ColorInputTests, SetColorWithAlphaUsingColorPicker)
     [webView synchronouslyLoadHTMLString:@"<input type='color' id='color' style='width: 200px; height: 200px;'>"];
 
     [webView sendClickAtPoint:NSMakePoint(50, 350)];
-    [webView waitForNextPresentationUpdate];
+    Util::waitFor([&] {
+        return isShowingColorPicker(webView.get());
+    });
 
     NSColor *color = [NSColor colorWithRed:0 green:0 blue:1 alpha:0.5];
     [webView _setSelectedColorForColorPicker:color];


### PR DESCRIPTION
#### 128fb92799f02173cf41a372e4e00c802cb99020
<pre>
[Site Isolation] Fix flaky ColorInputTests by waiting for color picker before setting color
<a href="https://bugs.webkit.org/show_bug.cgi?id=310294">https://bugs.webkit.org/show_bug.cgi?id=310294</a>
<a href="https://rdar.apple.com/172931262">rdar://172931262</a>

Reviewed by Aditya Keerthi.

The tests called _setSelectedColorForColorPicker: after a single waitForNextPresentationUpdate,
which is sometimes not enough time to guarantee that the ShowColorPicker IPC message has been
handled and internals().colorPicker is not null, due to recent site isolation work in this area.
When we hit the null check in didChooseColor() is hit, the color change is silently dropped,
causing us to read back the initial value #000000.

Spin the run loop until the WKPopoverColorWell appears in the view hierarchy before calling
_setSelectedColorForColorPicker:, matching the approach used by
UIScriptControllerMac::isShowingColorPicker.

* Tools/TestWebKitAPI/Tests/mac/ColorInputTests.mm:
(TestWebKitAPI::isShowingColorPicker):
(TestWebKitAPI::TEST(ColorInputTests, SetColorUsingColorPicker)):
(TestWebKitAPI::TEST(ColorInputTests, SetColorWithAlphaUsingColorPicker)):

Canonical link: <a href="https://commits.webkit.org/309594@main">https://commits.webkit.org/309594@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ee071bb1c26afd47112b7e8d41bedb35ff91d3b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151131 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23893 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17464 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159860 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104567 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7bdd82dc-753e-495b-a8fa-9bec4ae81885) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153004 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24324 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24120 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116679 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/82823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2de5eae5-a6b9-4a92-8bc4-66a1a0906771) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154091 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18803 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135599 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97400 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17896 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15846 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7705 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127514 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13516 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162332 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15087 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124687 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23695 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19896 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124875 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33876 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23685 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135313 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80129 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19939 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12078 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23295 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23007 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23159 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23061 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->