### PR TITLE
[JSC][WASM][Debugger] Fix WASM debugger stop-the-world races during VM construction and destruction

### DIFF
--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1952,6 +1952,8 @@
 		DE26E9031CB5DD0500D2BE82 /* BuiltinExecutableCreator.h in Headers */ = {isa = PBXBuildFile; fileRef = DE26E9021CB5DD0500D2BE82 /* BuiltinExecutableCreator.h */; };
 		DEA7E2451BBC677F00D78440 /* JSTypedArrayViewPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = 53917E7C1B791106000EBD33 /* JSTypedArrayViewPrototype.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E124A8F70E555775003091F1 /* OpaqueJSString.h in Headers */ = {isa = PBXBuildFile; fileRef = E124A8F50E555775003091F1 /* OpaqueJSString.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E30001002EF0001000000004 /* MicrotaskCall.h in Headers */ = {isa = PBXBuildFile; fileRef = E30001002EF0001000000001 /* MicrotaskCall.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E30001002EF0001000000005 /* MicrotaskCallInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E30001002EF0001000000002 /* MicrotaskCallInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E306C1BC2D79000D0011D5AC /* MicrotaskQueueInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E306C1BB2D7900050011D5AC /* MicrotaskQueueInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E307178324C7827100DF0644 /* IntlRelativeTimeFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = A3BF885024480BE1001B9F35 /* IntlRelativeTimeFormat.h */; };
 		E307178424C7827700DF0644 /* IntlRelativeTimeFormatConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = A3BF884E24480BE0001B9F35 /* IntlRelativeTimeFormatConstructor.h */; };
@@ -2308,6 +2310,7 @@
 		FFA2E02F2EA16F37006661A3 /* UnaryTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FFA2E0262EA16F37006661A3 /* UnaryTests.cpp */; };
 		FFB951142C043CA800349750 /* OrderedHashTableHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = FFB951132C043CA800349750 /* OrderedHashTableHelper.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FFB963922E38302B0069A70F /* WasmBreakpointManager.h in Headers */ = {isa = PBXBuildFile; fileRef = FFB9638F2E38302B0069A70F /* WasmBreakpointManager.h */; };
+		FFBD27052F6B133900DE6C3D /* ExecutionHandlerVMLifecycleTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FFBD27042F6B133900DE6C3D /* ExecutionHandlerVMLifecycleTest.cpp */; };
 		FFBF548A2F189712008F124F /* WasmGDBPacketParser.h in Headers */ = {isa = PBXBuildFile; fileRef = FFBF54872F189712008F124F /* WasmGDBPacketParser.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FFCC9A412BDD7C4700C75345 /* OrderedHashTable.h in Headers */ = {isa = PBXBuildFile; fileRef = FFCC9A402BDD7C4700C75345 /* OrderedHashTable.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FFD49E6E2E276CA10083E383 /* WasmDebugServer.h in Headers */ = {isa = PBXBuildFile; fileRef = FFD49E5A2E276CA10083E383 /* WasmDebugServer.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -5795,6 +5798,9 @@
 		E178636C0D9BEEC300D74E75 /* InitializeThreading.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = InitializeThreading.cpp; sourceTree = "<group>"; };
 		E18E3A560DF9278C00D90B34 /* VM.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = VM.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		E18E3A570DF9278C00D90B34 /* VM.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; path = VM.cpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
+		E30001002EF0001000000001 /* MicrotaskCall.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MicrotaskCall.h; sourceTree = "<group>"; };
+		E30001002EF0001000000002 /* MicrotaskCallInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MicrotaskCallInlines.h; sourceTree = "<group>"; };
+		E30001002EF0001000000003 /* MicrotaskCall.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MicrotaskCall.cpp; sourceTree = "<group>"; };
 		E3060128228F978100FAABDF /* UnlinkedMetadataTable.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = UnlinkedMetadataTable.cpp; sourceTree = "<group>"; };
 		E30677971B8BC6F5003F87F0 /* ModuleLoader.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = ModuleLoader.js; sourceTree = "<group>"; };
 		E306C1BB2D7900050011D5AC /* MicrotaskQueueInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MicrotaskQueueInlines.h; sourceTree = "<group>"; };
@@ -6426,6 +6432,8 @@
 		FFB951132C043CA800349750 /* OrderedHashTableHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OrderedHashTableHelper.h; sourceTree = "<group>"; };
 		FFB9638F2E38302B0069A70F /* WasmBreakpointManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmBreakpointManager.h; sourceTree = "<group>"; };
 		FFB963902E38302B0069A70F /* WasmBreakpointManager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WasmBreakpointManager.cpp; sourceTree = "<group>"; };
+		FFBD27032F6B133900DE6C3D /* ExecutionHandlerVMLifecycleTest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ExecutionHandlerVMLifecycleTest.h; sourceTree = "<group>"; };
+		FFBD27042F6B133900DE6C3D /* ExecutionHandlerVMLifecycleTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ExecutionHandlerVMLifecycleTest.cpp; sourceTree = "<group>"; };
 		FFBF54872F189712008F124F /* WasmGDBPacketParser.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmGDBPacketParser.h; sourceTree = "<group>"; };
 		FFBF54882F189712008F124F /* WasmGDBPacketParser.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WasmGDBPacketParser.cpp; sourceTree = "<group>"; };
 		FFCC9A402BDD7C4700C75345 /* OrderedHashTable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OrderedHashTable.h; sourceTree = "<group>"; };
@@ -10702,6 +10710,8 @@
 				FFE88B9C2EC96CA700C9F5E2 /* ExecutionHandlerTest.h */,
 				FFFAF8CD2EC9A7C000042238 /* ExecutionHandlerTestSupport.cpp */,
 				FFFAF8CC2EC9A7C000042238 /* ExecutionHandlerTestSupport.h */,
+				FFBD27042F6B133900DE6C3D /* ExecutionHandlerVMLifecycleTest.cpp */,
+				FFBD27032F6B133900DE6C3D /* ExecutionHandlerVMLifecycleTest.h */,
 				FF1344652EB3F2A600940C00 /* ExtGCTests.cpp */,
 				FF06E8BE2F19BC33007B3403 /* GDBPacketParserTest.cpp */,
 				FF06E8BD2F19BC33007B3403 /* GDBPacketParserTest.h */,
@@ -13994,6 +14004,7 @@
 				FFE0C0472F24802E00198308 /* ExecutionHandlerIdleStopTest.cpp in Sources */,
 				FFE88B9E2EC96CA700C9F5E2 /* ExecutionHandlerTest.cpp in Sources */,
 				FFFAF8CE2EC9A7C000042238 /* ExecutionHandlerTestSupport.cpp in Sources */,
+				FFBD27052F6B133900DE6C3D /* ExecutionHandlerVMLifecycleTest.cpp in Sources */,
 				FF1344662EB3F2A600940C00 /* ExtGCTests.cpp in Sources */,
 				FF06E8BF2F19BC33007B3403 /* GDBPacketParserTest.cpp in Sources */,
 				FFA2E02E2EA16F37006661A3 /* MemoryTests.cpp in Sources */,

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -172,6 +172,10 @@
 #include <wtf/darwin/DispatchExtras.h>
 #endif
 
+#if ENABLE(WEBASSEMBLY_DEBUGGER)
+#include "WasmDebugServerUtilities.h"
+#endif
+
 #include <span>
 
 namespace JSC {
@@ -226,25 +230,6 @@ void VM::computeCanUseJIT()
 #endif
     g_jscConfig.vm.canUseJIT = VM::canUseAssembler() && Options::useJIT();
 #endif
-}
-
-// This function is not meant to be called by anyone. It just provides a convenient scope
-// that can is permitted to access private members of VM in order to do some needed
-// static_asserts.
-inline void VM::checkStaticAsserts()
-{
-    // VM registration is done in the instantiation of its VMThreadContext.
-    //
-    // VM registration with the VMManager can only be done after m_apiLock is initialized
-    // because VMManager may trigger traps to stop the VM, and VMTraps the which uses
-    // m_apiLock for the VMTraps::SignalSender uses m_apiLock.
-    //
-    // VM registration needs to be done before the heap is initialized because we may Global GC
-    // may want to block the VM from doing any heap activity. In a Global GC world, we would be
-    // binding this VM to the global heap instead of instantiating the heap field. We want to
-    // be able to block before that point.
-    static_assert(OBJECT_OFFSETOF(VM, m_apiLock) < OBJECT_OFFSETOF(VM, m_threadContext));
-    static_assert(OBJECT_OFFSETOF(VM, m_threadContext) < OBJECT_OFFSETOF(VM, heap));
 }
 
 static bool vmCreationShouldCrash = false;
@@ -515,6 +500,10 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     // We must set this at the end only after the VM is fully initialized.
     WTF::storeStoreFence();
     m_isInService = true;
+
+    // Register after all VM state is initialized so that a stop-the-world triggered
+    // immediately on registration sees a fully constructed VM.
+    VMManager::singleton().notifyVMConstruction(*this);
 }
 
 static ReadWriteLock s_destructionLock;
@@ -531,6 +520,10 @@ void VM::setCrossTaskToken(RefPtr<CrossTaskToken>&& token)
 
 VM::~VM()
 {
+    // Remove from VMManager before marking as no longer in service or cancelling traps,
+    // so requestStopAllInternal() never iterates a VM with m_isShuttingDown set.
+    VMManager::singleton().notifyVMDestruction(*this);
+
     Locker destructionLocker { s_destructionLock.read() };
 
     if (vmType == VMType::Default)

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -1345,7 +1345,6 @@ private:
 
     DoublyLinkedList<Debugger> m_debuggers;
 
-    void checkStaticAsserts(); // Not for calling.
 
     friend class Heap;
     friend class ExceptionScope; // Friend for exception checking purpose only.

--- a/Source/JavaScriptCore/runtime/VMManager.cpp
+++ b/Source/JavaScriptCore/runtime/VMManager.cpp
@@ -48,21 +48,8 @@ VMManager& VMManager::singleton()
     return manager.get();
 }
 
-VMThreadContext::VMThreadContext()
-{
-    VM* vm = VM::fromThreadContext(this);
-    // Ensure that VM is not in-service yet. Since notifyVMConstruction has memory barrier (lock),
-    // if we are ensuring this condition here, concurrent threads will see this consistent state.
-    // Make sure m_isInService is initialized to false before VMThreadContext is initialized.
-    RELEASE_ASSERT(!vm->isInService());
-    VMManager::singleton().notifyVMConstruction(*vm);
-}
-
-VMThreadContext::~VMThreadContext()
-{
-    VM* vm = VM::fromThreadContext(this);
-    VMManager::singleton().notifyVMDestruction(*vm);
-}
+VMThreadContext::VMThreadContext() = default;
+VMThreadContext::~VMThreadContext() = default;
 
 bool VMManager::isValidVMSlow(VM* vm)
 {
@@ -142,7 +129,7 @@ auto VMManager::info() -> Info
     Locker lock { manager.m_worldLock };
     info.numberOfVMs = manager.m_numberOfVMs;
     info.numberOfActiveVMs = manager.m_numberOfActiveVMs;
-    info.numberOfStoppedVMs = manager.m_numberOfStoppedVMs.loadRelaxed();
+    info.numberOfStoppedVMs = manager.m_numberOfStoppedVMs;
     info.worldMode = manager.m_worldMode;
     info.targetVM = manager.m_targetVM;
     return info;
@@ -165,10 +152,7 @@ void VMManager::setMemoryDebuggerCallback(StopTheWorldCallback callback)
 
 void VMManager::incrementActiveVMs(VM& vm) WTF_REQUIRES_LOCK(m_worldLock)
 {
-    if (m_worldMode == Mode::RunAll) {
-        RELEASE_ASSERT(m_numberOfActiveVMs == invalidNumberOfActiveVMs);
-        return;
-    }
+    RELEASE_ASSERT(m_worldMode != Mode::RunAll);
 
     if (!vm.traps().m_hasBeenCountedAsActive) {
         m_numberOfActiveVMs++;
@@ -190,7 +174,7 @@ void VMManager::decrementActiveVMs(VM& vm) WTF_REQUIRES_LOCK(m_worldLock)
         vm.traps().m_hasBeenCountedAsActive = false;
     }
 
-    auto shouldResumeAll = [&] {
+    auto shouldResumeAll = [&] WTF_REQUIRES_LOCK(m_worldLock) {
         if (m_worldMode != Mode::RunAll && !m_numberOfActiveVMs)
             return true;
         if (m_worldMode == Mode::RunOne) {
@@ -351,7 +335,23 @@ void VMManager::notifyVMStop(VM& vm, StopTheWorldEvent event)
     // counted (entry services succeeded), this does nothing.
     {
         Locker lock { m_worldLock };
+        // Guard against a late-arriving notifyVMStop() after resumeTheWorld() has already
+        // completed. Once the world is back in RunAll, touching the counters would corrupt
+        // the m_numberOfStoppedVMs == m_numberOfActiveVMs invariant used in the following stop section.
+        if (m_worldMode == Mode::RunAll)
+            return;
+
         incrementActiveVMs(vm);
+        ++m_numberOfStoppedVMs;
+
+        // Must be inside this lock. Once m_numberOfStoppedVMs == m_numberOfActiveVMs,
+        // the STW callback fires and the debugger assumes isStopped() on every VM.
+        // A VM preempted between releasing this lock and calling setStopped() would
+        // cause isStopped() to return false after the STW callback fires.
+#if ENABLE(WEBASSEMBLY_DEBUGGER)
+        if (Options::enableWasmDebugger()) [[unlikely]]
+            vm.debugState()->setStopped();
+#endif
     }
 
     // Due to races, we may end up calling notifyVMStop() even when there is no stop to be serviced.
@@ -365,19 +365,12 @@ void VMManager::notifyVMStop(VM& vm, StopTheWorldEvent event)
     // called when in Mode::RunOne because new VM thread can be started, and we want those new
     // threads to also stop since they aren't the targetVM thread.
 
-#if ENABLE(WEBASSEMBLY_DEBUGGER)
-    bool enableWasmDebugger = Options::enableWasmDebugger();
-    if (enableWasmDebugger) [[unlikely]]
-        vm.debugState()->setStopped();
-#endif
-
-    m_numberOfStoppedVMs.exchangeAdd(1);
 
     for (;;) {
         {
             Locker lock { m_worldLock };
 
-            RELEASE_ASSERT(m_numberOfStoppedVMs.loadRelaxed() <= m_numberOfActiveVMs);
+            RELEASE_ASSERT(m_numberOfStoppedVMs <= m_numberOfActiveVMs);
 
             auto fetchTopPriorityStopReason = [&] {
                 auto pendingRequests = m_pendingStopRequestBits.loadRelaxed();
@@ -401,7 +394,7 @@ void VMManager::notifyVMStop(VM& vm, StopTheWorldEvent event)
                 // below.
             }
 
-            auto shouldStop = [&] {
+            auto shouldStop = [&] WTF_REQUIRES_LOCK(m_worldLock) {
                 // 1. If the targetVM is already selected, and we're not the targetVM, then stop.
                 //    We need to check this first because in RunOne mode, even if there is no more
                 //    STW request to service, any VM that is not the targetVM still needs to stop.
@@ -415,7 +408,9 @@ void VMManager::notifyVMStop(VM& vm, StopTheWorldEvent event)
 
                 // 3. We have a STW request. If not all active VMs are at the stopping point yet,
                 //    then stop and wait for the last VM to stop.
-                return m_numberOfStoppedVMs.loadRelaxed() != m_numberOfActiveVMs;
+                //    FIXME: rdar://173360944 Any VM may serve the STW callback, not just the last to stop,
+                //    since once the counter lock above is released, any VM can observe m_numberOfStoppedVMs == m_numberOfActiveVMs.
+                return m_numberOfStoppedVMs != m_numberOfActiveVMs;
             };
 
             while (shouldStop())
@@ -487,20 +482,24 @@ void VMManager::notifyVMStop(VM& vm, StopTheWorldEvent event)
         }
     }
 
+    unsigned numberOfStoppedVMs = UINT_MAX;
+
+    {
+        Locker lock { m_worldLock };
+
+        // If we get here, we're either transitioning to RunOne or Running mode.
+        RELEASE_ASSERT(!m_targetVM || m_targetVM == &vm);
+
+        numberOfStoppedVMs = --m_numberOfStoppedVMs;
+
 #if ENABLE(WEBASSEMBLY_DEBUGGER)
-    if (enableWasmDebugger) [[unlikely]] {
-        vm.debugState()->clearStop();
-        WTF::storeLoadFence();
-    }
+        if (Options::enableWasmDebugger()) [[unlikely]]
+            vm.debugState()->clearStop();
 #endif
-
-    auto previousCount = m_numberOfStoppedVMs.exchangeSub(1);
-
-    // If we get here, we're either transitioning to RunOne or Running mode.
-    RELEASE_ASSERT(!m_targetVM || m_targetVM == &vm);
+    }
 
     // Call post-resume callback once when last VM exits and all VMs are running.
-    if (previousCount == 1 && m_needsWasmDebuggerOnResume.exchange(false))
+    if (!numberOfStoppedVMs && m_needsWasmDebuggerOnResume.exchange(false))
         g_jscConfig.wasmDebuggerOnResume();
 }
 
@@ -518,7 +517,6 @@ void VMManager::notifyVMConstruction(VM& vm)
         // If a stop is in progress, we cannot proceed onto initializing (i.e. mutating)
         // the heap in the VM constructor. GlobalGC may be expecting a quiescent world
         // state at this point. So, go park this thread if needed.
-        vm.requestStop();
         notifyVMStop(vm, StopTheWorldEvent::VMCreated); // Cannot be called while holding m_worldLock.
 
         Locker locker { m_worldLock };
@@ -555,10 +553,8 @@ void VMManager::notifyVMActivation(VM& vm)
         s_recentVM = &vm;
         needsStopping = m_worldMode != Mode::RunAll;
     }
-    if (needsStopping) {
-        vm.requestStop();
+    if (needsStopping)
         notifyVMStop(vm, StopTheWorldEvent::VMActivated);
-    }
 }
 
 void VMManager::notifyVMDeactivation(VM& vm)

--- a/Source/JavaScriptCore/runtime/VMManager.h
+++ b/Source/JavaScriptCore/runtime/VMManager.h
@@ -384,9 +384,9 @@ private:
     //
     // The choice to not track a valid m_numberOfActiveVMs at all times is just an optimization so
     // that we can skip this work when not doing Stop the World.
-    unsigned m_numberOfActiveVMs { invalidNumberOfActiveVMs };
+    unsigned m_numberOfActiveVMs WTF_GUARDED_BY_LOCK(m_worldLock) { invalidNumberOfActiveVMs };
 
-    Atomic<unsigned> m_numberOfStoppedVMs { 0 };
+    unsigned m_numberOfStoppedVMs WTF_GUARDED_BY_LOCK(m_worldLock) { 0 };
 
     // === End of variables only relevant for StopTheWorld =================================
 

--- a/Source/JavaScriptCore/runtime/VMTraps.cpp
+++ b/Source/JavaScriptCore/runtime/VMTraps.cpp
@@ -435,7 +435,7 @@ bool VMTraps::handleTraps(VMTraps::BitField mask)
     VM& vm = this->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     ASSERT(onlyContainsAsyncEvents(mask));
-    ASSERT(needHandling(mask));
+    // No ASSERT(needHandling(mask)): cancelStop() from resumeTheWorld() can race with this call.
 
     if (m_trapsDeferred)
         return false; // We'll service them on the next opportunity after deferring has stopped.
@@ -503,6 +503,10 @@ bool VMTraps::handleTraps(VMTraps::BitField mask)
         case NeedStopTheWorld:
             VMManager::singleton().notifyVMStop(vm, StopTheWorldEvent::VMStopped);
             didHandleTrap = true;
+            break;
+
+        // cancelStop() cleared the bit between needHandling() and takeTopPriorityTrap().
+        case NoEvent:
             break;
 
         case NeedExceptionHandling:

--- a/Source/JavaScriptCore/shell/CMakeLists.txt
+++ b/Source/JavaScriptCore/shell/CMakeLists.txt
@@ -89,6 +89,7 @@ if (DEVELOPER_MODE)
         ../wasm/debugger/tests/ExecutionHandlerIdleStopTest.cpp
         ../wasm/debugger/tests/ExecutionHandlerTest.cpp
         ../wasm/debugger/tests/ExecutionHandlerTestSupport.cpp
+        ../wasm/debugger/tests/ExecutionHandlerVMLifecycleTest.cpp
         ../wasm/debugger/tests/ExtGCTests.cpp
         ../wasm/debugger/tests/GDBPacketParserTest.cpp
         ../wasm/debugger/tests/MemoryTests.cpp

--- a/Source/JavaScriptCore/wasm/debugger/README.md
+++ b/Source/JavaScriptCore/wasm/debugger/README.md
@@ -230,15 +230,6 @@ See [RWI_ARCHITECTURE.md](./RWI_ARCHITECTURE.md) for complete setup instructions
 - **Issue**: Thread select and stop reply protocol handlers need improvement to correctly display multi-VM data in LLDB
 - **Current Status**: Multi-VM stop-the-world is implemented, but thread information may not display correctly in LLDB UI
 
-### VM Lifecycle and Synchronization Testing
-
-- **Issue**: ExecutionHandler stress tests need additional coverage for VM lifecycle edge cases and race conditions
-- **Current Test Limitations**: Tests wait for VM construction and instance registration, but this doesn't guarantee VMs are actively running code that checks traps
-- **Missing Test Coverage**:
-  - VM lifecycle edge cases (construction, initialization, instance registration)
-  - `interrupt()` race conditions when VMs are not yet executing code
-  - Synchronization between VM construction and actual code execution
-
 ### X86_64 Support
 
 - **Issue**: The WebAssembly debugger is currently restricted to ARM64 platforms only

--- a/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.cpp
@@ -843,8 +843,8 @@ void ExecutionHandler::sendErrorReply(ProtocolError error) { m_debugServer.sendE
 uint64_t ExecutionHandler::threadId(const VM& vm)
 {
     auto uid = vm.ownerThreadUID();
-    RELEASE_ASSERT(uid.has_value());
-    return *uid;
+    // nullopt when JSLock was never acquired (e.g. during VM construction); fall back to current thread.
+    return uid.value_or(Thread::currentSingleton().uid());
 }
 
 DebugState* ExecutionHandler::debuggeeState() const { return m_debuggee->debugState(); }

--- a/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTest.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTest.cpp
@@ -327,13 +327,7 @@ static void waitForVMCleanupFromPreviousTest()
 }
 
 // setupScriptAndWaitForVMs ensures all VMs are constructed, instances registered, entered with owner threads,
-// and actively running before tests start. However, this doesn't test edge cases where interrupt() races with:
-// FIXME: Add tests for VM lifecycle edge cases:
-// - interrupt() during VM construction (before m_debugState initialized)
-// - interrupt() during instance registration
-// - interrupt() race with VMs entering/activating
-// These edge cases could expose timing issues in stopTheWorld coordination that don't occur when
-// all VMs are already in a stable running state.
+// and actively running before tests start.
 static bool setupScriptAndWaitForVMs(const TestScript& script, RefPtr<Thread>& outWorkerThread)
 {
     ModuleManager& moduleManager = debugServer->moduleManager();
@@ -417,10 +411,7 @@ UNUSED_FUNCTION static int runTests()
         waitForVMCleanupFromPreviousTest();
 
         RefPtr<Thread> workerThread;
-        if (!setupScriptAndWaitForVMs(script, workerThread)) {
-            totalFailures++;
-            continue;
-        }
+        RELEASE_ASSERT(setupScriptAndWaitForVMs(script, workerThread));
 
         testRapidInterruptResumeCycles();
         testVMContextSwitching();

--- a/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerVMLifecycleTest.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerVMLifecycleTest.cpp
@@ -1,0 +1,295 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ExecutionHandlerVMLifecycleTest.h"
+
+#include <wtf/DataLog.h>
+
+#if ENABLE(WEBASSEMBLY_DEBUGGER)
+
+#include "Completion.h"
+#include "ExecutionHandlerTestSupport.h"
+#include "JSCJSValue.h"
+#include "JSGlobalObject.h"
+#include "JSLock.h"
+#include "Protect.h"
+#include "SourceCode.h"
+#include "SourceOrigin.h"
+#include "StructureInlines.h"
+#include "VM.h"
+#include "VMManager.h"
+#include "WasmDebugServer.h"
+#include "WasmExecutionHandler.h"
+#include <wtf/Condition.h>
+#include <wtf/Lock.h>
+#include <wtf/Threading.h>
+#include <wtf/URL.h>
+#include <wtf/Vector.h>
+
+namespace ExecutionHandlerVMLifecycleTest {
+
+using ExecutionHandlerTestSupport::setupTestEnvironment;
+using ExecutionHandlerTestSupport::waitForCondition;
+using JSC::VM;
+using JSC::VMManager;
+using JSC::Wasm::DebugServer;
+using JSC::Wasm::ExecutionHandler;
+
+// ========== Test Configuration ==========
+
+static constexpr bool verboseLogging = false;
+// Each test keeps one permanent anchor VM alive so interrupt() always has at least one
+// VM to drive the STW to completion.
+static constexpr unsigned NUM_VMS = 10;
+static constexpr unsigned STRESS_TEST_ITERATIONS = 1000;
+static constexpr ASCIILiteral LIFECYCLE_THREAD_NAME = "LifecycleTestVM"_s;
+
+// ========== Test Runtime State ==========
+
+static int failuresFound = 0;
+static DebugServer* debugServer = nullptr;
+static ExecutionHandler* executionHandler = nullptr;
+
+// doneTesting: signals vmAnchorTask and vmFullLifecycleTask threads to exit.
+static std::atomic<bool> doneTesting { false };
+
+// Barrier for waiting until N VM threads have completed construction.
+static Lock vmReadyLock;
+static Condition vmReadyCondition;
+static unsigned vmReadyCount = 0;
+
+#define TEST_LOG(...) dataLogLn(__VA_ARGS__)
+#define VLOG(...) dataLogLnIf(verboseLogging, __VA_ARGS__)
+
+// On failure: log, increment counter, and return from the enclosing function.
+#define CHECK(condition, ...)                                   \
+    do {                                                        \
+        if (!(condition)) {                                     \
+            dataLogLn("FAIL: ", #condition, ": ", __VA_ARGS__); \
+            dataLogLn("    @ " __FILE__ ":", __LINE__);         \
+            failuresFound++;                                    \
+            return;                                             \
+        }                                                       \
+    } while (false)
+
+// ========== Helpers ==========
+
+static bool isStopped()
+{
+    return VMManager::info().worldMode == VMManager::Mode::Stopped;
+}
+
+static bool isRunning()
+{
+    return VMManager::info().worldMode == VMManager::Mode::RunAll;
+}
+
+static void signalVMReady()
+{
+    Locker locker { vmReadyLock };
+    vmReadyCount++;
+    vmReadyCondition.notifyAll();
+}
+
+static void waitForVMsConstruction(unsigned count)
+{
+    Locker locker { vmReadyLock };
+    while (vmReadyCount < count)
+        vmReadyCondition.wait(vmReadyLock);
+}
+
+static void waitForAllVMsGone()
+{
+    VLOG("Waiting for all VMs (including anchor) to be destroyed...");
+    bool ok = waitForCondition([]() {
+        return !VMManager::info().numberOfVMs;
+    });
+    if (!ok) {
+        dataLogLn("FAIL: VMs not cleaned up within timeout (count: ", VMManager::info().numberOfVMs, ")");
+        failuresFound++;
+    }
+}
+
+// ========== VM Task: anchor — idles in RunLoop until doneTesting ==========
+
+static void vmAnchorTask()
+{
+    VLOG("[AnchorVM] Creating VM");
+    VM& vm = VM::create(JSC::HeapType::Small).leakRef();
+    JSC::JSGlobalObject* globalObject = nullptr;
+
+    {
+        JSC::JSLockHolder locker(vm);
+        globalObject = JSC::JSGlobalObject::create(vm, JSC::JSGlobalObject::createStructure(vm, JSC::jsNull()));
+        gcProtect(globalObject);
+        signalVMReady();
+        VLOG("[AnchorVM] Ready");
+    } // Release API lock — VM is idle
+
+    while (!doneTesting.load())
+        WTF::RunLoop::cycle(DefaultRunLoopMode);
+
+    VLOG("[AnchorVM] Releasing VM");
+    {
+        JSC::JSLockHolder locker(vm);
+        gcUnprotect(globalObject);
+        vm.derefSuppressingSaferCPPChecking();
+    }
+}
+
+// ========== VM Task: continuous construct → run JS → destroy loop ==========
+
+static void vmFullLifecycleTask()
+{
+    // Number of RunLoop cycles to spin between JSLock acquisitions. Wider idle windows
+    // give STW interrupts a better chance of landing while the VM is registered but not entered.
+    static constexpr unsigned idleSpinCount = 3;
+
+    VLOG("[FullLifecycleVM] Starting");
+    while (!doneTesting.load()) {
+        VM& vm = VM::create(JSC::HeapType::Small).leakRef();
+        JSC::JSGlobalObject* globalObject = nullptr;
+
+        for (unsigned i = 0; i < idleSpinCount; ++i)
+            WTF::RunLoop::cycle(DefaultRunLoopMode);
+
+        {
+            JSC::JSLockHolder locker(vm);
+            globalObject = JSC::JSGlobalObject::create(vm, JSC::JSGlobalObject::createStructure(vm, JSC::jsNull()));
+            gcProtect(globalObject);
+        } // Release API lock — VM is idle and in the VMManager list
+
+        for (unsigned i = 0; i < idleSpinCount; ++i)
+            WTF::RunLoop::cycle(DefaultRunLoopMode);
+
+        // Execute a trivial script so the VM transitions through active state.
+        {
+            JSC::JSLockHolder locker(vm);
+            JSC::SourceOrigin origin(URL({ }, "lifecycle-test"_s));
+            JSC::SourceCode sourceCode = JSC::makeSource("(function() { var x = 0; for (var i = 0; i < 100000; ++i) x += i; return x; })()"_s, origin, JSC::SourceTaintedOrigin::Untainted);
+            NakedPtr<JSC::Exception> exception;
+            JSC::evaluate(globalObject, sourceCode, JSC::JSValue(), exception);
+        }
+
+        for (unsigned i = 0; i < idleSpinCount; ++i)
+            WTF::RunLoop::cycle(DefaultRunLoopMode);
+
+        // Destroy — removes VM from the VMManager list.
+        {
+            JSC::JSLockHolder locker(vm);
+            gcUnprotect(globalObject);
+            vm.derefSuppressingSaferCPPChecking();
+        }
+    }
+    VLOG("[FullLifecycleVM] Exiting");
+}
+
+// ========== Full Lifecycle Race ==========
+// NUM_VMS threads cycle construct → run JS → destroy while STW fires concurrently.
+
+static void testFullLifecycleRace()
+{
+    TEST_LOG("\n=== VM Lifecycle Test: Full Lifecycle Race ===");
+    TEST_LOG("1 anchor VM + ", NUM_VMS, " cycling VMs, STW fires concurrently");
+
+    // Start the anchor VM and wait until it is in the VMManager list.
+    doneTesting = false;
+    vmReadyCount = 0;
+    RefPtr<Thread> anchorThread = Thread::create(LIFECYCLE_THREAD_NAME, vmAnchorTask);
+    waitForVMsConstruction(1);
+
+    // Cycling VMs: continuously construct → run JS → destroy until doneTesting.
+    Vector<RefPtr<Thread>> cyclingThreads;
+    cyclingThreads.reserveInitialCapacity(NUM_VMS);
+    for (unsigned i = 0; i < NUM_VMS; ++i)
+        cyclingThreads.append(Thread::create(LIFECYCLE_THREAD_NAME, vmFullLifecycleTask));
+
+    unsigned successCount = 0;
+
+    for (unsigned iter = 0; iter < STRESS_TEST_ITERATIONS; ++iter) {
+        VLOG("[FullLifecycle][Iter ", iter, "] start");
+
+        executionHandler->interrupt();
+        CHECK(isStopped(), "Should be stopped after interrupt (full lifecycle iter ", iter, ")");
+        VLOG("[FullLifecycle][Iter ", iter, "] stopped OK, numberOfVMs=", VMManager::info().numberOfVMs);
+
+        executionHandler->resume();
+        CHECK(isRunning(), "Should be running after resume (full lifecycle iter ", iter, ")");
+        VLOG("[FullLifecycle][Iter ", iter, "] resumed OK");
+
+        successCount++;
+    }
+
+    TEST_LOG("PASS: ", successCount, "/", STRESS_TEST_ITERATIONS, " iterations succeeded");
+
+    doneTesting = true;
+    anchorThread->waitForCompletion();
+    for (auto& t : cyclingThreads)
+        t->waitForCompletion();
+    waitForAllVMsGone();
+    executionHandler->reset();
+    doneTesting = false;
+}
+
+// ========== Main Test Runner ==========
+
+UNUSED_FUNCTION static int runVMLifecycleTests()
+{
+    TEST_LOG("========================================");
+    TEST_LOG("VM Lifecycle Race Tests");
+    TEST_LOG("Validates debugState() lifetime matches VMManager list membership");
+    TEST_LOG("Each test: 1 anchor VM + ", NUM_VMS, " test VMs  STRESS_TEST_ITERATIONS=", STRESS_TEST_ITERATIONS);
+    TEST_LOG("========================================");
+
+    setupTestEnvironment(debugServer, executionHandler);
+
+    testFullLifecycleRace();
+
+    TEST_LOG("\n========================================");
+    TEST_LOG(failuresFound ? "FAIL" : "PASS", " - VM Lifecycle Race Tests");
+    TEST_LOG("Total Failures: ", failuresFound);
+    TEST_LOG("========================================");
+
+    return failuresFound;
+}
+
+#undef TEST_LOG
+#undef VLOG
+#undef CHECK
+
+} // namespace ExecutionHandlerVMLifecycleTest
+
+#endif // ENABLE(WEBASSEMBLY_DEBUGGER)
+
+int testExecutionHandlerVMLifecycle()
+{
+#if ENABLE(WEBASSEMBLY_DEBUGGER) && CPU(ARM64)
+    return ExecutionHandlerVMLifecycleTest::runVMLifecycleTests();
+#else
+    dataLogLn("VM Lifecycle Race Tests SKIPPED (only supported on ARM64)");
+    return 0;
+#endif
+}

--- a/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerVMLifecycleTest.h
+++ b/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerVMLifecycleTest.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+int testExecutionHandlerVMLifecycle();

--- a/Source/JavaScriptCore/wasm/debugger/testwasmdebugger.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/testwasmdebugger.cpp
@@ -38,6 +38,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 #include "ExecutionHandlerIdleStopTest.h"
 #include "ExecutionHandlerTest.h"
+#include "ExecutionHandlerVMLifecycleTest.h"
 #include "GDBPacketParserTest.h"
 #include "InitializeThreading.h"
 #include "Options.h"
@@ -315,15 +316,19 @@ static void testWASMVirtualAddressOperators()
     dataLogLn("\n--- WASM Debugger Idle VM Stress Tests ---");
     int idleStopTestsFailed = testExecutionHandlerIdleStop();
 
+    dataLogLn("\n--- WASM Debugger VM Lifecycle Race Tests ---");
+    int vmLifecycleTestsFailed = testExecutionHandlerVMLifecycle();
+
     dataLogLn("===============================================");
     dataLogLn("Combined Test Results:");
     dataLogLn("  VirtualAddress Tests - PASSED (assertion-based)");
     dataLogLn("  WASM Debug Info Tests - See detailed results above");
     dataLogLn("  WASM Debugger Stress Tests - See detailed results above");
     dataLogLn("  WASM Debugger Idle VM Tests - See detailed results above");
-    dataLogLn("  Total Failures: ", testsFailed, " (VirtualAddress) + ", debugInfoTestsFailed, " (Debug Info) + ", executionHandlerTestsFailed, " (Stress) + ", idleStopTestsFailed, " (Idle VM) = ", testsFailed + debugInfoTestsFailed + executionHandlerTestsFailed + idleStopTestsFailed);
+    dataLogLn("  WASM Debugger VM Lifecycle Race Tests - See detailed results above");
+    dataLogLn("  Total Failures: ", testsFailed, " (VirtualAddress) + ", debugInfoTestsFailed, " (Debug Info) + ", executionHandlerTestsFailed, " (Stress) + ", idleStopTestsFailed, " (Idle VM) + ", vmLifecycleTestsFailed, " (VM Lifecycle) = ", testsFailed + debugInfoTestsFailed + executionHandlerTestsFailed + idleStopTestsFailed + vmLifecycleTestsFailed);
 
-    int totalFailures = testsFailed + debugInfoTestsFailed + executionHandlerTestsFailed + idleStopTestsFailed;
+    int totalFailures = testsFailed + debugInfoTestsFailed + executionHandlerTestsFailed + idleStopTestsFailed + vmLifecycleTestsFailed;
     if (!totalFailures) {
         dataLogLn("All tests PASSED!");
         dataLogLn("WASM debugger infrastructure is working correctly");


### PR DESCRIPTION
#### d6d27c0ed374d16469872b40217fa8faaa3da36a
<pre>
[JSC][WASM][Debugger] Fix WASM debugger stop-the-world races during VM construction and destruction
<a href="https://bugs.webkit.org/show_bug.cgi?id=310328">https://bugs.webkit.org/show_bug.cgi?id=310328</a>
<a href="https://rdar.apple.com/172974905">rdar://172974905</a>

Reviewed by Mark Lam.

Fix crashes and assertion failures in the Wasm debugger&apos;s stop-the-world
(STW) machinery when VMs are created or destroyed concurrently with a
debugger interrupt.

- Move m_numberOfStoppedVMs and m_numberOfActiveVMs from Atomic&lt;unsigned&gt;
to plain unsigned WTF_GUARDED_BY_LOCK(m_worldLock), and consolidate all
counter updates and debugState()-&gt;setStopped()/clearStop() into the same
lock acquisitions as the mode checks, eliminating races where the counters
could be observed in an inconsistent state across separate lock acquisitions.

- Remove vm.requestStop() from notifyVMConstruction and notifyVMActivation.
requestStop() installs a VMTrap to indirectly drive notifyVMStop(), but
both functions already call notifyVMStop() directly, making the requestStop() redundant.

- Separate VMManager registration from VMThreadContext lifecycle. Call
notifyVMConstruction() explicitly at the end of VM::VM() after all VM
state is initialized, so any STW triggered immediately on registration
sees a fully constructed VM. Call notifyVMDestruction() explicitly at
the start of VM::~VM() before any teardown. VMThreadContext is now a
pure data holder with a default constructor and destructor.

- Fix VMTraps::handleTraps() to tolerate a NoEvent result from
takeTopPriorityTrap() when cancelStop() races with trap dispatch.

Tests: JSC::Wasm::testExecutionHandlerVMLifecycle
Canonical link: <a href="https://commits.webkit.org/309965@main">https://commits.webkit.org/309965@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad1bf0f8fb710888c88616ee0fe042b991f9780c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152288 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25070 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18668 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161031 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5babf970-e408-4c96-9a3e-d25ac71ae6d4) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25597 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25376 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117650 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f8b61cf1-05df-41b6-9a7b-47be8f54d47a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155248 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136709 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98363 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9ca1e5a0-7f09-45c8-acd3-b07c4449f49c) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/18937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16875 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8865 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144300 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14583 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163499 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13089 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6643 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16177 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125684 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24868 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20913 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125858 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34146 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24869 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136379 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81468 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20863 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13157 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/183912 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24486 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88771 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46889 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24177 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24337 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24238 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->