### PR TITLE
[Site Isolation] Dynamically created cross-site iframes should not add back/forward list entries

### DIFF
--- a/LayoutTests/http/tests/site-isolation/history/dynamic-cross-site-iframe-does-not-add-history-entry-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/history/dynamic-cross-site-iframe-does-not-add-history-entry-expected.txt
@@ -1,0 +1,10 @@
+Verifies that navigating a dynamically created subframe from about:blank to a cross-site URL does not create an extra back/forward list entry.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS history.length is 2
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/history/dynamic-cross-site-iframe-does-not-add-history-entry.html
+++ b/LayoutTests/http/tests/site-isolation/history/dynamic-cross-site-iframe-does-not-add-history-entry.html
@@ -1,0 +1,31 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true UsesBackForwardCache=false ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Verifies that navigating a dynamically created subframe from about:blank to a cross-site URL does not create an extra back/forward list entry.");
+jsTestIsAsync = true;
+
+onload = async () => {
+    if (sessionStorage.step === "check") {
+        delete sessionStorage.step;
+
+        // Create an iframe, append it, and immediately navigate via
+        // contentWindow.location.href without waiting for about:blank onload.
+        // This mimics third-party JS that creates and navigates iframes
+        // without waiting for the initial load.
+        const iframe = document.createElement("iframe");
+        document.body.appendChild(iframe);
+        iframe.contentWindow.location.href = "http://localhost:8000/site-isolation/resources/simple.html";
+
+        iframe.onload = () => {
+            shouldBe("history.length", "2");
+            finishJSTest();
+        };
+        return;
+    }
+
+    await testRunner?.clearBackForwardList();
+
+    sessionStorage.step = "check";
+    location.href = location.pathname + "?step2";
+}
+</script>

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -336,6 +336,8 @@ void WebFrameProxy::didFailProvisionalLoad()
 void WebFrameProxy::didCommitLoad(const String& contentType, const WebCore::CertificateInfo& certificateInfo, bool containsPluginDocument, DocumentSecurityPolicy&& documentSecurityPolicy)
 {
     m_frameLoadState.didCommitLoad();
+    if (m_isShowingInitialAboutBlank && !url().isAboutBlank())
+        m_isShowingInitialAboutBlank = false;
 
     m_title = String();
     m_MIMEType = contentType;

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -267,6 +267,8 @@ public:
     void setIsPendingInitialHistoryItem(bool isPending) { m_isPendingInitialHistoryItem = isPending; }
     bool isPendingInitialHistoryItem() const { return m_isPendingInitialHistoryItem; }
 
+    bool isShowingInitialAboutBlank() const { return m_isShowingInitialAboutBlank; }
+
     WebCore::LayerHostingContextIdentifier layerHostingContextIdentifier() const { return m_layerHostingContextIdentifier; }
     void setAppBadge(const WebCore::SecurityOriginData&, std::optional<uint64_t> badge);
     void findFocusableElementDescendingIntoRemoteFrame(WebCore::FocusDirection, const WebCore::FocusEventData&, WebCore::ShouldFocusElement, CompletionHandler<void(WebCore::FoundElementInRemoteFrame)>&&);
@@ -349,6 +351,7 @@ private:
     CompletionHandler<void(std::optional<WebCore::PageIdentifier>, std::optional<WebCore::FrameIdentifier>)> m_navigateCallback;
     const WebCore::LayerHostingContextIdentifier m_layerHostingContextIdentifier;
     bool m_isPendingInitialHistoryItem { false };
+    bool m_isShowingInitialAboutBlank { true };
     std::optional<WebCore::IntRect> m_remoteFrameRect;
     WebCore::SandboxFlags m_effectiveSandboxFlags;
     WebCore::ReferrerPolicy m_effectiveReferrerPolicy { WebCore::ReferrerPolicy::EmptyString };

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5734,14 +5734,15 @@ void WebPageProxy::continueNavigationInNewProcess(API::Navigation& navigation, W
         loadParameters.navigationID = navigation.navigationID();
         loadParameters.effectiveSandboxFlags = frame.effectiveSandboxFlags();
         loadParameters.effectiveReferrerPolicy = frame.effectiveReferrerPolicy();
-        loadParameters.lockBackForwardList = navigation.isInitialFrameSrcLoad() ? LockBackForwardList::No : navigation.lockBackForwardList();
+        bool isPendingInitialHistoryItem = navigation.isInitialFrameSrcLoad() || frame.isShowingInitialAboutBlank();
+        loadParameters.lockBackForwardList = isPendingInitialHistoryItem ? LockBackForwardList::No : navigation.lockBackForwardList();
         loadParameters.ownerPermissionsPolicy = navigation.ownerPermissionsPolicy();
         loadParameters.navigationUpgradeToHTTPSBehavior = navigationUpgradeToHTTPSBehavior;
         loadParameters.isHandledByAboutSchemeHandler = m_aboutSchemeHandler->canHandleURL(loadParameters.request.url());
         if (auto& action = navigation.lastNavigationAction())
             loadParameters.requester = action->requester;
 
-        if (navigation.isInitialFrameSrcLoad())
+        if (isPendingInitialHistoryItem)
             frame.setIsPendingInitialHistoryItem(true);
 
         frame.prepareForProvisionalLoadInProcess(newProcess, navigation, browsingContextGroup, originator, [


### PR DESCRIPTION
#### 6c3c6413ec831ba8a424de99ed0c7b786a377ccd
<pre>
[Site Isolation] Dynamically created cross-site iframes should not add back/forward list entries
<a href="https://bugs.webkit.org/show_bug.cgi?id=310369">https://bugs.webkit.org/show_bug.cgi?id=310369</a>
<a href="https://rdar.apple.com/161250444">rdar://161250444</a>

Reviewed by Brady Eidson.

When a dynamically created iframe (still at about:blank) navigates to a
cross-site URL under site isolation, it was creating a duplicate
back/forward list entry. This happened because isPendingInitialHistoryItem
was only set for isInitialFrameSrcLoad navigations (&lt;iframe src=&quot;...&quot;&gt;),
not for iframes navigated from about:blank via JavaScript.

The fix adds isShowingInitialAboutBlank state to WebFrameProxy, which is
initialized to true and cleared on the first non-about:blank commit. This
is used alongside isInitialFrameSrcLoad to determine whether a frame&apos;s
first cross-site navigation should be registered as a child item in the
back/forward list tree rather than creating a new entry.

Test: http/tests/site-isolation/history/dynamic-cross-site-iframe-does-not-add-history-entry.html

* LayoutTests/http/tests/site-isolation/history/dynamic-cross-site-iframe-does-not-add-history-entry-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/history/dynamic-cross-site-iframe-does-not-add-history-entry.html: Added.
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::didCommitLoad):
* Source/WebKit/UIProcess/WebFrameProxy.h:
(WebKit::WebFrameProxy::isShowingInitialAboutBlank const):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::continueNavigationInNewProcess):
(WebKit::WebPageProxy::resetState):
(WebKit::WebPageProxy::resetStateAfterProcessExited):

Canonical link: <a href="https://commits.webkit.org/309666@main">https://commits.webkit.org/309666@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/932dfb8f8f3e78d8a0ce787ecb0880dbd197baac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151347 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24111 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17681 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160078 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/104785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ced620b3-c509-4865-9469-054b36df4e68) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24542 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24406 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116855 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/104785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d2f48970-b630-4a18-a2c6-bc573192bee6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154307 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18990 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135797 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97573 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/276e543b-2540-4c1f-89a6-9ebb958f6e14) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18081 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16023 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7923 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127703 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13709 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162550 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5683 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15286 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124867 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23912 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20077 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125051 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33931 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23902 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135505 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80398 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20114 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12275 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23511 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87815 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23223 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23376 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23277 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->