### PR TITLE
[JSC] Add comments explaining PropertyInlineCache and subclasses

### DIFF
--- a/Source/JavaScriptCore/bytecode/PropertyInlineCache.h
+++ b/Source/JavaScriptCore/bytecode/PropertyInlineCache.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -98,6 +98,30 @@ enum class AccessType : int8_t {
 #define JSC_INCREMENT_ACCESS_TYPE(name) + 1
 static constexpr unsigned numberOfAccessTypes = 0 JSC_FOR_EACH_PROPERTY_INLINE_CACHE_ACCESS_TYPE(JSC_INCREMENT_ACCESS_TYPE);
 #undef JSC_INCREMENT_ACCESS_TYPE
+
+// This file defines two distinct inline cache (IC) dispatch strategies used across
+// JSC's JIT tiers. Both strategies work the same way conceptually: each IC site is
+// guarded by one or more conditions, either runtime checks (e.g. a structureID
+// comparison, a property UID check) or Watchpoints on values assumed to be stable.
+// When a guard passes, the IC performs the cached access; when it fails, we fall
+// through to the next case or the slow path, which may add new cases.
+//
+// The two strategies differ in how they store and dispatch through those cases:
+//
+//   HandlerIC: used by Baseline JIT and DFG. The call site never modifies machine
+//   code; instead it loads a pointer to the head of a singly-linked list of
+//   InlineCacheHandler nodes and dispatches through them at runtime.
+//
+//   RepatchingIC: used by FTL only. The call site owns a fixed-size
+//   slab of inline machine code embedded in the compiled function body. That slab
+//   is rewritten at runtime as new cases are learned.
+//
+// The choice between them is a throughput vs. cost tradeoff. RepatchingIC can generate
+// bespoke, case-specific code and, once sufficiently polymorphic, dispatch via a binary switch,
+// which is meaningfully faster than walking a chain of indirect branches.
+// However, rewriting machine code at runtime is expensive. So we only pay that
+// cost in the FTL, where we have substantially more profiling and thus think the code
+// is most likely to be in a steady state.
 
 enum class PropertyInlineCacheType : uint8_t { Handler, Repatching };
 
@@ -463,8 +487,99 @@ public:
     const PropertyInlineCacheType m_icType : 1;
 };
 
-// HandlerPropertyInlineCache: Used by Baseline JIT and DFG.
-// Data-only dispatch through a handler chain — code is never rewritten.
+// HandlerPropertyInlineCache
+// ==========================
+// Implements handler-list dispatch. The call site never modifies machine code;
+// instead, as new cases are learned, handler nodes are prepended to a linked list
+// that the call site walks at runtime.
+//
+// Call site layout (Baseline / DFG JIT):
+//
+//     load  handlerGPR, [PropertyInlineCache + offsetOfHandler]   // head of list
+//     call  [handlerGPR + InlineCacheHandler::offsetOfJumpTarget] // enter first handler
+//
+// Handler chain layout in memory:
+//
+//   PropertyInlineCache
+//   +------------------+
+//   | m_handler        |---> InlineCacheHandler #N  (most recently added, checked first)
+//   +------------------+     +-------------------+
+//                            | structureID        |
+//                            | offset / uid       |
+//                            | m_next             |---> InlineCacheHandler #N-1
+//                            +-------------------+     +-------------------+
+//                                                      | ...               |
+//                                                      | m_next            |---> (slow-path handler)
+//                                                      +-------------------+
+//
+// Most handler stub follows a uniform pattern compiled by InlineCacheCompiler::compileHandler():
+//
+//     emitDataICPrologue()       // save frame pointer; does NOT update callFrameRegister
+//     check guard                // e.g. do a structure check: load from base, compare against
+//                                //   [handlerGPR + offsetOfStructureID]
+//     --- on match ---
+//     perform access             // load / store / call, depending on AccessCase kind
+//     emitDataICEpilogue()       // restore frame pointer
+//     return
+//     --- on miss ---
+//     load  handlerGPR, [handlerGPR + offsetOfNext]
+//     jump  [handlerGPR + offsetOfJumpTarget]            // offset skips prologue
+//
+// Not modifying callFrameRegister is important because it means handler stubs execute in the
+// caller's frame context. Thus, exception unwinding and access to CallFrame* via
+// callFrameRegister require no special handling in the handler prologue/epilogue.
+//
+// The terminal handler is always the slow-path. It calls m_slowOperation
+// to fall back to the C++ runtime. The slow path may generate and prepend a new
+// InlineCacheHandler to the front of the list (LIFO ordering).
+//
+// Cached-field fast path (m_inlinedHandler):
+//
+// For simple access patterns (GetByIdSelf, PutByIdReplace, InByIdSelf, etc.) that match
+// preconfiguredCacheType, we also store the handler in m_inlinedHandler and write the
+// structure, offset, and holder into the IC's own fields (m_inlineAccessBaseStructureID,
+// byIdSelfOffset, m_inlineHolder). The JIT emits a structure check inline at the call
+// site (before loading m_handler) that can succeed without touching the chain at all.
+// These fields are read from memory at runtime, so no constants are embedded in the
+// generated assembly.
+//
+// Watchpoint invalidation:
+//
+// Some access cases (e.g. loading a property from a prototype assumed not to change)
+// attach a PropertyInlineCacheClearingWatchpoint to the relevant WatchpointSet. When
+// the watchpoint fires, PropertyInlineCacheClearingWatchpoint::fireInternal() eventually calls
+// resetStubAsJumpInAccess(). That function walks the entire m_handler chain calling
+// removeOwner() on each node, then assigns m_handler to a freshly generated slow-path
+// handler, dropping the old chain's RefPtr and potentially running every
+// InlineCacheHandler destructor in the chain.
+//
+// N.B. A watchpoint can fire while a handler stub is mid-execution — for example, a
+// getter or custom accessor calls JS, that JS mutates a prototype, and the watchpoint
+// fires before the getter returns. We rely on two distinct practices to avoid
+// use-after-free:
+//
+//   1. InlineCacheHandler struct: if the chain is reset while a stub is on the
+//      stack and no other Ref holds the node, the InlineCacheHandler wrapper and its
+//      trailing DataOnlyCallLinkInfo array are freed immediately. This is safe because
+//      handler stubs access InlineCacheHandler fields only before making calls: the
+//      structure check and the m_next load both occur on the miss path, ahead of any
+//      JS call. After the call returns, the result is in a register and the stub
+//      performs the epilogue and returns without touching the handler struct again.
+//
+//   2. Machine code: each InlineCacheHandler holds a
+//      Ref<GCAwareJITStubRoutine>. GCAwareJITStubRoutine does not free the routine
+//      immediately when its refcount reaches zero; it sets m_isJettisoned = true and
+//      defers actual deletion until the GC confirms that the routine is no longer on
+//      any call stack. So the code being executed remains valid even if m_handler is
+//      cleared under us.
+//
+// Shared handler thunks:
+//
+// Many common handler shapes (e.g. getByIdLoadOwnPropertyHandler, putByIdReplaceHandler)
+// are pre-compiled as shared thunks stored in VM::m_sharedJITStubs. compileHandler()
+// reuses an existing shared stub before generating a new one, so multiple IC sites with
+// the same access pattern share the same machine code. This sharing works because
+// everything is data only, unlike with repatching ICs.
 class HandlerPropertyInlineCache final : public PropertyInlineCache {
     WTF_MAKE_NONCOPYABLE(HandlerPropertyInlineCache);
 public:
@@ -488,8 +603,77 @@ public:
     RefPtr<InlineCacheHandler> m_inlinedHandler;
 };
 
-// RepatchingPropertyInlineCache: Used by FTL (when handler IC is not enabled) and 32-bit DFG.
-// Classic inline cache where code is recompiled/repatched on the fly.
+// RepatchingPropertyInlineCache
+// =============================
+// Implements slab-patching dispatch (used by FTL only). The call site owns a
+// fixed-size region of inline machine code embedded in the compiled function body.
+// When new cases are learned, we rewrite either that slab in place, or a
+// separately-allocated stub it jumps to.
+//
+// Inline code region layout inside the JIT-compiled function body:
+//
+//   startLocation --> +--------------------------------------+
+//                     |  inline IC code (inlineCodeSize      |
+//                     |  bytes; initially: call to slow path)|
+//                     +--------------------------------------+
+//   doneLocation  --> (next instruction in the function)
+//
+// The IC evolves through the following states:
+//
+//   1. [slow path]: initial state; the slab contains a call to operationXyzOptimize.
+//
+//   2. [inline access]: after the first hit. InlineAccess patches the slab in-place
+//      with a monomorphic structure check and access (e.g. a direct load at a known
+//      offset). No separate stub is needed yet.
+//
+//   3. [jump -> stub]: when a second structure is seen, rewireStubAsJumpInAccess()
+//      overwrites the slab with a direct jump to a PolymorphicAccess stub. The stub
+//      holds all accumulated AccessCases compiled together by InlineCacheCompiler::compile().
+//
+// The stub uses one of two dispatch strategies, chosen when the stub is (re)generated:
+//
+//   Cascade (linear, newest-first):
+//       case N:   check guard --match--> perform access, jump to doneLocation
+//                              --miss --> fall through
+//       case N-1: check guard --match--> perform access, jump to doneLocation
+//                              --miss --> fall through
+//       ...
+//       slow path
+//
+//   BinarySwitch (O(log n)):  used when every case is guarded solely by a structure
+//       check (no proxies, no non-structure guards). A balanced binary tree of
+//       structureID comparisons is emitted; each leaf performs its access and jumps
+//       to doneLocation. We cannot use this form if any case involves a proxy, since
+//       proxies require additional checks beyond the structureID.
+//
+// Because compiling a new stub is expensive, new cases are buffered in the
+// PolymorphicAccess case list and the stub is only regenerated when bufferingCountdown
+// reaches zero (reset to Options::repatchBufferingCountdown() after each regeneration).
+// This batches multiple new cases into a single regeneration pass.
+//
+// Why only in FTL:
+//
+// Rewriting machine code at runtime incurs instruction cache flushes and, on some
+// platforms, requires toggling memory write permissions. The generated stub code is
+// also bespoke (built for exactly the set of cases we have seen), so every new case
+// requires a full recompile of the entire stub. The payoff is tight dispatch: no
+// indirect branches through a handler chain, and potentially O(log n) dispatch via
+// binary switch. This tradeoff is only worthwhile in the FTL, where a function is
+// hot enough to amortize the patching cost over many executions.
+//
+// Watchpoint invalidation:
+//
+// Cases that depend on stable conditions (prototype-chain stability, equivalence of a
+// property value, etc.) register watchpoints on the relevant WatchpointSets. When a
+// watchpoint fires, PropertyInlineCacheClearingWatchpoint::fireInternal() eventually calls
+// resetStubAsJumpInAccess(). For RepatchingIC that function overwrites the inline slab
+// with a jump back to the slow path and drops the reference to the PolymorphicAccess
+// stub; the IC then begins accumulating cases from scratch.
+//
+// If a stub is mid-execution when the watchpoint fires (e.g. a polymorphic accessor
+// case calls JS), the machine code is protected by GCAwareJITStubRoutine (as described above),
+// this guarantees the code of the stub is still valid. No inline slabs can be at the
+// first instruction when this rewrite happens either.
 class RepatchingPropertyInlineCache final : public PropertyInlineCache {
     WTF_MAKE_NONCOPYABLE(RepatchingPropertyInlineCache);
 public:


### PR DESCRIPTION
#### eaba1c267428516c010a7ede5ae9844a4c8f9ed3
<pre>
[JSC] Add comments explaining PropertyInlineCache and subclasses
<a href="https://bugs.webkit.org/show_bug.cgi?id=310320">https://bugs.webkit.org/show_bug.cgi?id=310320</a>
<a href="https://rdar.apple.com/172964358">rdar://172964358</a>

Reviewed by Justin Michaud.

This system is pretty hard to follow if you don&apos;t already know how it
works. The comments provide a high level summary along with some
important invariants.

Canonical link: <a href="https://commits.webkit.org/309680@main">https://commits.webkit.org/309680@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2640213d3a567b8206d3580b34b9543e5947236f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151149 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23911 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17482 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159878 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104585 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8a62fe11-20a6-4f62-bfd8-d714233ed097) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24342 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24140 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116694 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82832 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b72cdcd7-a7e7-4cd9-af59-5ff46d4093c6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154109 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18817 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135619 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97415 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c67e21d9-a823-4e7d-abc8-e7cc3bedb711) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17910 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15859 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7723 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/143133 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127528 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13536 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162350 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/11948 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5475 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15107 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124703 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23713 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19909 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124891 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23703 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135333 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80147 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23260 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19955 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12098 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/182758 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23313 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87607 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46639 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23025 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23177 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23079 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->