### PR TITLE
[iOS] Encapsulate AVExperienceController in a Swift type inside WKSExperienceController

### DIFF
--- a/Source/WebKit/WebKitSwift/AVKit/WKSExperienceController.swift
+++ b/Source/WebKit/WebKitSwift/AVKit/WKSExperienceController.swift
@@ -23,7 +23,6 @@
 
 #if HAVE_AVEXPERIENCECONTROLLER
 
-import AVKit
 import AVKit_Private
 import os
 @_spi(AVExperienceController) import AVKit
@@ -39,28 +38,39 @@ extension WKSExperienceController {
     weak var delegate: (any WKSExperienceControllerDelegate)?
 
     @nonobjc
-    final let experienceController: AVExperienceController
+    private let platformExperienceController: WKSPlatformExperienceController
 
     @objc(initWithContentSource:)
     init(contentSource: AVPlayerViewControllerContentSource) {
-        experienceController = AVExperienceController(contentSource: contentSource)
+        platformExperienceController = WKSPlatformExperienceController(contentSource: contentSource)
         super.init()
-        experienceController.delegate = self
+        platformExperienceController.experienceController = self
         Logger.experienceController.log("\(#function)")
     }
 
     @objc(enterFullscreenWithCompletionHandler:)
     func enterFullscreen(completionHandler: @MainActor @Sendable @escaping (Bool) -> Void) {
         Task { @MainActor in
-            completionHandler(await transitionToFullscreen())
+            completionHandler(await platformExperienceController.transitionToFullscreen())
         }
     }
 
     @objc(exitFullscreenWithCompletionHandler:)
     func exitFullscreen(completionHandler: @MainActor @Sendable @escaping (Bool) -> Void) {
         Task { @MainActor in
-            completionHandler(await transitionFromFullscreen())
+            completionHandler(await platformExperienceController.transitionFromFullscreen())
         }
+    }
+}
+
+@MainActor
+class WKSPlatformExperienceController {
+    weak var experienceController: WKSExperienceController?
+    let avExperienceController: AVExperienceController
+
+    init(contentSource: AVPlayerViewControllerContentSource) {
+        avExperienceController = AVExperienceController(contentSource: contentSource)
+        avExperienceController.delegate = self
     }
 }
 


### PR DESCRIPTION
#### e28a1c9b34ec4f8e46315ce1898b7679d71979b6
<pre>
[iOS] Encapsulate AVExperienceController in a Swift type inside WKSExperienceController
<a href="https://bugs.webkit.org/show_bug.cgi?id=310426">https://bugs.webkit.org/show_bug.cgi?id=310426</a>
<a href="https://rdar.apple.com/173054983">rdar://173054983</a>

Reviewed by Richard Robinson.

Introduced WKSPlatformExperienceController to encapsulate the use of AVExperienceController.

* Source/WebKit/WebKitSwift/AVKit/WKSExperienceController.swift:
(WKSExperienceController.enterFullscreen(_:)):
(WKSExperienceController.exitFullscreen(_:)):
(WKSPlatformExperienceController.experienceController):

Canonical link: <a href="https://commits.webkit.org/309691@main">https://commits.webkit.org/309691@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5e479f7f8367610387a8c76bae54d23565e1a99

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151415 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24179 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17749 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160147 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104853 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7209ad9e-214a-4095-a1b9-62a4c872adda) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24610 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24479 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116906 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82985 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/994ed47a-d69a-4ad4-85a3-95067498cc0e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154375 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19051 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135858 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97624 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8392f70b-543b-4225-a2e4-69b8063944d8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18142 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16082 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7991 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127764 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162618 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5751 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15347 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124923 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23980 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20136 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125106 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33947 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23970 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135566 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80466 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20167 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12336 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23581 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87883 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23291 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23444 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23346 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->