### PR TITLE
[WPE][GTK] Ensure that jhbuild or flatpak is only used if set explicitly via WEBKIT_JHBUILD=1 or WEBKIT_FLATPAK=1 (follow-up patch)

### DIFF
--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -3766,25 +3766,29 @@ sub runGitUpdate()
 }
 
 
+# Never returns to the caller: either exec()s an external program or exit()s directly.
+# Exit code follows shell convention (0 = success, non-zero = failure).
 sub updateGtkOrWpeLibs
 {
     my ($port) = @_;
     my $scriptsDir = relativeScriptsDir();
     if (defined $ENV{'WEBKIT_JHBUILD'} and $ENV{'WEBKIT_JHBUILD'}) {
-        system("perl", "$scriptsDir/update-webkit-libs-jhbuild", "--$port", @ARGV) == 0 or die $!;
+        exec("perl", "$scriptsDir/update-webkit-libs-jhbuild", "--$port", @ARGV)
+            or die "Failed to exec update-webkit-libs-jhbuild: $!";
     } elsif (defined $ENV{'WEBKIT_CROSS_TARGET'} or grep(/^--cross-target/, @ARGV)) {
-        system("$scriptsDir/cross-toolchain-helper", "--build-toolchain", @ARGV) == 0 or die $!;
+        exec("$scriptsDir/cross-toolchain-helper", "--build-toolchain", @ARGV)
+            or die "Failed to exec cross-toolchain-helper: $!";
     } elsif (defined $ENV{'WEBKIT_FLATPAK'} and $ENV{'WEBKIT_FLATPAK'}) {
-        system("$scriptsDir/update-webkit-flatpak", @ARGV) == 0 or die $!;
+        exec("$scriptsDir/update-webkit-flatpak", @ARGV)
+            or die "Failed to exec update-webkit-flatpak: $!";
     }
-
     if (defined $ENV{'WEBKIT_CONTAINER_SDK'} and $ENV{'WEBKIT_CONTAINER_SDK'}) {
         # FIXME: implement a way to check if the update is needed by calling some script at /wkdev-sdk and then print a different message.
         print "Running inside wkdev-sdk: execute wkdev-update on the host to check for updates.\n";
-    } else {
-        warn "Please download and install wkdev-sdk from https://github.com/Igalia/webkit-container-sdk\n";
-        exit 1;
+        exit 0;  # success
     }
+    warn "Please download and install wkdev-sdk from https://github.com/Igalia/webkit-container-sdk\n";
+    exit 1;  # failure
 }
 
 


### PR DESCRIPTION
#### c5cdc14ccf8df858900838efd606b8984e7a90f3
<pre>
[WPE][GTK] Ensure that jhbuild or flatpak is only used if set explicitly via WEBKIT_JHBUILD=1 or WEBKIT_FLATPAK=1 (follow-up patch)
<a href="https://bugs.webkit.org/show_bug.cgi?id=310187">https://bugs.webkit.org/show_bug.cgi?id=310187</a>

Unreviewed follow-up patch.

The refactor in 309557@main that moved the update logic from update-webkit*-libs
into webkitdirs.pm introduced a bug: the function could fall through the initial
if/elsif chain and enter the final if block, for example printing the wkdev-sdk
warning even after a successful run of update-webkit-libs-jhbuild.

Fix this by replacing system() with exec() so each branch is final: the Perl
process is replaced by the child program and never returns to the caller.
The `or die` guards on each exec() catch failures such as a missing script.

* Tools/Scripts/webkitdirs.pm:
(updateGtkOrWpeLibs):

Canonical link: <a href="https://commits.webkit.org/309613@main">https://commits.webkit.org/309613@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5f6f732cdd9acabd5b3a58210761a16b9a3bf53

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151220 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23983 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/17553 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/159949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104656 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153093 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24414 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24228 "Hash b5f6f732 for PR 61002 does not build (failure)") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/159949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/82884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154180 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/18877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/135680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/159949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/17970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/24228 "Hash b5f6f732 for PR 61002 does not build (failure)") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/7794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/143204 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/127588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/13597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/162421 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/12019 "Built successfully and passed tests") | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/15168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/162421 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23784 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/24228 "Hash b5f6f732 for PR 61002 does not build (failure)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/162421 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23774 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/135394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80249 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23233 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/20012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/12159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/182829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23384 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/182829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23096 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23248 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23150 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->