### PR TITLE
Stop running git-gc automatically on EWS bots

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -6748,30 +6748,56 @@ class CleanGitRepo(steps.ShellSequence, ShellMixin):
 
     def run(self):
         self.commands = []
-        if self.getProperty('platform', '*') == 'win':
-            self.commands.append(util.ShellArg(
-                command=self.shell_command(r'del .git\gc.log || {}'.format(self.shell_exit_0())),
-                logname='stdio',
-            ))
-        else:
-            self.commands.append(util.ShellArg(
-                command=self.shell_command('rm -f .git/gc.log || {}'.format(self.shell_exit_0())),
-                logname='stdio',
-            ))
 
-        for command in [
-            self.shell_command('git rebase --abort || {}'.format(self.shell_exit_0())),
-            self.shell_command('git am --abort || {}'.format(self.shell_exit_0())),
-            self.shell_command('git cherry-pick --abort || {}'.format(self.shell_exit_0())),
-            ['git', 'clean', '-f', '-d'],  # Remove any left-over layout test results, added files, etc.
-            ['git', 'checkout', '--progress', '{}/{}'.format(self.git_remote, self.default_branch), '-f'],  # Checkout branch from specific remote
-            ['git', 'branch', '-D', self.default_branch],  # Delete any local cache of the specified branch
-            ['git', 'branch', self.default_branch],  # Create local instance of branch from remote, but don't track it
-            self.shell_command("git branch | grep -v ' {}$' | grep -v 'HEAD detached at' | xargs git branch -D || {}".format(self.default_branch, self.shell_exit_0())),
-            self.shell_command("git remote | grep -v '{}$' | xargs -L 1 git remote rm || {}".format(self.git_remote, self.shell_exit_0())),
-            ['git', 'prune'],
-        ]:
+        def add_cmd(cmd, shell=False):
+            if shell:
+                command = self.shell_command(cmd)
+            else:
+                command = cmd
             self.commands.append(util.ShellArg(command=command, logname='stdio'))
+
+        # Kill any running git processes to ensure clean state
+        add_cmd(f'pkill -9 git || {self.shell_exit_0()}', shell=True)
+
+        # Delete stale lock files (must run first to unblock git config)
+        add_cmd("find .git -name '*.lock' -delete", shell=True)
+
+        # Disable auto-gc; configure aggressive pruning for gc
+        add_cmd(['git', 'config', 'gc.auto', '0'])
+        add_cmd(['git', 'config', 'gc.reflogExpireUnreachable', 'now'])
+        add_cmd(['git', 'config', 'gc.pruneExpire', 'now'])
+        add_cmd(['git', 'config', 'gc.worktreePruneExpire', 'now'])
+
+        # Abort any in-progress git operations
+        add_cmd(f'git rebase --abort || {self.shell_exit_0()}', shell=True)
+        add_cmd(f'git am --abort || {self.shell_exit_0()}', shell=True)
+        add_cmd(f'git cherry-pick --abort || {self.shell_exit_0()}', shell=True)
+        add_cmd(f'git merge --abort || {self.shell_exit_0()}', shell=True)
+        add_cmd(f'git revert --abort || {self.shell_exit_0()}', shell=True)
+
+        # Switch to the remote branch (ensures working directory is in known state)
+        add_cmd(['git', 'switch', '--force', '--detach', f'refs/remotes/{self.git_remote}/{self.default_branch}'])
+
+        # Remove untracked files/dirs (not -x, so build artifacts survive)
+        add_cmd(['git', 'clean', '-f', '-d'])
+
+        # Delete all refs except refs/remotes/{remote}/{branch} and tags
+        add_cmd(
+            "git for-each-ref --format='delete %(refname)'"
+            " | sed -e '\\|^delete refs/remotes/{remote}/{branch}$|d' -e '\\|^delete refs/tags/|d'"
+            " | git update-ref --stdin --no-deref".format(remote=self.git_remote, branch=self.default_branch),
+            shell=True
+        )
+
+        # Recreate local branch from remote-tracking ref (not tracked)
+        add_cmd(['git', 'branch', '--no-track', self.default_branch, f'refs/remotes/{self.git_remote}/{self.default_branch}'])
+
+        # Remove extra remote config sections
+        add_cmd(f"git remote | grep -v '^{self.git_remote}$' | xargs -L 1 git remote rm || {self.shell_exit_0()}", shell=True)
+
+        # Full GC: expires all unreachable objects
+        self.commands.append(util.ShellArg(command=['git', 'gc', '--force'], logname='stdio'))
+
         return super().run()
 
     def getResultSummary(self):

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -6265,7 +6265,17 @@ class TestCleanGitRepo(BuildStepMixinAdditions, unittest.TestCase):
         self.setProperty('buildername', 'Style-EWS')
 
         self.expectRemoteCommands(
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'rm -f .git/gc.log || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'pkill -9 git || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
+            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "find .git -name '*.lock' -delete"], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
+            ExpectShell(command=['git', 'config', 'gc.auto', '0'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
+            ExpectShell(command=['git', 'config', 'gc.reflogExpireUnreachable', 'now'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
+            ExpectShell(command=['git', 'config', 'gc.pruneExpire', 'now'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
+            ExpectShell(command=['git', 'config', 'gc.worktreePruneExpire', 'now'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout=''),
             ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'git rebase --abort || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout=''),
@@ -6273,19 +6283,21 @@ class TestCleanGitRepo(BuildStepMixinAdditions, unittest.TestCase):
             .log('stdio', stdout=''),
             ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'git cherry-pick --abort || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout=''),
+            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'git merge --abort || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
+            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'git revert --abort || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
+            ExpectShell(command=['git', 'switch', '--force', '--detach', 'refs/remotes/origin/main'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
             ExpectShell(command=['git', 'clean', '-f', '-d'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout=''),
-            ExpectShell(command=['git', 'checkout', '--progress', 'origin/main', '-f'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout='You are in detached HEAD state.'),
-            ExpectShell(command=['git', 'branch', '-D', 'main'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout='Deleted branch main (was 57015967fef9).'),
-            ExpectShell(command=['git', 'branch', 'main'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout="Switched to a new branch 'main'"),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "git branch | grep -v ' main$' | grep -v 'HEAD detached at' | xargs git branch -D || true"], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "git for-each-ref --format='delete %(refname)' | sed -e '\\|^delete refs/remotes/origin/main$|d' -e '\\|^delete refs/tags/|d' | git update-ref --stdin --no-deref"], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "git remote | grep -v 'origin$' | xargs -L 1 git remote rm || true"], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            ExpectShell(command=['git', 'branch', '--no-track', 'main', 'refs/remotes/origin/main'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout=''),
-            ExpectShell(command=['git', 'prune'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "git remote | grep -v '^origin$' | xargs -L 1 git remote rm || true"], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
+            ExpectShell(command=['git', 'gc', '--force'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout=''),
         )
         self.expect_outcome(result=SUCCESS, state_string='Cleaned up git repository')
@@ -6297,7 +6309,17 @@ class TestCleanGitRepo(BuildStepMixinAdditions, unittest.TestCase):
         self.setProperty('platform', 'win')
 
         self.expectRemoteCommands(
-            ExpectShell(command=['bash', '--posix', '-o', 'pipefail', '-c', r'del .git\gc.log || exit 0'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            ExpectShell(command=['bash', '--posix', '-o', 'pipefail', '-c', 'pkill -9 git || exit 0'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
+            ExpectShell(command=['bash', '--posix', '-o', 'pipefail', '-c', "find .git -name '*.lock' -delete"], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
+            ExpectShell(command=['git', 'config', 'gc.auto', '0'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
+            ExpectShell(command=['git', 'config', 'gc.reflogExpireUnreachable', 'now'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
+            ExpectShell(command=['git', 'config', 'gc.pruneExpire', 'now'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
+            ExpectShell(command=['git', 'config', 'gc.worktreePruneExpire', 'now'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout=''),
             ExpectShell(command=['bash', '--posix', '-o', 'pipefail', '-c', 'git rebase --abort || exit 0'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout=''),
@@ -6305,19 +6327,21 @@ class TestCleanGitRepo(BuildStepMixinAdditions, unittest.TestCase):
             .log('stdio', stdout=''),
             ExpectShell(command=['bash', '--posix', '-o', 'pipefail', '-c', 'git cherry-pick --abort || exit 0'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout=''),
+            ExpectShell(command=['bash', '--posix', '-o', 'pipefail', '-c', 'git merge --abort || exit 0'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
+            ExpectShell(command=['bash', '--posix', '-o', 'pipefail', '-c', 'git revert --abort || exit 0'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
+            ExpectShell(command=['git', 'switch', '--force', '--detach', 'refs/remotes/origin/main'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
             ExpectShell(command=['git', 'clean', '-f', '-d'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout=''),
-            ExpectShell(command=['git', 'checkout', '--progress', 'origin/main', '-f'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout='You are in detached HEAD state.'),
-            ExpectShell(command=['git', 'branch', '-D', 'main'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout='Deleted branch main (was 57015967fef9).'),
-            ExpectShell(command=['git', 'branch', 'main'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout="Switched to a new branch 'main'"),
-            ExpectShell(command=['bash', '--posix', '-o', 'pipefail', '-c', "git branch | grep -v ' main$' | grep -v 'HEAD detached at' | xargs git branch -D || exit 0"], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            ExpectShell(command=['bash', '--posix', '-o', 'pipefail', '-c', "git for-each-ref --format='delete %(refname)' | sed -e '\\|^delete refs/remotes/origin/main$|d' -e '\\|^delete refs/tags/|d' | git update-ref --stdin --no-deref"], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout=''),
-            ExpectShell(command=['bash', '--posix', '-o', 'pipefail', '-c', "git remote | grep -v 'origin$' | xargs -L 1 git remote rm || exit 0"], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            ExpectShell(command=['git', 'branch', '--no-track', 'main', 'refs/remotes/origin/main'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout=''),
-            ExpectShell(command=['git', 'prune'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            ExpectShell(command=['bash', '--posix', '-o', 'pipefail', '-c', "git remote | grep -v '^origin$' | xargs -L 1 git remote rm || exit 0"], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
+            ExpectShell(command=['git', 'gc', '--force'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout=''),
         )
         self.expect_outcome(result=SUCCESS, state_string='Cleaned up git repository')
@@ -6328,7 +6352,17 @@ class TestCleanGitRepo(BuildStepMixinAdditions, unittest.TestCase):
         self.setProperty('buildername', 'Commit-Queue')
 
         self.expectRemoteCommands(
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'rm -f .git/gc.log || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'pkill -9 git || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
+            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "find .git -name '*.lock' -delete"], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
+            ExpectShell(command=['git', 'config', 'gc.auto', '0'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
+            ExpectShell(command=['git', 'config', 'gc.reflogExpireUnreachable', 'now'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
+            ExpectShell(command=['git', 'config', 'gc.pruneExpire', 'now'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
+            ExpectShell(command=['git', 'config', 'gc.worktreePruneExpire', 'now'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout=''),
             ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'git rebase --abort || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout=''),
@@ -6336,19 +6370,21 @@ class TestCleanGitRepo(BuildStepMixinAdditions, unittest.TestCase):
             .log('stdio', stdout=''),
             ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'git cherry-pick --abort || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout=''),
+            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'git merge --abort || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
+            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'git revert --abort || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
+            ExpectShell(command=['git', 'switch', '--force', '--detach', 'refs/remotes/origin/master'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
             ExpectShell(command=['git', 'clean', '-f', '-d'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout=''),
-            ExpectShell(command=['git', 'checkout', '--progress', 'origin/master', '-f'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout='You are in detached HEAD state.'),
-            ExpectShell(command=['git', 'branch', '-D', 'master'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout='Deleted branch master (was 57015967fef9).'),
-            ExpectShell(command=['git', 'branch', 'master'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout="Switched to a new branch 'master'"),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "git branch | grep -v ' master$' | grep -v 'HEAD detached at' | xargs git branch -D || true"], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "git for-each-ref --format='delete %(refname)' | sed -e '\\|^delete refs/remotes/origin/master$|d' -e '\\|^delete refs/tags/|d' | git update-ref --stdin --no-deref"], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "git remote | grep -v 'origin$' | xargs -L 1 git remote rm || true"], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            ExpectShell(command=['git', 'branch', '--no-track', 'master', 'refs/remotes/origin/master'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout=''),
-            ExpectShell(command=['git', 'prune'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "git remote | grep -v '^origin$' | xargs -L 1 git remote rm || true"], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
+            ExpectShell(command=['git', 'gc', '--force'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout=''),
         )
         self.expect_outcome(result=SUCCESS, state_string='Cleaned up git repository')
@@ -6359,7 +6395,17 @@ class TestCleanGitRepo(BuildStepMixinAdditions, unittest.TestCase):
         self.setProperty('buildername', 'Commit-Queue')
 
         self.expectRemoteCommands(
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'rm -f .git/gc.log || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'pkill -9 git || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
+            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "find .git -name '*.lock' -delete"], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
+            ExpectShell(command=['git', 'config', 'gc.auto', '0'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
+            ExpectShell(command=['git', 'config', 'gc.reflogExpireUnreachable', 'now'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
+            ExpectShell(command=['git', 'config', 'gc.pruneExpire', 'now'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
+            ExpectShell(command=['git', 'config', 'gc.worktreePruneExpire', 'now'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout=''),
             ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'git rebase --abort || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout=''),
@@ -6367,19 +6413,21 @@ class TestCleanGitRepo(BuildStepMixinAdditions, unittest.TestCase):
             .log('stdio', stdout=''),
             ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'git cherry-pick --abort || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout=''),
+            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'git merge --abort || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
+            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'git revert --abort || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
+            ExpectShell(command=['git', 'switch', '--force', '--detach', 'refs/remotes/origin/main'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
             ExpectShell(command=['git', 'clean', '-f', '-d'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout=''),
-            ExpectShell(command=['git', 'checkout', '--progress', 'origin/main', '-f'], workdir='wkdir', timeout=300, log_environ=False).exit(128)
-            .log('stdio', stdout='You are in detached HEAD state.'),
-            ExpectShell(command=['git', 'branch', '-D', 'main'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout='Deleted branch main (was 57015967fef9).'),
-            ExpectShell(command=['git', 'branch', 'main'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout="Switched to a new branch 'main'"),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "git branch | grep -v ' main$' | grep -v 'HEAD detached at' | xargs git branch -D || true"], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "git for-each-ref --format='delete %(refname)' | sed -e '\\|^delete refs/remotes/origin/main$|d' -e '\\|^delete refs/tags/|d' | git update-ref --stdin --no-deref"], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "git remote | grep -v 'origin$' | xargs -L 1 git remote rm || true"], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            ExpectShell(command=['git', 'branch', '--no-track', 'main', 'refs/remotes/origin/main'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout=''),
-            ExpectShell(command=['git', 'prune'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "git remote | grep -v '^origin$' | xargs -L 1 git remote rm || true"], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
+            ExpectShell(command=['git', 'gc', '--force'], workdir='wkdir', timeout=300, log_environ=False).exit(128)
             .log('stdio', stdout=''),
         )
         self.expect_outcome(result=FAILURE, state_string='Encountered some issues during cleanup')
@@ -6391,7 +6439,17 @@ class TestCleanGitRepo(BuildStepMixinAdditions, unittest.TestCase):
         self.setProperty('basename', 'safari-612-branch')
 
         self.expectRemoteCommands(
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'rm -f .git/gc.log || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'pkill -9 git || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
+            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "find .git -name '*.lock' -delete"], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
+            ExpectShell(command=['git', 'config', 'gc.auto', '0'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
+            ExpectShell(command=['git', 'config', 'gc.reflogExpireUnreachable', 'now'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
+            ExpectShell(command=['git', 'config', 'gc.pruneExpire', 'now'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
+            ExpectShell(command=['git', 'config', 'gc.worktreePruneExpire', 'now'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout=''),
             ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'git rebase --abort || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout=''),
@@ -6399,19 +6457,21 @@ class TestCleanGitRepo(BuildStepMixinAdditions, unittest.TestCase):
             .log('stdio', stdout=''),
             ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'git cherry-pick --abort || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout=''),
+            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'git merge --abort || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
+            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'git revert --abort || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
+            ExpectShell(command=['git', 'switch', '--force', '--detach', 'refs/remotes/origin/main'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
             ExpectShell(command=['git', 'clean', '-f', '-d'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout=''),
-            ExpectShell(command=['git', 'checkout', '--progress', 'origin/main', '-f'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout='You are in detached HEAD state.'),
-            ExpectShell(command=['git', 'branch', '-D', 'main'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout='Deleted branch main (was 57015967fef9).'),
-            ExpectShell(command=['git', 'branch', 'main'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout="Switched to a new branch 'main'"),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "git branch | grep -v ' main$' | grep -v 'HEAD detached at' | xargs git branch -D || true"], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "git for-each-ref --format='delete %(refname)' | sed -e '\\|^delete refs/remotes/origin/main$|d' -e '\\|^delete refs/tags/|d' | git update-ref --stdin --no-deref"], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "git remote | grep -v 'origin$' | xargs -L 1 git remote rm || true"], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            ExpectShell(command=['git', 'branch', '--no-track', 'main', 'refs/remotes/origin/main'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout=''),
-            ExpectShell(command=['git', 'prune'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "git remote | grep -v '^origin$' | xargs -L 1 git remote rm || true"], workdir='wkdir', timeout=300, log_environ=False).exit(0)
+            .log('stdio', stdout=''),
+            ExpectShell(command=['git', 'gc', '--force'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
             .log('stdio', stdout=''),
         )
         self.expect_outcome(result=SUCCESS, state_string='Cleaned up git repository')


### PR DESCRIPTION
#### 170676f3ca40
<pre>
Stop running git-gc automatically on EWS bots
<a href="https://bugs.webkit.org/show_bug.cgi?id=290569">https://bugs.webkit.org/show_bug.cgi?id=290569</a>
<a href="https://rdar.apple.com/148054035">rdar://148054035</a>

Reviewed by NOBODY (OOPS!).

This significantly tidies up and improves our git cleanup step;
notably, we move to running `git gc` explicitly rather than it running
automatically at arbitrary points (and potentially getting killed by
`KillOldProcesses`). This should give us stronger guarantees we&apos;re
pruning objects that no longer exist (versus `git-prune` which only
prunes loose objects, and if an `git-gc --auto` had packed them, they
would no longer be loose).

We also move to getting rid of lock files in general, to ensure we can
set everything we need, after we have killed all ongoing git commands.

Additionally, we now checkout the remote ref before cleaning, so that
we clean v. what&apos;s on the remote ref, not based on the previous state
of the working tree.

* Tools/CISupport/ews-build/steps.py:
(CleanGitRepo.run):
(CleanGitRepo.run.add_cmd):
* Tools/CISupport/ews-build/steps_unittest.py:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/170676f3ca404278a20cf13d6ab82877d88e0116

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151158 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23920 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17491 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159887 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104594 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/50fe48f4-c786-4c1b-89a5-09c9b90fbfe1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153031 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24351 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24150 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116702 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82837 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5caa6760-e4f8-407d-965e-d4d9ae8c2c5a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154118 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18824 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135625 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97423 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0f829064-3794-4348-adf4-c1c284be3e05) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17917 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15866 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7732 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127535 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13542 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162359 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15113 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124710 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/150558 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23722 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19916 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124898 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23712 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135339 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80156 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19961 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12104 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23322 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23034 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23186 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23088 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->