### PR TITLE
Style checker should warn about unsafe/@safe in Swift files

### DIFF
--- a/Tools/Scripts/webkitpy/style/checkers/swift.py
+++ b/Tools/Scripts/webkitpy/style/checkers/swift.py
@@ -31,7 +31,7 @@ class SwiftChecker(object):
         self.file_path = file_path
         self.handle_style_error = handle_style_error
 
-    def _process_lines(self, file_path, lines, error):
+    def _swift_format(self, file_path, lines, error):
         lint_result = subprocess.run(['/usr/bin/swift', 'format', 'lint', '--strict', file_path], capture_output=True, text=True)
 
         # matches <filename>:<line>: error: [<category>] <message>
@@ -55,5 +55,33 @@ class SwiftChecker(object):
 
             self.handle_style_error(int(line_number), category, 5, message)
 
+    def _check_unsafe(self, lines):
+        in_block_comment = False
+        for index, line in enumerate(lines):
+            if in_block_comment:
+                if '*/' in line:
+                    in_block_comment = False
+                continue
+
+            stripped = line.lstrip()
+            if stripped.startswith('//'):
+                continue
+
+            if '/*' in line:
+                if '*/' not in line[line.index('/*') + 2:]:
+                    in_block_comment = True
+                continue
+
+            if re.search(r'"[^"]*\bunsafe\b[^"]*"', line):
+                continue
+            elif re.search(r'@unsafe\b', line):
+                continue
+            elif re.search(r'\bunsafe\b', line):
+                self.handle_style_error(index + 1, 'webkit/unsafe', 5, "Please avoid new use of 'unsafe' in WebKit. See https://github.com/WebKit/WebKit/wiki/Safer-Swift-Guidelines.")
+
+            if re.search(r'@safe\b', line) and not re.search(r'@unsafe\b', line):
+                self.handle_style_error(index + 1, 'webkit/unsafe', 5, "Please avoid new use of '@safe' in WebKit. See https://github.com/WebKit/WebKit/wiki/Safer-Swift-Guidelines.")
+
     def check(self, lines):
-        self._process_lines(self.file_path, lines, self.handle_style_error)
+        self._swift_format(self.file_path, lines, self.handle_style_error)
+        self._check_unsafe(lines)

--- a/Tools/Scripts/webkitpy/style/checkers/swift_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/swift_unittest.py
@@ -81,3 +81,54 @@ class SwiftCheckerTest(unittest.TestCase):
         ]
 
         self.assertEqual(errors, expected_errors)
+
+    def test_check_unsafe(self):
+        """Test _check_unsafe() method."""
+        errors = []
+
+        def _mock_handle_style_error(line_number, category, confidence, message):
+            errors.append((line_number, category, confidence, message))
+
+        checker = SwiftChecker("foo.swift", _mock_handle_style_error)
+
+        lines = [
+            'let x = unsafe ptr.pointee',          # 1: flagged
+            '// unsafe is fine in comments',         # 2: not flagged
+            '@unsafe func foo() {}',                 # 3: not flagged (@unsafe is ok)
+            'let s = "unsafe pointer"',              # 4: not flagged (string)
+            '/* unsafe block comment */',             # 5: not flagged (block comment)
+            'func safeFunc() {}',                    # 6: not flagged
+            'let y = unsafe something',              # 7: flagged
+        ]
+
+        checker._check_unsafe(lines)
+
+        expected_errors = [
+            (1, 'webkit/unsafe', 5, "Please avoid new use of 'unsafe' in WebKit. See https://github.com/WebKit/WebKit/wiki/Safer-Swift-Guidelines."),
+            (7, 'webkit/unsafe', 5, "Please avoid new use of 'unsafe' in WebKit. See https://github.com/WebKit/WebKit/wiki/Safer-Swift-Guidelines."),
+        ]
+
+        self.assertEqual(errors, expected_errors)
+
+    def test_check_safe(self):
+        """Test that @safe is flagged."""
+        errors = []
+
+        def _mock_handle_style_error(line_number, category, confidence, message):
+            errors.append((line_number, category, confidence, message))
+
+        checker = SwiftChecker("foo.swift", _mock_handle_style_error)
+
+        lines = [
+            '@safe func bar() {}',                   # 1: flagged
+            '@unsafe func baz() {}',                  # 2: not flagged
+            'func safeFunc() {}',                     # 3: not flagged
+        ]
+
+        checker._check_unsafe(lines)
+
+        expected_errors = [
+            (1, 'webkit/unsafe', 5, "Please avoid new use of '@safe' in WebKit. See https://github.com/WebKit/WebKit/wiki/Safer-Swift-Guidelines."),
+        ]
+
+        self.assertEqual(errors, expected_errors)


### PR DESCRIPTION
#### 8220ffea7d8bec59de1a8b90b3b09ca0e053cb0a
<pre>
Style checker should warn about unsafe/@safe in Swift files
<a href="https://bugs.webkit.org/show_bug.cgi?id=310316">https://bugs.webkit.org/show_bug.cgi?id=310316</a>
<a href="https://rdar.apple.com/172956774">rdar://172956774</a>

Reviewed by Richard Robinson.

Swift is a multi-paradigm language that does not dogmatically require memory
safety.

This check will remind engineers that upholding Strict Safety is our goal in
WebKit.

* Tools/Scripts/webkitpy/style/checkers/swift.py:
(SwiftChecker._swift_format):
(SwiftChecker._check_unsafe):
(SwiftChecker.check):
(SwiftChecker._process_lines): Deleted.
* Tools/Scripts/webkitpy/style/checkers/swift_unittest.py:
(SwiftCheckerTest.test_check):
(SwiftCheckerTest):
(SwiftCheckerTest.test_check_unsafe):
(SwiftCheckerTest.test_check_unsafe._mock_handle_style_error):
(SwiftCheckerTest.test_check_safe):
(SwiftCheckerTest.test_check_safe._mock_handle_style_error):

Canonical link: <a href="https://commits.webkit.org/309774@main">https://commits.webkit.org/309774@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6494a765fcad2040c7230fb8ef642d8db1574a6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151134 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23896 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17467 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159863 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104570 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/461e3fc8-37be-4874-bc54-29aa4ea7da88) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153007 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24327 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24123 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116681 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82824 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154094 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18806 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135604 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97402 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/35500768-d55e-4b95-bec8-b1cf984bb096) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/150455 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17899 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15848 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7708 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127517 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13521 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162335 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15092 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124688 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23698 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19898 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124876 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23688 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135318 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80132 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23289 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19943 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12083 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23298 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23010 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23162 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23064 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->