### PR TITLE
[GTK] API test /webkit/WebKitFaviconDatabase/get-favicon often times out

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitFaviconDatabase.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitFaviconDatabase.cpp
@@ -103,8 +103,10 @@ public:
     {
         if (!g_strcmp0(webkit_web_view_get_uri(test->webView()), pageURI)) {
             test->m_faviconURI = faviconURI;
-            if (test->m_waitingForFaviconURI)
+            if (test->m_waitingForFaviconURI) {
+                test->m_waitingForFaviconURI = false;
                 test->quitMainLoop();
+            }
         }
     }
 
@@ -179,13 +181,37 @@ public:
         g_main_loop_run(m_mainLoop);
     }
 
-    void waitUntilFaviconURIChanged()
+    void willWaitForFaviconURIChanged()
+    {
+        m_waitingForFaviconURI = false;
+        m_faviconURI.reset();
+    }
+
+    void waitUntilFaviconURIChangedIfNeeded(unsigned timeoutMilliseconds = 0)
     {
         g_assert_false(m_waitingForFaviconURI);
-        m_faviconURI = CString();
-        m_waitingForFaviconURI = true;
-        g_main_loop_run(m_mainLoop);
-        m_waitingForFaviconURI = false;
+
+        if (m_faviconURI)
+            g_assert_false(m_waitingForFaviconURI);
+        else {
+            m_waitingForFaviconURI = true;
+            if (timeoutMilliseconds) {
+                g_assert_cmpint(m_waitingForFaviconURITimeoutID, ==, 0);
+                m_waitingForFaviconURITimeoutID = g_timeout_add(timeoutMilliseconds, [](void* data) -> gboolean {
+                    auto* test = static_cast<FaviconDatabaseTest*>(data);
+                    test->m_waitingForFaviconURITimeoutID = 0;
+                    test->quitMainLoop();
+                    return G_SOURCE_REMOVE;
+                }, this);
+            }
+            g_main_loop_run(m_mainLoop);
+            g_clear_handle_id(&m_waitingForFaviconURITimeoutID, g_source_remove);
+        }
+
+        if (!timeoutMilliseconds) {
+            g_assert_false(m_waitingForFaviconURI);
+            g_assert_true(m_faviconURI.has_value());
+        }
     }
 
     GRefPtr<WebKitFaviconDatabase> m_database;
@@ -194,11 +220,12 @@ public:
 #else
     cairo_surface_t* m_favicon { nullptr };
 #endif
-    CString m_faviconURI;
+    std::optional<CString> m_faviconURI { std::nullopt };
     GUniqueOutPtr<GError> m_error;
     bool m_faviconNotificationReceived { false };
     bool m_loadFinished { false };
     bool m_waitingForFaviconURI { false };
+    unsigned m_waitingForFaviconURITimeoutID { 0 };
 };
 
 static void serverCallback(SoupServer*, SoupServerMessage* message, const char* path, GHashTable* query, gpointer)
@@ -264,11 +291,15 @@ static void testFaviconDatabaseGetFavicon(FaviconDatabaseTest* test, gconstpoint
 {
     test->open("testFaviconDatabaseGetFavicon");
 
+    test->willWaitForFaviconURIChanged();
+
     test->loadURI(kServer->getURIForPath("/foo").data());
     test->waitUntilLoadFinishedAndFaviconChanged();
     CString faviconURI = kServer->getURIForPath("/icon/favicon.ico");
 
     test->getFaviconForPageURIAndWaitUntilReady(kServer->getURIForPath("/foo").data());
+    test->waitUntilFaviconURIChangedIfNeeded();
+
     g_assert_nonnull(test->m_favicon);
 #if USE(GTK4)
     g_assert_cmpint(gdk_texture_get_width(test->m_favicon.get()), ==, 16);
@@ -277,41 +308,52 @@ static void testFaviconDatabaseGetFavicon(FaviconDatabaseTest* test, gconstpoint
     g_assert_cmpint(cairo_image_surface_get_width(test->m_favicon), ==, 16);
     g_assert_cmpint(cairo_image_surface_get_height(test->m_favicon), ==, 16);
 #endif
-    g_assert_cmpstr(test->m_faviconURI.data(), ==, faviconURI.data());
+    g_assert_true(test->m_faviconURI.has_value());
+    g_assert_cmpstr(test->m_faviconURI->data(), ==, faviconURI.data());
     g_assert_no_error(test->m_error.get());
 
 #if !USE(GTK4)
     // Check that another page with the same favicon returns the same icon.
     cairo_surface_t* favicon = cairo_surface_reference(test->m_favicon);
+    test->willWaitForFaviconURIChanged();
     test->loadURI(kServer->getURIForPath("/bar").data());
     test->waitUntilLoadFinishedAndFaviconChanged();
+    test->waitUntilFaviconURIChangedIfNeeded();
     // favicon changes twice, first to reset it and then when the new icon is loaded.
     if (!test->m_favicon)
         test->waitUntilFaviconChanged();
     test->getFaviconForPageURIAndWaitUntilReady(kServer->getURIForPath("/bar").data());
     g_assert_nonnull(test->m_favicon);
     g_assert_true(test->m_favicon == favicon);
-    g_assert_cmpstr(test->m_faviconURI.data(), ==, faviconURI.data());
+    g_assert_true(test->m_faviconURI.has_value());
+    g_assert_cmpstr(test->m_faviconURI->data(), ==, faviconURI.data());
     g_assert_no_error(test->m_error.get());
     cairo_surface_destroy(favicon);
 #endif
 
+    test->willWaitForFaviconURIChanged();
     faviconURI = kServer->getURIForPath("/favicon.ico");
     test->loadURI(kServer->getURIForPath("/nofavicon").data());
     test->waitUntilLoadFinishedAndFaviconChanged();
-    test->waitUntilFaviconURIChanged();
+
+    // Note that /favicon.icon results in HTTP 404 Not Found, and when an icon
+    // is not loaded, there will be no WebKitFaviconDatabase:favicon-changed signal.
+    test->waitUntilFaviconURIChangedIfNeeded(1000);
+    // Still waiting for the icon that was never fetched...
+    g_assert_true(test->m_waitingForFaviconURI);
+
     test->getFaviconForPageURIAndWaitUntilReady(kServer->getURIForPath("/nofavicon").data());
     g_assert_null(test->m_favicon);
-    g_assert_cmpstr(test->m_faviconURI.data(), ==, faviconURI.data());
+    g_assert_false(test->m_faviconURI.has_value());
     g_assert_error(test->m_error.get(), WEBKIT_FAVICON_DATABASE_ERROR, WEBKIT_FAVICON_DATABASE_ERROR_FAVICON_UNKNOWN);
 
     // Loading an icon that is already in the database should emit
     // WebKitWebView::notify::favicon, but not WebKitFaviconDatabase::icon-changed.
     g_assert_null(webkit_web_view_get_favicon(test->webView()));
-    test->m_faviconURI = { };
+    test->m_faviconURI.reset();
     test->loadURI(kServer->getURIForPath("/foo").data());
     test->waitUntilFaviconChanged();
-    g_assert_true(test->m_faviconURI.isNull());
+    g_assert_false(test->m_faviconURI.has_value());
     g_assert_nonnull(webkit_web_view_get_favicon(test->webView()));
 }
 

--- a/Tools/TestWebKitAPI/glib/TestExpectations.json
+++ b/Tools/TestWebKitAPI/glib/TestExpectations.json
@@ -140,13 +140,6 @@
             }
         }
     },
-    "TestWebKitFaviconDatabase": {
-        "subtests": {
-            "/webkit/WebKitFaviconDatabase/get-favicon": {
-                "expected": {"gtk": {"status": ["FAIL", "TIMEOUT", "PASS"], "bug": "webkit.org/b/205381"}}
-            }
-        }
-    },
     "TestWebKitWebContext": {
         "subtests": {
             "/webkit/WebKitWebContext/uri-scheme": {


### PR DESCRIPTION
#### dd71161da413086851ceeee9cb066d7d3b5f6cae
<pre>
[GTK] API test /webkit/WebKitFaviconDatabase/get-favicon often times out
<a href="https://bugs.webkit.org/show_bug.cgi?id=188110">https://bugs.webkit.org/show_bug.cgi?id=188110</a>

Reviewed by Carlos Garcia Campos.

A test case that loads a page that has no &lt;link&gt; element for favicons
results in WebKit using /favicon.ico as fallback; then the HTTP server
used for testing returns an HTTP 404 Not Found for it. Then the test
checked for the WebKitFaviconDatabase:favicon-changed signal; but given
that there is no actual icon loaded, the signal was never emitted and
the test timed out waiting for it.

The test case is wrong because the API documentation implies that an
icon image can always be fetched after :favicon-changed is emitted,
which needs that a favicon is actually loaded and stored in the
database. Therefore it makes more sense to change the test case to
validate that the signal is *not* emitted for a page where for which a
favicon cannot be loaded.

A second issue is that depending on the order of completion of
asynchronous it may happen that WebKitFaviconDatabase:favicon-changed
may be emitted while waiting e.g. for page load using
waitUntilLoadFinishedAndFaviconChanged(), before explicitly waiting
for it with waitUntilFaviconChanged(). If that happened, the call to
waitUntilFaviconChanged() call would spin the main loop again to wait
for a signal emission that never arrives (because it had already
happened).

This patch fixes those two issues, in the following way:

  0. Using an std::optional&lt;CString&gt; for the favicon URI, which is a
     more logical representation if the &quot;no value provided&quot; state.

  1. Split waitUntilFaviconChanged() into two separate functions:
     willWaitForFaviconURIChanged() to use at the beginning of a test
     case to indicate that checks will be made on :favicon-changed
     (and reset values), and waitUntilFaviconURIChangedIfNeeded().
     The latter checks first whether a value was already recorded,
     and returns early in that case to avoid spinning the main loop
     causing a timeout.

  2. Allow a timeout for waitUntilFaviconURIChangedIfNeeded(), in order
     to not wait forever in the case where testing the page for which
     a favicon cannot be loaded. The timeout avoids spinning the main
     loop forever, and afterwards it is possible to check that the
     :favicon-changed signal was not emitted, and that there was no
     favicon URI recorded.

* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitFaviconDatabase.cpp:
(testFaviconDatabaseGetFavicon):
* Tools/TestWebKitAPI/glib/TestExpectations.json: Remove test expectation,
it should always pass now.

Canonical link: <a href="https://commits.webkit.org/309642@main">https://commits.webkit.org/309642@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf5a858cb8daece216544ff3a4271d100acef37d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151218 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23981 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17551 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159947 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104654 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153091 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24412 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24225 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116751 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82883 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154178 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18875 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135682 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97472 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17968 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15917 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7792 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127586 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13599 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162419 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15170 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124760 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23782 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19967 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124948 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33913 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23772 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135396 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80247 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20017 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12161 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23382 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23094 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23246 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23148 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->