### PR TITLE
[GStreamer] Reduce unsafe buffer usage accross GStreamer classes

### DIFF
--- a/Source/WebCore/platform/audio/glib/MediaSessionGLib.cpp
+++ b/Source/WebCore/platform/audio/glib/MediaSessionGLib.cpp
@@ -227,9 +227,9 @@ bool MediaSessionGLib::ensureMprisSessionRegistered()
     if (m_ownerId)
         return true;
 
-    const auto& mprisInterface = m_manager.mprisInterface();
+    const auto mprisInterfaces = unsafeMakeSpan(m_manager.mprisInterface()->interfaces, 2);
     GUniqueOutPtr<GError> error;
-    m_rootRegistrationId = g_dbus_connection_register_object(m_connection.get(), DBUS_MPRIS_OBJECT_PATH, mprisInterface->interfaces[0],
+    m_rootRegistrationId = g_dbus_connection_register_object(m_connection.get(), DBUS_MPRIS_OBJECT_PATH, mprisInterfaces[0],
         &gInterfaceVTable, this, nullptr, &error.outPtr());
 
     if (!m_rootRegistrationId) {
@@ -237,10 +237,8 @@ bool MediaSessionGLib::ensureMprisSessionRegistered()
         return false;
     }
 
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
-    m_playerRegistrationId = g_dbus_connection_register_object(m_connection.get(), DBUS_MPRIS_OBJECT_PATH, mprisInterface->interfaces[1],
+    m_playerRegistrationId = g_dbus_connection_register_object(m_connection.get(), DBUS_MPRIS_OBJECT_PATH, mprisInterfaces[1],
         &gInterfaceVTable, this, nullptr, &error.outPtr());
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     if (!m_playerRegistrationId) {
         g_warning("Failed at MPRIS object registration: %s", error->message);

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -54,6 +54,7 @@
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/URL.h>
 #include <wtf/UUID.h>
+#include <wtf/ZippedRange.h>
 #include <wtf/glib/GMallocString.h>
 #include <wtf/glib/GSpanExtras.h>
 #include <wtf/glib/GThreadSafeWeakPtr.h>
@@ -467,14 +468,13 @@ bool ensureGStreamerInitialized()
             WTFLogAlways("The USE_PLAYBIN3 variable was detected in the environment. Expect playback issues or please unset it.");
 
 #if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
-        Vector<String> parameters = s_UIProcessCommandLineOptions.value_or(extractGStreamerOptionsFromCommandLine());
-        s_UIProcessCommandLineOptions.reset();
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
-        char** argv = g_new0(char*, parameters.size() + 2);
+        auto parameters = std::exchange(s_UIProcessCommandLineOptions, std::nullopt).value_or(extractGStreamerOptionsFromCommandLine());
         int argc = parameters.size() + 1;
-        argv[0] = g_strdup(FileSystem::currentExecutableName().data());
-        for (unsigned i = 0; i < parameters.size(); i++)
-            argv[i + 1] = g_strdup(parameters[i].utf8().data());
+        char** argv = g_new0(char*, argc + 1);
+        auto argvSpan = unsafeMakeSpan(argv, argc);
+        argvSpan[0] = g_strdup(FileSystem::currentExecutableName().data());
+        for (auto [arg, parameter] : zippedRange(argvSpan.subspan(1), parameters))
+            arg = g_strdup(parameter.utf8().data());
 
         GUniqueOutPtr<GError> error;
         isGStreamerInitialized = gst_init_check(&argc, &argv, &error.outPtr());
@@ -493,7 +493,6 @@ bool ensureGStreamerInitialized()
             if (!disableFastMalloc || disableFastMalloc == "0"_s)
                 gst_allocator_set_default(GST_ALLOCATOR(g_object_new(gst_allocator_fast_malloc_get_type(), nullptr)));
         }
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #if USE(GSTREAMER_MPEGTS)
         if (isGStreamerInitialized)

--- a/Source/WebCore/platform/gstreamer/WebKitFliteSourceGStreamer.cpp
+++ b/Source/WebCore/platform/gstreamer/WebKitFliteSourceGStreamer.cpp
@@ -87,15 +87,12 @@ WEBKIT_DEFINE_TYPE_WITH_CODE(WebKitFliteSrc, webkit_flite_src, GST_TYPE_BASE_SRC
     GST_DEBUG_CATEGORY_INIT(webkit_flite_src_debug, "webkitflitesrc", 0, "flitesrc element"));
 
 // To add more voices, add voice register functions here.
-using VoiceRegisterFunction = Function<cst_voice*(const char*)>;
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
-static VoiceRegisterFunction voiceRegisterFunctions[] = {
+static auto voiceRegisterFunctions = std::to_array({
     register_cmu_us_kal,
     register_cmu_us_slt,
     register_cmu_us_rms,
     register_cmu_us_awb,
-};
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+});
 
 static void webkitFliteSrcReset(WebKitFliteSrc* src)
 {
@@ -166,12 +163,12 @@ static GstFlowReturn webkitFliteSrcCreate(GstBaseSrc* baseSource, guint64 offset
         gsize bufferSize = priv->info.channels * sizeof(gint16) * wave->num_samples;
         GRefPtr<GstBuffer> buf = adoptGRef(gst_buffer_new_allocate(nullptr, bufferSize, nullptr));
         GstMappedBuffer map(buf, GST_MAP_WRITE);
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
         gint16* data = reinterpret_cast<gint16*>(map.data());
-        memset(data, 0, bufferSize);
-        for (int i = 0; i < wave->num_samples; i++)
-            data[i * priv->info.channels] = wave->samples[i];
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+        auto dataSpan = unsafeMakeSpan(data, bufferSize / sizeof(gint16));
+        zeroSpan(dataSpan);
+        unsigned i = 0;
+        for (auto& sample : unsafeMakeSpan(wave->samples, wave->num_samples))
+            dataSpan[i++ * priv->info.channels] = sample;
 
         gst_adapter_push(members->adapter.get(), buf.leakRef());
     }
@@ -222,9 +219,8 @@ static Vector<GUniquePtr<cst_voice>>& fliteVoices()
     static Vector<GUniquePtr<cst_voice>> voices;
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [] {
-        const unsigned voiceRegisterFunctionCount = sizeof(voiceRegisterFunctions) / sizeof(VoiceRegisterFunction);
-        for (unsigned i = 0; i < voiceRegisterFunctionCount; ++i) {
-            GUniquePtr<cst_voice> voice(voiceRegisterFunctions[i](nullptr));
+        for (auto& function : voiceRegisterFunctions) {
+            GUniquePtr<cst_voice> voice(function(nullptr));
             voices.append(WTF::move(voice));
         }
     });


### PR DESCRIPTION
#### f6b3d04bd8dec18906ccb19c13299b8033d48b26
<pre>
[GStreamer] Reduce unsafe buffer usage accross GStreamer classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=310366">https://bugs.webkit.org/show_bug.cgi?id=310366</a>

Reviewed by Philippe Normand.

* Source/WebCore/platform/audio/glib/MediaSessionGLib.cpp:
(WebCore::MediaSessionGLib::ensureMprisSessionRegistered):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::ensureGStreamerInitialized):
* Source/WebCore/platform/gstreamer/WebKitFliteSourceGStreamer.cpp:
(std::to_array):
(webkitFliteSrcCreate):
(fliteVoices):

Canonical link: <a href="https://commits.webkit.org/309676@main">https://commits.webkit.org/309676@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3286291882fa1bedf65d2d7a4c5f5be364b8d81

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151252 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24015 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17585 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159981 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104688 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153125 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24446 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24261 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116780 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82909 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154212 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18912 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135714 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97501 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17996 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15946 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7826 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127614 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13631 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162453 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5578 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15202 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124787 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23816 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19996 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124975 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23806 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135428 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80287 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23258 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20042 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12193 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23416 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87726 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23128 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23280 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23182 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->