### PR TITLE
[WKTR] Workaround image dimension mismatch in windowSnapshotImage

### DIFF
--- a/Tools/WebKitTestRunner/mac/PlatformWebViewMac.mm
+++ b/Tools/WebKitTestRunner/mac/PlatformWebViewMac.mm
@@ -222,11 +222,42 @@ RetainPtr<CGImageRef> PlatformWebView::windowSnapshotImage()
     [platformView() display];
     CGWindowImageOption options = kCGWindowImageBoundsIgnoreFraming | kCGWindowImageShouldBeOpaque;
 
-    if ([m_window backingScaleFactor] == 1)
+    CGFloat backingScaleFactor = [m_window backingScaleFactor];
+    if (backingScaleFactor == 1)
         options |= kCGWindowImageNominalResolution;
 
-    RetainPtr image = adoptNS([platformView() _windowSnapshotInRect:CGRectNull withOptions:options]);
-    return [image CGImageForProposedRect:nil context:nil hints:nil];
+    NSRect viewFrame = [platformView() frame];
+    size_t expectedWidth = viewFrame.size.width * backingScaleFactor;
+    size_t expectedHeight = viewFrame.size.height * backingScaleFactor;
+
+    // Work around <rdar://problem/17084993>: CGWindowListCreateImage() can return images with
+    // incorrect dimensions immediately after a window resolution change via _setWindowResolution:,
+    // because the window server reallocates the backing store asynchronously. There is no public
+    // synchronization API to wait for this, so validate the captured dimensions and retry if needed.
+    constexpr unsigned maxRetries = 10;
+    for (unsigned attempt = 0; ; ++attempt) {
+        RetainPtr image = adoptNS([platformView() _windowSnapshotInRect:CGRectNull withOptions:options]);
+        if (!image)
+            return nil;
+
+        auto cgImage = [image CGImageForProposedRect:nil context:nil hints:nil];
+        if (!cgImage)
+            return nil;
+
+        size_t actualWidth = CGImageGetWidth(cgImage);
+        size_t actualHeight = CGImageGetHeight(cgImage);
+        if (actualWidth == expectedWidth && actualHeight == expectedHeight)
+            return cgImage;
+
+        if (attempt >= maxRetries)
+            break;
+
+        usleep(10000); // 10ms — allow the window server to finish the backing store update
+        [platformView() display];
+    }
+
+    WTFLogAlways("Failed to take snapshot of window -- expected dimensions don't match captured images."); // NOLINT
+    return nil;
 }
 
 void PlatformWebView::changeWindowScaleIfNeeded(float newScale)


### PR DESCRIPTION
#### 75a1e8a0fcb3233e6df17a2ca751084c94c7d4d3
<pre>
[WKTR] Workaround image dimension mismatch in windowSnapshotImage
<a href="https://bugs.webkit.org/show_bug.cgi?id=310343">https://bugs.webkit.org/show_bug.cgi?id=310343</a>

Reviewed by Simon Fraser.

Running svg/compositing layout tests in Release showed spurious failures
due to image size mismatches (e.g. 798x598 instead of 800x600). This seems
to happen when a hidpi test (deviceScaleFactor=2) ran before a 1x test,
causing WebView re-creation with a resolution change via _setWindowResolution:

CGWindowListCreateImage() returns images with incorrect dimensions, most likely
because the window server hasn&apos;t finished reallocating the backing store after a
resolution change. Debug builds naturally avoid this due to slower execution.
The takeViewSnapshot() in WebViewImpl.mm works around the same issue
(<a href="https://rdar.apple.com/problem/17084993">rdar://problem/17084993</a>) with a similar dimension check, which inspired this
solution.

Therefore validate the captured image dimensions against expectations and retry
with a 10ms delay if they don&apos;t match, up to 10 times. In my testing 1-2 retries
were sufficient even on a loaded machine, but to be sure use a generous approach
here, which delays snapshotting up to 100ms, but _only_ in cases where the WebView
has been re-created or the scale factor changes, which is not common during
layout test execution, so shouldn&apos;t be a performance penalty.

* Tools/WebKitTestRunner/mac/PlatformWebViewMac.mm:
(WTR::PlatformWebView::windowSnapshotImage):

Canonical link: <a href="https://commits.webkit.org/309870@main">https://commits.webkit.org/309870@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88e9b5e01c880a14093f0eefd974334a8273a4c7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151874 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24655 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18226 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160616 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105331 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153748 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25148 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24953 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117309 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83230 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154834 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19481 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136286 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98024 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18566 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16503 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8451 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128198 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14189 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163080 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15781 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125327 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24454 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20562 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125508 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34079 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24455 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135985 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81030 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20539 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12760 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24072 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23763 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23923 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23824 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->