### PR TITLE
Remove logic adding scene understanding component to immersive models

### DIFF
--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -1093,11 +1093,9 @@ void ModelProcessModelPlayerProxy::ensureImmersivePresentation(CompletionHandler
         if (!protectedThis)
             return completion(std::nullopt);
 
-        RetainPtr entity = protectedThis->m_modelRKEntity;
-        if (loaded && entity) {
-            [entity ensureSceneUnderstanding];
+        if (loaded)
             completion(protectedThis->layerHostingContextIdentifier().value());
-        } else {
+        else {
             protectedThis->setImmersivePresentation(false);
             completion(std::nullopt);
         }

--- a/Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.h
+++ b/Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.h
@@ -75,9 +75,6 @@ NS_SWIFT_UI_ACTOR
 - (void)interactionContainerDidRecenterFromTransform:(simd_float4x4)transform;
 - (void)recenterEntityAtTransform:(WKEntityTransform)transform;
 - (void)applyDefaultIBL;
-#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
-- (void)ensureSceneUnderstanding;
-#endif
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.swift
+++ b/Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.swift
@@ -395,20 +395,6 @@ extension WKRKEntity {
         #endif
     }
 
-    #if ENABLE_MODEL_ELEMENT_IMMERSIVE
-    func ensureSceneUnderstanding() {
-        applySceneUnderstandingComponentRecursively(to: entity)
-    }
-
-    @nonobjc
-    private final func applySceneUnderstandingComponentRecursively(to entity: Entity) {
-        entity.components[SceneUnderstandingComponent.self] = .init(entityType: .meshChunk)
-        for child in entity.children {
-            applySceneUnderstandingComponentRecursively(to: child)
-        }
-    }
-    #endif
-
     private func animationPlaybackStateDidUpdate() {
         delegate?.entityAnimationPlaybackStateDidUpdate?(self)
     }


### PR DESCRIPTION
#### aa7e45300ed1afb5c9c603be82a5b1698eb1ba4a
<pre>
Remove logic adding scene understanding component to immersive models
<a href="https://bugs.webkit.org/show_bug.cgi?id=310342">https://bugs.webkit.org/show_bug.cgi?id=310342</a>
<a href="https://rdar.apple.com/172933410">rdar://172933410</a>

Reviewed by Etienne Segonzac.

Since this component should rather be intentionally added during
the asset creation process, we are removing the logic that was adding
this component recursively to a model when transitioning to immersive.
This essentially reverts <a href="https://bugs.webkit.org/show_bug.cgi?id=306788">https://bugs.webkit.org/show_bug.cgi?id=306788</a>

* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::ModelProcessModelPlayerProxy::ensureImmersivePresentation):
* Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.h:
* Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.swift:
(WKRKEntity.ensureSceneUnderstanding): Deleted.
(WKRKEntity.applySceneUnderstandingComponentRecursively(to:)): Deleted.

Canonical link: <a href="https://commits.webkit.org/309617@main">https://commits.webkit.org/309617@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0fb7e7481e153e122fec41330495c2cefb8db72

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151203 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23966 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17536 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159932 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104639 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24397 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24209 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116736 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82868 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154163 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18860 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135664 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97457 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17953 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15903 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7777 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127571 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162404 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/12002 "Build is in progress. Recent messages:") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5529 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15152 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124745 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23767 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19953 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124933 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33894 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23757 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135378 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80218 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19996 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12143 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23367 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87661 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23079 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23231 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23133 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->