### PR TITLE
[Swift in WebKit] Integrate Swift Testing into run-api-tests (part 1)

### DIFF
--- a/Tools/Scripts/run-api-tests
+++ b/Tools/Scripts/run-api-tests
@@ -117,6 +117,8 @@ def parse_args(args):
                              help='Only build, check and run TestWTF'),
         optparse.make_option('--webkit-only', action='store_const', const='TestWebKitAPI', dest='api_binary',
                              help='Only check and run TestWebKitAPI'),
+        optparse.make_option('--swift-only', action='store_const', const='SwiftTesting', dest='api_binary',
+                             help='Only check and run Swift Testing tests (Cocoa ports only)'),
         optparse.make_option('--ipc-only', action='store_const', const='TestIPC', dest='api_binary',
                              help='Only check and run TestIPC (Darwin ports only)'),
         optparse.make_option('--web-core-only', action='store_const', const='TestWebCore', dest='api_binary',

--- a/Tools/Scripts/webkitpy/api_tests/manager.py
+++ b/Tools/Scripts/webkitpy/api_tests/manager.py
@@ -22,14 +22,15 @@
 
 import json
 import logging
-import os
 import re
 import time
-from typing import Optional
+from typing import Optional, Union
 
-from webkitpy.api_tests.runner import Runner
-from webkitpy.common.iteration_compatibility import iteritems
+from webkitpy.api_tests.runner import Runner, RunnerTestStatus
+from webkitpy.api_tests.swift_runner import SwiftTestingRunner
 from webkitpy.common.system.executive import ScriptError
+from webkitpy.layout_tests.views.metered_stream import MeteredStream
+from webkitpy.port.darwin import DarwinPort
 
 _log = logging.getLogger(__name__)
 
@@ -44,7 +45,7 @@ class Manager(object):
     FAILED_TESTS = 3
     FAILED_UPLOAD = 4
 
-    def __init__(self, port, options, stream):
+    def __init__(self, port, options, stream: MeteredStream):
         self._port = port
         self.host = port.host
         self._options = options
@@ -102,8 +103,12 @@ class Manager(object):
     @classmethod
     def _is_exact_test_name(cls, arg: str) -> bool:
         """Returns True if arg looks like an exact fully-qualified test name (no globs)."""
+        if arg.startswith('SwiftTesting'):
+            return True
+
         if '*' in arg:
             return False
+
         parts = arg.split('.')
         # Must be <Suite>.<Test> or <Binary>.<Suite>.<Test> (or with / for parameterized suites)
         return len(parts) >= 2 and '' not in parts
@@ -127,7 +132,10 @@ class Manager(object):
             parts = arg.split('.')
             candidate_binary = parts[0]
 
-            if candidate_binary in known_binaries:
+            # Swift Testing tests can be consumed as-is by xcodebuild and don't need to be enumerated beforehand.
+            if candidate_binary == "SwiftTesting":
+                result.append(arg)
+            elif candidate_binary in known_binaries:
                 # First part is a binary name. Need at least 3 parts
                 # (Binary.Suite.Test) to be an exact test. With only 2 parts
                 # (Binary.Suite), it's a suite filter that requires listing.
@@ -185,13 +193,13 @@ class Manager(object):
             stream.writeln('')
         return not has_output
 
-    def _print_tests_result_with_status(self, status, runner):
+    def _print_tests_result_with_status(self, status: RunnerTestStatus, runner: Union[Runner, SwiftTestingRunner]):
         mapping = runner.result_map_by_status(status)
         if mapping:
-            self._stream.writeln(runner.NAME_FOR_STATUS[status])
+            self._stream.writeln(str(status))
             self._stream.writeln('')
             need_newline = False
-            for test, output in iteritems(mapping):
+            for test, output in mapping.items():
                 need_newline = Manager._print_test_result(self._stream, test, output)
             if need_newline:
                 self._stream.writeln('')
@@ -280,13 +288,30 @@ class Manager(object):
         if self._options.repeat_each != 1:
             _log.debug(f'Repeating each test {self._options.iterations} times')
 
-        runner = None
+        gtest_names: list[str] = []
+        swift_test_names: list[str] = []
+
+        for test in test_names:
+            if test.startswith("SwiftTesting"):
+                swift_test_names.append(test)
+            else:
+                gtest_names.append(test)
+
+        gtest_runner: Optional[Runner] = None
+        swift_runner: Optional[SwiftTestingRunner] = None
         try:
             _log.info('Running tests')
-            runner = Runner(self._port, self._stream)
-            for i in range(self._options.iterations):
-                _log.debug(f'\nIteration {i + 1}')
-                runner.run(test_names, int(self._options.child_processes) if self._options.child_processes else None)
+
+            if gtest_names:
+                gtest_runner = Runner(self._port, self._stream)
+                for i in range(self._options.iterations):
+                    _log.debug(f'\nIteration {i + 1}')
+                    gtest_runner.run(test_names, int(self._options.child_processes) if self._options.child_processes else None)
+
+            if swift_test_names:
+                assert self._port is DarwinPort
+                swift_runner = SwiftTestingRunner(self._port, self._stream)
+                swift_runner.run(swift_test_names, self._options.iterations)
         except KeyboardInterrupt:
             # If we receive a KeyboardInterrupt, print results.
             self._stream.writeln('')
@@ -295,19 +320,25 @@ class Manager(object):
 
         end_time = time.time()
 
-        if not runner:
+        if not any([gtest_runner, swift_runner]):
             return Manager.FAILED_TESTS
 
-        successful = runner.result_map_by_status(runner.STATUS_PASSED)
-        disabled = len(runner.result_map_by_status(runner.STATUS_DISABLED))
+        successful = 0
+        disabled = 0
+        total = 0
+
+        for runner in {runner for runner in [gtest_runner, swift_runner] if runner is not None}:
+            successful += len(runner.result_map_by_status(RunnerTestStatus.PASSED))
+            disabled += len(runner.result_map_by_status(RunnerTestStatus.DISABLED))
+            total += len(runner.results)
 
         # Check if running in test-parallel-safety mode
         test_parallel_safety_tests = self._port.get_option('test_parallel_safety') or []
         is_parallel_safety_mode = bool(test_parallel_safety_tests)
 
-        _log.info(f'Ran {len(runner.results) - disabled} tests of {len(set(test_names))} with {len(successful)} successful')
+        _log.info(f'Ran {total - disabled} tests of {len(set(test_names))} with {successful} successful')
 
-        result_dictionary = {
+        result_dictionary: dict[str, list[dict[str, Optional[str]]]] = {
             'Skipped': [],
             'Failed': [],
             'Crashed': [],
@@ -318,9 +349,16 @@ class Manager(object):
         result = Manager.SUCCESS
 
         # Count actual failures (not skipped)
-        failed_tests = runner.result_map_by_status(runner.STATUS_FAILED)
-        crashed_tests = runner.result_map_by_status(runner.STATUS_CRASHED)
-        timedout_tests = runner.result_map_by_status(runner.STATUS_TIMEOUT)
+
+        failed_tests: dict[str, str] = {}
+        crashed_tests: dict[str, str] = {}
+        timedout_tests: dict[str, str] = {}
+
+        for runner in {runner for runner in [gtest_runner, swift_runner] if runner is not None}:
+            failed_tests.update(runner.result_map_by_status(RunnerTestStatus.FAILED))
+            crashed_tests.update(runner.result_map_by_status(RunnerTestStatus.CRASHED))
+            timedout_tests.update(runner.result_map_by_status(RunnerTestStatus.TIMEOUT))
+
         has_real_failures = bool(failed_tests or crashed_tests or timedout_tests)
 
         if is_parallel_safety_mode:
@@ -333,7 +371,7 @@ class Manager(object):
                 self._stream.writeln('All parallel-safety tests passed!')
                 if json_output:
                     self.host.filesystem.write_text_file(json_output, json.dumps(result_dictionary, indent=4))
-        elif len(successful) + disabled == len(set(test_names)):
+        elif successful + disabled == len(set(test_names)):
             self._stream.writeln('All tests successfully passed!')
             if json_output:
                 self.host.filesystem.write_text_file(json_output, json.dumps(result_dictionary, indent=4))
@@ -341,13 +379,17 @@ class Manager(object):
             self._stream.writeln('Test suite failed')
             result = Manager.FAILED_TESTS
 
+        all_results: dict[str, tuple[RunnerTestStatus, str, Optional[int]]] = {}
+        for runner in {runner for runner in [gtest_runner, swift_runner] if runner is not None}:
+            all_results.update(runner.results)
+
         # Always collect skipped/failed info for reporting
         if result != Manager.SUCCESS or is_parallel_safety_mode:
             self._stream.writeln('')
 
             skipped = []
             for test in test_names:
-                if test not in runner.results:
+                if test not in all_results:
                     skipped.append(test)
                     result_dictionary['Skipped'].append({'name': test, 'output': None})
             if skipped:
@@ -357,15 +399,16 @@ class Manager(object):
                     for test in skipped:
                         self._stream.writeln(f'    {test}')
 
-            self._print_tests_result_with_status(runner.STATUS_FAILED, runner)
-            self._print_tests_result_with_status(runner.STATUS_CRASHED, runner)
-            self._print_tests_result_with_status(runner.STATUS_TIMEOUT, runner)
+            for runner in {runner for runner in [gtest_runner, swift_runner] if runner is not None}:
+                self._print_tests_result_with_status(RunnerTestStatus.FAILED, runner)
+                self._print_tests_result_with_status(RunnerTestStatus.CRASHED, runner)
+                self._print_tests_result_with_status(RunnerTestStatus.TIMEOUT, runner)
 
-            for test, test_result in iteritems(runner.results):
+            for test, test_result in all_results.items():
                 status_to_string = {
-                    runner.STATUS_FAILED: 'Failed',
-                    runner.STATUS_CRASHED: 'Crashed',
-                    runner.STATUS_TIMEOUT: 'Timedout',
+                    RunnerTestStatus.FAILED: 'Failed',
+                    RunnerTestStatus.CRASHED: 'Crashed',
+                    RunnerTestStatus.TIMEOUT: 'Timedout',
                 }.get(test_result[0])
                 if not status_to_string:
                     continue
@@ -383,10 +426,10 @@ class Manager(object):
             configuration_for_upload = self._port.configuration_for_upload(self._port.target_host(0))
 
             status_to_test_result = {
-                runner.STATUS_PASSED: None,
-                runner.STATUS_FAILED: Upload.Expectations.FAIL,
-                runner.STATUS_CRASHED: Upload.Expectations.CRASH,
-                runner.STATUS_TIMEOUT: Upload.Expectations.TIMEOUT,
+                RunnerTestStatus.PASSED: None,
+                RunnerTestStatus.FAILED: Upload.Expectations.FAIL,
+                RunnerTestStatus.CRASHED: Upload.Expectations.CRASH,
+                RunnerTestStatus.TIMEOUT: Upload.Expectations.TIMEOUT,
             }
             upload = Upload(
                 suite=self._options.suite or 'api-tests',
@@ -401,7 +444,7 @@ class Manager(object):
                     test: Upload.create_test_result(
                         actual=status_to_test_result[result[0]],
                         time=int(result[2] * 1000),
-                    ) for test, result in iteritems(runner.results) if result[0] in status_to_test_result
+                    ) for test, result in all_results.items() if result[0] in status_to_test_result
                 },
             )
             for url in self._options.report_urls:

--- a/Tools/Scripts/webkitpy/api_tests/runner.py
+++ b/Tools/Scripts/webkitpy/api_tests/runner.py
@@ -20,12 +20,14 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import os
 import logging
+import os
 import time
+from enum import Enum
+from typing import Optional
 
-from webkitcorepy import string_utils
 from webkitcorepy import TaskPool
+from webkitcorepy import string_utils
 
 from webkitpy.common.iteration_compatibility import iteritems
 from webkitpy.port.server_process import ServerProcess, _log as server_process_logger
@@ -44,6 +46,18 @@ class _NoisyOutputFilter(logging.Filter):
 
 
 _log.addFilter(_NoisyOutputFilter())
+
+
+class RunnerTestStatus(Enum):
+    PASSED = 0
+    FAILED = 1
+    CRASHED = 2
+    TIMEOUT = 3
+    DISABLED = 4
+    RUNNING = 5
+
+    def __str__(self):
+        return ['Passed', 'Failed', 'Crashed', 'Timeout', 'Disabled'][self.value]
 
 
 def setup_shard(port=None, devices=None, log_limit=None):
@@ -77,15 +91,16 @@ def run_test_parallel_safety_single_iteration(test_name):
         _log.error(f'Error in test-parallel-safety iteration for {test_name}: {e}')
         raise  # Re-raise so TaskPool can handle the error appropriately
 
-def report_result(worker, test, status, output, elapsed=None):
-    if elapsed < Runner.ELAPSED_THRESHOLD and status == Runner.STATUS_PASSED and (not output or Runner.instance.port.get_option('quiet')):
-        Runner.instance.printer.write_update(f'{worker} {test} {Runner.NAME_FOR_STATUS[status]}')
+
+def report_result(worker, test, status: RunnerTestStatus, output: str, elapsed: Optional[int] = None):
+    if elapsed < Runner.ELAPSED_THRESHOLD and status == RunnerTestStatus.PASSED and (not output or Runner.instance.port.get_option('quiet')):
+        Runner.instance.printer.write_update(f'{worker} {test} {status}')
     else:
         elapsed_log = f' (took {round(elapsed, 1)} seconds)' if elapsed > Runner.ELAPSED_THRESHOLD else ''
-        Runner.instance.printer.writeln(f'{worker} {test} {Runner.NAME_FOR_STATUS[status]}{elapsed_log}')
+        Runner.instance.printer.writeln(f'{worker} {test} {status}{elapsed_log}')
     if test in Runner.instance.results:
         existing_status = Runner.instance.results[test][0]
-        if status > existing_status or (status == existing_status and status != Runner.STATUS_PASSED):
+        if status > existing_status or (status == existing_status and status != RunnerTestStatus.PASSED):
             Runner.instance.results[test] = status, output, elapsed
     else:
         Runner.instance.results[test] = status, output, elapsed
@@ -96,22 +111,7 @@ def teardown_shard():
 
 
 class Runner(object):
-    STATUS_PASSED = 0
-    STATUS_FAILED = 1
-    STATUS_CRASHED = 2
-    STATUS_TIMEOUT = 3
-    STATUS_DISABLED = 4
-    STATUS_RUNNING = 5
-
     ELAPSED_THRESHOLD = 3
-
-    NAME_FOR_STATUS = [
-        'Passed',
-        'Failed',
-        'Crashed',
-        'Timeout',
-        'Disabled',
-    ]
 
     instance = None
 
@@ -122,7 +122,7 @@ class Runner(object):
         self._num_workers = 1
         self.log_limit = log_limit
         self._has_logged_for_test = True  # Suppress an empty line between "Running tests" and the first test's output.
-        self.results = {}
+        self.results: dict[str, tuple[RunnerTestStatus, str, Optional[int]]] = {}
 
     # FIXME API tests should run as an app, we won't need this function <https://bugs.webkit.org/show_bug.cgi?id=175204>
     @staticmethod
@@ -180,7 +180,9 @@ class Runner(object):
                 raise RuntimeError('Cannot nest API test runners')
             Runner.instance = self
             mutually_exclusive_groups = list(self.port.sharding_groups(suite='api-tests').keys())
-            workers = (num_workers if num_workers and num_workers >= self._num_workers else max(self.port.default_child_processes() or self._num_workers, self._num_workers) if mutually_exclusive_groups else self._num_workers)
+            workers = (num_workers if num_workers and num_workers >= self._num_workers else max(
+                self.port.default_child_processes() or self._num_workers,
+                self._num_workers) if mutually_exclusive_groups else self._num_workers)
 
             devices = None
             if getattr(self.port, 'DEVICE_MANAGER', None):
@@ -208,10 +210,12 @@ class Runner(object):
                     for i in range(0, len(supplied_tests), max_repeat_workers):
                         batch = supplied_tests[i:i + max_repeat_workers]
                         test_parallel_safety_batches.append(batch)
-                    _log.info(f'Test-parallel-safety batching: {len(supplied_tests)} tasks split into {len(test_parallel_safety_batches)} batches of max {max_repeat_workers} tasks each')
+                    _log.info(
+                        f'Test-parallel-safety batching: {len(supplied_tests)} tasks split into {len(test_parallel_safety_batches)} batches of max {max_repeat_workers} tasks each')
 
             # For minimum worker calculation, use current batch size (first batch or all if unbatched)
-            self._num_workers = min(workers, max(len(shards) + (len(test_parallel_safety_batches[0]) if test_parallel_safety_batches else 0), 1))
+            self._num_workers = min(workers, max(len(shards) + (
+                len(test_parallel_safety_batches[0]) if test_parallel_safety_batches else 0), 1))
 
             system_shards = {}
             non_system_shards = {}
@@ -226,7 +230,8 @@ class Runner(object):
             # Process test-parallel-safety batches sequentially
             for batch_index, test_parallel_safety_batch in enumerate(test_parallel_safety_batches if test_parallel_safety_batches else [[]]):
                 if test_parallel_safety_batch:
-                    _log.info(f'Running batch {batch_index + 1}/{len(test_parallel_safety_batches)}: {len(non_system_shards)} regular shards with {len(test_parallel_safety_batch)} test-parallel-safety repeat tasks')
+                    _log.info(
+                        f'Running batch {batch_index + 1}/{len(test_parallel_safety_batches)}: {len(non_system_shards)} regular shards with {len(test_parallel_safety_batch)} test-parallel-safety repeat tasks')
 
                 non_system_groups = [group for group in mutually_exclusive_groups if group != 'system']
                 test_parallel_safety_groups = []
@@ -245,14 +250,17 @@ class Runner(object):
                 with TaskPool(
                     workers=batch_workers,
                     mutually_exclusive_groups=non_system_groups,
-                    setup=setup_shard, setupkwargs=dict(port=self.port, devices=devices, log_limit=self.log_limit), teardown=teardown_shard,
+                    setup=setup_shard, setupkwargs=dict(port=self.port, devices=devices, log_limit=self.log_limit),
+                    teardown=teardown_shard,
                 ) as pool:
 
                     if test_parallel_safety_batch:
                         for i, test_name in enumerate(test_parallel_safety_batch):
                             test_parallel_safety_group = test_parallel_safety_groups[i]
-                            _log.info(f'Dispatching repeat test-parallel-safety task for {test_name} to group {test_parallel_safety_group} (batch {batch_index + 1}/{len(test_parallel_safety_batches)})')
-                            pool.do(run_test_parallel_safety_single_iteration, test_name, repeat=True, group=test_parallel_safety_group)
+                            _log.info(
+                                f'Dispatching repeat test-parallel-safety task for {test_name} to group {test_parallel_safety_group} (batch {batch_index + 1}/{len(test_parallel_safety_batches)})')
+                            pool.do(run_test_parallel_safety_single_iteration, test_name, repeat=True,
+                                    group=test_parallel_safety_group)
 
                     # Run regular shards with each batch - this is the whole point of test-parallel-safety testing
                     for name, tests in iteritems(non_system_shards):
@@ -275,7 +283,8 @@ class Runner(object):
                 with TaskPool(
                     workers=1,  # System tests run with single worker to avoid conflicts
                     mutually_exclusive_groups=[],
-                    setup=setup_shard, setupkwargs=dict(port=self.port, devices=devices, log_limit=self.log_limit), teardown=teardown_shard,
+                    setup=setup_shard, setupkwargs=dict(port=self.port, devices=devices, log_limit=self.log_limit),
+                    teardown=teardown_shard,
                 ) as pool:
                     for name, tests in iteritems(system_shards):
                         pool.do(run_shard, name, *tests)
@@ -288,9 +297,9 @@ class Runner(object):
             server_process_logger.setLevel(original_level)
             Runner.instance = None
 
-    def result_map_by_status(self, status=None):
+    def result_map_by_status(self, status: Optional[RunnerTestStatus] = None) -> dict[str, str]:
         map = {}
-        for test_name, result in iteritems(self.results):
+        for test_name, result in self.results.items():
             if result[0] == status:
                 map[test_name] = result[1]
         return map
@@ -333,9 +342,9 @@ class _Worker(object):
             Runner.command_for_port(self._port, [self._port.path_to_api_test(binary_name), f'--gtest_filter={test}']),
             env=self._port.environment_for_api_tests())
 
-        status = Runner.STATUS_RUNNING
+        status: RunnerTestStatus = RunnerTestStatus.RUNNING
         if test.split('.')[1].startswith('DISABLED_') and not self._port.get_option('force'):
-            status = Runner.STATUS_DISABLED
+            status = RunnerTestStatus.DISABLED
 
         stdout_buffer = ''
         stderr_buffer = ''
@@ -343,10 +352,10 @@ class _Worker(object):
 
         try:
             started = time.time()
-            if status != Runner.STATUS_DISABLED:
+            if status != RunnerTestStatus.DISABLED:
                 server_process.start()
 
-            while status == Runner.STATUS_RUNNING:
+            while status == RunnerTestStatus.RUNNING:
                 stdout_line, stderr_line = server_process.read_either_stdout_or_stderr_line(started + self._timeout)
                 if not stderr_line and not stdout_line:
                     break
@@ -359,7 +368,7 @@ class _Worker(object):
                     stderr_buffer += stderr_line
                     _log.error(stderr_line[:-1])
                     server_process.stop()
-                    status = Runner.STATUS_FAILED
+                    status = RunnerTestStatus.FAILED
                     break
 
                 if stderr_line:
@@ -369,21 +378,21 @@ class _Worker(object):
                 if stdout_line:
                     stdout_line = string_utils.decode(stdout_line, target_type=str)
                     if '**PASS**' in stdout_line:
-                        status = Runner.STATUS_PASSED
+                        status = RunnerTestStatus.PASSED
                     elif '**FAIL**' in stdout_line:
-                        status = Runner.STATUS_FAILED
+                        status = RunnerTestStatus.FAILED
                     else:
                         stdout_buffer += stdout_line
                         _log.error(stdout_line[:-1])
 
-            if status == Runner.STATUS_DISABLED:
+            if status == RunnerTestStatus.DISABLED:
                 pass
             elif server_process.timed_out:
-                status = Runner.STATUS_TIMEOUT
+                status = RunnerTestStatus.TIMEOUT
             elif server_process.has_crashed():
-                status = Runner.STATUS_CRASHED
-            elif status == Runner.STATUS_RUNNING:
-                status = Runner.STATUS_FAILED
+                status = RunnerTestStatus.CRASHED
+            elif status == RunnerTestStatus.RUNNING:
+                status = RunnerTestStatus.FAILED
 
         finally:
             output_buffer = stderr_buffer + stdout_buffer
@@ -392,7 +401,7 @@ class _Worker(object):
             for line in (remaining_stdout + remaining_stderr).splitlines(False):
                 line_count += 1
                 if line_count > self.log_limit:
-                    status = Runner.STATUS_FAILED
+                    status = RunnerTestStatus.FAILED
                     line = self.EXCEEDED_LOG_LINE_MESSAGE.format(self.log_limit)
 
                 _log.error(line)
@@ -433,7 +442,8 @@ class _Worker(object):
 
                 server_process.start()
                 while remaining_tests:
-                    stdout = string_utils.decode(server_process.read_stdout_line(started + self._timeout), target_type=str)
+                    stdout = string_utils.decode(server_process.read_stdout_line(started + self._timeout),
+                                                 target_type=str)
 
                     # If we've triggered a timeout, we don't know which test caused it. Break out and run singly.
                     if stdout is None and server_process.timed_out:
@@ -441,10 +451,10 @@ class _Worker(object):
 
                     if stdout is None and server_process.has_crashed():
                         # It's possible we crashed before printing anything.
-                        if last_status == Runner.STATUS_PASSED:
+                        if last_status == RunnerTestStatus.PASSED:
                             last_test = None
                         else:
-                            last_status = Runner.STATUS_CRASHED
+                            last_status = RunnerTestStatus.CRASHED
                         break
 
                     assert stdout is not None
@@ -473,16 +483,17 @@ class _Worker(object):
                         buffer = ''
 
                     if '**PASS**' == stdout_split[0]:
-                        last_status = Runner.STATUS_PASSED
+                        last_status = RunnerTestStatus.PASSED
                     else:
-                        last_status = Runner.STATUS_FAILED
+                        last_status = RunnerTestStatus.FAILED
                     last_test = stdout_split[1]
 
                 # We assume that stderr is only relevant if there is a crash (meaning we triggered an assert)
                 if last_test:
                     remaining_tests.remove(last_test)
                     stdout_buffer = string_utils.decode(server_process.pop_all_buffered_stdout(), target_type=str)
-                    stderr_buffer = string_utils.decode(server_process.pop_all_buffered_stderr(), target_type=str) if last_status == Runner.STATUS_CRASHED else ''
+                    stderr_buffer = string_utils.decode(server_process.pop_all_buffered_stderr(),
+                                                        target_type=str) if last_status == RunnerTestStatus.CRASHED else ''
                     for line in (stdout_buffer + stderr_buffer).splitlines():
                         line_count += 1
                         if line_count > self.log_limit:
@@ -491,7 +502,7 @@ class _Worker(object):
                         _log.error(line[:-1])
 
                     if line_count > self.log_limit:
-                        last_status = Runner.STATUS_FAILED
+                        last_status = RunnerTestStatus.FAILED
                         line = self.EXCEEDED_LOG_LINE_MESSAGE.format(self.log_limit)
                         buffer += line
                         _log.error(line[:-1])

--- a/Tools/Scripts/webkitpy/api_tests/swift_runner.py
+++ b/Tools/Scripts/webkitpy/api_tests/swift_runner.py
@@ -1,0 +1,41 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from typing import Optional
+
+from webkitpy.api_tests.runner import RunnerTestStatus
+from webkitpy.layout_tests.views.metered_stream import MeteredStream
+from webkitpy.port.darwin import DarwinPort
+
+
+class SwiftTestingRunner:
+
+    def __init__(self, port: DarwinPort, stream: MeteredStream):
+        self._port = port
+        self._stream = stream
+        self.results = {}
+
+    def run(self, swift_test_names: list[str], iterations: int):
+        pass
+
+    def result_map_by_status(self, status: Optional[RunnerTestStatus] = None) -> dict[str, str]:
+        return {}

--- a/Tools/Scripts/webkitpy/port/base.py
+++ b/Tools/Scripts/webkitpy/port/base.py
@@ -1173,7 +1173,7 @@ class Port(object):
         config_file_name = self._apache_config_file_name_for_platform(sys.platform)
         return self._filesystem.join(self.layout_tests_dir(), 'http', 'conf', config_file_name)
 
-    def _build_path(self, *comps):
+    def _build_path(self, *comps) -> str:
         root_directory = self.get_option('_cached_root') or self.get_option('root')
         if not root_directory:
             root_directory = self._config.build_directory(self.get_option('configuration'))
@@ -1253,10 +1253,10 @@ class Port(object):
 
     API_TEST_BINARY_NAMES = ['TestWTF', 'TestWebKitAPI']
 
-    def path_to_api_test(self, program_name):
+    def path_to_api_test(self, program_name: str) -> str:
         return self._build_path(program_name)
 
-    def path_to_api_test_binaries(self):
+    def path_to_api_test_binaries(self) -> dict[str, str]:
         return {binary: self.path_to_api_test(binary) for binary in self.API_TEST_BINARY_NAMES}
 
     def _webkit_baseline_path(self, platform):


### PR DESCRIPTION
#### 43c2dbc8abb92d82979832a1ea74953d32d04dd8
<pre>
[Swift in WebKit] Integrate Swift Testing into run-api-tests (part 1)
<a href="https://bugs.webkit.org/show_bug.cgi?id=310396">https://bugs.webkit.org/show_bug.cgi?id=310396</a>
<a href="https://rdar.apple.com/173031028">rdar://173031028</a>

Reviewed by NOBODY (OOPS!).

This starts the process of connecting xcodebuild-based Swift Testing into `run-api-tests`.

* Add a new SwiftTestingRunner stub to be used for Swift Tests, which will eventually invoke xcodebuild and run the tests
* Slightly refactor `manager.py` to accomodate for the multiple runners
* Add type hints / fix formatting

* Tools/Scripts/run-api-tests:
(parse_args):
* Tools/Scripts/webkitpy/api_tests/manager.py:
(Manager.__init__):
(Manager._try_collect_exact_tests):
(Manager._print_tests_result_with_status):
(Manager.run):
* Tools/Scripts/webkitpy/api_tests/runner.py:
(RunnerTestStatus):
(RunnerTestStatus.__str__):
(run_test_parallel_safety_single_iteration):
(report_result):
(Runner):
(Runner.__init__):
(Runner.run):
(Runner.result_map_by_status):
(_Worker._run_single_test):
(_Worker.run):
* Tools/Scripts/webkitpy/api_tests/swift_runner.py: Added.
(SwiftTestingRunner):
(SwiftTestingRunner.__init__):
(SwiftTestingRunner.run):
(SwiftTestingRunner.result_map_by_status):
* Tools/Scripts/webkitpy/port/base.py:
(Port._build_path):
(Port.path_to_api_test):
(Port.path_to_api_test_binaries):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43c2dbc8abb92d82979832a1ea74953d32d04dd8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151341 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24105 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17675 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160072 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104779 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/231c6faa-00ef-4fbe-b01c-f9abe634ba79) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153214 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24536 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24400 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116851 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82962 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3e87ee5a-bb67-4e8f-94e1-d98eebfabe64) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154301 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18986 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135791 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97569 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/35bfa571-cb33-4b7b-863e-146273dfb378) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/150662 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18077 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16022 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7917 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127699 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13703 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162544 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15280 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124863 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23906 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20076 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125047 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23896 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135499 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80392 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20110 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12269 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23505 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23217 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23370 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23271 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->