### PR TITLE
Fix hidpi-legacy-svg-compositing-sibling-no-shift.html to actually test compositing change

### DIFF
--- a/LayoutTests/svg/compositing/hidpi-legacy-svg-compositing-sibling-no-shift.html
+++ b/LayoutTests/svg/compositing/hidpi-legacy-svg-compositing-sibling-no-shift.html
@@ -3,7 +3,6 @@
 <head>
 <title>Test that legacy SVG does not shift when sibling becomes composited</title>
 <meta name="fuzzy" content="maxDifference=0-5;totalPixels=0-100">
-<script src="../repaint/resources/reftest-repaint.js"></script>
 <style>
     body {
         margin: 0;
@@ -32,7 +31,7 @@
     }
 </style>
 </head>
-<body onload="runRepaintRefTest()">
+<body onload="runTest()">
 <p>Test passes if the green circle does not shift when the sibling becomes composited.</p>
 <div class="container">
     <svg viewBox="0 0 50 50">
@@ -41,10 +40,17 @@
     <div id="overlay" class="overlay"></div>
 </div>
 <script>
-function repaintRefTest() {
+function runTest() {
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
+        testRunner.display();
+    }
+
     requestAnimationFrame(() => {
         requestAnimationFrame(() => {
             document.getElementById("overlay").style.transform = "translateZ(0)";
+            if (window.testRunner)
+                testRunner.notifyDone();
         });
     });
 }


### PR DESCRIPTION
#### 09886b4325ddbde1f9c1f853ce563b3a774f0850
<pre>
Fix hidpi-legacy-svg-compositing-sibling-no-shift.html to actually test compositing change
<a href="https://bugs.webkit.org/show_bug.cgi?id=310344">https://bugs.webkit.org/show_bug.cgi?id=310344</a>

Reviewed by Rob Buis.

The test used reftest-repaint.js, whose callRepaintRefTest() calls
notifyDone() via setTimeout(0) immediately after repaintRefTest().
However, repaintRefTest() used a double requestAnimationFrame to apply
the translateZ(0) change asynchronously. The setTimeout(0) fired before
the rAF callbacks, ending the test before the compositing change was
ever applied. The test trivially matched the reference without exercising
the code path it was meant to validate.

Fix by removing the reftest-repaint.js dependency and managing the test
lifecycle directly: waitUntilDone() + display() upfront, then
notifyDone() inside the inner rAF callback after the translateZ(0)
change is applied.

* LayoutTests/svg/compositing/hidpi-legacy-svg-compositing-sibling-no-shift.html:

Canonical link: <a href="https://commits.webkit.org/309920@main">https://commits.webkit.org/309920@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d10a7105816b0a2b276f0168f230052c40a90cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151238 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24001 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17571 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159967 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104674 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24432 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24247 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116768 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82899 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154198 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18893 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135699 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97489 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17986 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15934 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7812 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127604 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13616 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162439 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15187 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124776 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23802 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19984 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124964 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34119 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23792 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135413 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80272 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20030 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12178 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23402 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23114 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23266 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23168 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->