### PR TITLE
Unreviewed, reverting 309595@main (552320967679)

### DIFF
--- a/Source/WebCore/editing/cocoa/EditingHTMLConverter.h
+++ b/Source/WebCore/editing/cocoa/EditingHTMLConverter.h
@@ -25,11 +25,8 @@
 
 #import <WebCore/AttributedString.h>
 #import <WebCore/SimpleRange.h>
-#import <wtf/WeakHashSet.h>
 
 namespace WebCore {
-
-class Node;
 
 enum class TextIteratorBehavior : uint16_t;
 
@@ -46,7 +43,7 @@ enum class IncludedElement : uint8_t {
     TextLists = 1 << 4,
 };
 
-WEBCORE_EXPORT AttributedString editingAttributedString(const SimpleRange&, OptionSet<IncludedElement> = { IncludedElement::Images }, const WeakHashSet<Node, WeakPtrImplWithEventTargetData>& clientPreservedNodes = { });
+WEBCORE_EXPORT AttributedString editingAttributedString(const SimpleRange&, OptionSet<IncludedElement> = { IncludedElement::Images });
 WEBCORE_EXPORT AttributedString editingAttributedStringReplacingNoBreakSpace(const SimpleRange&, OptionSet<TextIteratorBehavior>, OptionSet<IncludedElement>);
 
 } // namespace WebCore

--- a/Source/WebCore/editing/cocoa/EditingHTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/EditingHTMLConverter.mm
@@ -39,7 +39,6 @@
 #import "ContainerNodeInlines.h"
 #import "Document.h"
 #import "DocumentLoader.h"
-#import "DocumentPage.h"
 #import "Editing.h"
 #import "ElementChildIteratorInlines.h"
 #import "ElementInlines.h"
@@ -58,7 +57,6 @@
 #import "LocalFrame.h"
 #import "LocalizedStrings.h"
 #import "NodeName.h"
-#import "Page.h"
 #import "RenderImage.h"
 #import "RenderObjectStyle.h"
 #import "RenderStyle+GettersInlines.h"
@@ -206,20 +204,11 @@ static RetainPtr<NSAttributedString> attributedStringWithAttachmentForElement(co
 }
 
 #if ENABLE(WRITING_TOOLS)
-static bool elementQualifiesForWritingToolsPreservation(Element* element, const WeakHashSet<Node, WeakPtrImplWithEventTargetData>& clientPreservedNodes)
+static bool elementQualifiesForWritingToolsPreservation(Element* element)
 {
-    if (clientPreservedNodes.contains(*element))
-        return true;
-
     // If the element is a mail blockquote, it should be preserved after a Writing Tools composition.
     if (isMailBlockquote(*element))
         return true;
-
-    if (element->getIdAttribute() == "AppleMailSignature"_s) [[unlikely]] {
-        // FIXME (310312): Remove this special case once Mail adopts `-_addWritingToolsPreservedNodes:`.
-        if (RefPtr page = element->document().page(); page && page->isEditable())
-            return true;
-    }
 
     // If the element is a tab span node, it is a tab character with `whitespace:pre`, and need not be preserved.
     if (tabSpanNode(element))
@@ -240,14 +229,14 @@ static bool elementQualifiesForWritingToolsPreservation(Element* element, const 
     return false;
 }
 
-static bool hasAncestorQualifyingForWritingToolsPreservation(Element* ancestor, ElementCache<bool>& cache, const WeakHashSet<Node, WeakPtrImplWithEventTargetData>& clientPreservedNodes)
+static bool hasAncestorQualifyingForWritingToolsPreservation(Element* ancestor, ElementCache<bool>& cache)
 {
     if (!ancestor)
         return false;
 
     auto entry = cache.find(*ancestor);
     if (entry == cache.end()) {
-        auto result = elementQualifiesForWritingToolsPreservation(ancestor, clientPreservedNodes) || hasAncestorQualifyingForWritingToolsPreservation(protect(ancestor->parentElement()).get(), cache, clientPreservedNodes);
+        auto result = elementQualifiesForWritingToolsPreservation(ancestor) || hasAncestorQualifyingForWritingToolsPreservation(protect(ancestor->parentElement()).get(), cache);
 
         cache.set(*ancestor, result);
         return result;
@@ -343,11 +332,11 @@ static void associateElementWithTextLists(Element* element, ElementCache<RefPtr<
 }
 
 // FIXME: Encapsulate all these parameters into a type for readability and maintainability.
-static void updateAttributes(const Node* node, const RenderStyle& style, OptionSet<IncludedElement> includedElements, ElementCache<bool>& elementQualifiesForWritingToolsPreservationCache, ElementCache<RefPtr<Element>>& enclosingLinkCache, ElementCache<RefPtr<Element>>& enclosingListCache, NSMutableDictionary<NSAttributedStringKey, id> *attributes, ElementCache<RetainPtr<NSArray<NSTextList *>>>& textListsForListElements, const WeakHashSet<Node, WeakPtrImplWithEventTargetData>& clientPreservedNodes)
+static void updateAttributes(const Node* node, const RenderStyle& style, OptionSet<IncludedElement> includedElements, ElementCache<bool>& elementQualifiesForWritingToolsPreservationCache, ElementCache<RefPtr<Element>>& enclosingLinkCache, ElementCache<RefPtr<Element>>& enclosingListCache, NSMutableDictionary<NSAttributedStringKey, id> *attributes, ElementCache<RetainPtr<NSArray<NSTextList *>>>& textListsForListElements)
 {
 #if ENABLE(WRITING_TOOLS)
     if (includedElements.contains(IncludedElement::PreservedContent)) {
-        if (hasAncestorQualifyingForWritingToolsPreservation(protect(node->parentElement()).get(), elementQualifiesForWritingToolsPreservationCache, clientPreservedNodes))
+        if (hasAncestorQualifyingForWritingToolsPreservation(protect(node->parentElement()).get(), elementQualifiesForWritingToolsPreservationCache))
             [attributes setObject:@(1) forKey:WTWritingToolsPreservedAttributeName];
         else
             [attributes removeObjectForKey:WTWritingToolsPreservedAttributeName];
@@ -356,7 +345,6 @@ static void updateAttributes(const Node* node, const RenderStyle& style, OptionS
     UNUSED_PARAM(node);
     UNUSED_PARAM(includedElements);
     UNUSED_PARAM(elementQualifiesForWritingToolsPreservationCache);
-    UNUSED_PARAM(clientPreservedNodes);
 #endif
 
     if (style.textDecorationLineInEffect().hasUnderline())
@@ -460,7 +448,7 @@ static void updateAttributes(const Node* node, const RenderStyle& style, OptionS
 
 // This function uses TextIterator, which makes offsets in its result compatible with HTML editing.
 enum class ReplaceAllNoBreakSpaces : bool { No, Yes };
-static AttributedString editingAttributedStringInternal(const SimpleRange& range, TextIteratorBehaviors behaviors, OptionSet<IncludedElement> includedElements, ReplaceAllNoBreakSpaces replaceAllNoBreakSpaces, const WeakHashSet<Node, WeakPtrImplWithEventTargetData>& clientPreservedNodes = { })
+static AttributedString editingAttributedStringInternal(const SimpleRange& range, TextIteratorBehaviors behaviors, OptionSet<IncludedElement> includedElements, ReplaceAllNoBreakSpaces replaceAllNoBreakSpaces)
 {
     ElementCache<RefPtr<Element>> enclosingLinkCache;
     ElementCache<RefPtr<Element>> enclosingListCache;
@@ -496,7 +484,7 @@ static AttributedString editingAttributedStringInternal(const SimpleRange& range
         CheckedPtr renderer = node->renderer();
 
         if (renderer)
-            updateAttributes(node.get(), protect(renderer->style()), includedElements, elementQualifiesForWritingToolsPreservationCache, enclosingLinkCache, enclosingListCache, attributes.get(), textListsForListElements, clientPreservedNodes);
+            updateAttributes(node.get(), protect(renderer->style()), includedElements, elementQualifiesForWritingToolsPreservationCache, enclosingLinkCache, enclosingListCache, attributes.get(), textListsForListElements);
         else if (!includedElements.contains(IncludedElement::NonRenderedContent))
             continue;
 
@@ -521,9 +509,9 @@ static AttributedString editingAttributedStringInternal(const SimpleRange& range
     return AttributedString::fromNSAttributedString(WTF::move(string));
 }
 
-AttributedString editingAttributedString(const SimpleRange& range, OptionSet<IncludedElement> includedElements, const WeakHashSet<Node, WeakPtrImplWithEventTargetData>& clientPreservedNodes)
+AttributedString editingAttributedString(const SimpleRange& range, OptionSet<IncludedElement> includedElements)
 {
-    return editingAttributedStringInternal(range, { }, includedElements, ReplaceAllNoBreakSpaces::No, clientPreservedNodes);
+    return editingAttributedStringInternal(range, { }, includedElements, ReplaceAllNoBreakSpaces::No);
 }
 
 AttributedString editingAttributedStringReplacingNoBreakSpace(const SimpleRange& range, TextIteratorBehaviors behaviors, OptionSet<IncludedElement> includedElements)

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -5558,9 +5558,9 @@ void Page::initializeGamepadAccessForPageLoad()
 #endif // ENABLE(GAMEPAD)
 
 #if ENABLE(WRITING_TOOLS)
-void Page::willBeginWritingToolsSession(const std::optional<WritingTools::Session>& session, WeakHashSet<Node, WeakPtrImplWithEventTargetData>&& preservedNodes, CompletionHandler<void(const Vector<WritingTools::Context>&)>&& completionHandler)
+void Page::willBeginWritingToolsSession(const std::optional<WritingTools::Session>& session, CompletionHandler<void(const Vector<WritingTools::Context>&)>&& completionHandler)
 {
-    m_writingToolsController->willBeginWritingToolsSession(session, WTF::move(preservedNodes), WTF::move(completionHandler));
+    m_writingToolsController->willBeginWritingToolsSession(session, WTF::move(completionHandler));
 }
 
 void Page::didBeginWritingToolsSession(const WritingTools::Session& session, const Vector<WritingTools::Context>& contexts)

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1270,7 +1270,7 @@ public:
 #endif
 
 #if ENABLE(WRITING_TOOLS)
-    WEBCORE_EXPORT void willBeginWritingToolsSession(const std::optional<WritingTools::Session>&, WeakHashSet<Node, WeakPtrImplWithEventTargetData>&&, CompletionHandler<void(const Vector<WritingTools::Context>&)>&&);
+    WEBCORE_EXPORT void willBeginWritingToolsSession(const std::optional<WritingTools::Session>&, CompletionHandler<void(const Vector<WritingTools::Context>&)>&&);
 
     WEBCORE_EXPORT void didBeginWritingToolsSession(const WritingTools::Session&, const Vector<WritingTools::Context>&);
 

--- a/Source/WebCore/page/writing-tools/WritingToolsController.h
+++ b/Source/WebCore/page/writing-tools/WritingToolsController.h
@@ -32,7 +32,6 @@
 #import "WritingToolsTypes.h"
 #import <wtf/CheckedPtr.h>
 #import <wtf/TZoneMalloc.h>
-#import <wtf/WeakHashSet.h>
 #import <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -57,7 +56,7 @@ class WritingToolsController final : public CanMakeWeakPtr<WritingToolsControlle
 public:
     explicit WritingToolsController(Page&);
 
-    void willBeginWritingToolsSession(const std::optional<WritingTools::Session>&, WeakHashSet<Node, WeakPtrImplWithEventTargetData>&&, CompletionHandler<void(const Vector<WritingTools::Context>&)>&&);
+    void willBeginWritingToolsSession(const std::optional<WritingTools::Session>&, CompletionHandler<void(const Vector<WritingTools::Context>&)>&&);
 
     void didBeginWritingToolsSession(const WritingTools::Session&, const Vector<WritingTools::Context>&);
 
@@ -224,7 +223,6 @@ private:
 
     WeakPtr<Page> m_page;
     std::unique_ptr<State> m_state;
-    WeakHashSet<Node, WeakPtrImplWithEventTargetData> m_clientPreservedNodes;
 };
 
 } // namespace WebKit

--- a/Source/WebCore/page/writing-tools/WritingToolsController.mm
+++ b/Source/WebCore/page/writing-tools/WritingToolsController.mm
@@ -216,11 +216,9 @@ WritingToolsController::WritingToolsController(Page& page)
 
 #pragma mark - Delegate methods.
 
-void WritingToolsController::willBeginWritingToolsSession(const std::optional<WritingTools::Session>& session, WeakHashSet<Node, WeakPtrImplWithEventTargetData>&& preservedNodes, CompletionHandler<void(const Vector<WritingTools::Context>&)>&& completionHandler)
+void WritingToolsController::willBeginWritingToolsSession(const std::optional<WritingTools::Session>& session, CompletionHandler<void(const Vector<WritingTools::Context>&)>&& completionHandler)
 {
     RELEASE_LOG(WritingTools, "WritingToolsController::willBeginWritingToolsSession (%s)", session ? session->identifier.toString().utf8().data() : "");
-
-    m_clientPreservedNodes = WTF::move(preservedNodes);
 
     RefPtr document = this->document();
     if (!document) {
@@ -262,7 +260,7 @@ void WritingToolsController::willBeginWritingToolsSession(const std::optional<Wr
 
     auto selectedTextRange = document->selection().selection().firstRange();
 
-    auto attributedStringFromRange = editingAttributedString(*contextRange, allIncludedElements, m_clientPreservedNodes);
+    auto attributedStringFromRange = editingAttributedString(*contextRange, allIncludedElements);
     auto selectedTextCharacterRange = selectedTextRange ? characterRange(*contextRange, *selectedTextRange) : CharacterRange { };
 
     if (attributedStringFromRange.string.isEmpty())
@@ -558,7 +556,6 @@ void WritingToolsController::removeCompositionClearStateDeferralReason()
 
     state = nullptr;
     m_state = nullptr;
-    m_clientPreservedNodes = { };
 }
 
 void WritingToolsController::intelligenceTextAnimationsDidComplete()
@@ -1006,7 +1003,6 @@ template<>
 void WritingToolsController::didEndWritingToolsSession<WritingTools::Session::Type::Proofreading>(bool)
 {
     m_state = nullptr;
-    m_clientPreservedNodes = { };
 }
 
 template<>
@@ -1059,7 +1055,6 @@ void WritingToolsController::didEndWritingToolsSession(const WritingTools::Sessi
     // FIXME: Remove this branch once all composition types use the new effects system.
     if (session.type == WritingTools::Session::Type::Composition && session.compositionType == WritingTools::Session::CompositionType::SmartReply) {
         m_state = nullptr;
-        m_clientPreservedNodes = { };
         return;
     }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -2510,13 +2510,6 @@ static _WKSelectionAttributes NODELETE selectionAttributes(const WebKit::EditorS
 #endif
 }
 
-- (void)_clearWritingToolsPreservedNodes
-{
-#if ENABLE(WRITING_TOOLS)
-    _writingToolsPreservedNodes = nil;
-#endif
-}
-
 #pragma mark - WTWritingToolsDelegate conformance
 
 - (CocoaWritingToolsResultOptions)allowedWritingToolsResultOptions
@@ -2533,20 +2526,6 @@ static _WKSelectionAttributes NODELETE selectionAttributes(const WebKit::EditorS
     return WebKit::convertToCocoaWritingToolsBehavior(_page->writingToolsBehavior());
 }
 
-static std::optional<WebCore::JSHandleIdentifier> jsHandleIdentifierInFrame(const WebKit::WebFrameProxy& frame, _WKJSHandle *nodeHandle)
-{
-    if (!nodeHandle)
-        return std::nullopt;
-
-    auto handleInfo = nodeHandle->_ref->info();
-    if (RefPtr handleFrame = WebKit::WebFrameProxy::webFrame(handleInfo.frameInfo.frameID)) {
-        if (handleFrame->process().coreProcessIdentifier() == frame.process().coreProcessIdentifier())
-            return handleInfo.identifier;
-    }
-
-    return std::nullopt;
-}
-
 - (void)willBeginWritingToolsSession:(WTSession *)session forProofreadingReview:(BOOL)proofreadingReview requestContexts:(void (^)(NSArray<WTContext *> *))completion
 {
     auto webSession = WebKit::convertToWebSession(session);
@@ -2560,15 +2539,7 @@ static std::optional<WebCore::JSHandleIdentifier> jsHandleIdentifierInFrame(cons
     if (proofreadingReview && webSession)
         webSession->isForProofreadingReview = WebCore::WritingTools::IsForProofreadingReview::Yes;
 
-    Vector<WebCore::JSHandleIdentifier> preservedNodeIdentifiers;
-    if (RefPtr mainFrame = _page->mainFrame()) {
-        for (_WKJSHandle *handle in _writingToolsPreservedNodes.get()) {
-            if (auto identifier = jsHandleIdentifierInFrame(*mainFrame, handle))
-                preservedNodeIdentifiers.append(WTF::move(*identifier));
-        }
-    }
-
-    _page->willBeginWritingToolsSession(webSession, WTF::move(preservedNodeIdentifiers), [completion = makeBlockPtr(completion)](const auto& contextData) {
+    _page->willBeginWritingToolsSession(webSession, [completion = makeBlockPtr(completion)](const auto& contextData) {
         auto contexts = [NSMutableArray arrayWithCapacity:contextData.size()];
         for (auto& context : contextData) {
             auto platformContext = WebKit::convertToPlatformContext(context);
@@ -7245,15 +7216,6 @@ static RetainPtr<_WKTextExtractionResult> createEmptyTextExtractionResult()
     });
 }
 
-- (void)_addWritingToolsPreservedNodes:(NSArray<_WKJSHandle *> *)nodes
-{
-#if ENABLE(WRITING_TOOLS)
-    if (!_writingToolsPreservedNodes)
-        _writingToolsPreservedNodes = adoptNS([[NSMutableArray alloc] initWithCapacity:nodes.count]);
-    [_writingToolsPreservedNodes addObjectsFromArray:nodes];
-#endif
-}
-
 @end
 
 @implementation WKWebView (WKDeprecated)
@@ -7282,6 +7244,20 @@ static RetainPtr<_WKTextExtractionResult> createEmptyTextExtractionResult()
 @implementation WKWebView (WKTextExtraction)
 
 #if USE(APPLE_INTERNAL_SDK) || (!PLATFORM(WATCHOS) && !PLATFORM(APPLETV))
+
+static std::optional<WebCore::JSHandleIdentifier> jsHandleIdentifierInFrame(const WebKit::WebFrameProxy& frame, _WKJSHandle *nodeHandle)
+{
+    if (!nodeHandle)
+        return std::nullopt;
+
+    auto handleInfo = nodeHandle->_ref->info();
+    if (RefPtr handleFrame = WebKit::WebFrameProxy::webFrame(handleInfo.frameInfo.frameID)) {
+        if (handleFrame->process().coreProcessIdentifier() == frame.process().coreProcessIdentifier())
+            return handleInfo.identifier;
+    }
+
+    return std::nullopt;
+}
 
 static Vector<WebCore::JSHandleIdentifier> extractHandleIdentifiersOfNodesToSkip(Ref<WebKit::WebFrameProxy>&& frame, _WKTextExtractionConfiguration *configuration)
 {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -189,7 +189,6 @@ enum class PreferSolidColorHardPocketReason : uint8_t {
 @class WKTextExtractionItem;
 @class WKWebViewContentProviderRegistry;
 @class _WKFrameHandle;
-@class _WKJSHandle;
 @class _WKWarningView;
 
 #if ENABLE(WEB_AUTHN)
@@ -354,8 +353,6 @@ struct PerWebProcessState {
     NSUInteger _partialIntelligenceTextAnimationCount;
     BOOL _writingToolsTextReplacementsFinished;
     BOOL _activeWritingToolsSessionIsForProofreadingReview;
-
-    RetainPtr<NSMutableArray<_WKJSHandle *>> _writingToolsPreservedNodes;
 #endif
 
 #if ENABLE(SCREEN_TIME)
@@ -603,8 +600,6 @@ struct PerWebProcessState {
 
 - (void)_addTextAnimationForAnimationID:(NSUUID *)uuid withData:(const WebCore::TextAnimationData&)styleData;
 - (void)_removeTextAnimationForAnimationID:(NSUUID *)uuid;
-
-- (void)_clearWritingToolsPreservedNodes;
 
 #endif
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -666,8 +666,6 @@ typedef NS_OPTIONS(NSUInteger, _WKWebViewDataType) {
 - (void)_extractDebugTextWithConfiguration:(_WKTextExtractionConfiguration *)configuration completionHandler:(WK_SWIFT_UI_ACTOR void(^)(_WKTextExtractionResult *))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) NS_SWIFT_NAME(_extractDebugText(with:completionHandler:));
 - (void)_performInteraction:(_WKTextExtractionInteraction *)interaction completionHandler:(WK_SWIFT_UI_ACTOR void(^)(_WKTextExtractionInteractionResult *))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) NS_SWIFT_NAME(_performInteraction(_:completionHandler:));
 
-- (void)_addWritingToolsPreservedNodes:(NSArray<_WKJSHandle *> *)nodes WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
-
 #if !TARGET_OS_TV && !TARGET_OS_WATCH
 @property (nonatomic, strong, setter=_setWebViewInformation:) id _webViewInformation WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 #endif

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -880,10 +880,6 @@ static WebCore::Color scrollViewBackgroundColor(WKWebView *webView, AllowPageBac
     [self _clearTextExtractionFilterCache];
 #endif
 
-#if ENABLE(WRITING_TOOLS)
-    [self _clearWritingToolsPreservedNodes];
-#endif
-
     if (_gestureController)
         protect(_gestureController)->disconnectFromProcess();
 

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -1436,9 +1436,9 @@ WebCore::WritingTools::Behavior WebPageProxy::writingToolsBehavior() const
     return WebCore::WritingTools::Behavior::Limited;
 }
 
-void WebPageProxy::willBeginWritingToolsSession(const std::optional<WebCore::WritingTools::Session>& session, Vector<WebCore::JSHandleIdentifier>&& preservedNodeIdentifiers, CompletionHandler<void(const Vector<WebCore::WritingTools::Context>&)>&& completionHandler)
+void WebPageProxy::willBeginWritingToolsSession(const std::optional<WebCore::WritingTools::Session>& session, CompletionHandler<void(const Vector<WebCore::WritingTools::Context>&)>&& completionHandler)
 {
-    protect(legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebPage::WillBeginWritingToolsSession(session, WTF::move(preservedNodeIdentifiers)), WTF::move(completionHandler), webPageIDInMainFrameProcess());
+    protect(legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebPage::WillBeginWritingToolsSession(session), WTF::move(completionHandler), webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::didBeginWritingToolsSession(const WebCore::WritingTools::Session& session, const Vector<WebCore::WritingTools::Context>& contexts)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -298,7 +298,6 @@ struct FrameIdentifierType;
 struct FrameTreeSyncSerializationData;
 struct GrammarDetail;
 struct HTMLModelElementCamera;
-struct JSHandleIdentifierType;
 struct ImageBufferParameters;
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
 struct InheritedFrameState;
@@ -417,7 +416,6 @@ using FloatBoxExtent = RectEdges<float>;
 using FrameIdentifier = ObjectIdentifier<FrameIdentifierType>;
 using IntDegrees = int32_t;
 using HTMLMediaElementIdentifier = ObjectIdentifier<MediaPlayerClientIdentifierType>;
-using JSHandleIdentifier = ProcessQualified<ObjectIdentifier<JSHandleIdentifierType>>;
 using LayerHostingContextIdentifier = ObjectIdentifier<LayerHostingContextIdentifierType>;
 using MediaControlsContextMenuItemID = uint64_t;
 using MediaKeySystemRequestIdentifier = ObjectIdentifier<MediaKeySystemRequestIdentifierType>;
@@ -2772,7 +2770,7 @@ public:
 
     WebCore::WritingTools::Behavior NODELETE writingToolsBehavior() const;
 
-    void willBeginWritingToolsSession(const std::optional<WebCore::WritingTools::Session>&, Vector<WebCore::JSHandleIdentifier>&& preservedNodeIdentifiers, CompletionHandler<void(const Vector<WebCore::WritingTools::Context>&)>&&);
+    void willBeginWritingToolsSession(const std::optional<WebCore::WritingTools::Session>&, CompletionHandler<void(const Vector<WebCore::WritingTools::Context>&)>&&);
 
     void didBeginWritingToolsSession(const WebCore::WritingTools::Session&, const Vector<WebCore::WritingTools::Context>&);
 

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -385,10 +385,6 @@ void PageClientImpl::didCommitLoadForMainFrame(const String& mimeType, bool useC
     [webView _clearTextExtractionFilterCache];
 #endif
 
-#if ENABLE(WRITING_TOOLS)
-    [webView _clearWritingToolsPreservedNodes];
-#endif
-
 #if ENABLE(SYSTEM_TEXT_EXTRACTION)
     if (protect(*[webView _page])->preferences().systemTextExtractionEnabled())
         [webView _addTextExtractionAnnotation];

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -323,10 +323,6 @@ void PageClientImpl::didCommitLoadForMainFrame(const String&, bool)
     [webView() _clearTextExtractionFilterCache];
 #endif
 
-#if ENABLE(WRITING_TOOLS)
-    [webView() _clearWritingToolsPreservedNodes];
-#endif
-
 #if ENABLE(SYSTEM_TEXT_EXTRACTION)
     if (impl->page().preferences().systemTextExtractionEnabled())
         [webView() _addTextExtractionAnnotation];

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -1470,10 +1470,6 @@ void WebViewImpl::handleProcessSwapOrExit()
     hideDOMPasteMenuWithResult(WebCore::DOMPasteAccessResponse::DeniedForGesture);
 
     [m_view.get() _updateFixedContainerEdges:FixedContainerEdges { }];
-
-#if ENABLE(WRITING_TOOLS)
-    [m_view.get() _clearWritingToolsPreservedNodes];
-#endif
 }
 
 void WebViewImpl::processWillSwap()

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -106,7 +106,6 @@
 #import <WebCore/HitTestResult.h>
 #import <WebCore/ImageOverlay.h>
 #import <WebCore/ImageUtilities.h>
-#import <WebCore/JSNode.h>
 #import <WebCore/LegacyWebArchive.h>
 #import <WebCore/LocalFrameInlines.h>
 #import <WebCore/LocalFrameView.h>
@@ -1277,19 +1276,9 @@ void WebPage::setDisplayCaptureEnvironment(const String& environment)
 #endif
 
 #if ENABLE(WRITING_TOOLS)
-void WebPage::willBeginWritingToolsSession(const std::optional<WebCore::WritingTools::Session>& session, Vector<WebCore::JSHandleIdentifier>&& preservedNodeIdentifiers, CompletionHandler<void(const Vector<WebCore::WritingTools::Context>&)>&& completionHandler)
+void WebPage::willBeginWritingToolsSession(const std::optional<WebCore::WritingTools::Session>& session, CompletionHandler<void(const Vector<WebCore::WritingTools::Context>&)>&& completionHandler)
 {
-    WeakHashSet<Node, WeakPtrImplWithEventTargetData> preservedNodes;
-    for (auto& identifier : preservedNodeIdentifiers) {
-        auto* object = WebKitJSHandle::objectForIdentifier(identifier);
-        if (!object)
-            continue;
-
-        if (auto* jsNode = JSC::jsDynamicCast<JSNode*>(object))
-            preservedNodes.add(protect(jsNode->wrapped()));
-    }
-
-    protect(corePage())->willBeginWritingToolsSession(session, WTF::move(preservedNodes), WTF::move(completionHandler));
+    protect(corePage())->willBeginWritingToolsSession(session, WTF::move(completionHandler));
 }
 
 void WebPage::didBeginWritingToolsSession(const WebCore::WritingTools::Session& session, const Vector<WebCore::WritingTools::Context>& contexts)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -66,7 +66,6 @@
 #include <WebCore/UserContentTypes.h>
 #include <WebCore/UserScriptTypes.h>
 #include <WebCore/WebCoreKeyboardUIMode.h>
-#include <WebCore/WebKitJSHandle.h>
 #include <memory>
 #include <pal/HysteresisActivity.h>
 #include <wtf/CallbackAggregator.h>
@@ -2681,7 +2680,7 @@ private:
     void frameWasFocusedInAnotherProcess(std::optional<WebCore::FrameIdentifier>&&);
 
 #if ENABLE(WRITING_TOOLS)
-    void willBeginWritingToolsSession(const std::optional<WebCore::WritingTools::Session>&, Vector<WebCore::JSHandleIdentifier>&& preservedNodeIdentifiers, CompletionHandler<void(const Vector<WebCore::WritingTools::Context>&)>&&);
+    void willBeginWritingToolsSession(const std::optional<WebCore::WritingTools::Session>&, CompletionHandler<void(const Vector<WebCore::WritingTools::Context>&)>&&);
 
     void didBeginWritingToolsSession(const WebCore::WritingTools::Session&, const Vector<WebCore::WritingTools::Context>&);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -878,7 +878,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
 #endif
 
 #if ENABLE(WRITING_TOOLS)
-    WillBeginWritingToolsSession(std::optional<WebCore::WritingTools::Session> session, Vector<WebCore::JSHandleIdentifier> preservedNodeIdentifiers) -> (Vector<WebCore::WritingTools::Context> contexts)
+    WillBeginWritingToolsSession(std::optional<WebCore::WritingTools::Session> session) -> (Vector<WebCore::WritingTools::Context> contexts)
 
     DidBeginWritingToolsSession(struct WebCore::WritingTools::Session session, Vector<WebCore::WritingTools::Context> contexts)
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
@@ -46,15 +46,11 @@
 #import <WebCore/ColorCocoa.h>
 #import <WebCore/FloatRect.h>
 #import <WebCore/IntRect.h>
-#import <WebKit/WKContentWorldPrivate.h>
-#import <WebKit/WKJSHandle.h>
 #import <WebKit/WKMenuItemIdentifiersPrivate.h>
 #import <WebKit/WKWebViewConfigurationPrivate.h>
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/WKWebViewPrivateForTesting.h>
 #import <WebKit/WebKit.h>
-#import <WebKit/_WKContentWorldConfiguration.h>
-#import <WebKit/_WKJSHandle.h>
 #import <WebKit/_WKProcessPoolConfiguration.h>
 #import <WebKit/_WKTextPreview.h>
 #import <pal/spi/cocoa/WritingToolsSPI.h>
@@ -4533,57 +4529,6 @@ TEST(WritingToolsContextGeneration, ContextWithStyledContentChildrenInList)
     } };
 
     runContextGenerationTest(html, expected);
-}
-
-TEST(WritingTools, WritingToolsPreservedNodesFromClient)
-{
-    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
-
-    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p>Hello world</p><div id='myPreservedNode'>Do not rewrite</div><p>Goodbye</p></body>"]);
-    [webView focusDocumentBodyAndSelectAll];
-
-    RetainPtr worldConfiguration = adoptNS([_WKContentWorldConfiguration new]);
-    [worldConfiguration setJSHandleCreationEnabled:YES];
-    RetainPtr world = [WKContentWorld _worldWithConfiguration:worldConfiguration.get()];
-
-    RetainPtr handle = [webView querySelector:@"#myPreservedNode" frame:nil world:world.get()];
-    EXPECT_NOT_NULL(handle);
-
-    [webView _addWritingToolsPreservedNodes:@[ handle.get() ]];
-
-    __block bool finished = false;
-    [[webView writingToolsDelegate] willBeginWritingToolsSession:session.get() requestContexts:^(NSArray<WTContext *> *contexts) {
-        EXPECT_EQ(1UL, contexts.count);
-
-        EXPECT_WK_STREQ(@"Hello world\n\nDo not rewrite\nGoodbye", contexts.firstObject.attributedText.string);
-
-        __block size_t i = 0;
-        [contexts.firstObject.attributedText enumerateAttribute:WTWritingToolsPreservedAttributeName inRange:NSMakeRange(0, [contexts.firstObject.attributedText length]) options:0 usingBlock:^(id value, NSRange attributeRange, BOOL *stop) {
-            switch (i) {
-            case 0: // "Hello world".
-                EXPECT_NULL(value);
-                break;
-
-            case 1: // "Do not rewrite".
-                EXPECT_EQ([value integerValue], 1);
-                break;
-
-            case 2: // "Goodbye".
-                EXPECT_NULL(value);
-                break;
-
-            default:
-                ASSERT_NOT_REACHED();
-                break;
-            }
-
-            ++i;
-        }];
-
-        finished = true;
-    }];
-
-    TestWebKitAPI::Util::run(&finished);
 }
 
 #endif


### PR DESCRIPTION
#### 3bba08a545b227e1add678c244fd50efbe4da561
<pre>
Unreviewed, reverting 309595@main (552320967679)
<a href="https://bugs.webkit.org/show_bug.cgi?id=310356">https://bugs.webkit.org/show_bug.cgi?id=310356</a>
<a href="https://rdar.apple.com/172999880">rdar://172999880</a>

REGRESSION(309595@main): Use of undeclared identifier &apos;jsHandleIdentifierInFrame&apos;

Reverted change:

    [Writing Tools] Add a way for clients to preserve specific DOM nodes when invoking writing tools
    <a href="https://bugs.webkit.org/show_bug.cgi?id=310232">https://bugs.webkit.org/show_bug.cgi?id=310232</a>
    <a href="https://rdar.apple.com/166250361">rdar://166250361</a>
    309595@main (552320967679)

Canonical link: <a href="https://commits.webkit.org/309614@main">https://commits.webkit.org/309614@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2804fc7044f480634ff7dd25a3ceb36357b5f6d6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151226 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23989 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/17559 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159955 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104662 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153099 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/24420 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24234 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/116758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/82890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154186 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/24420 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/135691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/97479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/24420 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/15925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/7800 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/24420 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/13608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162427 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5552 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/15179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/124766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23790 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/19975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/124954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23780 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/135405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80256 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23234 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/20023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/12170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23390 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87684 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23102 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23254 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23156 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->