### PR TITLE
AX: Add the ability to get the RGBA representation of an image via the accessibility API

### DIFF
--- a/LayoutTests/accessibility/image-data-expected.txt
+++ b/LayoutTests/accessibility/image-data-expected.txt
@@ -1,0 +1,17 @@
+This tests that AXImageDataSize and AXImageData can be retrieved for image elements.
+
+PASS: image.imageDataSize.indexOf('AXImageDataSize') >= 0 === true
+PASS: image.imageDataSize.indexOf('{0, 0}') >= 0 === false
+PASS: image.imageDataForParameters(100, 100) === 'AXImageData: 40000 bytes'
+PASS: image.imageDataForParameters(0, 0) === 'AXImageData: 234080 bytes'
+PASS: image.imageDataForParametersWithFormat(100, 100, 'PNG') === '(null)'
+PASS: image.imageDataForSubrect(200, 200, 10, 10, 50, 50) === 'AXImageData: 10000 bytes'
+PASS: image.imageDataForSubrect(100, 100, 80, 80, 50, 50) === 'AXImageData: 10000 bytes'
+PASS: image.imageDataForSubrect(0, 0, 250, 200, 100, 100) === 'AXImageData: 40000 bytes'
+PASS: nonImage.imageDataForParameters(100, 100) === '(null)'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+Not an image

--- a/LayoutTests/accessibility/image-data.html
+++ b/LayoutTests/accessibility/image-data.html
@@ -1,0 +1,56 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<img src="resources/cake.png" id="image" onload="runTest();">
+<div id="nonimage">Not an image</div>
+
+<script>
+var output = "This tests that AXImageDataSize and AXImageData can be retrieved for image elements.\n\n";
+
+window.jsTestIsAsync = true;
+
+var image, nonImage;
+function runTest() {
+    if (!window.accessibilityController)
+        return;
+
+    image = accessibilityController.accessibleElementById("image");
+    // imageDataSize should return non-empty dimensions for an image.
+    output += expect("image.imageDataSize.indexOf('AXImageDataSize') >= 0", "true");
+    output += expect("image.imageDataSize.indexOf('{0, 0}') >= 0", "false");
+
+    // imageDataForParameters with resize 100x100 should return 100*100*4 = 40000 bytes.
+    output += expect("image.imageDataForParameters(100, 100)", "'AXImageData: 40000 bytes'");
+
+    // Native-size fetch (0, 0 means use original dimensions). cake.png is 280x209 = 234080 bytes.
+    output += expect("image.imageDataForParameters(0, 0)", "'AXImageData: 234080 bytes'");
+
+    // Invalid format should return null.
+    output += expect("image.imageDataForParametersWithFormat(100, 100, 'PNG')", "'(null)'");
+
+    // Subrect extraction: resize to 200x200, extract a 50x50 subrect = 50*50*4 = 10000 bytes.
+    output += expect("image.imageDataForSubrect(200, 200, 10, 10, 50, 50)", "'AXImageData: 10000 bytes'");
+
+    // Out-of-bounds subrect: resize to 100x100, request subrect starting at (80, 80) with size 50x50.
+    // The extraction rect extends beyond the buffer, but getPixelBuffer clips and zero-fills.
+    // The returned buffer is still 50*50*4 = 10000 bytes.
+    output += expect("image.imageDataForSubrect(100, 100, 80, 80, 50, 50)", "'AXImageData: 10000 bytes'");
+
+    // Out-of-bounds subrect without resize: native size is 280x209, request subrect at (250, 200) with size 100x100.
+    // The returned buffer is still 100*100*4 = 40000 bytes due to aforementioned zero-filling.
+    output += expect("image.imageDataForSubrect(0, 0, 250, 200, 100, 100)", "'AXImageData: 40000 bytes'");
+
+    nonImage = accessibilityController.accessibleElementById("nonimage");
+    output += expect("nonImage.imageDataForParameters(100, 100)", "'(null)'");
+
+    debug(output);
+    finishJSTest();
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/image-link-expected.txt
+++ b/LayoutTests/accessibility/image-link-expected.txt
@@ -71,6 +71,7 @@ AXVisibleCharacterRange: NSRange: {0, 0}
 AXElementBusy: 0
 AXImageOverlayElements: (null)
 AXEmbeddedImageDescription:
+AXImageDataSize: NSSize: {280, 209}
 AXURL: LayoutTests/accessibility/resources/cake.png
 
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1119,6 +1119,7 @@ webkit.org/b/228915 accessibility/selected-state-changed-notifications.html [ Fa
 
 # Not supported
 accessibility/embedded-image-description.html [ Skip ]
+accessibility/image-data.html [ Skip ]
 accessibility/aria-keyshortcuts.html [ Skip ]
 accessibility/radio-button-group-dynamic-changes.html [ Failure ]
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7193,6 +7193,7 @@ accessibility/img-with-empty-alt-is-ignored-without-fallbacks.html [ Pass ]
 accessibility/insert-newline.html [ Pass ]
 accessibility/keyevents-posted-for-dismiss-action.html [ Pass ]
 accessibility/embedded-image-description.html [ Pass ]
+accessibility/image-data.html [ Pass ]
 accessibility/aria-description.html [ Pass ]
 fast/multicol/flexbox-rows.html [ Skip ]
 

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -107,6 +107,7 @@ class Path;
 class QualifiedName;
 class RenderObject;
 class ScrollView;
+class SharedBuffer;
 
 struct AccessibilitySearchCriteria;
 struct AccessibilityText;
@@ -127,6 +128,17 @@ enum class ClickHandlerFilter : bool {
 };
 
 enum class PreSortedObjectType : uint8_t { LiveRegion, WebArea };
+
+struct AXImageDataParameters {
+    static constexpr unsigned maxDimension = 2000;
+
+    unsigned resizeWidth { 0 };
+    unsigned resizeHeight { 0 };
+    unsigned left { 0 };
+    unsigned top { 0 };
+    unsigned width { 0 };
+    unsigned height { 0 };
+};
 
 enum class DateComponentsType : uint8_t;
 
@@ -748,6 +760,8 @@ public:
     virtual String brailleRoleDescription() const = 0;
     virtual String embeddedImageDescription() const = 0;
     virtual std::optional<AccessibilityChildrenVector> imageOverlayElements() = 0;
+    virtual FloatSize imageDataSize() const = 0;
+    virtual RefPtr<SharedBuffer> imageData(const AXImageDataParameters&) const = 0;
     virtual String extendedDescription() const = 0;
 
     bool NODELETE supportsActiveDescendant() const;
@@ -1796,6 +1810,7 @@ constexpr Seconds GeneralPropertyTimeout = 25_ms;
 constexpr Seconds VisibilityCheckTimeout = 50_ms;
 constexpr Seconds SpellCheckTimeout = 100_ms;
 constexpr Seconds InteractiveTimeout = 250_ms;
+constexpr Seconds ImageDataTimeout = 250_ms;
 
 template<typename U>
 inline DidTimeout performFunctionOnMainThreadAndWaitWithTimeout(U&& lambda, Seconds timeout)

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -45,6 +45,7 @@
 #include "AccessibilityObjectInlines.h"
 #include "AccessibilityRenderObject.h"
 #include "AccessibilityScrollView.h"
+#include "CachedImage.h"
 #include "Chrome.h"
 #include "ChromeClient.h"
 #include "ContainerNodeInlines.h"
@@ -81,6 +82,8 @@
 #include "HTMLTableSectionElement.h"
 #include "HTMLTextAreaElement.h"
 #include "HitTestResult.h"
+#include "Image.h"
+#include "ImageBuffer.h"
 #include "LocalFrame.h"
 #include "LocalizedStrings.h"
 #include "Logging.h"
@@ -89,11 +92,13 @@
 #include "NodeName.h"
 #include "NodeTraversal.h"
 #include "Page.h"
+#include "PixelBuffer.h"
 #include "PositionInlines.h"
 #include "ProgressTracker.h"
 #include "Range.h"
 #include "RenderElementInlines.h"
 #include "RenderImage.h"
+#include "RenderImageResource.h"
 #include "RenderInline.h"
 #include "RenderLayer.h"
 #include "RenderLayerInlines.h"
@@ -108,6 +113,7 @@
 #include "RenderedPosition.h"
 #include "SVGNames.h"
 #include "Settings.h"
+#include "SharedBuffer.h"
 #include "TextCheckerClient.h"
 #include "TextCheckingHelper.h"
 #include "TextIterator.h"
@@ -3067,6 +3073,68 @@ String AccessibilityObject::embeddedImageDescription() const
         return { };
 
     return renderImage->accessibilityDescription();
+}
+
+static RefPtr<Image> imageFromRenderer(RenderObject* renderer)
+{
+    CheckedPtr renderImage = dynamicDowncast<RenderImage>(renderer);
+    auto* cachedImage = renderImage ? renderImage->cachedImage() : nullptr;
+    return cachedImage ? cachedImage->image() : nullptr;
+}
+
+FloatSize AccessibilityObject::imageDataSize() const
+{
+    if (RefPtr image = imageFromRenderer(renderer()))
+        return image->size();
+    return { };
+}
+
+RefPtr<SharedBuffer> AccessibilityObject::imageData(const AXImageDataParameters& parameters) const
+{
+    RefPtr image = imageFromRenderer(renderer());
+    if (!image || image->isNull())
+        return nullptr;
+
+    auto nativeSize = image->size();
+    if (nativeSize.isEmpty())
+        return nullptr;
+
+    // Determine the resize dimensions.
+    float targetWidth = parameters.resizeWidth ? parameters.resizeWidth : nativeSize.width();
+    float targetHeight = parameters.resizeHeight ? parameters.resizeHeight : nativeSize.height();
+
+    // Clamp to a maximum of maxDimension x maxDimension pixels, preserving aspect ratio.
+    constexpr float maxPixelArea = AXImageDataParameters::maxDimension * AXImageDataParameters::maxDimension;
+    float pixelArea = targetWidth * targetHeight;
+    if (pixelArea > maxPixelArea) {
+        float scale = std::sqrt(maxPixelArea / pixelArea);
+        targetWidth = std::floor(targetWidth * scale);
+        targetHeight = std::floor(targetHeight * scale);
+    }
+
+    FloatSize bufferSize(targetWidth, targetHeight);
+    auto imageBuffer = ImageBuffer::create(bufferSize, RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, 1.0f, DestinationColorSpace::SRGB(), PixelFormat::BGRA8);
+    if (!imageBuffer)
+        return nullptr;
+
+    // Draw the source image scaled into the buffer.
+    imageBuffer->context().drawImage(*image, FloatRect({ }, bufferSize), FloatRect({ }, nativeSize));
+
+    // Determine the extraction rect from subrect parameters or full image.
+    IntRect extractionRect;
+    if (parameters.width && parameters.height)
+        extractionRect = IntRect(parameters.left, parameters.top, parameters.width, parameters.height);
+    else
+        extractionRect = IntRect(IntPoint(), IntSize(targetWidth, targetHeight));
+
+    // Extract pixels as unpremultiplied RGBA8.
+    PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, DestinationColorSpace::SRGB() };
+    auto pixelBuffer = imageBuffer->getPixelBuffer(format, extractionRect);
+    if (!pixelBuffer)
+        return nullptr;
+
+    std::span<const uint8_t> bytes = pixelBuffer->bytes();
+    return SharedBuffer::create(bytes);
 }
 
 bool AccessibilityObject::isLoaded() const

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -467,6 +467,8 @@ public:
     String brailleLabel() const override { return getAttribute(HTMLNames::aria_braillelabelAttr); }
     String brailleRoleDescription() const override { return getAttribute(HTMLNames::aria_brailleroledescriptionAttr); }
     String embeddedImageDescription() const final;
+    FloatSize imageDataSize() const final;
+    RefPtr<SharedBuffer> imageData(const AXImageDataParameters&) const final;
     std::optional<AccessibilityChildrenVector> imageOverlayElements() override { return std::nullopt; }
     String extendedDescription() const final;
 

--- a/Source/WebCore/accessibility/cocoa/CocoaAccessibilityConstants.h
+++ b/Source/WebCore/accessibility/cocoa/CocoaAccessibilityConstants.h
@@ -186,6 +186,17 @@
 #define NSAccessibilityHasPopupAttribute @"AXHasPopup"
 #define NSAccessibilityHighestEditableAncestorAttribute @"AXHighestEditableAncestor"
 #define NSAccessibilityImageOverlayElementsAttribute @"AXImageOverlayElements"
+#define NSAccessibilityImageDataSizeAttribute @"AXImageDataSize"
+#ifndef NSAccessibilityImageDataParameterizedAttribute
+#define NSAccessibilityImageDataParameterizedAttribute @"AXImageData"
+#endif
+#define NSAccessibilityImageDataResizeWidthKey @"AXImageDataResizeWidth"
+#define NSAccessibilityImageDataResizeHeightKey @"AXImageDataResizeHeight"
+#define NSAccessibilityImageDataFormatKey @"AXImageDataFormat"
+#define NSAccessibilityImageDataLeftKey @"AXImageDataLeft"
+#define NSAccessibilityImageDataTopKey @"AXImageDataTop"
+#define NSAccessibilityImageDataWidthKey @"AXImageDataWidth"
+#define NSAccessibilityImageDataHeightKey @"AXImageDataHeight"
 #define NSAccessibilityInfoStringForTestingAttribute @"AXInfoStringForTesting"
 #define NSAccessibilityInlineTextAttribute @"AXInlineText"
 #define NSAccessibilityInvalidAttribute @"AXInvalid"

--- a/Source/WebCore/accessibility/cocoa/WebAccessibilityObjectWrapperBase.h
+++ b/Source/WebCore/accessibility/cocoa/WebAccessibilityObjectWrapperBase.h
@@ -37,6 +37,7 @@
 #import <wtf/WeakPtr.h>
 
 namespace WebCore {
+struct AXImageDataParameters;
 struct AccessibilitySearchCriteria;
 class AccessibilityObject;
 class AXIsolatedObject;
@@ -142,3 +143,7 @@ extern std::optional<WebCore::SimpleRange> makeDOMRange(WebCore::Document*, NSRa
 #endif
 
 @end
+
+namespace WebCore {
+std::optional<AXImageDataParameters> imageDataParametersFromDictionary(NSDictionary *);
+}

--- a/Source/WebCore/accessibility/cocoa/WebAccessibilityObjectWrapperBase.mm
+++ b/Source/WebCore/accessibility/cocoa/WebAccessibilityObjectWrapperBase.mm
@@ -40,6 +40,7 @@
 #import "AccessibilitySpinButton.h"
 #import "AccessibilityTableColumn.h"
 #import "BoundaryPointInlines.h"
+#import "CocoaAccessibilityConstants.h"
 #import "ColorMac.h"
 #import "ContextMenuController.h"
 #import "Editing.h"
@@ -1028,3 +1029,42 @@ AccessibilitySearchCriteria accessibilitySearchCriteriaForSearchPredicate(AXCore
 }
 
 @end
+
+namespace WebCore {
+
+std::optional<AXImageDataParameters> imageDataParametersFromDictionary(NSDictionary *dictionary)
+{
+    if (!dictionary)
+        return std::nullopt;
+
+    RetainPtr format = dynamic_objc_cast<NSString>([dictionary objectForKey:NSAccessibilityImageDataFormatKey]);
+    if (!format || ![format isEqualToString:@"RGBA"])
+        return std::nullopt;
+
+    auto validatedValue = [](NSString *key, NSDictionary *dict) -> std::optional<unsigned> {
+        id rawValue = [dict objectForKey:key];
+        if (!rawValue)
+            return 0u;
+        RetainPtr number = dynamic_objc_cast<NSNumber>(rawValue);
+        if (!number)
+            return std::nullopt;
+        int value = [number intValue];
+        if (value < 0 || static_cast<unsigned>(value) > AXImageDataParameters::maxDimension)
+            return std::nullopt;
+        return static_cast<unsigned>(value);
+    };
+
+    auto resizeWidth = validatedValue(NSAccessibilityImageDataResizeWidthKey, dictionary);
+    auto resizeHeight = validatedValue(NSAccessibilityImageDataResizeHeightKey, dictionary);
+    auto left = validatedValue(NSAccessibilityImageDataLeftKey, dictionary);
+    auto top = validatedValue(NSAccessibilityImageDataTopKey, dictionary);
+    auto width = validatedValue(NSAccessibilityImageDataWidthKey, dictionary);
+    auto height = validatedValue(NSAccessibilityImageDataHeightKey, dictionary);
+
+    if (!resizeWidth || !resizeHeight || !left || !top || !width || !height)
+        return std::nullopt;
+
+    return AXImageDataParameters { *resizeWidth, *resizeHeight, *left, *top, *width, *height };
+}
+
+} // namespace WebCore

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -39,6 +39,7 @@
 #import "AccessibilityScrollView.h"
 #import "Chrome.h"
 #import "ChromeClient.h"
+#import "CocoaAccessibilityConstants.h"
 #import "FontCascade.h"
 #import "FrameSelection.h"
 #import "HTMLFrameOwnerElement.h"
@@ -2033,6 +2034,29 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
         return nil;
 
     return self.axBackingObject->embeddedImageDescription().createNSString().autorelease();
+}
+
+- (NSValue *)accessibilityImageDataSize
+{
+    if (![self _prepareAccessibilityCall])
+        return nil;
+
+    auto size = self.axBackingObject->imageDataSize();
+    return [NSValue valueWithCGSize:CGSizeMake(size.width(), size.height())];
+}
+
+- (NSData *)accessibilityImageDataWithParameters:(NSDictionary *)dictionary
+{
+    if (![self _prepareAccessibilityCall] || !self.axBackingObject->isImage())
+        return nil;
+
+    auto parameters = imageDataParametersFromDictionary(dictionary);
+    RefPtr buffer = parameters ? self.axBackingObject->imageData(*parameters) : nullptr;
+    if (!buffer)
+        return nil;
+
+    auto span = buffer->span();
+    return [NSData dataWithBytes:span.data() length:span.size()];
 }
 
 - (NSArray *)accessibilityImageOverlayElements

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -43,6 +43,7 @@
 #include "Logging.h"
 #include "PathUtilities.h"
 #include "RenderObject.h"
+#include "SharedBuffer.h"
 #include "WebAnimation.h"
 #include <wtf/text/MakeString.h>
 
@@ -454,6 +455,24 @@ void AXIsolatedObject::performDismissActionIgnoringResult()
     performFunctionOnMainThread([] (auto* axObject) {
         axObject->performDismissActionIgnoringResult();
     });
+}
+
+FloatSize AXIsolatedObject::imageDataSize() const
+{
+    return Accessibility::retrieveValueFromMainThreadWithTimeoutAndDefault([context = mainThreadContext()] () -> FloatSize {
+        if (RefPtr axObject = context.axObjectOnMainThread())
+            return axObject->imageDataSize();
+        return { };
+    }, Accessibility::GeneralPropertyTimeout, FloatSize());
+}
+
+RefPtr<SharedBuffer> AXIsolatedObject::imageData(const AXImageDataParameters& parameters) const
+{
+    return Accessibility::retrieveValueFromMainThreadWithTimeoutAndDefault([parameters, context = mainThreadContext()] () -> RefPtr<SharedBuffer> {
+        if (RefPtr axObject = context.axObjectOnMainThread())
+            return axObject->imageData(parameters);
+        return nullptr;
+    }, Accessibility::ImageDataTimeout, nullptr);
 }
 
 void AXIsolatedObject::scrollToMakeVisible() const

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -357,6 +357,8 @@ private:
     String brailleRoleDescription() const final { return stringAttributeValue(AXProperty::BrailleRoleDescription); }
     String embeddedImageDescription() const final { return stringAttributeValue(AXProperty::EmbeddedImageDescription); }
     std::optional<AccessibilityChildrenVector> imageOverlayElements() final { return std::nullopt; }
+    FloatSize imageDataSize() const final;
+    RefPtr<SharedBuffer> imageData(const AXImageDataParameters&) const final;
     String extendedDescription() const final { return stringAttributeValue(AXProperty::ExtendedDescription); }
     String computedRoleString() const final;
     bool isValueAutofillAvailable() const final { return boolAttributeValue(AXProperty::IsValueAutofillAvailable); }

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -931,6 +931,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
         auto tempArray = adoptNS([[NSMutableArray alloc] initWithArray:attributes.get().get()]);
         [tempArray addObject:NSAccessibilityImageOverlayElementsAttribute];
         [tempArray addObject:NSAccessibilityEmbeddedImageDescriptionAttribute];
+        [tempArray addObject:NSAccessibilityImageDataSizeAttribute];
         [tempArray addObject:NSAccessibilityURLAttribute];
         return tempArray;
     }();
@@ -1571,6 +1572,12 @@ static id handleBlockQuoteLevelAttribute(WebAccessibilityObjectWrapper*, AXCoreO
 static id handleEmbeddedImageDescriptionAttribute(WebAccessibilityObjectWrapper*, AXCoreObject& backingObject)
 {
     return backingObject.embeddedImageDescription().createNSString().autorelease();
+}
+
+static id handleImageDataSizeAttribute(WebAccessibilityObjectWrapper*, AXCoreObject& backingObject)
+{
+    auto size = backingObject.imageDataSize();
+    return [NSValue valueWithSize:NSMakeSize(size.width(), size.height())];
 }
 
 static id handleContentsAttribute(WebAccessibilityObjectWrapper*, AXCoreObject& backingObject)
@@ -2303,6 +2310,7 @@ static MemoryCompactLookupOnlyRobinHoodHashMap<String, AttributeHandlerEntry> cr
         { NSAccessibilityVisitedAttribute, { handleVisitedAttribute, { } } },
         { NSAccessibilityBlockQuoteLevelAttribute, { handleBlockQuoteLevelAttribute, { } } },
         { NSAccessibilityEmbeddedImageDescriptionAttribute, { handleEmbeddedImageDescriptionAttribute, { } } },
+        { NSAccessibilityImageDataSizeAttribute, { handleImageDataSizeAttribute, { } } },
         { NSAccessibilityContentsAttribute, { handleContentsAttribute, { } } },
         { NSAccessibilityHelpAttribute, { handleHelpAttribute, { } } },
         { NSAccessibilityDisclosingAttribute, { handleDisclosingAttribute, { } } },
@@ -2928,6 +2936,11 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
         [tempArray addObject:NSAccessibilityUIElementsForSearchPredicateParameterizedAttribute];
         return tempArray;
     }();
+    static NeverDestroyed imageParamAttrs = [] {
+        RetainPtr tempArray = adoptNS([[NSMutableArray alloc] initWithArray:paramAttrs.get().get()]);
+        [tempArray addObject:NSAccessibilityImageDataParameterizedAttribute];
+        return tempArray;
+    }();
 
     if (backingObject->isSecureField())
         return secureFieldParamAttrs.get().get();
@@ -2943,6 +2956,9 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 
     if (backingObject->isStaticText())
         return staticTextParamAttrs.get().get();
+
+    if (backingObject->isImage())
+        return imageParamAttrs.get().get();
 
 #if !ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     // The object that serves up the remote frame also is the one that does the frame conversion.
@@ -4150,6 +4166,20 @@ static id handleConvertRelativeFrameParameterizedAttribute(WebAccessibilityObjec
 }
 #endif
 
+static id handleImageDataParameterizedAttribute(WebAccessibilityObjectWrapper*, AXCoreObject& backingObject, const ParameterizedAttributeContext& context)
+{
+    if (!backingObject.isImage())
+        return nil;
+
+    auto parameters = imageDataParametersFromDictionary(context.dictionary.get());
+    auto buffer = parameters ? backingObject.imageData(*parameters) : nullptr;
+    if (!buffer)
+        return nil;
+
+    auto span = buffer->span();
+    return [NSData dataWithBytes:span.data() length:span.size()];
+}
+
 static MemoryCompactLookupOnlyRobinHoodHashMap<String, ParameterizedAttributeHandlerEntry> createParameterizedAttributeHandlerMap()
 {
     struct ParameterizedAttributeMapping {
@@ -4213,6 +4243,7 @@ static MemoryCompactLookupOnlyRobinHoodHashMap<String, ParameterizedAttributeHan
 #if !ENABLE(ACCESSIBILITY_LOCAL_FRAME)
         { NSAccessibilityConvertRelativeFrameParameterizedAttribute, { handleConvertRelativeFrameParameterizedAttribute } },
 #endif
+        { NSAccessibilityImageDataParameterizedAttribute, { handleImageDataParameterizedAttribute } },
     });
 
     MemoryCompactLookupOnlyRobinHoodHashMap<String, ParameterizedAttributeHandlerEntry> map;

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp
@@ -481,6 +481,26 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::embeddedImageDescription() cons
     return nullptr;
 }
 
+JSRetainPtr<JSStringRef> AccessibilityUIElement::imageDataSize() const
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::imageDataForParameters(int, int) const
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::imageDataForParametersWithFormat(int, int, JSStringRef) const
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::imageDataForSubrect(int, int, int, int, int, int) const
+{
+    return nullptr;
+}
+
 RefPtr<AccessibilityTextMarker> AccessibilityUIElement::endTextMarker()
 {
     return nullptr;

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
@@ -213,6 +213,10 @@ public:
     virtual JSRetainPtr<JSStringRef> url();
     virtual JSRetainPtr<JSStringRef> classList() const;
     virtual JSRetainPtr<JSStringRef> embeddedImageDescription() const;
+    virtual JSRetainPtr<JSStringRef> imageDataSize() const;
+    virtual JSRetainPtr<JSStringRef> imageDataForParameters(int resizeWidth, int resizeHeight) const;
+    virtual JSRetainPtr<JSStringRef> imageDataForParametersWithFormat(int resizeWidth, int resizeHeight, JSStringRef format) const;
+    virtual JSRetainPtr<JSStringRef> imageDataForSubrect(int resizeWidth, int resizeHeight, int left, int top, int width, int height) const;
     virtual JSValueRef imageOverlayElements(JSContextRef);
 
     // CSS3-speech properties.

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl
@@ -123,6 +123,7 @@ interface AccessibilityUIElement {
     readonly attribute DOMString classList;
     readonly attribute DOMString embeddedImageDescription;
     readonly attribute object imageOverlayElements;
+    readonly attribute DOMString imageDataSize;
     readonly attribute boolean isInsertion;
     readonly attribute boolean isDeletion;
     readonly attribute boolean isFirstItemInSuggestion;
@@ -219,6 +220,9 @@ interface AccessibilityUIElement {
 
     // Paramaterized attributes.
     DOMString parameterizedAttributeNames();
+    DOMString imageDataForParameters(long resizeWidth, long resizeHeight);
+    DOMString imageDataForParametersWithFormat(long resizeWidth, long resizeHeight, DOMString format);
+    DOMString imageDataForSubrect(long resizeWidth, long resizeHeight, long left, long top, long width, long height);
     long lineForIndex(long index);
     DOMString rangeForLine(long index);
     DOMString rangeForPosition(long x, long y);

--- a/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.h
@@ -164,6 +164,10 @@ public:
     JSRetainPtr<JSStringRef> brailleRoleDescription() const override;
 
     JSRetainPtr<JSStringRef> embeddedImageDescription() const override;
+    JSRetainPtr<JSStringRef> imageDataSize() const override;
+    JSRetainPtr<JSStringRef> imageDataForParameters(int resizeWidth, int resizeHeight) const override;
+    JSRetainPtr<JSStringRef> imageDataForParametersWithFormat(int resizeWidth, int resizeHeight, JSStringRef format) const override;
+    JSRetainPtr<JSStringRef> imageDataForSubrect(int resizeWidth, int resizeHeight, int left, int top, int width, int height) const override;
     JSValueRef imageOverlayElements(JSContextRef) override;
 
     bool hasDocumentRoleAncestor() const;

--- a/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm
@@ -129,6 +129,8 @@ typedef void (*AXPostedNotificationCallback)(id element, NSString* notification,
 - (id)_accessibilityLandmarkAncestor;
 - (id)_accessibilityListAncestor;
 - (id)_accessibilityPhotoDescription;
+- (NSValue *)accessibilityImageDataSize;
+- (NSData *)accessibilityImageDataWithParameters:(NSDictionary *)parameters;
 - (NSArray *)accessibilityImageOverlayElements;
 - (NSRange)accessibilityVisibleCharacterRange;
 - (NSString *)_accessibilityWebRoleAsString;
@@ -1275,6 +1277,54 @@ bool AccessibilityUIElementIOS::isOffScreen() const
 JSRetainPtr<JSStringRef> AccessibilityUIElementIOS::embeddedImageDescription() const
 {
     return concatenateAttributeAndValue(@"AXEmbeddedImageDescription", [m_element _accessibilityPhotoDescription]);
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementIOS::imageDataSize() const
+{
+    NSValue *sizeValue = [m_element accessibilityImageDataSize];
+    if (!sizeValue)
+        return adopt(JSStringCreateWithUTF8CString("AXImageDataSize: (null)"));
+    CGSize size = [sizeValue CGSizeValue];
+    RetainPtr description = adoptNS([[NSString alloc] initWithFormat:@"NSSize: {%g, %g}", size.width, size.height]);
+    return concatenateAttributeAndValue(@"AXImageDataSize", description.get());
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementIOS::imageDataForParameters(int resizeWidth, int resizeHeight) const
+{
+    return imageDataForParametersWithFormat(resizeWidth, resizeHeight, nullptr);
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementIOS::imageDataForParametersWithFormat(int resizeWidth, int resizeHeight, JSStringRef format) const
+{
+    NSString *formatString = format ? [NSString stringWithJSStringRef:format] : @"RGBA";
+    NSDictionary *dictionary = @{
+        @"AXImageDataResizeWidth" : @(resizeWidth),
+        @"AXImageDataResizeHeight" : @(resizeHeight),
+        @"AXImageDataFormat" : formatString
+    };
+    NSData *data = [m_element accessibilityImageDataWithParameters:dictionary];
+    if (!data)
+        return adopt(JSStringCreateWithUTF8CString("(null)"));
+    RetainPtr description = adoptNS([[NSString alloc] initWithFormat:@"AXImageData: %lu bytes", (unsigned long)[data length]]);
+    return adopt(JSStringCreateWithCFString((__bridge CFStringRef)description.get()));
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementIOS::imageDataForSubrect(int resizeWidth, int resizeHeight, int left, int top, int width, int height) const
+{
+    NSDictionary *dictionary = @{
+        @"AXImageDataResizeWidth" : @(resizeWidth),
+        @"AXImageDataResizeHeight" : @(resizeHeight),
+        @"AXImageDataFormat" : @"RGBA",
+        @"AXImageDataLeft" : @(left),
+        @"AXImageDataTop" : @(top),
+        @"AXImageDataWidth" : @(width),
+        @"AXImageDataHeight" : @(height)
+    };
+    NSData *data = [m_element accessibilityImageDataWithParameters:dictionary];
+    if (!data)
+        return adopt(JSStringCreateWithUTF8CString("(null)"));
+    RetainPtr description = adoptNS([[NSString alloc] initWithFormat:@"AXImageData: %lu bytes", (unsigned long)[data length]]);
+    return adopt(JSStringCreateWithCFString((__bridge CFStringRef)description.get()));
 }
 
 JSValueRef AccessibilityUIElementIOS::imageOverlayElements(JSContextRef context)

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.h
@@ -186,6 +186,10 @@ public:
     JSRetainPtr<JSStringRef> url() override;
     JSRetainPtr<JSStringRef> classList() const override;
     JSRetainPtr<JSStringRef> embeddedImageDescription() const override;
+    JSRetainPtr<JSStringRef> imageDataSize() const override;
+    JSRetainPtr<JSStringRef> imageDataForParameters(int resizeWidth, int resizeHeight) const override;
+    JSRetainPtr<JSStringRef> imageDataForParametersWithFormat(int resizeWidth, int resizeHeight, JSStringRef format) const override;
+    JSRetainPtr<JSStringRef> imageDataForSubrect(int resizeWidth, int resizeHeight, int left, int top, int width, int height) const override;
     JSValueRef imageOverlayElements(JSContextRef) override;
 
     JSRetainPtr<JSStringRef> speakAs() override;

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
@@ -215,6 +215,7 @@ static id attributeValue(id element, NSString *attribute)
         @"AXIsMultiSelectable",
         @"AXIsOnScreen",
         @"AXIsRemoteFrame",
+        @"AXImageDataSize",
         @"AXLabelFor",
         @"AXLabelledBy",
         @"AXLineRectsAndText",
@@ -2153,6 +2154,61 @@ JSRetainPtr<JSStringRef> AccessibilityUIElementMac::embeddedImageDescription() c
     BEGIN_AX_OBJC_EXCEPTIONS
     auto value = descriptionOfValue(attributeValue(@"AXEmbeddedImageDescription").get());
     return concatenateAttributeAndValue(@"AXEmbeddedImageDescription", value.get());
+    END_AX_OBJC_EXCEPTIONS
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementMac::imageDataSize() const
+{
+    BEGIN_AX_OBJC_EXCEPTIONS
+    auto value = descriptionOfValue(attributeValue(@"AXImageDataSize").get());
+    return concatenateAttributeAndValue(@"AXImageDataSize", value.get());
+    END_AX_OBJC_EXCEPTIONS
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementMac::imageDataForParameters(int resizeWidth, int resizeHeight) const
+{
+    return imageDataForParametersWithFormat(resizeWidth, resizeHeight, nullptr);
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementMac::imageDataForParametersWithFormat(int resizeWidth, int resizeHeight, JSStringRef format) const
+{
+    BEGIN_AX_OBJC_EXCEPTIONS
+    NSString *formatString = format ? [NSString stringWithJSStringRef:format] : @"RGBA";
+    NSDictionary *dictionary = @{
+        @"AXImageDataResizeWidth" : @(resizeWidth),
+        @"AXImageDataResizeHeight" : @(resizeHeight),
+        @"AXImageDataFormat" : formatString
+    };
+    auto value = attributeValueForParameter(@"AXImageData", dictionary);
+    if (!value)
+        return adopt(JSStringCreateWithUTF8CString("(null)"));
+    NSData *data = (NSData *)value.get();
+    RetainPtr description = adoptNS([[NSString alloc] initWithFormat:@"AXImageData: %lu bytes", (unsigned long)[data length]]);
+    return adopt(JSStringCreateWithCFString((__bridge CFStringRef)description.get()));
+    END_AX_OBJC_EXCEPTIONS
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementMac::imageDataForSubrect(int resizeWidth, int resizeHeight, int left, int top, int width, int height) const
+{
+    BEGIN_AX_OBJC_EXCEPTIONS
+    NSDictionary *dictionary = @{
+        @"AXImageDataResizeWidth" : @(resizeWidth),
+        @"AXImageDataResizeHeight" : @(resizeHeight),
+        @"AXImageDataFormat" : @"RGBA",
+        @"AXImageDataLeft" : @(left),
+        @"AXImageDataTop" : @(top),
+        @"AXImageDataWidth" : @(width),
+        @"AXImageDataHeight" : @(height)
+    };
+    auto value = attributeValueForParameter(@"AXImageData", dictionary);
+    if (!value)
+        return adopt(JSStringCreateWithUTF8CString("(null)"));
+    NSData *data = (NSData *)value.get();
+    RetainPtr description = adoptNS([[NSString alloc] initWithFormat:@"AXImageData: %lu bytes", (unsigned long)[data length]]);
+    return adopt(JSStringCreateWithCFString((__bridge CFStringRef)description.get()));
     END_AX_OBJC_EXCEPTIONS
     return nullptr;
 }


### PR DESCRIPTION
#### 69bb8cb9c0309011f88a5736dd5fb4e4f83f75fe
<pre>
AX: Add the ability to get the RGBA representation of an image via the accessibility API
<a href="https://bugs.webkit.org/show_bug.cgi?id=310322">https://bugs.webkit.org/show_bug.cgi?id=310322</a>
<a href="https://rdar.apple.com/172968062">rdar://172968062</a>

Reviewed by Joshua Hoffman (OOPS\!).

Some ATs can benefit from being able to get the image data associated
with an accessibility object.

There was an earlier attempt at doing something similar in 307711@main,
but that was reverted because it&apos;s not safe to return PNGs outside the
web content process.

This implementation uses two new attributes:
- AXImageDataSize: a regular attribute returning native pixel dimensions
  as NSValue (CGSize).
- AXImageData: a parameterized attribute taking an NSDictionary with
  resize dimensions, format (&quot;RGBA&quot;), and optional subrect keys. Returns
  raw uncompressed RGBA pixel data as NSData, satisfying the security
  constraint of only allowing uncompressed pixels to egress from the
  WebContent process.

The pixel data is capped at 4 million pixels (preserving aspect ratio)
to bound memory usage, and supports efficient partial fetches via
subrect extraction. Out-of-bounds subrects are clipped and zero-filled.

* LayoutTests/accessibility/image-data-expected.txt: Added.
* LayoutTests/accessibility/image-data.html: Added.
* LayoutTests/accessibility/image-link-expected.txt:
* LayoutTests/platform/glib/TestExpectations: Disable new test.
* LayoutTests/platform/ios/TestExpectations: Enable new test.
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::imageFromRenderer):
(WebCore::AccessibilityObject::imageDataSize const):
(WebCore::AccessibilityObject::imageData const):
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper _accessibilityImageDataSize]):
(-[WebAccessibilityObjectWrapper _accessibilityImageDataWithParameters:]):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::imageDataSize const):
(WebCore::AXIsolatedObject::imageData const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/mac/CocoaAccessibilityConstants.h:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.h:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm:
(WebCore::imageDataParametersFromDictionary):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper accessibilityAttributeNames]):
(handleImageDataSizeAttribute):
(createAttributeHandlerMap):
(-[WebAccessibilityObjectWrapper accessibilityParameterizedAttributeNames]):
(handleImageDataParameterizedAttribute):
(createParameterizedAttributeHandlerMap):
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp:
(WTR::AccessibilityUIElement::imageDataSize const):
(WTR::AccessibilityUIElement::imageDataForParameters const):
(WTR::AccessibilityUIElement::imageDataForParametersWithFormat const):
(WTR::AccessibilityUIElement::imageDataForSubrect const):
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl:
* Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.h:
* Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm:
(WTR::AccessibilityUIElementIOS::imageDataSize const):
(WTR::AccessibilityUIElementIOS::imageDataForParameters const):
(WTR::AccessibilityUIElementIOS::imageDataForParametersWithFormat const):
(WTR::AccessibilityUIElementIOS::imageDataForSubrect const):
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.h:
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm:
(WTR::attributeValue):
(WTR::AccessibilityUIElementMac::imageDataSize const):
(WTR::AccessibilityUIElementMac::imageDataForParameters const):
(WTR::AccessibilityUIElementMac::imageDataForParametersWithFormat const):
(WTR::AccessibilityUIElementMac::imageDataForSubrect const):

Canonical link: <a href="https://commits.webkit.org/311801@main">https://commits.webkit.org/311801@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1cd4ebde2dc2d862f6fc11ace2d567f9a6b81a3f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156700 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30036 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23219 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165523 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110781 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158571 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30172 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30039 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121374 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85253 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159658 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23599 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140719 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102042 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22655 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20853 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13295 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132334 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18548 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168006 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12167 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20167 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129489 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29638 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24931 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129598 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35390 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29561 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140342 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87362 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24423 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17146 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29269 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93286 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28794 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29024 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28920 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->