### PR TITLE
Allow constructing a CheckedPtr/CheckedRef from a WeakPtr/WeakRef

### DIFF
--- a/Source/JavaScriptCore/inspector/InjectedScriptBase.cpp
+++ b/Source/JavaScriptCore/inspector/InjectedScriptBase.cpp
@@ -126,7 +126,7 @@ InjectedScriptBase::~InjectedScriptBase() = default;
 
 bool InjectedScriptBase::hasAccessToInspectedScriptState() const
 {
-    if (CheckedPtr environment = m_environment.get())
+    if (CheckedPtr environment = m_environment)
         return environment->canAccessInspectedScriptState(m_globalObject);
     return false;
 }

--- a/Source/WTF/wtf/CheckedPtr.h
+++ b/Source/WTF/wtf/CheckedPtr.h
@@ -126,6 +126,10 @@ public:
         ASSERT(get());
     }
 
+    template<typename X, typename Y, typename Z> CheckedPtr(const WeakPtr<X, Y, Z>& o) requires std::is_convertible_v<X*, T*>
+        : CheckedPtr(o.get())
+    { }
+
     CheckedPtr(HashTableDeletedValueType)
         : m_ptr(PtrTraits::hashTableDeletedValue())
     { }
@@ -214,6 +218,9 @@ private:
 
     typename PtrTraits::StorageType m_ptr;
 };
+
+template<typename X, typename Y, typename Z> CheckedPtr(WeakPtr<X, Y, Z>&) -> CheckedPtr<X>;
+template<typename X, typename Y, typename Z> CheckedPtr(const WeakPtr<X, Y, Z>&) -> CheckedPtr<X>;
 
 template <typename T, typename PtrTraits>
 struct GetPtrHelper<CheckedPtr<T, PtrTraits>> {

--- a/Source/WTF/wtf/CheckedRef.h
+++ b/Source/WTF/wtf/CheckedRef.h
@@ -105,6 +105,11 @@ public:
         ASSERT(m_ptr);
     }
 
+    template<typename X, typename WeakPtrImplType>
+    CheckedRef(const WeakRef<X, WeakPtrImplType>& other) requires std::is_convertible_v<X*, T*>
+        : CheckedRef(other.get())
+    { }
+
     CheckedRef(HashTableDeletedValueType) : m_ptr(PtrTraits::hashTableDeletedValue()) { }
     bool isHashTableDeletedValue() const { return PtrTraits::isHashTableDeletedValue(m_ptr); }
 
@@ -210,6 +215,9 @@ private:
 
     typename PtrTraits::StorageType m_ptr;
 };
+
+template<typename X, typename WeakPtrImplType> CheckedRef(WeakRef<X, WeakPtrImplType>&) -> CheckedRef<X>;
+template<typename X, typename WeakPtrImplType> CheckedRef(const WeakRef<X, WeakPtrImplType>&) -> CheckedRef<X>;
 
 template <typename T, typename PtrTraits>
 struct GetPtrHelper<CheckedRef<T, PtrTraits>> {

--- a/Source/WTF/wtf/RunLoop.h
+++ b/Source/WTF/wtf/RunLoop.h
@@ -226,7 +226,7 @@ public:
         requires (!WTF::HasThreadSafeWeakPtrFunctions<TimerFiredClass>::value && WTF::HasWeakPtrFunctions<TimerFiredClass>::value && !WTF::HasRefPtrMemberFunctions<TimerFiredClass>::value && WTF::HasCheckedPtrMemberFunctions<TimerFiredClass>::value)
         Timer(Ref<RunLoop>&& runLoop, ASCIILiteral description, TimerFiredClass* object, void (TimerFiredClass::*function)())
             : Timer(WTF::move(runLoop), description, [weakObject = WeakPtr { *object }, function] {
-                if (CheckedPtr object = weakObject.get())
+                if (CheckedPtr object = weakObject)
                     (object.get()->*function)();
             })
         {

--- a/Source/WebCore/accessibility/AXAttributeCacheScope.cpp
+++ b/Source/WebCore/accessibility/AXAttributeCacheScope.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
 AXAttributeCacheScope::AXAttributeCacheScope(AXObjectCache* cache)
     : m_cache(cache)
 {
-    if (CheckedPtr protectedCache = m_cache.get()) {
+    if (CheckedPtr protectedCache = m_cache) {
         if (protectedCache->computedObjectAttributeCache())
             m_wasAlreadyCaching = true;
         else
@@ -46,7 +46,7 @@ AXAttributeCacheScope::AXAttributeCacheScope(AXObjectCache* cache)
 
 AXAttributeCacheScope::~AXAttributeCacheScope()
 {
-    if (CheckedPtr protectedCache = m_cache.get(); protectedCache && !m_wasAlreadyCaching)
+    if (CheckedPtr protectedCache = m_cache; protectedCache && !m_wasAlreadyCaching)
         protectedCache->stopCachingComputedObjectAttributes();
 }
 

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -611,7 +611,7 @@ void AXIsolatedTree::objectChangedIgnoredState(const AccessibilityObject& object
     }
 
     if (object.isLink()) {
-        CheckedPtr axObjectCache = m_axObjectCache.get();
+        CheckedPtr axObjectCache = m_axObjectCache;
         if (RefPtr webArea = axObjectCache ? axObjectCache->rootWebArea() : nullptr)
             queueNodeUpdate(webArea->objectID(), { AXProperty::DocumentLinks });
     }
@@ -1295,7 +1295,7 @@ void AXIsolatedTree::updateRootScreenRelativePosition()
     AXTRACE("AXIsolatedTree::updateRootScreenRelativePosition"_s);
     AX_ASSERT(isMainThread());
 
-    CheckedPtr cache = m_axObjectCache.get();
+    CheckedPtr cache = m_axObjectCache;
     if (RefPtr axRoot = cache && cache->document() ? dynamicDowncast<AccessibilityScrollView>(cache->getOrCreate(cache->document()->view())) : nullptr) {
         queueNodeUpdate(axRoot->objectID(), { AXProperty::ScreenRelativePosition });
 
@@ -1673,7 +1673,7 @@ void AXIsolatedTree::processQueuedNodeUpdates()
         return;
 
     if (AXObjectCache::isAppleInternalInstall()) [[unlikely]]
-        WTFBeginSignpostAlways(this, UpdateAccessibilityIsolatedTree, "updating isolated tree for AXObjectCache: %" PRIVATE_LOG_STRING "", cache ? CheckedPtr { cache.get() }->debugDescription().utf8().data() : "null");
+        WTFBeginSignpostAlways(this, UpdateAccessibilityIsolatedTree, "updating isolated tree for AXObjectCache: %" PRIVATE_LOG_STRING "", cache ? CheckedPtr { cache }->debugDescription().utf8().data() : "null");
 
     for (const auto& nodeIDs : m_needsNodeRemoval)
         removeNode(nodeIDs.key, nodeIDs.value);

--- a/Source/WebCore/editing/TextCheckingHelper.cpp
+++ b/Source/WebCore/editing/TextCheckingHelper.cpp
@@ -518,7 +518,7 @@ TextCheckingGuesses TextCheckingHelper::guessesForMisspelledWordOrUngrammaticalP
     VisibleSelection currentSelection;
     if (auto frame = m_range.start.document().frame())
         currentSelection = frame->selection().selection();
-    CheckedRef client = m_client.get();
+    CheckedRef client = m_client;
     checkTextOfParagraph(*client->textChecker(), paragraph.text(), checkingTypes, results, currentSelection);
 
     for (auto& result : results) {

--- a/Source/WebCore/page/CaptionUserPreferences.cpp
+++ b/Source/WebCore/page/CaptionUserPreferences.cpp
@@ -179,7 +179,7 @@ void CaptionUserPreferences::setUserPrefersTextDescriptions(bool preference)
 
 void CaptionUserPreferences::captionPreferencesChanged()
 {
-    CheckedRef { m_pageGroup.get() }->captionPreferencesChanged();
+    CheckedRef { m_pageGroup }->captionPreferencesChanged();
 }
 
 Vector<String> CaptionUserPreferences::preferredLanguages() const

--- a/Source/WebCore/platform/KeyboardScrollingAnimator.cpp
+++ b/Source/WebCore/platform/KeyboardScrollingAnimator.cpp
@@ -146,7 +146,7 @@ const std::optional<ScrollGranularity> scrollGranularityForKeyboardEvent(const K
 
 float KeyboardScrollingAnimator::scrollDistance(ScrollDirection direction, ScrollGranularity granularity) const
 {
-    CheckedRef scrollableArea = m_scrollableArea.get();
+    CheckedRef scrollableArea = m_scrollableArea;
     RefPtr scrollbar = scrollableArea->scrollbarForDirection(direction);
     if (!scrollbar)
         return false;
@@ -178,7 +178,7 @@ RectEdges<bool> KeyboardScrollingAnimator::scrollingDirections() const
 {
     RectEdges<bool> edges;
 
-    CheckedRef scrollableArea = m_scrollableArea.get();
+    CheckedRef scrollableArea = m_scrollableArea;
     edges.setTop(scrollableArea->allowsVerticalScrolling());
     edges.setBottom(edges.top());
     edges.setLeft(scrollableArea->allowsHorizontalScrolling());
@@ -211,7 +211,7 @@ bool KeyboardScrollingAnimator::beginKeyboardScrollGesture(ScrollDirection direc
     if (!scroll)
         return false;
 
-    CheckedRef scrollableArea = m_scrollableArea.get();
+    CheckedRef scrollableArea = m_scrollableArea;
     if (scrollableArea->isUserScrollInProgress()) {
         m_scrollTriggeringKeyIsPressed = false;
         scrollableArea->endKeyboardScroll(true);

--- a/Source/WebCore/platform/ScrollAnimator.cpp
+++ b/Source/WebCore/platform/ScrollAnimator.cpp
@@ -68,7 +68,7 @@ ScrollAnimator::~ScrollAnimator()
 
 bool ScrollAnimator::singleAxisScroll(ScrollEventAxis axis, float scrollDelta, OptionSet<ScrollBehavior> behavior)
 {
-    CheckedRef scrollableArea = m_scrollableArea.get();
+    CheckedRef scrollableArea = m_scrollableArea;
     scrollableArea->scrollbarsController().setScrollbarAnimationsUnsuspendedByUserInteraction(true);
 
     auto delta = setValueForAxis(FloatSize { }, axis, scrollDelta);
@@ -104,7 +104,7 @@ bool ScrollAnimator::singleAxisScroll(ScrollEventAxis axis, float scrollDelta, O
 
 bool ScrollAnimator::scrollToPositionWithoutAnimation(const FloatPoint& position, ScrollClamping clamping)
 {
-    CheckedRef scrollableArea = m_scrollableArea.get();
+    CheckedRef scrollableArea = m_scrollableArea;
     FloatPoint currentPosition = this->currentPosition();
     auto adjustedPosition = clamping == ScrollClamping::Clamped ? position.constrainedBetween(scrollableArea->minimumScrollPosition(), scrollableArea->maximumScrollPosition()) : position;
 
@@ -122,7 +122,7 @@ bool ScrollAnimator::scrollToPositionWithoutAnimation(const FloatPoint& position
 
 bool ScrollAnimator::scrollToPositionWithAnimation(const FloatPoint& position, ScrollClamping clamping)
 {
-    CheckedRef scrollableArea = m_scrollableArea.get();
+    CheckedRef scrollableArea = m_scrollableArea;
     auto adjustedPosition = clamping == ScrollClamping::Clamped ? position.constrainedBetween(scrollableArea->minimumScrollPosition(), scrollableArea->maximumScrollPosition()) : position;
     bool positionChanged = adjustedPosition != currentPosition();
     if (!positionChanged && !scrollableArea->scrollOriginChanged())
@@ -185,7 +185,7 @@ bool ScrollAnimator::handleWheelEvent(const PlatformWheelEvent& wheelEvent)
 // "Stepped scrolling" is only used by RenderListBox. It's special in that it has no rubberbanding, and scroll deltas respect Scrollbar::pixelStep().
 bool ScrollAnimator::handleSteppedScrolling(const PlatformWheelEvent& wheelEvent)
 {
-    CheckedRef scrollableArea = m_scrollableArea.get();
+    CheckedRef scrollableArea = m_scrollableArea;
 #if ENABLE(KINETIC_SCROLLING)
     if ((wheelEvent.phase() == PlatformWheelEventPhase::Ended && wheelEvent.momentumPhase() == PlatformWheelEventPhase::None) || wheelEvent.momentumPhase() == PlatformWheelEventPhase::Ended) {
         scrollableArea->scrollDidEnd();
@@ -273,7 +273,7 @@ void ScrollAnimator::updateActiveScrollSnapIndexForOffset()
 
 void ScrollAnimator::notifyPositionChanged(const FloatSize& delta)
 {
-    CheckedRef scrollableArea = m_scrollableArea.get();
+    CheckedRef scrollableArea = m_scrollableArea;
     scrollableArea->scrollbarsController().notifyContentAreaScrolled(delta);
     scrollableArea->setScrollPositionFromAnimation(roundedIntPoint(m_currentPosition));
     m_scrollController.scrollPositionChanged();
@@ -311,7 +311,7 @@ void ScrollAnimator::willStartAnimatedScroll()
 
 void ScrollAnimator::didStopAnimatedScroll()
 {
-    CheckedRef scrollableArea = m_scrollableArea.get();
+    CheckedRef scrollableArea = m_scrollableArea;
     scrollableArea->setScrollAnimationStatus(ScrollAnimationStatus::NotAnimating);
     scrollableArea->animatedScrollDidEnd();
     scrollableArea->scrollDidEnd();
@@ -337,7 +337,7 @@ bool ScrollAnimator::isPinnedOnSide(BoxSide side) const
 
 void ScrollAnimator::adjustScrollPositionToBoundsIfNecessary()
 {
-    CheckedRef scrollableArea = m_scrollableArea.get();
+    CheckedRef scrollableArea = m_scrollableArea;
     auto previousClamping = scrollableArea->scrollClamping();
     scrollableArea->setScrollClamping(ScrollClamping::Clamped);
 
@@ -350,7 +350,7 @@ void ScrollAnimator::adjustScrollPositionToBoundsIfNecessary()
 
 FloatPoint ScrollAnimator::adjustScrollPositionIfNecessary(const FloatPoint& position) const
 {
-    CheckedRef scrollableArea = m_scrollableArea.get();
+    CheckedRef scrollableArea = m_scrollableArea;
     if (scrollableArea->scrollClamping() == ScrollClamping::Unclamped)
         return position;
 
@@ -372,7 +372,7 @@ void ScrollAnimator::immediateScrollBy(const FloatSize& delta, ScrollClamping cl
 
 ScrollExtents ScrollAnimator::scrollExtents() const
 {
-    CheckedRef scrollableArea = m_scrollableArea.get();
+    CheckedRef scrollableArea = m_scrollableArea;
     return {
         scrollableArea->totalContentsSize(),
         scrollableArea->visibleSize()

--- a/Source/WebCore/platform/Scrollbar.cpp
+++ b/Source/WebCore/platform/Scrollbar.cpp
@@ -281,7 +281,7 @@ void Scrollbar::moveThumb(int pos, bool draggingDocument)
         if (m_draggingDocument)
             delta = pos - m_documentDragPos;
         m_draggingDocument = true;
-        CheckedRef scrollableArea = m_scrollableArea.get();
+        CheckedRef scrollableArea = m_scrollableArea;
         FloatPoint currentPosition = scrollableArea->scrollAnimator().currentPosition();
         int destinationPosition = (m_orientation == ScrollbarOrientation::Horizontal ? currentPosition.x() : currentPosition.y()) + delta;
         if (delta > 0)
@@ -403,7 +403,7 @@ bool Scrollbar::mouseUp(const PlatformMouseEvent& mouseEvent)
     m_draggingDocument = false;
     stopTimerIfNeeded();
 
-    CheckedRef scrollableArea = m_scrollableArea.get();
+    CheckedRef scrollableArea = m_scrollableArea;
     scrollableArea->mouseIsDownInScrollbar(this, false);
 
     // m_hoveredPart won't be updated until the next mouseMoved or mouseDown, so we have to hit test
@@ -517,7 +517,7 @@ bool Scrollbar::supportsUpdateOnSecondaryThread() const
     // It's unfortunate that this needs to be done with an ifdef. Ideally there would be a way to feature-detect
     // the necessary support within AppKit.
 #if PLATFORM(MAC) || USE(COORDINATED_GRAPHICS_ASYNC_SCROLLBAR)
-    CheckedRef scrollableArea = m_scrollableArea.get();
+    CheckedRef scrollableArea = m_scrollableArea;
     return !scrollableArea->forceUpdateScrollbarsOnMainThreadForPerformanceTesting()
         && (scrollableArea->hasLayerForVerticalScrollbar() || scrollableArea->hasLayerForHorizontalScrollbar())
         && scrollableArea->usesAsyncScrolling();

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -1437,7 +1437,7 @@ unsigned MediaPlayer::videoDecodedByteCount() const
 void MediaPlayer::reloadTimerFired()
 {
     protect(m_private)->cancelLoad();
-    loadWithNextMediaEngine(CheckedPtr { m_currentMediaEngine.get() });
+    loadWithNextMediaEngine(CheckedPtr { m_currentMediaEngine });
 }
 
 template<typename T>

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AVOutputDeviceMenuControllerTargetPicker.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AVOutputDeviceMenuControllerTargetPicker.mm
@@ -189,7 +189,7 @@ AVOutputContext * AVOutputDeviceMenuControllerTargetPicker::outputContext()
         return;
 
     callOnMainThread([self, protectedSelf = retainPtr(self), keyPath = retainPtr(keyPath)] {
-        CheckedPtr callback = m_callback.get();
+        CheckedPtr callback = m_callback;
         if (!callback)
             return;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AVRoutePickerViewTargetPicker.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AVRoutePickerViewTargetPicker.mm
@@ -266,7 +266,7 @@ void AVRoutePickerViewTargetPicker::devicePickerWasDismissed()
         return;
 
     callOnMainThread([self, protectedSelf = retainPtr(self)] {
-        if (CheckedPtr callback = m_callback.get())
+        if (CheckedPtr callback = m_callback)
             callback->devicePickerWasDismissed();
     });
 }
@@ -279,7 +279,7 @@ void AVRoutePickerViewTargetPicker::devicePickerWasDismissed()
         return;
 
     callOnMainThread([self, protectedSelf = retainPtr(self), notification = retainPtr(notification)] {
-        CheckedPtr callback = m_callback.get();
+        CheckedPtr callback = m_callback;
         if (!callback)
             return;
 

--- a/Source/WebCore/platform/graphics/cocoa/TextTrackRepresentationCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/TextTrackRepresentationCocoa.mm
@@ -170,7 +170,7 @@ IntRect TextTrackRepresentationCocoa::bounds() const
 void TextTrackRepresentationCocoa::boundsChanged()
 {
     callOnMainThread([weakThis = WeakPtr { *this }] {
-        if (CheckedPtr checkedThis = weakThis.get())
+        if (CheckedPtr checkedThis = weakThis)
             checkedThis->client().textTrackRepresentationBoundsChanged(checkedThis->bounds());
     });
 }

--- a/Source/WebCore/platform/mac/ScrollAnimatorMac.mm
+++ b/Source/WebCore/platform/mac/ScrollAnimatorMac.mm
@@ -108,7 +108,7 @@ static bool gestureShouldBeginSnap(const PlatformWheelEvent& wheelEvent, ScrollE
 
 bool ScrollAnimatorMac::allowsVerticalStretching(const PlatformWheelEvent& wheelEvent) const
 {
-    CheckedRef scrollableArea = m_scrollableArea.get();
+    CheckedRef scrollableArea = m_scrollableArea;
     if (scrollableArea->verticalOverscrollBehavior() == OverscrollBehavior::None)
         return false;
     
@@ -135,7 +135,7 @@ bool ScrollAnimatorMac::allowsVerticalStretching(const PlatformWheelEvent& wheel
 
 bool ScrollAnimatorMac::allowsHorizontalStretching(const PlatformWheelEvent& wheelEvent) const
 {
-    CheckedRef scrollableArea = m_scrollableArea.get();
+    CheckedRef scrollableArea = m_scrollableArea;
     if (scrollableArea->horizontalOverscrollBehavior() == OverscrollBehavior::None)
         return false;
     

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
@@ -114,7 +114,7 @@ const RenderElement* RenderSVGModelObject::pushMappingToContainer(const RenderLa
 
     ASSERT_UNUSED(ancestorSkipped, !ancestorSkipped);
 
-    pushOntoGeometryMap(geometryMap, ancestorToStopAt, CheckedPtr { container.get() }, ancestorSkipped);
+    pushOntoGeometryMap(geometryMap, ancestorToStopAt, CheckedPtr { container }, ancestorSkipped);
     return container.get();
 }
 

--- a/Source/WebKit/UIProcess/mac/WKImmediateActionController.mm
+++ b/Source/WebKit/UIProcess/mac/WKImmediateActionController.mm
@@ -236,7 +236,7 @@
 
     protect(_page)->immediateActionDidCancel();
 
-    CheckedPtr { _viewImpl.get() }->cancelImmediateActionAnimation();
+    CheckedPtr { _viewImpl }->cancelImmediateActionAnimation();
 
     protect(_page)->setTextIndicatorAnimationProgress(0);
     [self _clearImmediateActionState];
@@ -250,7 +250,7 @@
 
     protect(_page)->immediateActionDidComplete();
 
-    CheckedPtr { _viewImpl.get() }->completeImmediateActionAnimation();
+    CheckedPtr { _viewImpl }->completeImmediateActionAnimation();
 
     protect(_page)->setTextIndicatorAnimationProgress(1);
 }
@@ -505,7 +505,7 @@
         return nil;
 #endif
 
-    CheckedPtr { _viewImpl.get() }->prepareForDictionaryLookup();
+    CheckedPtr { _viewImpl }->prepareForDictionaryLookup();
     return WebCore::DictionaryLookup::animationControllerForPopup(dictionaryPopupInfo, _view.get().get(), [self](WebCore::TextIndicator& textIndicator) {
         protect(_page)->setTextIndicator(textIndicator, WebCore::TextIndicatorLifetime::Permanent);
     }, nullptr, [strongSelf = retainPtr(self)]() {

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -1153,7 +1153,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (NSViewController *)textListViewController
 {
     if (!_textListTouchBarViewController)
-        _textListTouchBarViewController = adoptNS([[WKTextListTouchBarViewController alloc] initWithWebViewImpl:CheckedPtr { _webViewImpl.get() }]);
+        _textListTouchBarViewController = adoptNS([[WKTextListTouchBarViewController alloc] initWithWebViewImpl:CheckedPtr { _webViewImpl }]);
     return _textListTouchBarViewController.get();
 }
 
@@ -1219,7 +1219,7 @@ static void* imageOverlayObservationContext = &imageOverlayObservationContext;
 
     BOOL oldHasActiveTextSelection = [change[NSKeyValueChangeOldKey] boolValue];
     BOOL newHasActiveTextSelection = [change[NSKeyValueChangeNewKey] boolValue];
-    RetainPtr webView = _impl ? CheckedPtr { _impl.get() }->view() : nil;
+    RetainPtr webView = _impl ? CheckedPtr { _impl }->view() : nil;
     RetainPtr<NSResponder> currentResponder = webView.get().window.firstResponder;
     if (oldHasActiveTextSelection && !newHasActiveTextSelection) {
         if (self.firstResponderIsInsideImageOverlay) {
@@ -1237,7 +1237,7 @@ static void* imageOverlayObservationContext = &imageOverlayObservationContext;
     if (!_impl)
         return NO;
 
-    for (RetainPtr view = dynamic_objc_cast<NSView>(protect(CheckedPtr { _impl.get() }->view()).get().window.firstResponder); view; view = view.get().superview) {
+    for (RetainPtr view = dynamic_objc_cast<NSView>(protect(CheckedPtr { _impl }->view()).get().window.firstResponder); view; view = view.get().superview) {
         if (view == _overlayView.get())
             return YES;
     }
@@ -1257,7 +1257,7 @@ static void* imageOverlayObservationContext = &imageOverlayObservationContext;
         return CGRectMake(0, 0, 1, 1);
 
     auto unitInteractionRect = _impl->imageAnalysisInteractionBounds();
-    WebCore::FloatRect unobscuredRect = protect(CheckedPtr { _impl.get() }->view()).get().bounds;
+    WebCore::FloatRect unobscuredRect = protect(CheckedPtr { _impl }->view()).get().bounds;
     unitInteractionRect.moveBy(-unobscuredRect.location());
     unitInteractionRect.scale(1 / unobscuredRect.size());
     return unitInteractionRect;

--- a/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp
+++ b/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp
@@ -163,7 +163,7 @@ SpeechRecognitionRealtimeMediaSourceManager::SpeechRecognitionRealtimeMediaSourc
 
 SpeechRecognitionRealtimeMediaSourceManager::~SpeechRecognitionRealtimeMediaSourceManager()
 {
-    CheckedRef { m_process.get() }->removeMessageReceiver(*this);
+    CheckedRef { m_process }->removeMessageReceiver(*this);
 }
 
 IPC::Connection& SpeechRecognitionRealtimeMediaSourceManager::connection() const

--- a/Source/WebKitLegacy/mac/WebView/WebViewRenderingUpdateScheduler.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebViewRenderingUpdateScheduler.mm
@@ -50,7 +50,7 @@ WebViewRenderingUpdateScheduler::WebViewRenderingUpdateScheduler(WebView* webVie
         // However if the flush is rescheduled from the callback it may get pushed past it, to the next cycle.
         WebThreadLock();
 #endif
-        CheckedPtr checkedThis = weakThis.get();
+        CheckedPtr checkedThis = weakThis;
         if (!checkedThis)
             return;
         checkedThis->renderingUpdateRunLoopObserverCallback();
@@ -60,7 +60,7 @@ WebViewRenderingUpdateScheduler::WebViewRenderingUpdateScheduler(WebView* webVie
 #if PLATFORM(IOS_FAMILY)
         WebThreadLock();
 #endif
-        CheckedPtr checkedThis = weakThis.get();
+        CheckedPtr checkedThis = weakThis;
         if (!checkedThis)
             return;
         checkedThis->postRenderingUpdateCallback();


### PR DESCRIPTION
#### 687172c1a2f2b20583c0e0d68e733c9969d77fdf
<pre>
Allow constructing a CheckedPtr/CheckedRef from a WeakPtr/WeakRef
<a href="https://bugs.webkit.org/show_bug.cgi?id=310350">https://bugs.webkit.org/show_bug.cgi?id=310350</a>

Reviewed by Darin Adler.

Allow constructing a CheckedPtr/CheckedRef from a WeakPtr/WeakRef, for
convenience.

* Source/JavaScriptCore/inspector/InjectedScriptBase.cpp:
(Inspector::InjectedScriptBase::hasAccessToInspectedScriptState const):
* Source/WTF/wtf/CheckedPtr.h:
* Source/WTF/wtf/CheckedRef.h:
* Source/WTF/wtf/RunLoop.h:
* Source/WebCore/accessibility/AXAttributeCacheScope.cpp:
(WebCore::AXAttributeCacheScope::AXAttributeCacheScope):
(WebCore::AXAttributeCacheScope::~AXAttributeCacheScope):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::objectChangedIgnoredState):
(WebCore::AXIsolatedTree::updateRootScreenRelativePosition):
(WebCore::AXIsolatedTree::processQueuedNodeUpdates):
* Source/WebCore/editing/TextCheckingHelper.cpp:
(WebCore::TextCheckingHelper::guessesForMisspelledWordOrUngrammaticalPhrase const):
* Source/WebCore/page/CaptionUserPreferences.cpp:
(WebCore::CaptionUserPreferences::captionPreferencesChanged):
* Source/WebCore/platform/KeyboardScrollingAnimator.cpp:
(WebCore::KeyboardScrollingAnimator::scrollDistance const):
(WebCore::KeyboardScrollingAnimator::scrollingDirections const):
(WebCore::KeyboardScrollingAnimator::beginKeyboardScrollGesture):
* Source/WebCore/platform/ScrollAnimator.cpp:
(WebCore::ScrollAnimator::singleAxisScroll):
(WebCore::ScrollAnimator::scrollToPositionWithoutAnimation):
(WebCore::ScrollAnimator::scrollToPositionWithAnimation):
(WebCore::ScrollAnimator::handleSteppedScrolling):
(WebCore::ScrollAnimator::notifyPositionChanged):
(WebCore::ScrollAnimator::didStopAnimatedScroll):
(WebCore::ScrollAnimator::adjustScrollPositionToBoundsIfNecessary):
(WebCore::ScrollAnimator::adjustScrollPositionIfNecessary const):
(WebCore::ScrollAnimator::scrollExtents const):
* Source/WebCore/platform/Scrollbar.cpp:
(WebCore::Scrollbar::moveThumb):
(WebCore::Scrollbar::mouseUp):
(WebCore::Scrollbar::supportsUpdateOnSecondaryThread const):
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::reloadTimerFired):
* Source/WebCore/platform/graphics/avfoundation/objc/AVOutputDeviceMenuControllerTargetPicker.mm:
(-[WebAVOutputDeviceMenuControllerHelper observeValueForKeyPath:ofObject:change:context:]):
* Source/WebCore/platform/graphics/avfoundation/objc/AVRoutePickerViewTargetPicker.mm:
(-[WebAVRoutePickerViewHelper routePickerViewDidEndPresentingRoutes:]):
(-[WebAVRoutePickerViewHelper notificationHandler:]):
* Source/WebCore/platform/graphics/cocoa/TextTrackRepresentationCocoa.mm:
(WebCore::TextTrackRepresentationCocoa::boundsChanged):
* Source/WebCore/platform/mac/ScrollAnimatorMac.mm:
(WebCore::ScrollAnimatorMac::allowsVerticalStretching const):
(WebCore::ScrollAnimatorMac::allowsHorizontalStretching const):
* Source/WebCore/rendering/svg/RenderSVGModelObject.cpp:
(WebCore::RenderSVGModelObject::pushMappingToContainer const):
* Source/WebKit/UIProcess/mac/WKImmediateActionController.mm:
(-[WKImmediateActionController immediateActionRecognizerDidCancelAnimation:]):
(-[WKImmediateActionController immediateActionRecognizerDidCompleteAnimation:]):
(-[WKImmediateActionController _animationControllerForText]):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(-[WKTextTouchBarItemController textListViewController]):
(-[WKImageAnalysisOverlayViewDelegate observeValueForKeyPath:ofObject:change:context:]):
(-[WKImageAnalysisOverlayViewDelegate firstResponderIsInsideImageOverlay]):
(-[WKImageAnalysisOverlayViewDelegate contentsRectForImageAnalysisOverlayView:]):
* Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp:
(WebKit::SpeechRecognitionRealtimeMediaSourceManager::~SpeechRecognitionRealtimeMediaSourceManager):
* Source/WebKitLegacy/mac/WebView/WebViewRenderingUpdateScheduler.mm:
(WebViewRenderingUpdateScheduler::WebViewRenderingUpdateScheduler):

Canonical link: <a href="https://commits.webkit.org/309658@main">https://commits.webkit.org/309658@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c72af31382c16553b7daaf78ffa106a3438b028d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151214 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23977 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17547 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159943 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104650 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153087 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24408 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24221 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116748 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82881 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154174 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18872 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135677 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97469 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17965 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15913 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7788 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/143198 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127583 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13594 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162415 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/12013 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5540 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15165 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124759 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23778 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19963 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124947 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33924 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23768 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135391 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80234 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20010 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12156 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/182823 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23378 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87672 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46642 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23090 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23242 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23144 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->