### PR TITLE
SMIL animations of href / xlink:href of <image> have no visual effect

### DIFF
--- a/LayoutTests/svg/animations/animate-image-href-expected.html
+++ b/LayoutTests/svg/animations/animate-image-href-expected.html
@@ -1,0 +1,10 @@
+<!DOCTYPE HTML>
+<html>
+<body>
+Test for crbug.com/279445: SVG image href should be animatable.<br/>
+This test passes if there is a green square below.<br/>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="100" height="100">
+  <image x="0" y="0" width="100" height="100" xlink:href="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0nMTAwJyBoZWlnaHQ9JzEwMCcgeG1sbnM9J2h0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnJz48cmVjdCBmaWxsPSdncmVlbicgd2lkdGg9JzEwMCcgaGVpZ2h0PScxMDAnPjwvcmVjdD48L3N2Zz4="/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/animations/animate-image-href.html
+++ b/LayoutTests/svg/animations/animate-image-href.html
@@ -1,0 +1,28 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script>
+  function runTest() {
+    if (window.testRunner)
+      testRunner.waitUntilDone();
+
+    // Wait for the animation to apply and a frame to be painted, then stop.
+    requestAnimationFrame(function() {
+      requestAnimationFrame(function() {
+        if (window.testRunner)
+          testRunner.notifyDone();
+      });
+    });
+  }
+</script>
+</head>
+<body onload="runTest()">
+Test for crbug.com/279445: SVG image href should be animatable.<br/>
+This test passes if there is a green square below.<br/>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="100" height="100">
+  <image x="0" y="0" width="100" height="100" xlink:href="">
+    <set attributeName="xlink:href" to="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0nMTAwJyBoZWlnaHQ9JzEwMCcgeG1sbnM9J2h0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnJz48cmVjdCBmaWxsPSdncmVlbicgd2lkdGg9JzEwMCcgaGVpZ2h0PScxMDAnPjwvcmVjdD48L3N2Zz4=" begin="0s" />
+  </image>
+</svg>
+</body>
+</html>

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3055,7 +3055,7 @@ ExceptionOr<void> Element::setPrefix(const AtomString& prefix)
     return { };
 }
 
-const AtomString& Element::imageSourceURL() const
+String Element::imageSourceURL() const
 {
     return attributeWithoutSynchronization(srcAttr);
 }

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -582,7 +582,7 @@ public:
     inline URL getURLAttributeForBindings(const QualifiedName&) const;
     URL getNonEmptyURLAttribute(const QualifiedName&) const;
 
-    virtual const AtomString& imageSourceURL() const;
+    virtual String imageSourceURL() const;
     virtual AtomString target() const { return nullAtom(); }
 
     static RefPtr<Element> findFocusDelegateForTarget(ContainerNode&, FocusTrigger);

--- a/Source/WebCore/editing/glib/EditorGLib.cpp
+++ b/Source/WebCore/editing/glib/EditorGLib.cpp
@@ -75,7 +75,7 @@ void Editor::platformPasteFont()
 {
 }
 
-static const AtomString& elementURL(Element& element)
+static String elementURL(Element& element)
 {
     if (is<HTMLImageElement>(element) || is<HTMLInputElement>(element))
         return element.attributeWithoutSynchronization(HTMLNames::srcAttr);
@@ -83,7 +83,7 @@ static const AtomString& elementURL(Element& element)
         return element.attributeWithoutSynchronization(XLinkNames::hrefAttr);
     if (is<HTMLEmbedElement>(element) || is<HTMLObjectElement>(element))
         return element.imageSourceURL();
-    return nullAtom();
+    return nullString();
 }
 
 static bool getImageForElement(Element& element, RefPtr<Image>& image)

--- a/Source/WebCore/html/HTMLEmbedElement.cpp
+++ b/Source/WebCore/html/HTMLEmbedElement.cpp
@@ -210,7 +210,7 @@ bool HTMLEmbedElement::isURLAttribute(const Attribute& attribute) const
     return attribute.name() == srcAttr || HTMLPlugInElement::isURLAttribute(attribute);
 }
 
-const AtomString& HTMLEmbedElement::imageSourceURL() const
+String HTMLEmbedElement::imageSourceURL() const
 {
     return attributeWithoutSynchronization(srcAttr);
 }

--- a/Source/WebCore/html/HTMLEmbedElement.h
+++ b/Source/WebCore/html/HTMLEmbedElement.h
@@ -42,7 +42,7 @@ private:
     bool rendererIsNeeded(const RenderStyle&) final;
 
     bool NODELETE isURLAttribute(const Attribute&) const final;
-    const AtomString& imageSourceURL() const final;
+    String imageSourceURL() const final;
 
     bool isInteractiveContent() const final { return true; }
 

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -232,7 +232,7 @@ void HTMLImageElement::collectExtraStyleForPresentationalHints(MutableStylePrope
         addPropertyToPresentationalHintStyle(style, CSSPropertyAspectRatio, CSSValueAuto);
 }
 
-const AtomString& HTMLImageElement::imageSourceURL() const
+String HTMLImageElement::imageSourceURL() const
 {
     return m_bestFitImageURL.isEmpty() ? attributeWithoutSynchronization(srcAttr) : m_bestFitImageURL;
 }
@@ -250,7 +250,7 @@ void HTMLImageElement::setBestFitURLAndDPRFromImageCandidate(const ImageCandidat
 {
     m_bestFitImageURL = candidate.string.toAtomString();
 
-    auto& sourceURL = imageSourceURL();
+    auto sourceURL = imageSourceURL();
     // Only complete the URL if it's non-empty to avoid resolving "" to the document base URL.
     m_currentURL = sourceURL.isEmpty() ? URL() : protect(document())->completeURL(sourceURL);
 

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -117,7 +117,7 @@ public:
 
     bool canContainRangeEndPoint() const override { return false; }
 
-    const AtomString& imageSourceURL() const override;
+    String imageSourceURL() const override;
     
 #if ENABLE(SERVICE_CONTROLS)
     bool isImageMenuEnabled() const { return m_isImageMenuEnabled; }

--- a/Source/WebCore/html/HTMLObjectElement.cpp
+++ b/Source/WebCore/html/HTMLObjectElement.cpp
@@ -273,7 +273,7 @@ bool HTMLObjectElement::isURLAttribute(const Attribute& attribute) const
     return attribute.name() == dataAttr || attribute.name() == codebaseAttr || HTMLPlugInElement::isURLAttribute(attribute);
 }
 
-const AtomString& HTMLObjectElement::imageSourceURL() const
+String HTMLObjectElement::imageSourceURL() const
 {
     return attributeWithoutSynchronization(dataAttr);
 }

--- a/Source/WebCore/html/HTMLObjectElement.h
+++ b/Source/WebCore/html/HTMLObjectElement.h
@@ -72,7 +72,7 @@ private:
     void childrenChanged(const ChildChange&) final;
 
     bool NODELETE isURLAttribute(const Attribute&) const final;
-    const AtomString& imageSourceURL() const final;
+    String imageSourceURL() const final;
 
     void addSubresourceAttributeURLs(ListHashSet<URL>&) const final;
 

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -316,7 +316,7 @@ bool HTMLVideoElement::isURLAttribute(const Attribute& attribute) const
     return attribute.name() == posterAttr || HTMLMediaElement::isURLAttribute(attribute);
 }
 
-const AtomString& HTMLVideoElement::imageSourceURL() const
+String HTMLVideoElement::imageSourceURL() const
 {
     const auto& url = attributeWithoutSynchronization(posterAttr);
     if (!StringView(url).containsOnly<isASCIIWhitespace<char16_t>>())
@@ -515,7 +515,7 @@ unsigned HTMLVideoElement::webkitDroppedFrameCount() const
 
 URL HTMLVideoElement::posterImageURL() const
 {
-    auto url = imageSourceURL().string().trim(isASCIIWhitespace);
+    auto url = imageSourceURL().trim(isASCIIWhitespace);
     if (url.isEmpty())
         return URL();
     return protect(document())->completeURL(url);

--- a/Source/WebCore/html/HTMLVideoElement.h
+++ b/Source/WebCore/html/HTMLVideoElement.h
@@ -164,7 +164,7 @@ private:
     bool hasVideo() const final { return player() && protect(player())->hasVideo(); }
     bool supportsFullscreen(HTMLMediaElementEnums::VideoFullscreenMode) const final;
     bool NODELETE isURLAttribute(const Attribute&) const final;
-    const AtomString& imageSourceURL() const final;
+    String imageSourceURL() const final;
 
     void didMoveToNewDocument(Document& oldDocument, Document& newDocument) final;
 

--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -213,7 +213,7 @@ void ImageLoader::updateFromElement(RelevantMutation relevantMutation)
     if (!document->hasLivingRenderTree())
         return;
 
-    AtomString attr = element->imageSourceURL();
+    auto attr = element->imageSourceURL();
 
     LOG_WITH_STREAM(LazyLoading, stream << "ImageLoader " << this << " updateFromElement, current URL is " << attr);
 
@@ -724,7 +724,7 @@ void ImageLoader::elementDidMoveToNewDocument(Document& oldDocument)
 
 inline void ImageLoader::clearFailedLoadURL()
 {
-    m_failedLoadURL = nullAtom();
+    m_failedLoadURL = { };
 }
 
 void ImageLoader::loadDeferredImage()

--- a/Source/WebCore/loader/ImageLoader.h
+++ b/Source/WebCore/loader/ImageLoader.h
@@ -135,8 +135,8 @@ private:
     CachedResourceHandle<CachedImage> m_image;
     Timer m_derefElementTimer;
     RefPtr<Element> m_protectedElement;
-    AtomString m_failedLoadURL;
-    AtomString m_pendingURL;
+    String m_failedLoadURL;
+    String m_pendingURL;
     Vector<Ref<DeferredPromise>> m_decodingPromises;
     bool m_hasPendingBeforeLoadEvent : 1;
     bool m_hasPendingLoadEvent : 1;

--- a/Source/WebCore/svg/SVGImageElement.cpp
+++ b/Source/WebCore/svg/SVGImageElement.cpp
@@ -197,9 +197,9 @@ Node::NeedsPostConnectionSteps SVGImageElement::insertionSteps(InsertionType ins
     return result;
 }
 
-const AtomString& SVGImageElement::imageSourceURL() const
+String SVGImageElement::imageSourceURL() const
 {
-    return getAttribute(SVGNames::hrefAttr, XLinkNames::hrefAttr);
+    return href();
 }
 
 void SVGImageElement::setCrossOrigin(const AtomString& value)

--- a/Source/WebCore/svg/SVGImageElement.h
+++ b/Source/WebCore/svg/SVGImageElement.h
@@ -36,7 +36,7 @@ public:
 
     WEBCORE_EXPORT CachedImage* NODELETE cachedImage() const;
     bool renderingTaintsOrigin() const;
-    const AtomString& imageSourceURL() const final;
+    String imageSourceURL() const final;
 
     const SVGLengthValue& x() const LIFETIME_BOUND { return m_x->currentValue(); }
     const SVGLengthValue& y() const LIFETIME_BOUND { return m_y->currentValue(); }


### PR DESCRIPTION
#### 4a210d1278f1dc12bbad797be4fb4ce8f954f8b8
<pre>
SMIL animations of href / xlink:href of &lt;image&gt; have no visual effect
<a href="https://bugs.webkit.org/show_bug.cgi?id=202791">https://bugs.webkit.org/show_bug.cgi?id=202791</a>
<a href="https://rdar.apple.com/96316808">rdar://96316808</a>

Reviewed by Ryosuke Niwa.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/93976b6624f40024070bea7dde68e81a3d366173">https://chromium.googlesource.com/chromium/src.git/+/93976b6624f40024070bea7dde68e81a3d366173</a>

SVGImageElement::imageSourceURL() returned the non-animating base
attribute value via getAttribute(), so SMIL animations of the &lt;image&gt;
element href/xlink:href had no effect. Changed it to return the
animating value via SVGURIReference::href().

This required changing the return type of imageSourceURL() from
const AtomString&amp; to String across the Element virtual hierarchy
to avoid returning a reference to a local object.

Drive-by fix: changed auto&amp; to auto in
HTMLImageElement::setBestFitURLAndDPRFromImageCandidate() to avoid
a dangling reference to the now-returned-by-value result.

Test: svg/animations/animate-image-href.html

* LayoutTests/svg/animations/animate-image-href-expected.html: Added.
* LayoutTests/svg/animations/animate-image-href.html: Added.
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::imageSourceURL const):
* Source/WebCore/dom/Element.h:
* Source/WebCore/editing/glib/EditorGLib.cpp:
(WebCore::elementURL):
* Source/WebCore/html/HTMLEmbedElement.cpp:
(WebCore::HTMLEmbedElement::imageSourceURL const):
* Source/WebCore/html/HTMLEmbedElement.h:
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::imageSourceURL const):
(WebCore::HTMLImageElement::setBestFitURLAndDPRFromImageCandidate):
* Source/WebCore/html/HTMLImageElement.h:
* Source/WebCore/html/HTMLObjectElement.cpp:
(WebCore::HTMLObjectElement::imageSourceURL const):
* Source/WebCore/html/HTMLObjectElement.h:
* Source/WebCore/html/HTMLVideoElement.cpp:
(WebCore::HTMLVideoElement::imageSourceURL const):
* Source/WebCore/html/HTMLVideoElement.h:
* Source/WebCore/svg/SVGImageElement.cpp:
(WebCore::SVGImageElement::imageSourceURL const):
* Source/WebCore/svg/SVGImageElement.h:

Canonical link: <a href="https://commits.webkit.org/310236@main">https://commits.webkit.org/310236@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3e935d11d105e29009537d572f130066de1a1c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152932 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25714 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19312 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161676 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106388 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154805 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26241 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26019 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118195 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83692 "2 flakes 5 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155891 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20431 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137347 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98908 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19505 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17498 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9512 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129158 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15168 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164150 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7286 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16762 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126258 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25511 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21482 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126416 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34353 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25513 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136964 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82132 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21372 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13743 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25129 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89416 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24821 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24980 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24881 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->