### PR TITLE
m_isAllowdByWebContentRestrictions should be m_isAllowedByWebContentRestrictions

### DIFF
--- a/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.h
+++ b/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.h
@@ -81,7 +81,7 @@ private:
     URL m_mainDocumentURL;
     Lock m_resultLock;
     Condition m_resultCondition;
-    std::optional<bool> m_isAllowdByWebContentRestrictions WTF_GUARDED_BY_LOCK(m_resultLock);
+    std::optional<bool> m_isAllowedByWebContentRestrictions WTF_GUARDED_BY_LOCK(m_resultLock);
     RetainPtr<NSData> m_webContentRestrictionsReplacementData WTF_GUARDED_BY_LOCK(m_resultLock);
 
 #if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)

--- a/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.mm
+++ b/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.mm
@@ -147,12 +147,12 @@ void ParentalControlsContentFilter::finishedAddingData()
 
     // Callers expect state is ready after finishing adding data.
     Locker resultLocker { m_resultLock };
-    while (!m_isAllowdByWebContentRestrictions) {
+    while (!m_isAllowedByWebContentRestrictions) {
         if (!m_resultCondition.waitFor(m_resultLock, 250_ms))
             RELEASE_LOG_ERROR(ContentFiltering, "ParentalControlsContentFilter::finishedAddingData timed out waiting for result after 250 ms");
     }
 
-    m_state = *m_isAllowdByWebContentRestrictions ? State::Allowed : State::Blocked;
+    m_state = *m_isAllowedByWebContentRestrictions ? State::Allowed : State::Blocked;
     m_replacementData = std::exchange(m_webContentRestrictionsReplacementData, nullptr);
 
 #elif HAVE(WEBCONTENTANALYSIS_FRAMEWORK)
@@ -188,8 +188,8 @@ void ParentalControlsContentFilter::didReceiveAllowDecisionOnQueue(bool isAllowe
     RELEASE_ASSERT(!isMainThread());
 
     Locker resultLocker { m_resultLock };
-    ASSERT(!m_isAllowdByWebContentRestrictions);
-    m_isAllowdByWebContentRestrictions = isAllowed;
+    ASSERT(!m_isAllowedByWebContentRestrictions);
+    m_isAllowedByWebContentRestrictions = isAllowed;
     m_webContentRestrictionsReplacementData = replacementData;
     m_resultCondition.notifyOne();
     callOnMainRunLoop([weakThis = ThreadSafeWeakPtr { *this }]() {
@@ -206,8 +206,8 @@ void ParentalControlsContentFilter::updateFilterStateOnMain()
         return;
 
     Locker resultLocker { m_resultLock };
-    ASSERT(m_isAllowdByWebContentRestrictions);
-    m_state = *m_isAllowdByWebContentRestrictions ? State::Allowed : State::Blocked;
+    ASSERT(m_isAllowedByWebContentRestrictions);
+    m_state = *m_isAllowedByWebContentRestrictions ? State::Allowed : State::Blocked;
     m_replacementData = std::exchange(m_webContentRestrictionsReplacementData, nullptr);
 }
 


### PR DESCRIPTION
#### c97dde725b3c75e96ee1de19a33a2dbc9d2e5a8a
<pre>
m_isAllowdByWebContentRestrictions should be m_isAllowedByWebContentRestrictions
<a href="https://bugs.webkit.org/show_bug.cgi?id=310329">https://bugs.webkit.org/show_bug.cgi?id=310329</a>
<a href="https://rdar.apple.com/172978762">rdar://172978762</a>

Reviewed by Aditya Keerthi.

We should fix the typo m_isAllowdByWebContentRestrictions. It should be m_isAllowedByWebContentRestrictions.

No new tests needed.

* Source/WebCore/platform/cocoa/ParentalControlsContentFilter.h:
* Source/WebCore/platform/cocoa/ParentalControlsContentFilter.mm:
(WebCore::ParentalControlsContentFilter::finishedAddingData):
(WebCore::ParentalControlsContentFilter::didReceiveAllowDecisionOnQueue):
(WebCore::ParentalControlsContentFilter::updateFilterStateOnMain):

Canonical link: <a href="https://commits.webkit.org/309601@main">https://commits.webkit.org/309601@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc7dd1d983ec2b696d4ee6448d061cce4fc1cb94

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151175 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23938 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17508 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159904 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/104611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ff81c649-0293-40e7-b1e9-437abfee7523) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153048 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24369 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24176 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116711 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/104611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/06db8694-0e24-4e38-bd90-27a7accbcf20) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154135 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/18835 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135639 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97432 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/124f6245-7d0f-4d9b-acd5-a088d1497c2f) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/150496 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17928 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15880 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7749 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127546 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13556 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162376 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5501 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15127 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124720 "Passed tests") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/150575 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23739 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19930 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124908 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23729 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135353 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80173 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23231 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19973 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12118 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/182784 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23339 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87633 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/182784 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23051 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23203 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23105 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->