### PR TITLE
Invalidate ::slotted nested pseudo-elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/slotted-user-agent-part-invalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/slotted-user-agent-part-invalidation-expected.txt
@@ -1,0 +1,5 @@
+Summary
+Details content
+
+PASS CSS Test: Style invalidation for ::slotted() combined with user-agent pseudo-elements
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/slotted-user-agent-part-invalidation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/slotted-user-agent-part-invalidation.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<title>CSS Test: Style invalidation for ::slotted() combined with user-agent pseudo-elements</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="help" href="https://drafts.csswg.org/css-scoping/#slotted-pseudo">
+<div id="host">
+  <details open>
+    <summary>Summary</summary>
+    <span id="content">Details content</span>
+  </details>
+</div>
+<script>
+test(function() {
+  const root = host.attachShadow({mode: "closed"});
+  root.innerHTML = `
+    <style>
+      ::slotted(details)::details-content {
+        color: red;
+      }
+      .active ::slotted(details)::details-content {
+        color: green;
+      }
+    </style>
+    <div id="wrapper"><slot></slot></div>
+  `;
+
+  const wrapper = root.querySelector("#wrapper");
+
+  assert_equals(getComputedStyle(content).color, "rgb(255, 0, 0)",
+    "initial ::slotted(details)::details-content style applies");
+
+  wrapper.className = "active";
+  assert_equals(getComputedStyle(content).color, "rgb(0, 128, 0)",
+    "::details-content style updates when ancestor class changes");
+});
+</script>

--- a/Source/WebCore/style/StyleInvalidator.cpp
+++ b/Source/WebCore/style/StyleInvalidator.cpp
@@ -149,6 +149,13 @@ static void invalidateAssignedElements(HTMLSlotElement& slot)
             continue;
         }
         element->invalidateStyleInternal();
+        // Invalidate ::slotted nested pseudo-elements.
+        if (RefPtr shadowRoot = element->userAgentShadowRoot()) {
+            for (Ref descendant : descendantsOfType<Element>(*shadowRoot)) {
+                if (!descendant->userAgentPart().isEmpty())
+                    descendant->invalidateStyleInternal();
+            }
+        }
     }
 }
 


### PR DESCRIPTION
#### 099f5a48c35a5e9055eef45f36aef0234f9e8ee3
<pre>
Invalidate ::slotted nested pseudo-elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=310355">https://bugs.webkit.org/show_bug.cgi?id=310355</a>

Reviewed by Tim Nguyen.

When we have ::slotted pseudo-element rules we already performed
invalidation, except we did not go into user agent shadow trees to
invalidate the nodes there, which meant that nested pseudo-elements
were not properly invalidated.

Test: imported/w3c/web-platform-tests/css/css-scoping/slotted-user-agent-part-invalidation.html

Upstream:

    <a href="https://github.com/web-platform-tests/wpt/pull/58644">https://github.com/web-platform-tests/wpt/pull/58644</a>

Canonical link: <a href="https://commits.webkit.org/309672@main">https://commits.webkit.org/309672@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64125379c73e3c3705fe29f14b2d690bfd26a659

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151222 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23985 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17555 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159951 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104658 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153095 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24416 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24230 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116753 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82886 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154182 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18879 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135687 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97474 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17972 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15919 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7796 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127590 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13604 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162423 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5548 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15175 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124762 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23786 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19969 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124950 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23776 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135401 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80252 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23256 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20025 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12166 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23386 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87680 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23098 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23250 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23152 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->