### PR TITLE
[Cookie Store API] Allow setting a cookie with a mixed case domain passed in

### DIFF
--- a/LayoutTests/fast/canvas/offscreen-no-script-context-crash.html
+++ b/LayoutTests/fast/canvas/offscreen-no-script-context-crash.html
@@ -21,7 +21,7 @@ function getObject(key) {
   storeObject('Document', Document.parseHTMLUnsafe( trustedTypes.emptyHTML));
   storeObject('HTMLCanvasElement', getObject('Document').createElementNS('http://www.w3.org/1999/xhtml', 'canvas'));
   let offscreen = getObject('HTMLCanvasElement').transferControlToOffscreen();
-  await (()=>{ return frames.cookieStore.delete("bar") })();
+  await (()=>{ return frames.cookieStore.delete("bar") })().catch(() => {});
   offscreen.getContext('bitmaprenderer');
   testRunner?.notifyDone();
 })();

--- a/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_set_domain_parsing.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_set_domain_parsing.sub.https-expected.txt
@@ -3,5 +3,5 @@ PASS cookieStore.set with domain on IDNA host
 PASS cookieStore.set with mixed casing domain
 PASS cookieStore.set with public suffix domain
 PASS cookieStore.set with domain on a IDNA host
-FAIL cookieStore.set with domain set to the current hostname but differently cased promise_test: Unhandled rejection with value: object "TypeError: The domain must domain-match current host"
+PASS cookieStore.set with domain set to the current hostname but differently cased
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/cookiestore/cookieStore_set_domain_parsing.sub.https-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/cookiestore/cookieStore_set_domain_parsing.sub.https-expected.txt
@@ -3,5 +3,5 @@ PASS cookieStore.set with domain on IDNA host
 PASS cookieStore.set with mixed casing domain
 FAIL cookieStore.set with public suffix domain assert_unreached: Should have rejected: ETLD should not be a valid domain attribute Reached unreachable code
 PASS cookieStore.set with domain on a IDNA host
-FAIL cookieStore.set with domain set to the current hostname but differently cased promise_test: Unhandled rejection with value: object "TypeError: The domain must domain-match current host"
+PASS cookieStore.set with domain set to the current hostname but differently cased
 

--- a/Source/WebCore/Modules/cookie-store/CookieStore.cpp
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.cpp
@@ -342,7 +342,6 @@ void CookieStore::set(CookieInit&& options, Ref<DeferredPromise>&& promise)
     static constexpr auto maximumAttributeValueSize = 1024;
 
     auto url = context->cookieURL();
-    auto host = url.host();
     auto domain = origin->domain();
 
     Cookie cookie;
@@ -407,19 +406,14 @@ void CookieStore::set(CookieInit&& options, Ref<DeferredPromise>&& promise)
             return;
         }
 
-        if (!host.endsWith(cookie.domain) || (host.length() > cookie.domain.length() && !host.substring(0, host.length() - cookie.domain.length()).endsWith('.'))) {
-            promise->reject(Exception { ExceptionCode::TypeError, "The domain must domain-match current host"_s });
+        if (!SecurityOrigin::create(url)->isMatchingRegistrableDomainSuffix(cookie.domain)) {
+            promise->reject(Exception { ExceptionCode::TypeError, "The domain must be a registrable domain suffix of or be equal to the current host"_s });
             return;
         }
 
         // FIXME: <rdar://85515842> Obtain the encoded length without allocating and encoding.
         if (cookie.domain.utf8().length() > maximumAttributeValueSize) {
             promise->reject(Exception { ExceptionCode::TypeError, makeString("The size of the domain must not be greater than "_s, maximumAttributeValueSize, " bytes"_s) });
-            return;
-        }
-
-        if (PublicSuffixStore::singleton().isPublicSuffix(cookie.domain)) {
-            promise->reject(Exception { ExceptionCode::TypeError, "The domain must not be a public suffix"_s });
             return;
         }
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/SecurityOrigin.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/SecurityOrigin.cpp
@@ -248,6 +248,7 @@ TEST_F(SecurityOriginTest, IsRegistrableDomainSuffix)
     auto exampleOrigin = SecurityOrigin::create(URL { "http://www.example.com"_str });
     EXPECT_TRUE(exampleOrigin->isMatchingRegistrableDomainSuffix("example.com"_s));
     EXPECT_TRUE(exampleOrigin->isMatchingRegistrableDomainSuffix("www.example.com"_s));
+    EXPECT_TRUE(exampleOrigin->isMatchingRegistrableDomainSuffix("www.EXAMple.com"_s));
     EXPECT_FALSE(exampleOrigin->isMatchingRegistrableDomainSuffix(emptyString()));
     EXPECT_FALSE(exampleOrigin->isMatchingRegistrableDomainSuffix("."_s));
     EXPECT_FALSE(exampleOrigin->isMatchingRegistrableDomainSuffix(".example.com"_s));

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/CookieStoreAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/CookieStoreAPI.mm
@@ -83,7 +83,7 @@ TEST(WebKit, CookieStoreSetCookieForPublicSuffixDomain)
     NSError *error;
     [webView objectByCallingAsyncFunction:@"await cookieStore.set({ name: 'cookieName', value: 'cookieValue', domain: 'com' });" withArguments:nil error:&error];
     EXPECT_NOT_NULL(error);
-    EXPECT_TRUE([[error description] containsString:@"The domain must not be a public suffix"]);
+    EXPECT_TRUE([[error description] containsString:@"The domain must be a registrable domain suffix of or be equal to the current host"]);
     error = NULL;
 
     // Test for "co.uk".
@@ -92,7 +92,7 @@ TEST(WebKit, CookieStoreSetCookieForPublicSuffixDomain)
 
     [webView objectByCallingAsyncFunction:@"await cookieStore.set({ name: 'cookieName', value: 'cookieValue', domain: 'co.uk' });" withArguments:nil error:&error];
     EXPECT_NOT_NULL(error);
-    EXPECT_TRUE([[error description] containsString:@"The domain must not be a public suffix"]);
+    EXPECT_TRUE([[error description] containsString:@"The domain must be a registrable domain suffix of or be equal to the current host"]);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 52f478f7656be56a1bd95b5f0514406d0b3246ad
<pre>
[Cookie Store API] Allow setting a cookie with a mixed case domain passed in
<a href="https://bugs.webkit.org/show_bug.cgi?id=310414">https://bugs.webkit.org/show_bug.cgi?id=310414</a>
<a href="https://rdar.apple.com/173043058">rdar://173043058</a>

Reviewed by Brady Eidson.

According to the spec (<a href="https://cookiestore.spec.whatwg.org/#set-a-cookie)">https://cookiestore.spec.whatwg.org/#set-a-cookie)</a>, when
setting a cookie:

&quot;If domain is not a registrable domain suffix of and is not equal to host, then
return failure&quot;

One of the first steps in checking this
(<a href="https://html.spec.whatwg.org/multipage/browsers.html#is-a-registrable-domain-suffix-of-or-is-equal-to)">https://html.spec.whatwg.org/multipage/browsers.html#is-a-registrable-domain-suffix-of-or-is-equal-to)</a>
is to &quot;parse&quot; the input (in our case the domain passed in):

&quot;Let hostSuffix be the result of parsing hostSuffixString&quot;

One of the steps of doing this parsing (<a href="https://url.spec.whatwg.org/#concept-host-parser)">https://url.spec.whatwg.org/#concept-host-parser)</a> is

&quot;Let asciiDomain be the result of running domain to ASCII with domain and false&quot;

One of the things that the &quot;domain to ASCII&quot; algorithm does
(<a href="https://url.spec.whatwg.org/#concept-domain-to-ascii)">https://url.spec.whatwg.org/#concept-domain-to-ascii)</a>
is equivalent to lowercaseing the domain:

&quot;this step is equivalent to ASCII lowercasing domain&quot;.

That means that we cannot reject setting a cookie because the domain passed in
does not match the case of the current host. If on google.com, we must be able to
set cookie by passing in the domain &quot;GOOGLE.com&quot; or even &quot;goGLe.com&quot;. Currently,
we do reject if the case doesn&apos;t match.

WebKit already has a function that does these steps:
SecurityOrigin::isMatchingRegistrableDomainSuffix(). So we change CookieStore::set()
to use it. Since it already does the PublicSuffix check, we don&apos;t need to explicitly
do it.

This fixes the test cookieStore_set_domain_parsing.sub.https.html.

We also add a check to the test SecurityOriginTest.IsRegistrableDomainSuffix() to
confirm that it indeed lowercases the domain before checking it.

This changes causes fast/canvas/offscreen-no-script-context-crash.html to fail.
It calls &quot;await frames.cookieStore.delete(&quot;bar&quot;)&quot; and this promise is rejected
because isMatchingRegistrableDomainSuffix() returns false. The issue is that
this test is run with a file URL. For file URL, ScriptExecutionContext&apos;s
securityOrigin&apos;s domain is empty. This is passed as cookie.domain to
isMatchingRegistrableDomainSuffix() which returns false for an empty domainSuffix.

So we update the test to catch this error so it can complete.

* LayoutTests/fast/canvas/offscreen-no-script-context-crash.html:
* LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_set_domain_parsing.sub.https-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/cookiestore/cookieStore_set_domain_parsing.sub.https-expected.txt:
* Source/WebCore/Modules/cookie-store/CookieStore.cpp:
(WebCore::CookieStore::set):
* Tools/TestWebKitAPI/Tests/WebCore/SecurityOrigin.cpp:
(TestWebKitAPI::TEST_F(SecurityOriginTest, IsRegistrableDomainSuffix)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/CookieStoreAPI.mm:
(TestWebKitAPI::TEST(WebKit, CookieStoreSetCookieForPublicSuffixDomain)):

Canonical link: <a href="https://commits.webkit.org/309770@main">https://commits.webkit.org/309770@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98f1657ddb4b716a36cee064a38193ba26671aec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151606 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24371 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17952 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160341 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105063 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a58a5c40-a64b-40ac-b361-1643970b0729) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153480 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24802 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24673 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117088 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83120 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ca1e7efd-8a78-4cc2-8487-dab9c1395fa8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154566 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19234 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136042 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97803 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e2822b64-7249-4c95-9260-b8767442d029) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18323 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16265 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8183 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127953 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13946 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162812 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5942 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15536 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125103 "Found 1 new test failure: media/media-sources-selection.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24172 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20323 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125286 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24164 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135742 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80762 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23286 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20339 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12517 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23773 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88085 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23483 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23637 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23539 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->