### PR TITLE
REGRESSION(309217@main): [iOS] ASSERTION FAILED: m_ptr in editing/input/cocoa/extended-proofreading.html

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8505,8 +8505,6 @@ imported/w3c/web-platform-tests/html/semantics/embedded-content/the-audio-elemen
 
 imported/w3c/web-platform-tests/uievents/keyboard/keypress-not-fired-for-modifier-shortcuts.html [ Skip ]
 
-webkit.org/b/310310 editing/input/cocoa/extended-proofreading.html [ Skip ]
-
 # webkit.org/b/310313 REGRESSION(309498@main): [iOS Debug] ASSERTION FAILED: request.hasHTTPHeaderField(HTTPHeaderName::SecFetchDest)
 [ Debug ] http/tests/navigation/post-frames-goback1.html [ Skip ]
 [ Debug ] http/tests/navigation/post-goback1.html [ Skip ]

--- a/Tools/TestRunnerShared/cocoa/LayoutTestSpellChecker.mm
+++ b/Tools/TestRunnerShared/cocoa/LayoutTestSpellChecker.mm
@@ -321,9 +321,11 @@ static const char *stringForCorrectionResponse(NSCorrectionResponse correctionRe
 
 - (void)requestProofreadingReviewOfString:(NSString *)stringToCheck range:(NSRange)range language:(NSString *)language options:(NSDictionary<NSString *, id> *)options completionHandler:(void (^)(NSArray<NSTextCheckingResult *> *results))completionHandler
 {
-    if (RetainPtr overrideResult = [_results objectForKey:stringToCheck])
+    if (RetainPtr overrideResult = [_results objectForKey:stringToCheck]) {
         completionHandler(overrideResult.get());
-    return [super requestProofreadingReviewOfString:stringToCheck range:range language:language options:options completionHandler:completionHandler];
+        return;
+    }
+    [super requestProofreadingReviewOfString:stringToCheck range:range language:language options:options completionHandler:completionHandler];
 }
 
 static NSDictionary *swizzledGrammarDetailsForString(id, SEL, NSString *stringToCheck, NSRange range, NSString *language)


### PR DESCRIPTION
#### 2236b2a0c44b31d7af4630641ef1dd2afd772db5
<pre>
REGRESSION(309217@main): [iOS] ASSERTION FAILED: m_ptr in editing/input/cocoa/extended-proofreading.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=310325">https://bugs.webkit.org/show_bug.cgi?id=310325</a>
<a href="https://rdar.apple.com/172949195">rdar://172949195</a>

Reviewed by Wenson Hsieh.

Root cause: In Tools/TestRunnerShared/cocoa/LayoutTestSpellChecker.mm: requestProofreadingReviewOfString:range:language:options:(completionHandler: when the LayoutTestSpellChecker has
override results for a string, the original code was:

if (RetainPtr overrideResult = [_results objectForKey:stringToCheck])
    completionHandler(overrideResult.get());
return [super requestProofreadingReviewOfString:...completionHandler:completionHandler];

The if body only covers the completionHandler(...) call. Execution then unconditionally falls through to call [super
requestProofreadingReviewOfString:...], which eventually calls the same completion handler a second time.

In TextCheckerIOS.mm, the completion handler moves the Ref&lt;TextCheckerCompletion&gt; via
WTF::move(textCheckerCompletion). The first call succeeds and moves the ref out. The second call tries to move from
the now-null ref, hitting ASSERTION FAILED: m_ptr.

Why it&apos;s flaky: It only crashes when LayoutTestSpellChecker has matching override results set for the checked string.
When there are no overrides, only super is called (once), so no crash.

Fix: Add an early return after calling the completion handler with override results, so super is only called when
there are no overrides. This matches the pattern used by requestGrammarCheckingOfString on the Mac side requestGrammarCheckingOfString:range:language:options:completionHandler:.

* LayoutTests/platform/ios/TestExpectations:
* Tools/TestRunnerShared/cocoa/LayoutTestSpellChecker.mm:
(-[LayoutTestSpellChecker requestProofreadingReviewOfString:range:language:options:completionHandler:]):

Canonical link: <a href="https://commits.webkit.org/309602@main">https://commits.webkit.org/309602@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3aa46879f074cb7e5032efccaa66d15dcea5903

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151163 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23926 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17496 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159892 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104599 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0b2da255-2027-4df4-91b2-9260072d2df3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153036 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24356 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24158 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116705 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/82843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154123 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18826 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135626 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97426 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ccee24ed-f15e-4d63-a91d-5efd8bc65f62) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17919 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15868 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7737 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127537 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13543 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162364 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15114 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124714 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23727 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19918 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124902 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33880 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23717 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135340 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80161 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19963 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12105 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23327 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23039 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23191 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23093 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->