### PR TITLE
[GStreamer][MSE] Include WebCore SourceBuffer logs in GStreamer logs

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -675,22 +675,7 @@ void WebCoreLogObserver::didLogMessage(const WTFLogChannel& channel, WTFLogLevel
         builder.append(value);
 
     auto logString = builder.toString();
-    GstDebugLevel gstDebugLevel;
-    switch (level) {
-    case WTFLogLevel::Error:
-        gstDebugLevel = GST_LEVEL_ERROR;
-        break;
-    case WTFLogLevel::Debug:
-        gstDebugLevel = GST_LEVEL_DEBUG;
-        break;
-    case WTFLogLevel::Always:
-    case WTFLogLevel::Info:
-        gstDebugLevel = GST_LEVEL_INFO;
-        break;
-    case WTFLogLevel::Warning:
-        gstDebugLevel = GST_LEVEL_WARNING;
-        break;
-    };
+    auto gstDebugLevel = gstDebugLevelFromWTFLogLevel(level);
     gst_debug_log(debugCategory(), gstDebugLevel, __FILE__, __FUNCTION__, __LINE__, nullptr, "%s", logString.utf8().data());
 #else
     UNUSED_PARAM(channel);
@@ -2291,6 +2276,24 @@ void dumpBinToDotFile(const GRefPtr<GstElement>& element, const String& filename
     ASSERT(GST_IS_BIN(element.get()));
     dumpBinToDotFile(GST_BIN_CAST(element.get()), filename, details);
 }
+
+#if !RELEASE_LOG_DISABLED
+GstDebugLevel gstDebugLevelFromWTFLogLevel(WTFLogLevel level)
+{
+    switch (level) {
+    case WTFLogLevel::Error:
+        return GST_LEVEL_ERROR;
+    case WTFLogLevel::Debug:
+        return GST_LEVEL_DEBUG;
+    case WTFLogLevel::Always:
+    case WTFLogLevel::Info:
+        return GST_LEVEL_INFO;
+    case WTFLogLevel::Warning:
+        return GST_LEVEL_WARNING;
+    };
+    return GST_LEVEL_NONE;
+}
+#endif
 
 #undef GST_CAT_DEFAULT
 

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -389,6 +389,10 @@ GRefPtr<GstElement> createVideoConvertScaleElement(const String& name = emptyStr
 void dumpBinToDotFile(GstBin*, const String&, GstDebugGraphDetails = GST_DEBUG_GRAPH_SHOW_ALL);
 void dumpBinToDotFile(const GRefPtr<GstElement>&, const String&, GstDebugGraphDetails = GST_DEBUG_GRAPH_SHOW_ALL);
 
+#if !RELEASE_LOG_DISABLED
+GstDebugLevel gstDebugLevelFromWTFLogLevel(WTFLogLevel);
+#endif
+
 } // namespace WebCore
 
 #ifndef GST_BUFFER_DTS_OR_PTS

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -521,13 +521,6 @@ void AppendPipeline::appsinkNewSample(const Track& track, GRefPtr<GstSample>&& s
 
     auto mediaSample = MediaSampleGStreamer::create(WTF::move(sample), track.presentationSize, track.trackId);
 
-    GST_TRACE_OBJECT(pipeline(), "append: trackId=%" PRIu64 " PTS=%s DTS=%s DUR=%s presentationSize=%.0fx%.0f",
-        mediaSample->trackID(),
-        mediaSample->presentationTime().toString().utf8().data(),
-        mediaSample->decodeTime().toString().utf8().data(),
-        mediaSample->duration().toString().utf8().data(),
-        mediaSample->presentationSize().width(), mediaSample->presentationSize().height());
-
     // Hack, rework when GStreamer >= 1.16 becomes a requirement:
     // We're not applying edit lists. GStreamer < 1.16 doesn't emit the correct segments to do so.
     // GStreamer fix in https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/-/commit/c2a0da8096009f0f99943f78dc18066965be60f9

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.h
@@ -60,6 +60,8 @@ public:
     SourceBufferPrivateGStreamer& sourceBufferPrivate() { return m_sourceBufferPrivate; }
     MediaPlayerPrivateGStreamerMSE* playerPrivate() { return m_playerPrivate; }
 
+    GstElement* pipeline() const { return m_pipeline.get(); }
+
 private:
     struct Track {
         // Track objects are created on pad-added for the first initialization segment, and destroyed after
@@ -126,7 +128,6 @@ private:
     void handleEndOfAppend();
     void didReceiveInitializationSegment();
 
-    GstElement* pipeline() { return m_pipeline.get(); }
     GstElement* appsrc() { return m_appsrc.get(); }
 
     static AtomString generateTrackId(StreamType, int padIndex);

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
@@ -82,16 +82,73 @@ SourceBufferPrivateGStreamer::SourceBufferPrivateGStreamer(MediaSourcePrivateGSt
     std::call_once(debugRegisteredFlag, [] {
         GST_DEBUG_CATEGORY_INIT(webkit_mse_sourcebuffer_debug, "webkitmsesourcebuffer", 0, "WebKit MSE SourceBuffer");
     });
+
+#if !RELEASE_LOG_DISABLED && !defined(GST_DISABLE_GST_DEBUG)
+    m_logger->addMessageHandlerObserver(*this);
+#endif
 }
 
 SourceBufferPrivateGStreamer::~SourceBufferPrivateGStreamer()
 {
+#if !RELEASE_LOG_DISABLED && !defined(GST_DISABLE_GST_DEBUG)
+    m_logger->removeMessageHandlerObserver(*this);
+#endif
+
     if (!m_appendPromise)
         return;
 
     m_appendPromise->reject(PlatformMediaError::BufferRemoved);
     m_appendPromise.reset();
 }
+
+#if !RELEASE_LOG_DISABLED && !defined(GST_DISABLE_GST_DEBUG)
+void SourceBufferPrivateGStreamer::handleLogMessage(const WTFLogChannel& channel, WTFLogLevel level, Vector<JSONLogValue>&& values)
+{
+    auto name = StringView::fromLatin1(channel.name);
+    if (name != "MediaSource"_s)
+        return;
+
+    if (!gst_debug_category_get_threshold(GST_CAT_DEFAULT))
+        return;
+
+    // Ignore logs containing only the call site information.
+    if (values.size() < 2)
+        return;
+
+    // Parse "foo::bar(hexidentifier) "
+    auto& callSite = values[0].value;
+    auto leftParenthesisIndex = callSite.reverseFind('(');
+    if (leftParenthesisIndex == notFound)
+        return;
+
+    auto rightParenthesisIndex = callSite.reverseFind(')');
+    if (rightParenthesisIndex == notFound)
+        return;
+
+    if (!m_objectIdentifierString)
+        m_objectIdentifierString = makeString(hex(sourceBufferLogIdentifier()));
+
+    auto identifier = callSite.substring(leftParenthesisIndex + 1, rightParenthesisIndex - leftParenthesisIndex - 1);
+    if (identifier != m_objectIdentifierString)
+        return;
+
+    StringBuilder builder;
+    for (auto& value : values.subvector(1))
+        builder.append(WTF::makeStringByReplacingAll(value.value, '\"', '\''));
+
+    // Find the C++ method name, foo::bar() -> bar.
+    auto methodName = emptyString();
+    auto methodNameSeparatorIndex = callSite.reverseFind(':');
+    if (methodNameSeparatorIndex != notFound)
+        methodName = callSite.substring(methodNameSeparatorIndex + 1, leftParenthesisIndex - methodNameSeparatorIndex - 1);
+
+    auto gstDebugLevel = gstDebugLevelFromWTFLogLevel(level);
+    auto message = builder.toString();
+    auto pipeline = m_appendPipeline ? m_appendPipeline->pipeline() : nullptr;
+    // FIXME: Filename and line number are inaccurate. https://bugs.webkit.org/show_bug.cgi?id=310526
+    gst_debug_log(GST_CAT_DEFAULT, gstDebugLevel, __FILE__, methodName.utf8().data(), __LINE__, G_OBJECT(pipeline), "%s", message.utf8().data());
+}
+#endif // !RELEASE_LOG_DISABLED && !defined(GST_DISABLE_GST_DEBUG)
 
 Ref<MediaPromise> SourceBufferPrivateGStreamer::appendInternal(Ref<SharedBuffer>&& data)
 {

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
@@ -56,7 +56,11 @@ typedef MediaSourcePrivateGStreamer::RegisteredTrack RegisteredTrack;
 class AppendPipeline;
 class MediaSourcePrivateGStreamer;
 
-class SourceBufferPrivateGStreamer final : public SourceBufferPrivate, public CanMakeWeakPtr<SourceBufferPrivateGStreamer> {
+class SourceBufferPrivateGStreamer final : public SourceBufferPrivate, public CanMakeWeakPtr<SourceBufferPrivateGStreamer>
+#if !RELEASE_LOG_DISABLED && !defined(GST_DISABLE_GST_DEBUG)
+    , public Logger::MessageHandlerObserver
+#endif
+{
 public:
     static bool isContentTypeSupported(const ContentType&);
     static Ref<SourceBufferPrivateGStreamer> create(MediaSourcePrivateGStreamer&, const ContentType&);
@@ -96,6 +100,9 @@ public:
     WTFLogChannel& logChannel() const final;
     const Logger& sourceBufferLogger() const final { return m_logger; }
     uint64_t sourceBufferLogIdentifier() final { return logIdentifier(); }
+#ifndef GST_DISABLE_GST_DEBUG
+    void handleLogMessage(const WTFLogChannel&, WTFLogLevel, Vector<JSONLogValue>&&) final;
+#endif
 #endif
 
     size_t platformMaximumBufferSize() const override;
@@ -130,6 +137,7 @@ private:
 #if !RELEASE_LOG_DISABLED
     const Ref<const Logger> m_logger;
     const uint64_t m_logIdentifier;
+    String m_objectIdentifierString;
 #endif
 };
 


### PR DESCRIPTION
#### ae1329f607273e693548aa8be0cd56e7c8e67f0a
<pre>
[GStreamer][MSE] Include WebCore SourceBuffer logs in GStreamer logs
<a href="https://bugs.webkit.org/show_bug.cgi?id=310374">https://bugs.webkit.org/show_bug.cgi?id=310374</a>

Reviewed by Xabier Rodriguez-Calvar.

By making SourceBufferPrivateGStreamer inherit from Logger::MessageHandlerObserver we can now be
notified of WebCore logs and translate them to GStreamer logs in order to ease debugging. The
generated GStreamer logs have incorrect filename and line numbers, that will be addressed in a
follow-up PR.

* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::WebCoreLogObserver::didLogMessage):
(WebCore::gstDebugLevelFromWTFLogLevel):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp:
(WebCore::AppendPipeline::appsinkNewSample):
* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.h:
(WebCore::AppendPipeline::pipeline const):
(WebCore::AppendPipeline::pipeline): Deleted.
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp:
(WebCore::SourceBufferPrivateGStreamer::SourceBufferPrivateGStreamer):
(WebCore::SourceBufferPrivateGStreamer::~SourceBufferPrivateGStreamer):
(WebCore::SourceBufferPrivateGStreamer::handleLogMessage):
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/309748@main">https://commits.webkit.org/309748@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef0573bcd83169273a77462f48aa1e603be39f3d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151630 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/24411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/17976 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160365 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153504 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/24828 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24704 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/117115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154590 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/24828 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/17976 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/97830 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/24828 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/16284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8207 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/24828 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/17976 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162836 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/5972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/17976 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/125129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/24210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20342 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125311 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33997 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/24211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/17976 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/80786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/24211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/17976 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/23827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/88112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/23519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/23679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/23579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->