### PR TITLE
Reduce memory overhead of user scripts and user styles in extensions with many distinct match patterns

### DIFF
--- a/Source/WebCore/page/UserScript.cpp
+++ b/Source/WebCore/page/UserScript.cpp
@@ -27,6 +27,8 @@
 #include "config.h"
 #include "UserScript.h"
 
+#include <wtf/HashCountedSet.h>
+#include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
@@ -40,8 +42,20 @@ static WTF::URL generateUserScriptUniqueURL()
     return { { }, makeString("user-script:"_s, ++identifier) };
 }
 
+static HashCountedSet<String>& sourceStrings()
+{
+    static NeverDestroyed<HashCountedSet<String>> set;
+    return set;
+}
+
+static String internedSourceString(const String& string)
+{
+    auto result = sourceStrings().add(string);
+    return result.iterator->key;
+}
+
 UserScript::UserScript(String&& source, URL&& url, Vector<String>&& allowlist, Vector<String>&& blocklist, UserScriptInjectionTime injectionTime, UserContentInjectedFrames injectedFrames, UserContentMatchParentFrame matchParentFrame)
-    : m_source(WTF::move(source))
+    : m_source(internedSourceString(source))
     , m_url(url.isEmpty() ? generateUserScriptUniqueURL() : WTF::move(url))
     , m_allowlist(WTF::move(allowlist))
     , m_blocklist(WTF::move(blocklist))
@@ -49,6 +63,11 @@ UserScript::UserScript(String&& source, URL&& url, Vector<String>&& allowlist, V
     , m_injectedFrames(injectedFrames)
     , m_matchParentFrame(matchParentFrame)
 {
+}
+
+UserScript::~UserScript()
+{
+    sourceStrings().remove(m_source);
 }
 
 String UserScript::debugDescription() const

--- a/Source/WebCore/page/UserScript.h
+++ b/Source/WebCore/page/UserScript.h
@@ -37,6 +37,7 @@ class UserScript {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(UserScript, WEBCORE_EXPORT);
 public:
     WEBCORE_EXPORT UserScript(String&& source, URL&& = { }, Vector<String>&& allowlist = { }, Vector<String>&& blocklist = { }, UserScriptInjectionTime = UserScriptInjectionTime::DocumentStart, UserContentInjectedFrames = UserContentInjectedFrames::InjectInAllFrames, UserContentMatchParentFrame = UserContentMatchParentFrame::Never);
+    WEBCORE_EXPORT ~UserScript();
 
     const String& source() const LIFETIME_BOUND { return m_source; }
     const URL& url() const LIFETIME_BOUND { return m_url; }

--- a/Source/WebCore/page/UserStyleSheet.cpp
+++ b/Source/WebCore/page/UserStyleSheet.cpp
@@ -27,6 +27,8 @@
 #include "config.h"
 #include "UserStyleSheet.h"
 
+#include <wtf/HashCountedSet.h>
+#include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
@@ -40,8 +42,20 @@ static WTF::URL generateUserStyleUniqueURL()
     return { { }, makeString("user-style:"_s, ++identifier) };
 }
 
+static HashCountedSet<String>& styleStrings()
+{
+    static NeverDestroyed<HashCountedSet<String>> set;
+    return set;
+}
+
+static String internedStyleString(const String& string)
+{
+    auto result = styleStrings().add(string);
+    return result.iterator->key;
+}
+
 UserStyleSheet::UserStyleSheet(const String& source, const URL& url, Vector<String>&& allowlist, Vector<String>&& blocklist, UserContentInjectedFrames injectedFrames, UserContentMatchParentFrame matchParentFrame, UserStyleLevel level, std::optional<PageIdentifier> pageID)
-    : m_source(source)
+    : m_source(internedStyleString(source))
     , m_url(url.isEmpty() ? generateUserStyleUniqueURL() : url)
     , m_allowlist(WTF::move(allowlist))
     , m_blocklist(WTF::move(blocklist))
@@ -50,6 +64,11 @@ UserStyleSheet::UserStyleSheet(const String& source, const URL& url, Vector<Stri
     , m_level(level)
     , m_pageID(pageID)
 {
+}
+
+UserStyleSheet::~UserStyleSheet()
+{
+    styleStrings().remove(m_source);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/UserStyleSheet.h
+++ b/Source/WebCore/page/UserStyleSheet.h
@@ -44,6 +44,7 @@ public:
     }
 
     WEBCORE_EXPORT UserStyleSheet(const String&, const URL&, Vector<String>&& = { }, Vector<String>&& = { }, UserContentInjectedFrames = UserContentInjectedFrames::InjectInAllFrames, UserContentMatchParentFrame = UserContentMatchParentFrame::Never, UserStyleLevel = UserStyleLevel::User, std::optional<PageIdentifier> = std::nullopt);
+    WEBCORE_EXPORT ~UserStyleSheet();
 
     const String& source() const LIFETIME_BOUND { return m_source; }
     const URL& url() const LIFETIME_BOUND { return m_url; }

--- a/Source/WebKit/Platform/IPC/TransferString.cpp
+++ b/Source/WebKit/Platform/IPC/TransferString.cpp
@@ -152,4 +152,43 @@ TransferString::IPCData TransferString::toIPCData() const LIFETIME_BOUND
     );
 }
 
+TransferString::TransferString(const TransferString& other)
+{
+    WTF::switchOn(other.m_storage,
+        [&](const String& string) {
+            m_storage = string;
+        },
+#if USE(CF)
+        [&](const RetainPtr<CFStringRef>& string) {
+            m_storage = string;
+        },
+#endif
+        [&](const SharedSpan8& handle) {
+            m_storage = SharedSpan8 { WebCore::SharedMemoryHandle { handle.dataHandle } };
+        },
+        [&](const SharedSpan16& handle) {
+            m_storage = SharedSpan16 { WebCore::SharedMemoryHandle { handle.dataHandle } };
+        }
+    );
+}
+
+TransferString& TransferString::operator=(const TransferString& other)
+{
+    if (this != &other)
+        *this = TransferString { other };
+    return *this;
+}
+
+bool TransferString::shouldCache() const
+{
+    return WTF::switchOn(m_storage,
+        [](const String&) { return false; },
+#if USE(CF)
+        [](const RetainPtr<CFStringRef>& string) { return false; },
+#endif
+        [](const SharedSpan8& handle) { return true; },
+        [](const SharedSpan16& handle) { return true; }
+    );
+}
+
 }

--- a/Source/WebKit/Platform/IPC/TransferString.h
+++ b/Source/WebKit/Platform/IPC/TransferString.h
@@ -64,6 +64,8 @@ public:
     TransferString(SharedSpan16&&);
 
     TransferString(IPCData&&);
+    TransferString(const TransferString&);
+    TransferString& operator=(const TransferString&);
     TransferString(TransferString&&) = default;
     TransferString& operator=(TransferString&&) = default;
 
@@ -79,6 +81,9 @@ public:
     std::optional<String> releaseToCopy() && { return WTF::move(*this).release(std::numeric_limits<size_t>::max()); };
 
     IPCData toIPCData() const LIFETIME_BOUND;
+
+    // Caching only makes sense if we can re-send a previously created shared memory handle.
+    bool shouldCache() const;
 
 private:
     static std::optional<TransferString> createCopy(std::span<const Latin1Character>);

--- a/Source/WebKit/Platform/IPC/cocoa/TransferStringCocoa.mm
+++ b/Source/WebKit/Platform/IPC/cocoa/TransferStringCocoa.mm
@@ -68,21 +68,14 @@ std::optional<TransferString> TransferString::createCached(NSString *string)
         if (!result)
             return std::nullopt;
 
-        // Caching only makes sense if we can re-send a previously created shared memory handle.
-        bool shouldCache = WTF::switchOn(result->m_storage,
-            [](const String&) { return false; },
-            [](const RetainPtr<CFStringRef>& string) { return false; },
-            [](const SharedSpan8& handle) { return true; },
-            [](const SharedSpan16& handle) { return true; }
-        );
-        if (!shouldCache)
+        if (!result->shouldCache())
             return result;
 
         wrapper = adoptNS([[_WKTransferStringWrapper alloc] initWithString:WTF::move(*result)]);
         objc_setAssociatedObject(string, transferStringWrapperKey, wrapper.get(), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
 
-    return TransferString { [wrapper string].toIPCData() };
+    return [wrapper string];
 }
 
 }

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1634,6 +1634,8 @@ def headers_for_type(type, for_implementation_file=False):
         'WebKit::WebPushD::WebPushDaemonConnectionConfiguration': ['"WebPushDaemonConnectionConfiguration.h"'],
         'WebKit::WebScriptMessageHandlerData': ['"WebUserContentControllerDataTypes.h"'],
         'WebKit::WebTransportSessionIdentifier': ['"WebTransportSession.h"'],
+        'WebKit::WebCoreUserScriptData': ['"WebUserContentControllerDataTypes.h"'],
+        'WebKit::WebCoreUserStyleSheetData': ['"WebUserContentControllerDataTypes.h"'],
         'WebKit::WebUserScriptData': ['"WebUserContentControllerDataTypes.h"'],
         'WebKit::WebUserStyleSheetData': ['"WebUserContentControllerDataTypes.h"'],
         'WTF::UnixFileDescriptor': ['<wtf/unix/UnixFileDescriptor.h>'],

--- a/Source/WebKit/Shared/WebUserContentControllerDataTypes.h
+++ b/Source/WebKit/Shared/WebUserContentControllerDataTypes.h
@@ -28,6 +28,7 @@
 #include "ContentWorldData.h"
 #include "ContentWorldShared.h"
 #include "ScriptMessageHandlerIdentifier.h"
+#include "TransferString.h"
 #include "UserScriptIdentifier.h"
 #include "UserStyleSheetIdentifier.h"
 #include <WebCore/UserScript.h>
@@ -40,16 +41,37 @@ class SharedMemoryHandle;
 
 namespace WebKit {
 
+struct WebCoreUserScriptData {
+    IPC::TransferString source;
+    URL url;
+    Vector<String> allowlist;
+    Vector<String> blocklist;
+    WebCore::UserScriptInjectionTime injectionTime;
+    WebCore::UserContentInjectedFrames injectedFrames;
+    WebCore::UserContentMatchParentFrame matchParentFrame;
+};
+
 struct WebUserScriptData {
     UserScriptIdentifier identifier;
     ContentWorldData worldData;
-    WebCore::UserScript userScript;
+    WebCoreUserScriptData userScript;
+};
+
+struct WebCoreUserStyleSheetData {
+    IPC::TransferString source;
+    URL url;
+    Vector<String> allowlist;
+    Vector<String> blocklist;
+    WebCore::UserContentInjectedFrames injectedFrames;
+    WebCore::UserContentMatchParentFrame matchParentFrame;
+    WebCore::UserStyleLevel level;
+    std::optional<WebCore::PageIdentifier> pageID;
 };
 
 struct WebUserStyleSheetData {
     UserStyleSheetIdentifier identifier;
     ContentWorldData worldData;
-    WebCore::UserStyleSheet userStyleSheet;
+    WebCoreUserStyleSheetData userStyleSheet;
 };
 
 struct WebScriptMessageHandlerData {

--- a/Source/WebKit/Shared/WebUserContentControllerDataTypes.serialization.in
+++ b/Source/WebKit/Shared/WebUserContentControllerDataTypes.serialization.in
@@ -21,16 +21,37 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 header: "WebUserContentControllerDataTypes.h"
+[CustomHeader, DebugDecodingFailure] struct WebKit::WebCoreUserScriptData {
+    IPC::TransferString source;
+    URL url;
+    Vector<String> allowlist;
+    Vector<String> blocklist;
+    WebCore::UserScriptInjectionTime injectionTime;
+    WebCore::UserContentInjectedFrames injectedFrames;
+    WebCore::UserContentMatchParentFrame matchParentFrame;
+}
+
 [CustomHeader, DebugDecodingFailure] struct WebKit::WebUserScriptData {
     WebKit::UserScriptIdentifier identifier;
     WebKit::ContentWorldData worldData;
-    WebCore::UserScript userScript;
+    WebKit::WebCoreUserScriptData userScript;
+}
+
+[CustomHeader, DebugDecodingFailure] struct WebKit::WebCoreUserStyleSheetData {
+    IPC::TransferString source;
+    URL url;
+    Vector<String> allowlist;
+    Vector<String> blocklist;
+    WebCore::UserContentInjectedFrames injectedFrames;
+    WebCore::UserContentMatchParentFrame matchParentFrame;
+    WebCore::UserStyleLevel level;
+    std::optional<WebCore::PageIdentifier> pageID;
 }
 
 [CustomHeader, DebugDecodingFailure] struct WebKit::WebUserStyleSheetData {
     WebKit::UserStyleSheetIdentifier identifier;
     WebKit::ContentWorldData worldData;
-    WebCore::UserStyleSheet userStyleSheet;
+    WebKit::WebCoreUserStyleSheetData userStyleSheet;
 }
 
 [CustomHeader, DebugDecodingFailure] struct WebKit::WebScriptMessageHandlerData {

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -119,14 +119,15 @@ WebExtension::WebExtension(NSBundle *appExtensionBundle, NSURL *resourceURL, Ref
 
 WebExtension::WebExtension(NSDictionary *manifest, Resources&& resources)
     : m_manifestJSON(JSON::Value::null())
-    , m_resources(WTF::move(resources))
+    , m_dataResources(toDataResources(resources))
+    , m_stringResources(toStringResources(resources))
 {
     RELEASE_ASSERT(manifest);
 
     auto *manifestString = encodeJSONString(manifest);
     RELEASE_ASSERT(manifestString);
 
-    m_resources.set("manifest.json"_s, manifestString);
+    m_stringResources.set("manifest.json"_s, manifestString);
 }
 
 NSDictionary *WebExtension::manifestDictionary()
@@ -238,14 +239,13 @@ Expected<Ref<API::Data>, RefPtr<API::Error>> WebExtension::resourceDataForPath(c
     if ([cocoaPath isEqualToString:generatedBackgroundPageFilename] || [cocoaPath isEqualToString:generatedBackgroundServiceWorkerFilename])
         return API::Data::create(generatedBackgroundContent().utf8().span());
 
-    if (auto entry = m_resources.find(path); entry != m_resources.end()) {
-        return WTF::switchOn(entry->value,
-            [](const Ref<API::Data>& data) {
-                return data;
-            },
-            [](const String& string) {
-                return API::Data::create(string.utf8().span());
-            });
+    if (auto maybeData = m_dataResources.getOptional(path))
+        return *maybeData;
+
+    if (auto maybeString = m_stringResources.getOptional(path)) {
+        auto data = API::Data::create(maybeString->utf8().span());
+        m_dataResources.set(path, data);
+        return data;
     }
 
     auto *resourceURL = resourceFileURLForPath(path).createNSURL().get();
@@ -272,7 +272,7 @@ Expected<Ref<API::Data>, RefPtr<API::Error>> WebExtension::resourceDataForPath(c
 
     Ref data = API::Data::createWithoutCopying(resultData);
     if (cacheResult == CacheResult::Yes)
-        m_resources.set(path, data);
+        m_dataResources.set(path, data);
 
     return data;
 }

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
@@ -160,9 +160,30 @@ static constexpr auto sidePanelPathManifestKey = "default_path"_s;
 
 static const size_t maximumNumberOfShortcutCommands = 4;
 
+WebExtension::DataResources WebExtension::toDataResources(const WebExtension::Resources& resources)
+{
+    DataResources result;
+    for (auto& [key, value] : resources) {
+        if (auto* data = std::get_if<Ref<API::Data>>(&value))
+            result.set(key, *data);
+    }
+    return result;
+}
+
+WebExtension::StringResources WebExtension::toStringResources(const WebExtension::Resources& resources)
+{
+    StringResources result;
+    for (auto& [key, value] : resources) {
+        if (auto* string = std::get_if<String>(&value))
+            result.set(key, *string);
+    }
+    return result;
+}
+
 WebExtension::WebExtension(Resources&& resources)
     : m_manifestJSON(JSON::Value::null())
-    , m_resources(WTF::move(resources))
+    , m_dataResources(toDataResources(resources))
+    , m_stringResources(toStringResources(resources))
 {
 }
 
@@ -548,14 +569,13 @@ Expected<String, RefPtr<API::Error>> WebExtension::resourceStringForPath(const S
     if (path == generatedBackgroundPageFilename || path == generatedBackgroundServiceWorkerFilename)
         return generatedBackgroundContent();
 
-    if (auto entry = m_resources.find(path); entry != m_resources.end()) {
-        return WTF::switchOn(entry->value,
-            [](const Ref<API::Data>& data) {
-                return String::fromUTF8(data->span());
-            },
-            [](const String& string) {
-                return string;
-            });
+    if (auto maybeString = m_stringResources.getOptional(path))
+        return *maybeString;
+
+    if (auto maybeData = m_dataResources.getOptional(path)) {
+        auto string = String::fromUTF8(maybeData->get().span());
+        m_stringResources.set(path, string);
+        return string;
     }
 
     auto dataResult = resourceDataForPath(path, cacheResult, suppressErrors);
@@ -572,7 +592,7 @@ Expected<String, RefPtr<API::Error>> WebExtension::resourceStringForPath(const S
 
     auto result = decoder->decode(data->span());
     if (cacheResult == CacheResult::Yes)
-        m_resources.set(path, result);
+        m_stringResources.set(path, result);
 
     return result;
 }
@@ -793,19 +813,24 @@ const Vector<String>& WebExtension::supportedLocales()
 
     // For tests that don't have a file system location, check the resource cache.
     auto prefixLength = localesString.length();
-    for (const auto& resourceEntry : m_resources) {
-        auto path = resourceEntry.key;
+    auto pathFunctor = [&](const String& path) {
         if (!path.startsWith(localesString))
-            continue;
+            return;
 
         auto localeEnd = path.find('/', prefixLength);
         if (localeEnd == notFound)
-            continue;
+            return;
 
         auto locale = path.substring(prefixLength, localeEnd - prefixLength);
         if (!m_supportedLocales.contains(locale))
             m_supportedLocales.append(locale);
-    }
+    };
+
+    for (auto& path : m_dataResources.keys())
+        pathFunctor(path);
+
+    for (auto& path : m_stringResources.keys())
+        pathFunctor(path);
 
     return m_supportedLocales;
 }

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -63,6 +63,8 @@ public:
     using IconCacheEntry = Variant<RefPtr<WebCore::Icon>, Vector<double>>;
     using IconsCache = HashMap<String, IconCacheEntry>;
     using Resources = HashMap<String, Variant<String, Ref<API::Data>>>;
+    using DataResources = HashMap<String, Ref<API::Data>>;
+    using StringResources = HashMap<String, String>;
 
     template<typename... Args>
     static Ref<WebExtension> create(Args&&... args)
@@ -357,6 +359,9 @@ public:
 #endif
 
 private:
+    static DataResources toDataResources(const Resources&);
+    static StringResources toStringResources(const Resources&);
+
     static String processFileAndExtractZipArchive(const String&);
 
     bool parseManifest(StringView);
@@ -407,7 +412,8 @@ private:
     URL m_resourceBaseURL;
     bool m_resourcesAreTemporary { false };
     Ref<const JSON::Value> m_manifestJSON;
-    Resources m_resources;
+    DataResources m_dataResources;
+    StringResources m_stringResources;
 
     String m_defaultLocale;
     Vector<String> m_supportedLocales;

--- a/Source/WebKit/UIProcess/Extensions/glib/WebExtensionGLib.cpp
+++ b/Source/WebKit/UIProcess/Extensions/glib/WebExtensionGLib.cpp
@@ -65,12 +65,13 @@ WebExtension::WebExtension(GFile* resourcesFile, RefPtr<API::Error>& outError)
 
 WebExtension::WebExtension(const JSON::Value& manifest, Resources&& resources)
     : m_manifestJSON(manifest)
-    , m_resources(WTF::move(resources))
+    , m_dataResources(toDataResources(resources))
+    , m_stringResources(toStringResources(resources))
 {
     auto manifestString = manifest.toJSONString();
     RELEASE_ASSERT(manifestString);
 
-    m_resources.set("manifest.json"_s, manifestString);
+    m_stringResources.set("manifest.json"_s, manifestString);
 }
 
 Expected<Ref<API::Data>, RefPtr<API::Error>> WebExtension::resourceDataForPath(const String& originalPath, CacheResult cacheResult, SuppressNotFoundErrors suppressErrors)
@@ -93,14 +94,13 @@ Expected<Ref<API::Data>, RefPtr<API::Error>> WebExtension::resourceDataForPath(c
     if (path == generatedBackgroundPageFilename || path  == generatedBackgroundServiceWorkerFilename)
         return API::Data::create(generatedBackgroundContent().utf8().span());
 
-    if (auto entry = m_resources.find(path); entry != m_resources.end()) {
-        return WTF::switchOn(entry->value,
-            [](const Ref<API::Data>& data) {
-                return data;
-            },
-            [](const String& string) {
-                return API::Data::create(string.utf8().span());
-            });
+    if (auto maybeData = m_dataResources.getOptional(path))
+        return *maybeData;
+
+    if (auto maybeString = m_stringResources.getOptional(path)) {
+        auto data = API::Data::create(maybeString->utf8().span());
+        m_dataResources.set(path, data);
+        return data;
     }
 
     auto resourceURL = resourceFileURLForPath(path);
@@ -119,7 +119,7 @@ Expected<Ref<API::Data>, RefPtr<API::Error>> WebExtension::resourceDataForPath(c
 
     Ref data = API::Data::create(*rawData);
     if (cacheResult == CacheResult::Yes)
-        m_resources.set(path, data);
+        m_dataResources.set(path, data);
 
     return data;
 }

--- a/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp
+++ b/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp
@@ -39,7 +39,6 @@
 #include "WebPageProxy.h"
 #include "WebProcessProxy.h"
 #include "WebScriptMessageHandler.h"
-#include "WebUserContentControllerDataTypes.h"
 #include "WebUserContentControllerMessages.h"
 #include <WebCore/SerializedScriptValue.h>
 #include <WebCore/SharedMemory.h>
@@ -97,17 +96,49 @@ void WebUserContentControllerProxy::removeNetworkProcess(NetworkProcessProxy& pr
 }
 #endif
 
+IPC::TransferString WebUserContentControllerProxy::cachedTransferString(const String& string) const
+{
+    if (auto maybeTransferString = m_transferStringCache.getOptional(string))
+        return *maybeTransferString;
+
+    auto result = IPC::TransferString::create(string);
+    RELEASE_ASSERT(result);
+
+    if (result->shouldCache())
+        m_transferStringCache.set(string, *result);
+
+    return *result;
+}
+
+void WebUserContentControllerProxy::resetTransferStringCache()
+{
+    // We could be more granular about clearing the cache when user scripts or user style sheets are
+    // removed. But since that is a rare operation, and this is just a cache, just clearing the
+    // entire cache on any removal seems fine.
+    m_transferStringCache.clear();
+}
+
+WebCoreUserScriptData WebUserContentControllerProxy::dataFromUserScript(const WebCore::UserScript& script) const
+{
+    return { cachedTransferString(script.source()), script.url(), script.allowlist(), script.blocklist(), script.injectionTime(), script.injectedFrames(), script.matchParentFrame() };
+}
+
+WebCoreUserStyleSheetData WebUserContentControllerProxy::dataFromUserStyleSheet(const WebCore::UserStyleSheet& sheet) const
+{
+    return { cachedTransferString(sheet.source()), sheet.url(), sheet.allowlist(), sheet.blocklist(), sheet.injectedFrames(), sheet.matchParentFrame(), sheet.level(), sheet.pageID() };
+}
+
 UserContentControllerParameters WebUserContentControllerProxy::parametersForProcess(WebProcessProxy& process) const
 {
     m_processes.add(process);
 
     Vector<WebUserScriptData> userScripts;
     for (RefPtr userScript : m_userScripts->elementsOfType<API::UserScript>())
-        userScripts.append({ userScript->identifier(), Ref { userScript->contentWorld() }->worldDataForProcess(process), userScript->userScript() });
+        userScripts.append({ userScript->identifier(), Ref { userScript->contentWorld() }->worldDataForProcess(process), dataFromUserScript(userScript->userScript()) });
 
     Vector<WebUserStyleSheetData> userStyleSheets;
     for (RefPtr userStyleSheet : m_userStyleSheets->elementsOfType<API::UserStyleSheet>())
-        userStyleSheets.append({ userStyleSheet->identifier(), Ref { userStyleSheet->contentWorld() }->worldDataForProcess(process), userStyleSheet->userStyleSheet() });
+        userStyleSheets.append({ userStyleSheet->identifier(), Ref { userStyleSheet->contentWorld() }->worldDataForProcess(process), dataFromUserStyleSheet(userStyleSheet->userStyleSheet()) });
 
     Vector<WebJSBufferData> buffers;
     for (auto& [pair, buffer] : m_buffers) {
@@ -147,7 +178,7 @@ void WebUserContentControllerProxy::addUserScript(API::UserScript& userScript, I
     m_userScripts->elements().append(&userScript);
 
     for (Ref process : m_processes)
-        process->send(Messages::WebUserContentController::AddUserScripts({ { userScript.identifier(), world->worldDataForProcess(process), userScript.userScript() } }, immediately), identifier());
+        process->send(Messages::WebUserContentController::AddUserScripts({ { userScript.identifier(), world->worldDataForProcess(process), dataFromUserScript(userScript.userScript()) } }, immediately), identifier());
 }
 
 void WebUserContentControllerProxy::removeUserScript(API::UserScript& userScript)
@@ -158,6 +189,7 @@ void WebUserContentControllerProxy::removeUserScript(API::UserScript& userScript
         process->send(Messages::WebUserContentController::RemoveUserScript(world->identifier(), userScript.identifier()), identifier());
 
     m_userScripts->elements().removeAll(&userScript);
+    resetTransferStringCache();
 }
 
 void WebUserContentControllerProxy::removeAllUserScripts(API::ContentWorld& world)
@@ -168,6 +200,7 @@ void WebUserContentControllerProxy::removeAllUserScripts(API::ContentWorld& worl
     m_userScripts->removeAllOfTypeMatching<API::UserScript>([&](const auto& userScript) {
         return &userScript->contentWorld() == &world;
     });
+    resetTransferStringCache();
 }
 
 #if ENABLE(WK_WEB_EXTENSIONS)
@@ -192,6 +225,7 @@ void WebUserContentControllerProxy::removeAllUserScripts()
             process->send(Messages::WebUserContentController::RemoveAllUserScripts(worldIdentifiers), identifier());
 
         m_userScripts->elements().clear();
+        resetTransferStringCache();
 
         return;
     }
@@ -218,7 +252,7 @@ void WebUserContentControllerProxy::addUserStyleSheet(API::UserStyleSheet& userS
     m_userStyleSheets->elements().append(&userStyleSheet);
 
     for (Ref process : m_processes)
-        process->send(Messages::WebUserContentController::AddUserStyleSheets({ { userStyleSheet.identifier(), world->worldDataForProcess(process), userStyleSheet.userStyleSheet() } }), identifier());
+        process->send(Messages::WebUserContentController::AddUserStyleSheets({ { userStyleSheet.identifier(), world->worldDataForProcess(process), dataFromUserStyleSheet(userStyleSheet.userStyleSheet()) } }), identifier());
 }
 
 void WebUserContentControllerProxy::removeUserStyleSheet(API::UserStyleSheet& userStyleSheet)
@@ -229,6 +263,7 @@ void WebUserContentControllerProxy::removeUserStyleSheet(API::UserStyleSheet& us
         process->send(Messages::WebUserContentController::RemoveUserStyleSheet(world->identifier(), userStyleSheet.identifier()), identifier());
 
     m_userStyleSheets->elements().removeAll(&userStyleSheet);
+    resetTransferStringCache();
 }
 
 void WebUserContentControllerProxy::removeAllUserStyleSheets(API::ContentWorld& world)
@@ -239,6 +274,7 @@ void WebUserContentControllerProxy::removeAllUserStyleSheets(API::ContentWorld& 
     m_userStyleSheets->removeAllOfTypeMatching<API::UserStyleSheet>([&](const auto& userStyleSheet) {
         return &userStyleSheet->contentWorld() == &world;
     });
+    resetTransferStringCache();
 }
 
 #if ENABLE(WK_WEB_EXTENSIONS)
@@ -263,6 +299,7 @@ void WebUserContentControllerProxy::removeAllUserStyleSheets()
             process->send(Messages::WebUserContentController::RemoveAllUserStyleSheets(worldIdentifiers), identifier());
 
         m_userStyleSheets->elements().clear();
+        resetTransferStringCache();
 
         return;
     }

--- a/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h
+++ b/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h
@@ -28,7 +28,9 @@
 #include "APIObject.h"
 #include "ContentWorldShared.h"
 #include "ScriptMessageHandlerIdentifier.h"
+#include "TransferString.h"
 #include "UserContentControllerIdentifier.h"
+#include "WebUserContentControllerDataTypes.h"
 #include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/HashCountedSet.h>
@@ -86,6 +88,9 @@ public:
 
     UserContentControllerParameters parametersForProcess(WebProcessProxy&) const;
 
+    IPC::TransferString cachedTransferString(const String&) const;
+    void resetTransferStringCache();
+
     API::Array& userScripts() { return m_userScripts.get(); }
     void addUserScript(API::UserScript&, InjectUserScriptImmediately);
     void removeUserScript(API::UserScript&);
@@ -95,6 +100,7 @@ public:
 #else
     void removeAllUserScripts();
 #endif
+    WebCoreUserScriptData dataFromUserScript(const WebCore::UserScript&) const;
 
     API::Array& userStyleSheets() { return m_userStyleSheets.get(); }
     void addUserStyleSheet(API::UserStyleSheet&);
@@ -105,6 +111,7 @@ public:
 #else
     void removeAllUserStyleSheets();
 #endif
+    WebCoreUserStyleSheetData dataFromUserStyleSheet(const WebCore::UserStyleSheet&) const;
 
     void addJSBuffer(API::JSBuffer&, API::ContentWorld&, const String&);
     void removeJSBuffer(API::ContentWorld&, const String&);
@@ -141,6 +148,7 @@ private:
     const Ref<API::Array> m_userStyleSheets;
     HashMap<ScriptMessageHandlerIdentifier, Ref<WebScriptMessageHandler>> m_scriptMessageHandlers;
     HashMap<std::pair<WebKit::ContentWorldIdentifier, String>, Ref<API::JSBuffer>> m_buffers;
+    mutable HashMap<String, IPC::TransferString> m_transferStringCache;
 
 #if ENABLE(CONTENT_EXTENSIONS)
     WeakHashSet<NetworkProcessProxy> m_networkProcesses;

--- a/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
+++ b/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
@@ -77,6 +77,20 @@ static WorldMap& worldMap()
     return map;
 }
 
+static WebCore::UserScript userScriptFromData(WebCoreUserScriptData&& data)
+{
+    auto maybeSource = WTF::move(data.source).release();
+    RELEASE_ASSERT(maybeSource);
+    return { WTF::move(*maybeSource), WTF::move(data.url), WTF::move(data.allowlist), WTF::move(data.blocklist), data.injectionTime, data.injectedFrames, data.matchParentFrame };
+}
+
+static WebCore::UserStyleSheet userStyleSheetFromData(WebCoreUserStyleSheetData&& data)
+{
+    auto maybeSource = WTF::move(data.source).release();
+    RELEASE_ASSERT(maybeSource);
+    return { WTF::move(*maybeSource), WTF::move(data.url), WTF::move(data.allowlist), WTF::move(data.blocklist), data.injectedFrames, data.matchParentFrame, data.level, data.pageID };
+}
+
 Ref<WebUserContentController> WebUserContentController::getOrCreate(UserContentControllerParameters&& parameters)
 {
     auto identifier = parameters.identifier;
@@ -190,7 +204,7 @@ void WebUserContentController::removeContentWorld(ContentWorldIdentifier worldId
 
 void WebUserContentController::addUserScripts(Vector<WebUserScriptData>&& userScripts, InjectUserScriptImmediately immediately)
 {
-    for (const auto& userScriptData : userScripts) {
+    for (auto& userScriptData : userScripts) {
         addContentWorldIfNecessary(userScriptData.worldData);
         RefPtr world = worldMap().get(userScriptData.worldData.identifier);
         if (!world) {
@@ -198,7 +212,7 @@ void WebUserContentController::addUserScripts(Vector<WebUserScriptData>&& userSc
             continue;
         }
 
-        UserScript script = userScriptData.userScript;
+        UserScript script = userScriptFromData(WTF::move(userScriptData.userScript));
         addUserScriptInternal(*world, userScriptData.identifier, WTF::move(script), immediately);
     }
 }
@@ -229,7 +243,7 @@ void WebUserContentController::removeAllUserScripts(const Vector<ContentWorldIde
 
 void WebUserContentController::addUserStyleSheets(Vector<WebUserStyleSheetData>&& userStyleSheets)
 {
-    for (const auto& userStyleSheetData : userStyleSheets) {
+    for (auto& userStyleSheetData : userStyleSheets) {
         addContentWorldIfNecessary(userStyleSheetData.worldData);
         RefPtr world = worldMap().get(userStyleSheetData.worldData.identifier);
         if (!world) {
@@ -237,7 +251,7 @@ void WebUserContentController::addUserStyleSheets(Vector<WebUserStyleSheetData>&
             continue;
         }
         
-        UserStyleSheet sheet = userStyleSheetData.userStyleSheet;
+        UserStyleSheet sheet = userStyleSheetFromData(WTF::move(userStyleSheetData.userStyleSheet));
         addUserStyleSheetInternal(*world, userStyleSheetData.identifier, WTF::move(sheet));
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm
@@ -29,6 +29,7 @@
 
 #import "HTTPServer.h"
 #import "WebExtensionUtilities.h"
+#import <WebKit/WKProcessPoolPrivate.h>
 #import <WebKit/WKUserContentControllerPrivate.h>
 
 namespace TestWebKitAPI {
@@ -1885,6 +1886,63 @@ TEST(WKWebExtensionAPIScripting, MigrateScriptDataToNewFormat)
     }
 
     [manager run];
+}
+
+TEST(WKWebExtensionAPIScripting, ContentScriptsAndStyleSheetsWithManyMatchPatterns)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<div id='test'>Test</div>"_s } }
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    NSMutableArray *matchPatterns = [NSMutableArray arrayWithObject:@"*://localhost/*"];
+    for (unsigned i = 1; i <= 50; ++i)
+        [matchPatterns addObject:[NSString stringWithFormat:@"*://foo%u/*", i]];
+
+    auto *contentScriptsManifest = @{
+        @"manifest_version": @3,
+
+        @"name": @"Scripting Test",
+        @"description": @"Scripting Test",
+        @"version": @"1.0",
+
+        @"content_scripts": @[ @{
+            @"matches": matchPatterns,
+            @"css": @[ @"content.css" ],
+            @"js": @[ @"content.js" ]
+        } ]
+    };
+
+    NSString *userStyle = @"#test { color: red; font-size: 555px; }";
+    NSString *userScript = Util::constructScript(@[
+        @"const testElement = document.getElementById('test')",
+        @"const style = window.getComputedStyle(testElement)",
+        @"browser.test.assertEq(style.color, 'rgb(255, 0, 0)', 'CSS should apply')",
+        @"browser.test.assertEq(style.fontSize, '555px', 'Font size should apply')",
+
+        @"browser.test.notifyPass()"
+    ]);
+
+    auto *oneMB = [@"" stringByPaddingToLength:(1 << 20) withString:@" " startingAtIndex:0];
+    auto *resources = @{
+        @"content.css": [userStyle stringByAppendingString:oneMB],
+        @"content.js": [userScript stringByAppendingString:oneMB]
+    };
+
+    auto manager = Util::loadExtension(contentScriptsManifest, resources);
+
+    auto *urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
+
+    [manager run];
+
+    size_t totalFootprint = 0;
+    for (_WKWebContentProcessInfo *info in [WKProcessPool _webContentProcessInfo])
+        totalFootprint += [info physicalFootprint];
+
+    constexpr size_t maxExpectedFootprint = 100 * 1024 * 1024;
+    EXPECT_LT(totalFootprint, maxExpectedFootprint);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 4ed5ff4bf1eeaa3c1c76abc87644016fe7a61203
<pre>
Reduce memory overhead of user scripts and user styles in extensions with many distinct match patterns
<a href="https://bugs.webkit.org/show_bug.cgi?id=310393">https://bugs.webkit.org/show_bug.cgi?id=310393</a>
<a href="https://rdar.apple.com/169436824">rdar://169436824</a>

Reviewed by Timothy Hatcher.

Extensions can specify user scripts and user styles with many distinct match patterns, either
directly via the extension manifest or due to user behavior (e.g. if the user decides to load
extensions only selectively on certain origins, and that origin list is very long).

In the current implementation of web extensions, this can lead to memory explosion because each
distinct match pattern carries its own copy of the same exact user script and user style strings
(see how `WebExtensionContext::addInjectedContent` loops over each pattern and creates an
`API::UserScript` object for each pattern). We have seen users that eventually accumulate match
lists of 300+ origins, which leads to 300+ copies of user scripts and user styles and which can
cause WebContent to OOM.

This patch fixes the issue by addressing three places where we are unnecessarily duplicating strings:

1. In `WebExtension`, we keep a cached copy of data and string resources. However, if a data
resource is already cached for a path, then we always create a new string instance from that cached
data resource. So 100 calls to `WebExtension::resourceStringForPath` can lead to 100 String
instances backed by 100 distinct StringImpls even if CacheResult::Yes is used. To fix this, we
separate the cached data and cached string hash maps in WebExtension so that cached strings are
always associated with a single String instance.

2. `WebUserContentControllerProxy` in UIProcess IPCs user script and user style strings to
`WebUserContentController` in WebProcess. The same strings are sent to all processes in the process
pool, but in the current implementation each process will have its own private copy of the
string. To fix this, use `IPC::TransferString` to transfer the string across processes, which allows
the strings in UIProcess and all WebProcesses to be backed by the same single memory allocation (see
SharedSpan8 and SharedSpan16 in TransferString).

3. Within the same WebContent process, there can be duplicate user script or user style strings,
because each distinct match pattern is associated with a separate UserScript object with a differing
match pattern but the same source string. To fix this, we now intern source strings in both
UserScript and UserStyleSheet.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm

* Source/WebCore/page/UserScript.cpp: Implement WebProcess user script string interning.
(WebCore::sourceStrings):
(WebCore::internedSourceString):
(WebCore::UserScript::UserScript):
(WebCore::UserScript::~UserScript):
* Source/WebCore/page/UserScript.h:

* Source/WebCore/page/UserStyleSheet.cpp: Implement WebProcess user style string interning.
(WebCore::styleStrings):
(WebCore::internedStyleString):
(WebCore::UserStyleSheet::UserStyleSheet):
(WebCore::UserStyleSheet::~UserStyleSheet):
* Source/WebCore/page/UserStyleSheet.h:

* Source/WebKit/Platform/IPC/TransferString.cpp: Make TransferString copyable. It was already copyable previously in a roundabout way using toIPCData.
(IPC::TransferString::TransferString):
(IPC::TransferString::operator=):
(IPC::TransferString::shouldCache const):
* Source/WebKit/Platform/IPC/TransferString.h:
* Source/WebKit/Platform/IPC/cocoa/TransferStringCocoa.mm:
(IPC::TransferString::createCached):

* Source/WebKit/Scripts/webkit/messages.py: Use TransferString to IPC user script and user style strings to WebProcess. This requires keeping a cache of TransferStrings in WebUserContentControllerProxy.
(headers_for_type):
* Source/WebKit/Shared/WebUserContentControllerDataTypes.h:
* Source/WebKit/Shared/WebUserContentControllerDataTypes.serialization.in:
* Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp:
(WebKit::WebUserContentControllerProxy::cachedTransferString const):
(WebKit::WebUserContentControllerProxy::resetTransferStringCache):
(WebKit::WebUserContentControllerProxy::dataFromUserScript const):
(WebKit::WebUserContentControllerProxy::dataFromUserStyleSheet const):
(WebKit::WebUserContentControllerProxy::parametersForProcess const):
(WebKit::WebUserContentControllerProxy::addUserScript):
(WebKit::WebUserContentControllerProxy::removeUserScript):
(WebKit::WebUserContentControllerProxy::removeAllUserScripts):
(WebKit::WebUserContentControllerProxy::addUserStyleSheet):
(WebKit::WebUserContentControllerProxy::removeUserStyleSheet):
(WebKit::WebUserContentControllerProxy::removeAllUserStyleSheets):
* Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h:
* Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp:
(WebKit::userScriptFromData):
(WebKit::userStyleSheetFromData):
(WebKit::WebUserContentController::addUserScripts):
(WebKit::WebUserContentController::addUserStyleSheets):

* Source/WebKit/UIProcess/Extensions/WebExtension.cpp: Cache extension data and string resources separately, so that cached strings are always backed by the same string instance.
(WebKit::WebExtension::toDataResources):
(WebKit::WebExtension::toStringResources):
(WebKit::WebExtension::WebExtension):
(WebKit::WebExtension::resourceStringForPath):
(WebKit::WebExtension::supportedLocales):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::WebExtension):
(WebKit::WebExtension::resourceDataForPath):
* Source/WebKit/UIProcess/Extensions/WebExtension.h:
* Source/WebKit/UIProcess/Extensions/glib/WebExtensionGLib.cpp:
(WebKit::WebExtension::WebExtension):
(WebKit::WebExtension::resourceDataForPath):

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, ContentScriptsAndStyleSheetsWithManyMatchPatterns)):

Canonical link: <a href="https://commits.webkit.org/309775@main">https://commits.webkit.org/309775@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd58f6c98da1cd8ca2256458bd1a1e6b6dc8d113

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151332 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24095 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17666 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160063 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104770 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/de805111-2e0a-4731-866d-2ff19b2c2c65) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153205 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24527 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24391 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116845 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82958 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154292 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18983 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135786 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97563 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ef055632-9078-4fa1-88ac-187021453612) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/150653 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18074 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16017 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7908 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127696 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13698 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162535 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5668 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15275 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124856 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23897 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20071 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125040 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34015 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23887 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135494 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80383 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20105 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12264 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23496 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87800 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23208 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23361 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23262 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->