### PR TITLE
Implement SVG overflow property resolution per SVG2 spec

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/render/reftests/overflow-resolution-per-element-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/render/reftests/overflow-resolution-per-element-expected.txt
@@ -1,0 +1,27 @@
+text
+
+PASS overflow:scroll resolves to hidden on <text>
+PASS overflow:auto resolves to visible on <text>
+PASS overflow:hidden stays hidden on <text>
+PASS overflow:visible stays visible on <text>
+PASS overflow:scroll resolves to hidden on <pattern>
+PASS overflow:auto resolves to visible on <pattern>
+PASS overflow:hidden stays hidden on <pattern>
+PASS overflow:visible stays visible on <pattern>
+PASS overflow:scroll resolves to hidden on <marker>
+PASS overflow:auto resolves to visible on <marker>
+PASS overflow:hidden stays hidden on <marker>
+PASS overflow:visible stays visible on <marker>
+PASS overflow:scroll resolves to hidden on <symbol>
+PASS overflow:auto resolves to visible on <symbol>
+PASS overflow:hidden stays hidden on <symbol>
+PASS overflow:visible stays visible on <symbol>
+PASS overflow:scroll resolves to hidden on <image>
+PASS overflow:auto resolves to visible on <image>
+PASS overflow:hidden stays hidden on <image>
+PASS overflow:visible stays visible on <image>
+PASS overflow:scroll stays scroll on <inner svg>
+PASS overflow:auto stays auto on <inner svg>
+PASS overflow:scroll stays scroll on <foreignObject>
+PASS overflow:auto stays auto on <foreignObject>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/render/reftests/overflow-resolution-per-element.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/render/reftests/overflow-resolution-per-element.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<title>SVG overflow property resolution per element type</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/render.html#OverflowAndClipProperties">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<svg id="root" width="200" height="200" style="overflow: visible">
+  <defs>
+    <pattern id="pat" width="10" height="10"/>
+    <marker id="mark"/>
+    <symbol id="sym"/>
+  </defs>
+  <svg id="inner" width="100" height="100"/>
+  <image id="img" width="10" height="10"/>
+  <text id="txt">text</text>
+  <foreignObject id="fo" width="10" height="10"/>
+</svg>
+<script>
+// Per https://w3c.github.io/svgwg/svg2-draft/render.html#OverflowAndClipProperties
+//
+// Element          | auto    | visible | hidden | scroll
+// -----------------+---------+---------+--------+-------
+// document root svg| vis/scr | visible | hidden | scroll
+// other svg        | vis/scr | visible | hidden | scroll
+// text             | visible | visible | hidden | hidden
+// pattern          | visible | visible | hidden | hidden
+// marker           | visible | visible | hidden | hidden
+// symbol           | visible | visible | hidden | hidden
+// image            | visible | visible | hidden | hidden
+// foreignObject    | vis/scr | visible | hidden | scroll
+
+// Elements where scroll resolves to hidden and auto resolves to visible.
+const clampedElements = [
+    { id: "txt", name: "text" },
+    { id: "pat", name: "pattern" },
+    { id: "mark", name: "marker" },
+    { id: "sym", name: "symbol" },
+    { id: "img", name: "image" },
+];
+
+for (const { id, name } of clampedElements) {
+    const el = document.getElementById(id);
+
+    test(() => {
+        el.style.overflow = "scroll";
+        assert_equals(getComputedStyle(el).overflowX, "hidden");
+        assert_equals(getComputedStyle(el).overflowY, "hidden");
+        el.style.overflow = "";
+    }, `overflow:scroll resolves to hidden on <${name}>`);
+
+    test(() => {
+        el.style.overflow = "auto";
+        assert_equals(getComputedStyle(el).overflowX, "visible");
+        assert_equals(getComputedStyle(el).overflowY, "visible");
+        el.style.overflow = "";
+    }, `overflow:auto resolves to visible on <${name}>`);
+
+    test(() => {
+        el.style.overflow = "hidden";
+        assert_equals(getComputedStyle(el).overflowX, "hidden");
+        assert_equals(getComputedStyle(el).overflowY, "hidden");
+        el.style.overflow = "";
+    }, `overflow:hidden stays hidden on <${name}>`);
+
+    test(() => {
+        el.style.overflow = "visible";
+        assert_equals(getComputedStyle(el).overflowX, "visible");
+        assert_equals(getComputedStyle(el).overflowY, "visible");
+        el.style.overflow = "";
+    }, `overflow:visible stays visible on <${name}>`);
+}
+
+// Elements where scroll and auto keep their values.
+const scrollableElements = [
+    { id: "inner", name: "inner svg" },
+    { id: "fo", name: "foreignObject" },
+];
+
+for (const { id, name } of scrollableElements) {
+    const el = document.getElementById(id);
+
+    test(() => {
+        el.style.overflow = "scroll";
+        assert_equals(getComputedStyle(el).overflowX, "scroll");
+        assert_equals(getComputedStyle(el).overflowY, "scroll");
+        el.style.overflow = "";
+    }, `overflow:scroll stays scroll on <${name}>`);
+
+    test(() => {
+        el.style.overflow = "auto";
+        assert_equals(getComputedStyle(el).overflowX, "auto");
+        assert_equals(getComputedStyle(el).overflowY, "auto");
+        el.style.overflow = "";
+    }, `overflow:auto stays auto on <${name}>`);
+}
+</script>

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -916,6 +916,26 @@ void Adjuster::adjustSVGElementStyle(RenderStyle& style, const SVGElement& svgEl
         style.setFontDescription(WTF::move(fontDescription));
     }
 
+    // Per SVG spec (https://w3c.github.io/svgwg/svg2-draft/render.html#OverflowAndClipProperties),
+    // for text, pattern, marker, symbol, and image elements:
+    //   overflow: scroll resolves to hidden
+    //   overflow: auto resolves to visible
+    if (svgElement.hasTagName(SVGNames::textTag)
+        || svgElement.hasTagName(SVGNames::patternTag)
+        || svgElement.hasTagName(SVGNames::markerTag)
+        || svgElement.hasTagName(SVGNames::symbolTag)
+        || svgElement.hasTagName(SVGNames::imageTag)) {
+        auto adjustOverflow = [](Overflow overflow) {
+            if (overflow == Overflow::Scroll)
+                return Overflow::Hidden;
+            if (overflow == Overflow::Auto)
+                return Overflow::Visible;
+            return overflow;
+        };
+        style.setOverflowX(adjustOverflow(style.overflowX()));
+        style.setOverflowY(adjustOverflow(style.overflowY()));
+    }
+
     // SVG text layout code expects us to be a block-level style element.
     // While in theory any block level element would work (flex, grid etc), since we construct RenderBlockFlow for both foreign object and svg text,
     // in practice only block layout happens here.


### PR DESCRIPTION
#### 26b1033df11b917cd5c59cf8ff95d5d92e4efbaa
<pre>
Implement SVG overflow property resolution per SVG2 spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=310427">https://bugs.webkit.org/show_bug.cgi?id=310427</a>
<a href="https://rdar.apple.com/173056797">rdar://173056797</a>

Reviewed by NOBODY (OOPS!).

Per the SVG2 specification [1], the overflow property resolves
differently depending on the SVG element type:

- For text, pattern, marker, symbol, and image elements:
overflow:scroll resolves to hidden, overflow:auto resolves to visible.
- For svg and foreignObject elements: scroll and auto retain their
values (scrollbars are permitted).

Add style adjustment in StyleAdjuster::adjustSVGElementStyle() to
enforce these mappings, and add a WPT testharness test verifying
computed values for all affected element types.

[1] <a href="https://w3c.github.io/svgwg/svg2-draft/render.html#OverflowAndClipProperties">https://w3c.github.io/svgwg/svg2-draft/render.html#OverflowAndClipProperties</a>

Test: imported/w3c/web-platform-tests/svg/render/reftests/overflow-resolution-per-element.html

* LayoutTests/imported/w3c/web-platform-tests/svg/render/reftests/overflow-resolution-per-element-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/render/reftests/overflow-resolution-per-element.html: Added.
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjustSVGElementStyle):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26b1033df11b917cd5c59cf8ff95d5d92e4efbaa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151416 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24180 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17750 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160148 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104854 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7e881f67-5f66-4f16-beb3-4052b1f0e960) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153289 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24611 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24480 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116907 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82986 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6c85958a-e7a3-4fe3-9f58-a5ba5f488dc8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154376 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19049 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135862 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97625 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/35c7cbcb-9961-4e7e-8bbf-63f3d39bc99c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18140 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16084 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7992 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127762 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13774 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162619 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5752 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15351 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124924 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23981 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20138 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125107 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23971 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135570 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80467 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20165 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12340 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23582 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87884 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23292 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23445 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23347 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->