### PR TITLE
[WKCI][WPE][GTK] Make the steps for GTK/WPE WK2 testing on the EWS less likely to mark as good patches introducing new flakes.

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -109,6 +109,7 @@ class ParseByLineLogObserver(logobserver.LineConsumerLogObserver):
             return
 
 
+# Buildbot messages about timeout reached appear on the header stream of BufferLog
 class BufferLogHeaderObserver(logobserver.BufferLogObserver):
 
     def __init__(self, **kwargs):
@@ -4238,7 +4239,7 @@ class RunWebKitTests(shell.Test, AddToLogMixin, ShellMixin):
         return result
 
     @defer.inlineCallbacks
-    def run(self, BufferLogObserverClass=logobserver.BufferLogObserver):
+    def run(self, BufferLogObserverClass=BufferLogHeaderObserver):
         self.log_observer = BufferLogObserverClass(wantStderr=True)
         self.addLogObserver('stdio', self.log_observer)
         self.log_observer_json = logobserver.BufferLogObserver()
@@ -4251,6 +4252,15 @@ class RunWebKitTests(shell.Test, AddToLogMixin, ShellMixin):
 
     # FIXME: This will break if run-webkit-tests changes its default log formatter.
     nrwt_log_message_regexp = re.compile(r'\d{2}:\d{2}:\d{2}(\.\d+)?\s+\d+\s+(?P<message>.*)')
+
+    def _did_command_timed_out(self, logHeadersText):
+        timed_out_line_start = f'command timed out: {self.timeout} seconds elapsed running'
+        timed_out_line_end = 'attempting to kill'
+        for line in logHeadersText.splitlines():
+            line = line.strip()
+            if line.startswith(timed_out_line_start) and line.endswith(timed_out_line_end):
+                return True
+        return False
 
     def _strip_python_logging_prefix(self, line):
         match_object = self.nrwt_log_message_regexp.match(line)
@@ -4309,6 +4319,8 @@ class RunWebKitTests(shell.Test, AddToLogMixin, ShellMixin):
                 self.setProperty('first_run_failures_filtered', sorted(self.failing_tests_filtered))
                 self.setProperty('results-db_first_run_pre_existing', sorted(self.preexisting_failures_in_results_db))
 
+        command_timedout = self._did_command_timed_out(self.log_observer.getHeaders())
+        self.setProperty('first_run_timedout', command_timedout)
         self._parseRunWebKitTestsOutput(logText)
 
     @defer.inlineCallbacks
@@ -4372,6 +4384,10 @@ class RunWebKitTests(shell.Test, AddToLogMixin, ShellMixin):
 
         return result
 
+    def _next_steps_for_platform(self, platform):
+        # method overriden in subclass RunWebKitTestsRedTree
+        return []
+
     def evaluateCommand(self, cmd):
         rc = self.evaluateResult(cmd)
         previous_build_summary = self.getProperty('build_summary', '')
@@ -4415,7 +4431,9 @@ class RunWebKitTests(shell.Test, AddToLogMixin, ShellMixin):
                 ExtractTestResults(),
                 ValidateChange(verifyBugClosed=False, addURLs=False),
             ]
-            if GitHub.NO_FAILURE_LIMITS_LABEL not in self.getProperty('github_labels', []):
+            if platform in ['gtk', 'wpe']:
+                steps_to_add += self._next_steps_for_platform(platform)
+            elif GitHub.NO_FAILURE_LIMITS_LABEL not in self.getProperty('github_labels', []):
                 steps_to_add += [
                     KillOldProcesses(),
                     ReRunWebKitTests(),
@@ -4705,6 +4723,7 @@ class RunWebKitTestsWithoutChange(RunWebKitTests):
 
     def evaluateCommand(self, cmd):
         rc = shell.Test.evaluateCommand(self, cmd)
+        platform = self.getProperty('platform')
         steps_to_add = []
 
         if SHOULD_FILTER_LOGS is True:
@@ -4720,7 +4739,13 @@ class RunWebKitTestsWithoutChange(RunWebKitTests):
                     content_type='text/plain',
                 )
             ]
-        steps_to_add += [ArchiveTestResults(), UploadTestResults(identifier='clean-tree'), ExtractTestResults(identifier='clean-tree'), AnalyzeLayoutTestsResults()]
+
+        steps_to_add += [
+            ArchiveTestResults(),
+            UploadTestResults(identifier='clean-tree'),
+            ExtractTestResults(identifier='clean-tree'),
+            AnalyzeLayoutTestsResultsRedTree() if platform in ['gtk', 'wpe'] else AnalyzeLayoutTestsResults()
+        ]
         self.build.addStepsAfterCurrentStep(steps_to_add)
         self.setProperty('clean_tree_run_status', rc)
         return rc
@@ -5060,158 +5085,42 @@ class RunWebKit1Tests(RunWebKitTests):
 
 
 # This is a specialized class designed to cope with a tree that is not always green.
-# It tries hard to avoid reporting any false positive, so it will only report new
-# consistent failures (fail always with the patch and pass always without it).
+# It tries hard to avoid reporting any false positive.
 class RunWebKitTestsRedTree(RunWebKitTests):
     EXIT_AFTER_FAILURES = 500
 
-    def _did_command_timed_out(self, logHeadersText):
-        timed_out_line_start = 'command timed out: {} seconds elapsed running'.format(self.MAX_SECONDS_STEP_RUN)
-        timed_out_line_end = 'attempting to kill'
-        for line in logHeadersText.splitlines():
-            line = line.strip()
-            if line.startswith(timed_out_line_start) and line.endswith(timed_out_line_end):
-                return True
-        return False
-
-    def evaluateCommand(self, cmd):
+    def _next_steps_for_platform(self, platform):
+        steps_to_add = []
         first_results_failing_tests = set(self.getProperty('first_run_failures', []))
         first_results_flaky_tests = set(self.getProperty('first_run_flakies', []))
-        platform = self.getProperty('platform')
-        rc = self.evaluateResult(cmd)
-        steps_to_add = []
-
-        if SHOULD_FILTER_LOGS is True:
-            steps_to_add = [
-                GenerateS3URL(
-                    f"{self.getProperty('fullPlatform')}-{self.getProperty('archForUpload')}-{self.getProperty('configuration')}-{self.name}",
-                    extension='txt',
-                    additions=f'{self.build.number}',
-                    content_type='text/plain',
-                ), UploadFileToS3(
-                    'logs.txt',
-                    links={self.name: 'Full logs'},
-                    content_type='text/plain',
-                )
-            ]
-        steps_to_add += [ArchiveTestResults(), UploadTestResults(), ExtractTestResults()]
-        if first_results_failing_tests:
-            steps_to_add.extend([ValidateChange(verifyBugClosed=False, addURLs=False), KillOldProcesses(), RunWebKitTestsRepeatFailuresRedTree()])
+        first_run_timedout = self.getProperty('first_run_timedout', False)
+        retry_count = int(self.getProperty('retry_count', 0))
+        step_to_add_without_patch = None
+        if first_run_timedout and retry_count < AnalyzeLayoutTestsResultsRedTree.MAX_RETRY:
+            steps_to_add.append(AnalyzeLayoutTestsResultsRedTree())
+        elif first_results_failing_tests:
+            step_to_add_without_patch = RunWebKitTestsRepeatFailuresWithoutChangeRedTree()
         elif first_results_flaky_tests:
             steps_to_add.append(AnalyzeLayoutTestsResultsRedTree())
-        elif rc == SUCCESS or rc == WARNINGS:
-            steps_to_add = None
-            message = 'Passed layout tests'
-            self.descriptionDone = message
-            self.build.results = SUCCESS
-            self.setProperty('build_summary', message)
         else:
             # We have a failure return code but not a list of failed or flaky tests, so we can't run the repeat steps.
             # If we are on the last retry then run the whole layout tests without patch.
             # If not, then go to analyze-layout-tests-results where we will retry everything hoping this was a random failure.
-            retry_count = int(self.getProperty('retry_count', 0))
             if retry_count < AnalyzeLayoutTestsResultsRedTree.MAX_RETRY:
                 steps_to_add.append(AnalyzeLayoutTestsResultsRedTree())
             else:
-                steps_to_add.extend([RevertAppliedChanges(), CleanWorkingDirectory()])
-                if platform == 'wpe':
-                    steps_to_add.append(InstallWpeDependencies())
-                elif platform == 'gtk':
-                    steps_to_add.append(InstallGtkDependencies())
-                steps_to_add.extend([
-                    CompileWebKitWithoutChange(retry_build_on_failure=True),
-                    ValidateChange(verifyBugClosed=False, addURLs=False),
-                    RunWebKitTestsWithoutChangeRedTree(),
-                ])
-        if steps_to_add:
-            self.build.addStepsAfterCurrentStep(steps_to_add)
-        return rc
-
-
-class RunWebKitTestsRepeatFailuresRedTree(RunWebKitTestsRedTree):
-    name = 'layout-tests-repeat-failures'
-    NUM_REPEATS_PER_TEST = 10
-    EXIT_AFTER_FAILURES = None
-    MAX_SECONDS_STEP_RUN = 18000  # 5h
-
-    def __init__(self, **kwargs):
-        super().__init__(maxTime=self.MAX_SECONDS_STEP_RUN, **kwargs)
-
-    def setLayoutTestCommand(self):
-        super().setLayoutTestCommand()
-        # On the repeat steps we don't enable coredump generation (makes the run much slower if there are crashes)
-        self.command = [arg for arg in self.command if arg != '--enable-core-dumps-nolimit']
-        first_results_failing_tests = set(self.getProperty('first_run_failures', []))
-        self.command += ['--fully-parallel', '--repeat-each=%s' % self.NUM_REPEATS_PER_TEST] + sorted(first_results_failing_tests)
-
-    def evaluateCommand(self, cmd):
-        with_change_repeat_failures_results_nonflaky_failures = set(self.getProperty('with_change_repeat_failures_results_nonflaky_failures', []))
-        with_change_repeat_failures_results_flakies = set(self.getProperty('with_change_repeat_failures_results_flakies', []))
-        with_change_repeat_failures_timedout = self.getProperty('with_change_repeat_failures_timedout', False)
-        first_results_flaky_tests = set(self.getProperty('first_run_flakies', []))
-        platform = self.getProperty('platform')
-        rc = self.evaluateResult(cmd)
-        self.setProperty('with_change_repeat_failures_retcode', rc)
-        steps_to_add = []
-
-        if SHOULD_FILTER_LOGS is True:
-            steps_to_add = [
-                GenerateS3URL(
-                    f"{self.getProperty('fullPlatform')}-{self.getProperty('archForUpload')}-{self.getProperty('configuration')}-{self.name}",
-                    extension='txt',
-                    additions=f'{self.build.number}',
-                    content_type='text/plain',
-                ), UploadFileToS3(
-                    'logs.txt',
-                    links={self.name: 'Full logs'},
-                    content_type='text/plain',
-                )
-            ]
-        steps_to_add += [ArchiveTestResults(), UploadTestResults(identifier='repeat-failures'), ExtractTestResults(identifier='repeat-failures')]
-        if with_change_repeat_failures_results_nonflaky_failures or with_change_repeat_failures_timedout:
-            steps_to_add.extend([
-                ValidateChange(verifyBugClosed=False, addURLs=False),
+                step_to_add_without_patch = RunWebKitTestsWithoutChangeRedTree()
+        if step_to_add_without_patch:
+            steps_to_add += [
                 KillOldProcesses(),
                 RevertAppliedChanges(),
                 CleanWorkingDirectory(),
-            ])
-            if platform == 'wpe':
-                steps_to_add.append(InstallWpeDependencies())
-            elif platform == 'gtk':
-                steps_to_add.append(InstallGtkDependencies())
-            steps_to_add.extend([
+                InstallGtkDependencies() if platform == 'gtk' else InstallWpeDependencies(),
                 CompileWebKitWithoutChange(retry_build_on_failure=True),
                 ValidateChange(verifyBugClosed=False, addURLs=False),
-                RunWebKitTestsRepeatFailuresWithoutChangeRedTree(),
-            ])
-        else:
-            steps_to_add.append(AnalyzeLayoutTestsResultsRedTree())
-        if steps_to_add:
-            self.build.addStepsAfterCurrentStep(steps_to_add)
-        return rc
-
-    @defer.inlineCallbacks
-    def runCommand(self, command):
-        yield shell.Test.runCommand(self, command)
-        yield self._addToLog('json', '\n')
-        logText = self.log_observer.getStdout() + self.log_observer.getStderr()
-        logTextJson = self.log_observer_json.getStdout().rstrip()
-        with_change_repeat_failures_results = LayoutTestFailures.results_from_string(logTextJson)
-        if with_change_repeat_failures_results:
-            self.setProperty('with_change_repeat_failures_results_exceed_failure_limit', with_change_repeat_failures_results.did_exceed_test_failure_limit)
-            self.setProperty('with_change_repeat_failures_results_nonflaky_failures', sorted(with_change_repeat_failures_results.failing_tests))
-            self.setProperty('with_change_repeat_failures_results_flakies', sorted(with_change_repeat_failures_results.flaky_tests))
-            if with_change_repeat_failures_results.failing_tests:
-                yield self._addToLog(self.test_failures_log_name, '\n'.join(with_change_repeat_failures_results.failing_tests))
-        command_timedout = self._did_command_timed_out(self.log_observer.getHeaders())
-        self.setProperty('with_change_repeat_failures_timedout', command_timedout)
-        self._parseRunWebKitTestsOutput(logText)
-
-    @defer.inlineCallbacks
-    def run(self):
-        # buildbot messages about timeout reached appear on the header stream of BufferLog
-        rc = yield super().run(BufferLogObserverClass=BufferLogHeaderObserver)
-        defer.returnValue(rc)
+                step_to_add_without_patch
+            ]
+        return steps_to_add
 
 
 class RunWebKitTestsRepeatFailuresWithoutChangeRedTree(RunWebKitTestsRedTree):
@@ -5227,15 +5136,12 @@ class RunWebKitTestsRepeatFailuresWithoutChangeRedTree(RunWebKitTestsRedTree):
         super().setLayoutTestCommand()
         # On the repeat steps we don't enable coredump generation (makes the run much slower if there are crashes)
         self.command = [arg for arg in self.command if arg != '--enable-core-dumps-nolimit']
-        with_change_nonflaky_failures = set(self.getProperty('with_change_repeat_failures_results_nonflaky_failures', []))
         first_run_failures = set(self.getProperty('first_run_failures', []))
-        with_change_repeat_failures_timedout = self.getProperty('with_change_repeat_failures_timedout', False)
-        failures_to_repeat = first_run_failures if with_change_repeat_failures_timedout else with_change_nonflaky_failures
         # Pass '--skipped=always' to ensure that any test passed via command line arguments
         # is skipped anyways if is marked as such on the Expectation files or if is marked
         # as failure (since we are passing also '--skip-failing-tests'). That way we ensure
         # to report the case of a change removing an expectation that still fails with it.
-        self.command += ['--fully-parallel', '--repeat-each=%s' % self.NUM_REPEATS_PER_TEST, '--skipped=always'] + sorted(failures_to_repeat)
+        self.command += ['--fully-parallel', '--repeat-each=%s' % self.NUM_REPEATS_PER_TEST, '--skipped=always'] + sorted(first_run_failures)
 
     def evaluateCommand(self, cmd):
         rc = self.evaluateResult(cmd)
@@ -5276,38 +5182,9 @@ class RunWebKitTestsRepeatFailuresWithoutChangeRedTree(RunWebKitTestsRedTree):
         self.setProperty('without_change_repeat_failures_timedout', command_timedout)
         self._parseRunWebKitTestsOutput(logText)
 
-    @defer.inlineCallbacks
-    def run(self):
-        # buildbot messages about timeout reached appear on the header stream of BufferLog
-        rc = yield super().run(BufferLogObserverClass=BufferLogHeaderObserver)
-        defer.returnValue(rc)
-
 
 class RunWebKitTestsWithoutChangeRedTree(RunWebKitTestsWithoutChange):
     EXIT_AFTER_FAILURES = 500
-
-    def evaluateCommand(self, cmd):
-        rc = shell.Test.evaluateCommand(self, cmd)
-        steps_to_add = []
-
-        if SHOULD_FILTER_LOGS is True:
-            steps_to_add = [
-                GenerateS3URL(
-                    f"{self.getProperty('fullPlatform')}-{self.getProperty('archForUpload')}-{self.getProperty('configuration')}-{self.name}",
-                    extension='txt',
-                    additions=f'{self.build.number}',
-                    content_type='text/plain',
-                ), UploadFileToS3(
-                    'logs.txt',
-                    links={self.name: 'Full logs'},
-                    content_type='text/plain',
-                )
-            ]
-
-        steps_to_add += [ArchiveTestResults(), UploadTestResults(identifier='clean-tree'), ExtractTestResults(identifier='clean-tree'), AnalyzeLayoutTestsResultsRedTree()]
-        self.build.addStepsAfterCurrentStep(steps_to_add)
-        self.setProperty('clean_tree_run_status', rc)
-        return rc
 
 
 class AnalyzeLayoutTestsResultsRedTree(AnalyzeLayoutTestsResults):
@@ -5386,23 +5263,25 @@ class AnalyzeLayoutTestsResultsRedTree(AnalyzeLayoutTestsResults):
         first_results_exceed_failure_limit = self.getProperty('first_results_exceed_failure_limit', False)
         first_run_failures = set(self.getProperty('first_run_failures', []))
         first_run_flakies = set(self.getProperty('first_run_flakies', []))
+        first_run_timedout = self.getProperty('first_run_timedout', False)
 
-        # Run with change, running first_run_failures 10 times each test
-        with_change_repeat_failures_results_exceed_failure_limit = self.getProperty('with_change_repeat_failures_results_exceed_failure_limit', False)
-        with_change_repeat_failures_results_nonflaky_failures = set(self.getProperty('with_change_repeat_failures_results_nonflaky_failures', []))
-        with_change_repeat_failures_results_flakies = set(self.getProperty('with_change_repeat_failures_results_flakies', []))
-        with_change_repeat_failures_timedout = self.getProperty('with_change_repeat_failures_timedout', False)
-
-        # Run without change, running with_change_repeat_failures_results_nonflaky_failures 10 times each test
+        # Run without change, running first_run_failures 10 times each test
         without_change_repeat_failures_results_exceed_failure_limit = self.getProperty('without_change_repeat_failures_results_exceed_failure_limit', False)
         without_change_repeat_failures_results_nonflaky_failures = set(self.getProperty('without_change_repeat_failures_results_nonflaky_failures', []))
         without_change_repeat_failures_results_flakies = set(self.getProperty('without_change_repeat_failures_results_flakies', []))
         without_change_repeat_failures_timedout = self.getProperty('without_change_repeat_failures_timedout', False)
+        without_change_repeat_failures_retcode = self.getProperty('without_change_repeat_failures_retcode', FAILURE)
+
+        retry_count = int(self.getProperty('retry_count', 0))
+
+        # If the first run with patch times out, then retry the whole step 2 times, but at the third try continue anyway and report what possible.
+        if first_run_timedout:
+            if retry_count < self.MAX_RETRY:
+                return defer.returnValue(self.report_infrastructure_issue_and_maybe_retry_build('The layout-test run with change timed out, retrying with the hope it was a random infrastructure error.'))
 
         # If we've made it here that means that the first_run failed (non-zero status) but we don't have a list of failures or flakies. That is not expected.
         if (not first_run_failures) and (not first_run_flakies):
             # If we are not on the last retry, then try to retry the whole testing with the hope it was a random infrastructure error.
-            retry_count = int(self.getProperty('retry_count', 0))
             if retry_count < self.MAX_RETRY:
                 return defer.returnValue(self.report_infrastructure_issue_and_maybe_retry_build('The layout-test run with change generated no list of results and exited with error, retrying with the hope it was a random infrastructure error.'))
             # Otherwise (last retry) report and error or a warning, since we already gave it enough retries for the issue to not be caused by a random infrastructure error.
@@ -5412,50 +5291,30 @@ class AnalyzeLayoutTestsResultsRedTree(AnalyzeLayoutTestsResults):
             clean_tree_run_status = self.getProperty('clean_tree_run_status', FAILURE)
             # If the clean-tree run generated some results then we assume this change broke the script run-webkit-tests or something like that.
             if (clean_tree_run_status in [SUCCESS, WARNINGS]) or clean_tree_run_failures or clean_tree_run_flakies:
-                rc = yield self.report_failure(set(), first_results_exceed_failure_limit)
+                rc = yield self.report_failure(set(), first_results_exceed_failure_limit or first_run_timedout)
                 return defer.returnValue(rc)
             # This will end the testing as retry_count will be now self.MAX_RETRY and a warning will be reported.
             return defer.returnValue(self.report_infrastructure_issue_and_maybe_retry_build('The layout-test run with change generated no list of results and exited with error, and the clean_tree without change run did the same thing.'))
 
-        if with_change_repeat_failures_results_exceed_failure_limit or without_change_repeat_failures_results_exceed_failure_limit:
-            return defer.returnValue(self.report_infrastructure_issue_and_maybe_retry_build('One of the steps for retrying the failed tests has exited early, but this steps should run without "--exit-after-n-failures" switch, so they should not exit early.'))
+        if without_change_repeat_failures_results_exceed_failure_limit:
+            return defer.returnValue(self.report_infrastructure_issue_and_maybe_retry_build('The step "layout-tests-repeat-failures-without-change" has exited early, but this step should run without "--exit-after-n-failures" switch, so it should not exit early.'))
 
         if without_change_repeat_failures_timedout:
             return defer.returnValue(self.report_infrastructure_issue_and_maybe_retry_build('The step "layout-tests-repeat-failures-without-change" was interrumped because it reached the timeout.'))
 
-        if with_change_repeat_failures_timedout:
-            # The change is causing the step 'layout-tests-repeat-failures-with-change' to timeout, likely the change is adding many failures or long timeouts needing lot of time to test the repeats.
-            # Report the tests that failed on the first run as we don't have the information of the ones that failed on 'layout-tests-repeat-failures-with-change' because it was interrupted due to the timeout.
-            # There is no point in repeating this run, it would happen the same on next runs and consume lot of time.
-            likely_new_non_flaky_failures = first_run_failures - without_change_repeat_failures_results_nonflaky_failures.union(without_change_repeat_failures_results_flakies)
-            self.send_email_for_infrastructure_issue('The step "layout-tests-repeat-failures-with-change" reached the timeout but the step "layout-tests-repeat-failures-without-change" ended. Not trying to repeat this. Reporting {} failures from the first run.'.format(len(likely_new_non_flaky_failures)))
-            rc = yield self.report_failure(likely_new_non_flaky_failures, first_results_exceed_failure_limit)
-            return defer.returnValue(rc)
-
-        # The checks below need to be after the timeout ones (above) because when a timeout is trigerred no results will be generated for the step.
-        # The step with_change_repeat_failures generated an error code. That means there should be either tests failing or tests flakies. Check that.
-        with_change_repeat_failures_retcode = self.getProperty('with_change_repeat_failures_retcode', FAILURE)
-        if first_run_failures and with_change_repeat_failures_retcode not in [SUCCESS, WARNINGS]:
-            if not with_change_repeat_failures_results_nonflaky_failures and not with_change_repeat_failures_results_flakies:
-                return defer.returnValue(self.report_infrastructure_issue_and_maybe_retry_build('The step "layout-tests-repeat-failures" failed to generate any list of failures or flakies and returned an error code.'))
-            elif with_change_repeat_failures_results_nonflaky_failures:
-                # Check the same for the step without_change_repeat_failures but only if there where failures on the previous step (with_change_repeat_failures), because otherwise the check doesn't make sense (the step would have not run at all)
-                without_change_repeat_failures_retcode = self.getProperty('without_change_repeat_failures_retcode', FAILURE)
-                if without_change_repeat_failures_retcode not in [SUCCESS, WARNINGS]:
-                    if not without_change_repeat_failures_results_nonflaky_failures and not without_change_repeat_failures_results_flakies:
-                        return defer.returnValue(self.report_infrastructure_issue_and_maybe_retry_build('The step "layout-tests-repeat-failures-without-change" failed to generate any list of failures or flakies and returned an error code.'))
+        # The step without_change_repeat_failures generated an error code. That means there should be either tests failing or tests flakies. Check that.
+        if first_run_failures and without_change_repeat_failures_retcode not in [SUCCESS, WARNINGS]:
+            if not without_change_repeat_failures_results_nonflaky_failures and not without_change_repeat_failures_results_flakies:
+                return defer.returnValue(self.report_infrastructure_issue_and_maybe_retry_build('The step "layout-tests-repeat-failures-without-change" failed to generate any list of failures or flakies and returned an error code.'))
 
         # Warn EWS bot watchers about flakies so they can garden those. Include the step where the flaky was found in the e-mail to know if it was found with change or without it.
         # Due to the way this class works most of the flakies are filtered on the step with change even when those were pre-existent issues (so this is also useful for bot watchers).
-        all_flaky_failures = first_run_flakies.union(with_change_repeat_failures_results_flakies).union(without_change_repeat_failures_results_flakies)
-        all_flaky_failures.update(first_run_failures - with_change_repeat_failures_results_nonflaky_failures)
+        all_flaky_failures = first_run_flakies.union(without_change_repeat_failures_results_flakies)
         flaky_steps_dict = {}
         for flaky_failure in all_flaky_failures:
             step_names = []
             if flaky_failure in without_change_repeat_failures_results_flakies:
                 step_names.append('layout-tests-repeat-failures-without-change')
-            if flaky_failure in with_change_repeat_failures_results_flakies:
-                step_names.append('layout-tests-repeat-failures (with change)')
             if flaky_failure in first_run_flakies:
                 step_names.append('layout-tests (with change)')
             flaky_steps_dict[flaky_failure] = step_names
@@ -5467,9 +5326,9 @@ class AnalyzeLayoutTestsResultsRedTree(AnalyzeLayoutTestsResults):
             self.send_email_for_pre_existent_failures(pre_existent_non_flaky_failures)
 
         # Finally check if there are new consistent (non-flaky) failures caused by the change and warn the change author stetting the status for the build.
-        new_non_flaky_failures = with_change_repeat_failures_results_nonflaky_failures - without_change_repeat_failures_results_nonflaky_failures.union(without_change_repeat_failures_results_flakies)
+        new_non_flaky_failures = first_run_failures - without_change_repeat_failures_results_nonflaky_failures.union(without_change_repeat_failures_results_flakies)
         if new_non_flaky_failures:
-            rc = yield self.report_failure(new_non_flaky_failures, first_results_exceed_failure_limit)
+            rc = yield self.report_failure(new_non_flaky_failures, first_results_exceed_failure_limit or first_run_timedout)
             return defer.returnValue(rc)
 
         return defer.returnValue(self.report_success())

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -3095,141 +3095,34 @@ class TestRunWebKitTestsRedTree(BuildStepMixinAdditions, unittest.TestCase):
         self.assertTrue(CompileWebKitWithoutChange(retry_build_on_failure=True))
         self.assertTrue(RunWebKitTestsWithoutChangeRedTree() in next_steps)
 
-    def test_flakies_but_no_failures_then_go_to_analyze_results(self):
+    def test_flakies_with_fail_retcode_then_go_to_analyze_results(self):
         self.configureStep()
         self.setProperty('first_run_failures', [])
         self.setProperty('first_run_flakies', ['fast/css/flaky1.html', 'fast/svg/flaky2.svg', 'imported/test/flaky3.html'])
         next_steps = []
         self.patch(self.build, 'addStepsAfterCurrentStep', lambda s: next_steps.extend(s))
         self.patch(RunWebKitTestsRedTree, 'evaluateResult', lambda s, r: r)
-        self.get_nth_step(0).evaluateCommand(SUCCESS)
+        self.get_nth_step(0).evaluateCommand(FAILURE)
         self.assertFalse(RevertAppliedChanges() in next_steps)
         self.assertFalse(InstallWpeDependencies() in next_steps)
         self.assertFalse(RunWebKitTestsWithoutChangeRedTree() in next_steps)
         self.assertTrue(AnalyzeLayoutTestsResultsRedTree() in next_steps)
+        self.assertFalse(hasattr(self.build, 'results'))
 
-
-class TestRunWebKitTestsRepeatFailuresRedTree(BuildStepMixinAdditions, unittest.TestCase):
-    def setUp(self):
-        self.longMessage = True
-        self.jsonFileName = 'layout-test-results/full_results.json'
-        return self.setup_test_build_step()
-
-    def tearDown(self):
-        return self.tear_down_test_build_step()
-
-    def configureStep(self):
-        self.setup_step(RunWebKitTestsRepeatFailuresRedTree())
-        self.setProperty('platform', 'wpe')
-        self.setProperty('fullPlatform', 'wpe')
-        self.setProperty('configuration', 'release')
-
-    def test_success(self):
+    def test_flakies_with_warning_retcode_then_finish(self):
         self.configureStep()
-        first_run_failures = ['fast/css/test1.html', 'imported/test/test2.html', 'fast/svg/test3.svg']
-        first_run_flakies = ['fast/css/flaky1.html', 'imported/test/flaky2.html', 'fast/svg/flaky3.svg']
-        self.setProperty('first_run_failures', first_run_failures)
-        self.setProperty('first_run_flakies', first_run_flakies)
-        self.expectRemoteCommands(
-            ExpectShell(workdir='wkdir',
-                        logfiles={'json': self.jsonFileName},
-                        log_environ=False,
-                        max_time=18000,
-                        timeout=19800,
-                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webkit-tests --no-build --no-show-results --no-new-test-results --clobber-old-results --release --wpe --results-directory layout-test-results --debug-rwt-logging --skip-failing-tests --fully-parallel --repeat-each=10 fast/css/test1.html fast/svg/test3.svg imported/test/test2.html 2>&1 | Tools/Scripts/filter-test-logs layout']
-                        )
-            .exit(0),
-        )
-        self.expect_outcome(result=SUCCESS, state_string='layout-tests')
-        return self.run_step()
-
-    def test_success_tests_names_with_shell_conflictive_chars(self):
-        self.configureStep()
-        first_run_failures = ['imported/w3c/web-platform-tests/html/dom/idlharness.https.html?exclude=(Document|Window|HTML.*)',
-                              'imported/w3c/web-platform-tests/html/dom/idlharness.https.html?include=HTML.*',
-                              'try/crash/for/test_with_brackets[]{}',
-                              'try/crash/for/test_with spaces " and \' quotes'
-                              ]
-        first_run_flakies = ['fast/css/flaky1.html', 'imported/test/flaky2.html', 'fast/svg/flaky3.svg']
-        self.setProperty('first_run_failures', first_run_failures)
-        self.setProperty('first_run_flakies', first_run_flakies)
-        self.expectRemoteCommands(
-            ExpectShell(workdir='wkdir',
-                        logfiles={'json': self.jsonFileName},
-                        log_environ=False,
-                        max_time=18000,
-                        timeout=19800,
-                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webkit-tests --no-build --no-show-results --no-new-test-results --clobber-old-results --release --wpe --results-directory layout-test-results --debug-rwt-logging --skip-failing-tests --fully-parallel --repeat-each=10 \'imported/w3c/web-platform-tests/html/dom/idlharness.https.html?exclude=(Document|Window|HTML.*)\' \'imported/w3c/web-platform-tests/html/dom/idlharness.https.html?include=HTML.*\' \'try/crash/for/test_with spaces " and \'"\'"\' quotes\' \'try/crash/for/test_with_brackets[]{}\' 2>&1 | Tools/Scripts/filter-test-logs layout']
-                        )
-            .exit(0),
-        )
-        self.expect_outcome(result=SUCCESS, state_string='layout-tests')
-        return self.run_step()
-
-    @defer.inlineCallbacks
-    def test_set_properties_when_executed_scope_this_class(self):
-        self.configureStep()
-        first_run_failures = ['fast/css/test1.html', 'imported/test/test2.html', 'fast/svg/test3.svg']
-        first_run_flakies = ['fast/css/flaky1.html', 'imported/test/flaky2.html', 'fast/svg/flaky3.svg']
-        # Set good values for properties that only the superclass should set
-        self.setProperty('first_run_failures', first_run_failures)
-        self.setProperty('first_run_flakies', first_run_flakies)
-        self.setProperty('first_results_exceed_failure_limit', False)
-        self.expectRemoteCommands(
-            ExpectShell(workdir='wkdir',
-                        logfiles={'json': self.jsonFileName},
-                        log_environ=False,
-                        max_time=18000,
-                        timeout=19800,
-                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webkit-tests --no-build --no-show-results --no-new-test-results --clobber-old-results --release --wpe --results-directory layout-test-results --debug-rwt-logging --skip-failing-tests --fully-parallel --repeat-each=10 fast/css/test1.html fast/svg/test3.svg imported/test/test2.html 2>&1 | Tools/Scripts/filter-test-logs layout']
-                        )
-            .exit(2)
-        )
-        # Patch LayoutTestFailures.results_from_string() so it always reports fake values.
-        # Check this fake values do not end on the properties that belong to the superclass.
-        fake_failing_tests = ['fake/should/not/happen/failure1.html', 'imported/fake/failure2.html']
-        fake_flaky_tests = ['fake/should/not/happen/flaky1.html', 'imported/fake/flaky2.html']
-        fake_layout_test_failures = MockLayoutTestFailures(fake_failing_tests, fake_flaky_tests, True)
-        self.patch(LayoutTestFailures, 'results_from_string', lambda f: fake_layout_test_failures)
-        self.expect_outcome(result=FAILURE, state_string='layout-tests (failure)')
-        rc = yield self.run_step()
-        # first_run properties should not be set to fake_layout_test_failures when running RunWebKitTestsRepeatFailuresRedTree()
-        self.expect_property('first_run_failures', first_run_failures)
-        self.expect_property('first_run_flakies', first_run_flakies)
-        self.assertFalse(self.getProperty('first_results_exceed_failure_limit'))
-        # Test also that this fake values are set _only_ for the properties this class should define
-        self.expect_property('with_change_repeat_failures_results_nonflaky_failures', fake_failing_tests)
-        self.expect_property('with_change_repeat_failures_results_flakies', fake_flaky_tests)
-        self.assertTrue(self.getProperty('with_change_repeat_failures_results_exceed_failure_limit'))
-        return rc
-
-    def test_last_run_with_patch_ends_with_list_of_failing_tests_then_schedule_update_libs_and_test_without_patch(self):
-        self.configureStep()
-        self.setProperty('with_change_repeat_failures_results_nonflaky_failures', ['fake/should/not/happen/failure1.html', 'imported/fake/failure2.html'])
-        self.setProperty('with_change_repeat_failures_results_flakies', [])
+        self.setProperty('first_run_failures', [])
+        self.setProperty('first_run_flakies', ['fast/css/flaky1.html', 'fast/svg/flaky2.svg', 'imported/test/flaky3.html'])
         next_steps = []
         self.patch(self.build, 'addStepsAfterCurrentStep', lambda s: next_steps.extend(s))
-        self.patch(RunWebKitTestsRepeatFailuresRedTree, 'evaluateResult', lambda s, r: r)
-        self.get_nth_step(0).evaluateCommand(FAILURE)
-        self.assertTrue(RevertAppliedChanges() in next_steps)
-        self.assertTrue(InstallWpeDependencies() in next_steps)
-        self.assertTrue(CompileWebKitWithoutChange(retry_build_on_failure=True) in next_steps)
-        self.assertTrue(RunWebKitTestsRepeatFailuresWithoutChangeRedTree() in next_steps)
-        self.assertFalse(AnalyzeLayoutTestsResultsRedTree() in next_steps)
-
-    def test_last_run_with_patch_ends_with_no_failing_tests_then_go_to_analyze(self):
-        self.configureStep()
-        self.setProperty('with_change_repeat_failures_results_nonflaky_failures', [])
-        self.setProperty('with_change_repeat_failures_results_flakies', ['fake/should/not/happen/flaky1.html', 'imported/fake/flaky2.html'])
-        next_steps = []
-        self.patch(self.build, 'addStepsAfterCurrentStep', lambda s: next_steps.extend(s))
-        self.patch(RunWebKitTestsRepeatFailuresRedTree, 'evaluateResult', lambda s, r: r)
-        self.get_nth_step(0).evaluateCommand(FAILURE)
+        self.patch(RunWebKitTestsRedTree, 'evaluateResult', lambda s, r: r)
+        self.get_nth_step(0).evaluateCommand(WARNINGS)
         self.assertFalse(RevertAppliedChanges() in next_steps)
         self.assertFalse(InstallWpeDependencies() in next_steps)
-        self.assertFalse(CompileWebKitWithoutChange(retry_build_on_failure=True) in next_steps)
-        self.assertFalse(RunWebKitTestsRepeatFailuresWithoutChangeRedTree() in next_steps)
-        self.assertTrue(AnalyzeLayoutTestsResultsRedTree() in next_steps)
+        self.assertFalse(RunWebKitTestsWithoutChangeRedTree() in next_steps)
+        self.assertFalse(AnalyzeLayoutTestsResultsRedTree() in next_steps)
+        self.assertTrue(hasattr(self.build, 'results'))
+        self.assertEqual(self.build.results, SUCCESS)
 
 
 class TestRunWebKitTestsRepeatFailuresWithoutChangeRedTree(BuildStepMixinAdditions, unittest.TestCase):
@@ -3251,38 +3144,8 @@ class TestRunWebKitTestsRepeatFailuresWithoutChangeRedTree(BuildStepMixinAdditio
         self.configureStep()
         first_run_failures = ['fast/css/test1.html', 'imported/test/test2.html', 'fast/svg/test3.svg']
         first_run_flakies = ['fast/css/flaky1.html', 'imported/test/flaky2.html', 'fast/svg/flaky3.svg']
-        with_change_repeat_failures_results_nonflaky_failures = ['fast/css/test1.html']
-        with_change_repeat_failures_results_flakies = ['imported/test/test2.html', 'fast/svg/test3.svg']
         self.setProperty('first_run_failures', first_run_failures)
         self.setProperty('first_run_flakies', first_run_flakies)
-        self.setProperty('with_change_repeat_failures_results_nonflaky_failures', with_change_repeat_failures_results_nonflaky_failures)
-        self.setProperty('with_change_repeat_failures_results_flakies', with_change_repeat_failures_results_flakies)
-        self.expectRemoteCommands(
-            ExpectShell(workdir='wkdir',
-                        logfiles={'json': self.jsonFileName},
-                        log_environ=False,
-                        max_time=10800,
-                        timeout=19800,
-                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webkit-tests --no-build --no-show-results --no-new-test-results --clobber-old-results --release --wpe --results-directory layout-test-results --debug-rwt-logging --skip-failing-tests --fully-parallel --repeat-each=10 --skipped=always fast/css/test1.html 2>&1 | Tools/Scripts/filter-test-logs layout']
-                        )
-            .exit(0),
-        )
-        self.expect_outcome(result=SUCCESS, state_string='layout-tests')
-        return self.run_step()
-
-    def test_step_with_change_did_timeout(self):
-        self.configureStep()
-        self.setProperty('fullPlatform', 'gtk')
-        self.setProperty('configuration', 'release')
-        first_run_failures = ['fast/css/test1.html', 'imported/test/test2.html', 'fast/svg/test3.svg']
-        first_run_flakies = ['fast/css/flaky1.html', 'imported/test/flaky2.html', 'fast/svg/flaky3.svg']
-        with_change_repeat_failures_results_nonflaky_failures = ['fast/css/test1.html']
-        with_change_repeat_failures_results_flakies = ['imported/test/test2.html', 'fast/svg/test3.svg']
-        self.setProperty('first_run_failures', first_run_failures)
-        self.setProperty('first_run_flakies', first_run_flakies)
-        self.setProperty('with_change_repeat_failures_results_nonflaky_failures', with_change_repeat_failures_results_nonflaky_failures)
-        self.setProperty('with_change_repeat_failures_results_flakies', with_change_repeat_failures_results_flakies)
-        self.setProperty('with_change_repeat_failures_timedout', True)
         self.expectRemoteCommands(
             ExpectShell(workdir='wkdir',
                         logfiles={'json': self.jsonFileName},
@@ -3296,27 +3159,45 @@ class TestRunWebKitTestsRepeatFailuresWithoutChangeRedTree(BuildStepMixinAdditio
         self.expect_outcome(result=SUCCESS, state_string='layout-tests')
         return self.run_step()
 
-    @defer.inlineCallbacks
-    def test_set_properties_when_executed_scope_this_class(self):
+    def test_success_tests_names_with_shell_conflictive_chars(self):
         self.configureStep()
-        first_run_failures = ['fast/css/test1.html', 'imported/test/test2.html', 'fast/svg/test3.svg']
+        first_run_failures = ['imported/w3c/web-platform-tests/html/dom/idlharness.https.html?exclude=(Document|Window|HTML.*)',
+                              'imported/w3c/web-platform-tests/html/dom/idlharness.https.html?include=HTML.*',
+                              'try/crash/for/test_with_brackets[]{}',
+                              'try/crash/for/test_with spaces " and \' quotes'
+                              ]
         first_run_flakies = ['fast/css/flaky1.html', 'imported/test/flaky2.html', 'fast/svg/flaky3.svg']
-        with_change_repeat_failures_results_nonflaky_failures = ['fast/css/test1.html']
-        with_change_repeat_failures_results_flakies = ['imported/test/test2.html', 'fast/svg/test3.svg']
-        # Set good values for properties that only the superclass should set
         self.setProperty('first_run_failures', first_run_failures)
         self.setProperty('first_run_flakies', first_run_flakies)
-        self.setProperty('first_results_exceed_failure_limit', False)
-        self.setProperty('with_change_repeat_failures_results_nonflaky_failures', with_change_repeat_failures_results_nonflaky_failures)
-        self.setProperty('with_change_repeat_failures_results_flakies', with_change_repeat_failures_results_flakies)
-        self.setProperty('with_change_repeat_failures_timedout', False)
         self.expectRemoteCommands(
             ExpectShell(workdir='wkdir',
                         logfiles={'json': self.jsonFileName},
                         log_environ=False,
                         max_time=10800,
                         timeout=19800,
-                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webkit-tests --no-build --no-show-results --no-new-test-results --clobber-old-results --release --wpe --results-directory layout-test-results --debug-rwt-logging --skip-failing-tests --fully-parallel --repeat-each=10 --skipped=always fast/css/test1.html 2>&1 | Tools/Scripts/filter-test-logs layout']
+                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webkit-tests --no-build --no-show-results --no-new-test-results --clobber-old-results --release --wpe --results-directory layout-test-results --debug-rwt-logging --skip-failing-tests --fully-parallel --repeat-each=10 --skipped=always \'imported/w3c/web-platform-tests/html/dom/idlharness.https.html?exclude=(Document|Window|HTML.*)\' \'imported/w3c/web-platform-tests/html/dom/idlharness.https.html?include=HTML.*\' \'try/crash/for/test_with spaces " and \'"\'"\' quotes\' \'try/crash/for/test_with_brackets[]{}\' 2>&1 | Tools/Scripts/filter-test-logs layout']
+                        )
+            .exit(0),
+        )
+        self.expect_outcome(result=SUCCESS, state_string='layout-tests')
+        return self.run_step()
+
+    @defer.inlineCallbacks
+    def test_set_properties_when_executed_scope_this_class(self):
+        self.configureStep()
+        first_run_failures = ['fast/css/test1.html', 'imported/test/test2.html', 'fast/svg/test3.svg']
+        first_run_flakies = ['fast/css/flaky1.html', 'imported/test/flaky2.html', 'fast/svg/flaky3.svg']
+        # Set good values for properties that only the superclass should set
+        self.setProperty('first_run_failures', first_run_failures)
+        self.setProperty('first_run_flakies', first_run_flakies)
+        self.setProperty('first_results_exceed_failure_limit', False)
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        logfiles={'json': self.jsonFileName},
+                        log_environ=False,
+                        max_time=10800,
+                        timeout=19800,
+                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webkit-tests --no-build --no-show-results --no-new-test-results --clobber-old-results --release --wpe --results-directory layout-test-results --debug-rwt-logging --skip-failing-tests --fully-parallel --repeat-each=10 --skipped=always fast/css/test1.html fast/svg/test3.svg imported/test/test2.html 2>&1 | Tools/Scripts/filter-test-logs layout']
                         )
             .exit(2)
         )
@@ -3328,18 +3209,29 @@ class TestRunWebKitTestsRepeatFailuresWithoutChangeRedTree(BuildStepMixinAdditio
         self.patch(LayoutTestFailures, 'results_from_string', lambda f: fake_layout_test_failures)
         self.expect_outcome(result=FAILURE, state_string='layout-tests (failure)')
         rc = yield self.run_step()
-        # first_run properties should not be set to fake_layout_test_failures when running RunWebKitTestsRepeatFailuresWithoutChangeRedTree()
+        # first_run properties should not be set to fake_layout_test_failures when running RunWebKitTestsRepeatFailuresRedTree()
         self.expect_property('first_run_failures', first_run_failures)
         self.expect_property('first_run_flakies', first_run_flakies)
         self.assertFalse(self.getProperty('first_results_exceed_failure_limit'))
-        self.expect_property('with_change_repeat_failures_results_nonflaky_failures', with_change_repeat_failures_results_nonflaky_failures)
-        self.expect_property('with_change_repeat_failures_results_flakies', with_change_repeat_failures_results_flakies)
-        self.assertFalse(self.getProperty('with_change_repeat_failures_timedout'))
         # Test also that this fake values are set _only_ for the properties this class should define
         self.expect_property('without_change_repeat_failures_results_nonflaky_failures', fake_failing_tests)
         self.expect_property('without_change_repeat_failures_results_flakies', fake_flaky_tests)
         self.assertTrue(self.getProperty('without_change_repeat_failures_results_exceed_failure_limit'))
         return rc
+
+    def test_run_ends_then_go_to_analyze(self):
+        self.configureStep()
+        self.setProperty('first_run_failures', ['fake/should/not/happen/failure1.html', 'imported/fake/failure2.html'])
+        self.setProperty('first_run_flakies', [])
+        next_steps = []
+        self.patch(self.build, 'addStepsAfterCurrentStep', lambda s: next_steps.extend(s))
+        self.patch(RunWebKitTestsRepeatFailuresWithoutChangeRedTree, 'evaluateResult', lambda s, r: r)
+        self.get_nth_step(0).evaluateCommand(SUCCESS)
+        self.assertFalse(RevertAppliedChanges() in next_steps)
+        self.assertFalse(InstallWpeDependencies() in next_steps)
+        self.assertFalse(CompileWebKitWithoutChange(retry_build_on_failure=True) in next_steps)
+        self.assertTrue(AnalyzeLayoutTestsResultsRedTree() in next_steps)
+        self.assertFalse(hasattr(self.build, 'results'))
 
 
 class TestAnalyzeLayoutTestsResultsRedTree(BuildStepMixinAdditions, unittest.TestCase):
@@ -3364,10 +3256,8 @@ class TestAnalyzeLayoutTestsResultsRedTree(BuildStepMixinAdditions, unittest.Tes
         self.configureCommonProperties()
         self.setProperty('first_run_failures', ["test/failure1.html", "test/failure2.html"])
         self.setProperty('first_run_flakies', ["test/flaky1.html", "test/flaky2.html"])
-        self.setProperty('with_change_repeat_failures_results_nonflaky_failures', ["test/failure1.html"])
-        self.setProperty('with_change_repeat_failures_results_flakies', ["test/failure2.html"])
         self.setProperty('without_change_repeat_failures_results_nonflaky_failures', [])
-        self.setProperty('without_change_repeat_failures_results_flakies', ["test/pre-existent/flaky.html"])
+        self.setProperty('without_change_repeat_failures_results_flakies', ["test/failure2.html", "test/pre-existent/flaky.html"])
         self.expect_outcome(result=FAILURE, state_string='Found 1 new test failure: test/failure1.html (failure)')
         step_result = self.run_step()
         self.assertEqual(len(self._emails_list), 2)
@@ -3384,10 +3274,8 @@ class TestAnalyzeLayoutTestsResultsRedTree(BuildStepMixinAdditions, unittest.Tes
         self.configureCommonProperties()
         self.setProperty('first_run_failures', ["test/failure1.html", "test/failure2.html", "test/pre-existent/failure.html", "test/pre-existent/flaky.html"])
         self.setProperty('first_run_flakies', ["test/flaky1.html", "test/flaky2.html"])
-        self.setProperty('with_change_repeat_failures_results_nonflaky_failures', ["test/failure1.html", "test/pre-existent/failure.html", "test/pre-existent/flaky.html"])
-        self.setProperty('with_change_repeat_failures_results_flakies', ["test/failure2.html"])
         self.setProperty('without_change_repeat_failures_results_nonflaky_failures', ["test/pre-existent/failure.html"])
-        self.setProperty('without_change_repeat_failures_results_flakies', ["test/pre-existent/flaky.html"])
+        self.setProperty('without_change_repeat_failures_results_flakies', ["test/pre-existent/flaky.html", "test/failure2.html"])
         self.expect_outcome(result=FAILURE, state_string='Found 1 new test failure: test/failure1.html (failure)')
         step_result = self.run_step()
         self.assertEqual(len(self._emails_list), 3)
@@ -3406,10 +3294,8 @@ class TestAnalyzeLayoutTestsResultsRedTree(BuildStepMixinAdditions, unittest.Tes
         self.configureCommonProperties()
         self.setProperty('first_run_failures', ["test/pre-existent/failure.html", "test/pre-existent/flaky.html"])
         self.setProperty('first_run_flakies', ["test/pre-existent/flaky2.html", "test/pre-existent/flaky3.html"])
-        self.setProperty('with_change_repeat_failures_results_nonflaky_failures', ["test/pre-existent/failure.html"])
-        self.setProperty('with_change_repeat_failures_results_flakies', ["test/pre-existent/flaky.html"])
         self.setProperty('without_change_repeat_failures_results_nonflaky_failures', ["test/pre-existent/failure.html"])
-        self.setProperty('without_change_repeat_failures_results_flakies', [])
+        self.setProperty('without_change_repeat_failures_results_flakies', ["test/pre-existent/flaky.html"])
         self.expect_outcome(result=SUCCESS, state_string='Passed layout tests')
         step_result = self.run_step()
         self.assertEqual(len(self._emails_list), 2)
@@ -3426,10 +3312,8 @@ class TestAnalyzeLayoutTestsResultsRedTree(BuildStepMixinAdditions, unittest.Tes
         self.configureCommonProperties()
         self.setProperty('first_run_failures', ["test/pre-existent/flaky1.html"])
         self.setProperty('first_run_flakies', ["test/pre-existent/flaky2.html", "test/pre-existent/flaky3.html"])
-        self.setProperty('with_change_repeat_failures_results_nonflaky_failures', [])
-        self.setProperty('with_change_repeat_failures_results_flakies', ["test/pre-existent/flaky1.html"])
         self.setProperty('without_change_repeat_failures_results_nonflaky_failures', [])
-        self.setProperty('without_change_repeat_failures_results_flakies', [])
+        self.setProperty('without_change_repeat_failures_results_flakies', ["test/pre-existent/flaky1.html"])
         self.setProperty('without_change_repeat_failures_retcode', SUCCESS)
         self.expect_outcome(result=SUCCESS, state_string='Passed layout tests')
         step_result = self.run_step()
@@ -3501,21 +3385,30 @@ class TestAnalyzeLayoutTestsResultsRedTree(BuildStepMixinAdditions, unittest.Tes
             self.assertTrue(f'Test name: <a href="https://github.com/WebKit/WebKit/blob/main/LayoutTests/{flaky_test}">{flaky_test}</a>' in self._emails_list[0])
         return step_result
 
-    def test_step_retry_with_change_exits_early_error(self):
+    def test_first_step_timeouts(self):
         self.configureStep()
         self.configureCommonProperties()
-        self.setProperty('first_run_failures', ["test/failure1.html", "test/failure2.html", "test/pre-existent/failure.html", "test/pre-existent/flaky.html"])
-        self.setProperty('first_run_flakies', ["test/flaky1.html", "test/flaky2.html"])
-        self.setProperty('with_change_repeat_failures_results_nonflaky_failures', ["test/failure1.html", "test/pre-existent/failure.html", "test/pre-existent/flaky.html"])
-        self.setProperty('with_change_repeat_failures_results_flakies', ["test/failure2.html"])
-        self.setProperty('without_change_repeat_failures_results_nonflaky_failures', ["test/pre-existent/failure.html"])
-        self.setProperty('without_change_repeat_failures_results_flakies', ["test/pre-existent/flaky.html"])
-        self.setProperty('with_change_repeat_failures_results_exceed_failure_limit', True)
-        expected_infrastructure_error = 'One of the steps for retrying the failed tests has exited early, but this steps should run without "--exit-after-n-failures" switch, so they should not exit early.'
+        self.setProperty('first_run_failures', [])
+        self.setProperty('first_run_flakies', [])
+        self.setProperty('first_run_timedout', True)
+        expected_infrastructure_error = 'The layout-test run with change timed out, retrying with the hope it was a random infrastructure error.'
         self.expect_outcome(result=RETRY, state_string=f'Unexpected infrastructure issue: {expected_infrastructure_error}\nRetrying build [retry count is 0 of 3] (retry)')
         step_result = self.run_step()
         self.assertEqual(len(self._emails_list), 1)
         self.assertTrue(expected_infrastructure_error in self._emails_list[0])
+        return step_result
+
+    def test_first_step_timeouts_last_try(self):
+        self.configureStep()
+        self.configureCommonProperties()
+        self.setProperty('first_run_failures', [])
+        self.setProperty('first_run_flakies', [])
+        self.setProperty('first_run_timedout', True)
+        self.setProperty('clean_tree_run_status', SUCCESS)
+        self.setProperty('retry_count', AnalyzeLayoutTestsResultsRedTree.MAX_RETRY)
+        expected_infrastructure_error = 'The layout-test run with change generated no list of results and exited with error, retrying with the hope it was a random infrastructure error.'
+        self.expect_outcome(result=FAILURE,  state_string='Found unexpected failure with change (failure)')
+        step_result = self.run_step()
         return step_result
 
     def test_step_retry_without_change_exits_early_error(self):
@@ -3523,28 +3416,26 @@ class TestAnalyzeLayoutTestsResultsRedTree(BuildStepMixinAdditions, unittest.Tes
         self.configureCommonProperties()
         self.setProperty('first_run_failures', ["test/failure1.html", "test/failure2.html", "test/pre-existent/failure.html", "test/pre-existent/flaky.html"])
         self.setProperty('first_run_flakies', ["test/flaky1.html", "test/flaky2.html"])
-        self.setProperty('with_change_repeat_failures_results_nonflaky_failures', ["test/failure1.html", "test/pre-existent/failure.html", "test/pre-existent/flaky.html"])
-        self.setProperty('with_change_repeat_failures_results_flakies', ["test/failure2.html"])
         self.setProperty('without_change_repeat_failures_results_nonflaky_failures', ["test/pre-existent/failure.html"])
         self.setProperty('without_change_repeat_failures_results_flakies', ["test/pre-existent/flaky.html"])
         self.setProperty('without_change_repeat_failures_results_exceed_failure_limit', True)
-        expected_infrastructure_error = 'One of the steps for retrying the failed tests has exited early, but this steps should run without "--exit-after-n-failures" switch, so they should not exit early.'
+        expected_infrastructure_error = 'The step "layout-tests-repeat-failures-without-change" has exited early, but this step should run without "--exit-after-n-failures" switch, so it should not exit early.'
         self.expect_outcome(result=RETRY, state_string=f'Unexpected infrastructure issue: {expected_infrastructure_error}\nRetrying build [retry count is 0 of 3] (retry)')
         step_result = self.run_step()
         self.assertEqual(len(self._emails_list), 1)
         self.assertTrue(expected_infrastructure_error in self._emails_list[0])
         return step_result
 
-    def test_step_retry_with_change_pass(self):
+    def test_step_retry_without_change_success(self):
         self.configureStep()
         self.configureCommonProperties()
         first_run_failures = ["test/failure1.html", "test/failure2.html", "test/pre-existent/flaky1.html", "test/pre-existent/flaky2.html"]
         first_run_flakies = ["test/flaky1.html", "test/flaky2.html"]
         self.setProperty('first_run_failures', first_run_failures)
         self.setProperty('first_run_flakies', first_run_flakies)
-        self.setProperty('with_change_repeat_failures_results_nonflaky_failures', [])
-        self.setProperty('with_change_repeat_failures_results_flakies', [])
-        self.setProperty('with_change_repeat_failures_retcode', SUCCESS)
+        self.setProperty('without_change_repeat_failures_results_nonflaky_failures', [])
+        self.setProperty('without_change_repeat_failures_results_flakies', first_run_failures)
+        self.setProperty('without_change_repeat_failures_retcode', SUCCESS)
         self.expect_outcome(result=SUCCESS, state_string='Passed layout tests')
         step_result = self.run_step()
         self.assertEqual(len(self._emails_list), 1)
@@ -3553,16 +3444,16 @@ class TestAnalyzeLayoutTestsResultsRedTree(BuildStepMixinAdditions, unittest.Tes
             self.assertTrue(f'Test name: <a href="https://github.com/WebKit/WebKit/blob/main/LayoutTests/{flaky_test}">{flaky_test}</a>' in self._emails_list[0])
         return step_result
 
-    def test_step_retry_with_change_warnings(self):
+    def test_step_retry_without_change_warnings(self):
         self.configureStep()
         self.configureCommonProperties()
         first_run_failures = ["test/failure1.html", "test/failure2.html", "test/pre-existent/flaky1.html", "test/pre-existent/flaky2.html"]
         first_run_flakies = ["test/flaky1.html", "test/flaky2.html"]
         self.setProperty('first_run_failures', first_run_failures)
         self.setProperty('first_run_flakies', first_run_flakies)
-        self.setProperty('with_change_repeat_failures_results_nonflaky_failures', [])
-        self.setProperty('with_change_repeat_failures_results_flakies', ["test/pre-existent/flaky1.html"])
-        self.setProperty('with_change_repeat_failures_retcode', WARNINGS)
+        self.setProperty('without_change_repeat_failures_results_nonflaky_failures', [])
+        self.setProperty('without_change_repeat_failures_results_flakies', first_run_failures)
+        self.setProperty('without_change_repeat_failures_retcode', WARNINGS)
         self.expect_outcome(result=SUCCESS, state_string='Passed layout tests')
         step_result = self.run_step()
         self.assertEqual(len(self._emails_list), 1)
@@ -3571,16 +3462,16 @@ class TestAnalyzeLayoutTestsResultsRedTree(BuildStepMixinAdditions, unittest.Tes
             self.assertTrue(f'Test name: <a href="https://github.com/WebKit/WebKit/blob/main/LayoutTests/{flaky_test}">{flaky_test}</a>' in self._emails_list[0])
         return step_result
 
-    def test_step_retry_with_change_error_with_flakies(self):
+    def test_step_retry_without_change_failure(self):
         self.configureStep()
         self.configureCommonProperties()
         first_run_failures = ["test/failure1.html", "test/failure2.html", "test/pre-existent/flaky1.html", "test/pre-existent/flaky2.html"]
         first_run_flakies = ["test/flaky1.html", "test/flaky2.html"]
         self.setProperty('first_run_failures', first_run_failures)
         self.setProperty('first_run_flakies', first_run_flakies)
-        self.setProperty('with_change_repeat_failures_results_nonflaky_failures', [])
-        self.setProperty('with_change_repeat_failures_results_flakies', ["test/pre-existent/flaky1.html"])
-        self.setProperty('with_change_repeat_failures_retcode', FAILURE)
+        self.setProperty('without_change_repeat_failures_results_nonflaky_failures', [])
+        self.setProperty('without_change_repeat_failures_results_flakies', first_run_failures)
+        self.setProperty('without_change_repeat_failures_retcode', FAILURE)
         self.expect_outcome(result=SUCCESS, state_string='Passed layout tests')
         step_result = self.run_step()
         self.assertEqual(len(self._emails_list), 1)
@@ -3594,28 +3485,10 @@ class TestAnalyzeLayoutTestsResultsRedTree(BuildStepMixinAdditions, unittest.Tes
         self.configureCommonProperties()
         self.setProperty('first_run_failures', ["test/failure1.html", "test/failure2.html", "test/pre-existent/failure.html", "test/pre-existent/flaky.html"])
         self.setProperty('first_run_flakies', ["test/flaky1.html", "test/flaky2.html"])
-        self.setProperty('with_change_repeat_failures_timedout', True)
+        self.setProperty('without_change_repeat_failures_timedout', True)
         self.setProperty('without_change_repeat_failures_results_nonflaky_failures', ["test/pre-existent/failure.html"])
         self.setProperty('without_change_repeat_failures_results_flakies', ["test/pre-existent/flaky.html"])
-        self.expect_outcome(result=FAILURE, state_string='Found 2 new test failures: test/failure1.html test/failure2.html (failure)')
-        step_result = self.run_step()
-        self.assertEqual(len(self._emails_list), 2)
-        expected_infrastructure_error = 'The step "layout-tests-repeat-failures-with-change" reached the timeout but the step "layout-tests-repeat-failures-without-change" ended. Not trying to repeat this. Reporting 2 failures from the first run.'
-        self.assertTrue(expected_infrastructure_error in self._emails_list[0])
-        self.assertTrue('Subject: Layout test failure for Patch' in self._emails_list[1])
-        for failed_test in ['test/failure1.html', 'test/failure2.html']:
-            self.assertTrue(failed_test in self._emails_list[1])
-        return step_result
-
-    def test_step_retry_with_change_unexpected_error(self):
-        self.configureStep()
-        self.configureCommonProperties()
-        self.setProperty('first_run_failures', ["test/failure1.html", "test/failure2.html", "test/pre-existent/failure.html", "test/pre-existent/flaky.html"])
-        self.setProperty('first_run_flakies', ["test/flaky1.html", "test/flaky2.html"])
-        self.setProperty('with_change_repeat_failures_results_nonflaky_failures', [])
-        self.setProperty('with_change_repeat_failures_results_flakies', [])
-        self.setProperty('with_change_repeat_failures_retcode', FAILURE)
-        expected_infrastructure_error = 'The step "layout-tests-repeat-failures" failed to generate any list of failures or flakies and returned an error code.'
+        expected_infrastructure_error = 'The step "layout-tests-repeat-failures-without-change" was interrumped because it reached the timeout.'
         self.expect_outcome(result=RETRY, state_string=f'Unexpected infrastructure issue: {expected_infrastructure_error}\nRetrying build [retry count is 0 of 3] (retry)')
         step_result = self.run_step()
         self.assertEqual(len(self._emails_list), 1)
@@ -3627,9 +3500,6 @@ class TestAnalyzeLayoutTestsResultsRedTree(BuildStepMixinAdditions, unittest.Tes
         self.configureCommonProperties()
         self.setProperty('first_run_failures', ["test/failure1.html", "test/failure2.html", "test/pre-existent/failure.html", "test/pre-existent/flaky.html"])
         self.setProperty('first_run_flakies', ["test/flaky1.html", "test/flaky2.html"])
-        self.setProperty('with_change_repeat_failures_results_nonflaky_failures', ["test/failure1.html", "test/failure2.html"])
-        self.setProperty('with_change_repeat_failures_results_flakies', [])
-        self.setProperty('with_change_repeat_failures_retcode', FAILURE)
         self.setProperty('without_change_repeat_failures_results_nonflaky_failures', [])
         self.setProperty('without_change_repeat_failures_results_flakies', [])
         self.setProperty('without_change_repeat_failures_retcode', FAILURE)
@@ -3645,7 +3515,6 @@ class TestAnalyzeLayoutTestsResultsRedTree(BuildStepMixinAdditions, unittest.Tes
         self.configureCommonProperties()
         self.setProperty('first_run_failures', ["test/failure1.html", "test/failure2.html", "test/pre-existent/failure.html", "test/pre-existent/flaky.html"])
         self.setProperty('first_run_flakies', ["test/flaky1.html", "test/flaky2.html"])
-        self.setProperty('with_change_repeat_failures_timedout', True)
         self.setProperty('without_change_repeat_failures_timedout', True)
         expected_infrastructure_error = 'The step "layout-tests-repeat-failures-without-change" was interrumped because it reached the timeout.'
         self.expect_outcome(result=RETRY, state_string=f'Unexpected infrastructure issue: {expected_infrastructure_error}\nRetrying build [retry count is 0 of 3] (retry)')
@@ -3659,8 +3528,6 @@ class TestAnalyzeLayoutTestsResultsRedTree(BuildStepMixinAdditions, unittest.Tes
         self.configureCommonProperties()
         self.setProperty('first_run_failures', ["test/failure1.html", "test/failure2.html", "test/pre-existent/failure.html", "test/pre-existent/flaky.html"])
         self.setProperty('first_run_flakies', ["test/flaky1.html", "test/flaky2.html"])
-        self.setProperty('with_change_repeat_failures_results_nonflaky_failures', ["test/failure1.html", "test/pre-existent/failure.html", "test/pre-existent/flaky.html"])
-        self.setProperty('with_change_repeat_failures_results_flakies', ["test/failure2.html"])
         self.setProperty('without_change_repeat_failures_timedout', True)
         expected_infrastructure_error = 'The step "layout-tests-repeat-failures-without-change" was interrumped because it reached the timeout.'
         self.expect_outcome(result=RETRY, state_string=f'Unexpected infrastructure issue: {expected_infrastructure_error}\nRetrying build [retry count is 0 of 3] (retry)')
@@ -3674,8 +3541,6 @@ class TestAnalyzeLayoutTestsResultsRedTree(BuildStepMixinAdditions, unittest.Tes
         self.configureCommonProperties()
         self.setProperty('first_run_failures', ["test/failure1.html", "test/failure2.html", "test/pre-existent/failure.html", "test/pre-existent/flaky.html"])
         self.setProperty('first_run_flakies', ["test/flaky1.html", "test/flaky2.html"])
-        self.setProperty('with_change_repeat_failures_results_nonflaky_failures', ["test/failure1.html", "test/pre-existent/failure.html", "test/pre-existent/flaky.html"])
-        self.setProperty('with_change_repeat_failures_results_flakies', ["test/failure2.html"])
         self.setProperty('without_change_repeat_failures_timedout', True)
         self.setProperty('retry_count', 2)
         expected_infrastructure_error = 'The step "layout-tests-repeat-failures-without-change" was interrumped because it reached the timeout.'
@@ -3690,8 +3555,6 @@ class TestAnalyzeLayoutTestsResultsRedTree(BuildStepMixinAdditions, unittest.Tes
         self.configureCommonProperties()
         self.setProperty('first_run_failures', ["test/failure1.html", "test/failure2.html", "test/pre-existent/failure.html", "test/pre-existent/flaky.html"])
         self.setProperty('first_run_flakies', ["test/flaky1.html", "test/flaky2.html"])
-        self.setProperty('with_change_repeat_failures_results_nonflaky_failures', ["test/failure1.html", "test/pre-existent/failure.html", "test/pre-existent/flaky.html"])
-        self.setProperty('with_change_repeat_failures_results_flakies', ["test/failure2.html"])
         self.setProperty('without_change_repeat_failures_timedout', True)
         self.setProperty('retry_count', 3)
         expected_infrastructure_error = 'The step "layout-tests-repeat-failures-without-change" was interrumped because it reached the timeout.'


### PR DESCRIPTION
#### 471453201b4f4770ce4eb2edb0539c8ff2cb4066
<pre>
[WKCI][WPE][GTK] Make the steps for GTK/WPE WK2 testing on the EWS less likely to mark as good patches introducing new flakes.
<a href="https://bugs.webkit.org/show_bug.cgi?id=310315">https://bugs.webkit.org/show_bug.cgi?id=310315</a>

Reviewed by Aakash Jain.

The current WK2 testing classes for GTK and WPE on the EWS were designed
when the layout test tree was frequently red, so they required a failure
to reproduce 10/10 times with the patch and 0/10 times without it before
marking a patch as bad. This makes it almost impossible to detect patches
that introduce new flakes.

Since the GTK and WPE trees are now consistently green, tighten the
failure detection: mark a patch as bad if a test fails once on the
first run with the patch and then passes all 10 retries without it.

This commit basically removes the step &quot;repeat-failures-with-patch&quot;
and adjusts the logic accordingly.

While at it, this also removes code duplication between the specialized
GTK/WPE class and the main WK2 EWS testing classes.

* Tools/CISupport/ews-build/steps.py:
(ParseByLineLogObserver.consumeLineGenerator):
(RunWebKitTests.run):
(RunWebKitTests._did_command_timed_out):
(RunWebKitTests.runCommand):
(RunWebKitTests._next_steps_for_platform):
(RunWebKitTests.evaluateCommand):
(RunWebKitTestsWithoutChange.evaluateCommand):
(RunWebKit1Tests.run):
(RunWebKitTestsRedTree._next_steps_for_platform):
(RunWebKitTestsRepeatFailuresWithoutChangeRedTree.setLayoutTestCommand):
(RunWebKitTestsRepeatFailuresWithoutChangeRedTree.runCommand):
(RunWebKitTestsWithoutChangeRedTree):
(AnalyzeLayoutTestsResultsRedTree.run):
(RunWebKitTestsRedTree._did_command_timed_out): Deleted.
(RunWebKitTestsRedTree.evaluateCommand): Deleted.
(RunWebKitTestsRepeatFailuresRedTree): Deleted.
(RunWebKitTestsRepeatFailuresRedTree.__init__): Deleted.
(RunWebKitTestsRepeatFailuresRedTree.setLayoutTestCommand): Deleted.
(RunWebKitTestsRepeatFailuresRedTree.evaluateCommand): Deleted.
(RunWebKitTestsRepeatFailuresRedTree.runCommand): Deleted.
(RunWebKitTestsRepeatFailuresRedTree.run): Deleted.
(RunWebKitTestsRepeatFailuresWithoutChangeRedTree.run): Deleted.
(RunWebKitTestsWithoutChangeRedTree.evaluateCommand): Deleted.
* Tools/CISupport/ews-build/steps_unittest.py:
(TestRunWebKitTestsRedTree.test_flakies_with_fail_retcode_then_go_to_analyze_results):
(TestRunWebKitTestsRedTree):
(TestRunWebKitTestsRedTree.test_flakies_with_warning_retcode_then_finish):
(TestRunWebKitTestsRepeatFailuresWithoutChangeRedTree):
(TestRunWebKitTestsRepeatFailuresWithoutChangeRedTree.configureStep):
(TestRunWebKitTestsRepeatFailuresWithoutChangeRedTree.test_success):
(TestRunWebKitTestsRepeatFailuresWithoutChangeRedTree.test_success_tests_names_with_shell_conflictive_chars):
(TestRunWebKitTestsRepeatFailuresWithoutChangeRedTree.test_set_properties_when_executed_scope_this_class):
(TestRunWebKitTestsRepeatFailuresWithoutChangeRedTree.test_run_ends_then_go_to_analyze):
(TestAnalyzeLayoutTestsResultsRedTree.test_failure_introduced_by_change_clean_tree_green):
(TestAnalyzeLayoutTestsResultsRedTree.test_failure_introduced_by_change_clean_tree_red):
(TestAnalyzeLayoutTestsResultsRedTree.test_pre_existent_failures):
(TestAnalyzeLayoutTestsResultsRedTree.test_pre_existent_flakies):
(TestAnalyzeLayoutTestsResultsRedTree.test_first_step_timeouts):
(TestAnalyzeLayoutTestsResultsRedTree.test_first_step_timeouts_last_try):
(TestAnalyzeLayoutTestsResultsRedTree.test_step_retry_without_change_exits_early_error):
(TestAnalyzeLayoutTestsResultsRedTree.test_step_retry_without_change_success):
(TestAnalyzeLayoutTestsResultsRedTree.test_step_retry_without_change_warnings):
(TestAnalyzeLayoutTestsResultsRedTree.test_step_retry_without_change_failure):
(TestAnalyzeLayoutTestsResultsRedTree.test_step_retry_with_change_timeouts):
(TestAnalyzeLayoutTestsResultsRedTree.test_step_retry_without_change_unexpected_error):
(TestAnalyzeLayoutTestsResultsRedTree.test_step_retry_without_change_timeouts):
(TestAnalyzeLayoutTestsResultsRedTree.test_step_retry_with_change_timeouts_and_without_change_timeouts):
(TestAnalyzeLayoutTestsResultsRedTree.test_retry_third_time):
(TestAnalyzeLayoutTestsResultsRedTree.test_retry_finish):
(TestRunWebKitTestsRedTree.test_flakies_but_no_failures_then_go_to_analyze_results): Deleted.
(TestRunWebKitTestsRepeatFailuresRedTree): Deleted.
(TestRunWebKitTestsRepeatFailuresRedTree.setUp): Deleted.
(TestRunWebKitTestsRepeatFailuresRedTree.tearDown): Deleted.
(TestRunWebKitTestsRepeatFailuresRedTree.configureStep): Deleted.
(TestRunWebKitTestsRepeatFailuresRedTree.test_success): Deleted.
(TestRunWebKitTestsRepeatFailuresRedTree.test_success_tests_names_with_shell_conflictive_chars): Deleted.
(TestRunWebKitTestsRepeatFailuresRedTree.test_set_properties_when_executed_scope_this_class): Deleted.
(TestRunWebKitTestsRepeatFailuresRedTree.test_last_run_with_patch_ends_with_list_of_failing_tests_then_schedule_update_libs_and_test_without_patch): Deleted.
(TestRunWebKitTestsRepeatFailuresRedTree.test_last_run_with_patch_ends_with_no_failing_tests_then_go_to_analyze): Deleted.
(TestRunWebKitTestsRepeatFailuresWithoutChangeRedTree.test_step_with_change_did_timeout): Deleted.
(TestAnalyzeLayoutTestsResultsRedTree.test_step_retry_with_change_exits_early_error): Deleted.
(TestAnalyzeLayoutTestsResultsRedTree.test_step_retry_with_change_pass): Deleted.
(TestAnalyzeLayoutTestsResultsRedTree.test_step_retry_with_change_warnings): Deleted.
(TestAnalyzeLayoutTestsResultsRedTree.test_step_retry_with_change_error_with_flakies): Deleted.
(TestAnalyzeLayoutTestsResultsRedTree.test_step_retry_with_change_unexpected_error): Deleted.

Canonical link: <a href="https://commits.webkit.org/309933@main">https://commits.webkit.org/309933@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b5b2c0660bf42156b26e6bb8157f6df3b9eff0f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151154 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23916 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17487 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159883 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104590 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153027 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24347 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24146 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116699 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82836 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154114 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18819 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135621 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97420 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17912 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15863 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7728 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127530 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13538 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162355 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15109 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124708 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/150554 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23718 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19913 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124896 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23708 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135335 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80152 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23344 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19957 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12100 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23318 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23030 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23182 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23084 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->