### PR TITLE
AX: AccessibilityRenderObject::setSelectedVisiblePositionRange fails for textarea inside iframe when called on the top-level web area.

### DIFF
--- a/LayoutTests/accessibility/mac/set-selected-textmarker-range-textarea-in-iframe-expected.txt
+++ b/LayoutTests/accessibility/mac/set-selected-textmarker-range-textarea-in-iframe-expected.txt
@@ -1,0 +1,14 @@
+Tests that setting AXSelectedTextMarkerRange on a web area correctly moves the selection inside a textarea in an iframe. This exercises the setSelectedVisiblePositionRange code path where the accessibility object is the web area but the target position is inside a textarea's shadow DOM.
+
+PASS: rootWebArea.role === 'AXRole: AXWebArea'
+PASS: textarea.role === 'AXRole: AXTextArea'
+PASS: textareaElement.selectionStart === 10
+PASS: textareaElement.selectionEnd === 10
+PASS: textareaElement.selectionStart === 9
+PASS: textareaElement.selectionEnd === 13
+PASS: textarea.stringForTextMarkerRange(selectedRange) === 'dark'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/set-selected-textmarker-range-textarea-in-iframe.html
+++ b/LayoutTests/accessibility/mac/set-selected-textmarker-range-textarea-in-iframe.html
@@ -1,0 +1,78 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+</head>
+<body>
+
+<iframe id="iframe" onload="startTest();" src="data:text/html,<body><label for='textarea'>Tell us your story:</label><textarea id='textarea' rows='3' cols='40'>It was a dark and stormy night.</textarea></body>"></iframe>
+
+<script>
+async function startTest() {
+    if (!window.accessibilityController)
+        return;
+
+    var output = "Tests that setting AXSelectedTextMarkerRange on a web area correctly moves the selection inside a textarea in an iframe. This exercises the setSelectedVisiblePositionRange code path where the accessibility object is the web area but the target position is inside a textarea's shadow DOM.\n\n";
+    window.jsTestIsAsync = true;
+
+    // Focus the textarea so it's editable and ready for selection changes.
+    var iframe = document.getElementById("iframe");
+    textareaElement = iframe.contentDocument.getElementById("textarea");
+    textareaElement.focus();
+
+    await waitFor(() => {
+        return accessibilityController.focusedElement.role == "AXRole: AXTextArea";
+    });
+
+    rootWebArea = accessibilityController.rootElement.childAtIndex(0);
+    output += expect("rootWebArea.role", "'AXRole: AXWebArea'");
+
+    textarea = accessibilityController.accessibleElementById("textarea");
+    output += expect("textarea.role", "'AXRole: AXTextArea'");
+
+    // Get the textarea's text range and create markers at specific offsets.
+    fullRange = textarea.textMarkerRangeForElement(textarea);
+
+    // Move caret to textarea offset 10 by walking from the textarea's start marker.
+    var marker = textarea.startTextMarkerForTextMarkerRange(fullRange);
+    for (var i = 0; i < 10; i++)
+        marker = textarea.nextTextMarker(marker);
+    var rangeAtOffset10 = rootWebArea.textMarkerRangeForMarkers(marker, marker);
+
+    // Set the selected text marker range on the top-level WEB AREA.
+    // The markers point to positions inside the iframe's textarea shadow DOM.
+    // Without the fix in setSelectedVisiblePositionRange, this fails because
+    // contains<ComposedTree> returns false for cross-document positions.
+    rootWebArea.setSelectedTextMarkerRange(rangeAtOffset10);
+    await waitFor(() => {
+        return textareaElement.selectionStart == 10;
+    });
+    output += expect("textareaElement.selectionStart", "10");
+    output += expect("textareaElement.selectionEnd", "10");
+
+    // Select "dark" (textarea offsets 9-13).
+    var startMarker = textarea.startTextMarkerForTextMarkerRange(fullRange);
+    for (var i = 0; i < 9; i++)
+        startMarker = textarea.nextTextMarker(startMarker);
+    var endMarker = startMarker;
+    for (var i = 0; i < 4; i++)
+        endMarker = textarea.nextTextMarker(endMarker);
+    var darkRange = rootWebArea.textMarkerRangeForMarkers(startMarker, endMarker);
+
+    rootWebArea.setSelectedTextMarkerRange(darkRange);
+    await waitFor(() => {
+        return textareaElement.selectionStart == 9 && textareaElement.selectionEnd == 13;
+    });
+    output += expect("textareaElement.selectionStart", "9");
+    output += expect("textareaElement.selectionEnd", "13");
+
+    selectedRange = textarea.selectedTextMarkerRange();
+    output += expect("textarea.stringForTextMarkerRange(selectedRange)", "'dark'");
+
+    debug(output);
+    finishJSTest();
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -78,6 +78,7 @@
 #include "HTMLSummaryElement.h"
 #include "HTMLTableElement.h"
 #include "HTMLTextAreaElement.h"
+#include "HTMLTextFormControlElement.h"
 #include "HTMLVideoElement.h"
 #include "HitTestRequest.h"
 #include "HitTestResult.h"
@@ -2107,10 +2108,22 @@ void AccessibilityRenderObject::setSelectedVisiblePositionRange(const VisiblePos
     if (client)
         client->willChangeSelectionForAccessibility();
 
+    // Resolve the target text control: either this object itself is a native
+    // text control, or the target position is inside one (e.g. a textarea in
+    // an iframe when this object is the web area). In the latter case, the
+    // else branch below would fail because contains<ComposedTree> returns
+    // false for cross-document positions, clamping the selection to the web
+    // area start.
+    RefPtr<HTMLTextFormControlElement> textControl;
     if (isNativeTextControl()) {
-        // isNativeTextControl returns true only if this->node() is<HTMLTextAreaElement> or is<HTMLInputElement>.
-        // Since both HTMLTextAreaElement and HTMLInputElement derive from HTMLTextFormControlElement, it is safe to downcast here.
-        Ref textControl = uncheckedDowncast<HTMLTextFormControlElement>(*node());
+        // isNativeTextControl returns true only for HTMLTextAreaElement or HTMLInputElement,
+        // both of which derive from HTMLTextFormControlElement.
+        ASSERT(is<HTMLTextFormControlElement>(node()));
+        textControl = downcast<HTMLTextFormControlElement>(node());
+    } else
+        textControl = enclosingTextFormControl(range.start.deepEquivalent());
+
+    if (textControl) {
         int start = textControl->indexForVisiblePosition(range.start);
         int end = textControl->indexForVisiblePosition(range.end);
 
@@ -2120,10 +2133,11 @@ void AccessibilityRenderObject::setSelectedVisiblePositionRange(const VisiblePos
         // the case when range is obtained from AXObjectCache::rangeForNodeContents
         // for the HTMLTextFormControlElement.
         // Thus, the following corrects the start and end indexes in such a case..
-        if (range.start.deepEquivalent().anchorNode() == range.end.deepEquivalent().anchorNode()
-            && range.start.deepEquivalent().anchorNode() == textControl.ptr()) {
+        if (isNativeTextControl()
+            && range.start.deepEquivalent().anchorNode() == range.end.deepEquivalent().anchorNode()
+            && range.start.deepEquivalent().anchorNode() == textControl) {
             if (auto innerText = textControl->innerTextElement()) {
-                auto textControlRange = makeVisiblePositionRange(AXObjectCache::rangeForNodeContents(textControl.get()));
+                auto textControlRange = makeVisiblePositionRange(AXObjectCache::rangeForNodeContents(*textControl));
                 auto innerRange = makeVisiblePositionRange(AXObjectCache::rangeForNodeContents(*innerText));
 
                 if (range.start.equals(textControlRange.end))


### PR DESCRIPTION
#### 9d54c7c9abaaf749ea932f09a5aff6c752a8aa31
<pre>
AX: AccessibilityRenderObject::setSelectedVisiblePositionRange fails for textarea inside iframe when called on the top-level web area.
<a href="https://bugs.webkit.org/show_bug.cgi?id=310387">https://bugs.webkit.org/show_bug.cgi?id=310387</a>
&lt;<a href="https://rdar.apple.com/problem/173025927">rdar://problem/173025927</a>&gt;

Reviewed by Joshua Hoffman.

When AXSelectedTextMarkerRange is set on a web area but the target position is
inside a textarea&apos;s shadow DOM (e.g. a textarea inside an iframe),
AccessibilityRenderObject::setSelectedVisiblePositionRange takes the
else-if-m_renderer branch. The contains&lt;ComposedTree&gt; check fails for
cross-document positions, clamping the selection to the web area start instead
of moving it into the textarea.

Fix by adding an enclosingTextFormControl fallback in
setSelectedVisiblePositionRange() when the target position is inside a native
text control but &apos;this&apos; is not the text control itself (e.g. this is the web
area), delegate to the text control&apos;s setSelectionRange which handles the
selection correctly.

Test: accessibility/mac/set-selected-textmarker-range-textarea-in-iframe.html

* LayoutTests/accessibility/mac/set-selected-textmarker-range-textarea-in-iframe-expected.txt: Added.
* LayoutTests/accessibility/mac/set-selected-textmarker-range-textarea-in-iframe.html: Added.
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::setSelectedVisiblePositionRange const):

Canonical link: <a href="https://commits.webkit.org/309759@main">https://commits.webkit.org/309759@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6fc253dd6be4c7e01a74a0eea219fc5f34b2bb15

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151663 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24444 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/18014 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160398 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f70a1e44-6f69-41a5-97e2-d573fad1d8dc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153537 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24917 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24737 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/117141 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/28abe815-b7ba-4391-81cb-8f1847d6fa69) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154623 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/136092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97856 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c7f33644-5525-4e44-83dd-107c1cf87ca9) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/18366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16315 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8240 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/127996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/13996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162869 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/6018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/15586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/125158 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/24243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20373 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125340 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34008 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/24244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/135792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/80819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/24244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/12567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23860 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88145 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/23552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/23712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/23612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->