### PR TITLE
Make :active, :focus-within, and :hover account for top layer

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/active-toplayer-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/active-toplayer-001-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Clicking inside a modal dialog should not propagate :active beyond the dialog.
+PASS Clicking inside a popover should not propagate :active beyond the popover.
+PASS With nested top layer elements, :active should stop at the innermost top layer boundary.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/active-toplayer-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/active-toplayer-001.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Selectors: :active should not propagate past top layer elements</title>
+<link rel="help" href="https://drafts.csswg.org/selectors/#the-active-pseudo">
+<link rel="help" href="https://drafts.csswg.org/css-position-4/#top-layer">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<style>
+  dialog::backdrop {
+    background: transparent;
+  }
+</style>
+
+<div id="outer">
+  <dialog id="dialog">
+    <div id="inner">click target</div>
+  </dialog>
+</div>
+
+<div id="popoverOuter">
+  <div id="popover" popover>
+    <div id="popoverInner">click target</div>
+  </div>
+</div>
+
+<div id="nestOuter">
+  <dialog id="nestDialog">
+    <div id="nestPopover" popover>
+      <div id="nestInner">click target</div>
+    </div>
+  </dialog>
+</div>
+
+<script>
+function captureActiveState(elements, target) {
+  return new Promise(resolve => {
+    target.addEventListener('mousedown', () => {
+      const result = {};
+      for (const [name, el] of Object.entries(elements)) {
+        result[name] = el.matches(':active');
+      }
+      resolve(result);
+    }, {once: true});
+  });
+}
+
+promise_test(async t => {
+  const dialog = document.getElementById('dialog');
+  dialog.showModal();
+  t.add_cleanup(() => dialog.close());
+
+  const inner = document.getElementById('inner');
+  const outer = document.getElementById('outer');
+
+  const statePromise = captureActiveState({
+    inner, dialog, outer, body: document.body
+  }, inner);
+
+  await new test_driver.Actions()
+    .pointerMove(1, 1, {origin: inner})
+    .pointerDown()
+    .pointerUp()
+    .send();
+
+  const state = await statePromise;
+  assert_true(state.inner, 'inner element should match :active');
+  assert_true(state.dialog, 'dialog (top layer) should match :active');
+  assert_false(state.outer, 'ancestor outside top layer should not match :active');
+  assert_false(state.body, 'body should not match :active');
+}, 'Clicking inside a modal dialog should not propagate :active beyond the dialog.');
+
+promise_test(async t => {
+  const popover = document.getElementById('popover');
+  popover.showPopover();
+  t.add_cleanup(() => popover.hidePopover());
+
+  const popoverInner = document.getElementById('popoverInner');
+  const popoverOuter = document.getElementById('popoverOuter');
+
+  const statePromise = captureActiveState({
+    popoverInner, popover, popoverOuter, body: document.body
+  }, popoverInner);
+
+  await new test_driver.Actions()
+    .pointerMove(1, 1, {origin: popoverInner})
+    .pointerDown()
+    .pointerUp()
+    .send();
+
+  const state = await statePromise;
+  assert_true(state.popoverInner, 'inner element should match :active');
+  assert_true(state.popover, 'popover (top layer) should match :active');
+  assert_false(state.popoverOuter, 'ancestor outside top layer should not match :active');
+  assert_false(state.body, 'body should not match :active');
+}, 'Clicking inside a popover should not propagate :active beyond the popover.');
+
+promise_test(async t => {
+  const nestDialog = document.getElementById('nestDialog');
+  nestDialog.showModal();
+  t.add_cleanup(() => nestDialog.close());
+
+  const nestPopover = document.getElementById('nestPopover');
+  nestPopover.showPopover();
+  t.add_cleanup(() => nestPopover.hidePopover());
+
+  const nestInner = document.getElementById('nestInner');
+  const nestOuter = document.getElementById('nestOuter');
+
+  const statePromise = captureActiveState({
+    nestInner, nestPopover, nestDialog, nestOuter, body: document.body
+  }, nestInner);
+
+  await new test_driver.Actions()
+    .pointerMove(1, 1, {origin: nestInner})
+    .pointerDown()
+    .pointerUp()
+    .send();
+
+  const state = await statePromise;
+  assert_true(state.nestInner, 'inner element should match :active');
+  assert_true(state.nestPopover, 'popover (innermost top layer) should match :active');
+  assert_false(state.nestDialog, 'dialog (outer top layer) should not match :active');
+  assert_false(state.nestOuter, 'ancestor outside both top layers should not match :active');
+}, 'With nested top layer elements, :active should stop at the innermost top layer boundary.');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/focus-within-toplayer-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/focus-within-toplayer-001-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Focusing inside a modal dialog should not propagate :focus-within beyond the dialog.
+PASS Focusing inside a popover should not propagate :focus-within beyond the popover.
+PASS With nested top layer elements, :focus-within should stop at the innermost top layer boundary.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/focus-within-toplayer-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/focus-within-toplayer-001.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Selectors: :focus-within should not propagate past top layer elements</title>
+<link rel="help" href="https://drafts.csswg.org/selectors/#the-focus-within-pseudo">
+<link rel="help" href="https://drafts.csswg.org/css-position-4/#top-layer">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  dialog::backdrop {
+    background: transparent;
+  }
+</style>
+
+<div id="outer">
+  <dialog id="dialog">
+    <input id="dialogInput">
+  </dialog>
+</div>
+
+<div id="popoverOuter">
+  <div id="popover" popover>
+    <input id="popoverInput">
+  </div>
+</div>
+
+<div id="nestOuter">
+  <dialog id="nestDialog">
+    <div id="nestPopover" popover>
+      <input id="nestInput">
+    </div>
+  </dialog>
+</div>
+
+<script>
+test(t => {
+  const dialog = document.getElementById('dialog');
+  dialog.showModal();
+  t.add_cleanup(() => dialog.close());
+
+  const dialogInput = document.getElementById('dialogInput');
+  const outer = document.getElementById('outer');
+
+  dialogInput.focus();
+  assert_true(dialogInput.matches(':focus'), 'input should be focused');
+  assert_true(dialog.matches(':focus-within'), 'dialog (top layer) should match :focus-within');
+  assert_false(outer.matches(':focus-within'), 'ancestor outside top layer should not match :focus-within');
+  assert_false(document.body.matches(':focus-within'), 'body should not match :focus-within');
+}, 'Focusing inside a modal dialog should not propagate :focus-within beyond the dialog.');
+
+test(t => {
+  const popover = document.getElementById('popover');
+  popover.showPopover();
+  t.add_cleanup(() => popover.hidePopover());
+
+  const popoverInput = document.getElementById('popoverInput');
+  const popoverOuter = document.getElementById('popoverOuter');
+
+  popoverInput.focus();
+  assert_true(popoverInput.matches(':focus'), 'input should be focused');
+  assert_true(popover.matches(':focus-within'), 'popover (top layer) should match :focus-within');
+  assert_false(popoverOuter.matches(':focus-within'), 'ancestor outside top layer should not match :focus-within');
+  assert_false(document.body.matches(':focus-within'), 'body should not match :focus-within');
+}, 'Focusing inside a popover should not propagate :focus-within beyond the popover.');
+
+test(t => {
+  const nestDialog = document.getElementById('nestDialog');
+  nestDialog.showModal();
+  t.add_cleanup(() => nestDialog.close());
+
+  const nestPopover = document.getElementById('nestPopover');
+  nestPopover.showPopover();
+  t.add_cleanup(() => nestPopover.hidePopover());
+
+  const nestInput = document.getElementById('nestInput');
+  const nestOuter = document.getElementById('nestOuter');
+
+  nestInput.focus();
+  assert_true(nestInput.matches(':focus'), 'input should be focused');
+  assert_true(nestPopover.matches(':focus-within'), 'popover (innermost top layer) should match :focus-within');
+  assert_false(nestDialog.matches(':focus-within'), 'dialog (outer top layer) should not match :focus-within');
+  assert_false(nestOuter.matches(':focus-within'), 'ancestor outside both top layers should not match :focus-within');
+}, 'With nested top layer elements, :focus-within should stop at the innermost top layer boundary.');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/hover-toplayer-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/hover-toplayer-001-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Hovering inside a modal dialog should not propagate :hover beyond the dialog.
+PASS Hovering inside a popover should not propagate :hover beyond the popover.
+PASS With nested top layer elements, :hover should stop at the innermost top layer boundary.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/hover-toplayer-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/hover-toplayer-001.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Selectors: :hover should not propagate past top layer elements</title>
+<link rel="help" href="https://drafts.csswg.org/selectors/#the-hover-pseudo">
+<link rel="help" href="https://drafts.csswg.org/css-position-4/#top-layer">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<style>
+  dialog::backdrop {
+    background: transparent;
+  }
+</style>
+
+<div id="outer">
+  <dialog id="dialog">
+    <div id="inner">hover target</div>
+  </dialog>
+</div>
+
+<div id="popoverOuter">
+  <div id="popover" popover>
+    <div id="popoverInner">hover target</div>
+  </div>
+</div>
+
+<div id="nestOuter">
+  <dialog id="nestDialog">
+    <div id="nestPopover" popover>
+      <div id="nestInner">hover target</div>
+    </div>
+  </dialog>
+</div>
+
+<script>
+promise_test(async t => {
+  const dialog = document.getElementById('dialog');
+  dialog.showModal();
+  t.add_cleanup(() => dialog.close());
+
+  const inner = document.getElementById('inner');
+  const outer = document.getElementById('outer');
+
+  await new test_driver.Actions()
+    .pointerMove(1, 1, {origin: inner})
+    .send();
+  await new Promise(requestAnimationFrame);
+
+  assert_true(inner.matches(':hover'), 'inner element should match :hover');
+  assert_true(dialog.matches(':hover'), 'dialog (top layer) should match :hover');
+  assert_false(outer.matches(':hover'), 'ancestor outside top layer should not match :hover');
+  assert_false(document.body.matches(':hover'), 'body should not match :hover');
+}, 'Hovering inside a modal dialog should not propagate :hover beyond the dialog.');
+
+promise_test(async t => {
+  const popover = document.getElementById('popover');
+  popover.showPopover();
+  t.add_cleanup(() => popover.hidePopover());
+
+  const popoverInner = document.getElementById('popoverInner');
+  const popoverOuter = document.getElementById('popoverOuter');
+
+  await new test_driver.Actions()
+    .pointerMove(1, 1, {origin: popoverInner})
+    .send();
+  await new Promise(requestAnimationFrame);
+
+  assert_true(popoverInner.matches(':hover'), 'inner element should match :hover');
+  assert_true(popover.matches(':hover'), 'popover (top layer) should match :hover');
+  assert_false(popoverOuter.matches(':hover'), 'ancestor outside top layer should not match :hover');
+  assert_false(document.body.matches(':hover'), 'body should not match :hover');
+}, 'Hovering inside a popover should not propagate :hover beyond the popover.');
+
+promise_test(async t => {
+  const nestDialog = document.getElementById('nestDialog');
+  nestDialog.showModal();
+  t.add_cleanup(() => nestDialog.close());
+
+  const nestPopover = document.getElementById('nestPopover');
+  nestPopover.showPopover();
+  t.add_cleanup(() => nestPopover.hidePopover());
+
+  const nestInner = document.getElementById('nestInner');
+  const nestOuter = document.getElementById('nestOuter');
+
+  await new test_driver.Actions()
+    .pointerMove(1, 1, {origin: nestInner})
+    .send();
+  await new Promise(requestAnimationFrame);
+
+  assert_true(nestInner.matches(':hover'), 'inner element should match :hover');
+  assert_true(nestPopover.matches(':hover'), 'popover (innermost top layer) should match :hover');
+  assert_false(nestDialog.matches(':hover'), 'dialog (outer top layer) should not match :hover');
+  assert_false(nestOuter.matches(':hover'), 'ancestor outside both top layers should not match :hover');
+}, 'With nested top layer elements, :hover should stop at the innermost top layer boundary.');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/toplayer-transition-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/toplayer-transition-001-expected.txt
@@ -1,0 +1,6 @@
+
+hover here
+
+PASS :focus-within should be adjusted on ancestors when popover enters/exits top layer.
+PASS :hover should be adjusted on ancestors when popover enters/exits top layer.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/toplayer-transition-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/toplayer-transition-001.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Selectors: top layer transitions should adjust pseudo-classes on ancestors</title>
+<link rel="help" href="https://drafts.csswg.org/selectors/#the-hover-pseudo">
+<link rel="help" href="https://drafts.csswg.org/selectors/#the-focus-within-pseudo">
+<link rel="help" href="https://drafts.csswg.org/css-position-4/#top-layer">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<style>
+  [popover] { display: block; }
+</style>
+
+<div id="container">
+  <div id="popover" popover="manual">
+    <input id="input">
+    <div id="hoverTarget">hover here</div>
+  </div>
+</div>
+
+<script>
+test(t => {
+  t.add_cleanup(() => { if (popover.matches(':popover-open')) popover.hidePopover(); });
+
+  input.focus();
+  assert_true(input.matches(':focus'), 'input should be focused');
+  assert_true(container.matches(':focus-within'), 'container should match :focus-within before showPopover');
+
+  popover.showPopover();
+  assert_true(input.matches(':focus'), 'input should still be focused after showPopover');
+  assert_true(popover.matches(':focus-within'), 'popover should match :focus-within after showPopover');
+  assert_false(container.matches(':focus-within'), 'container should not match :focus-within after showPopover');
+  assert_false(document.body.matches(':focus-within'), 'body should not match :focus-within after showPopover');
+
+  popover.hidePopover();
+  assert_true(input.matches(':focus'), 'input should still be focused after hidePopover');
+  assert_true(container.matches(':focus-within'), 'container should match :focus-within after hidePopover');
+  assert_true(document.body.matches(':focus-within'), 'body should match :focus-within after hidePopover');
+}, ':focus-within should be adjusted on ancestors when popover enters/exits top layer.');
+
+promise_test(async t => {
+  t.add_cleanup(() => { if (popover.matches(':popover-open')) popover.hidePopover(); });
+
+  await new test_driver.Actions()
+    .pointerMove(1, 1, {origin: hoverTarget})
+    .send();
+  await new Promise(requestAnimationFrame);
+
+  assert_true(hoverTarget.matches(':hover'), 'hoverTarget should match :hover');
+  assert_true(container.matches(':hover'), 'container should match :hover before showPopover');
+
+  popover.showPopover();
+  assert_true(hoverTarget.matches(':hover'), 'hoverTarget should still match :hover after showPopover');
+  assert_true(popover.matches(':hover'), 'popover should match :hover after showPopover');
+  assert_false(container.matches(':hover'), 'container should not match :hover after showPopover');
+  assert_false(document.body.matches(':hover'), 'body should not match :hover after showPopover');
+
+  popover.hidePopover();
+  assert_true(hoverTarget.matches(':hover'), 'hoverTarget should still match :hover after hidePopover');
+  assert_true(container.matches(':hover'), 'container should match :hover after hidePopover');
+  assert_true(document.body.matches(':hover'), 'body should match :hover after hidePopover');
+}, ':hover should be adjusted on ancestors when popover enters/exits top layer.');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-hover-active-pseudo-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-hover-active-pseudo-expected.txt
@@ -1,8 +1,7 @@
   button
-option
 
 PASS defaultbutton: select should match :hover and :active when interacting with button.
-FAIL defaultbutton: select should not match :hover or :active when interacting with elements in the picker. assert_false: select should not match :hover. expected false got true
+PASS defaultbutton: select should not match :hover or :active when interacting with elements in the picker.
 PASS custombutton: select should match :hover and :active when interacting with button.
-FAIL custombutton: select should not match :hover or :active when interacting with elements in the picker. assert_false: select should not match :hover. expected false got true
+PASS custombutton: select should not match :hover or :active when interacting with elements in the picker.
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3369,6 +3369,7 @@ webkit.org/b/209250 imported/w3c/web-platform-tests/css/css-text/line-break/line
 
 webkit.org/b/207858 fast/canvas/webgl/simulated-vertexAttrib0-invalid-indicies.html [ Skip ]
 
+imported/w3c/web-platform-tests/css/selectors/active-toplayer-001.html [ Skip ]
 webkit.org/b/209734 imported/w3c/web-platform-tests/css/selectors/focus-visible-001.html [ Skip ]
 webkit.org/b/209734 imported/w3c/web-platform-tests/css/selectors/focus-visible-005.html [ Skip ]
 webkit.org/b/209734 imported/w3c/web-platform-tests/css/selectors/focus-visible-006.html [ Skip ]
@@ -3398,6 +3399,7 @@ webkit.org/b/250767 imported/w3c/web-platform-tests/html/user-activation/activat
 
 # :hover simulation not working on iOS
 imported/w3c/web-platform-tests/css/selectors/hover-002.html [ Skip ]
+imported/w3c/web-platform-tests/css/selectors/hover-toplayer-001.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-text-decor/invalidation/text-decoration-thickness.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-view-transitions/hit-test-unrelated-element.html [ Skip ]
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/selectors/toplayer-transition-001-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/selectors/toplayer-transition-001-expected.txt
@@ -1,0 +1,6 @@
+
+hover here
+
+PASS :focus-within should be adjusted on ancestors when popover enters/exits top layer.
+FAIL :hover should be adjusted on ancestors when popover enters/exits top layer. assert_true: hoverTarget should match :hover expected true got false
+

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -9603,7 +9603,7 @@ DocumentParserYieldToken::~DocumentParserYieldToken()
         parser->didEndYieldingParser();
 }
 
-static Element* findNearestCommonComposedAncestor(Element* elementA, Element* elementB)
+static Element* findNearestCommonComposedAncestorForHover(Element* elementA, Element* elementB)
 {
     if (!elementA || !elementB)
         return nullptr;
@@ -9612,12 +9612,17 @@ static Element* findNearestCommonComposedAncestor(Element* elementA, Element* el
         return elementA;
 
     HashSet<Ref<Element>> ancestorChain;
-    for (SUPPRESS_UNCHECKED_LOCAL auto* element = elementA; element; element = element->parentElementInComposedTree())
+    for (SUPPRESS_UNCHECKED_LOCAL auto* element = elementA; element; element = element->parentElementInComposedTree()) {
         ancestorChain.add(*element);
+        if (element->isInTopLayer())
+            break;
+    }
 
     for (SUPPRESS_UNCHECKED_LOCAL auto* element = elementB; element; element = element->parentElementInComposedTree()) {
         if (ancestorChain.contains(*element))
             return element;
+        if (element->isInTopLayer())
+            break;
     }
     return nullptr;
 }
@@ -9643,6 +9648,8 @@ void Document::updateHoverActiveState(const HitTestRequest& request, Element* in
         for (RefPtr currentElement = oldActiveElement; currentElement; currentElement = currentElement->parentElementInComposedTree()) {
             elementsToClearActive.append(*currentElement);
             m_userActionElements.setInActiveChain(*currentElement, false);
+            if (currentElement->isInTopLayer())
+                break;
         }
         m_activeElement = nullptr;
     } else {
@@ -9655,6 +9662,8 @@ void Document::updateHoverActiveState(const HitTestRequest& request, Element* in
                 if (!element || curr->isRenderTextOrLineBreak())
                     continue;
                 m_userActionElements.setInActiveChain(*element, true);
+                if (element->isInTopLayer())
+                    break;
             }
 
             m_activeElement = newActiveElement;
@@ -9684,7 +9693,7 @@ void Document::updateHoverActiveState(const HitTestRequest& request, Element* in
 
     m_hoveredElement = newHoveredElement;
 
-    RefPtr commonAncestor = findNearestCommonComposedAncestor(oldHoveredElement.get(), newHoveredElement.get());
+    RefPtr commonAncestor = findNearestCommonComposedAncestorForHover(oldHoveredElement.get(), newHoveredElement.get());
 
     if (oldHoveredElement != newHoveredElement) {
         for (CheckedPtr element = oldHoveredElement.get(); element; element = element->parentElementInComposedTree()) {
@@ -9693,6 +9702,8 @@ void Document::updateHoverActiveState(const HitTestRequest& request, Element* in
             if (mustBeInActiveChain && !element->isInActiveChain())
                 continue;
             elementsToClearHover.append(*element);
+            if (element->isInTopLayer())
+                break;
         }
         // Unset hovered nodes in sub frame documents if the old hovered node was a frame owner.
         if (auto* frameOwnerElement = dynamicDowncast<HTMLFrameOwnerElement>(oldHoveredElement.get())) {
@@ -9703,14 +9714,20 @@ void Document::updateHoverActiveState(const HitTestRequest& request, Element* in
 
     bool sawCommonAncestor = false;
     for (RefPtr element = newHoveredElement; element; element = element->parentElementInComposedTree()) {
-        if (mustBeInActiveChain && !element->isInActiveChain())
+        bool atTopLayerBoundary = element->isInTopLayer();
+        if (mustBeInActiveChain && !element->isInActiveChain()) {
+            if (atTopLayerBoundary)
+                break;
             continue;
+        }
         if (allowActiveChanges)
             elementsToSetActive.append(*element);
         if (element == commonAncestor)
             sawCommonAncestor = true;
         if (!sawCommonAncestor)
             elementsToSetHover.append(*element);
+        if (atTopLayerBoundary)
+            break;
     }
 
     auto changeState = [](auto& elements, auto pseudoClass, auto value, auto&& setter) {

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1018,6 +1018,9 @@ public:
     void hoveredElementDidDetach(Element&);
     void elementInActiveChainDidDetach(Element&);
 
+    Element* hoveredElement() const { return m_hoveredElement.get(); }
+    Element* activatedElement() const { return m_activeElement.get(); }
+
     enum class CaptureChange : bool { No, Yes };
     void updateHoverActiveState(const HitTestRequest&, Element*, CaptureChange = CaptureChange::No);
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -1020,8 +1020,11 @@ void Element::setFocus(bool value, FocusVisibility visibility)
         root->host()->invalidateStyle();
     }
 
-    for (RefPtr element = this; element; element = element->parentElementInComposedTree())
+    for (RefPtr element = this; element; element = element->parentElementInComposedTree()) {
         element->setHasFocusWithin(value);
+        if (element->isInTopLayer())
+            break;
+    }
 
     setHasFocusVisible(value && (visibility == FocusVisibility::Visible || (visibility == FocusVisibility::Invisible && shouldAlwaysHaveFocusVisibleWhenFocused(*this))));
 }
@@ -1053,9 +1056,13 @@ void Element::setHasFocusWithin(bool value)
 void Element::setHasTentativeFocus(bool value)
 {
     // Tentative focus is used when trying to set the focus on a new element.
+    if (isInTopLayer())
+        return;
     for (Ref ancestor : composedTreeAncestors(*this)) {
         ASSERT(ancestor->hasFocusWithin() != value);
         document().userActionElements().setHasFocusWithin(ancestor, value);
+        if (ancestor->isInTopLayer())
+            break;
     }
 }
 
@@ -4556,6 +4563,22 @@ static void forEachRenderLayer(Element& element, const std::function<void(Render
     });
 }
 
+static void propagateUserActionPseudoClassesToAncestors(Element& element, bool value, bool hover, bool active, bool focusWithin)
+{
+    for (Ref ancestor : composedTreeAncestors(element)) {
+        if (hover)
+            ancestor->setHovered(value);
+        if (active) {
+            ancestor->setActive(value);
+            element.document().userActionElements().setInActiveChain(ancestor, value);
+        }
+        if (focusWithin)
+            ancestor->setHasFocusWithin(value);
+        if (value && ancestor->isInTopLayer())
+            break;
+    }
+}
+
 void Element::addToTopLayer()
 {
     RELEASE_ASSERT(!isInTopLayer());
@@ -4569,6 +4592,13 @@ void Element::addToTopLayer()
     Ref document = this->document();
     document->addTopLayerElement(*this);
     setEventTargetFlag(EventTargetFlag::IsInTopLayer);
+
+    // User-action pseudo-classes should not propagate past top layer boundaries.
+    bool clearHover = document->hoveredElement() && contains(document->hoveredElement());
+    bool clearActive = document->activatedElement() && contains(document->activatedElement());
+    bool clearFocusWithin = hasFocusWithin();
+    if (clearHover || clearActive || clearFocusWithin)
+        propagateUserActionPseudoClassesToAncestors(*this, false, clearHover, clearActive, clearFocusWithin);
 
     document->scheduleContentRelevancyUpdate(ContentRelevancy::IsInTopLayer);
 
@@ -4604,6 +4634,14 @@ void Element::removeFromTopLayer()
     // Unable to protect the document as it may have started destruction.
     document().removeTopLayerElement(*this);
     clearEventTargetFlag(EventTargetFlag::IsInTopLayer);
+
+    // User-action pseudo-classes should now propagate past this element since it is
+    // no longer a top layer boundary.
+    bool setHover = document().hoveredElement() && contains(document().hoveredElement());
+    bool setActive = document().activatedElement() && contains(document().activatedElement());
+    bool setFocusWithin = hasFocusWithin();
+    if (setHover || setActive || setFocusWithin)
+        propagateUserActionPseudoClassesToAncestors(*this, true, setHover, setActive, setFocusWithin);
 
     document().scheduleContentRelevancyUpdate(ContentRelevancy::IsInTopLayer);
 


### PR DESCRIPTION
#### 335d97ee53b6878be6a3ccc94f56b645faaa7383
<pre>
Make :active, :focus-within, and :hover account for top layer
<a href="https://bugs.webkit.org/show_bug.cgi?id=310365">https://bugs.webkit.org/show_bug.cgi?id=310365</a>

Reviewed by Ryosuke Niwa.

This implements the requirement from

    <a href="https://drafts.csswg.org/selectors/#useraction-pseudos">https://drafts.csswg.org/selectors/#useraction-pseudos</a>

&gt; Specifically, if these match on a given element, they also match on
&gt; the element’s flat tree ancestors, up to and including the first top
&gt; layer element or the root element, whichever is encountered first.

Tests: imported/w3c/web-platform-tests/css/selectors/active-toplayer-001.html
       imported/w3c/web-platform-tests/css/selectors/focus-within-toplayer-001.html
       imported/w3c/web-platform-tests/css/selectors/hover-toplayer-001.html
       imported/w3c/web-platform-tests/css/selectors/toplayer-transition-001.html

Upstream:

    <a href="https://github.com/web-platform-tests/wpt/pull/58648">https://github.com/web-platform-tests/wpt/pull/58648</a>

Canonical link: <a href="https://commits.webkit.org/309755@main">https://commits.webkit.org/309755@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4fd1afd65d22d6fda4119aef7d59cc53e78111b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151613 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24378 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17959 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160348 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105070 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3419716d-c5d1-46d8-84b4-bc0fddd8b998) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153487 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24809 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24680 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117098 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/daab957a-5662-4ab8-ac8f-86b660f053e8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154573 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19241 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136048 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97813 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/52fa5cf9-4ec3-4356-afde-84d3d3dbb890) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18330 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16271 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8190 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/127960 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13952 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162819 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/5974 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15542 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125111 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24179 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20329 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125294 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24171 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135748 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80769 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23278 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20345 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12523 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23780 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88107 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23490 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23644 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/23562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->