### PR TITLE
Top color overhang may briefly disappear during rubberband restoration

### DIFF
--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -35,6 +35,7 @@
 #include "ChromeClient.h"
 #include "ContainerNodeInlines.h"
 #include "DocumentFullscreen.h"
+#include "FixedContainerEdges.h"
 #include "GraphicsLayer.h"
 #include "HTMLCanvasElement.h"
 #include "HTMLIFrameElement.h"
@@ -3238,7 +3239,18 @@ void RenderLayerCompositor::updateRootLayerPosition()
         RefPtr { m_contentShadowLayer }->setSize(m_rootContentsLayer->size());
     }
 
-    updateLayerForTopOverhangColorExtension(m_layerForTopOverhangColorExtension);
+    bool wantsLayer = m_layerForTopOverhangColorExtension;
+    Color cachedTopColor;
+    if (!wantsLayer) {
+        cachedTopColor = page().fixedContainerEdges().predominantColor(BoxSide::Top);
+        wantsLayer = cachedTopColor.isVisible();
+    }
+
+    if (RefPtr layer = updateLayerForTopOverhangColorExtension(wantsLayer)) {
+        if (cachedTopColor.isVisible())
+            layer->setBackgroundColor(cachedTopColor);
+    }
+
     updateSizeAndPositionForTopOverhangColorExtensionLayer();
     updateLayerForTopOverhangImage(m_layerForTopOverhangImage);
     updateLayerForBottomOverhangArea(m_layerForBottomOverhangArea);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ObscuredContentInsets.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ObscuredContentInsets.mm
@@ -437,6 +437,67 @@ TEST(ObscuredContentInsets, OverflowHeightForTopScrollEdgeEffect)
     checkScrollPocket();
 }
 
+TEST(ObscuredContentInsets, TopOverhangColorExtensionLayerAppearsImmediatelyAfterReload)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 400)]);
+
+    [webView setObscuredContentInsets:NSEdgeInsetsMake(100, 0, 0, 0)];
+    [webView waitForNextPresentationUpdate];
+
+    [webView synchronouslyLoadTestPageNamed:@"top-fixed-element"];
+    [webView waitForNextPresentationUpdate];
+
+    RetainPtr layerBeforeReload = [webView firstLayerWithNameContaining:@"top overhang"];
+    EXPECT_NOT_NULL(layerBeforeReload.get());
+
+    RetainPtr expectedColor = [webView _sampledTopFixedPositionContentColor];
+    EXPECT_NOT_NULL(expectedColor.get());
+
+    RetainPtr actualColorBeforeReload = [NSColor colorWithCGColor:[layerBeforeReload backgroundColor]];
+    EXPECT_TRUE(Util::compareColors(actualColorBeforeReload, expectedColor.get()));
+
+    __block bool layerChecked = false;
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    [navigationDelegate setDidCommitNavigation:^(WKWebView *view, WKNavigation *) {
+        [view _doAfterNextPresentationUpdate:^{
+            layerChecked = true;
+        }];
+    }];
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    [webView reload];
+    Util::run(&layerChecked);
+
+    RetainPtr layerAfterReload = [webView firstLayerWithNameContaining:@"top overhang"];
+    EXPECT_NOT_NULL(layerAfterReload.get());
+
+    if (layerAfterReload) {
+        RetainPtr actualColorAfterReload = [NSColor colorWithCGColor:[layerAfterReload backgroundColor]];
+        EXPECT_TRUE(Util::compareColors(actualColorAfterReload, expectedColor.get()));
+    }
+}
+
+TEST(ObscuredContentInsets, TopOverhangColorExtensionLayerRemovedQuicklyAfterNavigatingToPageWithoutFixedHeader)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 400)]);
+
+    [webView setObscuredContentInsets:NSEdgeInsetsMake(100, 0, 0, 0)];
+    [webView waitForNextPresentationUpdate];
+
+    [webView synchronouslyLoadTestPageNamed:@"top-fixed-element"];
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_NOT_NULL([webView firstLayerWithNameContaining:@"top overhang"]);
+
+    [webView synchronouslyLoadHTMLString:@"<body style='height:4000px'>No fixed header</body>"];
+
+    [webView waitForNextPresentationUpdate];
+    [webView waitForNextPresentationUpdate];
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_NULL([webView firstLayerWithNameContaining:@"top overhang"]);
+}
+
 #endif // ENABLE(CONTENT_INSET_BACKGROUND_FILL)
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 0be722ca6723faca88fecd1c806b2192ff065ffa
<pre>
Top color overhang may briefly disappear during rubberband restoration
<a href="https://bugs.webkit.org/show_bug.cgi?id=310392">https://bugs.webkit.org/show_bug.cgi?id=310392</a>
<a href="https://rdar.apple.com/173028532">rdar://173028532</a>

Reviewed by Wenson Hsieh.

After a page reloads during a rubberbanding animation and the animation
is restored, the top color overhang layer is not immediately created,
resulting in the scroll stretch region flickering white.

To fix this, simply check if the `Page` has any top color stored already,
and if it does, create a layer using this color. It is then updated like
normal afterwards if needed.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/ObscuredContentInsets.mm

* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::updateRootLayerPosition):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ObscuredContentInsets.mm:
(TestWebKitAPI::TEST(ObscuredContentInsets, TopOverhangColorExtensionLayerAppearsImmediatelyAfterReload)):
(TestWebKitAPI::TEST(ObscuredContentInsets, TopOverhangColorExtensionLayerRemovedQuicklyAfterNavigatingToPageWithoutFixedHeader)):

Canonical link: <a href="https://commits.webkit.org/309729@main">https://commits.webkit.org/309729@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8ac6fa7cd9b21b0b16ef26b307b744ade931d66

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151352 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24116 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17686 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160083 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104790 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3305afa7-77de-422a-8dac-01bcded4688b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153225 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24547 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24411 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116860 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82966 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d8868709-ad97-4967-bd22-0a17055d104f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154312 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18995 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135803 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97578 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18086 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16029 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7928 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127708 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13715 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162555 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5688 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15292 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124871 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23917 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20083 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125055 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33973 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23907 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135511 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80403 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20117 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12281 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23516 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87820 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23228 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23381 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23282 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->