### PR TITLE
AX: enable client-side accessibility calls to be made to test WebKitTestRunner

### DIFF
--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -126,6 +126,7 @@ webkit.org/b/306558 accessibility/mac/style-range.html [ Failure ]
 # Skip accessibility tests that use the accessibility client API on most builders;
 # requires an extra permission for WKTR
 accessibility/mac/client [ Skip ]
+accessibility/mac/client/button.html [ Pass ]
 
 # Skip glib-only combobox accessibility tests.
 accessibility/combobox/gtk [ Skip ]

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
@@ -38,6 +38,7 @@
 #include "WKData.h"
 #include "WebFrame.h"
 #include "WebPage.h"
+#include "WebProcess.h"
 #include <WebCore/AXIsolatedObject.h>
 #include <WebCore/AXIsolatedTree.h>
 #include <WebCore/AXObjectCache.h>
@@ -343,4 +344,11 @@ void* _WKAccessibilityRootObjectForTesting(WKBundleFrameRef frameRef)
     CheckedPtr cache = getAXObjectCache();
     RefPtr root = cache ? cache->rootObjectForFrame(*protect(protect(WebKit::toImpl(frameRef))->coreLocalFrame())) : nullptr;
     return root ? root->wrapper() : nullptr;
+}
+
+void _WKAccessibilityAllowAuthenticationForTesting(bool allow)
+{
+#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
+    WebKit::WebProcess::setAllowAXAuthenticationForTesting(allow);
+#endif
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFramePrivate.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFramePrivate.h
@@ -58,6 +58,8 @@ WK_EXPORT void _WKBundleFrameGenerateTestReport(WKBundleFrameRef, WKStringRef me
 
 WK_EXPORT void* _WKAccessibilityRootObjectForTesting(WKBundleFrameRef frame);
 
+WK_EXPORT void _WKAccessibilityAllowAuthenticationForTesting(bool allow);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -426,6 +426,9 @@ public:
 #endif
     void unblockServicesRequiredByAccessibility(Vector<SandboxExtension::Handle>&&);
     static id accessibilityFocusedUIElement();
+#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
+    static void setAllowAXAuthenticationForTesting(bool);
+#endif
     void powerSourceDidChange(bool);
 #endif
 

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -314,8 +314,18 @@ static void preventAppKitFromContactingLaunchServices(NSApplication*, SEL)
 #endif
 
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)
+static std::atomic<bool> allowAllAXAuthenticationForTesting { false };
+
+void WebProcess::setAllowAXAuthenticationForTesting(bool allow)
+{
+    allowAllAXAuthenticationForTesting = allow;
+}
+
 static Boolean isAXAuthenticatedCallback(audit_token_t auditToken)
 {
+    if (allowAllAXAuthenticationForTesting) [[unlikely]]
+        return true;
+
     bool authenticated = false;
     // IPC must be done on the main runloop, so dispatch it to avoid crashes when the secondary AX thread handles this callback.
     callOnMainRunLoopAndWait([&authenticated, auditToken] {

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityControllerMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityControllerMac.mm
@@ -264,22 +264,10 @@ void AccessibilityController::platformInitializeClientAccessibility()
 {
     setIsolatedTreeMode(true);
 
+    _WKAccessibilityAllowAuthenticationForTesting(true);
+
     // This triggers WebKit's normal accessibility initialization flow via IPC
     WTR::postSynchronousMessage("InitializeWebProcessAccessibility");
-
-    // The above IPC triggers async initialization. Force the isolated tree to be built
-    // now by accessing the root object ON THE AX THREAD, so it's ready before the first
-    // axGetRoot() call from the test.
-    WKBundlePageRef page = InjectedBundle::singleton().page()->page();
-    WKBundleFrameRef mainFrame = WKBundlePageGetMainFrame(page);
-    if (!mainFrame)
-        return;
-
-    // Access the root object on the AX thread to trigger isolated tree creation with proper thread setup
-    RetainPtr<PlatformUIElement> root;
-    executeOnAXThreadAndWait([&mainFrame, &root] () {
-        root = static_cast<PlatformUIElement>(_WKAccessibilityRootObjectForTesting(mainFrame));
-    });
 }
 
 } // namespace WTR


### PR DESCRIPTION
#### 17d1151aab776f8d4d22baea8cd999e94458219e
<pre>
AX: enable client-side accessibility calls to be made to test WebKitTestRunner
<a href="https://rdar.apple.com/173035589">rdar://173035589</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=310401">https://bugs.webkit.org/show_bug.cgi?id=310401</a>

Reviewed by Chris Dumez.

We added some layout tests that use client-side accessibility APIs on
macOS to provide better coverage for site isolation. Previously that
required an entitlement; instead we can just have WebKitTestRunner set
a flag that authorizes those calls.

Enables a test that was previously skipped.

* LayoutTests/platform/mac/TestExpectations:
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp:
(_WKAccessibilityAllowAuthenticationForTesting):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFramePrivate.h:
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::accessibilityFocusedUIElement):
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityControllerMac.mm:
(WTR::AccessibilityController::platformInitializeClientAccessibility):

Canonical link: <a href="https://commits.webkit.org/310021@main">https://commits.webkit.org/310021@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eceea49d501689b082b566e5ef5b85c4b1fc3d76

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152416 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25198 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18797 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161159 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154290 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25726 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25504 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117772 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155376 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19980 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136829 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98486 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19057 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16995 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8994 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128707 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14703 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163629 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6771 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16297 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125808 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24996 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21034 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125979 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34187 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24998 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136499 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81598 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20971 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13278 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24614 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88900 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24305 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24465 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24366 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->