### PR TITLE
-internal-auto-base() should be an arbitrary substitution function

### DIFF
--- a/LayoutTests/fast/forms/appearance-base/internal-auto-base-function-expected.html
+++ b/LayoutTests/fast/forms/appearance-base/internal-auto-base-function-expected.html
@@ -23,6 +23,9 @@
 
     <div>This should be visible (base).</div>
 
+    <div style="border: 1px solid red">This should have 1px solid red border (default).</div>
+    <div style="border: 2px dashed blue">This should have 2px dashed blue border (base).</div>
+
     <div>block-start span-inline-end, block-end span-inline-start</div>
     <div>block-end span-inline-end, block-start span-inline-start, block-start span-inline-start</div>
 

--- a/LayoutTests/fast/forms/appearance-base/internal-auto-base-function.html
+++ b/LayoutTests/fast/forms/appearance-base/internal-auto-base-function.html
@@ -13,11 +13,15 @@
         .display-toggle {
             display: -internal-auto-base(none, block);
         }
-        /* Test argument parsing with braces */
+        /* Test a shorthand property */
+        .border-toggle {
+            border: -internal-auto-base(1px solid red, 2px dashed blue);
+        }
+        /* Test comma-containing values with brace syntax */
         .position-try-fallbacks {
             position-try-fallbacks: -internal-auto-base({block-start span-inline-end, block-end span-inline-start}, {
-                block-end span-inline-end,   /* First try above and span-right. */
-                block-start span-inline-start,   /* Then below but span-left. */
+                block-end span-inline-end,
+                block-start span-inline-start,
                 block-start span-inline-start });
         }
         select {
@@ -37,6 +41,9 @@
     <div class="display-toggle">This should be hidden.</div>
     <div class="display-toggle" style="appearance: base-select">This should be hidden (base-select on non-select).</div>
     <div class="display-toggle" style="appearance: base">This should be visible (base).</div>
+
+    <div class="border-toggle">This should have 1px solid red border (default).</div>
+    <div class="border-toggle" style="appearance: base">This should have 2px dashed blue border (base).</div>
 
     <div class="position-try-fallbacks"></div>
     <div class="position-try-fallbacks" style="appearance: base"></div>

--- a/Source/WebCore/css/CSSVariableReferenceValue.cpp
+++ b/Source/WebCore/css/CSSVariableReferenceValue.cpp
@@ -75,6 +75,14 @@ void CSSVariableReferenceValue::cacheSimpleReference()
     auto range = m_data->tokenRange();
 
     auto functionId = range.peek().functionId();
+
+    if (functionId == CSSValueInternalAutoBase) {
+        range.consumeBlock();
+        if (range.atEnd())
+            m_simpleReference = SimpleReference { { }, CSSValueInternalAutoBase };
+        return;
+    }
+
     if (functionId != CSSValueVar && functionId != CSSValueEnv)
         return;
 

--- a/Source/WebCore/css/CSSVariableReferenceValue.h
+++ b/Source/WebCore/css/CSSVariableReferenceValue.h
@@ -67,7 +67,7 @@ private:
     const Ref<CSSVariableData> m_data;
     mutable String m_stringValue;
 
-    // For quickly resolving simple var(--foo) values.
+    // For quickly resolving simple substitution functions.
     struct SimpleReference {
         AtomString name;
         CSSValueID functionId;
@@ -75,7 +75,10 @@ private:
     std::optional<SimpleReference> m_simpleReference;
 
     struct Cache {
+        // For var() case: cache key is the substituted data pointer.
         RefPtr<CSSVariableData> dependencyData;
+        // For -internal-auto-base() case: cache key is the base appearance state.
+        std::optional<bool> isBaseAppearance;
         RefPtr<CSSValue> value;
         CSSPropertyID propertyID { CSSPropertyInvalid };
     };

--- a/Source/WebCore/css/ShorthandSerializer.cpp
+++ b/Source/WebCore/css/ShorthandSerializer.cpp
@@ -26,7 +26,6 @@
 #include "ShorthandSerializer.h"
 
 #include "CSSBorderImageWidthValue.h"
-#include "CSSFunctionValue.h"
 #include "CSSGridLineNamesValue.h"
 #include "CSSGridTemplateAreasValue.h"
 #include "CSSParserIdioms.h"
@@ -263,12 +262,8 @@ bool ShorthandSerializer::commonSerializationChecks(const StyleProperties& prope
             continue;
         }
 
-        // Don't serialize if any longhand was set to a variable.
+        // Don't serialize if any longhand was set to a variable or substitution function.
         if (is<CSSVariableReferenceValue>(value))
-            return true;
-
-        // Don't serialize if any longhand was set to -internal-auto-base().
-        if (auto* functionValue = dynamicDowncast<CSSFunctionValue>(*value); functionValue && functionValue->name() == CSSValueInternalAutoBase)
             return true;
 
         // Don't serialize if any longhand was set by a different shorthand.

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -225,69 +225,6 @@ static std::optional<CSSWideKeyword> consumeCSSWideKeyword(CSSParserTokenRange& 
     return keyword;
 }
 
-// MARK: - function value consumer
-
-static bool consumeFunctionArgument(CSSParserTokenRange& range, unsigned index, CSSPropertyID property, CSS::PropertyParserState& state, CSS::PropertyParserResult& result)
-{
-    auto argument = CSSPropertyParserHelpers::consumeArgument(range, index);
-    if (!argument)
-        return false;
-
-    // If the argument is a block, strip the braces.
-    if (argument->peek().type() == LeftBraceToken) {
-        auto last = argument->consumeLast();
-        if (last.type() != RightBraceToken)
-            return false;
-        argument->consume(); // Consume left brace.
-        argument->consumeWhitespace();
-        argument->trimTrailingWhitespace();
-    }
-
-    const auto& context = state.context;
-    auto important = state.important;
-    auto ruleType = state.currentRule;
-
-    return consumeStyleProperty(*argument, context, property, important, ruleType, result);
-}
-
-static bool consumeInternalAutoBaseFunction(CSSParserTokenRange& range, CSSPropertyID property, CSS::PropertyParserState& state, CSS::PropertyParserResult& result)
-{
-    // -internal-auto-base() = -internal-auto-base( <auto value>, <base value> )
-
-    if (!state.context.cssInternalAutoBaseParsingEnabled)
-        return false;
-
-    if (range.peek().functionId() != CSSValueInternalAutoBase)
-        return false;
-
-    auto args = CSSPropertyParserHelpers::consumeFunction(range);
-
-    Vector<CSSProperty, 256> autoProperties;
-    CSS::PropertyParserResult autoResult { autoProperties };
-
-    if (!consumeFunctionArgument(args, 0, property, state, autoResult))
-        return false;
-
-    Vector<CSSProperty, 256> baseProperties;
-    CSS::PropertyParserResult baseResult { baseProperties };
-
-    if (!consumeFunctionArgument(args, 1, property, state, baseResult))
-        return false;
-
-    if (autoProperties.size() != baseProperties.size())
-        return false;
-
-    for (unsigned index = 0; index < autoProperties.size(); ++index) {
-        const auto& autoProperty = autoProperties[index];
-        const auto& baseProperty = baseProperties[index];
-
-        Ref value = CSSFunctionValue::create(CSSValueInternalAutoBase, protect(*autoProperty.value()), protect(*baseProperty.value()));
-        result.addProperty(CSSProperty(autoProperty.metadata(), WTF::move(value)));
-    }
-
-    return true;
-}
-
 // MARK: - Parser entry points
 
 using namespace CSSPropertyParserHelpers;
@@ -671,9 +608,6 @@ bool consumeStyleProperty(CSSParserTokenRange& range, const CSSParserContext& co
         .currentProperty = property,
         .important = important,
     };
-
-    if (consumeInternalAutoBaseFunction(range, property, state, result))
-        return true;
 
     if (WebCore::isShorthand(property)) {
         auto rangeCopy = range;

--- a/Source/WebCore/css/parser/CSSVariableParser.cpp
+++ b/Source/WebCore/css/parser/CSSVariableParser.cpp
@@ -134,6 +134,10 @@ static std::optional<ClassifyBlockResult> classifyBlock(CSSParserTokenRange rang
                 result.hasSubstitutionFunctions = true;
                 continue;
             }
+            if (token.functionId() == CSSValueInternalAutoBase && parserContext.cssInternalAutoBaseParsingEnabled) {
+                result.hasSubstitutionFunctions = true;
+                continue;
+            }
             if (token.type() == FunctionToken && isCustomPropertyName(token.value()) && parserContext.propertySettings.cssFunctionAtRuleEnabled) {
                 // https://drafts.csswg.org/css-mixins/#typedef-dashed-function
                 if (!isValidDashedFunction(block, parserContext))

--- a/Source/WebCore/html/HTMLMeterElement.cpp
+++ b/Source/WebCore/html/HTMLMeterElement.cpp
@@ -218,7 +218,7 @@ void HTMLMeterElement::appendShadowTreeForAutoAppearance(ShadowRoot& root)
     ScriptDisallowedScope::EventAllowedScope innerScope { innerElement };
     innerElement->setIdAttribute("inner"_s);
     innerElement->setUserAgentPart(UserAgentParts::webkitMeterInnerElement());
-    innerElement->setInlineStyleProperty(CSSPropertyDisplay, "-internal-auto-base(inline-block, none) !important"_s);
+    innerElement->setInlineStyleProperty(CSSPropertyDisplay, "-internal-auto-base(inline-block, none)"_s, IsImportant::Yes);
     root.appendChild(innerElement);
 
     Ref barElement = HTMLDivElement::create(document);
@@ -241,7 +241,7 @@ void HTMLMeterElement::appendShadowTreeForBaseAppearance(ShadowRoot& root)
     ScriptDisallowedScope::EventAllowedScope trackScope { trackElement };
     trackElement->setUserAgentPart(UserAgentParts::sliderTrack());
     trackElement->setInlineStyleProperty(CSSPropertyAppearance, "inherit"_s);
-    trackElement->setInlineStyleProperty(CSSPropertyDisplay, "-internal-auto-base(none, inline-block) !important"_s);
+    trackElement->setInlineStyleProperty(CSSPropertyDisplay, "-internal-auto-base(none, inline-block)"_s, IsImportant::Yes);
     ScriptDisallowedScope::EventAllowedScope rootScope { root };
     root.appendChild(trackElement);
 

--- a/Source/WebCore/html/HTMLProgressElement.cpp
+++ b/Source/WebCore/html/HTMLProgressElement.cpp
@@ -157,7 +157,7 @@ void HTMLProgressElement::appendShadowTreeForAutoAppearance(ShadowRoot& root)
     ScriptDisallowedScope::EventAllowedScope innerScope { innerElement };
     innerElement->setUserAgentPart(UserAgentParts::webkitProgressInnerElement());
     innerElement->setInlineStyleProperty(CSSPropertyAppearance, "inherit"_s);
-    innerElement->setInlineStyleProperty(CSSPropertyDisplay, "-internal-auto-base(inline-block, none) !important"_s);
+    innerElement->setInlineStyleProperty(CSSPropertyDisplay, "-internal-auto-base(inline-block, none)"_s, IsImportant::Yes);
     ScriptDisallowedScope::EventAllowedScope rootScope { root };
     root.appendChild(innerElement);
 
@@ -183,7 +183,7 @@ void HTMLProgressElement::appendShadowTreeForBaseAppearance(ShadowRoot& root)
     ScriptDisallowedScope::EventAllowedScope trackScope { trackElement };
     trackElement->setUserAgentPart(UserAgentParts::sliderTrack());
     trackElement->setInlineStyleProperty(CSSPropertyAppearance, "inherit"_s);
-    trackElement->setInlineStyleProperty(CSSPropertyDisplay, "-internal-auto-base(none, inline-block) !important"_s);
+    trackElement->setInlineStyleProperty(CSSPropertyDisplay, "-internal-auto-base(none, inline-block)"_s, IsImportant::Yes);
     ScriptDisallowedScope::EventAllowedScope rootScope { root };
     root.appendChild(trackElement);
 

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -32,7 +32,6 @@
 
 #include "CSSCustomPropertyValue.h"
 #include "CSSFontSelector.h"
-#include "CSSFunctionValue.h"
 #include "CSSPaintImageValue.h"
 #include "CSSPendingSubstitutionValue.h"
 #include "CSSPropertyParser.h"
@@ -43,11 +42,9 @@
 #include "ComputedStyleDependencies.h"
 #include "Document.h"
 #include "HTMLElement.h"
-#include "HTMLSelectElement.h"
 #include "PaintWorkletGlobalScope.h"
 #include "RenderStyle+GettersInlines.h"
 #include "RenderStyle+SettersInlines.h"
-#include "SelectPopoverElement.h"
 #include "Settings.h"
 #include "StyleAdjuster.h"
 #include "StyleBuilderGenerated.h"
@@ -345,12 +342,11 @@ void Builder::applyProperty(CSSPropertyID id, CSSValue& value, SelectorChecker::
     ASSERT_WITH_MESSAGE(!isShorthand(id), "Shorthand property id = %d wasn't expanded at parsing time", id);
     ASSERT_WITH_MESSAGE(id != CSSPropertyCustom, "Custom property should be handled by applyCustomProperty");
 
-    auto valueToApply = resolveInternalAutoBaseFunction(value);
     auto& style = m_state->style();
 
     id = CSSProperty::resolveDirectionAwareProperty(id, style.writingMode());
 
-    valueToApply = resolveSubstitutionFunctions(id, valueToApply);
+    auto valueToApply = resolveSubstitutionFunctions(id, value);
 
     if (m_state->positionTryFallback())
         id = AnchorPositionEvaluator::resolvePositionTryFallbackProperty(id, style.writingMode(), *m_state->positionTryFallback());
@@ -574,31 +570,6 @@ void Builder::applyCustomProperty(const AtomString& name, Variant<Ref<const Styl
             applyValue(WTF::move(resolved));
         }
     );
-}
-
-Ref<CSSValue> Builder::resolveInternalAutoBaseFunction(CSSValue& value)
-{
-    RefPtr functionValue = dynamicDowncast<CSSFunctionValue>(value);
-    if (!functionValue)
-        return value;
-
-    if (functionValue->name() != CSSValueInternalAutoBase)
-        return value;
-
-    // usedAppearance() is inaccurate at this stage of style resolution, check against both `appearance: base-select` & `appearance: base`.
-    bool isAppearanceBase = [&] {
-        if (m_state->style().appearance() == StyleAppearance::Base)
-            return true;
-        if (m_state->style().appearance() != StyleAppearance::BaseSelect)
-            return false;
-        return isAnyOf<HTMLSelectElement, SelectPopoverElement>(m_state->element());
-    }();
-    RefPtr result = const_cast<CSSValue*>(isAppearanceBase ? functionValue->item(1) : functionValue->item(0));
-
-    if (!result)
-        return value;
-
-    return result.releaseNonNull();
 }
 
 Ref<CSSValue> Builder::resolveSubstitutionFunctions(CSSPropertyID propertyID, CSSValue& value)

--- a/Source/WebCore/style/StyleBuilder.h
+++ b/Source/WebCore/style/StyleBuilder.h
@@ -75,7 +75,6 @@ private:
     void applyProperty(CSSPropertyID, CSSValue&, SelectorChecker::LinkMatchMask, PropertyCascade::Origin);
     void applyCustomProperty(const AtomString& name, Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>&&);
 
-    Ref<CSSValue> resolveInternalAutoBaseFunction(CSSValue&);
     Ref<CSSValue> resolveSubstitutionFunctions(CSSPropertyID, CSSValue&);
     std::optional<Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>> resolveCustomPropertyValue(CSSCustomPropertyValue&);
 

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -39,8 +39,10 @@
 #include "CustomFunctionRegistry.h"
 #include "Document.h"
 #include "Element.h"
+#include "HTMLSelectElement.h"
 #include "RenderStyle+GettersInlines.h"
 #include "RenderStyle+SettersInlines.h"
+#include "SelectPopoverElement.h"
 #include "StyleBuilder.h"
 #include "StyleCustomProperty.h"
 #include "StyleCustomPropertyRegistry.h"
@@ -207,6 +209,34 @@ bool SubstitutionResolver::substituteAttrFunction(CSSParserTokenRange range, Vec
     return true;
 }
 
+bool SubstitutionResolver::substituteInternalAutoBaseFunction(CSSParserTokenRange range, Vector<CSSParserToken>& tokens, const CSSParserContext& context) const
+{
+    // -internal-auto-base(autoValue, baseValue)
+    // Picks between the two arguments based on whether the element has base appearance.
+
+    auto firstArgRange = CSSPropertyParserHelpers::consumeArgument(range, 0);
+    if (!firstArgRange)
+        return false;
+
+    auto secondArgRange = CSSPropertyParserHelpers::consumeArgument(range, 1);
+    if (!secondArgRange)
+        return false;
+
+    auto selectedRange = isBaseAppearance() ? *secondArgRange : *firstArgRange;
+
+    // Strip outer braces if present, allowing comma-containing values like:
+    // -internal-auto-base({value1, value2}, {value3, value4})
+    if (!selectedRange.atEnd() && selectedRange.peek().type() == LeftBraceToken)
+        selectedRange = selectedRange.consumeBlock();
+
+    auto selectedTokens = substituteTokenRange(selectedRange, context);
+    if (!selectedTokens)
+        return false;
+
+    tokens.appendVector(*selectedTokens);
+    return true;
+}
+
 std::optional<Vector<CSSParserToken>> SubstitutionResolver::substituteTokenRange(CSSParserTokenRange range, const CSSParserContext& context) const
 {
     Vector<CSSParserToken> tokens;
@@ -222,6 +252,11 @@ std::optional<Vector<CSSParserToken>> SubstitutionResolver::substituteTokenRange
             }
             if (functionId == CSSValueAttr) {
                 if (!substituteAttrFunction(range.consumeBlock(), tokens, context))
+                    success = false;
+                continue;
+            }
+            if (functionId == CSSValueInternalAutoBase) {
+                if (!substituteInternalAutoBaseFunction(range.consumeBlock(), tokens, context))
                     success = false;
                 continue;
             }
@@ -245,13 +280,28 @@ RefPtr<CSSVariableData> SubstitutionResolver::trySimpleSubstitution(const CSSVar
     if (!value.m_simpleReference)
         return nullptr;
 
-    // Shortcut for the simple common case of property:var(--foo)
+    // Shortcut for simple -internal-auto-base(val1, val2): return cached data if appearance hasn't changed.
+    if (value.m_simpleReference->functionId == CSSValueInternalAutoBase)
+        return value.m_cache.isBaseAppearance == isBaseAppearance() ? value.m_cache.dependencyData : nullptr;
 
+    // Shortcut for the simple common case of property:var(--foo)
     RefPtr property = propertyValueForVariableName(value.m_simpleReference->name, value.m_simpleReference->functionId);
     if (!property || !std::holds_alternative<Ref<CSSVariableData>>(property->value()))
         return nullptr;
 
     return std::get<Ref<CSSVariableData>>(property->value()).ptr();
+}
+
+bool SubstitutionResolver::isBaseAppearance() const
+{
+    auto& state = m_styleBuilder.state();
+    if (state.style().appearance() == StyleAppearance::Base)
+        return true;
+    if (state.style().appearance() == StyleAppearance::BaseSelect) {
+        CheckedPtr element = state.element();
+        return element && isAnyOf<HTMLSelectElement, SelectPopoverElement>(*element);
+    }
+    return false;
 }
 
 RefPtr<CSSVariableData> SubstitutionResolver::substitute(const CSSVariableReferenceValue& value) const
@@ -279,6 +329,9 @@ RefPtr<CSSValue> SubstitutionResolver::substituteAndParse(const CSSVariableRefer
     }
     variableRef.m_cache.dependencyData = WTF::move(data);
 
+    if (variableRef.m_simpleReference && variableRef.m_simpleReference->functionId == CSSValueInternalAutoBase)
+        variableRef.m_cache.isBaseAppearance = isBaseAppearance();
+
     return variableRef.m_cache.value;
 }
 
@@ -300,6 +353,9 @@ RefPtr<CSSValue> SubstitutionResolver::substituteAndParseShorthand(const CSSPend
             substitution.m_cachedPropertyValues = parsedProperties;
     }
     variableRef.m_cache.dependencyData = WTF::move(data);
+
+    if (variableRef.m_simpleReference && variableRef.m_simpleReference->functionId == CSSValueInternalAutoBase)
+        variableRef.m_cache.isBaseAppearance = isBaseAppearance();
 
     for (auto& property : substitution.m_cachedPropertyValues) {
         if (CSSProperty::resolveDirectionAwareProperty(property.id(), m_styleBuilder.state().style().writingMode()) == propertyID)

--- a/Source/WebCore/style/StyleSubstitutionResolver.h
+++ b/Source/WebCore/style/StyleSubstitutionResolver.h
@@ -56,12 +56,14 @@ private:
     bool substituteVariableFunction(CSSParserTokenRange, CSSValueID, Vector<CSSParserToken>&, const CSSParserContext&) const;
     bool substituteDashedFunction(StringView functionName, CSSParserTokenRange, Vector<CSSParserToken>&) const;
     bool substituteAttrFunction(CSSParserTokenRange, Vector<CSSParserToken>&, const CSSParserContext&) const;
+    bool substituteInternalAutoBaseFunction(CSSParserTokenRange, Vector<CSSParserToken>&, const CSSParserContext&) const;
 
     enum class FallbackResult : uint8_t { None, Valid, Invalid };
     std::pair<FallbackResult, Vector<CSSParserToken>> substituteVariableFallback(const AtomString& variableName, CSSParserTokenRange, CSSValueID functionId, const CSSParserContext&) const;
 
     RefPtr<const CustomProperty> propertyValueForVariableName(const AtomString&, CSSValueID) const;
     RefPtr<CSSVariableData> trySimpleSubstitution(const CSSVariableReferenceValue&) const;
+    bool isBaseAppearance() const;
 
     Builder& m_styleBuilder;
 };


### PR DESCRIPTION
#### 9e2221188ec5b01aa9fa416917abc2369c9667be
<pre>
-internal-auto-base() should be an arbitrary substitution function
<a href="https://bugs.webkit.org/show_bug.cgi?id=310336">https://bugs.webkit.org/show_bug.cgi?id=310336</a>
<a href="https://rdar.apple.com/172987749">rdar://172987749</a>

Reviewed by Tim Nguyen.

While internal it can use the machinery of <a href="https://drafts.csswg.org/css-values-5/#arbitrary-substitution">https://drafts.csswg.org/css-values-5/#arbitrary-substitution</a>

* LayoutTests/fast/forms/appearance-base/internal-auto-base-function-expected.html:
* LayoutTests/fast/forms/appearance-base/internal-auto-base-function.html:
* Source/WebCore/css/CSSVariableReferenceValue.cpp:
(WebCore::CSSVariableReferenceValue::cacheSimpleReference):

Add caching support for the simple common case of single -internal-auto-base().

* Source/WebCore/css/CSSVariableReferenceValue.h:
* Source/WebCore/css/ShorthandSerializer.cpp:
(WebCore::ShorthandSerializer::commonSerializationChecks):
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::consumeStyleProperty):
(WebCore::consumeFunctionArgument): Deleted.
(WebCore::consumeInternalAutoBaseFunction): Deleted.

Remove the CSSValue based implementation.

* Source/WebCore/css/parser/CSSVariableParser.cpp:
(WebCore::classifyBlock):

Classify -internal-auto-base() as a arbitrary substitution function.

* Source/WebCore/html/HTMLMeterElement.cpp:
(WebCore::HTMLMeterElement::appendShadowTreeForAutoAppearance):
(WebCore::HTMLMeterElement::appendShadowTreeForBaseAppearance):
* Source/WebCore/html/HTMLProgressElement.cpp:
(WebCore::HTMLProgressElement::appendShadowTreeForAutoAppearance):
(WebCore::HTMLProgressElement::appendShadowTreeForBaseAppearance):

Use IsImportant::Yes instead of passing &quot;!important&quot; as part of the string.

* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::applyProperty):
(WebCore::Style::Builder::resolveInternalAutoBaseFunction): Deleted.
* Source/WebCore/style/StyleBuilder.h:
* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::SubstitutionResolver::substituteInternalAutoBaseFunction const):

Implement substitution for -internal-auto-base().

(WebCore::Style::SubstitutionResolver::substituteTokenRange const):
(WebCore::Style::SubstitutionResolver::trySimpleSubstitution const):

Caching support.

(WebCore::Style::SubstitutionResolver::isBaseAppearance const):
(WebCore::Style::SubstitutionResolver::substituteAndParse const):
(WebCore::Style::SubstitutionResolver::substituteAndParseShorthand const):
* Source/WebCore/style/StyleSubstitutionResolver.h:

Canonical link: <a href="https://commits.webkit.org/309756@main">https://commits.webkit.org/309756@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26da096eda2632e22fa24d6f6b0ca2866bf66a9d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151654 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/24435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/18005 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160389 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2abb603e-5ee9-4014-8312-12d1bb9326c3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153528 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/24907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24728 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117130 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6fbefbf3-1961-42b3-8b5e-a61c630a1d65) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154614 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/24907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/136083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97845 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/21ec7047-35b3-45fe-9f24-a2cf74e143e2) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/24907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/16305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/8231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/24907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/13987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162860 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/6009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/15577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/125145 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/24234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20363 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125327 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34007 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/24235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/135783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/80810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/24235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/12558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/23851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/88136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/23543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/23703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/23603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->