### PR TITLE
[Site Isolation] Web Inspector: Consider involving a provisional frame target on page-level cross-origin navigation

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/debugger/resources/site-isolation-debugger-test-utilities.js
+++ b/LayoutTests/http/tests/site-isolation/inspector/debugger/resources/site-isolation-debugger-test-utilities.js
@@ -19,4 +19,18 @@ window.waitForExpressionInTarget = async function waitForExpressionInTarget(targ
     return undefined;
 };
 
+// Evaluate document.location.href in each frame target and return a Map of {url => target}.
+// Useful for identifying which frame target corresponds to a particular nested frame.
+window.fetchDocumentURLsForTargets = async function fetchDocumentURLsForTargets(targets) {
+    let entries = await Promise.all(targets.map(async function (target) {
+        let { result } = await target.RuntimeAgent.evaluate.invoke({
+            expression: "document.location.href",
+            objectGroup: "test",
+            returnByValue: true,
+        });
+        return [result.value, target];
+    }));
+    return new Map(entries);
+};
+
 });

--- a/LayoutTests/http/tests/site-isolation/inspector/target/target-cross-origin-page-navigation-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/target/target-cross-origin-page-navigation-expected.txt
@@ -12,7 +12,9 @@ http://127.0.0.1:8000/site-isolation/inspector/target/resources/middle-iframe.ht
 http://127.0.0.1:8000/site-isolation/inspector/target/target-cross-origin-page-navigation.html
 http://localhost:8000/site-isolation/inspector/target/resources/leaf-iframe.html
 Navigating cross-origin...
-ERROR: Received a command response without a corresponding callback or promise. [object Object]
+PASS: Provisional main frame target gets created.
+PASS: Main frame target is committed.
+PASS: Previous id reported by the commit event should be the old main frame target's id.
 PASS: Should have main, middle, and leaf frame targets after navigation.
 Frame URLs after navigation:
 http://127.0.0.1:8000/site-isolation/inspector/target/resources/leaf-iframe.html

--- a/LayoutTests/http/tests/site-isolation/inspector/target/target-cross-origin-page-navigation.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/target/target-cross-origin-page-navigation.html
@@ -1,4 +1,5 @@
 <script src="../../../inspector/resources/inspector-test.js"></script>
+<script src="../debugger/resources/site-isolation-debugger-test-utilities.js"></script>
 
 <script>
     function test() {
@@ -7,37 +8,55 @@
         suite.addTestCase({
             name: "SiteIsolation.Target.CrossOriginPageNavigation.FrameTargetLifetime",
             description: "On cross-origin page navigation, frame targets are destroyed and created as appropriate.",
-            async test() {
-                async function logDocumentURLs(targets) {
-                    let urls = await Promise.all(targets.map(async function (target) {
-                        let { result } = await target.RuntimeAgent.evaluate.invoke({
-                            expression: "document.location.href",
-                            objectGroup: "test",
-                            returnByValue: true,
-                        });
-                        return result.value;
-                    }));
-                    InspectorTest.log(urls.sort().join("\n"));
-                }
-
+            async test(script) {
                 let oldFrameTargets = WI.targets.filter((t) => t.type === WI.TargetType.Frame);
                 InspectorTest.expectEqual(oldFrameTargets.length, 3, "Should have main, middle, and leaf frame targets before navigation.");
+                let urlTargetMap = await fetchDocumentURLsForTargets(oldFrameTargets);
                 InspectorTest.log("Frame URLs before navigation:");
-                await logDocumentURLs(oldFrameTargets);
+                InspectorTest.log(Array.from(urlTargetMap.keys()).sort().join("\n"));
+
+                let oldMainFrameTargetId = urlTargetMap.get(WI.networkManager.mainFrame.url).identifier;
+
+                // Promises that wait for the next TargetAdded and DidCommitProvisionalTarget events for a frame.
+                let provisionalFrameTargetAdded = new Promise(function (resolve) {
+                    function handle(event) {
+                        let { target } = event.data;
+                        if (target.type === WI.TargetType.Frame) {
+                            WI.targetManager.removeEventListener(WI.TargetManager.Event.TargetAdded, handle);
+                            resolve(target.identifier);
+                        }
+                    }
+                    WI.targetManager.addEventListener(WI.TargetManager.Event.TargetAdded, handle);
+                });
+                let provisionalFrameTargetCommitted = new Promise(function (resolve) {
+                    function handle(event) {
+                        let { previousTargetId, target } = event.data;
+                        if (target.type === WI.TargetType.Frame) {
+                            WI.targetManager.removeEventListener(WI.TargetManager.Event.DidCommitProvisionalTarget, handle);
+                            resolve({ previousTargetId, newTargetId: target.identifier });
+                        }
+                    }
+                    WI.targetManager.addEventListener(WI.TargetManager.Event.DidCommitProvisionalTarget, handle);
+                });
 
                 InspectorTest.log("Navigating cross-origin...");
                 InspectorTest.deferOutputUntilTestPageIsReloaded();
-                // FIXME <https://webkit.org/b/309922>: Address the unrelated console error that shows up
-                // during this navigation.
                 InspectorTest.evaluateInPage(`location.hostname = "localhost";`);
 
                 // Wait for the log from leaf-iframe to ensure all loading has completed.
                 await WI.consoleManager.awaitEvent(WI.ConsoleManager.Event.MessageAdded);
 
+                let provisionalFrameTargetId = await provisionalFrameTargetAdded;
+                InspectorTest.pass("Provisional main frame target gets created.");
+
+                let { previousTargetId, newTargetId } = await provisionalFrameTargetCommitted;
+                InspectorTest.expectEqual(newTargetId, provisionalFrameTargetId, "Main frame target is committed.");
+                InspectorTest.expectEqual(previousTargetId, oldMainFrameTargetId, "Previous id reported by the commit event should be the old main frame target's id.");
+
                 let newFrameTargets = WI.targets.filter((t) => t.type === WI.TargetType.Frame);
                 InspectorTest.expectEqual(newFrameTargets.length, 3, "Should have main, middle, and leaf frame targets after navigation.");
                 InspectorTest.log("Frame URLs after navigation:");
-                await logDocumentURLs(newFrameTargets);
+                InspectorTest.log(Array.from((await fetchDocumentURLsForTargets(newFrameTargets)).keys()).sort().join("\n"));
 
                 let oldIds = oldFrameTargets.map((t) => t.identifier);
                 let targetsHaveNewIds = newFrameTargets.every((t) => !oldIds.includes(t.identifier));

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2442,17 +2442,13 @@ webkit.org/b/307889 http/tests/multipart/multipart-async-image.html [ Pass Failu
 
 webkit.org/b/310302 imported/w3c/web-platform-tests/uievents/mouse/mouse_boundary_events_on_image_map.html [ Pass Failure ]
 
-webkit.org/b/298909 http/tests/site-isolation/inspector/debugger/scriptParsed-frame-target.html [ Skip ]
-webkit.org/b/298909 http/tests/site-isolation/inspector/debugger/pause-in-cross-origin-iframe.html [ Skip ]
-webkit.org/b/298909 http/tests/site-isolation/inspector/debugger/setBreakpoint-cross-origin-iframe.html [ Skip ]
-webkit.org/b/298909 http/tests/site-isolation/inspector/console/message-from-iframe.html [ Skip ]
-webkit.org/b/298909 http/tests/site-isolation/inspector/console/message-from-worker.html [ Skip ]
-webkit.org/b/298909 http/tests/site-isolation/inspector/target/target-cross-origin-page-navigation.html [ Skip ]
-webkit.org/b/298909 http/tests/site-isolation/inspector/target/target.html [ Skip ]
-webkit.org/b/298909 http/tests/site-isolation/inspector/unit-tests/target-manager.html [ Skip ]
-webkit.org/b/308240 http/tests/site-isolation/inspector/runtime/evaluate-in-cross-origin-iframe.html [ Failure ]
-webkit.org/b/308240 http/tests/site-isolation/inspector/runtime/execution-context-from-frame-target.html [ Failure ]
-webkit.org/b/308240 http/tests/site-isolation/inspector/runtime/executionContextCreated-frame-target.html [ Failure ]
+# FIXME <https://webkit.org/b/311136>: Additional work needed to pass these tests
+http/tests/site-isolation/inspector/debugger/scriptParsed-frame-target.html [ Skip ]
+http/tests/site-isolation/inspector/debugger/pause-in-cross-origin-iframe.html [ Skip ]
+http/tests/site-isolation/inspector/debugger/setBreakpoint-cross-origin-iframe.html [ Skip ]
+http/tests/site-isolation/inspector/runtime/evaluate-in-cross-origin-iframe.html [ Failure Crash ]
+http/tests/site-isolation/inspector/runtime/execution-context-from-frame-target.html [ Failure ]
+http/tests/site-isolation/inspector/runtime/executionContextCreated-frame-target.html [ Failure ]
 
 webkit.org/b/308165 [ Debug ] scrollingcoordinator/mac/latching/simple-page-rubberbands.html [ Pass Failure ]
 

--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
@@ -208,41 +208,69 @@ void WebPageInspectorController::setContinueLoadingCallback(const ProvisionalPag
     target->setResumeCallback(WTF::move(callback));
 }
 
-void WebPageInspectorController::didCreateProvisionalPage(ProvisionalPageProxy& provisionalPage)
+void WebPageInspectorController::didCreateProvisionalPage(ProvisionalPageProxy& provisionalPage, WebCore::FrameIdentifier mainFrameID, WebProcessProxy& mainFrameProcess)
 {
     addTarget(PageInspectorTargetProxy::create(provisionalPage, getTargetID(provisionalPage), Inspector::InspectorTargetType::Page));
-}
-
-void WebPageInspectorController::willDestroyProvisionalPage(const ProvisionalPageProxy& provisionalPage)
-{
-    removeTarget(getTargetID(provisionalPage));
-}
-
-void WebPageInspectorController::didCommitProvisionalPage(WebCore::PageIdentifier oldWebPageID, WebCore::PageIdentifier newWebPageID)
-{
-    String oldID = PageInspectorTarget::toTargetID(oldWebPageID);
-    String newID = PageInspectorTarget::toTargetID(newWebPageID);
-    auto newTarget = m_targets.take(newID);
-    CheckedPtr targetAgent = m_targetAgent;
-    ASSERT(newTarget);
-    newTarget->didCommitProvisionalTarget();
-    targetAgent->didCommitProvisionalTarget(oldID, newID);
-
-    // Update target list to only include targets from the committed page.
-    for (auto& target : m_targets.values())
-        targetAgent->targetDestroyed(*target);
-    m_targets.clear();
-    m_targets.set(newTarget->identifier(), WTF::move(newTarget));
 
     if (shouldManageFrameTargets()) {
-        // WebFrameProxies are structurally preserved across page navigation rather than destroyed and recreated,
-        // so no didCreateFrame/willDestroyFrame callbacks fire for them. Recreate the frame targets here.
-        //
-        // (Frame target ids include the process id, which changes across a cross-origin navigation,
-        // so surviving frames need to surface as new targets to the frontend.)
-        for (RefPtr frame = m_inspectedPage->mainFrame(); frame; frame = frame->traverseNext().frame)
-            didCreateFrame(*frame);
+        constexpr bool isProvisional = true;
+        addTarget(makeUnique<FrameInspectorTargetProxy>(mainFrameID, mainFrameProcess, isProvisional));
     }
+}
+
+void WebPageInspectorController::willDestroyProvisionalPage(const ProvisionalPageProxy& provisionalPage, WebCore::FrameIdentifier mainFrameID, WebCore::ProcessIdentifier mainFrameProcessID)
+{
+    removeTarget(getTargetID(provisionalPage));
+
+    if (shouldManageFrameTargets())
+        removeTarget(FrameInspectorTarget::toTargetID(mainFrameID, mainFrameProcessID));
+}
+
+void WebPageInspectorController::didCommitProvisionalPage(std::optional<WebCore::FrameIdentifier> oldMainFrameID, WebCore::ProcessIdentifier oldProcessID, WebCore::PageIdentifier oldWebPageID, WebCore::PageIdentifier newWebPageID)
+{
+    String oldPageTargetID = PageInspectorTarget::toTargetID(oldWebPageID);
+    String newPageTargetID = PageInspectorTarget::toTargetID(newWebPageID);
+    CheckedPtr targetAgent = m_targetAgent;
+
+    // Commit the provisional page target.
+    CheckedPtr newPageTarget = m_targets.get(newPageTargetID);
+    ASSERT(newPageTarget);
+    newPageTarget->didCommitProvisionalTarget();
+    targetAgent->didCommitProvisionalTarget(oldPageTargetID, newPageTargetID);
+
+    // Commit the provisional main frame target.
+    bool shouldManageFrameTargets = this->shouldManageFrameTargets();
+    String mainFrameTargetID;
+    if (shouldManageFrameTargets) {
+        RefPtr mainFrame = protect(m_inspectedPage)->mainFrame();
+        mainFrameTargetID = FrameInspectorTarget::toTargetID(mainFrame->frameID(), protect(mainFrame->process())->coreProcessIdentifier());
+
+        CheckedPtr mainFrameTarget = m_targets.get(mainFrameTargetID);
+        ASSERT(mainFrameTarget && mainFrameTarget->isProvisional());
+        mainFrameTarget->didCommitProvisionalTarget();
+
+        ASSERT(oldMainFrameID);
+        String oldMainFrameTargetID = FrameInspectorTarget::toTargetID(*oldMainFrameID, oldProcessID);
+        targetAgent->didCommitProvisionalTarget(oldMainFrameTargetID, mainFrameTargetID);
+    }
+
+    // Update target list to only include targets belonging to the committed page.
+    Vector<String> targetIDsToRemove;
+    for (auto& [targetID, target] : m_targets) {
+        if (targetID == newPageTargetID)
+            continue;
+        if (shouldManageFrameTargets && targetID == mainFrameTargetID)
+            continue;
+        targetIDsToRemove.append(targetID);
+    }
+
+    for (auto& targetID : targetIDsToRemove) {
+        if (CheckedPtr target = m_targets.get(targetID))
+            targetAgent->targetDestroyed(*target);
+    }
+
+    for (auto& targetID : targetIDsToRemove)
+        m_targets.remove(targetID);
 }
 
 void WebPageInspectorController::didCreateFrame(WebFrameProxy& frame)

--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h
@@ -32,6 +32,7 @@
 #include <JavaScriptCore/InspectorTargetAgent.h>
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/PageIdentifier.h>
+#include <WebCore/ProcessIdentifier.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
@@ -77,9 +78,9 @@ public:
     bool shouldPauseLoading(const ProvisionalPageProxy&) const;
     void setContinueLoadingCallback(const ProvisionalPageProxy&, WTF::Function<void()>&&);
 
-    void didCreateProvisionalPage(ProvisionalPageProxy&);
-    void willDestroyProvisionalPage(const ProvisionalPageProxy&);
-    void didCommitProvisionalPage(WebCore::PageIdentifier oldWebPageID, WebCore::PageIdentifier newWebPageID);
+    void didCreateProvisionalPage(ProvisionalPageProxy&, WebCore::FrameIdentifier mainFrameID, WebProcessProxy& mainFrameProcess);
+    void willDestroyProvisionalPage(const ProvisionalPageProxy&, WebCore::FrameIdentifier mainFrameID, WebCore::ProcessIdentifier mainFrameProcessID);
+    void didCommitProvisionalPage(std::optional<WebCore::FrameIdentifier> oldMainFrameID, WebCore::ProcessIdentifier oldProcessID, WebCore::PageIdentifier oldWebPageID, WebCore::PageIdentifier newWebPageID);
     void didCreateFrame(WebFrameProxy&);
     void willDestroyFrame(const WebFrameProxy&);
     void didCreateProvisionalFrame(ProvisionalFrameProxy&);

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -173,7 +173,7 @@ ProvisionalPageProxy::~ProvisionalPageProxy()
 
     if (!m_wasCommitted && m_page) {
         Ref page = *m_page;
-        page->inspectorController().willDestroyProvisionalPage(*this);
+        page->inspectorController().willDestroyProvisionalPage(*this, m_mainFrame->frameID(), protect(m_frameProcess->process())->coreProcessIdentifier());
 
         RefPtr dataStore = process->websiteDataStore();
         if (dataStore && dataStore!= &page->websiteDataStore())
@@ -301,7 +301,7 @@ void ProvisionalPageProxy::initializeWebPage(RefPtr<API::WebsitePolicies>&& webs
     if (page->isLayerTreeFrozenDueToSwipeAnimation())
         send(Messages::WebPage::SwipeAnimationDidStart());
 
-    page->inspectorController().didCreateProvisionalPage(*this);
+    page->inspectorController().didCreateProvisionalPage(*this, m_mainFrame->frameID(), protect(m_frameProcess->process()));
 }
 
 void ProvisionalPageProxy::loadData(API::Navigation& navigation, Ref<WebCore::SharedBuffer>&& data, const String& mimeType, const String& encoding, const String& baseURL, API::Object* userData, WebCore::ShouldTreatAsContinuingLoad shouldTreatAsContinuingLoad, std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain, RefPtr<API::WebsitePolicies>&& websitePolicies, SubstituteData::SessionHistoryVisibility sessionHistoryVisibility)

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -138,8 +138,6 @@ WebFrameProxy::WebFrameProxy(WebPageProxy& page, FrameProcess& process, FrameIde
     allFrames().set(frameID, *this);
     WebProcessPool::statistics().wkFrameCount++;
 
-    page.inspectorController().didCreateFrame(*this);
-
     m_frameProcess->incrementFrameCount();
 
     m_parentFrame = parent;
@@ -548,6 +546,7 @@ void WebFrameProxy::didCreateSubframe(WebCore::FrameIdentifier frameID, String&&
     Ref child = WebFrameProxy::create(*page, m_frameProcess, frameID, effectiveSandboxFlags, effectiveReferrerPolicy, scrollingMode, nullptr, this, IsMainFrame::No, std::nullopt);
     child->m_parentFrame = *this;
     child->m_frameName = WTF::move(frameName);
+    page->inspectorController().didCreateFrame(child);
     page->observeAndCreateRemoteSubframesInOtherProcesses(child, child->m_frameName);
     m_childFrames.add(child.copyRef());
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1841,6 +1841,7 @@ void WebPageProxy::initializeWebPage(const Site& site, WebCore::SandboxFlags eff
     }();
 
     m_mainFrame = WebFrameProxy::create(*this, frameProcess, generateFrameIdentifier(), effectiveSandboxFlags, effectiveReferrerPolicy, ScrollbarMode::Auto, protect(openerFrame.get()), nullptr, IsMainFrame::Yes, std::nullopt);
+    m_inspectorController->didCreateFrame(protect(*m_mainFrame));
     if (preferences->siteIsolationEnabled())
         browsingContextGroup->addPage(*this);
     process->send(Messages::WebProcess::CreateWebPage(m_webPageID, creationParameters(process, *protect(drawingArea()), m_mainFrame->frameID(), std::nullopt)), 0);
@@ -5613,13 +5614,16 @@ void WebPageProxy::commitProvisionalPage(IPC::Connection& connection, FrameIdent
 
     RefPtr mainFrameInPreviousProcess = m_mainFrame;
     Ref preferences = m_preferences;
+    std::optional<WebCore::FrameIdentifier> oldMainFrameID;
     if (mainFrameInPreviousProcess && preferences->siteIsolationEnabled()) {
+        oldMainFrameID = mainFrameInPreviousProcess->frameID();
+
         // Update the back/forward list so existing entries use the new main frame's FrameIdentifier.
         // This is needed for back/forward navigations that trigger a process swap, since no new
         // back/forward list item is added (unlike forward navigations where backForwardAddItemShared
         // handles the update).
-        if (mainFrameInPreviousProcess->frameID() != frameID)
-            backForwardList().updateFrameIdentifier(mainFrameInPreviousProcess->frameID(), frameID);
+        if (*oldMainFrameID != frameID)
+            backForwardList().updateFrameIdentifier(*oldMainFrameID, frameID);
         mainFrameInPreviousProcess->removeChildFrames();
     }
 
@@ -5657,12 +5661,13 @@ void WebPageProxy::commitProvisionalPage(IPC::Connection& connection, FrameIdent
         dismissImmersiveElement([] { });
 #endif
 
+    const auto oldProcessID = siteIsolatedProcess().coreProcessIdentifier();
     const auto oldWebPageID = m_webPageID;
     swapToProvisionalPage(provisionalPage.releaseNonNull());
 
     didCommitLoadForFrame(connection, frameID, WTF::move(frameInfo), WTF::move(request), navigationID, WTF::move(mimeType), frameHasCustomContentProvider, frameLoadType, certificateInfo, usedLegacyTLS, privateRelayed, WTF::move(proxyName), source, containsPluginDocument, hasInsecureContent, mouseEventPolicy, WTF::move(documentSecurityPolicy), userData);
 
-    m_inspectorController->didCommitProvisionalPage(oldWebPageID, m_webPageID);
+    m_inspectorController->didCommitProvisionalPage(oldMainFrameID, oldProcessID, oldWebPageID, m_webPageID);
 }
 
 bool WebPageProxy::shouldClosePreviousPage(const ProvisionalPageProxy& provisionalPage)


### PR DESCRIPTION
#### 0b243f712b46a34f96911dd160dc0236266c3361
<pre>
[Site Isolation] Web Inspector: Consider involving a provisional frame target on page-level cross-origin navigation
<a href="https://bugs.webkit.org/show_bug.cgi?id=310143">https://bugs.webkit.org/show_bug.cgi?id=310143</a>

Reviewed by BJ Burg.

In 308662@main, we introduced the provisional frame target which
surfaces during a cross-origin navigation of an iframe. A provisional
target helps maintain inspector continuity across process swaps: it
allows the inspector to connect to the new page or frame element before
the element e.g. begins script evaluation.

However, that implementation does not address the case of a page-level
cross-origin navigation. A ProvisionalPageProxy creates a regular main
frame (WebFrameProxy, rather than ProvisionalFrameProxy), which surfaces
as a non-provisional frame target in the frontend. This means we are
still relying on the provisional page target for all the provisional
loading support, which is unreliable especially as more features migrate
to the frame target. At minimum, in the far future when we deprecate the
page target altogether, we will need a provisional frame target
representation during a page-level navigation as well.

This patch makes the regular main frame created by a provisional page
show up as a provisional frame target as well. From frontend&apos;s
perspective, a page-level cross-origin navigation is the same as a
main frame cross-origin navigation, and the same procedure of a
provisional target applies. Now:
- Normally, there&apos;s one page target and some frame targets, one of the
  frame targets being the main frame target.
- When a page navigation begins, a provisional page target and a
  provisional main frame target are created.
- When provisional loading commits, the two provisional targets commit,
  while all other targets get destroyed.
     - Any other frames that the new page ends up loading will be
       reported as new provisional (if cross-origin) or non-provisional
       (if same-origin) frame targets after this point.
- When provisional loading is cancelled, the two provisional targets
  get destroyed.

I made a mistake while composing the mentioned patch 308662@main: I
said WebFrameProxies were &quot;preserved&quot; during a page navigation, which
was false. In reality, all non-main frames belonging to the new page are
newly created. For the main frame, the ProvisionalPageProxy may either
create a new WebFrameProxy or reuse it while setting it to a new
web process. In either case, we create a provisional main frame target
proxying to the resulting WebFrame in the appropriate web process,
identified by the frame id and the process reference. In
didCommitProvisionalPage, we don&apos;t need to recreate any frame targets:
the new non-main targets will be created with their new WebFrameProxies,
after document parsing begins.

* LayoutTests/http/tests/site-isolation/inspector/debugger/resources/site-isolation-debugger-test-utilities.js:
* LayoutTests/http/tests/site-isolation/inspector/target/target-cross-origin-page-navigation-expected.txt:
* LayoutTests/http/tests/site-isolation/inspector/target/target-cross-origin-page-navigation.html:
   Updated to verify the provisional main frame target&apos;s presence.
   The unexpected console error noise no longer shows up apparently as
   a result of this change.

* LayoutTests/platform/mac-wk2/TestExpectations:
   - As a drive-by, fix the formatting of nearby related inspector test
     expectations to include the correct bug ID and the correct build
     marker ([ Debug ]).

* Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp:
(WebKit::WebPageInspectorController::didCreateProvisionalPage):
(WebKit::WebPageInspectorController::willDestroyProvisionalPage):
(WebKit::WebPageInspectorController::didCommitProvisionalPage):
* Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h:
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::~ProvisionalPageProxy):
(WebKit::ProvisionalPageProxy::initializeWebPage):
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::WebFrameProxy):
(WebKit::WebFrameProxy::didCreateSubframe):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::initializeWebPage):
(WebKit::WebPageProxy::commitProvisionalPage):

Canonical link: <a href="https://commits.webkit.org/310448@main">https://commits.webkit.org/310448@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/482279ac3ba9347ffcc7254f673bbe8211f50e09

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153772 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26556 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20173 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162523 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107233 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cff3a446-1090-45f7-9f60-8d1280936aaa) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27084 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26878 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118887 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84069 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156731 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21153 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138073 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99597 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b396004b-ebfb-446a-951b-693ac83762af) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20233 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18190 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10355 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129881 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Running apply-patch; Checked out pull request; run-api-tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15932 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164993 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8127 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17526 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126972 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26353 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22221 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127139 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26355 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137727 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83033 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23506 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22042 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14510 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25972 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90260 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25663 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25823 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25723 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->