### PR TITLE
Add fast path to String(CFStringRef) constructor

### DIFF
--- a/Source/WTF/wtf/text/cf/StringCF.cpp
+++ b/Source/WTF/wtf/text/cf/StringCF.cpp
@@ -43,6 +43,18 @@ String::String(CFStringRef str)
         return;
     }
 
+    // Fast path: check if CF exposes its internal buffer directly.
+    if (auto span = CFStringGetLatin1CStringSpan(str); span.data()) {
+        m_impl = StringImpl::create(span);
+        return;
+    }
+
+    if (auto span = CFStringGetCharactersSpan(str); span.data()) {
+        m_impl = StringImpl::create8BitIfPossible(span);
+        return;
+    }
+
+    // Slow path: try converting to Latin1, then fall back to UTF-16.
     {
         StringBuffer<Latin1Character> buffer(size);
         CFIndex usedBufLen;

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -226,6 +226,7 @@
 		44AC8BC621D0245A00CAFB34 /* RetainPtr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC029B161486AD6400817DA9 /* RetainPtr.cpp */; };
 		44B28A0528D18AD20010172C /* RetainPtrHashing.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C0991C50143C7D68007998F2 /* RetainPtrHashing.cpp */; };
 		44B28A0728D18ADA0010172C /* VectorCF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 44B289FC28D18AAA0010172C /* VectorCF.cpp */; };
+		BE606FF491F5983FDE2D79A8 /* StringCF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0B2C1116CEC224BD5FD603A6 /* StringCF.cpp */; };
 		44CDE4D426EE6E4A009F6ACB /* TypeCastsCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 44CDE4D326EE6E41009F6ACB /* TypeCastsCocoa.mm */; };
 		44CF31FD249941E8009CB6CB /* ContextMenuAction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 44CF31FB24993F66009CB6CB /* ContextMenuAction.cpp */; };
 		44D3F8402BE1A74200BE0218 /* XMLParsing.mm in Sources */ = {isa = PBXBuildFile; fileRef = 44D3F8382BE1A6BE00BE0218 /* XMLParsing.mm */; };
@@ -2961,6 +2962,7 @@
 		44A622C114A0E2B60048515B /* WTFTestUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WTFTestUtilities.h; sourceTree = "<group>"; };
 		44ABED4A2DA6E46600F472EF /* WKFragmentDirectiveGeneration.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKFragmentDirectiveGeneration.mm; sourceTree = "<group>"; };
 		44B289FC28D18AAA0010172C /* VectorCF.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VectorCF.cpp; sourceTree = "<group>"; };
+		0B2C1116CEC224BD5FD603A6 /* StringCF.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StringCF.cpp; sourceTree = "<group>"; };
 		44C2FBE125E7592C00ABC72F /* WKAppHighlights.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKAppHighlights.mm; sourceTree = "<group>"; };
 		44CDE4D326EE6E41009F6ACB /* TypeCastsCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = TypeCastsCocoa.mm; sourceTree = "<group>"; };
 		44CF31FB24993F66009CB6CB /* ContextMenuAction.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ContextMenuAction.cpp; sourceTree = "<group>"; };
@@ -7024,6 +7026,7 @@
 			children = (
 				BC029B161486AD6400817DA9 /* RetainPtr.cpp */,
 				C0991C50143C7D68007998F2 /* RetainPtrHashing.cpp */,
+				0B2C1116CEC224BD5FD603A6 /* StringCF.cpp */,
 				44B289FC28D18AAA0010172C /* VectorCF.cpp */,
 			);
 			path = cf;
@@ -7827,6 +7830,7 @@
 				7BF5017828E55F7A0008BB16 /* StackTraceTest.cpp in Sources */,
 				FE2BCDC72470FDA300DEC33B /* StdLibExtrasTests.cpp in Sources */,
 				7C83DF321D0A590C00FEBCF3 /* StringBuilder.cpp in Sources */,
+				BE606FF491F5983FDE2D79A8 /* StringCF.cpp in Sources */,
 				E3DE273C28A8D67800873DF2 /* StringCommon.cpp in Sources */,
 				7CD4C26E1E2C0E6E00929470 /* StringConcatenate.cpp in Sources */,
 				7C83DF361D0A590C00FEBCF3 /* StringHasher.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WTF/cf/StringCF.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/cf/StringCF.cpp
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "Test.h"
+#include <CoreFoundation/CoreFoundation.h>
+#include <wtf/RetainPtr.h>
+#include <wtf/Vector.h>
+#include <wtf/text/WTFString.h>
+
+namespace TestWebKitAPI {
+
+TEST(StringCF, ConstructFromNull)
+{
+    String string(static_cast<CFStringRef>(nullptr));
+    EXPECT_TRUE(string.isNull());
+}
+
+TEST(StringCF, ConstructFromEmpty)
+{
+    String string(CFSTR(""));
+    EXPECT_FALSE(string.isNull());
+    EXPECT_TRUE(string.isEmpty());
+    EXPECT_TRUE(string.is8Bit());
+}
+
+TEST(StringCF, ConstructFromLatin1)
+{
+    String string(CFSTR("Hello, world!"));
+    EXPECT_EQ(string.length(), 13u);
+    EXPECT_TRUE(string.is8Bit());
+    EXPECT_EQ(string, "Hello, world!"_s);
+}
+
+TEST(StringCF, ConstructFromLatin1WithHighBytes)
+{
+    // Create a CFString with Latin-1 characters above ASCII range (e.g. U+00E9 = é).
+    const uint8_t latin1Bytes[] = { 'r', 0xE9, 's', 'u', 'm', 0xE9 }; // "résumé" in Latin-1
+    auto cfString = adoptCF(CFStringCreateWithBytes(kCFAllocatorDefault, latin1Bytes, sizeof(latin1Bytes), kCFStringEncodingISOLatin1, false));
+
+    String string(cfString.get());
+    EXPECT_EQ(string.length(), 6u);
+    EXPECT_FALSE(string.isNull());
+    EXPECT_EQ(string, String::fromUTF8("résumé"));
+}
+
+TEST(StringCF, ConstructFromUTF16WithLatin1Characters)
+{
+    // Create a long CFString from UTF-16 characters that are all in the Latin-1 range.
+    // Use a long string so CF is likely to expose its internal UTF-16 buffer via
+    // CFStringGetCharactersSpan, exercising the create8BitIfPossible narrowing path.
+    Vector<char16_t> characters(4096, 'A');
+    auto cfString = adoptCF(CFStringCreateWithCharacters(kCFAllocatorDefault, reinterpret_cast<const UniChar*>(characters.span().data()), characters.size()));
+
+    String string(cfString.get());
+    EXPECT_EQ(string.length(), 4096u);
+    EXPECT_TRUE(string.is8Bit());
+    EXPECT_EQ(string, String(Vector<Latin1Character>(4096, 'A')));
+}
+
+TEST(StringCF, ConstructFromUTF16WithHighLatin1Characters)
+{
+    // Create a CFString from UTF-16 characters that include high Latin-1 chars (U+00E9).
+    const char16_t characters[] = { 'r', 0x00E9, 's', 'u', 'm', 0x00E9 }; // "résumé"
+    auto cfString = adoptCF(CFStringCreateWithCharacters(kCFAllocatorDefault, reinterpret_cast<const UniChar*>(characters), std::size(characters)));
+
+    String string(cfString.get());
+    EXPECT_EQ(string.length(), 6u);
+    EXPECT_FALSE(string.isNull());
+    EXPECT_EQ(string, String::fromUTF8("résumé"));
+}
+
+TEST(StringCF, ConstructFromUTF16WithNonLatin1Characters)
+{
+    // Create a CFString with characters outside Latin-1 range (e.g. U+4E16 = 世, U+754C = 界).
+    const char16_t characters[] = { 0x4E16, 0x754C }; // "世界"
+    auto cfString = adoptCF(CFStringCreateWithCharacters(kCFAllocatorDefault, reinterpret_cast<const UniChar*>(characters), std::size(characters)));
+
+    String string(cfString.get());
+    EXPECT_EQ(string.length(), 2u);
+    EXPECT_FALSE(string.is8Bit());
+    EXPECT_EQ(string[0], 0x4E16);
+    EXPECT_EQ(string[1], 0x754C);
+}
+
+TEST(StringCF, ConstructFromUTF16MixedLatin1AndNonLatin1)
+{
+    // Mix of Latin-1 and non-Latin-1 characters — should stay 16-bit.
+    const char16_t characters[] = { 'H', 'i', 0x4E16 }; // "Hi世"
+    auto cfString = adoptCF(CFStringCreateWithCharacters(kCFAllocatorDefault, reinterpret_cast<const UniChar*>(characters), std::size(characters)));
+
+    String string(cfString.get());
+    EXPECT_EQ(string.length(), 3u);
+    EXPECT_FALSE(string.is8Bit());
+    EXPECT_EQ(string[0], 'H');
+    EXPECT_EQ(string[1], 'i');
+    EXPECT_EQ(string[2], 0x4E16);
+}
+
+TEST(StringCF, RoundTrip)
+{
+    String original("WebKit"_s);
+    auto cfString = original.createCFString();
+    String roundTripped(cfString.get());
+    EXPECT_EQ(original, roundTripped);
+    EXPECT_TRUE(roundTripped.is8Bit());
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### e1702a8a40ee43d64f5e3e9718ac8b2b7659f96e
<pre>
Add fast path to String(CFStringRef) constructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=310364">https://bugs.webkit.org/show_bug.cgi?id=310364</a>

Reviewed by Darin Adler.

The optimization adds two fast paths before the existing slow path:
1. CFStringGetLatin1CStringSpan — If CF&apos;s internal storage is already
   Latin1, this returns a direct pointer in O(1). We just StringImpl::create()
   from it (a memcpy), avoiding the CFStringGetBytes per-character
   conversion overhead.
2. CFStringGetCharactersSpan — Similarly, if the internal storage is
   UTF-16 and CF exposes it, we copy directly, avoiding the unnecessary
   Latin1 conversion attempt followed by the CFStringCopyCharactersSpan
   fallback.

This optimization is copied from AtomStringImplCF.cpp where we do the
exact same thing.

On a microbenchmark, I see neutral results on Latin1 strings but a
1.4-2.6x speedup with UTF-16 strings.

* Source/WTF/wtf/text/cf/StringCF.cpp:
(WTF::String::String):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WTF/cf/StringCF.cpp: Added.
(TestWebKitAPI::TEST(StringCF, ConstructFromNull)):
(TestWebKitAPI::TEST(StringCF, ConstructFromEmpty)):
(TestWebKitAPI::TEST(StringCF, ConstructFromLatin1)):
(TestWebKitAPI::TEST(StringCF, ConstructFromLatin1WithHighBytes)):
(TestWebKitAPI::TEST(StringCF, ConstructFromUTF16WithLatin1Characters)):
(TestWebKitAPI::TEST(StringCF, ConstructFromUTF16WithHighLatin1Characters)):
(TestWebKitAPI::TEST(StringCF, ConstructFromUTF16WithNonLatin1Characters)):
(TestWebKitAPI::TEST(StringCF, ConstructFromUTF16MixedLatin1AndNonLatin1)):
(TestWebKitAPI::TEST(StringCF, RoundTrip)):

Canonical link: <a href="https://commits.webkit.org/309697@main">https://commits.webkit.org/309697@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b81597e7a5a8aad9057b33a05090b87733c6864

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151500 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24265 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17846 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160232 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104938 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/617ccfb0-d60e-47fe-91a7-888cf8967951) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153374 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24696 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24567 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/116990 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/be99ec40-436f-4f1e-a4a0-f0ddd12f888a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154460 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135941 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97708 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bc11cc94-0222-43eb-8a78-2f71e6911b9e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18227 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16172 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8076 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/143497 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/127854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13846 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162703 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/12301 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5836 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15435 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/125007 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24066 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20230 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125191 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33952 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24058 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135642 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80608 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20248 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12417 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/183109 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23667 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87979 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46694 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23377 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23531 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23433 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->