### PR TITLE
StyleLineHeight: Add Evaluation<LineHeight, float> specialization

### DIFF
--- a/Source/WebCore/rendering/style/RenderStyle+GettersInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyle+GettersInlines.h
@@ -634,11 +634,6 @@ inline float RenderStyle::computedLineHeight() const
     return m_computedStyle.computedLineHeight();
 }
 
-inline float RenderStyle::computeLineHeight(const Style::LineHeight& lineHeight) const
-{
-    return m_computedStyle.computeLineHeight(lineHeight);
-}
-
 // MARK: - Derived used values
 
 inline UserModify RenderStyle::usedUserModify() const

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -384,7 +384,6 @@ public:
     // MARK: - Derived Values
 
     inline float computedLineHeight() const;
-    inline float computeLineHeight(const Style::LineHeight&) const;
     LayoutBoxExtent imageOutsets(const Style::BorderImage&) const;
     LayoutBoxExtent imageOutsets(const Style::MaskBorder&) const;
     LayoutBoxExtent borderImageOutsets() const;

--- a/Source/WebCore/style/computed/StyleComputedStyle.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyle.cpp
@@ -29,6 +29,7 @@
 #include "Pagination.h"
 #include "StyleComputedStyleBase+ConstructionInlines.h"
 #include "StyleCustomPropertyRegistry.h"
+#include "StyleLineHeight.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
 #include "StyleScaleTransformFunction.h"
 #include <wtf/MathExtras.h>
@@ -209,25 +210,7 @@ bool ComputedStyle::borderAndBackgroundEqual(const ComputedStyle& other) const
 
 float ComputedStyle::computedLineHeight() const
 {
-    return computeLineHeight(lineHeight());
-}
-
-float ComputedStyle::computeLineHeight(const LineHeight& lineHeight) const
-{
-    return WTF::switchOn(lineHeight,
-        [&](const CSS::Keyword::Normal&) -> float {
-            return metricsOfPrimaryFont().lineSpacing();
-        },
-        [&](const LineHeight::Fixed& fixed) -> float {
-            return evaluate<LayoutUnit>(fixed, usedZoomForLength()).toFloat();
-        },
-        [&](const LineHeight::Percentage& percentage) -> float {
-            return evaluate<LayoutUnit>(percentage, LayoutUnit { computedFontSize() }).toFloat();
-        },
-        [&](const LineHeight::Calc& calc) -> float {
-            return evaluate<LayoutUnit>(calc, LayoutUnit { computedFontSize() }, usedZoomForLength()).toFloat();
-        }
-    );
+    return evaluate<float>(lineHeight(), LineHeightEvaluationContext { computedFontSize(), metricsOfPrimaryFont().lineSpacing() }, usedZoomForLength());
 }
 
 bool ComputedStyle::scrollSnapDataEquivalent(const ComputedStyle& other) const

--- a/Source/WebCore/style/computed/StyleComputedStyle.h
+++ b/Source/WebCore/style/computed/StyleComputedStyle.h
@@ -74,7 +74,6 @@ public:
     // MARK: - Derived Values
 
     WEBCORE_EXPORT float computedLineHeight() const;
-    float computeLineHeight(const LineHeight&) const;
 
     // MARK: - Non-property initial values.
 

--- a/Source/WebCore/style/values/inline/StyleLineHeight.cpp
+++ b/Source/WebCore/style/values/inline/StyleLineHeight.cpp
@@ -29,6 +29,7 @@
 #include "AnimationUtilities.h"
 
 #include "CSSPropertyParserConsumer+Font.h"
+#include "StylePrimitiveNumericTypes+Evaluation.h"
 #include "RenderStyle+GettersInlines.h"
 #include "StyleBuilderChecking.h"
 #include "StyleLengthWrapper+Blending.h"
@@ -150,6 +151,27 @@ auto Blending<LineHeight>::blend(const LineHeight& a, const LineHeight& b, const
             context
         );
     }
+}
+
+// MARK: - Evaluation
+
+auto Evaluation<LineHeight, float>::operator()(
+    const LineHeight& lineHeight, LineHeightEvaluationContext context, ZoomFactor zoom) -> float
+{
+    return WTF::switchOn(lineHeight,
+        [&](const LineHeight::Fixed& fixed) {
+            return evaluate<LayoutUnit>(fixed, zoom).toFloat();
+        },
+        [&](const LineHeight::Percentage& percentage) {
+            return evaluate<LayoutUnit>(percentage, LayoutUnit { context.computedFontSize }).toFloat();
+        },
+        [&](const LineHeight::Calc& calc) {
+            return evaluate<LayoutUnit>(calc, LayoutUnit { context.computedFontSize }, zoom).toFloat();
+        },
+        [&](const CSS::Keyword::Normal&) {
+            return context.lineSpacing;
+        }
+    );
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/inline/StyleLineHeight.h
+++ b/Source/WebCore/style/values/inline/StyleLineHeight.h
@@ -64,6 +64,17 @@ template<> struct Blending<LineHeight> {
     auto blend(const LineHeight&, const LineHeight&, const BlendingContext&) -> LineHeight;
 };
 
+// MARK: - Evaluation
+
+struct LineHeightEvaluationContext {
+    float computedFontSize;
+    float lineSpacing;
+};
+
+template<> struct Evaluation<LineHeight, float> {
+    auto operator()(const LineHeight&, LineHeightEvaluationContext, ZoomFactor) -> float;
+};
+
 } // namespace Style
 } // namespace WebCore
 

--- a/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
+++ b/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
@@ -41,6 +41,7 @@
 #include "RenderStyle.h"
 #include "RenderStyle+GettersInlines.h"
 #include "RenderView.h"
+#include "StyleLineHeight.h"
 #include "StylePrimitiveNumericTypes+Conversions.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
 
@@ -330,11 +331,11 @@ double computeNonCalcLengthDouble(double value, CSS::LengthUnit lengthUnit, cons
         break;
 
     case Rlh:
-        if (conversionData.rootStyle()) {
+        if (auto* rootStyle = conversionData.rootStyle()) {
             if (conversionData.computingLineHeight() || conversionData.computingFontSize())
-                value *= conversionData.rootStyle()->computeLineHeight(conversionData.rootStyle()->specifiedLineHeight());
+                value *= Style::evaluate<float>(rootStyle->specifiedLineHeight(), Style::LineHeightEvaluationContext { rootStyle->computedFontSize(), rootStyle->metricsOfPrimaryFont().lineSpacing() }, rootStyle->usedZoomForLength());
             else
-                value *= conversionData.rootStyle()->computedLineHeight();
+                value *= rootStyle->computedLineHeight();
         }
         break;
 


### PR DESCRIPTION
#### a4e11ec0893d1e55ed22826a5bfe0491e29dc2ce
<pre>
StyleLineHeight: Add Evaluation&lt;LineHeight, float&gt; specialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=310318">https://bugs.webkit.org/show_bug.cgi?id=310318</a>
<a href="https://rdar.apple.com/172959114">rdar://172959114</a>

Reviewed by Sammy Gill.

Add an Evaluation&lt;LineHeight, float&gt; specialization so that LineHeight can be
evaluated with an explicit ZoomFactor via the standard evaluate&lt;&gt; template,
matching the pattern used by other properties. Therefore, computeLineHeight
is no longer needed and computedLineHeight delegates to evaluate directly.

* Source/WebCore/rendering/style/RenderStyle+GettersInlines.h:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/style/computed/StyleComputedStyle.cpp:
(WebCore::Style::ComputedStyle::computedLineHeight):
* Source/WebCore/style/computed/StyleComputedStyle.h:
* Source/WebCore/style/values/inline/StyleLineHeight.cpp:
(WebCore::Style::Evaluation&lt;LineHeight, float&gt;::operator()):
* Source/WebCore/style/values/inline/StyleLineHeight.h:
* Source/WebCore/style/values/primitives/StyleLengthResolution.cpp:
(WebCore::Style::computeNonCalcLengthDouble):

Canonical link: <a href="https://commits.webkit.org/309625@main">https://commits.webkit.org/309625@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/268c2784f20b4f6a3b83f7ac10948f053ab3cb0b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151141 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23903 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17474 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159870 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104577 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/09c63145-1f8d-49be-973d-020805f39343) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153014 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24334 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24130 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116686 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82830 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/45e6b309-ff40-4b8c-8dae-24aeb39c13b5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154101 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18808 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135614 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97407 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17901 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15853 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7715 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127519 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13531 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162342 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5467 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15102 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124695 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23705 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19903 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124883 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33900 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23695 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135328 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80139 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19947 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12093 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23305 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87599 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23017 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23169 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23071 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->