### PR TITLE
TextBreakIteratorCFStringTokenizer::setText() uses wrong range when prior context is non-empty

### DIFF
--- a/Source/WTF/wtf/text/cf/TextBreakIteratorCFStringTokenizer.h
+++ b/Source/WTF/wtf/text/cf/TextBreakIteratorCFStringTokenizer.h
@@ -86,7 +86,7 @@ public:
         auto stringObject = createString(string, priorContext);
         m_stringLength = string.length();
         m_priorContextLength = priorContext.length();
-        CFStringTokenizerSetString(m_stringTokenizer.get(), stringObject.get(), CFRangeMake(0, m_stringLength));
+        CFStringTokenizerSetString(m_stringTokenizer.get(), stringObject.get(), CFRangeMake(0, m_stringLength + m_priorContextLength));
     }
 
     std::optional<unsigned> preceding(unsigned location) const

--- a/Tools/TestWebKitAPI/Tests/WTF/TextBreakIterator.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/TextBreakIterator.cpp
@@ -547,6 +547,45 @@ TEST(WTF_TextBreakIterator, CFBackwardDeletion)
     }
 }
 
+TEST(WTF_TextBreakIterator, CFStringTokenizerSetTextWithPriorContext)
+{
+    // Tests that setText() correctly accounts for prior context length in the
+    // tokenizer range. Previously, setText() passed CFRangeMake(0, m_stringLength)
+    // instead of CFRangeMake(0, m_stringLength + m_priorContextLength), which
+    // truncated the end of the string when prior context was non-empty.
+    auto string = u"some words here"_str;
+    WTF::TextBreakIteratorCF iterator(string, { }, WTF::TextBreakIteratorCF::Mode::LineBreak, AtomString("en_US"_str));
+
+    // Now call setText with a non-empty prior context, exercising the bug fix.
+    auto context = u"hello "_str;
+    auto newString = u"world test"_str;
+    iterator.setText(newString, context.span16());
+
+    // "hello world test" has line breaks after "hello " and "world ".
+    // Relative to newString, breaks are at 6 and 10 (end).
+    auto result1 = iterator.following(0);
+    ASSERT_TRUE(result1.has_value());
+    EXPECT_EQ(*result1, 6U);
+
+    // following(6) should find the next break at 10 (end of string).
+    // With the bug, position 6 + priorContextLength(6) = 12 in the combined string
+    // would be outside the truncated range, causing this to fail.
+    auto result2 = iterator.following(6);
+    ASSERT_TRUE(result2.has_value());
+    EXPECT_EQ(*result2, 10U);
+
+    // following() at end of string should return nullopt.
+    EXPECT_FALSE(iterator.following(newString.length()).has_value());
+
+    // isBoundary() at end of string should return true.
+    EXPECT_TRUE(iterator.isBoundary(newString.length()));
+
+    // preceding() from end of string should find the last break.
+    auto result3 = iterator.preceding(newString.length());
+    ASSERT_TRUE(result3.has_value());
+    EXPECT_EQ(*result3, 6U);
+}
+
 #endif // USE(CF)
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 7bea18c41ee9a0ddcf37d41b197041b515d82032
<pre>
TextBreakIteratorCFStringTokenizer::setText() uses wrong range when prior context is non-empty
<a href="https://bugs.webkit.org/show_bug.cgi?id=310363">https://bugs.webkit.org/show_bug.cgi?id=310363</a>

Reviewed by Darin Adler.

TextBreakIteratorCFStringTokenizer::setText() passed CFRangeMake(0, m_stringLength)
to CFStringTokenizerSetString(), but the string object includes the
prior context prepended before the actual content. The correct range is
CFRangeMake(0, m_stringLength + m_priorContextLength), as the
constructor already does. With the shorter range, the tokenizer only
operated on the prior context plus the beginning of the actual string,
cutting off characters at the end. This caused following(), preceding(),
and isBoundary() to return incorrect results near the end of the string
whenever setText() was called with a non-empty prior context.

Claude helped me write the API test for this.

Test: Tools/TestWebKitAPI/Tests/WTF/TextBreakIterator.cpp

* Source/WTF/wtf/text/cf/TextBreakIteratorCFStringTokenizer.h:
(WTF::TextBreakIteratorCFStringTokenizer::setText):
* Tools/TestWebKitAPI/Tests/WTF/TextBreakIterator.cpp:
(TestWebKitAPI::TEST(WTF_TextBreakIterator, CFStringTokenizerSetTextWithPriorContext)):

Canonical link: <a href="https://commits.webkit.org/309678@main">https://commits.webkit.org/309678@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d664a90c9b22c979802381f441b2e75f276ae59

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151242 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24005 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17575 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159971 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104678 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153115 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24436 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24251 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116769 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82903 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154202 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18898 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135702 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97490 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17991 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15939 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7816 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/143226 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127609 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13619 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162443 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/12041 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5568 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15190 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124778 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23806 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19989 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124966 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33938 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23796 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135416 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80277 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20033 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12181 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/182851 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23406 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87700 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46647 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23118 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23270 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23172 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->