### PR TITLE
Remove a lot of `CLANG_WEBKIT_BRANCH` conditions now that SaferCPP bot builds Swift

### DIFF
--- a/Source/WebCore/PAL/pal/crypto/commoncrypto/CryptoDigestCommonCrypto.cpp
+++ b/Source/WebCore/PAL/pal/crypto/commoncrypto/CryptoDigestCommonCrypto.cpp
@@ -32,12 +32,10 @@
 #include <span>
 #include <wtf/TZoneMallocInlines.h>
 
-#if !defined(CLANG_WEBKIT_BRANCH)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
 #include "PALSwift-Generated.h"
 #pragma clang diagnostic pop
-#endif // !defined(CLANG_WEBKIT_BRANCH)
 
 namespace PAL {
 
@@ -45,9 +43,7 @@ struct CryptoDigestContext {
     WTF_MAKE_STRUCT_TZONE_ALLOCATED(CryptoDigestContext);
 
     using CCContext = Variant<
-#if !defined(CLANG_WEBKIT_BRANCH)
         std::unique_ptr<pal::Digest>,
-#endif
         std::unique_ptr<CC_SHA1_CTX>,
         std::unique_ptr<CC_SHA256_CTX>,
         std::unique_ptr<CC_SHA512_CTX>
@@ -89,8 +85,6 @@ CryptoDigest::~CryptoDigest()
 {
 }
 
-#if !defined(CLANG_WEBKIT_BRANCH)
-
 static CryptoDigestContext::CCContext createCryptoDigest(CryptoDigest::Algorithm algorithm)
 {
     switch (algorithm) {
@@ -115,27 +109,19 @@ static CryptoDigestContext::CCContext createCryptoDigest(CryptoDigest::Algorithm
     }
 }
 
-#endif
-
 std::unique_ptr<CryptoDigest> CryptoDigest::create(CryptoDigest::Algorithm algorithm)
 {
-#if !defined(CLANG_WEBKIT_BRANCH)
     std::unique_ptr<CryptoDigest> digest = WTF::makeUnique<CryptoDigest>();
     ASSERT(digest->m_context);
     digest->m_context->algorithm = algorithm;
     digest->m_context->ccContext = createCryptoDigest(algorithm);
     return digest;
-#else
-    UNUSED_PARAM(algorithm);
-    RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("CLANG_WEBKIT_BRANCH");
-#endif
 }
 
 IGNORE_CLANG_WARNINGS_BEGIN("missing-noreturn")
 
 void CryptoDigest::addBytes(std::span<const uint8_t> input)
 {
-#if !defined(CLANG_WEBKIT_BRANCH)
     switch (m_context->algorithm) {
     case CryptoDigest::Algorithm::SHA_1:
     case CryptoDigest::Algorithm::SHA_256:
@@ -148,17 +134,12 @@ void CryptoDigest::addBytes(std::span<const uint8_t> input)
         CC_SHA256_Update(toSHA256Context(m_context.get()), static_cast<const void*>(input.data()), input.size());
         return;
     }
-#else
-    UNUSED_PARAM(input);
-    RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("CLANG_WEBKIT_BRANCH");
-#endif
 }
 
 IGNORE_CLANG_WARNINGS_END
 
 Vector<uint8_t> CryptoDigest::computeHash()
 {
-#if !defined(CLANG_WEBKIT_BRANCH)
     Vector<uint8_t> result;
     switch (m_context->algorithm) {
     case CryptoDigest::Algorithm::SHA_1:
@@ -171,9 +152,6 @@ Vector<uint8_t> CryptoDigest::computeHash()
         break;
     }
     return result;
-#else
-    RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("CLANG_WEBKIT_BRANCH");
-#endif
 }
 
 } // namespace PAL

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESGCMCocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESGCMCocoa.cpp
@@ -33,12 +33,10 @@
 #include <wtf/CryptographicUtilities.h>
 #include <wtf/StdLibExtras.h>
 
-#if !defined(CLANG_WEBKIT_BRANCH)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
 #include "PALSwift-Generated.h"
 #pragma clang diagnostic pop
-#endif // !defined(CLANG_WEBKIT_BRANCH)
 
 namespace WebCore {
 
@@ -59,19 +57,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 static ExceptionOr<Vector<uint8_t>> encryptCryptoKitAESGCM(const Vector<uint8_t>& iv, const Vector<uint8_t>& key, const Vector<uint8_t>& plainText, const Vector<uint8_t>& additionalData, size_t desiredTagLengthInBytes)
 {
-#if !defined(CLANG_WEBKIT_BRANCH)
     auto rv = pal::AesGcm::encrypt(key.span(), iv.span(), additionalData.span(), plainText.span(), desiredTagLengthInBytes);
     if (rv.errorCode != Cpp::ErrorCodes::Success)
         return Exception { ExceptionCode::OperationError };
     return WTF::move(rv.result);
-#else
-    UNUSED_PARAM(iv);
-    UNUSED_PARAM(key);
-    UNUSED_PARAM(plainText);
-    UNUSED_PARAM(additionalData);
-    UNUSED_PARAM(desiredTagLengthInBytes);
-    RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("CLANG_WEBKIT_BRANCH");
-#endif
 }
 
 static ExceptionOr<Vector<uint8_t>> decyptAESGCM(const Vector<uint8_t>& iv, const Vector<uint8_t>& key, const Vector<uint8_t>& cipherText, const Vector<uint8_t>& additionalData, size_t desiredTagLengthInBytes)

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESKWCocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESKWCocoa.cpp
@@ -30,41 +30,27 @@
 #include <CommonCrypto/CommonCrypto.h>
 #include <pal/PALSwift.h>
 
-#if !defined(CLANG_WEBKIT_BRANCH)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
 #include "PALSwift-Generated.h"
 #pragma clang diagnostic pop
-#endif // !defined(CLANG_WEBKIT_BRANCH)
 
 namespace WebCore {
 
 static ExceptionOr<Vector<uint8_t>> wrapKeyAESKWCryptoKit(const Vector<uint8_t>& key, const Vector<uint8_t>& data)
 {
-#if !defined(CLANG_WEBKIT_BRANCH)
     auto rv = pal::AesKw::wrap(data.span(), key.span());
     if (rv.errorCode != Cpp::ErrorCodes::Success)
         return Exception { ExceptionCode::OperationError };
     return WTF::move(rv.result);
-#else
-    UNUSED_PARAM(key);
-    UNUSED_PARAM(data);
-    RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("CLANG_WEBKIT_BRANCH");
-#endif
 }
 
 static ExceptionOr<Vector<uint8_t>> unwrapKeyAESKWCryptoKit(const Vector<uint8_t>& key, const Vector<uint8_t>& data)
 {
-#if !defined(CLANG_WEBKIT_BRANCH)
     auto rv = pal::AesKw::unwrap(data.span(), key.span());
     if (rv.errorCode != Cpp::ErrorCodes::Success)
         return Exception { ExceptionCode::OperationError };
     return WTF::move(rv.result);
-#else
-    UNUSED_PARAM(key);
-    UNUSED_PARAM(data);
-    RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("CLANG_WEBKIT_BRANCH");
-#endif
 }
 
 ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESKW::platformWrapKey(const CryptoKeyAES& key, const Vector<uint8_t>& data)

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmECDHCocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmECDHCocoa.cpp
@@ -30,27 +30,19 @@
 #include "CryptoKeyEC.h"
 #include <pal/PALSwift.h>
 
-#if !defined(CLANG_WEBKIT_BRANCH)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
 #include "PALSwift-Generated.h"
 #pragma clang diagnostic pop
-#endif // !defined(CLANG_WEBKIT_BRANCH)
 
 namespace WebCore {
 
 static std::optional<Vector<uint8_t>> platformDeriveBitsCryptoKit(const CryptoKeyEC& baseKey, const CryptoKeyEC& publicKey)
 {
-#if !defined(CLANG_WEBKIT_BRANCH)
     auto rv = baseKey.platformKey()->deriveBits(publicKey.platformKey());
     if (rv.errorCode != Cpp::ErrorCodes::Success)
         return std::nullopt;
     return std::make_optional(WTF::move(rv.result));
-#else
-    UNUSED_PARAM(baseKey);
-    UNUSED_PARAM(publicKey);
-    RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("CLANG_WEBKIT_BRANCH");
-#endif
 }
 
 std::optional<Vector<uint8_t>> CryptoAlgorithmECDH::platformDeriveBits(const CryptoKeyEC& baseKey, const CryptoKeyEC& publicKey)

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSACocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSACocoa.cpp
@@ -39,34 +39,19 @@ namespace WebCore {
 
 static ExceptionOr<Vector<uint8_t>> signECDSACryptoKit(CryptoAlgorithmIdentifier hash, const PlatformECKeyContainer& key, const Vector<uint8_t>& data)
 {
-#if !defined(CLANG_WEBKIT_BRANCH)
     if (!isValidHashParameter(hash))
         return Exception { ExceptionCode::OperationError };
     auto rv = key->sign(data.span(), std::to_underlying(toCKHashFunction(hash)));
     if (rv.errorCode != Cpp::ErrorCodes::Success)
         return Exception { ExceptionCode::OperationError };
     return WTF::move(rv.result);
-#else
-    UNUSED_PARAM(hash);
-    UNUSED_PARAM(key);
-    UNUSED_PARAM(data);
-    RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("CLANG_WEBKIT_BRANCH");
-#endif
 }
 
 static ExceptionOr<bool> verifyECDSACryptoKit(CryptoAlgorithmIdentifier hash, const PlatformECKeyContainer& key, const Vector<uint8_t>& signature, const Vector<uint8_t> data)
 {
-#if !defined(CLANG_WEBKIT_BRANCH)
     if (!isValidHashParameter(hash))
         return Exception { ExceptionCode::OperationError };
     return key->verify(data.span(), signature.span(), std::to_underlying(toCKHashFunction(hash))).errorCode == Cpp::ErrorCodes::Success;
-#else
-    UNUSED_PARAM(hash);
-    UNUSED_PARAM(key);
-    UNUSED_PARAM(signature);
-    UNUSED_PARAM(data);
-    RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("CLANG_WEBKIT_BRANCH");
-#endif
 }
 
 ExceptionOr<Vector<uint8_t>> CryptoAlgorithmECDSA::platformSign(const CryptoAlgorithmEcdsaParams& parameters, const CryptoKeyEC& key, const Vector<uint8_t>& data)

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmEd25519Cocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmEd25519Cocoa.cpp
@@ -31,44 +31,29 @@
 #include <pal/PALSwift.h>
 #include <pal/spi/cocoa/CoreCryptoSPI.h>
 
-#if !defined(CLANG_WEBKIT_BRANCH)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
 #include "PALSwift-Generated.h"
 #pragma clang diagnostic pop
-#endif // !defined(CLANG_WEBKIT_BRANCH)
 
 namespace WebCore {
 
 static ExceptionOr<Vector<uint8_t>> signEd25519CryptoKit(const Vector<uint8_t>&sk, const Vector<uint8_t>& data)
 {
-#if !defined(CLANG_WEBKIT_BRANCH)
     if (sk.size() != ed25519KeySize)
         return Exception { ExceptionCode::OperationError };
     auto rv = pal::EdKey::sign(pal::EdSigningAlgorithm::ed25519(), sk.span(), data.span());
     if (rv.errorCode != Cpp::ErrorCodes::Success)
         return Exception { ExceptionCode::OperationError };
     return WTF::move(rv.result);
-#else
-    UNUSED_PARAM(sk);
-    UNUSED_PARAM(data);
-    RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("CLANG_WEBKIT_BRANCH");
-#endif
 }
 
 static ExceptionOr<bool> verifyEd25519CryptoKit(const Vector<uint8_t>& pubKey, const Vector<uint8_t>& signature, const Vector<uint8_t>& data)
 {
-#if !defined(CLANG_WEBKIT_BRANCH)
     if (pubKey.size() != ed25519KeySize || signature.size() != ed25519SignatureSize)
         return false;
     auto rv = pal::EdKey::verify(pal::EdSigningAlgorithm::ed25519(), pubKey.span(), signature.span(), data.span());
     return rv.errorCode == Cpp::ErrorCodes::Success;
-#else
-    UNUSED_PARAM(pubKey);
-    UNUSED_PARAM(signature);
-    UNUSED_PARAM(data);
-    RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("CLANG_WEBKIT_BRANCH");
-#endif
 }
 
 ExceptionOr<Vector<uint8_t>> CryptoAlgorithmEd25519::platformSign(const CryptoKeyOKP& key, const Vector<uint8_t>& data)

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmHKDFCocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmHKDFCocoa.cpp
@@ -32,30 +32,21 @@
 #include "CryptoUtilitiesCocoa.h"
 #include <pal/PALSwift.h>
 
-#if !defined(CLANG_WEBKIT_BRANCH)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
 #include "PALSwift-Generated.h"
 #pragma clang diagnostic pop
-#endif // !defined(CLANG_WEBKIT_BRANCH)
 
 namespace WebCore {
 
 static ExceptionOr<Vector<uint8_t>> platformDeriveBitsCryptoKit(const CryptoAlgorithmHkdfParams& parameters, const CryptoKeyRaw& key, size_t length)
 {
-#if !defined(CLANG_WEBKIT_BRANCH)
     if (!isValidHashParameter(parameters.hashIdentifier))
         return Exception { ExceptionCode::OperationError };
     auto rv = pal::HKDF::deriveBits(key.key().span(), parameters.saltVector().span(), parameters.infoVector().span(), length, std::to_underlying(toCKHashFunction(parameters.hashIdentifier)));
     if (rv.errorCode != Cpp::ErrorCodes::Success)
         return Exception { ExceptionCode::OperationError };
     return WTF::move(rv.result);
-#else
-    UNUSED_PARAM(parameters);
-    UNUSED_PARAM(key);
-    UNUSED_PARAM(length);
-    RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("CLANG_WEBKIT_BRANCH");
-#endif
 }
 
 ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHKDF::platformDeriveBits(const CryptoAlgorithmHkdfParams& parameters, const CryptoKeyRaw& key, size_t length)

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmHMACCocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmHMACCocoa.cpp
@@ -36,29 +36,16 @@ namespace WebCore {
 
 static ExceptionOr<Vector<uint8_t>> platformSignCryptoKit(const CryptoKeyHMAC& key, const Vector<uint8_t>& data)
 {
-#if !defined(CLANG_WEBKIT_BRANCH)
     if (!isValidHashParameter(key.hashAlgorithmIdentifier()))
         return Exception { ExceptionCode::OperationError };
     return pal::HMAC::sign(key.key().span(), data.span(), std::to_underlying(toCKHashFunction(key.hashAlgorithmIdentifier())));
-#else
-    UNUSED_PARAM(key);
-    UNUSED_PARAM(data);
-    RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("CLANG_WEBKIT_BRANCH");
-#endif
 }
 
 static ExceptionOr<bool> platformVerifyCryptoKit(const CryptoKeyHMAC& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data)
 {
-#if !defined(CLANG_WEBKIT_BRANCH)
     if (!isValidHashParameter(key.hashAlgorithmIdentifier()))
         return Exception { ExceptionCode::OperationError };
     return pal::HMAC::verify(signature.span(), key.key().span(), data.span(), std::to_underlying(toCKHashFunction(key.hashAlgorithmIdentifier())));
-#else
-    UNUSED_PARAM(key);
-    UNUSED_PARAM(signature);
-    UNUSED_PARAM(data);
-    RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("CLANG_WEBKIT_BRANCH");
-#endif
 }
 
 ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHMAC::platformSign(const CryptoKeyHMAC& key, const Vector<uint8_t>& data)

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmX25519Cocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmX25519Cocoa.cpp
@@ -24,29 +24,21 @@
 #include <pal/PALSwift.h>
 #include <pal/spi/cocoa/CoreCryptoSPI.h>
 
-#if !defined(CLANG_WEBKIT_BRANCH)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
 #include "PALSwift-Generated.h"
 #pragma clang diagnostic pop
-#endif // !defined(CLANG_WEBKIT_BRANCH)
 
 namespace WebCore {
 
 static std::optional<Vector<uint8_t>> deriveBitsCryptoKit(const Vector<uint8_t>& baseKey, const Vector<uint8_t>& publicKey)
 {
-#if !defined(CLANG_WEBKIT_BRANCH)
     if (baseKey.size() != ed25519KeySize || publicKey.size() != ed25519KeySize)
         return std::nullopt;
     auto rv = pal::EdKey::deriveBits(pal::EdKeyAgreementAlgorithm::x25519(), baseKey.span(), publicKey.span());
     if (rv.errorCode != Cpp::ErrorCodes::Success)
         return std::nullopt;
     return WTF::move(rv.result);
-#else
-    UNUSED_PARAM(baseKey);
-    UNUSED_PARAM(publicKey);
-    RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("CLANG_WEBKIT_BRANCH");
-#endif
 }
 
 std::optional<Vector<uint8_t>> CryptoAlgorithmX25519::platformDeriveBits(const CryptoKeyOKP& baseKey, const CryptoKeyOKP& publicKey)

--- a/Source/WebCore/crypto/cocoa/CryptoKeyECCocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoKeyECCocoa.cpp
@@ -97,8 +97,6 @@ bool CryptoKeyEC::platformSupportedCurve(NamedCurve curve)
     return curve == NamedCurve::P256 || curve == NamedCurve::P384 || curve == NamedCurve::P521;
 }
 
-#if !defined(CLANG_WEBKIT_BRANCH)
-
 static pal::ECCurve namedCurveToCryptoKitCurve(CryptoKeyEC::NamedCurve curve)
 {
     switch (curve) {
@@ -118,26 +116,15 @@ static PlatformECKeyContainer toPlatformKey(pal::ECKey key)
     return makeUniqueRefWithoutFastMallocCheck<pal::ECKey>(key);
 }
 
-#endif
-
 std::optional<CryptoKeyPair> CryptoKeyEC::platformGeneratePair(CryptoAlgorithmIdentifier identifier, NamedCurve curve, bool extractable, CryptoKeyUsageBitmap usages)
 {
-#if !defined(CLANG_WEBKIT_BRANCH)
     auto privateKey = CryptoKeyEC::create(identifier, curve, CryptoKeyType::Private, toPlatformKey(pal::ECKey::init(namedCurveToCryptoKitCurve(curve))), extractable, usages);
     auto publicKey = CryptoKeyEC::create(identifier, curve, CryptoKeyType::Public, toPlatformKey(privateKey->platformKey()->toPub()), true, usages);
     return CryptoKeyPair { WTF::move(publicKey), WTF::move(privateKey) };
-#else
-    UNUSED_PARAM(identifier);
-    UNUSED_PARAM(curve);
-    UNUSED_PARAM(extractable);
-    UNUSED_PARAM(usages);
-    RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("CLANG_WEBKIT_BRANCH");
-#endif
 }
 
 RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportRaw(CryptoAlgorithmIdentifier identifier, NamedCurve curve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap usages)
 {
-#if !defined(CLANG_WEBKIT_BRANCH)
     if (!doesUncompressedPointMatchNamedCurve(curve, keyData.size()))
         return nullptr;
 
@@ -145,19 +132,10 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportRaw(CryptoAlgorithmIdentifier ide
     if (!rv.getErrorCode().isSuccess() || !rv.getKey())
         return nullptr;
     return create(identifier, curve, CryptoKeyType::Public, toPlatformKey(rv.getKey().get()), extractable, usages);
-#else
-    UNUSED_PARAM(identifier);
-    UNUSED_PARAM(curve);
-    UNUSED_PARAM(keyData);
-    UNUSED_PARAM(extractable);
-    UNUSED_PARAM(usages);
-    RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("CLANG_WEBKIT_BRANCH");
-#endif
 }
 
 Vector<uint8_t> CryptoKeyEC::platformExportRaw() const
 {
-#if !defined(CLANG_WEBKIT_BRANCH)
     size_t expectedSize = 2 * keySizeInBytes() + 1; // Per Section 2.3.4 of http://www.secg.org/sec1-v2.pdf
     auto rv = platformKey()->exportX963Pub();
     if (rv.errorCode != Cpp::ErrorCodes::Success)
@@ -165,9 +143,6 @@ Vector<uint8_t> CryptoKeyEC::platformExportRaw() const
     if (rv.result.size() != expectedSize)
         return { };
     return WTF::move(rv.result);
-#else
-    RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("CLANG_WEBKIT_BRANCH");
-#endif
 }
 
 RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportJWKPublic(CryptoAlgorithmIdentifier identifier, NamedCurve curve, Vector<uint8_t>&& x, Vector<uint8_t>&& y, bool extractable, CryptoKeyUsageBitmap usages)
@@ -182,7 +157,6 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportJWKPublic(CryptoAlgorithmIdentifi
 
 RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportJWKPrivate(CryptoAlgorithmIdentifier identifier, NamedCurve curve, Vector<uint8_t>&& x, Vector<uint8_t>&& y, Vector<uint8_t>&& d, bool extractable, CryptoKeyUsageBitmap usages)
 {
-#if !defined(CLANG_WEBKIT_BRANCH)
     if (!doesFieldElementMatchNamedCurve(curve, x.size()) || !doesFieldElementMatchNamedCurve(curve, y.size()) || !doesFieldElementMatchNamedCurve(curve, d.size()))
         return nullptr;
 
@@ -198,21 +172,10 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportJWKPrivate(CryptoAlgorithmIdentif
     if (!rv.getErrorCode().isSuccess() || !rv.getKey())
         return nullptr;
     return create(identifier, curve, CryptoKeyType::Private, toPlatformKey(rv.getKey().get()), extractable, usages);
-#else
-    UNUSED_PARAM(identifier);
-    UNUSED_PARAM(curve);
-    UNUSED_PARAM(x);
-    UNUSED_PARAM(y);
-    UNUSED_PARAM(d);
-    UNUSED_PARAM(extractable);
-    UNUSED_PARAM(usages);
-    RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("CLANG_WEBKIT_BRANCH");
-#endif
 }
 
 bool CryptoKeyEC::platformAddFieldElements(JsonWebKey& jwk) const
 {
-#if !defined(CLANG_WEBKIT_BRANCH)
     size_t keySizeInBytes = this->keySizeInBytes();
     size_t publicKeySize = keySizeInBytes * 2 + 1; // 04 + X + Y per Section 2.3.4 of http://www.secg.org/sec1-v2.pdf
     size_t privateKeySize = keySizeInBytes * 3 + 1; // 04 + X + Y + D
@@ -244,13 +207,8 @@ bool CryptoKeyEC::platformAddFieldElements(JsonWebKey& jwk) const
     if (result.size() > publicKeySize)
         jwk.d = base64URLEncodeToString(result.subspan(publicKeySize, keySizeInBytes));
     return true;
-#else
-    UNUSED_PARAM(jwk);
-    RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("CLANG_WEBKIT_BRANCH");
-#endif
 }
 
-#if !defined(CLANG_WEBKIT_BRANCH)
 static std::span<const uint8_t> getOID(CryptoKeyEC::NamedCurve curve)
 {
     switch (curve) {
@@ -262,7 +220,6 @@ static std::span<const uint8_t> getOID(CryptoKeyEC::NamedCurve curve)
         return Secp521r1;
     }
 }
-#endif
 
 // Per https://www.ietf.org/rfc/rfc5280.txt
 // SubjectPublicKeyInfo ::= SEQUENCE { algorithm AlgorithmIdentifier, subjectPublicKey BIT STRING }
@@ -274,7 +231,6 @@ static std::span<const uint8_t> getOID(CryptoKeyEC::NamedCurve curve)
 // secp521r1 OBJECT IDENTIFIER      ::= { iso(1) identified-organization(3) certicom(132) curve(0) 35 }
 RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportSpki(CryptoAlgorithmIdentifier identifier, NamedCurve curve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap usages)
 {
-#if !defined(CLANG_WEBKIT_BRANCH)
     // The following is a loose check on the provided SPKI key, it aims to extract AlgorithmIdentifier, ECParameters, and Key.
     // Once the underlying crypto library is updated to accept SPKI EC Key, we should remove this hack.
     // <rdar://problem/30987628>
@@ -307,19 +263,10 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportSpki(CryptoAlgorithmIdentifier id
     if (!rv.getErrorCode().isSuccess() || !rv.getKey())
         return nullptr;
     return create(identifier, curve, CryptoKeyType::Public, toPlatformKey(rv.getKey().get()), extractable, usages);
-#else
-    UNUSED_PARAM(identifier);
-    UNUSED_PARAM(curve);
-    UNUSED_PARAM(keyData);
-    UNUSED_PARAM(extractable);
-    UNUSED_PARAM(usages);
-    RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("CLANG_WEBKIT_BRANCH");
-#endif
 }
 
 Vector<uint8_t> CryptoKeyEC::platformExportSpki() const
 {
-#if !defined(CLANG_WEBKIT_BRANCH)
     size_t expectedKeySize = 2 * keySizeInBytes() + 1; // Per Section 2.3.4 of http://www.secg.org/sec1-v2.pdf
     Vector<uint8_t> keyBytes(expectedKeySize);
     size_t keySize = keyBytes.size();
@@ -354,9 +301,6 @@ Vector<uint8_t> CryptoKeyEC::platformExportSpki() const
     result.appendVector(keyBytes);
 
     return result;
-#else
-    RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("CLANG_WEBKIT_BRANCH");
-#endif
 }
 
 // Per https://www.ietf.org/rfc/rfc5208.txt
@@ -366,7 +310,6 @@ Vector<uint8_t> CryptoKeyEC::platformExportSpki() const
 // OpenSSL uses custom ECParameters. We follow OpenSSL as a compatibility concern.
 RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportPkcs8(CryptoAlgorithmIdentifier identifier, NamedCurve curve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap usages)
 {
-#if !defined(CLANG_WEBKIT_BRANCH)
     // The following is a loose check on the provided PKCS8 key, it aims to extract AlgorithmIdentifier, ECParameters, and Key.
     // Once the underlying crypto library is updated to accept PKCS8 EC Key, we should remove this hack.
     // <rdar://problem/30987628>
@@ -420,19 +363,10 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportPkcs8(CryptoAlgorithmIdentifier i
     if (!rv.getErrorCode().isSuccess() || !rv.getKey())
         return nullptr;
     return create(identifier, curve, CryptoKeyType::Private, toPlatformKey(rv.getKey().get()), extractable, usages);
-#else
-    UNUSED_PARAM(identifier);
-    UNUSED_PARAM(curve);
-    UNUSED_PARAM(keyData);
-    UNUSED_PARAM(extractable);
-    UNUSED_PARAM(usages);
-    RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("CLANG_WEBKIT_BRANCH");
-#endif
 }
 
 Vector<uint8_t> CryptoKeyEC::platformExportPkcs8() const
 {
-#if !defined(CLANG_WEBKIT_BRANCH)
     size_t keySizeInBytes = this->keySizeInBytes();
     size_t expectedKeySize = keySizeInBytes * 3 + 1; // 04 + X + Y + D
     Vector<uint8_t> keyBytes(expectedKeySize);
@@ -485,9 +419,6 @@ Vector<uint8_t> CryptoKeyEC::platformExportPkcs8() const
     result.append(keyBytes.subspan(0, publicKeySize - 1));
 
     return result;
-#else
-    RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("CLANG_WEBKIT_BRANCH");
-#endif
 }
 
 } // namespace WebCore

--- a/Source/WebCore/crypto/cocoa/CryptoKeyOKPCocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoKeyOKPCocoa.cpp
@@ -44,7 +44,6 @@ bool CryptoKeyOKP::supportsNamedCurve()
 
 std::optional<CryptoKeyPair> CryptoKeyOKP::platformGeneratePair(CryptoAlgorithmIdentifier identifier, NamedCurve namedCurve, bool extractable, CryptoKeyUsageBitmap usages)
 {
-#if !defined(CLANG_WEBKIT_BRANCH)
     if (!supportsNamedCurve())
         return { };
 
@@ -79,18 +78,10 @@ std::optional<CryptoKeyPair> CryptoKeyOKP::platformGeneratePair(CryptoAlgorithmI
         RELEASE_ASSERT_NOT_REACHED();
         return std::nullopt;
     }
-#else
-    UNUSED_PARAM(identifier);
-    UNUSED_PARAM(namedCurve);
-    UNUSED_PARAM(extractable);
-    UNUSED_PARAM(usages);
-    RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("CLANG_WEBKIT_BRANCH");
-#endif
 }
 
 bool CryptoKeyOKP::platformCheckPairedKeys(CryptoAlgorithmIdentifier identifier, NamedCurve, const Vector<uint8_t>& privateKey, const Vector<uint8_t>& publicKey)
 {
-#if !defined(CLANG_WEBKIT_BRANCH)
     if (!supportsNamedCurve())
         return false;
 
@@ -106,12 +97,6 @@ bool CryptoKeyOKP::platformCheckPairedKeys(CryptoAlgorithmIdentifier identifier,
         RELEASE_ASSERT_NOT_REACHED();
         return false;
     }
-#else
-    UNUSED_PARAM(identifier);
-    UNUSED_PARAM(privateKey);
-    UNUSED_PARAM(publicKey);
-    RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("CLANG_WEBKIT_BRANCH");
-#endif
 }
 
 // Per https://www.ietf.org/rfc/rfc5280.txt
@@ -365,7 +350,6 @@ String CryptoKeyOKP::generateJwkD() const
 
 String CryptoKeyOKP::generateJwkX() const
 {
-#if !defined(CLANG_WEBKIT_BRANCH)
     if (type() == CryptoKeyType::Public)
         return base64URLEncodeToString(m_data);
 
@@ -385,9 +369,6 @@ String CryptoKeyOKP::generateJwkX() const
         RELEASE_ASSERT_NOT_REACHED();
         return String(""_s);
     }
-#else
-    RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("CLANG_WEBKIT_BRANCH");
-#endif
 }
 
 Vector<uint8_t> CryptoKeyOKP::platformExportRaw() const

--- a/Source/WebCore/crypto/keys/CryptoKeyEC.cpp
+++ b/Source/WebCore/crypto/keys/CryptoKeyEC.cpp
@@ -33,12 +33,10 @@
 
 #if OS(DARWIN) && !PLATFORM(GTK)
 #include <pal/PALSwift.h>
-#if !defined(CLANG_WEBKIT_BRANCH)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
 #include "PALSwift-Generated.h"
 #pragma clang diagnostic pop
-#endif // !defined(CLANG_WEBKIT_BRANCH)
 #endif
 
 namespace WebCore {

--- a/Source/WebCore/crypto/keys/CryptoKeyEC.h
+++ b/Source/WebCore/crypto/keys/CryptoKeyEC.h
@@ -31,7 +31,6 @@
 #include <wtf/Platform.h>
 #if OS(DARWIN) && !PLATFORM(GTK)
 #include <WebCore/CommonCryptoUtilities.h>
-#if !defined(CLANG_WEBKIT_BRANCH)
 namespace pal {
 class ECKey;
 }
@@ -39,11 +38,6 @@ class ECKey;
 namespace WebCore {
 using PlatformECKeyContainer = UniqueRef<pal::ECKey>;
 }
-#else
-namespace WebCore {
-using PlatformECKeyContainer = std::unique_ptr<std::monostate>;
-}
-#endif
 #endif
 
 #if USE(GCRYPT)

--- a/Source/WebCore/workers/service/ServiceWorkerRoute.mm
+++ b/Source/WebCore/workers/service/ServiceWorkerRoute.mm
@@ -28,25 +28,16 @@
 
 #import <pal/PALSwift.h>
 
-#if !defined(CLANG_WEBKIT_BRANCH)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
 #include "PALSwift-Generated.h"
 #pragma clang diagnostic pop
-#endif // !defined(CLANG_WEBKIT_BRANCH)
 
 namespace WebCore {
 
 bool isRegexpMatching(const String& pattern, StringView value, bool shouldIgnoreCase)
 {
-#if !defined(CLANG_WEBKIT_BRANCH)
     return pal::RegexHelper::match(pattern.createNSString().get(), value.createNSString().get(), shouldIgnoreCase);
-#else
-    UNUSED_PARAM(pattern);
-    UNUSED_PARAM(value);
-    UNUSED_PARAM(shouldIgnoreCase);
-    return false;
-#endif
 }
 
 }


### PR DESCRIPTION
#### d4ea38232527cc2ea629c2d4eb0ec4373777e238
<pre>
Remove a lot of `CLANG_WEBKIT_BRANCH` conditions now that SaferCPP bot builds Swift
<a href="https://bugs.webkit.org/show_bug.cgi?id=310400">https://bugs.webkit.org/show_bug.cgi?id=310400</a>
<a href="https://rdar.apple.com/173034965">rdar://173034965</a>

Reviewed by Aditya Keerthi.

This is no longer needed now that the SaferCPP bot knows about Swift.

* Source/WebCore/PAL/pal/crypto/commoncrypto/CryptoDigestCommonCrypto.cpp:
(PAL::CryptoDigest::create):
(PAL::CryptoDigest::addBytes):
(PAL::CryptoDigest::computeHash):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmAESGCMCocoa.cpp:
(WebCore::encryptCryptoKitAESGCM):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmAESKWCocoa.cpp:
(WebCore::wrapKeyAESKWCryptoKit):
(WebCore::unwrapKeyAESKWCryptoKit):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmECDHCocoa.cpp:
(WebCore::platformDeriveBitsCryptoKit):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSACocoa.cpp:
(WebCore::signECDSACryptoKit):
(WebCore::verifyECDSACryptoKit):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmEd25519Cocoa.cpp:
(WebCore::signEd25519CryptoKit):
(WebCore::verifyEd25519CryptoKit):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmHKDFCocoa.cpp:
(WebCore::platformDeriveBitsCryptoKit):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmHMACCocoa.cpp:
(WebCore::platformSignCryptoKit):
(WebCore::platformVerifyCryptoKit):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmX25519Cocoa.cpp:
(WebCore::deriveBitsCryptoKit):
* Source/WebCore/crypto/cocoa/CryptoKeyECCocoa.cpp:
(WebCore::CryptoKeyEC::platformGeneratePair):
(WebCore::CryptoKeyEC::platformImportRaw):
(WebCore::CryptoKeyEC::platformExportRaw const):
(WebCore::CryptoKeyEC::platformImportJWKPrivate):
(WebCore::CryptoKeyEC::platformAddFieldElements const):
(WebCore::getOID):
(WebCore::CryptoKeyEC::platformImportSpki):
(WebCore::CryptoKeyEC::platformExportSpki const):
(WebCore::CryptoKeyEC::platformImportPkcs8):
(WebCore::CryptoKeyEC::platformExportPkcs8 const):
* Source/WebCore/crypto/cocoa/CryptoKeyOKPCocoa.cpp:
(WebCore::CryptoKeyOKP::platformGeneratePair):
(WebCore::CryptoKeyOKP::platformCheckPairedKeys):
(WebCore::CryptoKeyOKP::generateJwkX const):
* Source/WebCore/crypto/keys/CryptoKeyEC.cpp:
* Source/WebCore/crypto/keys/CryptoKeyEC.h:
* Source/WebCore/workers/service/ServiceWorkerRoute.mm:
(WebCore::isRegexpMatching):

Canonical link: <a href="https://commits.webkit.org/309664@main">https://commits.webkit.org/309664@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92039343d3410302c171e3683b96da3ceba59f7e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151351 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24115 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17685 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160082 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/104789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153224 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24546 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24410 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116859 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/104789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154311 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19002 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135801 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97577 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18093 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16026 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7927 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127715 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13713 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162554 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5687 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15290 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124870 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23916 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20080 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125054 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33929 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23906 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135509 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80402 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20119 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12279 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23515 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87819 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23227 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23380 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23281 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->