### PR TITLE
Mail prepends bulleted list with extra blank bullet after send

### DIFF
--- a/LayoutTests/editing/inserting/insert-html-into-list-item-expected.txt
+++ b/LayoutTests/editing/inserting/insert-html-into-list-item-expected.txt
@@ -1,0 +1,20 @@
+This tests that inserting html into an empty list item produces flat sibling list items, not nested ones
+
+Before:
+| "\n"
+| <ul>
+|   <li>
+|     <#selection-caret>
+|     <br>
+| "\n"
+
+After:
+| "\n"
+| <ul>
+|   <li>
+|     "Line one"
+|   <li>
+|     "Line two"
+|   <li>
+|     "Line three<#selection-caret>"
+| "\n"

--- a/LayoutTests/editing/inserting/insert-html-into-list-item.html
+++ b/LayoutTests/editing/inserting/insert-html-into-list-item.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../editing.js"></script>
+<script src="../../resources/dump-as-markup.js"></script>
+</head>
+<body>
+<div id="test" contenteditable>
+<ul><li><br></li></ul>
+</div>
+<script>
+Markup.description('This tests that inserting html into an empty list item produces flat sibling list items, not nested ones');
+
+var listItem = document.querySelector('li');
+setSelectionCommand(listItem, 0, listItem, 0);
+
+Markup.dump('test', 'Before');
+
+insertHTMLCommand('<li>Line one</li><li>Line two</li><li>Line three</li>');
+
+Markup.dump('test', 'After');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/inserting/insert-paste-plain-text-into-list-item-expected.txt
+++ b/LayoutTests/editing/inserting/insert-paste-plain-text-into-list-item-expected.txt
@@ -1,0 +1,22 @@
+This tests that pasting plain text into an empty list item produces flat sibling list items, not nested ones
+
+Before:
+| "\n"
+| <ul>
+|   <li>
+|     <#selection-caret>
+|     <br>
+| "\n"
+
+After:
+| "\n"
+| <ul>
+|   <li>
+|     "Line one"
+|   <li>
+|     "Line two"
+|   <li>
+|     "Line three"
+|   <li>
+|     <#selection-caret>
+| "\n"

--- a/LayoutTests/editing/inserting/insert-paste-plain-text-into-list-item.html
+++ b/LayoutTests/editing/inserting/insert-paste-plain-text-into-list-item.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../editing.js"></script>
+<script src="../../resources/dump-as-markup.js"></script>
+</head>
+<body>
+<textarea id="source">
+Line one
+Line two
+Line three
+</textarea>
+<div id="test" contenteditable>
+<ul><li><br></li></ul>
+</div>
+<script>
+Markup.description('This tests that pasting plain text into an empty list item produces flat sibling list items, not nested ones');
+
+var textarea = document.getElementById('source');
+textarea.focus();
+document.execCommand('SelectAll');
+document.execCommand('Copy');
+
+var listItem = document.querySelector('li');
+setSelectionCommand(listItem, 0, listItem, 0);
+
+Markup.dump('test', 'Before');
+
+document.execCommand('Paste');
+
+Markup.dump('test', 'After');
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -1348,11 +1348,31 @@ void ReplaceSelectionCommand::doApply()
         fragment.removeNode(*refNode);
 
     RefPtr blockStart { enclosingBlock(protect(insertionPos.deprecatedNode())) };
-    bool isInsertingIntoList = (isListHTMLElement(refNode.get()) || (isLegacyAppleStyleSpan(refNode.get()) && isListHTMLElement(refNode->firstChild())))
-    && blockStart && blockStart->renderer()->isRenderListItem() && blockStart->parentNode()->hasEditableStyle();
+
+    bool isListOrLegacyAppleStyleSpanWrappingListElement = isListHTMLElement(refNode.get()) || (isLegacyAppleStyleSpan(refNode.get()) && isListHTMLElement(refNode->firstChild()));
+    bool isBlockStartInEditableList = blockStart && blockStart->renderer()->isRenderListItem() && blockStart->parentNode()->hasEditableStyle();
+    bool isInsertingIntoList = isListOrLegacyAppleStyleSpanWrappingListElement && isBlockStartInEditableList;
+    bool isInsertingIntoListItem = refNode && refNode->hasTagName(liTag) && isStartOfBlock(VisiblePosition(insertionPos));
+
     if (isInsertingIntoList)
         refNode = insertAsListItems(downcast<HTMLElement>(*refNode), blockStart.get(), insertionPos, insertedNodes);
-    else if (isEditablePosition(insertionPos)) {
+    else if (isBlockStartInEditableList && isInsertingIntoListItem) {
+        if (RefPtr parentList = enclosingList(blockStart.get())) {
+            Ref wrapperList = parentList->cloneElementWithoutChildren(document(), nullptr);
+            wrapperList->appendChild(*refNode);
+            while (node && node->hasTagName(liTag)) {
+                RefPtr next = node->nextSibling();
+                fragment.removeNode(*node);
+                wrapperList->appendChild(*node);
+                node = WTF::move(next);
+            }
+            refNode = insertAsListItems(downcast<HTMLElement>(wrapperList.get()), blockStart.get(), insertionPos, insertedNodes);
+            isInsertingIntoList = true;
+            node = refNode->nextSibling();
+        }
+    }
+
+    if (!isInsertingIntoList && isEditablePosition(insertionPos)) {
         insertNodeAt(*refNode, insertionPos);
         insertedNodes.respondToNodeInsertion(refNode.get());
     }


### PR DESCRIPTION
#### e6281bc65176e4c8dd02463ceefe7ec7873b5e89
<pre>
Mail prepends bulleted list with extra blank bullet after send
<a href="https://bugs.webkit.org/show_bug.cgi?id=310311">https://bugs.webkit.org/show_bug.cgi?id=310311</a>
<a href="https://rdar.apple.com/11819519">rdar://11819519</a>

Reviewed by Aditya Keerthi.

When there is an empty list item and plain text gets pasted,
insertAsListItems in ReplaceSelectionCommand::doApply() does not
get called. This is due to refNode as the empty list item, not
a list html element (such as &lt;ol&gt; or &lt;ul&gt;). Thus, isInsertingIntoList
is false.

The plain text which was processed as individual list items (&lt;li&gt;) part of
fragment is appended inside the empty list item (as children of the empty
list item instead of siblings), resulting in the nested &lt;li&gt; that is shown.
Given this invalid/unexpected DOM, serializing and re-parsing this yields
unexpected results, such as empty list items in random places.

To fix this issue, correct the invalid nested list item structure. This is achieved by
adding an additional case: if isInsertingIntoList is false yet refNode is a list item...

- Create a wrapper list to house the refNode list item as well as the other list items
to be appended. As the node is removed from fragment, add them to the wrapper list.

- Once the wrapper list is populated, call insertAsListItems with the wrapper list. This will
ensure the items inside the wrapper list get added to the actual parent list. Now, refNode
points to the last list item that was appended.

Additionally, write a layout test that inserts html to an empty list item and a test that copies
and pastes three lines from a text area into an empty list item. Without this change, the test fails
and yields the nested &lt;li&gt; structure.

* LayoutTests/editing/inserting/insert-html-into-list-item-expected.txt: Added.
* LayoutTests/editing/inserting/insert-html-into-list-item.html: Added.
* LayoutTests/editing/inserting/insert-paste-plain-text-into-list-item-expected.txt: Added.
* LayoutTests/editing/inserting/insert-paste-plain-text-into-list-item.html: Added.
* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
(WebCore::ReplaceSelectionCommand::doApply):

Canonical link: <a href="https://commits.webkit.org/309805@main">https://commits.webkit.org/309805@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0be381b7591af79ece1bb945c3a553ea1c0297e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151719 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24500 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18070 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160459 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105176 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0f4881ff-d36f-45ff-a9a6-ef6fc29f9b28) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153593 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24973 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24793 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117185 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83169 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1da576d3-4582-4a3e-85c0-ab9816fb0eb9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154679 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19326 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136147 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97900 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18412 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16363 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8296 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128042 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14051 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162925 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6074 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15642 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125202 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24299 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20422 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125384 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34033 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24300 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135847 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80875 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20420 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12622 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23916 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88201 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23608 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23768 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23668 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->