### PR TITLE
[Test] Strip only ASCII spaces from SMIL 'values' attributes

### DIFF
--- a/LayoutTests/svg/animations/animate-values-whitespace-expected.txt
+++ b/LayoutTests/svg/animations/animate-values-whitespace-expected.txt
@@ -1,0 +1,23 @@
+
+PASS Character Tabulation (U+9) is stripped.
+PASS Line Feed (U+a) is stripped.
+PASS Form Feed (U+c) is stripped.
+PASS Carriage Return (U+d) is stripped.
+PASS Space (U+20) is stripped.
+PASS No-Break Space (U+a0) is not stripped.
+PASS Ogham Space Mark (U+1680) is not stripped.
+PASS EN Quad (U+2000) is not stripped.
+PASS EM Quad (U+2001) is not stripped.
+PASS EN Space (U+2002) is not stripped.
+PASS EM Space (U+2003) is not stripped.
+PASS Three-Per-Em Space (U+2004) is not stripped.
+PASS Four-Per-Em Space (U+2005) is not stripped.
+PASS Six-Per-Em Space (U+2006) is not stripped.
+PASS Figure Space (U+2007) is not stripped.
+PASS Punctuation Space (U+2008) is not stripped.
+PASS Thin Space (U+2009) is not stripped.
+PASS Hair Space (U+200a) is not stripped.
+PASS Narrow No-Break Space (U+202f) is not stripped.
+PASS Medium Mathematical Space (U+205f) is not stripped.
+PASS Ideographic Space (U+3000) is not stripped.
+

--- a/LayoutTests/svg/animations/animate-values-whitespace.html
+++ b/LayoutTests/svg/animations/animate-values-whitespace.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<title>SMIL 'values' whitespace</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<svg></svg>
+<script>
+let subjects = [
+  { char: '\u0009', stripped: true,  name: 'Character Tabulation' },
+  { char: '\u000A', stripped: true,  name: 'Line Feed' },
+  { char: '\u000C', stripped: true,  name: 'Form Feed' },
+  { char: '\u000D', stripped: true,  name: 'Carriage Return' },
+  { char: '\u0020', stripped: true,  name: 'Space' },
+  { char: '\u00A0', stripped: false, name: 'No-Break Space' },
+  { char: '\u1680', stripped: false, name: 'Ogham Space Mark' },
+  { char: '\u2000', stripped: false, name: 'EN Quad' },
+  { char: '\u2001', stripped: false, name: 'EM Quad' },
+  { char: '\u2002', stripped: false, name: 'EN Space' },
+  { char: '\u2003', stripped: false, name: 'EM Space' },
+  { char: '\u2004', stripped: false, name: 'Three-Per-Em Space' },
+  { char: '\u2005', stripped: false, name: 'Four-Per-Em Space' },
+  { char: '\u2006', stripped: false, name: 'Six-Per-Em Space' },
+  { char: '\u2007', stripped: false, name: 'Figure Space' },
+  { char: '\u2008', stripped: false, name: 'Punctuation Space' },
+  { char: '\u2009', stripped: false, name: 'Thin Space' },
+  { char: '\u200A', stripped: false, name: 'Hair Space' },
+  { char: '\u202F', stripped: false, name: 'Narrow No-Break Space' },
+  { char: '\u205F', stripped: false, name: 'Medium Mathematical Space' },
+  { char: '\u3000', stripped: false, name: 'Ideographic Space' },
+];
+
+function makeTestSubject(subjectText) {
+  const svgNs = 'http://www.w3.org/2000/svg';
+  let aLink = document.createElementNS(svgNs, 'a');
+  let rect = aLink.appendChild(document.createElementNS(svgNs, 'rect'));
+  rect.setAttribute('width', 100);
+  rect.setAttribute('height', 100);
+  rect.setAttribute('fill', 'blue');
+  let animate = aLink.appendChild(document.createElementNS(svgNs, 'animate'));
+  animate.setAttribute('attributeName', 'href');
+  animate.setAttribute('values', subjectText);
+  return aLink;
+}
+
+let svgRoot = document.querySelector('svg');
+for (let subject of subjects) {
+  async_test(function(t) {
+    let payload = 'javascript:alert("' + subject.name + '")';
+    let fragment = makeTestSubject(subject.char + payload);
+    svgRoot.appendChild(fragment);
+    let expected = (subject.stripped ? '' : subject.char) + payload;
+    let animate = fragment.lastChild;
+    animate.onbegin = t.step_func_done(function() {
+      var target = animate.parentNode;
+      assert_equals(target.href.animVal, expected);
+    });
+  }, subject.name + ' (U+' +  subject.char.codePointAt(0).toString(16) +  ') is ' +
+     (subject.stripped ? '' : 'not ') + 'stripped.');
+};
+</script>


### PR DESCRIPTION
#### b8b000ae1cb7a6995f6d1e4f9de5369a393ca520
<pre>
[Test] Strip only ASCII spaces from SMIL &apos;values&apos; attributes
<a href="https://bugs.webkit.org/show_bug.cgi?id=310422">https://bugs.webkit.org/show_bug.cgi?id=310422</a>
<a href="https://rdar.apple.com/173047235">rdar://173047235</a>

Reviewed by NOBODY (OOPS!).

Merge (Test): <a href="https://chromium.googlesource.com/chromium/src/+/cd2205139c375696291bffcf86d27ef4e83d7994">https://chromium.googlesource.com/chromium/src/+/cd2205139c375696291bffcf86d27ef4e83d7994</a>

It is just to increase our coverage around whitespace handling so we don&apos;t
regress in future.

* LayoutTests/svg/animations/animate-values-whitespace-expected.txt: Added.
* LayoutTests/svg/animations/animate-values-whitespace.html: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8b000ae1cb7a6995f6d1e4f9de5369a393ca520

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151398 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24162 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17732 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160130 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104836 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/222f3600-577c-40bb-9543-00ac94384d91) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24593 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24460 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116893 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82981 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8df89e8e-a87c-4832-92e3-65c2dddefee2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154358 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19035 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135843 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97611 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3f7d7a2b-fe02-421e-8766-ace968e505c3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18126 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16069 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7974 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127748 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13755 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162601 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15332 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124909 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23963 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20123 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125092 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23953 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135551 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80449 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20151 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12321 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23563 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23274 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23427 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23339 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->