### PR TITLE
[JSC] Improve worst case performance of Air stack allocation

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirAllocateStackByGraphColoring.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateStackByGraphColoring.cpp
@@ -306,7 +306,7 @@ private:
         CompilerTimingScope timingScope("Air"_s, "StackAllocator::assign"_s);
 
         // Now we assign stack locations. At its heart this algorithm is just first-fit. For each
-        // StackSlot we just want to find the offsetFromFP that is closest to zero while ensuring no
+        // StackSlot we just want to find the offsetFromFP that is least negative while ensuring no
         // overlap with other StackSlots that this overlaps with.
         Vector<StackSlot*> otherSlots = assignedEscapedStackSlots;
         for (StackSlot* slot : m_code.stackSlots()) {
@@ -318,14 +318,17 @@ private:
                 continue;
             }
 
-            otherSlots.resize(assignedEscapedStackSlots.size());
+            otherSlots.shrink(0);
+            otherSlots.appendVector(assignedEscapedStackSlots);
             for (unsigned otherSlotIndex : m_interference[slot->index()]) {
                 if (isRemappedSlotIndex(otherSlotIndex))
                     continue;
                 StackSlot* otherSlot = m_code.stackSlots()[otherSlotIndex];
-                otherSlots.append(otherSlot);
+                if (otherSlot->offsetFromFP())
+                    otherSlots.append(otherSlot);
             }
 
+            std::ranges::sort(otherSlots, std::ranges::greater { }, &StackSlot::offsetFromFP);
             assign(slot, otherSlots);
         }
     }

--- a/Source/JavaScriptCore/b3/air/AirStackAllocation.cpp
+++ b/Source/JavaScriptCore/b3/air/AirStackAllocation.cpp
@@ -51,51 +51,32 @@ void updateFrameSizeBasedOnStackSlotsImpl(Code& code, const Collection& collecti
 
 } // anonymous namespace
 
-bool attemptAssignment(
-    StackSlot* slot, intptr_t offsetFromFP, const Vector<StackSlot*>& otherSlots)
+void assign(StackSlot* slot, const Vector<StackSlot*>& otherSlots)
 {
-    if (AirStackAllocationInternal::verbose)
-        dataLog("Attempting to assign ", pointerDump(slot), " to ", offsetFromFP, " with interference ", pointerListDump(otherSlots), "\n");
+    dataLogLnIf(AirStackAllocationInternal::verbose, "Attempting to assign ", pointerDump(slot), " with interference ", pointerListDump(otherSlots));
 
-    // Need to align it to the slot's desired alignment.
+    // Start candidate at the top of the frame and push it down past any overlapping slot.
+    intptr_t offsetFromFP = -static_cast<intptr_t>(slot->byteSize());
     offsetFromFP = -WTF::roundUpToMultipleOf(slot->alignment(), -offsetFromFP);
-    
+
+    intptr_t prevOffset = 0;
     for (StackSlot* otherSlot : otherSlots) {
-        if (!otherSlot->offsetFromFP())
-            continue;
+        ASSERT(otherSlot->offsetFromFP() < 0);
+        ASSERT_UNUSED(prevOffset, otherSlot->offsetFromFP() <= prevOffset);
+        prevOffset = otherSlot->offsetFromFP();
         bool overlap = WTF::rangesOverlap(
             offsetFromFP,
             offsetFromFP + static_cast<intptr_t>(slot->byteSize()),
             otherSlot->offsetFromFP(),
             otherSlot->offsetFromFP() + static_cast<intptr_t>(otherSlot->byteSize()));
-        if (overlap)
-            return false;
+        if (overlap) {
+            offsetFromFP = otherSlot->offsetFromFP() - static_cast<intptr_t>(slot->byteSize());
+            offsetFromFP = -WTF::roundUpToMultipleOf(slot->alignment(), -offsetFromFP);
+        }
     }
 
-    if (AirStackAllocationInternal::verbose)
-        dataLog("Assigned ", pointerDump(slot), " to ", offsetFromFP, "\n");
+    dataLogLnIf(AirStackAllocationInternal::verbose, "Assigned ", pointerDump(slot), " to ", offsetFromFP);
     slot->setOffsetFromFP(offsetFromFP);
-    return true;
-}
-
-void assign(StackSlot* slot, const Vector<StackSlot*>& otherSlots)
-{
-    if (AirStackAllocationInternal::verbose)
-        dataLog("Attempting to assign ", pointerDump(slot), " with interference ", pointerListDump(otherSlots), "\n");
-    
-    if (attemptAssignment(slot, -static_cast<intptr_t>(slot->byteSize()), otherSlots))
-        return;
-
-    for (StackSlot* otherSlot : otherSlots) {
-        if (!otherSlot->offsetFromFP())
-            continue;
-        bool didAssign = attemptAssignment(
-            slot, otherSlot->offsetFromFP() - static_cast<intptr_t>(slot->byteSize()), otherSlots);
-        if (didAssign)
-            return;
-    }
-
-    RELEASE_ASSERT_NOT_REACHED();
 }
 
 Vector<StackSlot*> allocateAndGetEscapedStackSlotsWithoutChangingFrameSize(Code& code)
@@ -116,12 +97,14 @@ Vector<StackSlot*> allocateAndGetEscapedStackSlotsWithoutChangingFrameSize(Code&
             ASSERT(!slot->offsetFromFP());
         }
     }
+    std::ranges::sort(assignedEscapedStackSlots, std::ranges::greater { }, &StackSlot::offsetFromFP);
     // This is a fairly expensive loop, but it's OK because we'll usually only have a handful of
     // escaped stack slots.
     while (!escapedStackSlotsWorklist.isEmpty()) {
         StackSlot* slot = escapedStackSlotsWorklist.takeLast();
         assign(slot, assignedEscapedStackSlots);
-        assignedEscapedStackSlots.append(slot);
+        auto it = std::ranges::upper_bound(assignedEscapedStackSlots, slot->offsetFromFP(), std::ranges::greater { }, &StackSlot::offsetFromFP);
+        assignedEscapedStackSlots.insert(it - assignedEscapedStackSlots.begin(), slot);
     }
     return assignedEscapedStackSlots;
 }

--- a/Source/JavaScriptCore/b3/air/AirStackAllocation.h
+++ b/Source/JavaScriptCore/b3/air/AirStackAllocation.h
@@ -36,12 +36,9 @@ class StackSlot;
 
 // This is a collection of utilities shared by stack allocators.
 
-// Attempt to put the given stack slot at the given offset. Returns false if this would cause
-// the slot to overlap with any of the given slots.
-bool attemptAssignment(StackSlot*, intptr_t offsetFromFP, const Vector<StackSlot*>& adjacent);
-
 // Performs a first-fit assignment (smallest possible offset) of the given stack slot such that
-// it does not overlap with any of the adjacent slots.
+// it does not overlap with any of the adjacent slots. The adjacent slots must all have assigned
+// offsets (offsetFromFP < 0) and be sorted by offsetFromFP descending (closest to FP first).
 void assign(StackSlot*, const Vector<StackSlot*>& adjacent);
 
 // Allocates all stack slots that escape - that is, that don't have live ranges that can be

--- a/Source/JavaScriptCore/b3/air/testair.cpp
+++ b/Source/JavaScriptCore/b3/air/testair.cpp
@@ -2464,8 +2464,6 @@ void testLinearScanSpillRangesEarlyDef()
 #if USE(JSVALUE64)
 void testZDefOfSpillSlotWithOffsetNeedingToBeMaterializedInARegister()
 {
-    if (Options::defaultB3OptLevel() == 2)
-        return;
 
     B3::Procedure proc;
     Code& code = proc.code();
@@ -2496,6 +2494,101 @@ void testZDefOfSpillSlotWithOffsetNeedingToBeMaterializedInARegister()
 
     const auto result = compileAndRun<uint64_t>(proc);
     CHECK(result == (numberOfLiveTmps * (numberOfLiveTmps - 1)) / 2);
+}
+
+void testStackSlotSharingWithNonInterferingSlots()
+{
+    // O0 uses a simple stack allocator that gives every slot a unique offset — no sharing.
+    // This test verifies the graph coloring stack allocator's sharing, which is used at O1+.
+    if (!Options::defaultB3OptLevel())
+        return;
+
+    B3::Procedure proc;
+    Code& code = proc.code();
+    BasicBlock* root = code.addBlock();
+
+    // "interfering" tmps are live across both phases — they interfere with all other tmps.
+    // "non-interfering" tmps per phase — phase 1 and phase 2 tmps don't interfere with each other.
+    // Choose values large enough to force spilling.
+    unsigned numberOfInterferingTmps = 200;
+    unsigned numberOfNonInterferingTmpsPerPhase = 200;
+
+    // Initialize shared tmps with values 0..numberOfInterferingTmps-1.
+    Vector<Tmp> sharedTmps;
+    Tmp counter = code.newTmp(GP);
+    root->append(Move, nullptr, Arg::imm(0), counter);
+    for (unsigned i = 0; i < numberOfInterferingTmps; ++i) {
+        Tmp tmp = code.newTmp(GP);
+        sharedTmps.append(tmp);
+        root->append(Move, nullptr, counter, tmp);
+        root->append(Add64, nullptr, Arg::imm(1), counter);
+    }
+
+    // Phase 1: create all local tmps first (so they're all simultaneously live), then consume them.
+    Vector<Tmp> phase1Tmps;
+    Tmp result = code.newTmp(GP);
+    Tmp loadResult = code.newTmp(GP);
+    root->append(Move, nullptr, Arg::imm(0), result);
+    for (unsigned i = 0; i < numberOfNonInterferingTmpsPerPhase; ++i) {
+        Tmp tmp = code.newTmp(GP);
+        phase1Tmps.append(tmp);
+        root->append(Move, nullptr, counter, tmp);
+        root->append(Add64, nullptr, Arg::imm(1), counter);
+    }
+    for (auto tmp : phase1Tmps) {
+        root->append(Move, nullptr, tmp, loadResult);
+        root->append(Add64, nullptr, loadResult, result);
+    }
+    // Phase 1 locals are now dead.
+
+    // Phase 2: same pattern — all local tmps live simultaneously, then consumed.
+    Vector<Tmp> phase2Tmps;
+    for (unsigned i = 0; i < numberOfNonInterferingTmpsPerPhase; ++i) {
+        Tmp tmp = code.newTmp(GP);
+        phase2Tmps.append(tmp);
+        root->append(Move, nullptr, counter, tmp);
+        root->append(Add64, nullptr, Arg::imm(1), counter);
+    }
+    for (auto tmp : phase2Tmps) {
+        root->append(Move, nullptr, tmp, loadResult);
+        root->append(Add64, nullptr, loadResult, result);
+    }
+    // Phase 2 locals are now dead.
+
+    // Use all shared tmps — they're still live, proving they interfere with both phases.
+    for (auto tmp : sharedTmps) {
+        root->append(Move, nullptr, tmp, loadResult);
+        root->append(Add64, nullptr, loadResult, result);
+    }
+
+    root->append(Move, nullptr, result, Tmp(GPRInfo::returnValueGPR));
+    root->append(Ret64, nullptr, Tmp(GPRInfo::returnValueGPR));
+
+    // Compile and check correctness.
+    prepareForGeneration(code);
+
+    // Verify frame size reflects sharing: phase 1 and phase 2 non-interfering tmps should share stack space.
+    // Without sharing: need space for numberOfInterferingTmps + 2*numberOfNonInterferingTmpsPerPhase spilled slots.
+    // With sharing: need space for only numberOfInterferingTmps + numberOfNonInterferingTmpsPerPhase spilled slots.
+    // Some tmps will be register-allocated rather than spilled, so account for that.
+    unsigned numGPRs = RegisterSet::allGPRs().numberOfSetRegisters();
+    unsigned minFrameSize = (numberOfInterferingTmps - numGPRs) * 8 + stackAdjustmentForAlignment();
+    // Allow some slack for callee-save slots and helper tmps that may spill.
+    unsigned slackSlots = numGPRs;
+    unsigned maxFrameSizeWithSharing = (numberOfInterferingTmps + numberOfNonInterferingTmpsPerPhase + slackSlots) * 8 + stackAdjustmentForAlignment();
+    CHECK(code.frameSize() >= minFrameSize);
+    CHECK(code.frameSize() <= maxFrameSizeWithSharing);
+
+    // Also verify the computed result is correct (no stack corruption).
+    unsigned total = numberOfInterferingTmps + 2 * numberOfNonInterferingTmpsPerPhase;
+    uint64_t expectedResult = static_cast<uint64_t>(total) * (total - 1) / 2;
+
+    CCallHelpers jit;
+    generate(code, jit);
+    LinkBuffer linkBuffer(jit, nullptr);
+    auto compilation = makeUnique<Compilation>(
+        FINALIZE_CODE(linkBuffer, JITCompilationPtrTag, nullptr, "testair compilation"), proc.releaseByproducts());
+    CHECK(invoke<uint64_t>(*compilation) == expectedResult);
 }
 
 void testEarlyAndLateUseOfSameTmp()
@@ -2981,6 +3074,7 @@ void run(const char* filter)
     RUN(testMulDoubleZeroWithOther());
 
     RUN(testZDefOfSpillSlotWithOffsetNeedingToBeMaterializedInARegister());
+    RUN(testStackSlotSharingWithNonInterferingSlots());
 
     RUN(testEarlyAndLateUseOfSameTmp());
     RUN(testEarlyClobberInterference());


### PR DESCRIPTION
#### c03651a49eb908c397709c0fae4596049cbe8bca
<pre>
[JSC] Improve worst case performance of Air stack allocation
<a href="https://bugs.webkit.org/show_bug.cgi?id=310376">https://bugs.webkit.org/show_bug.cgi?id=310376</a>
<a href="https://rdar.apple.com/173019617">rdar://173019617</a>

Reviewed by Yusuke Suzuki.

Eventually we may want to replace the interference graph based stack
allocator with one based on live-range intervals (similar to the
greedy register allocator).

But in the meantime, optimize the stack slot assignment algorithm from
O(n²) to O(n log n). The old code tried each candidate position and
re-scanned all interfering slots to verify no overlap. The new code sorts
the interference list by offset and does a single sweep, pushing the
candidate down past any overlapping slot.

This also makes the assignment truly first-fit (closest to FP), whereas
the old code iterated interference lists in arbitrary order and took the
first valid position found.

Improves testair performance from ~5 minutes to a few seconds because
a test case (testZDefOfSpillSlotWithOffsetNeedingToBeMaterializedInARegister)
had a lot of interfering tmps.

Test: Source/JavaScriptCore/b3/air/testair.cpp
* Source/JavaScriptCore/b3/air/testair.cpp:
* Source/JavaScriptCore/b3/air/AirAllocateStackByGraphColoring.cpp:
* Source/JavaScriptCore/b3/air/AirStackAllocation.cpp:
(JSC::B3::Air::assign):
(JSC::B3::Air::attemptAssignment): Deleted.
* Source/JavaScriptCore/b3/air/AirStackAllocation.h:

Canonical link: <a href="https://commits.webkit.org/309668@main">https://commits.webkit.org/309668@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5eac0f54dee1ba7f6b8b0036801c31fcc93b46c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151354 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24118 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17688 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160085 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/104792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24549 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24413 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116861 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/104792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eaa1f276-248a-41df-92c5-251abc3bf909) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154314 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19001 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135802 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97579 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ef4eb0a0-1e11-460c-aa3f-61fed47af7e3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18092 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16033 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7930 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/143342 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127714 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13714 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162557 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/12154 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5690 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15291 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124874 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23919 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20087 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125058 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33932 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23909 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135510 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80405 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20126 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12280 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/182963 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23518 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87822 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46665 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23230 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23383 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23284 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->