### PR TITLE
[Site Isolation] Cross-site subframe navigations should preserve lockBackForwardList

### DIFF
--- a/LayoutTests/http/tests/site-isolation/history/cross-site-iframe-does-not-add-history-entry-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/history/cross-site-iframe-does-not-add-history-entry-expected.txt
@@ -1,0 +1,10 @@
+Verifies that navigating a subframe to a cross-site URL does not create an extra back/forward list entry.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS history.length is 2
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/history/cross-site-iframe-does-not-add-history-entry.html
+++ b/LayoutTests/http/tests/site-isolation/history/cross-site-iframe-does-not-add-history-entry.html
@@ -1,0 +1,36 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true UsesBackForwardCache=false ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Verifies that navigating a subframe to a cross-site URL does not create an extra back/forward list entry.");
+jsTestIsAsync = true;
+
+onload = async () => {
+    if (sessionStorage.step === "check") {
+        delete sessionStorage.step;
+
+        // We navigated here from step 1, so history.length should be 2.
+        // Now add an iframe and navigate it cross-site via JS.
+        const iframe = document.createElement("iframe");
+        let loadCount = 0;
+        iframe.onload = () => {
+            loadCount++;
+            if (loadCount === 1) {
+                // First load is about:blank. Now navigate cross-site.
+                iframe.contentWindow.location.href = "http://localhost:8000/site-isolation/resources/simple.html";
+            } else {
+                // Cross-site iframe has loaded. Check history.length.
+                shouldBe("history.length", "2");
+                finishJSTest();
+            }
+        };
+        document.body.appendChild(iframe);
+        return;
+    }
+
+    await testRunner?.clearBackForwardList();
+
+    // Step 1: Navigate to this same test but with a different query string.
+    sessionStorage.step = "check";
+    location.href = location.pathname + "?step2";
+}
+</script>

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5734,7 +5734,7 @@ void WebPageProxy::continueNavigationInNewProcess(API::Navigation& navigation, W
         loadParameters.navigationID = navigation.navigationID();
         loadParameters.effectiveSandboxFlags = frame.effectiveSandboxFlags();
         loadParameters.effectiveReferrerPolicy = frame.effectiveReferrerPolicy();
-        loadParameters.lockBackForwardList = !!navigation.backForwardFrameLoadType() ? LockBackForwardList::Yes : LockBackForwardList::No;
+        loadParameters.lockBackForwardList = navigation.isInitialFrameSrcLoad() ? LockBackForwardList::No : navigation.lockBackForwardList();
         loadParameters.ownerPermissionsPolicy = navigation.ownerPermissionsPolicy();
         loadParameters.navigationUpgradeToHTTPSBehavior = navigationUpgradeToHTTPSBehavior;
         loadParameters.isHandledByAboutSchemeHandler = m_aboutSchemeHandler->canHandleURL(loadParameters.request.url());


### PR DESCRIPTION
#### 14816432aca5ad27cb05e5a953c0ad37528ce34d
<pre>
[Site Isolation] Cross-site subframe navigations should preserve lockBackForwardList
<a href="https://bugs.webkit.org/show_bug.cgi?id=310326">https://bugs.webkit.org/show_bug.cgi?id=310326</a>
<a href="https://rdar.apple.com/168640900">rdar://168640900</a>

Reviewed by Brady Eidson.

When site isolation triggers a process swap for a cross-site subframe
navigation, the lockBackForwardList flag was not correctly propagated to
the new process. The site isolation path in continueNavigationInNewProcess
used navigation.backForwardFrameLoadType() to determine lockBackForwardList,
but that field is only set for back/forward navigations and is nullopt for
regular subframe loads. This caused lockBackForwardList to always be No,
resulting in extra back/forward list entries being created for cross-site
iframe loads.

The fix uses navigation.lockBackForwardList() directly, matching all other
code paths. For initial frame src loads, lockBackForwardList is kept as No
so that the isPendingInitialHistoryItem mechanism in backForwardAddItemShared
can properly register the child frame&apos;s initial content in the back/forward
list tree and clear the pending flag for subsequent navigations.

Test: http/tests/site-isolation/history/cross-site-iframe-does-not-add-history-entry.html
* LayoutTests/http/tests/site-isolation/history/cross-site-iframe-does-not-add-history-entry-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/history/cross-site-iframe-does-not-add-history-entry.html: Added.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::continueNavigationInNewProcess):

Canonical link: <a href="https://commits.webkit.org/309629@main">https://commits.webkit.org/309629@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b805cee3737307d41ef5ed65aa3e171144269cdf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151231 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23994 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17564 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159960 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104667 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24425 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24239 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116761 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82892 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154191 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18883 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135692 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97482 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17976 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15927 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7805 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127594 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13609 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162432 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5557 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15180 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124769 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23795 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19977 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124957 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33903 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23785 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135406 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80264 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20020 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12171 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23395 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87689 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23107 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23259 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23161 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->