### PR TITLE
Enable zooming outline: auto

### DIFF
--- a/LayoutTests/fast/css/outline-auto-zoom-canvas-expected.txt
+++ b/LayoutTests/fast/css/outline-auto-zoom-canvas-expected.txt
@@ -1,0 +1,11 @@
+This test ensures that the canvas drawFocusIfNeeded focus ring scales with CSS zoom and canvas scale.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS pixels2xZoom > pixels1x is true
+PASS pixels2xScale > pixels1x is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/css/outline-auto-zoom-canvas-rotated-scale-expected.txt
+++ b/LayoutTests/fast/css/outline-auto-zoom-canvas-rotated-scale-expected.txt
@@ -1,0 +1,10 @@
+This test ensures that the canvas drawFocusIfNeeded focus ring scales correctly under a rotated non-uniform transform, exercising the singular value decomposition.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS pixelsRotatedScale > pixelsIdentity is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/css/outline-auto-zoom-canvas-rotated-scale.html
+++ b/LayoutTests/fast/css/outline-auto-zoom-canvas-rotated-scale.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<style>
+canvas {
+    display: block;
+}
+</style>
+</head>
+<body>
+<canvas id="canvas1" width="100" height="100">
+    <button id="btn1" tabindex="0">X</button>
+</canvas>
+<canvas id="canvas2" width="100" height="100">
+    <button id="btn2" tabindex="0">X</button>
+</canvas>
+<script>
+description("This test ensures that the canvas drawFocusIfNeeded focus ring scales correctly under a rotated non-uniform transform, exercising the singular value decomposition.");
+
+function countFocusRingPixels(canvas, setupTransform) {
+    var context = canvas.getContext("2d");
+    context.clearRect(0, 0, canvas.width, canvas.height);
+
+    if (setupTransform) {
+        context.save();
+        setupTransform(context);
+    }
+
+    var button = canvas.querySelector("button");
+    context.beginPath();
+    context.rect(10, 10, 20, 20);
+    button.focus();
+    context.drawFocusIfNeeded(button);
+    button.blur();
+
+    if (setupTransform)
+        context.restore();
+
+    var imageData = context.getImageData(0, 0, canvas.width, canvas.height).data;
+    var count = 0;
+    for (var i = 3; i < imageData.length; i += 4) {
+        if (imageData[i] > 0)
+            count++;
+    }
+    return count;
+}
+
+var canvas1 = document.getElementById("canvas1");
+var canvas2 = document.getElementById("canvas2");
+
+var pixelsIdentity = countFocusRingPixels(canvas1);
+
+// Rotate 45 degrees then scale non-uniformly (2x, 1x). The largest singular
+// value is 2, but reading just the diagonal entries of the resulting matrix
+// would give sqrt(2.5) ≈ 1.58 — only the full eigenvalue decomposition
+// produces the correct value.
+var pixelsRotatedScale = countFocusRingPixels(canvas2, function(ctx) {
+    ctx.rotate(Math.PI / 4);
+    ctx.scale(2, 1);
+});
+
+shouldBeTrue("pixelsRotatedScale > pixelsIdentity");
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/css/outline-auto-zoom-canvas.html
+++ b/LayoutTests/fast/css/outline-auto-zoom-canvas.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<style>
+canvas {
+    display: block;
+}
+</style>
+</head>
+<body>
+<canvas id="canvas1" width="100" height="100">
+    <button id="btn1" tabindex="0">X</button>
+</canvas>
+<canvas id="canvas2" width="100" height="100" style="zoom: 2">
+    <button id="btn2" tabindex="0">X</button>
+</canvas>
+<canvas id="canvas3" width="100" height="100">
+    <button id="btn3" tabindex="0">X</button>
+</canvas>
+<script>
+description("This test ensures that the canvas drawFocusIfNeeded focus ring scales with CSS zoom and canvas scale.");
+
+function countFocusRingPixels(canvas, scale) {
+    var context = canvas.getContext("2d");
+    context.clearRect(0, 0, canvas.width, canvas.height);
+
+    if (scale) {
+        context.save();
+        context.scale(scale, scale);
+    }
+
+    var button = canvas.querySelector("button");
+    context.beginPath();
+    context.rect(10, 10, 30, 30);
+    button.focus();
+    context.drawFocusIfNeeded(button);
+    button.blur();
+
+    if (scale)
+        context.restore();
+
+    var imageData = context.getImageData(0, 0, canvas.width, canvas.height).data;
+    var count = 0;
+    for (var i = 3; i < imageData.length; i += 4) {
+        if (imageData[i] > 0)
+            count++;
+    }
+    return count;
+}
+
+var canvas1 = document.getElementById("canvas1");
+var canvas2 = document.getElementById("canvas2");
+var canvas3 = document.getElementById("canvas3");
+
+var pixels1x = countFocusRingPixels(canvas1);
+var pixels2xZoom = countFocusRingPixels(canvas2);
+var pixels2xScale = countFocusRingPixels(canvas3, 2);
+
+// At 2x zoom the focus ring radius should be doubled, producing more painted
+// pixels. We check that the zoomed canvas has strictly more focus ring pixels.
+shouldBeTrue("pixels2xZoom > pixels1x");
+
+// Similarly, ctx.scale(2, 2) should also produce a scaled
+// focus ring with more pixels than the unscaled version.
+shouldBeTrue("pixels2xScale > pixels1x");
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/css/outline-auto-zoom-expected.html
+++ b/LayoutTests/fast/css/outline-auto-zoom-expected.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    body { margin: 0 }
+    #target {
+        outline: auto;
+        width: 100px;
+        height: 100px;
+        margin: 50px;
+        zoom: 2;
+    }
+</style>
+<script>
+window.onload = function() {
+    document.getElementById("target").focus();
+}
+</script>
+</head>
+<body>
+<div id="target" tabindex="0"></div>
+</body>
+</html>

--- a/LayoutTests/fast/css/outline-auto-zoom.html
+++ b/LayoutTests/fast/css/outline-auto-zoom.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    body { margin: 0 }
+    #target {
+        outline: auto;
+        width: 100px;
+        height: 100px;
+        margin: 50px;
+    }
+</style>
+<script>
+window.onload = function() {
+    document.getElementById("target").focus();
+    if (window.internals)
+        internals.setPageZoomFactor(2);
+}
+</script>
+</head>
+<body>
+<div id="target" tabindex="0"></div>
+</body>
+</html>

--- a/LayoutTests/fast/images/image-map-outline-with-scale-transform-expected.html
+++ b/LayoutTests/fast/images/image-map-outline-with-scale-transform-expected.html
@@ -3,24 +3,26 @@
 <head>
 <title>This tests that we paint area outline properly when the image's container is scaled.</title>
 <style>
-img {
-    position: absolute;
-    top: 23px;
-    left: 25px;
+.container {
+  transform: scale(2);
+  position: absolute;
+  left: 50px;
+  top: 50px;
 }
-
-div {
-    position: absolute;
-    top: 33px;
-    left: 35px;
-    width: 40px;
-    height: 40px;
-	outline: auto;
+.outline {
+  position: absolute;
+  top: 5px;
+  left: 5px;
+  width: 20px;
+  height: 20px;
+  outline: auto;
 }
 </style>
 </head>
 <body>
-<img src="./resources/green.jpg" width=100 height=100>
-<div></div>
+<div class="container">
+  <img src="./resources/green.jpg" width=50 height=50>
+  <div class="outline"></div>
+</div>
 </body>
 </html>

--- a/LayoutTests/fast/images/imagemap-focus-ring-zoom-style-expected.html
+++ b/LayoutTests/fast/images/imagemap-focus-ring-zoom-style-expected.html
@@ -1,18 +1,12 @@
 <html>
 <head>
-<script>
-window.onload = function()
-{
-    document.getElementById("area").focus();
-}
-</script>
+<style>
+img { zoom: 2.0; outline: auto }
+</style>
 </head>
 <body>
 <p>Assuming the port-specific theme draws focus rings, this test ensures that a focus ring is drawn correctly for an imagemap when the zoom style is applied to the image. This test PASSED if a focus ring is drawn around the perimeter of the &lt;area&gt; in the imagemap (below).</p>
-<map name="imagemap">
-    <area id="area" shape="rect" coords="0,0,256,256" href="#dummy" />
-</map>
-<img src="imagemap.jpg" width="256" height="256" usemap="#imagemap" ismap />
+<img src="imagemap.jpg" width="128" height="128">
 </body>
 </head>
 </html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -5401,6 +5401,11 @@ webkit.org/b/310274 media/media-controller-time.html [ Pass Timeout ]
 
 webkit.org/b/310278 media/video-pause-play-resolve.html [ Pass Timeout ]
 
+webkit.org/b/310543 fast/css/outline-auto-zoom.html [ ImageOnlyFailure ]
+webkit.org/b/310543 fast/css/outline-auto-zoom-canvas.html [ Failure ]
+webkit.org/b/310543 fast/css/outline-auto-zoom-canvas-rotated-scale.html [ Failure ]
+webkit.org/b/310543 fast/images/imagemap-focus-ring-zoom-style.html [ ImageOnlyFailure ]
+webkit.org/b/310543 fast/images/image-map-outline-with-scale-transform.html [ ImageOnlyFailure ]
 webkit.org/b/310543 fast/images/image-map-outline-with-paint-root-offset.html [ ImageOnlyFailure ]
 webkit.org/b/310543 fast/inline/hidpi-outline-auto-with-border-radius-horizontal-ltr.html [ ImageOnlyFailure ]
 webkit.org/b/310543 fast/inline/hidpi-outline-auto-with-border-radius-vertical-ltr.html [ ImageOnlyFailure ]

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
@@ -165,7 +165,9 @@ void CanvasRenderingContext2D::drawFocusIfNeededInternal(const Path& path, Eleme
     Ref canvas = this->canvas();
     if (!element.focused() || !hasInvertibleTransform() || path.isEmpty() || !element.isDescendantOf(canvas.get()) || !context)
         return;
-    context->drawFocusRing(path, 1, RenderTheme::singleton().focusRingColor(protect(element.document())->styleColorOptions(canvas->computedStyle())));
+    CheckedPtr canvasStyle = canvas->computedStyle();
+    auto zoomFactor = canvasStyle ? canvasStyle->usedZoom() : 1.f;
+    context->drawFocusRing(path, 1, RenderTheme::singleton().focusRingColor(protect(element.document())->styleColorOptions(canvasStyle)), zoomFactor);
     didDrawEntireCanvas();
 }
 

--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
@@ -504,18 +504,18 @@ AffineTransform BifurcatedGraphicsContext::getCTM(IncludeDeviceScale includeDevi
     return m_primaryContext.getCTM(includeDeviceScale);
 }
 
-void BifurcatedGraphicsContext::drawFocusRing(const Path& path, float outlineWidth, const Color& color)
+void BifurcatedGraphicsContext::drawFocusRing(const Path& path, float outlineWidth, const Color& color, float zoomFactor)
 {
-    m_primaryContext.drawFocusRing(path, outlineWidth, color);
-    m_secondaryContext.drawFocusRing(path, outlineWidth, color);
+    m_primaryContext.drawFocusRing(path, outlineWidth, color, zoomFactor);
+    m_secondaryContext.drawFocusRing(path, outlineWidth, color, zoomFactor);
 
     VERIFY_STATE_SYNCHRONIZATION();
 }
 
-void BifurcatedGraphicsContext::drawFocusRing(const Vector<FloatRect>& rects, float outlineWidth, const Color& color)
+void BifurcatedGraphicsContext::drawFocusRing(const Vector<FloatRect>& rects, float outlineWidth, const Color& color, float zoomFactor)
 {
-    m_primaryContext.drawFocusRing(rects, outlineWidth, color);
-    m_secondaryContext.drawFocusRing(rects, outlineWidth, color);
+    m_primaryContext.drawFocusRing(rects, outlineWidth, color, zoomFactor);
+    m_secondaryContext.drawFocusRing(rects, outlineWidth, color, zoomFactor);
 
     VERIFY_STATE_SYNCHRONIZATION();
 }

--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h
@@ -128,8 +128,8 @@ public:
 
     AffineTransform getCTM(IncludeDeviceScale = PossiblyIncludeDeviceScale) const final;
 
-    void drawFocusRing(const Path&, float outlineWidth, const Color&) final;
-    void drawFocusRing(const Vector<FloatRect>&, float outlineWidth, const Color&) final;
+    void drawFocusRing(const Path&, float outlineWidth, const Color&, float zoomFactor) final;
+    void drawFocusRing(const Vector<FloatRect>&, float outlineWidth, const Color&, float zoomFactor) final;
 
     FloatSize drawText(const FontCascade&, const TextRun&, const FloatPoint&, unsigned from = 0, std::optional<unsigned> to = std::nullopt) final;
     void drawGlyphs(const Font&, std::span<const GlyphBufferGlyph>, std::span<const GlyphBufferAdvance>, const FloatPoint&, FontSmoothingMode) final;

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -325,8 +325,8 @@ public:
 
     // Focus Rings
 
-    virtual void drawFocusRing(const Path&, float outlineWidth, const Color&) = 0;
-    virtual void drawFocusRing(const Vector<FloatRect>&, float outlineWidth, const Color&) = 0;
+    virtual void drawFocusRing(const Path&, float outlineWidth, const Color&, float zoomFactor) = 0;
+    virtual void drawFocusRing(const Vector<FloatRect>&, float outlineWidth, const Color&, float zoomFactor) = 0;
 
     // Transforms
 

--- a/Source/WebCore/platform/graphics/NullGraphicsContext.h
+++ b/Source/WebCore/platform/graphics/NullGraphicsContext.h
@@ -123,8 +123,8 @@ private:
     ImageDrawResult drawTiledImage(Image&, const FloatRect&, const FloatPoint&, const FloatSize&, const FloatSize&, ImagePaintingOptions = { }) final { return ImageDrawResult::DidNothing; }
     ImageDrawResult drawTiledImage(Image&, const FloatRect&, const FloatRect&, const FloatSize&, Image::TileRule, Image::TileRule, ImagePaintingOptions = { }) final { return ImageDrawResult::DidNothing; }
 
-    void drawFocusRing(const Path&, float, const Color&) final { }
-    void drawFocusRing(const Vector<FloatRect>&, float, const Color&) final { }
+    void drawFocusRing(const Path&, float, const Color&, float) final { }
+    void drawFocusRing(const Vector<FloatRect>&, float, const Color&, float) final { }
 
     void drawImageBuffer(ImageBuffer&, const FloatRect&, const FloatRect&, ImagePaintingOptions = { }) final { }
 

--- a/Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.cpp
+++ b/Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.cpp
@@ -762,7 +762,7 @@ void OperationRecorder::drawEllipse(const FloatRect& rect)
     append(createCommand<DrawEllipse>(rect, state.fillBrush().color(), state.strokeStyle(), state.strokeBrush().color(), state.strokeThickness()));
 }
 
-void OperationRecorder::drawFocusRing(const Path& path, float outlineWidth, const Color& color)
+void OperationRecorder::drawFocusRing(const Path& path, float outlineWidth, const Color& color, float)
 {
 #if USE(THEME_ADWAITA)
     Adwaita::paintFocus(*this, path, color);
@@ -786,7 +786,7 @@ void OperationRecorder::drawFocusRing(const Path& path, float outlineWidth, cons
 #endif
 }
 
-void OperationRecorder::drawFocusRing(const Vector<FloatRect>& rects, float outlineWidth, const Color& color)
+void OperationRecorder::drawFocusRing(const Vector<FloatRect>& rects, float outlineWidth, const Color& color, float)
 {
 #if USE(THEME_ADWAITA)
     Adwaita::paintFocus(*this, rects, color);

--- a/Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.h
+++ b/Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.h
@@ -79,8 +79,8 @@ private:
     void drawDotsForDocumentMarker(const WebCore::FloatRect&, WebCore::DocumentMarkerLineStyle) override;
     void drawEllipse(const WebCore::FloatRect&) override;
 
-    void drawFocusRing(const WebCore::Path&, float outlineWidth, const WebCore::Color&) override;
-    void drawFocusRing(const Vector<WebCore::FloatRect>&, float outlineWidth, const WebCore::Color&) override;
+    void drawFocusRing(const WebCore::Path&, float outlineWidth, const WebCore::Color&, float zoomFactor) override;
+    void drawFocusRing(const Vector<WebCore::FloatRect>&, float outlineWidth, const WebCore::Color&, float zoomFactor) override;
 
     void save(WebCore::GraphicsContextState::Purpose = WebCore::GraphicsContextState::Purpose::SaveRestore) override;
     void restore(WebCore::GraphicsContextState::Purpose = WebCore::GraphicsContextState::Purpose::SaveRestore) override;

--- a/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.cpp
@@ -224,7 +224,7 @@ void GraphicsContextCairo::clipToImageBuffer(ImageBuffer& buffer, const FloatRec
         Cairo::clipToImageBuffer(*this, nativeImage->platformImage().get(), destRect);
 }
 
-void GraphicsContextCairo::drawFocusRing(const Path& path, float outlineWidth, const Color& color)
+void GraphicsContextCairo::drawFocusRing(const Path& path, float outlineWidth, const Color& color, float)
 {
 #if USE(THEME_ADWAITA)
     Adwaita::paintFocus(*this, path, color);
@@ -235,7 +235,7 @@ void GraphicsContextCairo::drawFocusRing(const Path& path, float outlineWidth, c
 #endif
 }
 
-void GraphicsContextCairo::drawFocusRing(const Vector<FloatRect>& rects, float outlineWidth, const Color& color)
+void GraphicsContextCairo::drawFocusRing(const Vector<FloatRect>& rects, float outlineWidth, const Color& color, float)
 {
 #if USE(THEME_ADWAITA)
     Adwaita::paintFocus(*this, rects, color);

--- a/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.h
+++ b/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.h
@@ -78,8 +78,8 @@ public:
     void drawDotsForDocumentMarker(const FloatRect&, DocumentMarkerLineStyle) final;
     void drawEllipse(const FloatRect&) final;
 
-    void drawFocusRing(const Path&, float outlineWidth, const Color&) final;
-    void drawFocusRing(const Vector<FloatRect>&, float outlineWidth, const Color&) final;
+    void drawFocusRing(const Path&, float outlineWidth, const Color&, float zoomFactor) final;
+    void drawFocusRing(const Vector<FloatRect>&, float outlineWidth, const Color&, float zoomFactor) final;
 
     void save(GraphicsContextState::Purpose = GraphicsContextState::Purpose::SaveRestore) final;
     void restore(GraphicsContextState::Purpose = GraphicsContextState::Purpose::SaveRestore) final;

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -62,9 +62,20 @@ static void setCGFillColor(CGContextRef context, const Color& color, const Desti
     CGContextSetFillColorWithColor(context, cachedCGColorInDestinationStandardRange(color, colorSpace).get());
 }
 
-inline CGAffineTransform getUserToBaseCTM(CGContextRef context)
+CGAffineTransform getUserToBaseCTM(CGContextRef context)
 {
     return CGAffineTransformConcat(CGContextGetCTM(context), CGAffineTransformInvert(CGContextGetBaseCTM(context)));
+}
+
+CGFloat singularValue(const CGAffineTransform& userToBaseCTM, SingularValueSelection selection)
+{
+    CGFloat A = userToBaseCTM.a * userToBaseCTM.a + userToBaseCTM.b * userToBaseCTM.b;
+    CGFloat B = userToBaseCTM.a * userToBaseCTM.c + userToBaseCTM.b * userToBaseCTM.d;
+    CGFloat D = userToBaseCTM.c * userToBaseCTM.c + userToBaseCTM.d * userToBaseCTM.d;
+    CGFloat discriminant = sqrt(4 * B * B + (A - D) * (A - D));
+    if (selection == SingularValueSelection::Smallest)
+        discriminant = -discriminant;
+    return narrowPrecisionToCGFloat(sqrt(0.5 * ((A + D) + discriminant)));
 }
 
 static InterpolationQuality coreInterpolationQuality(CGContextRef context)
@@ -1095,16 +1106,8 @@ void GraphicsContextCG::endTransparencyLayer()
 
 static CGFloat scaledBlurRadius(CGFloat blurRadius, const CGAffineTransform& userToBaseCTM, bool shadowsIgnoreTransforms)
 {
-    if (!shadowsIgnoreTransforms) {
-        CGFloat A = userToBaseCTM.a * userToBaseCTM.a + userToBaseCTM.b * userToBaseCTM.b;
-        CGFloat B = userToBaseCTM.a * userToBaseCTM.c + userToBaseCTM.b * userToBaseCTM.d;
-        CGFloat C = B;
-        CGFloat D = userToBaseCTM.c * userToBaseCTM.c + userToBaseCTM.d * userToBaseCTM.d;
-
-        CGFloat smallEigenvalue = narrowPrecisionToCGFloat(sqrt(0.5 * ((A + D) - sqrt(4 * B * C + (A - D) * (A - D)))));
-
-        blurRadius *= smallEigenvalue;
-    }
+    if (!shadowsIgnoreTransforms)
+        blurRadius *= singularValue(userToBaseCTM, SingularValueSelection::Smallest);
 
     // Extreme "blur" values can make text drawing crash or take crazy long times, so clamp
     return std::min(blurRadius, narrowPrecisionToCGFloat(1000.0));

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
@@ -118,8 +118,8 @@ public:
 
     AffineTransform getCTM(IncludeDeviceScale = PossiblyIncludeDeviceScale) const override;
 
-    void drawFocusRing(const Path&, float outlineWidth, const Color&) final;
-    void drawFocusRing(const Vector<FloatRect>&, float outlineWidth, const Color&) final;
+    void drawFocusRing(const Path&, float outlineWidth, const Color&, float zoomFactor) final;
+    void drawFocusRing(const Vector<FloatRect>&, float outlineWidth, const Color&, float zoomFactor) final;
 
     void drawLinesForText(const FloatPoint&, float thickness, std::span<const FloatSegment>, bool isPrinting, bool doubleLines, StrokeStyle) final;
 
@@ -182,6 +182,9 @@ private:
 };
 
 CGAffineTransform getUserToBaseCTM(CGContextRef);
+
+enum class SingularValueSelection : bool { Smallest, Largest };
+CGFloat singularValue(const CGAffineTransform& userToBaseCTM, SingularValueSelection);
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextCocoa.mm
@@ -99,7 +99,7 @@ ImageDrawResult GraphicsContext::drawMultiRepresentationHEIC(Image& image, const
 
 #endif
 
-void GraphicsContextCG::drawFocusRing(const Path& path, float, const Color& color)
+void GraphicsContextCG::drawFocusRing(const Path& path, float, const Color& color, float zoomFactor)
 {
     if (path.isEmpty())
         return;
@@ -117,14 +117,19 @@ void GraphicsContextCG::drawFocusRing(const Path& path, float, const Color& colo
     focusRingStyle.bounds = CGRectZero;
 #endif
 
+    // zoomFactor covers CSS zoom / page zoom (Cmd+/-). ctmScale covers page scale (pinch-to-zoom), canvas transforms, etc.
+    CGContextRef platformContext = this->platformContext();
+    auto ctmScale = singularValue(getUserToBaseCTM(platformContext), SingularValueSelection::Largest);
+    if (ctmScale <= 0)
+        ctmScale = 1.0f;
+    focusRingStyle.radius *= zoomFactor * ctmScale;
+
     // We want to respect the CGContext clipping and also not overpaint any
     // existing focus ring. The way to do this is set accumulate to
     // -1. According to CoreGraphics, the reasoning for this behavior has been
     // lost in time.
     focusRingStyle.accumulate = -1;
     auto style = adoptCF(CGStyleCreateFocusRingWithColor(&focusRingStyle, cachedCGColor(color).get()));
-
-    CGContextRef platformContext = this->platformContext();
 
     CGContextStateSaver stateSaver(platformContext);
 
@@ -135,12 +140,12 @@ void GraphicsContextCG::drawFocusRing(const Path& path, float, const Color& colo
     CGContextFillPath(platformContext);
 }
 
-void GraphicsContextCG::drawFocusRing(const Vector<FloatRect>& rects, float outlineWidth, const Color& color)
+void GraphicsContextCG::drawFocusRing(const Vector<FloatRect>& rects, float outlineWidth, const Color& color, float zoomFactor)
 {
     Path path;
     for (const auto& rect : rects)
         path.addRect(rect);
-    drawFocusRing(path, outlineWidth, color);
+    drawFocusRing(path, outlineWidth, color, zoomFactor);
 }
 
 static inline void setPatternPhaseInUserSpace(CGContextRef context, CGPoint phasePoint)

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
@@ -493,7 +493,7 @@ void DrawPath::dump(TextStream& ts, OptionSet<AsTextFlag>) const
 
 void DrawFocusRingPath::apply(GraphicsContext& context) const
 {
-    context.drawFocusRing(m_path, m_outlineWidth, m_color);
+    context.drawFocusRing(m_path, m_outlineWidth, m_color, m_zoomFactor);
 }
 
 void DrawFocusRingPath::dump(TextStream& ts, OptionSet<AsTextFlag>) const
@@ -501,11 +501,12 @@ void DrawFocusRingPath::dump(TextStream& ts, OptionSet<AsTextFlag>) const
     ts.dumpProperty("path"_s, path());
     ts.dumpProperty("outline-width"_s, outlineWidth());
     ts.dumpProperty("color"_s, color());
+    ts.dumpProperty("zoom-factor"_s, zoomFactor());
 }
 
 void DrawFocusRingRects::apply(GraphicsContext& context) const
 {
-    context.drawFocusRing(m_rects, m_outlineWidth, m_color);
+    context.drawFocusRing(m_rects, m_outlineWidth, m_color, m_zoomFactor);
 }
 
 void DrawFocusRingRects::dump(TextStream& ts, OptionSet<AsTextFlag>) const
@@ -513,6 +514,7 @@ void DrawFocusRingRects::dump(TextStream& ts, OptionSet<AsTextFlag>) const
     ts.dumpProperty("rects"_s, rects());
     ts.dumpProperty("outline-width"_s, outlineWidth());
     ts.dumpProperty("color"_s, color());
+    ts.dumpProperty("zoom-factor"_s, zoomFactor());
 }
 
 void FillRect::apply(GraphicsContext& context) const

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
@@ -918,23 +918,26 @@ class DrawFocusRingPath {
 public:
     static constexpr char name[] = "draw-focus-ring-path";
 
-    DrawFocusRingPath(const Path& path, float outlineWidth, const Color& color)
+    DrawFocusRingPath(const Path& path, float outlineWidth, const Color& color, float zoomFactor)
         : m_path(path)
         , m_outlineWidth(outlineWidth)
         , m_color(color)
+        , m_zoomFactor(zoomFactor)
     {
     }
 
-    DrawFocusRingPath(Path&& path, float outlineWidth, const Color& color)
+    DrawFocusRingPath(Path&& path, float outlineWidth, const Color& color, float zoomFactor)
         : m_path(WTF::move(path))
         , m_outlineWidth(outlineWidth)
         , m_color(color)
+        , m_zoomFactor(zoomFactor)
     {
     }
 
     const Path& path() const LIFETIME_BOUND { return m_path; }
     float outlineWidth() const { return m_outlineWidth; }
     const Color& color() const LIFETIME_BOUND { return m_color; }
+    float zoomFactor() const { return m_zoomFactor; }
 
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
@@ -943,29 +946,33 @@ private:
     Path m_path;
     float m_outlineWidth;
     Color m_color;
+    float m_zoomFactor;
 };
 
 class DrawFocusRingRects {
 public:
     static constexpr char name[] = "draw-focus-ring-rects";
 
-    DrawFocusRingRects(const Vector<FloatRect>& rects, float outlineWidth, const Color& color)
+    DrawFocusRingRects(const Vector<FloatRect>& rects, float outlineWidth, const Color& color, float zoomFactor)
         : m_rects(rects)
         , m_outlineWidth(outlineWidth)
         , m_color(color)
+        , m_zoomFactor(zoomFactor)
     {
     }
 
-    DrawFocusRingRects(Vector<FloatRect>&& rects, float outlineWidth, Color color)
+    DrawFocusRingRects(Vector<FloatRect>&& rects, float outlineWidth, Color color, float zoomFactor)
         : m_rects(WTF::move(rects))
         , m_outlineWidth(outlineWidth)
         , m_color(color)
+        , m_zoomFactor(zoomFactor)
     {
     }
 
     const Vector<FloatRect>& rects() const LIFETIME_BOUND { return m_rects; }
     float outlineWidth() const { return m_outlineWidth; }
     const Color& color() const LIFETIME_BOUND { return m_color; }
+    float zoomFactor() const { return m_zoomFactor; }
 
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
@@ -974,6 +981,7 @@ private:
     Vector<FloatRect> m_rects;
     float m_outlineWidth;
     Color m_color;
+    float m_zoomFactor;
 };
 
 class FillRect {

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
@@ -306,16 +306,16 @@ void RecorderImpl::drawPath(const Path& path)
     m_items.append(DrawPath(path));
 }
 
-void RecorderImpl::drawFocusRing(const Path& path, float outlineWidth, const Color& color)
+void RecorderImpl::drawFocusRing(const Path& path, float outlineWidth, const Color& color, float zoomFactor)
 {
     appendStateChangeItemIfNecessary();
-    m_items.append(DrawFocusRingPath(path, outlineWidth, color));
+    m_items.append(DrawFocusRingPath(path, outlineWidth, color, zoomFactor));
 }
 
-void RecorderImpl::drawFocusRing(const Vector<FloatRect>& rects, float outlineWidth, const Color& color)
+void RecorderImpl::drawFocusRing(const Vector<FloatRect>& rects, float outlineWidth, const Color& color, float zoomFactor)
 {
     appendStateChangeItemIfNecessary();
-    m_items.append(DrawFocusRingRects(rects, outlineWidth, color));
+    m_items.append(DrawFocusRingRects(rects, outlineWidth, color, zoomFactor));
 }
 
 void RecorderImpl::fillRect(const FloatRect& rect, RequiresClipToRect requiresClipToRect)

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
@@ -80,8 +80,8 @@ public:
     void drawDotsForDocumentMarker(const FloatRect&, DocumentMarkerLineStyle) final;
     void drawEllipse(const FloatRect&) final;
     void drawPath(const Path&) final;
-    void drawFocusRing(const Path&, float outlineWidth, const Color&) final;
-    void drawFocusRing(const Vector<FloatRect>&, float outlineWidth, const Color&) final;
+    void drawFocusRing(const Path&, float outlineWidth, const Color&, float zoomFactor) final;
+    void drawFocusRing(const Vector<FloatRect>&, float outlineWidth, const Color&, float zoomFactor) final;
     void drawPattern(const NativeImage&, const FloatRect& destRect, const FloatRect& tileRect, const AffineTransform&, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions) final;
     void drawPattern(ImageBuffer&, const FloatRect& destRect, const FloatRect& tileRect, const AffineTransform&, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions) final;
     void fillEllipse(const FloatRect&) final;

--- a/Source/WebCore/platform/graphics/mac/controls/SwitchTrackMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SwitchTrackMac.mm
@@ -209,7 +209,7 @@ void SwitchTrackMac::draw(GraphicsContext& context, const FloatRoundedRect& bord
 
     if (isFocused) {
         auto color = colorFromCocoaColor([NSColor keyboardFocusIndicatorColor]).opaqueColor();
-        context.drawFocusRing(Vector { trackRect }, 0, color);
+        context.drawFocusRing(Vector { trackRect }, 0, color, style.zoomFactor);
     }
 }
 

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
@@ -789,7 +789,7 @@ void GraphicsContextSkia::clipToImageBuffer(ImageBuffer& buffer, const FloatRect
     }
 }
 
-void GraphicsContextSkia::drawFocusRing(const Path& path, float, const Color& color)
+void GraphicsContextSkia::drawFocusRing(const Path& path, float, const Color& color, float)
 {
 #if USE(THEME_ADWAITA)
     Adwaita::paintFocus(*this, path, color);
@@ -800,7 +800,7 @@ void GraphicsContextSkia::drawFocusRing(const Path& path, float, const Color& co
 #endif
 }
 
-void GraphicsContextSkia::drawFocusRing(const Vector<FloatRect>& rects, float, const Color& color)
+void GraphicsContextSkia::drawFocusRing(const Vector<FloatRect>& rects, float, const Color& color, float)
 {
 #if USE(THEME_ADWAITA)
     Adwaita::paintFocus(*this, rects, color);

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
@@ -91,8 +91,8 @@ public:
     void drawDotsForDocumentMarker(const FloatRect&, DocumentMarkerLineStyle) final;
     void drawEllipse(const FloatRect&) final;
 
-    void drawFocusRing(const Path&, float outlineWidth, const Color&) final;
-    void drawFocusRing(const Vector<FloatRect>&, float outlineWidth, const Color&) final;
+    void drawFocusRing(const Path&, float outlineWidth, const Color&, float zoomFactor) final;
+    void drawFocusRing(const Vector<FloatRect>&, float outlineWidth, const Color&, float zoomFactor) final;
 
     void save(GraphicsContextState::Purpose = GraphicsContextState::Purpose::SaveRestore) final;
     void restore(GraphicsContextState::Purpose = GraphicsContextState::Purpose::SaveRestore) final;

--- a/Source/WebCore/rendering/OutlinePainter.cpp
+++ b/Source/WebCore/rendering/OutlinePainter.cpp
@@ -241,12 +241,12 @@ static bool NODELETE useShrinkWrappedFocusRingForOutlineStyleAuto()
 
 static void drawFocusRing(GraphicsContext& context, const Path& path, const RenderStyle& style, const Color& color)
 {
-    context.drawFocusRing(path, Style::evaluate<float>(style.usedOutlineWidth(), Style::ZoomNeeded { }), color);
+    context.drawFocusRing(path, Style::evaluate<float>(style.usedOutlineWidth(), Style::ZoomNeeded { }), color, style.usedZoom());
 }
 
 static void drawFocusRing(GraphicsContext& context, Vector<FloatRect> rects, const RenderStyle& style, const Color& color)
 {
-    context.drawFocusRing(rects, Style::evaluate<float>(style.usedOutlineWidth(), Style::ZoomNeeded { }), color);
+    context.drawFocusRing(rects, Style::evaluate<float>(style.usedOutlineWidth(), Style::ZoomNeeded { }), color, style.usedZoom());
 }
 
 void OutlinePainter::paintFocusRing(const RenderElement& renderer, const Vector<LayoutRect>& focusRingRects) const

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -749,7 +749,7 @@ void RenderImage::paintAreaElementFocusRing(PaintInfo& paintInfo, const LayoutPo
 
     auto styleOptions = styleColorOptions();
     styleOptions.add(StyleColorOptions::UseSystemAppearance);
-    paintInfo.context().drawFocusRing(path, outlineWidth, RenderTheme::singleton().focusRingColor(styleOptions));
+    paintInfo.context().drawFocusRing(path, outlineWidth, RenderTheme::singleton().focusRingColor(styleOptions), style().usedZoom());
 }
 
 void RenderImage::areaElementFocusChanged(HTMLAreaElement* element)

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -149,7 +149,7 @@ static void drawFocusRingForPathForVectorBasedControls(const RenderObject& box, 
 
     // We pass 0.f as the border thickness because the parameter is not used by
     // the context. It will determine an appropriate value for us.
-    context.drawFocusRing(path, 0.f, focusRingColor);
+    context.drawFocusRing(path, 0.f, focusRingColor, box.style().usedZoom());
 }
 
 #if PLATFORM(MAC)

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -403,9 +403,15 @@ Style::LineWidth RenderStyle::usedColumnRuleWidth() const
 Style::Length<> RenderStyle::usedOutlineOffset() const
 {
     auto& outline = m_computedStyle.outline();
-    if (static_cast<OutlineStyle>(outline.outlineStyle) == OutlineStyle::Auto)
-        return Style::Length<> { Style::evaluate<float>(outline.outlineOffset, Style::ZoomNeeded { }) + RenderTheme::singleton().platformFocusRingWidthOffset(Style::evaluate<float>(outline.outlineWidth, Style::ZoomNeeded { })) };
-    return outline.outlineOffset;
+    if (static_cast<OutlineStyle>(outline.outlineStyle) != OutlineStyle::Auto)
+        return outline.outlineOffset;
+
+    auto zoom = usedZoom();
+    auto unzoomedWidth = Style::evaluate<float>(outline.outlineWidth, Style::ZoomNeeded { }) / zoom;
+    return Style::Length<> {
+        Style::evaluate<float>(outline.outlineOffset, Style::ZoomNeeded { })
+        + RenderTheme::singleton().platformFocusRingWidthOffset(unzoomedWidth) * zoom
+    };
 }
 
 Style::LineWidth RenderStyle::usedOutlineWidth() const
@@ -414,7 +420,7 @@ Style::LineWidth RenderStyle::usedOutlineWidth() const
     if (static_cast<OutlineStyle>(outline.outlineStyle) == OutlineStyle::None)
         return 0_css_px;
     if (static_cast<OutlineStyle>(outline.outlineStyle) == OutlineStyle::Auto)
-        return Style::LineWidth { std::max(Style::evaluate<float>(outline.outlineWidth, Style::ZoomNeeded { }), RenderTheme::singleton().platformFocusRingWidth()) };
+        return Style::LineWidth { std::max(Style::evaluate<float>(outline.outlineWidth, Style::ZoomNeeded { }), RenderTheme::singleton().platformFocusRingWidth() * usedZoom()) };
     return outline.outlineWidth;
 }
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.cpp
@@ -507,14 +507,14 @@ void RemoteGraphicsContext::drawPath(const Path& path)
     context().drawPath(path);
 }
 
-void RemoteGraphicsContext::drawFocusRingPath(const Path& path, float outlineWidth, const Color& color)
+void RemoteGraphicsContext::drawFocusRingPath(const Path& path, float outlineWidth, const Color& color, float zoomFactor)
 {
-    context().drawFocusRing(path, outlineWidth, color);
+    context().drawFocusRing(path, outlineWidth, color, zoomFactor);
 }
 
-void RemoteGraphicsContext::drawFocusRingRects(const Vector<FloatRect>& rects, float outlineWidth, const Color& color)
+void RemoteGraphicsContext::drawFocusRingRects(const Vector<FloatRect>& rects, float outlineWidth, const Color& color, float zoomFactor)
 {
-    context().drawFocusRing(rects, outlineWidth, color);
+    context().drawFocusRing(rects, outlineWidth, color, zoomFactor);
 }
 
 void RemoteGraphicsContext::fillRect(const FloatRect& rect, GraphicsContext::RequiresClipToRect requiresClipToRect)

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.h
@@ -118,8 +118,8 @@ public:
     void drawDotsForDocumentMarker(const WebCore::FloatRect&, const WebCore::DocumentMarkerLineStyle&);
     void drawEllipse(const WebCore::FloatRect&);
     void drawPath(const WebCore::Path&);
-    void drawFocusRingPath(const WebCore::Path&, float outlineWidth, const WebCore::Color&);
-    void drawFocusRingRects(const Vector<WebCore::FloatRect>&, float outlineWidth, const WebCore::Color&);
+    void drawFocusRingPath(const WebCore::Path&, float outlineWidth, const WebCore::Color&, float zoomFactor);
+    void drawFocusRingRects(const Vector<WebCore::FloatRect>&, float outlineWidth, const WebCore::Color&, float zoomFactor);
     void fillRect(const WebCore::FloatRect&, WebCore::RequiresClipToRect);
     void fillRectWithColor(const WebCore::FloatRect&, const WebCore::Color&);
     void fillRectWithGradient(const WebCore::FloatRect&, Ref<WebCore::Gradient>&&);

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.messages.in
@@ -92,8 +92,8 @@ messages -> RemoteGraphicsContext Stream {
     DrawDotsForDocumentMarker(WebCore::FloatRect rect, struct WebCore::DocumentMarkerLineStyle style) StreamBatched
     DrawEllipse(WebCore::FloatRect rect) StreamBatched
     DrawPath(WebCore::Path path) StreamBatched
-    DrawFocusRingPath(WebCore::Path path, float outlineWidth, WebCore::Color color) StreamBatched
-    DrawFocusRingRects(Vector<WebCore::FloatRect> rects, float outlineWidth, WebCore::Color color) StreamBatched
+    DrawFocusRingPath(WebCore::Path path, float outlineWidth, WebCore::Color color, float zoomFactor) StreamBatched
+    DrawFocusRingRects(Vector<WebCore::FloatRect> rects, float outlineWidth, WebCore::Color color, float zoomFactor) StreamBatched
     FillRect(WebCore::FloatRect rect, enum:bool WebCore::RequiresClipToRect requiresClipToRect) StreamBatched
     FillRectWithColor(WebCore::FloatRect rect, WebCore::Color color) StreamBatched
     FillRectWithGradient(WebCore::FloatRect rect, Ref<WebCore::Gradient> gradient) StreamBatched

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp
@@ -430,16 +430,16 @@ void RemoteGraphicsContextProxy::drawPath(const Path& path)
     send(Messages::RemoteGraphicsContext::DrawPath(path));
 }
 
-void RemoteGraphicsContextProxy::drawFocusRing(const Path& path, float outlineWidth, const Color& color)
+void RemoteGraphicsContextProxy::drawFocusRing(const Path& path, float outlineWidth, const Color& color, float zoomFactor)
 {
     appendStateChangeItemIfNecessary();
-    send(Messages::RemoteGraphicsContext::DrawFocusRingPath(path, outlineWidth, color));
+    send(Messages::RemoteGraphicsContext::DrawFocusRingPath(path, outlineWidth, color, zoomFactor));
 }
 
-void RemoteGraphicsContextProxy::drawFocusRing(const Vector<FloatRect>& rects, float outlineWidth, const Color& color)
+void RemoteGraphicsContextProxy::drawFocusRing(const Vector<FloatRect>& rects, float outlineWidth, const Color& color, float zoomFactor)
 {
     appendStateChangeItemIfNecessary();
-    send(Messages::RemoteGraphicsContext::DrawFocusRingRects(rects, outlineWidth, color));
+    send(Messages::RemoteGraphicsContext::DrawFocusRingRects(rects, outlineWidth, color, zoomFactor));
 }
 
 void RemoteGraphicsContextProxy::fillPath(const Path& path)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.h
@@ -112,8 +112,8 @@ private:
     void drawDotsForDocumentMarker(const WebCore::FloatRect&, WebCore::DocumentMarkerLineStyle) final;
     void drawEllipse(const WebCore::FloatRect&) final;
     void drawPath(const WebCore::Path&) final;
-    void drawFocusRing(const WebCore::Path&, float outlineWidth, const WebCore::Color&) final;
-    void drawFocusRing(const Vector<WebCore::FloatRect>&, float outlineWidth, const WebCore::Color&) final;
+    void drawFocusRing(const WebCore::Path&, float outlineWidth, const WebCore::Color&, float zoomFactor) final;
+    void drawFocusRing(const Vector<WebCore::FloatRect>&, float outlineWidth, const WebCore::Color&, float zoomFactor) final;
     void drawPattern(const WebCore::NativeImage&, const WebCore::FloatRect& destRect, const WebCore::FloatRect& tileRect, const WebCore::AffineTransform&, const WebCore::FloatPoint& phase, const WebCore::FloatSize& spacing, WebCore::ImagePaintingOptions = { }) final;
     void drawPattern(WebCore::ImageBuffer&, const WebCore::FloatRect& destRect, const WebCore::FloatRect& tileRect, const WebCore::AffineTransform&, const WebCore::FloatPoint& phase, const WebCore::FloatSize& spacing, WebCore::ImagePaintingOptions = { }) final;
     void fillPath(const WebCore::Path&) final;


### PR DESCRIPTION
#### bd74c28ba866eb914227b80709e95d968978d614
<pre>
Enable zooming outline: auto
<a href="https://bugs.webkit.org/show_bug.cgi?id=310434">https://bugs.webkit.org/show_bug.cgi?id=310434</a>
<a href="https://rdar.apple.com/173068660">rdar://173068660</a>

Reviewed by Simon Fraser.

The outline: auto focus ring would never change in size. This placed it
outside the CSS coordinate system which could get awkward/ugly when
combined with outline-offset, which does participate in the CSS
coordinate system.

To address this we need to account for two types of zoom, &quot;page zoom&quot;
(Cmd+) and &quot;page scale&quot; (pinch). The changes in GraphicsContextCocoa
take care these. We repurpose some of the logic from scaledBlurRadius()
to handle rotation and skew correctly, but go for the larger value so
the focus ring is sufficiently large in all directions. That&apos;s also why
we go from 0 to 1: to ensure there&apos;s a focus ring visible.

Most of the other changes are about forwarding the
relevant &quot;page zoom&quot; factor to the graphics layer.

Finally, the change in RenderStyle takes fixes a bug where we pass the
zoomed outline-width value to platformFocusRingWidthOffset() which
operates on un-zoomed values. This results in an outline snug to a
border getting an ever larger gap as you page zoom.

Tests: fast/css/mac/outline-auto-zoom.html
       fast/css/outline-auto-zoom-canvas.html

Canonical link: <a href="https://commits.webkit.org/309926@main">https://commits.webkit.org/309926@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3711ee709fbd0be402ae5672964f354cda28a75b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152165 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24947 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18539 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160908 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105622 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154039 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25439 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25253 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117560 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155125 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19745 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/136604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98273 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18822 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/16773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8742 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14478 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163374 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6520 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16070 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125586 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24745 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20814 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125762 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24746 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136274 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81345 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23339 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20773 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13051 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24363 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88648 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24054 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24214 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24115 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->