### PR TITLE
[AppKit Gestures] REGRESSION(309295@main): PDF form fields unexpectedly focused after automated input

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -65,6 +65,7 @@
 #include <WebCore/LocalFrameView.h>
 #include <WebCore/MIMETypeRegistry.h>
 #include <WebCore/MouseEvent.h>
+#include <WebCore/MouseEventTypes.h>
 #include <WebCore/NetscapePlugInStreamLoader.h>
 #include <WebCore/NetworkStorageSession.h>
 #include <WebCore/NodeDocument.h>
@@ -703,6 +704,12 @@ void PluginView::handleEvent(Event& event)
 {
     if (!m_isInitialized)
         return;
+
+    {
+        RefPtr mouseEvent = dynamicDowncast<WebCore::MouseEvent>(event);
+        if (mouseEvent && mouseEvent->inputSource() == WebCore::MouseEventInputSource::Automation)
+            return;
+    }
 
     const CheckedPtr currentEvent = WebPage::currentEvent();
     if (!currentEvent)


### PR DESCRIPTION
#### 14a440f03caeaea2f97968535be8f80c30ca950c
<pre>
[AppKit Gestures] REGRESSION(309295@main): PDF form fields unexpectedly focused after automated input
<a href="https://bugs.webkit.org/show_bug.cgi?id=310324">https://bugs.webkit.org/show_bug.cgi?id=310324</a>
<a href="https://rdar.apple.com/172971256">rdar://172971256</a>

Reviewed by Aditya Keerthi.

Automated input should not lead to PDF interactions. In 309295@main, the
mouse tracking GR we added undid this assumption since it continuously
produces a stream of mouse events that funnel through EventHandler into
the plugin. In this patch, we restore status quo by ducking out of the
way for automation inputs.

* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::handleEvent):

Canonical link: <a href="https://commits.webkit.org/309603@main">https://commits.webkit.org/309603@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e13c0bf8a015dcbcc1b335e7ead4d7328b68565

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151161 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23923 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17494 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159890 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104597 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9d031dac-bbb0-4ba7-8837-cafdffda1d8d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24354 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24156 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116703 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82839 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7088642d-db47-4b24-bd55-a901b301fa13) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154121 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18831 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135629 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97424 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2ebf4d72-d723-4e7d-b5cf-46721a7b3b05) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17924 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15867 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7735 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127542 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162362 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5487 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15117 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124712 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23725 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19917 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124900 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33883 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23715 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135343 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80159 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19962 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12108 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23325 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87619 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23037 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23189 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23091 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->