### PR TITLE
AX: Functions should be excluded from accessibility/ARIA-reflection.html

### DIFF
--- a/LayoutTests/accessibility/ARIA-reflection.html
+++ b/LayoutTests/accessibility/ARIA-reflection.html
@@ -23,6 +23,14 @@
     var currentProperty;
     var currentAttribute;
 
+    function isNonReflectionMethod(method) {
+        switch (method) {
+            case "ariaNotify":
+                return true;
+        }
+        return false;
+    }
+
     function isElementReflectionProperty(property) {
         switch (property) {
             case "ariaActiveDescendantElement":
@@ -122,7 +130,7 @@
         // There are 46 ARIA attributes in total.
         var count = 0;
         for (var propertyName in element) {
-          if (propertyName.startsWith("aria")) {
+          if (propertyName.startsWith("aria") && !isNonReflectionMethod(propertyName)) {
               currentProperty = propertyName;
               testElement();
               count++;


### PR DESCRIPTION
#### 772bdd2f596b86cb92ed2daf8f72fbcb369237af
<pre>
AX: Functions should be excluded from accessibility/ARIA-reflection.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=310388">https://bugs.webkit.org/show_bug.cgi?id=310388</a>
<a href="https://rdar.apple.com/173026713">rdar://173026713</a>

Reviewed by Tyler Wilcock.

We now have aria- prefixed methods exposed on Element, so we should skip those
when testing reflections. This helper method is extendable in case more aria
methods are added in the future.

* LayoutTests/accessibility/ARIA-reflection.html:

Canonical link: <a href="https://commits.webkit.org/309656@main">https://commits.webkit.org/309656@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/658557f5366a0ae9b25fbb4c5782a118cff373e1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151307 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24070 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17641 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160038 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104745 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/86416b50-db72-49b6-82f3-110abc6b7500) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24502 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24357 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116825 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82950 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3b60ce6b-6722-416e-8586-da69b3294206) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154267 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18958 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135765 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97543 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5bd7ebbf-102d-461b-8f8c-d3140a1e22ea) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18049 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15998 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7883 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127671 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13677 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162510 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15254 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124837 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23872 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20052 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125021 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33922 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23862 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135473 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80358 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20094 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12243 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23471 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23183 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23336 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23237 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->