### PR TITLE
rdar://165926852 ([ Build-Failure ] error: unrecognized symbol "PFMetadataImageSourceIsSpatialMedia")

### DIFF
--- a/Source/WebCore/platform/cocoa/PhotosFormatSoftLink.h
+++ b/Source/WebCore/platform/cocoa/PhotosFormatSoftLink.h
@@ -25,5 +25,7 @@
 
 #import <wtf/SoftLinking.h>
 
+#if ENABLE(SPATIAL_IMAGE_DETECTION)
 SOFT_LINK_FRAMEWORK_FOR_HEADER(WebCore, PhotosFormats);
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(WebCore, PhotosFormats, PFMetadataImageSourceIsSpatialMedia, bool, (CGImageSourceRef source), (source));
+#endif

--- a/Source/WebCore/platform/cocoa/PhotosFormatSoftLink.mm
+++ b/Source/WebCore/platform/cocoa/PhotosFormatSoftLink.mm
@@ -26,5 +26,7 @@
 #import <ImageIO/CGImageSource.h>
 #import <wtf/SoftLinking.h>
 
+#if ENABLE(SPATIAL_IMAGE_DETECTION)
 SOFT_LINK_PRIVATE_FRAMEWORK_FOR_SOURCE(WebCore, PhotosFormats);
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE(WebCore, PhotosFormats, PFMetadataImageSourceIsSpatialMedia, bool, (CGImageSourceRef source), (source));
+#endif


### PR DESCRIPTION
#### 14584f550acdcafcb10c7d30a1d8fb897a958857
<pre>
<a href="https://rdar.apple.com/165926852">rdar://165926852</a> ([ Build-Failure ] error: unrecognized symbol &quot;PFMetadataImageSourceIsSpatialMedia&quot;)

Reviewed by Aditya Keerthi.

Add missing (vision) ifdefs in the PhotosFormat soft link.

* Source/WebCore/platform/cocoa/PhotosFormatSoftLink.h:
* Source/WebCore/platform/cocoa/PhotosFormatSoftLink.mm:

Originally-landed-as: 301765.355@safari-7623-branch (4349a1a8ad37). <a href="https://rdar.apple.com/173068147">rdar://173068147</a>
Canonical link: <a href="https://commits.webkit.org/309682@main">https://commits.webkit.org/309682@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3fce01ea3f95f5595d25848673de6fe8e9a9f280

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151448 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24213 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/17794 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160180 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104886 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153322 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24644 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24515 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/116938 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83011 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154408 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/135892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97658 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/18176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/16120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8024 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/127803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/13797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162651 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5784 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/15385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/124955 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24014 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/20177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125141 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24006 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/135593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80528 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23263 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/20196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/12367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23615 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87927 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/23325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/23479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23381 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->