### PR TITLE
[Cookie Store API] Add support for setting maxAge

### DIFF
--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/cookiestore/cookieStore_set_maxAge.https.window-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/cookiestore/cookieStore_set_maxAge.https.window-expected.txt
@@ -1,6 +1,6 @@
 
 PASS cookieStore.set with maxAge set to a positive value
 PASS cookieStore.set with maxAge set to a negative value
-PASS cookieStore.set with maxAge set to zero, cookie change event not dispatched
+FAIL cookieStore.set with maxAge set to zero, cookie change event not dispatched assert_equals: expected null but got object "[object Object]"
 PASS cookieStore.set fails with both maxAge and expires
 

--- a/Source/WebCore/Modules/cookie-store/CookieInit.h
+++ b/Source/WebCore/Modules/cookie-store/CookieInit.h
@@ -33,15 +33,16 @@
 namespace WebCore {
 
 struct CookieInit {
-    CookieInit isolatedCopy() const & { return { name.isolatedCopy(), value.isolatedCopy(), expires, domain.isolatedCopy(), path.isolatedCopy(), sameSite }; }
-    CookieInit isolatedCopy() && { return { WTF::move(name).isolatedCopy(), WTF::move(value).isolatedCopy(), expires, WTF::move(domain).isolatedCopy(), WTF::move(path).isolatedCopy(), sameSite }; }
+    CookieInit isolatedCopy() const & { return { name.isolatedCopy(), value.isolatedCopy(), expires, domain.isolatedCopy(), path.isolatedCopy(), sameSite, maxAge }; }
+    CookieInit isolatedCopy() && { return { WTF::move(name).isolatedCopy(), WTF::move(value).isolatedCopy(), expires, WTF::move(domain).isolatedCopy(), WTF::move(path).isolatedCopy(), sameSite, maxAge }; }
 
     String name;
     String value;
-    std::optional<DOMHighResTimeStamp> expires { };
+    std::optional<DOMHighResTimeStamp> expires { }; // Milliseconds
     String domain { };
     String path { "/"_s };
     CookieSameSite sameSite { CookieSameSite::Strict };
+    std::optional<int64_t> maxAge { }; // Seconds
 };
 
 }

--- a/Source/WebCore/Modules/cookie-store/CookieInit.idl
+++ b/Source/WebCore/Modules/cookie-store/CookieInit.idl
@@ -35,6 +35,5 @@ dictionary CookieInit {
     CookieSameSite sameSite = "strict";
     // FIXME: Add support for `partitioned`.
     // boolean partitioned = false;
-    // FIXME: Add support for `maxAge`.
-    // long long? maxAge = null;
+    long long? maxAge = null;
 };

--- a/Source/WebCore/Modules/cookie-store/CookieStore.cpp
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.cpp
@@ -452,20 +452,30 @@ void CookieStore::set(CookieInit&& options, Ref<DeferredPromise>&& promise)
     }
 
     if (options.expires) {
+        if (options.maxAge) {
+            promise->reject(Exception { ExceptionCode::TypeError, "Only one of 'expires' or 'maxAge' may be specified"_s });
+            return;
+        }
+
         // When this cookie is converted to an NSHTTPCookie, the creation and expiration
-        // times will first be converted to seconds and then CFNetwork will floor these times.
-        // If the creation and expiration differ by less than 1 second, flooring them may
-        // reduce the difference to 0 seconds. This can cause the onchange event to wrongly
-        // fire as a deletion instead of a change. In such cases, account for this flooring by
-        // adding 1 second to the expiration.
+        // times will first be converted from milliseconds to seconds and then CFNetwork will
+        // floor these times. If the creation and expiration differ by less than 1 second,
+        // flooring them may reduce the difference to 0 seconds. This can cause the onchange
+        // event to wrongly fire as a deletion instead of a change. In such cases, account for
+        // this flooring by adding 1 second to the expiration.
 
         auto expires = *options.expires;
-        bool equalAfterConversion = floor(expires / 1000.0) == floor(cookie.created / 1000.0);
+
+        auto expiresConverted = floor(Seconds::fromMilliseconds(expires).value());
+        auto createdConverted = floor(Seconds::fromMilliseconds(cookie.created).value());
+        bool equalAfterConversion = expiresConverted == createdConverted;
+
         if (equalAfterConversion && (expires > cookie.created))
-            expires += 1000.0;
+            expires += Seconds(1).milliseconds();
 
         cookie.expires = expires;
-    }
+    } else if (options.maxAge)
+        cookie.expires = cookie.created + Seconds(*options.maxAge).milliseconds();
 
     switch (options.sameSite) {
     case CookieSameSite::Strict:


### PR DESCRIPTION
#### f9cc88e07ed1bb57fa94be970f04495ff1e536c1
<pre>
[Cookie Store API] Add support for setting maxAge
<a href="https://bugs.webkit.org/show_bug.cgi?id=303549">https://bugs.webkit.org/show_bug.cgi?id=303549</a>
<a href="https://rdar.apple.com/166301541">rdar://166301541</a>

Reviewed by Anne van Kesteren.

The Cookie Store API already supports the expires attribute. This is an absolute
timestamp in milliseconds since epoch: &quot;Cookie expires at 3:00 PM on March 25, 2026.&quot;

Recently, the Cookie Store API spec was updated to add a maxAge attribute in
<a href="https://github.com/whatwg/cookiestore/pull/292.">https://github.com/whatwg/cookiestore/pull/292.</a>

This patch adds support for this new maxAge attribute. This is a relative duration
in seconds: &quot;Cookie expires 60 seconds from now.&quot;

When setting a cookie, you can only specify one of the two. Since the WebCore::Cookie
has only expiry-related property (WebCore::Cookie::expires), both of these Cookie
Store API attributes will use that.

We also update the code to use Seconds so it&apos;s more clear which units are being used.

* LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_set_maxAge.https.window-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/cookiestore/cookieStore_set_maxAge.https.window-expected.txt: Added.
* Source/WebCore/Modules/cookie-store/CookieInit.h:
(WebCore::CookieInit::isolatedCopy const):
(WebCore::CookieInit::isolatedCopy):
* Source/WebCore/Modules/cookie-store/CookieInit.idl:
* Source/WebCore/Modules/cookie-store/CookieStore.cpp:
(WebCore::CookieStore::set):

Canonical link: <a href="https://commits.webkit.org/309738@main">https://commits.webkit.org/309738@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69bbbcc36d31375fd552bca2c881803a355351c6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151488 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24253 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17834 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160220 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104926 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/36329329-e171-46b4-b5db-e8d4f0848918) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153362 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24684 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24555 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116976 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83049 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/84a974bd-581b-4c84-b20f-efed55ffa45d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154448 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19127 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135938 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97695 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5b4bd1e6-e15d-4971-a55b-a14a42f121ed) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18217 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16162 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8064 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127844 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13843 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162691 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5824 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15432 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124995 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24054 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20220 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125179 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24046 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135639 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80595 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23274 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20236 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12414 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23655 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87967 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23365 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23519 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23421 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->