### PR TITLE
AX: Comboboxes don't forward focus to it's active descendant, preventing ATs from interacting with the combobox list items

### DIFF
--- a/LayoutTests/accessibility/combobox/mac/combobox-activedescendant-notifications-expected.txt
+++ b/LayoutTests/accessibility/combobox/mac/combobox-activedescendant-notifications-expected.txt
@@ -1,10 +1,11 @@
-This test makes sure that an ARIA active descendant change does not change focus, because focus should remain in the textfield portion of the combo box.
+This test ensures that changing aria-activedescendant on a combobox posts AXFocusedUIElementChanged for the active descendant, and that the focused element becomes the active descendant.
 
 The ComboBox should start out as the focused element.
 PASS: axCombo.isEqual(accessibilityController.focusedElement) === true
-Received notification: AXActiveElementChanged
-The ComboBox should still be the focused element even after the aria-activedescendant was changed.
-PASS: axCombo.isEqual(accessibilityController.focusedElement) === true
+After setting aria-activedescendant, the focused element should be the active descendant, not the combobox.
+PASS: axCombo.isEqual(accessibilityController.focusedElement) === false
+PASS: focusedElement.role.toLowerCase().includes('statictext') === true
+PASS: platformStaticTextValue(focusedElement).includes('item1') === true
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/accessibility/combobox/mac/combobox-activedescendant-notifications.html
+++ b/LayoutTests/accessibility/combobox/mac/combobox-activedescendant-notifications.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML PUBLIC>
 <html>
 <head>
-<script src="../../../resources/js-test.js"></script>
 <script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
 </head>
 <body>
 
@@ -14,32 +14,43 @@
 </div>
 
 <script>
-let output = "This test makes sure that an ARIA active descendant change does not change focus, because focus should remain in the textfield portion of the combo box.\n\n";
+var output = "This test ensures that changing aria-activedescendant on a combobox posts AXFocusedUIElementChanged for the active descendant, and that the focused element becomes the active descendant.\n\n";
+
+var receivedFocusChanged = false;
+var receivedActiveElementChanged = false;
+var axCombo, focusedElement;
 
 if (window.accessibilityController) {
     window.jsTestIsAsync = true;
 
     combo.focus();
-    var axCombo = accessibilityController.accessibleElementById("combo");
-    output += "The ComboBox should start out as the focused element.\n";
-    output += expect("axCombo.isEqual(accessibilityController.focusedElement)", "true");
+    axCombo = accessibilityController.accessibleElementById("combo");
 
-    // When the active descendant changes, we should receive a selected children changed notification.
-    axCombo.addNotificationListener((notification) => {
-        output += `Received notification: ${notification}\n`;
-        if (notification == "AXActiveElementChanged") {
-            output += "The ComboBox should still be the focused element even after the aria-activedescendant was changed.\n";
-            output += expect("axCombo.isEqual(accessibilityController.focusedElement)", "true");
+    setTimeout(async () => {
+        output += "The ComboBox should start out as the focused element.\n";
+        output += await expectAsync("axCombo.isEqual(accessibilityController.focusedElement)", "true");
 
-            axCombo.removeNotificationListener();
-            content.style.visibility = "hidden";
-            debug(output);
-            finishJSTest();
-        }
-    });
+        accessibilityController.addNotificationListener((target, notification) => {
+            if (notification === "AXFocusedUIElementChanged")
+                receivedFocusChanged = true;
+            if (notification === "AXActiveElementChanged")
+                receivedActiveElementChanged = true;
+        });
 
-    // After the descendant changes, the combo box should still be the focused object.
-    combo.setAttribute("aria-activedescendant", "item1");
+        combo.setAttribute("aria-activedescendant", "item1");
+        await waitFor(() => receivedFocusChanged && receivedActiveElementChanged);
+
+        output += "After setting aria-activedescendant, the focused element should be the active descendant, not the combobox.\n";
+        output += expect("axCombo.isEqual(accessibilityController.focusedElement)", "false");
+        focusedElement = accessibilityController.focusedElement;
+        output += expect("focusedElement.role.toLowerCase().includes('statictext')", "true");
+        output += expect("platformStaticTextValue(focusedElement).includes('item1')", "true");
+
+        accessibilityController.removeNotificationListener();
+        content.style.visibility = "hidden";
+        debug(output);
+        finishJSTest();
+    }, 0);
 }
 </script>
 </body>

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -4223,6 +4223,7 @@ AXCoreObject::AccessibilityChildrenVector AccessibilityObject::relatedObjects(AX
 bool AccessibilityObject::shouldFocusActiveDescendant() const
 {
     switch (ariaRoleAttribute()) {
+    case AccessibilityRole::ComboBox:
     case AccessibilityRole::Group:
     case AccessibilityRole::ListBox:
     case AccessibilityRole::Menu:


### PR DESCRIPTION
#### 57486e8cd2b77c1af67f202a1c3dc0dce8b05e4d
<pre>
AX: Comboboxes don&apos;t forward focus to it&apos;s active descendant, preventing ATs from interacting with the combobox list items
<a href="https://rdar.apple.com/172931277">rdar://172931277</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=310295">https://bugs.webkit.org/show_bug.cgi?id=310295</a>

Reviewed by Joshua Hoffman.

AccessibilityObject::shouldFocusActiveDescendant() was missing ComboBox, even though
supportsActiveDescendant() already included it. This meant that when aria-activedescendant
changed on a combobox (e.g. as the user arrows through options), WebKit posted
AXActiveElementChanged but not AXFocusedUIElementChanged for the active descendant. Without
the FocusedUIElementChanged notification, VoiceOver didn&apos;t move its cursor to the highlighted
option, preventing it from reading the option text.

Fix this by adding ComboBox to shouldFocusActiveDescendant().

* LayoutTests/accessibility/combobox/mac/combobox-activedescendant-notifications-expected.txt:
* LayoutTests/accessibility/combobox/mac/combobox-activedescendant-notifications.html:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::shouldFocusActiveDescendant const):

Canonical link: <a href="https://commits.webkit.org/309641@main">https://commits.webkit.org/309641@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93500aa144e1b80e43a85fe2b48c08f09cfd17c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151250 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24013 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17583 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159979 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104686 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153123 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24444 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24259 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116778 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82910 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154210 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18917 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135711 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97499 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17997 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15947 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7824 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127615 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13628 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162451 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5576 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15199 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124786 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23814 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19997 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124974 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33912 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23804 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135425 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80285 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20041 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12190 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23414 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87708 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23126 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23278 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23180 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->