### PR TITLE
[API Tests] Filter NSEventConcurrentProcessingEnabled log noise from run-api-tests

### DIFF
--- a/Tools/Scripts/webkitpy/api_tests/runner.py
+++ b/Tools/Scripts/webkitpy/api_tests/runner.py
@@ -33,6 +33,19 @@ from webkitpy.port.server_process import ServerProcess, _log as server_process_l
 _log = logging.getLogger(__name__)
 
 
+class _NoisyOutputFilter(logging.Filter):
+    def filter(self, record):
+        msg = record.getMessage()
+        if msg.lstrip().startswith('objc['):
+            return False
+        if 'NSEventConcurrentProcessingEnabled' in msg:
+            return False
+        return True
+
+
+_log.addFilter(_NoisyOutputFilter())
+
+
 def setup_shard(port=None, devices=None, log_limit=None):
     if devices and getattr(port, 'DEVICE_MANAGER', None):
         port.DEVICE_MANAGER.AVAILABLE_DEVICES = devices.get('available_devices', [])
@@ -308,6 +321,8 @@ class _Worker(object):
         result = ''
         for line in output.splitlines():
             if line.lstrip().startswith('objc['):
+                continue
+            if 'NSEventConcurrentProcessingEnabled' in line:
                 continue
             result += line + '\n'
         return result.rstrip()


### PR DESCRIPTION
#### ad8bd4321d54afb2d37f43f22a0249d00f65f37b
<pre>
[API Tests] Filter NSEventConcurrentProcessingEnabled log noise from run-api-tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=310327">https://bugs.webkit.org/show_bug.cgi?id=310327</a>
<a href="https://rdar.apple.com/172974332">rdar://172974332</a>

Reviewed by Megan Gardner.

Each test run by run-api-tests logs a line like:
  NSEventConcurrentProcessingEnabled=NO

This clutters the output and makes it harder to spot real failures.

There was already a _filter_noisy_output method that strips objc[] messages
from test result buffers, but it only filtered the output passed in task
results -- noisy lines were still printed to the console via _log.error()
calls during test execution.

Added a logging.Filter on the module logger to suppress noisy lines from
console output, and extended _filter_noisy_output to also strip
NSEventConcurrentProcessingEnabled lines from result buffers. Using a
logging filter avoids repeating the check at every _log.error() call site.

* Tools/Scripts/webkitpy/api_tests/runner.py:
(_NoisyOutputFilter):
(_NoisyOutputFilter.filter):
(_Worker._filter_noisy_output):

Canonical link: <a href="https://commits.webkit.org/309597@main">https://commits.webkit.org/309597@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b3f969355f53072ce166ecbb239dbc8aad2318a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151168 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23931 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17501 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159897 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/104604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153041 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24361 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24163 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116709 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/104604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/38d3ffe0-65e4-42ac-b52c-a820fa77b817) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154128 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18828 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135633 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97430 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ab301503-c8ff-494c-8137-0b500ee51a37) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/150489 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17921 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15874 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7742 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127539 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13550 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162369 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15121 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124718 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23732 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19924 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124906 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23722 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135347 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80166 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23229 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19967 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12112 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23332 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23044 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23196 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23098 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->