### PR TITLE
WebGL: timer queries make the result available in wrong ScriptExecutionContext

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -179,7 +179,6 @@ html/ValidatedFormListedElement.cpp
 html/ValidationMessage.cpp
 html/canvas/CanvasRenderingContext2D.cpp
 html/canvas/CanvasRenderingContext2DBase.cpp
-html/canvas/EXTDisjointTimerQuery.cpp
 html/canvas/OffscreenCanvasRenderingContext2D.cpp
 html/parser/HTMLConstructionSite.cpp
 html/parser/HTMLDocumentParser.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -309,7 +309,6 @@ html/canvas/CanvasRenderingContext.cpp
 html/canvas/CanvasRenderingContext2D.cpp
 html/canvas/CanvasRenderingContext2DBase.cpp
 html/canvas/CanvasStyle.cpp
-html/canvas/EXTDisjointTimerQuery.cpp
 html/canvas/GPUCanvasContextCocoa.mm
 html/canvas/OffscreenCanvasRenderingContext2D.cpp
 html/canvas/PlaceholderRenderingContext.cpp

--- a/Source/WebCore/html/canvas/EXTDisjointTimerQuery.cpp
+++ b/Source/WebCore/html/canvas/EXTDisjointTimerQuery.cpp
@@ -98,7 +98,7 @@ GCGLboolean EXTDisjointTimerQuery::isQueryEXT(WebGLTimerQueryEXT* query)
     Ref context = this->context();
     if (!context->validateIsWebGLObject(query))
         return false;
-    return context->graphicsContextGL()->isQueryEXT(query->object());
+    return protect(context->graphicsContextGL())->isQueryEXT(query->object());
 }
 
 void EXTDisjointTimerQuery::beginQueryEXT(GCGLenum target, WebGLTimerQueryEXT& query)
@@ -133,16 +133,14 @@ void EXTDisjointTimerQuery::beginQueryEXT(GCGLenum target, WebGLTimerQueryEXT& q
 
     context->m_activeQuery = &query;
 
-    context->graphicsContextGL()->beginQueryEXT(target, query.object());
+    protect(context->graphicsContextGL())->beginQueryEXT(target, query.object());
 }
 
-void EXTDisjointTimerQuery::endQueryEXT(GCGLenum target)
+void EXTDisjointTimerQuery::endQueryEXT(ScriptExecutionContext& scriptExecutionContext, GCGLenum target)
 {
     if (isContextLost())
         return;
     Ref context = this->context();
-    if (!context->scriptExecutionContext())
-        return;
 
     Locker locker { context->objectGraphLock() };
 
@@ -156,22 +154,19 @@ void EXTDisjointTimerQuery::endQueryEXT(GCGLenum target)
         return;
     }
 
-    context->graphicsContextGL()->endQueryEXT(target);
+    protect(context->graphicsContextGL())->endQueryEXT(target);
 
     // A query's result must not be made available until control has returned to the user agent's main loop.
-    context->scriptExecutionContext()->eventLoop().queueMicrotask(context->scriptExecutionContext()->vm(), [query = WTF::move(context->m_activeQuery)] {
+    protect(scriptExecutionContext.eventLoop())->queueMicrotask(scriptExecutionContext.vm(), [query = WTF::move(context->m_activeQuery)] {
         query->makeResultAvailable();
     });
 }
 
-void EXTDisjointTimerQuery::queryCounterEXT(WebGLTimerQueryEXT& query, GCGLenum target)
+void EXTDisjointTimerQuery::queryCounterEXT(ScriptExecutionContext& scriptExecutionContext, WebGLTimerQueryEXT& query, GCGLenum target)
 {
     if (isContextLost())
         return;
     Ref context = this->context();
-    if (!context->scriptExecutionContext())
-        return;
-
     if (!context->validateWebGLObject("queryCounterEXT"_s, query))
         return;
 
@@ -190,8 +185,8 @@ void EXTDisjointTimerQuery::queryCounterEXT(WebGLTimerQueryEXT& query, GCGLenum 
     protect(context->graphicsContextGL())->queryCounterEXT(query.object(), target);
 
     // A query's result must not be made available until control has returned to the user agent's main loop.
-    context->scriptExecutionContext()->eventLoop().queueMicrotask(context->scriptExecutionContext()->vm(), [&] {
-        query.makeResultAvailable();
+    protect(scriptExecutionContext.eventLoop())->queueMicrotask(scriptExecutionContext.vm(), [query = Ref { query }] {
+        query->makeResultAvailable();
     });
 }
 
@@ -212,7 +207,7 @@ WebGLAny EXTDisjointTimerQuery::getQueryEXT(GCGLenum target, GCGLenum pname)
             return toWebGLAny(context->m_activeQuery);
         return nullptr;
     case GraphicsContextGL::QUERY_COUNTER_BITS_EXT:
-        return context->graphicsContextGL()->getQueryiEXT(target, pname);
+        return protect(context->graphicsContextGL())->getQueryiEXT(target, pname);
     }
     context->synthesizeGLError(GraphicsContextGL::INVALID_ENUM, "getQueryEXT"_s, "invalid parameter name"_s);
     return nullptr;
@@ -241,11 +236,11 @@ WebGLAny EXTDisjointTimerQuery::getQueryObjectEXT(WebGLTimerQueryEXT& query, GCG
     case GraphicsContextGL::QUERY_RESULT_EXT:
         if (!query.isResultAvailable())
             return 0;
-        return static_cast<unsigned long long>(context->graphicsContextGL()->getQueryObjectui64EXT(query.object(), pname));
+        return static_cast<unsigned long long>(protect(context->graphicsContextGL())->getQueryObjectui64EXT(query.object(), pname));
     case GraphicsContextGL::QUERY_RESULT_AVAILABLE_EXT:
         if (!query.isResultAvailable())
             return false;
-        return static_cast<bool>(context->graphicsContextGL()->getQueryObjectiEXT(query.object(), pname));
+        return static_cast<bool>(protect(context->graphicsContextGL())->getQueryObjectiEXT(query.object(), pname));
     }
     context->synthesizeGLError(GraphicsContextGL::INVALID_ENUM, "getQueryObjectEXT"_s, "invalid parameter name"_s);
     return nullptr;

--- a/Source/WebCore/html/canvas/EXTDisjointTimerQuery.h
+++ b/Source/WebCore/html/canvas/EXTDisjointTimerQuery.h
@@ -47,8 +47,8 @@ public:
     void deleteQueryEXT(WebGLTimerQueryEXT*);
     GCGLboolean isQueryEXT(WebGLTimerQueryEXT*);
     void beginQueryEXT(GCGLenum target, WebGLTimerQueryEXT&);
-    void endQueryEXT(GCGLenum target);
-    void queryCounterEXT(WebGLTimerQueryEXT&, GCGLenum target);
+    void endQueryEXT(ScriptExecutionContext&, GCGLenum target);
+    void queryCounterEXT(ScriptExecutionContext&, WebGLTimerQueryEXT&, GCGLenum target);
     WebGLAny getQueryEXT(GCGLenum target, GCGLenum pname);
     WebGLAny getQueryObjectEXT(WebGLTimerQueryEXT&, GCGLenum pname);
 };

--- a/Source/WebCore/html/canvas/EXTDisjointTimerQuery.idl
+++ b/Source/WebCore/html/canvas/EXTDisjointTimerQuery.idl
@@ -40,8 +40,8 @@
   undefined deleteQueryEXT(WebGLTimerQueryEXT? query);
   boolean isQueryEXT(WebGLTimerQueryEXT? query);
   undefined beginQueryEXT(unsigned long target, WebGLTimerQueryEXT query);
-  undefined endQueryEXT(unsigned long target);
-  undefined queryCounterEXT(WebGLTimerQueryEXT query, unsigned long target);
+  [CallWith=CurrentScriptExecutionContext] undefined endQueryEXT(unsigned long target);
+  [CallWith=CurrentScriptExecutionContext] undefined queryCounterEXT(WebGLTimerQueryEXT query, unsigned long target);
   [OverrideIDLType=IDLWebGLAny] any getQueryEXT(unsigned long target, unsigned long pname);
   [OverrideIDLType=IDLWebGLAny] any getQueryObjectEXT(WebGLTimerQueryEXT query, unsigned long pname);
 };

--- a/Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.cpp
+++ b/Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.cpp
@@ -51,13 +51,11 @@ bool EXTDisjointTimerQueryWebGL2::supported(GraphicsContextGL& context)
     return context.supportsExtension(GCGLExtension::EXT_disjoint_timer_query);
 }
 
-void EXTDisjointTimerQueryWebGL2::queryCounterEXT(WebGLQuery& query, GCGLenum target)
+void EXTDisjointTimerQueryWebGL2::queryCounterEXT(ScriptExecutionContext& scriptExecutionContext, WebGLQuery& query, GCGLenum target)
 {
     if (isContextLost())
         return;
     Ref context = this->context();
-    if (!context->scriptExecutionContext())
-        return;
 
     if (!context->validateWebGLObject("queryCounterEXT"_s, query))
         return;
@@ -77,7 +75,7 @@ void EXTDisjointTimerQueryWebGL2::queryCounterEXT(WebGLQuery& query, GCGLenum ta
     protect(context->graphicsContextGL())->queryCounterEXT(query.object(), target);
 
     // A query's result must not be made available until control has returned to the user agent's main loop.
-    protect(protect(context->scriptExecutionContext())->eventLoop())->queueMicrotask(protect(context->scriptExecutionContext())->vm(), [query = Ref { query }] {
+    protect(scriptExecutionContext.eventLoop())->queueMicrotask(scriptExecutionContext.vm(), [query = Ref { query }] {
         query->makeResultAvailable();
     });
 }

--- a/Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.h
+++ b/Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.h
@@ -41,7 +41,7 @@ public:
 
     static bool supported(GraphicsContextGL&);
 
-    void queryCounterEXT(WebGLQuery&, GCGLenum target);
+    void queryCounterEXT(ScriptExecutionContext&, WebGLQuery&, GCGLenum target);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.idl
+++ b/Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.idl
@@ -33,5 +33,5 @@
   const unsigned long TIMESTAMP_EXT          = 0x8E28;
   const unsigned long GPU_DISJOINT_EXT       = 0x8FBB;
 
-  undefined queryCounterEXT(WebGLQuery query, unsigned long target);
+  [CallWith=CurrentScriptExecutionContext] undefined queryCounterEXT(WebGLQuery query, unsigned long target);
 };

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -1793,10 +1793,10 @@ void WebGL2RenderingContext::beginQuery(GCGLenum target, WebGLQuery& query)
     query.setTarget(target);
 }
 
-void WebGL2RenderingContext::endQuery(GCGLenum target)
+void WebGL2RenderingContext::endQuery(ScriptExecutionContext& scriptExecutionContext, GCGLenum target)
 {
     Locker locker { objectGraphLock() };
-    if (isContextLost() || !scriptExecutionContext())
+    if (isContextLost())
         return;
     auto activeQueryKey = validateQueryTarget("endQuery"_s, target);
     if (!activeQueryKey)
@@ -1808,14 +1808,14 @@ void WebGL2RenderingContext::endQuery(GCGLenum target)
     graphicsContextGL()->endQuery(target);
 
     // A query's result must not be made available until control has returned to the user agent's main loop.
-    protect(protect(scriptExecutionContext())->eventLoop())->queueMicrotask(protect(scriptExecutionContext())->vm(), [query = WTF::move(m_activeQueries[*activeQueryKey])] {
+    protect(scriptExecutionContext.eventLoop())->queueMicrotask(scriptExecutionContext.vm(), [query = WTF::move(m_activeQueries[*activeQueryKey])] {
         query->makeResultAvailable();
     });
 }
 
 WebGLAny WebGL2RenderingContext::getQuery(GCGLenum target, GCGLenum pname)
 {
-    if (isContextLost() || !scriptExecutionContext())
+    if (isContextLost())
         return nullptr;
 
     RefPtr context = m_context;

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.h
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.h
@@ -192,7 +192,7 @@ public:
     void deleteQuery(WebGLQuery*);
     GCGLboolean isQuery(WebGLQuery*);
     void beginQuery(GCGLenum target, WebGLQuery&);
-    void endQuery(GCGLenum target);
+    void endQuery(ScriptExecutionContext&, GCGLenum target);
     WebGLAny getQuery(GCGLenum target, GCGLenum pname);
     WebGLAny getQueryParameter(WebGLQuery&, GCGLenum pname);
     

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.idl
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.idl
@@ -424,7 +424,7 @@ typedef (ImageBitmap or ImageData or HTMLImageElement or HTMLCanvasElement
     undefined deleteQuery(WebGLQuery? query);
     GLboolean isQuery(WebGLQuery? query);
     undefined beginQuery(GLenum target, WebGLQuery query);
-    undefined endQuery(GLenum target);
+    [CallWith=CurrentScriptExecutionContext] undefined endQuery(GLenum target);
     [OverrideIDLType=IDLWebGLAny] any getQuery(GLenum target, GLenum pname);
     [OverrideIDLType=IDLWebGLAny] any getQueryParameter(WebGLQuery query, GLenum pname);
 


### PR DESCRIPTION
#### 96452b6bf4819f8fc84a14a3d2bb06c9c87ad47d
<pre>
WebGL: timer queries make the result available in wrong ScriptExecutionContext
<a href="https://bugs.webkit.org/show_bug.cgi?id=310348">https://bugs.webkit.org/show_bug.cgi?id=310348</a>
<a href="https://rdar.apple.com/172995028">rdar://172995028</a>

Reviewed by Anne van Kesteren.

The query -induced event loop tasks should be run in the calling JS
ScriptExecutionContext, not the ScriptExecutionContext of the element.
Calling context always exists. Fixes incorrect
`if (scriptExecutionContext)` early exists.

* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/html/canvas/EXTDisjointTimerQuery.cpp:
(WebCore::EXTDisjointTimerQuery::beginQueryEXT):
(WebCore::EXTDisjointTimerQuery::endQueryEXT):
(WebCore::EXTDisjointTimerQuery::queryCounterEXT):
(WebCore::EXTDisjointTimerQuery::getQueryEXT):
(WebCore::EXTDisjointTimerQuery::getQueryObjectEXT):
* Source/WebCore/html/canvas/EXTDisjointTimerQuery.h:
* Source/WebCore/html/canvas/EXTDisjointTimerQuery.idl:
* Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.cpp:
(WebCore::EXTDisjointTimerQueryWebGL2::queryCounterEXT):
* Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.h:
* Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.idl:
* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::endQuery):
(WebCore::WebGL2RenderingContext::getQuery):
* Source/WebCore/html/canvas/WebGL2RenderingContext.h:
* Source/WebCore/html/canvas/WebGL2RenderingContext.idl:

Canonical link: <a href="https://commits.webkit.org/309744@main">https://commits.webkit.org/309744@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/226dd5f70581d7975cdf3f135c842bba421bf36f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151612 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24377 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17958 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160347 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fa179ac0-1556-46a7-9034-2c78ef9d7891) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153486 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24808 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24679 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117094 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6dc63dbc-c89e-495f-a402-91e3008b5857) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154572 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19237 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136047 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97809 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8171aa78-13b1-4097-97bf-7c6762727410) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18326 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/16269 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8189 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/127956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/13951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162818 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/5948 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15541 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125109 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24178 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20327 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125292 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33994 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24170 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135747 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/80768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20340 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12522 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23779 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88091 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23489 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23643 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/23549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->