### PR TITLE
Logical shorthand properties with var() fail to resolve when reverted

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-logical/logicalprops-with-variables-revert-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-logical/logicalprops-with-variables-revert-expected.txt
@@ -1,0 +1,8 @@
+
+PASS padding-block - padding-top
+PASS padding-block - padding-bottom
+PASS padding-block-two - padding-top
+PASS padding-block-two - padding-bottom
+PASS margin-inline - margin-left
+PASS margin-inline - margin-right
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-logical/logicalprops-with-variables-revert.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-logical/logicalprops-with-variables-revert.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Logical shorthand properties with <code>var()</code> and revert</title>
+<link rel="help" href="https://drafts.csswg.org/css-logical-1/#box">
+<link rel="help" href="https://drafts.csswg.org/css-variables-1/">
+<link rel="help" href="https://drafts.csswg.org/css-cascade-5/#revert-layer">
+<meta name="assert" content="Checks that logical shorthand properties with var() resolve correctly when combined with revert-layer.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+@layer base, override;
+@layer base {
+  .padding-block {
+    --p: 10px;
+    padding-block: var(--p);
+  }
+  .padding-block-two {
+    --p1: 10px;
+    --p2: 20px;
+    padding-block: var(--p1) var(--p2);
+  }
+  .margin-inline {
+    --m: 5px;
+    margin-inline: var(--m);
+  }
+}
+@layer override {
+  .padding-block,
+  .padding-block-two,
+  .margin-inline {
+    padding-block: revert-layer;
+    margin-inline: revert-layer;
+  }
+}
+</style>
+<div id="log"></div>
+<div id="padding-block" class="padding-block"></div>
+<div id="padding-block-two" class="padding-block-two"></div>
+<div id="margin-inline" class="margin-inline"></div>
+<script>
+function check(id, property, expected) {
+  test(() => {
+    const el = document.getElementById(id);
+    const value = getComputedStyle(el).getPropertyValue(property);
+    assert_equals(value, expected);
+  }, id + " - " + property);
+}
+
+check("padding-block", "padding-top", "10px");
+check("padding-block", "padding-bottom", "10px");
+check("padding-block-two", "padding-top", "10px");
+check("padding-block-two", "padding-bottom", "20px");
+check("margin-inline", "margin-left", "5px");
+check("margin-inline", "margin-right", "5px");
+</script>

--- a/Source/WebCore/css/CSSVariableReferenceValue.h
+++ b/Source/WebCore/css/CSSVariableReferenceValue.h
@@ -77,9 +77,7 @@ private:
     struct Cache {
         RefPtr<CSSVariableData> dependencyData;
         RefPtr<CSSValue> value;
-#if ASSERT_ENABLED
         CSSPropertyID propertyID { CSSPropertyInvalid };
-#endif
     };
     mutable Cache m_cache;
 };

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -346,14 +346,11 @@ void Builder::applyProperty(CSSPropertyID id, CSSValue& value, SelectorChecker::
     ASSERT_WITH_MESSAGE(id != CSSPropertyCustom, "Custom property should be handled by applyCustomProperty");
 
     auto valueToApply = resolveInternalAutoBaseFunction(value);
-    valueToApply = resolveSubstitutionFunctions(id, valueToApply);
     auto& style = m_state->style();
 
-    if (CSSProperty::isDirectionAwareProperty(id)) {
-        CSSPropertyID newId = CSSProperty::resolveDirectionAwareProperty(id, style.writingMode());
-        ASSERT(newId != id);
-        return applyProperty(newId, valueToApply.get(), linkMatchMask, cascadeOrigin);
-    }
+    id = CSSProperty::resolveDirectionAwareProperty(id, style.writingMode());
+
+    valueToApply = resolveSubstitutionFunctions(id, valueToApply);
 
     if (m_state->positionTryFallback())
         id = AnchorPositionEvaluator::resolvePositionTryFallbackProperty(id, style.writingMode(), *m_state->positionTryFallback());

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -273,20 +273,19 @@ RefPtr<CSSValue> SubstitutionResolver::substituteAndParse(const CSSVariableRefer
     if (!data)
         return nullptr;
 
-    if (!arePointingToEqualData(variableRef.m_cache.dependencyData, data)) {
+    if (!arePointingToEqualData(variableRef.m_cache.dependencyData, data) || variableRef.m_cache.propertyID != propertyID) {
         variableRef.m_cache.value = CSSPropertyParser::parseStylePropertyLonghand(propertyID, data->tokens(), variableRef.context());
-#if ASSERT_ENABLED
         variableRef.m_cache.propertyID = propertyID;
-#endif
     }
     variableRef.m_cache.dependencyData = WTF::move(data);
 
-    ASSERT(variableRef.m_cache.propertyID == propertyID);
     return variableRef.m_cache.value;
 }
 
 RefPtr<CSSValue> SubstitutionResolver::substituteAndParseShorthand(const CSSPendingSubstitutionValue& substitution, CSSPropertyID propertyID) const
 {
+    ASSERT(!CSSProperty::isDirectionAwareProperty(propertyID));
+
     auto& variableRef = substitution.shorthandValue();
 
     auto data = substitute(variableRef);
@@ -303,7 +302,7 @@ RefPtr<CSSValue> SubstitutionResolver::substituteAndParseShorthand(const CSSPend
     variableRef.m_cache.dependencyData = WTF::move(data);
 
     for (auto& property : substitution.m_cachedPropertyValues) {
-        if (property.id() == propertyID)
+        if (CSSProperty::resolveDirectionAwareProperty(property.id(), m_styleBuilder.state().style().writingMode()) == propertyID)
             return property.value();
     }
 


### PR DESCRIPTION
#### 58847a17c7fc8d43d1a861b4d3bf43cf2b4e74ef
<pre>
Logical shorthand properties with var() fail to resolve when reverted
<a href="https://bugs.webkit.org/show_bug.cgi?id=310435">https://bugs.webkit.org/show_bug.cgi?id=310435</a>
<a href="https://rdar.apple.com/173073798">rdar://173073798</a>

Reviewed by Alan Baradlay.

Logical shorthand properties with var() fail to resolve when reverted, because the substitution
lookup compared physical property IDs against the parser&apos;s logical longhand IDs.

Test: imported/w3c/web-platform-tests/css/css-logical/logicalprops-with-variables-revert.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-logical/logicalprops-with-variables-revert-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-logical/logicalprops-with-variables-revert.html: Added.
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::applyProperty):

Map logical-&gt;physical before substitution.
Remove the now-unneeded recursion in direction aware property case.

* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::SubstitutionResolver::substituteAndParse const):

Save and test against the cached property so we don&apos;t get tripped by logical/physical mismatch.

(WebCore::Style::SubstitutionResolver::substituteAndParseShorthand const):

Map the shorthand properties to physical for comparison.

Canonical link: <a href="https://commits.webkit.org/309703@main">https://commits.webkit.org/309703@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c402ebe657b0b9e1fbde8920a83d11c86344b00d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151490 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24255 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17836 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160222 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104928 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7dc2c163-49c2-418d-9178-369143b6b5d8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153364 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24686 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24557 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116980 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83050 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/da7e5699-2675-400d-a494-b7eef520b7b6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154450 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19132 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135934 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97699 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b95acb9b-139f-4d07-aad2-61188df1c85a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18222 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16165 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8066 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127849 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13839 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162693 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5826 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15428 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124998 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24056 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20223 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125182 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33955 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24048 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135635 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80597 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20240 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12410 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23657 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87969 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23367 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23521 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23423 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->