### PR TITLE
The current document immersive element should be updated as soon as it gets presented

### DIFF
--- a/Source/WebCore/dom/DocumentImmersive.cpp
+++ b/Source/WebCore/dom/DocumentImmersive.cpp
@@ -227,7 +227,7 @@ void DocumentImmersive::handleImmersiveError(HTMLModelElement* element, const St
     completionHandler(Exception { code, message });
 }
 
-std::optional<Exception> DocumentImmersive::checkRequestStillValid(HTMLModelElement* element, ActiveRequest::Stage expectedStage)
+std::optional<Exception> DocumentImmersive::isRequestOutdated(HTMLModelElement* element, ActiveRequest::Stage expectedStage)
 {
     if (m_activeRequest.stage != expectedStage || m_activeRequest.element != element || m_pendingImmersiveElement != element)
         return Exception { ExceptionCode::AbortError, "Immersive request was superseded by another request."_s };
@@ -237,28 +237,9 @@ std::optional<Exception> DocumentImmersive::checkRequestStillValid(HTMLModelElem
 
 void DocumentImmersive::cancelActiveRequest(CompletionHandler<void()>&& completionHandler)
 {
-    RefPtr element = m_activeRequest.element.get();
-    if (!element)
-        return completionHandler();
-
-    auto stage = m_activeRequest.stage;
     m_activeRequest.stage = ActiveRequest::Stage::None;
     m_activeRequest.element = nullptr;
-
-    switch (stage) {
-    case ActiveRequest::Stage::None:
-    case ActiveRequest::Stage::Permission:
-    case ActiveRequest::Stage::ModelPlayer:
-        completionHandler();
-        break;
-
-    case ActiveRequest::Stage::Presentation:
-        dismissClientImmersivePresentation([element, completionHandler = WTF::move(completionHandler)]() mutable {
-            element->exitImmersivePresentation([] { });
-            completionHandler();
-        });
-        break;
-    }
+    completionHandler();
 }
 
 void DocumentImmersive::beginImmersiveRequest(Ref<HTMLModelElement>&& element, CompletionHandler<void(ExceptionOr<void>)>&& completionHandler)
@@ -277,7 +258,7 @@ void DocumentImmersive::beginImmersiveRequest(Ref<HTMLModelElement>&& element, C
         if (!protectedThis || !protectedElement)
             return completionHandler(Exception { ExceptionCode::AbortError });
 
-        if (auto error = protectedThis->checkRequestStillValid(protectedElement.get(), ActiveRequest::Stage::Permission))
+        if (auto error = protectedThis->isRequestOutdated(protectedElement.get(), ActiveRequest::Stage::Permission))
             return protectedThis->handleImmersiveError(protectedElement.get(), error->message(), EmitErrorEvent::Yes, error->code(), WTF::move(completionHandler));
 
         if (!allowed)
@@ -298,7 +279,7 @@ void DocumentImmersive::createModelPlayerForImmersive(Ref<HTMLModelElement>&& el
         if (!protectedThis || !protectedElement)
             return completionHandler(Exception { ExceptionCode::AbortError });
 
-        if (auto error = protectedThis->checkRequestStillValid(protectedElement.get(), ActiveRequest::Stage::ModelPlayer)) {
+        if (auto error = protectedThis->isRequestOutdated(protectedElement.get(), ActiveRequest::Stage::ModelPlayer)) {
             protectedElement->exitImmersivePresentation([] { });
             return protectedThis->handleImmersiveError(protectedElement.get(), error->message(), EmitErrorEvent::Yes, error->code(), WTF::move(completionHandler));
         }
@@ -322,7 +303,7 @@ void DocumentImmersive::createModelPlayerForImmersive(Ref<HTMLModelElement>&& el
                 if (!protectedThis || !protectedElement)
                     return completionHandler(Exception { ExceptionCode::AbortError });
 
-                if (auto error = protectedThis->checkRequestStillValid(protectedElement.get(), ActiveRequest::Stage::ModelPlayer)) {
+                if (auto error = protectedThis->isRequestOutdated(protectedElement.get(), ActiveRequest::Stage::ModelPlayer)) {
                     protectedElement->exitImmersivePresentation([] { });
                     return protectedThis->handleImmersiveError(protectedElement.get(), error->message(), EmitErrorEvent::Yes, error->code(), WTF::move(completionHandler));
                 }
@@ -345,9 +326,21 @@ void DocumentImmersive::presentImmersiveElement(Ref<HTMLModelElement>&& element,
 
     m_activeRequest.stage = ActiveRequest::Stage::Presentation;
 
-    protectedPage->chrome().client().presentImmersiveElement(contextID, [weakElement = WeakPtr { element }, weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler)](bool success) mutable {
+    RefPtr oldElement = immersiveElement();
+    m_immersiveElement = element.get();
+    updateElementIsImmersive(element.ptr(), true);
+
+    protectedPage->chrome().client().presentImmersiveElement(contextID, [weakElement = WeakPtr { element }, weakOldElement = WeakPtr { oldElement }, weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler)](bool success) mutable {
         RefPtr protectedThis = weakThis.get();
         RefPtr protectedElement = weakElement.get();
+
+        // We exit the immersive presentation of the old element only after we finished presenting the new element.
+        // This is because the old element can remain visible during this transition.
+        if (RefPtr protectedOldElement = weakOldElement.get()) {
+            protectedOldElement->exitImmersivePresentation([] { });
+            if (protectedThis)
+                protectedThis->updateElementIsImmersive(protectedOldElement.get(), false);
+        }
 
         if (!protectedElement)
             return completionHandler(Exception { ExceptionCode::AbortError });
@@ -357,27 +350,20 @@ void DocumentImmersive::presentImmersiveElement(Ref<HTMLModelElement>&& element,
             return completionHandler(Exception { ExceptionCode::AbortError });
         }
 
-        if (auto error = protectedThis->checkRequestStillValid(protectedElement.get(), ActiveRequest::Stage::Presentation)) {
-            protectedElement->exitImmersivePresentation([] { });
-            return protectedThis->handleImmersiveError(protectedElement.get(), error->message(), EmitErrorEvent::Yes, error->code(), WTF::move(completionHandler));
-        }
-
         if (!success) {
             protectedElement->exitImmersivePresentation([] { });
+            if (protectedThis->m_immersiveElement == protectedElement.get())
+                protectedThis->m_immersiveElement = nullptr;
+            protectedThis->updateElementIsImmersive(protectedElement.get(), false);
             return protectedThis->handleImmersiveError(protectedElement.get(), "Failure to present the immersive element."_s, EmitErrorEvent::Yes, ExceptionCode::AbortError, WTF::move(completionHandler));
         }
 
-        if (RefPtr oldImmersiveElement = protectedThis->immersiveElement()) {
-            oldImmersiveElement->exitImmersivePresentation([] { });
-            protectedThis->updateElementIsImmersive(oldImmersiveElement.get(), false);
-        }
+        if (protectedThis->isRequestOutdated(protectedElement.get(), ActiveRequest::Stage::Presentation))
+            return completionHandler({ });
 
-        protectedThis->m_immersiveElement = protectedElement.get();
         protectedThis->m_pendingImmersiveElement = nullptr;
         protectedThis->m_activeRequest.stage = ActiveRequest::Stage::None;
         protectedThis->m_activeRequest.element = nullptr;
-        protectedThis->updateElementIsImmersive(protectedElement.get(), true);
-
         completionHandler({ });
     });
 }

--- a/Source/WebCore/dom/DocumentImmersive.h
+++ b/Source/WebCore/dom/DocumentImmersive.h
@@ -89,7 +89,7 @@ private:
         WeakPtr<HTMLModelElement, WeakPtrImplWithEventTargetData> element;
     };
     ActiveRequest m_activeRequest;
-    std::optional<Exception> checkRequestStillValid(HTMLModelElement*, ActiveRequest::Stage expectedStage);
+    std::optional<Exception> isRequestOutdated(HTMLModelElement*, ActiveRequest::Stage expectedStage);
 
     void cancelActiveRequest(CompletionHandler<void()>&&);
     void beginImmersiveRequest(Ref<HTMLModelElement>&&, CompletionHandler<void(ExceptionOr<void>)>&&);


### PR DESCRIPTION
#### 2661f9a26e1dcf5c1001cad57dbc68f7ab329f7d
<pre>
The current document immersive element should be updated as soon as it gets presented
<a href="https://bugs.webkit.org/show_bug.cgi?id=310337">https://bugs.webkit.org/show_bug.cgi?id=310337</a>
<a href="https://rdar.apple.com/172987822">rdar://172987822</a>

Reviewed by Etienne Segonzac.

The issue was that the immersivechange event was triggered after we got the
callback from the chrome client. But this callback is usually triggered when the immersive
transition is completely finished. In reality, the immersive element starts to
be displayed at the begining of this transition. This is why the immersivechange
event should be triggered as soon as we ask the client to present the model.
Additionally, the immersiveElement should be updated as well.
In the case where the client fails to transition to immersive (rare scenario since
we already checked the client for permission), an error is thrown in the request,
an immersiveerror event is triggered, and a new immersivechange event is notifying
the website that the immersiveElement switched back to null.

* Source/WebCore/dom/DocumentImmersive.cpp:
(WebCore::DocumentImmersive::cancelActiveRequest):
If another request comes in and we are in the presentation stage of an old request,
we don&apos;t need to dismiss the client presentation right away.
This is already handled in the new transition&apos;s logic.

(WebCore::DocumentImmersive::beginImmersiveRequest):
(WebCore::DocumentImmersive::createModelPlayerForImmersive):
(WebCore::DocumentImmersive::presentImmersiveElement):
(WebCore::DocumentImmersive::isRequestOutdated):
(WebCore::DocumentImmersive::checkRequestStillValid): Deleted.
* Source/WebCore/dom/DocumentImmersive.h:
Renamed checkRequestStillValid to isRequestOutdated.

Canonical link: <a href="https://commits.webkit.org/309771@main">https://commits.webkit.org/309771@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3dd3bcd6badd4596622d192f29009bb2f224211c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151664 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24445 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18015 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160399 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153538 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24918 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24738 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117142 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154624 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19277 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136093 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97857 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18364 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16316 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8241 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/127994 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13997 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162870 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6019 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15587 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125159 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24244 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20374 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125341 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34014 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24245 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135793 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80820 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20371 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12568 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23861 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88146 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23553 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23713 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23613 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->