### PR TITLE
Micro-optimize charactersAreAllASCII()

### DIFF
--- a/Source/WTF/wtf/text/ASCIIFastPath.h
+++ b/Source/WTF/wtf/text/ASCIIFastPath.h
@@ -23,6 +23,7 @@
 
 #include <stdint.h>
 #include <unicode/utypes.h>
+#include <wtf/ASCIICType.h>
 #include <wtf/BitSet.h>
 #include <wtf/SIMDHelpers.h>
 #include <wtf/StdLibExtras.h>
@@ -118,29 +119,55 @@ inline bool containsOnlyASCII(MachineWord word)
     return !(word & NonASCIIMask<sizeof(MachineWord), CharacterType>::value());
 }
 
-// Note: This function assume the input is likely all ASCII, and
-// does not leave early if it is not the case.
 template<typename CharacterType>
-inline bool charactersAreAllASCII(std::span<const CharacterType> span)
+SUPPRESS_NODELETE inline bool NODELETE charactersAreAllASCII(std::span<const CharacterType> span)
 {
-    MachineWord allCharBits = 0;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+    using UnsignedType = SameSizeUnsignedInteger<CharacterType>;
+    constexpr size_t simdStride = SIMD::stride<UnsignedType>;
+    constexpr size_t chunkSize = 8 * simdStride;
 
-    // Prologue: align the input.
-    while (!span.empty() && !isAlignedToMachineWord(span.data()))
-        allCharBits |= WTF::consume(span);
+    const auto* characters = span.data();
+    size_t length = span.size();
+    const auto* end = characters + length;
 
-    // Compare the values of CPU word size.
-    size_t sizeAfterAlignedEnd = std::to_address(span.end()) - alignToMachineWord(std::to_address(span.end()));
-    const size_t loopIncrement = sizeof(MachineWord) / sizeof(CharacterType);
-    while (span.size() > sizeAfterAlignedEnd)
-        allCharBits |= reinterpretCastSpanStartTo<const MachineWord>(consumeSpan(span, loopIncrement));
+    if (length >= simdStride) {
+        constexpr auto nonASCIIMask = static_cast<UnsignedType>(~UnsignedType { 0x7F });
+        auto mask = SIMD::splat<UnsignedType>(nonASCIIMask);
 
-    // Process the remaining bytes.
-    while (!span.empty())
-        allCharBits |= WTF::consume(span);
+        // Process chunkSize elements per chunk (8 x SIMD vectors), check once per chunk.
+        const auto* chunkEnd = characters + (length & ~(chunkSize - 1));
+        while (characters < chunkEnd) {
+            auto acc = SIMD::load(std::bit_cast<const UnsignedType*>(characters));
+            acc = SIMD::bitOr2(acc, SIMD::load(std::bit_cast<const UnsignedType*>(characters + simdStride)));
+            acc = SIMD::bitOr2(acc, SIMD::load(std::bit_cast<const UnsignedType*>(characters + 2 * simdStride)));
+            acc = SIMD::bitOr2(acc, SIMD::load(std::bit_cast<const UnsignedType*>(characters + 3 * simdStride)));
+            acc = SIMD::bitOr2(acc, SIMD::load(std::bit_cast<const UnsignedType*>(characters + 4 * simdStride)));
+            acc = SIMD::bitOr2(acc, SIMD::load(std::bit_cast<const UnsignedType*>(characters + 5 * simdStride)));
+            acc = SIMD::bitOr2(acc, SIMD::load(std::bit_cast<const UnsignedType*>(characters + 6 * simdStride)));
+            acc = SIMD::bitOr2(acc, SIMD::load(std::bit_cast<const UnsignedType*>(characters + 7 * simdStride)));
+            if (SIMD::isNonZero(SIMD::bitAnd2(acc, mask)))
+                return false;
+            characters += chunkSize;
+        }
+        // Handle remaining SIMD vectors.
+        const auto* simdEnd = characters + (static_cast<size_t>(end - characters) & ~(simdStride - 1));
+        auto acc = SIMD::splat<UnsignedType>(0);
+        while (characters < simdEnd) {
+            acc = SIMD::bitOr2(acc, SIMD::load(std::bit_cast<const UnsignedType*>(characters)));
+            characters += simdStride;
+        }
+        if (SIMD::isNonZero(SIMD::bitAnd2(acc, mask)))
+            return false;
+    }
 
-    MachineWord nonASCIIBitMask = NonASCIIMask<sizeof(MachineWord), CharacterType>::value();
-    return !(allCharBits & nonASCIIBitMask);
+    // Scalar tail with early exit.
+    while (characters < end) {
+        if (!isASCII(*characters++))
+            return false;
+    }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    return true;
 }
 
 ALWAYS_INLINE bool charactersAreAllLatin1(std::span<const Latin1Character>)


### PR DESCRIPTION
#### a9b993168909f12fcf81a18375c02a9bb910643d
<pre>
Micro-optimize charactersAreAllASCII()
<a href="https://bugs.webkit.org/show_bug.cgi?id=310368">https://bugs.webkit.org/show_bug.cgi?id=310368</a>

Reviewed by Yusuke Suzuki.

Optimize charactersAreAllASCII() using the portable SIMD:: helpers
(which use simde under the hood), replacing the previous branchless
machine-word (8-byte) OR-accumulation that always scanned the entire
buffer even when non-ASCII appeared at the very start.

The new implementation OR-accumulates 8 SIMD vector loads (128 bytes
for 8-bit, 64 chars for 16-bit) per chunk, masking and checking once
per chunk. This gives both wider throughput for the all-ASCII case and
early exit for non-ASCII input. Buffers shorter than one SIMD stride
fall back to a scalar loop.

Using SIMD:: helpers with typed pointers and SIMD::stride&lt;CharacterType&gt;
allows a single generic implementation for both 8-bit and 16-bit
character types, and works on all platforms (ARM64 and x86).

Summarized microbenchmark results (Apple Silicon, -O2):
- All ASCII: 1.1-1.4x faster (16KB: 1.2-1.35x)
- Non-ASCII at start: up to 250x faster
- Non-ASCII at middle: 1.4-2.7x faster
- Non-ASCII at end: 1.1-2.5x faster

Full microbenchmark results (Apple Silicon, -O2):
=== uint8_t: all ASCII ===
  allASCII                     len=4       old=    2.30 ns  new=    2.03 ns  speedup=1.13x
  allASCII                     len=8       old=    1.88 ns  new=    2.93 ns  speedup=0.64x
  allASCII                     len=16      old=    1.92 ns  new=    1.34 ns  speedup=1.42x
  allASCII                     len=32      old=    2.33 ns  new=    1.57 ns  speedup=1.49x
  allASCII                     len=64      old=    1.95 ns  new=    2.03 ns  speedup=0.96x
  allASCII                     len=128     old=    2.19 ns  new=    1.84 ns  speedup=1.19x
  allASCII                     len=256     old=    2.67 ns  new=    2.80 ns  speedup=0.95x
  allASCII                     len=512     old=    3.67 ns  new=    3.39 ns  speedup=1.08x
  allASCII                     len=1024    old=    6.15 ns  new=    5.60 ns  speedup=1.10x
  allASCII                     len=4096    old=   25.75 ns  new=   20.99 ns  speedup=1.23x
  allASCII                     len=16384   old=  113.13 ns  new=   83.74 ns  speedup=1.35x

=== uint8_t: non-ASCII at start ===
  nonASCII@0                   len=16      old=    1.85 ns  new=    1.12 ns  speedup=1.66x
  nonASCII@0                   len=32      old=    2.28 ns  new=    1.14 ns  speedup=2.01x
  nonASCII@0                   len=64      old=    2.15 ns  new=    1.57 ns  speedup=1.37x
  nonASCII@0                   len=128     old=    2.42 ns  new=    0.97 ns  speedup=2.50x
  nonASCII@0                   len=256     old=    2.69 ns  new=    0.89 ns  speedup=3.01x
  nonASCII@0                   len=512     old=    4.41 ns  new=    0.92 ns  speedup=4.80x
  nonASCII@0                   len=1024    old=    6.44 ns  new=    0.98 ns  speedup=6.57x
  nonASCII@0                   len=4096    old=   24.65 ns  new=    0.89 ns  speedup=27.83x
  nonASCII@0                   len=16384   old=  108.68 ns  new=    0.89 ns  speedup=122.47x

=== uint8_t: non-ASCII at middle ===
  nonASCII@mid                 len=16      old=    1.88 ns  new=    1.11 ns  speedup=1.68x
  nonASCII@mid                 len=32      old=    2.38 ns  new=    1.11 ns  speedup=2.14x
  nonASCII@mid                 len=64      old=    2.18 ns  new=    1.58 ns  speedup=1.37x
  nonASCII@mid                 len=128     old=    2.44 ns  new=    0.95 ns  speedup=2.57x
  nonASCII@mid                 len=256     old=    2.86 ns  new=    1.41 ns  speedup=2.02x
  nonASCII@mid                 len=512     old=    3.90 ns  new=    2.07 ns  speedup=1.88x
  nonASCII@mid                 len=1024    old=    6.35 ns  new=    3.31 ns  speedup=1.92x
  nonASCII@mid                 len=4096    old=   25.34 ns  new=   11.23 ns  speedup=2.26x
  nonASCII@mid                 len=16384   old=  112.95 ns  new=   42.08 ns  speedup=2.68x

=== uint8_t: non-ASCII at end ===
  nonASCII@end                 len=16      old=    1.92 ns  new=    1.12 ns  speedup=1.71x
  nonASCII@end                 len=32      old=    2.36 ns  new=    1.11 ns  speedup=2.12x
  nonASCII@end                 len=64      old=    2.12 ns  new=    1.56 ns  speedup=1.36x
  nonASCII@end                 len=128     old=    2.41 ns  new=    0.96 ns  speedup=2.50x
  nonASCII@end                 len=256     old=    2.92 ns  new=    1.46 ns  speedup=2.00x
  nonASCII@end                 len=512     old=    3.91 ns  new=    2.68 ns  speedup=1.46x
  nonASCII@end                 len=1024    old=    6.59 ns  new=    5.28 ns  speedup=1.25x
  nonASCII@end                 len=4096    old=   25.25 ns  new=   20.68 ns  speedup=1.22x
  nonASCII@end                 len=16384   old=  111.56 ns  new=   92.43 ns  speedup=1.21x

=== char16_t: all ASCII ===
  allASCII                     len=4       old=    1.84 ns  new=    2.01 ns  speedup=0.92x
  allASCII                     len=8       old=    1.87 ns  new=    1.34 ns  speedup=1.40x
  allASCII                     len=16      old=    2.27 ns  new=    1.56 ns  speedup=1.46x
  allASCII                     len=32      old=    2.13 ns  new=    2.01 ns  speedup=1.06x
  allASCII                     len=64      old=    2.26 ns  new=    1.82 ns  speedup=1.24x
  allASCII                     len=128     old=    2.86 ns  new=    2.55 ns  speedup=1.12x
  allASCII                     len=256     old=    3.86 ns  new=    3.59 ns  speedup=1.07x
  allASCII                     len=512     old=    6.54 ns  new=    5.73 ns  speedup=1.14x
  allASCII                     len=1024    old=   11.82 ns  new=   10.44 ns  speedup=1.13x
  allASCII                     len=4096    old=   53.56 ns  new=   41.63 ns  speedup=1.29x
  allASCII                     len=16384   old=  229.09 ns  new=  165.93 ns  speedup=1.38x

=== char16_t: non-ASCII at start ===
  nonASCII@0                   len=16      old=    2.29 ns  new=    1.11 ns  speedup=2.06x
  nonASCII@0                   len=32      old=    2.08 ns  new=    1.55 ns  speedup=1.34x
  nonASCII@0                   len=64      old=    2.40 ns  new=    0.96 ns  speedup=2.50x
  nonASCII@0                   len=128     old=    2.92 ns  new=    0.96 ns  speedup=3.03x
  nonASCII@0                   len=256     old=    3.89 ns  new=    0.96 ns  speedup=4.04x
  nonASCII@0                   len=512     old=    6.76 ns  new=    0.94 ns  speedup=7.18x
  nonASCII@0                   len=1024    old=   11.69 ns  new=    0.99 ns  speedup=11.86x
  nonASCII@0                   len=4096    old=   53.21 ns  new=    0.89 ns  speedup=60.08x
  nonASCII@0                   len=16384   old=  227.52 ns  new=    0.89 ns  speedup=256.38x

=== char16_t: non-ASCII at middle ===
  nonASCII@mid                 len=16      old=    2.29 ns  new=    1.11 ns  speedup=2.06x
  nonASCII@mid                 len=32      old=    2.16 ns  new=    1.56 ns  speedup=1.38x
  nonASCII@mid                 len=64      old=    2.38 ns  new=    0.89 ns  speedup=2.68x
  nonASCII@mid                 len=128     old=    2.69 ns  new=    1.38 ns  speedup=1.95x
  nonASCII@mid                 len=256     old=    3.85 ns  new=    2.05 ns  speedup=1.88x
  nonASCII@mid                 len=512     old=    6.63 ns  new=    3.27 ns  speedup=2.03x
  nonASCII@mid                 len=1024    old=   11.61 ns  new=    5.89 ns  speedup=1.97x
  nonASCII@mid                 len=4096    old=   53.69 ns  new=   21.35 ns  speedup=2.52x
  nonASCII@mid                 len=16384   old=  229.69 ns  new=   94.22 ns  speedup=2.44x

=== char16_t: non-ASCII at end ===
  nonASCII@end                 len=16      old=    2.26 ns  new=    1.11 ns  speedup=2.03x
  nonASCII@end                 len=32      old=    2.06 ns  new=    1.55 ns  speedup=1.32x
  nonASCII@end                 len=64      old=    2.39 ns  new=    0.96 ns  speedup=2.48x
  nonASCII@end                 len=128     old=    2.90 ns  new=    1.46 ns  speedup=1.99x
  nonASCII@end                 len=256     old=    3.89 ns  new=    2.68 ns  speedup=1.45x
  nonASCII@end                 len=512     old=    6.32 ns  new=    5.26 ns  speedup=1.20x
  nonASCII@end                 len=1024    old=   11.69 ns  new=   10.48 ns  speedup=1.12x
  nonASCII@end                 len=4096    old=   54.15 ns  new=   41.83 ns  speedup=1.29x
  nonASCII@end                 len=16384   old=  220.46 ns  new=  163.63 ns  speedup=1.35x

* Source/WTF/wtf/text/ASCIIFastPath.h:
(WTF::charactersAreAllASCII):

Canonical link: <a href="https://commits.webkit.org/309695@main">https://commits.webkit.org/309695@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de16205d0517d17c527b6ed54ce910e990f6f61b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151434 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24198 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17768 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160166 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104872 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24629 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24499 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116925 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83001 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154394 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19067 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135880 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97645 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18158 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16102 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8010 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/143423 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127793 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13792 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162637 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/12234 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5770 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15369 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124943 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23999 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20156 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125129 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33950 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23989 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135588 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80496 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20186 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12358 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/183043 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23600 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87902 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46674 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23310 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23463 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23365 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->