### PR TITLE
Web Inspector: Simplify FrameInspectorTargetProxy to be based on process and a frame id only

### DIFF
--- a/Source/WebKit/UIProcess/Inspector/FrameInspectorTargetProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/FrameInspectorTargetProxy.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "FrameInspectorTargetProxy.h"
 
+#include "FrameInspectorTarget.h"
 #include "InspectorTargetProxy.h"
 #include "MessageSenderInlines.h"
 #include "ProvisionalFrameProxy.h"
@@ -42,22 +43,11 @@ using namespace Inspector;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(FrameInspectorTargetProxy);
 
-std::unique_ptr<FrameInspectorTargetProxy> FrameInspectorTargetProxy::create(WebFrameProxy& frame, const String& targetId)
-{
-    return makeUnique<FrameInspectorTargetProxy>(frame, targetId);
-}
-
-std::unique_ptr<FrameInspectorTargetProxy> FrameInspectorTargetProxy::create(ProvisionalFrameProxy& provisionalFrame, const String& targetId)
-{
-    Ref frame { provisionalFrame.frame() };
-    std::unique_ptr target = FrameInspectorTargetProxy::create(frame.get(), targetId);
-    target->m_provisionalFrame = provisionalFrame;
-    return target;
-}
-
-FrameInspectorTargetProxy::FrameInspectorTargetProxy(WebFrameProxy& frame, const String& targetId)
-    : InspectorTargetProxy(targetId, Inspector::InspectorTargetType::Frame)
-    , m_frame(frame)
+FrameInspectorTargetProxy::FrameInspectorTargetProxy(WebCore::FrameIdentifier frameID, WebProcessProxy& process, bool isProvisional)
+    : InspectorTargetProxy(FrameInspectorTarget::toTargetID(frameID, process.coreProcessIdentifier()), Inspector::InspectorTargetType::Frame)
+    , m_targetProcess(process)
+    , m_frameID(frameID)
+    , m_isProvisional(isProvisional)
 {
 }
 
@@ -65,13 +55,7 @@ FrameInspectorTargetProxy::~FrameInspectorTargetProxy() = default;
 
 void FrameInspectorTargetProxy::connect(Inspector::FrontendChannel::ConnectionType connectionType)
 {
-    if (RefPtr provisionalFrame = m_provisionalFrame.get()) {
-        protect(provisionalFrame->process())->send(Messages::WebFrame::ConnectInspector(connectionType), protect(provisionalFrame->frame())->frameID());
-        return;
-    }
-
-    Ref frame = m_frame.get();
-    protect(frame->process())->send(Messages::WebFrame::ConnectInspector(connectionType), frame->frameID());
+    protect(m_targetProcess.get())->send(Messages::WebFrame::ConnectInspector(connectionType), m_frameID);
 }
 
 void FrameInspectorTargetProxy::disconnect()
@@ -79,34 +63,22 @@ void FrameInspectorTargetProxy::disconnect()
     if (isPaused())
         resume();
 
-    if (RefPtr provisionalFrame = m_provisionalFrame.get()) {
-        protect(provisionalFrame->process())->send(Messages::WebFrame::DisconnectInspector(), protect(provisionalFrame->frame())->frameID());
-        return;
-    }
-
-    Ref frame = m_frame.get();
-    protect(frame->process())->send(Messages::WebFrame::DisconnectInspector(), frame->frameID());
+    protect(m_targetProcess.get())->send(Messages::WebFrame::DisconnectInspector(), m_frameID);
 }
 
 void FrameInspectorTargetProxy::sendMessageToTargetBackend(const String& message)
 {
-    if (RefPtr provisionalFrame = m_provisionalFrame.get()) {
-        protect(provisionalFrame->process())->send(Messages::WebFrame::SendMessageToInspectorTarget(message), protect(provisionalFrame->frame())->frameID());
-        return;
-    }
-
-    Ref frame = m_frame.get();
-    protect(frame->process())->send(Messages::WebFrame::SendMessageToInspectorTarget(message), frame->frameID());
+    protect(m_targetProcess.get())->send(Messages::WebFrame::SendMessageToInspectorTarget(message), m_frameID);
 }
 
 void FrameInspectorTargetProxy::didCommitProvisionalTarget()
 {
-    m_provisionalFrame = nullptr;
+    m_isProvisional = false;
 }
 
 bool FrameInspectorTargetProxy::isProvisional() const
 {
-    return !!m_provisionalFrame;
+    return m_isProvisional;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Inspector/FrameInspectorTargetProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/FrameInspectorTargetProxy.h
@@ -27,25 +27,23 @@
 
 #include "InspectorTargetProxy.h"
 #include <JavaScriptCore/InspectorTarget.h>
+#include <WebCore/FrameIdentifier.h>
 #include <memory>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/TypeCasts.h>
-#include <wtf/WeakPtr.h>
+#include <wtf/WeakRef.h>
 
 namespace WebKit {
 
-class ProvisionalFrameProxy;
-class WebFrameProxy;
+class WebProcessProxy;
 
 class FrameInspectorTargetProxy final : public InspectorTargetProxy {
     WTF_MAKE_TZONE_ALLOCATED(FrameInspectorTargetProxy);
     WTF_MAKE_NONCOPYABLE(FrameInspectorTargetProxy);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FrameInspectorTargetProxy);
 public:
-    static std::unique_ptr<FrameInspectorTargetProxy> create(WebFrameProxy&, const String& targetId);
-    static std::unique_ptr<FrameInspectorTargetProxy> create(ProvisionalFrameProxy&, const String& targetId);
-    FrameInspectorTargetProxy(WebFrameProxy&, const String& targetId);
+    FrameInspectorTargetProxy(WebCore::FrameIdentifier, WebProcessProxy&, bool isProvisional);
     ~FrameInspectorTargetProxy();
 
     void didCommitProvisionalTarget() override;
@@ -56,8 +54,9 @@ public:
     void sendMessageToTargetBackend(const String&) override;
 
 private:
-    WeakRef<WebFrameProxy> m_frame;
-    WeakPtr<ProvisionalFrameProxy> m_provisionalFrame;
+    WeakRef<WebProcessProxy> m_targetProcess;
+    WebCore::FrameIdentifier m_frameID;
+    bool m_isProvisional { false };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
@@ -250,7 +250,8 @@ void WebPageInspectorController::didCreateFrame(WebFrameProxy& frame)
     if (!shouldManageFrameTargets())
         return;
 
-    addTarget(FrameInspectorTargetProxy::create(frame, getTargetID(frame)));
+    constexpr bool isProvisional = false;
+    addTarget(makeUnique<FrameInspectorTargetProxy>(frame.frameID(), protect(frame.process()), isProvisional));
 }
 
 void WebPageInspectorController::willDestroyFrame(const WebFrameProxy& frame)
@@ -266,7 +267,8 @@ void WebPageInspectorController::didCreateProvisionalFrame(ProvisionalFrameProxy
     if (!shouldManageFrameTargets())
         return;
 
-    addTarget(FrameInspectorTargetProxy::create(provisionalFrame, getTargetID(provisionalFrame)));
+    constexpr bool isProvisional = true;
+    addTarget(makeUnique<FrameInspectorTargetProxy>(protect(provisionalFrame.frame())->frameID(), protect(provisionalFrame.process()), isProvisional));
 }
 
 void WebPageInspectorController::willDestroyProvisionalFrame(const ProvisionalFrameProxy& provisionalFrame)


### PR DESCRIPTION
#### 616546bc4c7cfe756225422197170be096c13264
<pre>
Web Inspector: Simplify FrameInspectorTargetProxy to be based on process and a frame id only
<a href="https://bugs.webkit.org/show_bug.cgi?id=310403">https://bugs.webkit.org/show_bug.cgi?id=310403</a>

Reviewed by Basuke Suzuki and BJ Burg.

The FrameInspectorTargetProxy currently records a WebFrameProxy and
optionally a ProvisionalFrameProxy so it knows how to find its true
target in the web process. It turns out that we only need the
FrameIdentifier and the WebProcessProxy to locate its target (to be able
to construct the appropriate IPC message).

Simplify the target proxy by only recording that minimal set of required
info. This will potentially make extending the idea of a provisional
frame target easier, particularly in the scenario of surfacing a
provisional target for the main frame of a provisional page.
(A ProvisionalPageProxy creates a non-provisional frame, WebFrameProxy.
Creating a FrameInspectorTargetProxy using the current design would be
confusing when we present the target as provisional without it tied to
a ProvisionalFrameProxy. This patch can help bypass that complication
by isolating a target&apos;s provisional-ness observed by the frontend with
what objects are relevant in the backend.)

No new tests; no changes in observable behavior.

* Source/WebKit/UIProcess/Inspector/FrameInspectorTargetProxy.cpp:
(WebKit::FrameInspectorTargetProxy::create):
(WebKit::FrameInspectorTargetProxy::FrameInspectorTargetProxy):
(WebKit::FrameInspectorTargetProxy::connect):
(WebKit::FrameInspectorTargetProxy::disconnect):
(WebKit::FrameInspectorTargetProxy::sendMessageToTargetBackend):
(WebKit::FrameInspectorTargetProxy::didCommitProvisionalTarget):
(WebKit::FrameInspectorTargetProxy::isProvisional const):
* Source/WebKit/UIProcess/Inspector/FrameInspectorTargetProxy.h:
* Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp:
(WebKit::WebPageInspectorController::didCreateFrame):
(WebKit::WebPageInspectorController::didCreateProvisionalFrame):

Canonical link: <a href="https://commits.webkit.org/310388@main">https://commits.webkit.org/310388@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/133d07cecc9751ecb1b998ab088d003333ace5d7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152492 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25274 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18873 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161237 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105949 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6bcc482b-cdb8-4d79-806a-3dd3b85927c7) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25802 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25580 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117838 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83513 "7 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0bf4f371-a9de-432b-ac95-9ad5cee71f37) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155452 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20050 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136902 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98552 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a6cc93d3-61a0-401a-a497-c7da4adde69f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19126 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17063 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9071 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128776 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163706 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6847 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16370 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125877 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25072 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21102 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126045 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34466 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25074 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136572 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81676 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21040 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13351 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24690 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88976 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24381 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24541 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24442 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->