### PR TITLE
[Site Isolation] Fix null dereference crash when focus navigates into cross-origin iframe containing a nested remote frame

### DIFF
--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -812,6 +812,8 @@ FocusableElementSearchResult FocusController::findFocusableElementAcrossFocusSco
     }
 
     auto candidateInCurrentScope = findFocusableElementWithinScope(direction, scope, currentNode, focusEventData, shouldFocusElement);
+    if (candidateInCurrentScope.continuedSearchInRemoteFrame == ContinuedSearchInRemoteFrame::Yes)
+        return candidateInCurrentScope;
     if (candidateInCurrentScope.element) {
         if (direction == FocusDirection::Backward) {
             // Skip through invokers if they have popovers with focusable contents, and navigate through those contents instead.
@@ -860,15 +862,19 @@ FocusableElementSearchResult FocusController::findFocusableElementAcrossFocusSco
             },
             [&](const RefPtr<Frame>& frame) -> FocusableElementSearchResult {
                 switch (frame->frameType()) {
-                case Frame::FrameType::Remote:
-
+                case Frame::FrameType::Remote: {
+                    if (!currentNode)
+                        return { };
+                    RefPtr currentFrame = currentNode->document().frame();
+                    if (!currentFrame)
+                        return { };
                     if (shouldFocusElement == ShouldFocusElement::Yes) {
-                        RefPtr currentFrame = currentNode->document().frame();
                         clearSelectionIfNeeded(currentFrame.get(), nullptr, nullptr);
                         currentNode->document().setFocusedElement(nullptr);
                     }
-                    downcast<RemoteFrame>(*frame).client().findFocusableElementContinuingFromFrame(direction, currentNode->document().frame()->frameID(), focusEventData, shouldFocusElement);
+                    downcast<RemoteFrame>(*frame).client().findFocusableElementContinuingFromFrame(direction, currentFrame->frameID(), focusEventData, shouldFocusElement);
                     return { nullptr, ContinuedSearchInRemoteFrame::Yes };
+                }
                 case Frame::FrameType::Local:
                     if (RefPtr ownerElement = frame->ownerElement())
                         return handleElementOwner(*ownerElement);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FocusWebView.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FocusWebView.mm
@@ -233,6 +233,48 @@ TEST(FocusWebView, MultipleFrames)
     EXPECT_WK_STREQ([uiDelegate waitForAlert], "https://apple.com focused");
 }
 
+// Regression test for rdar://172564611
+TEST(FocusWebView, FocusNavigationIntoFrameWithNestedRemoteFrame)
+{
+    auto mainHTML = "<body>"
+        "<input id='mainInput'>"
+        "<iframe id='outerFrame' src='https://webkit.org/outerframe'></iframe>"
+        "</body>"_s;
+
+    // This frame begins with a cross-origin nested iframe (a RemoteFrame from webkit.org's
+    // process perspective), followed by a local input. The crash triggers when focus navigation
+    // enters this frame and the first focusable candidate is the nested RemoteFrame.
+    auto outerFrameHTML = "<body>"
+        "<iframe src='https://apple.com/innerframe'></iframe>"
+        "<input id='outerInput'>"
+        "<script>document.getElementById('outerInput').addEventListener('focusin', () => alert('outerInput focused'));</script>"
+        "</body>"_s;
+
+    auto innerFrameHTML = "<body><input id='innerInput'></body>"_s;
+
+    HTTPServer server({
+        { "/main"_s, { mainHTML } },
+        { "/outerframe"_s, { outerFrameHTML } },
+        { "/innerframe"_s, { innerFrameHTML } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    [[configuration preferences] _setSiteIsolationEnabled:YES];
+
+    auto [webView, navigationDelegate, uiDelegate] = makeWebViewAndDelegates(WTF::move(configuration));
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/main"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    [webView evaluateJavaScript:@""
+        "document.getElementById('mainInput').addEventListener('focusin', () => alert('mainInput focused'));"
+        "document.getElementById('mainInput').focus();" completionHandler:nil];
+    EXPECT_WK_STREQ([uiDelegate waitForAlert], "mainInput focused");
+
+    [webView typeCharacter:'\t'];
+    EXPECT_WK_STREQ([uiDelegate waitForAlert], "outerInput focused");
+}
+
 TEST(FocusWebView, DoNotFocusWebViewWhenUnparented)
 {
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];


### PR DESCRIPTION
#### 91d5f2e2933817cf98eea67665b13fd2405014dc
<pre>
[Site Isolation] Fix null dereference crash when focus navigates into cross-origin iframe containing a nested remote frame
<a href="https://rdar.apple.com/172564611">rdar://172564611</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=310307">https://bugs.webkit.org/show_bug.cgi?id=310307</a>

Reviewed by Megan Gardner.

When findFocusableElementAcrossFocusScope found a candidate with ContinuedSearchInRemoteFrame::Yes,
it did not return early, allowing execution to continue into the Remote frame owner case with a
null currentNode, causing a crash. Also adds null checks for currentNode and currentFrame in the
Remote frame handling path.

* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::findFocusableElementAcrossFocusScope): Scope the Remote case with
case Frame::FrameType::Remote: { } to satisfy C++ jump-past-initialization rules.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/FocusWebView.mm:
(FocusWebView.FocusNavigationIntoFrameWithNestedRemoteFrame): Regression test for
<a href="https://rdar.apple.com/172564611">rdar://172564611</a> — site isolation crash when focus navigation enters a cross-origin iframe
(Process B) whose document itself begins with a nested cross-origin iframe (another RemoteFrame
from Process B&apos;s perspective). Previously, findFocusableElementAcrossFocusScope found the nested
RemoteFrame as the first candidate (returning { null, ContinuedSearchInRemoteFrame::Yes }) but
did not return early, allowing a null dereference of currentNode in the Remote owner case.

Canonical link: <a href="https://commits.webkit.org/309671@main">https://commits.webkit.org/309671@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7300d8335b7abe356d5cc30b7c2db1d606f8b279

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151348 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24112 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17682 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160079 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104786 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153221 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24543 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24407 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116856 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82965 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154308 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18992 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135795 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97574 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18083 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16024 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7924 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127705 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13707 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162551 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5684 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15284 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124868 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23913 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20078 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125052 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33935 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23903 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135503 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/80399 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20118 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12273 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23512 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87816 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23224 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23377 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23278 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->