### PR TITLE
[webkit.org] Content Spoofing / Text injection

### DIFF
--- a/Websites/bugs.webkit.org/show_bug.cgi
+++ b/Websites/bugs.webkit.org/show_bug.cgi
@@ -38,6 +38,22 @@ if (!$cgi->param('id') && $single) {
     exit;
 }
 
+#if WEBKIT_CHANGES
+# Reject invalid bug IDs/aliases early to prevent content spoofing.
+# Valid input is either a numeric bug ID or a bug alias
+# (max 40 chars, no spaces/commas). Anything else is rejected
+# without reflecting the input.
+if ($single) {
+    my $raw_id = $cgi->param('id');
+    if (defined $raw_id) {
+        my $trimmed = trim($raw_id);
+        if ($trimmed !~ /^[\w\.\-]{1,40}$/) {
+            ThrowUserError('improper_bug_id_field_value');
+        }
+    }
+}
+#endif // WEBKIT_CHANGES
+
 my (@bugs, @illegal_bugs);
 my %marks;
 
@@ -68,6 +84,13 @@ if ($single) {
 
         foreach my $bug_id (@ids) {
             next unless $bug_id;
+            #if WEBKIT_CHANGES
+            # Reject non-ID/alias values to prevent content spoofing.
+            if (trim($bug_id) !~ /^[\w\.\-]{1,40}$/) {
+                push(@illegal_bugs, { bug_id => '#', error => 'InvalidBugId' });
+                next;
+            }
+            #endif // WEBKIT_CHANGES
             my $bug = new Bugzilla::Bug({ id => $bug_id, cache => 1 });
             if (!$bug->{error}) {
                 push(@check_bugs, $bug);


### PR DESCRIPTION
#### 6a23de8fae095e89a51361b5ff684fea33b254ec
<pre>
[webkit.org] Content Spoofing / Text injection
<a href="https://bugs.webkit.org/show_bug.cgi?id=310377">https://bugs.webkit.org/show_bug.cgi?id=310377</a>
<a href="https://rdar.apple.com/159668969">rdar://159668969</a>

Reviewed by Alexey Proskuryakov.

Reject invalid bug IDs/aliases early to prevent content spoofing when
error message is displayed.
Valid input is either a numeric bug ID or a bug alias
(max 40 chars, no spaces/commas).
Anything else is rejected without reflecting the input.

* Websites/bugs.webkit.org/show_bug.cgi:

Canonical link: <a href="https://commits.webkit.org/309639@main">https://commits.webkit.org/309639@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d64c2f9c0a766c4f5e3b036820db9949990c08f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151309 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24072 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17643 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160040 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/104747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/71df1ba0-8706-4e56-9df7-4387c29dee88) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24504 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24362 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/116828 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/104747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3088baf3-599f-44bb-9d6d-63de729a1deb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154269 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/18968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/135767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97546 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/20f812fb-b12c-49b6-b462-4b4cacdc34fa) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/18059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/15997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7885 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/127681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162512 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15256 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/124839 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23874 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/20051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125023 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33907 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23864 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135475 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80360 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20090 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/12245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23473 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23185 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23338 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23239 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->