### PR TITLE
[JSC] Do not store m_lastToken

### DIFF
--- a/Source/JavaScriptCore/parser/Lexer.cpp
+++ b/Source/JavaScriptCore/parser/Lexer.cpp
@@ -557,8 +557,7 @@ void Lexer<T>::setCode(const SourceCode& source, ParserArena* arena)
     m_arena = &arena->identifierArena();
     
     m_lineNumber = source.firstLine().oneBasedInt();
-    m_lastToken = -1;
-    
+
     StringView sourceString = source.provider()->source();
 
     if (!sourceString.isNull())
@@ -731,10 +730,9 @@ void Lexer<T>::shiftLineTerminator()
     m_lineStart = m_code;
 }
 
-template <typename T>
-ALWAYS_INLINE bool Lexer<T>::lastTokenWasRestrKeyword() const
+static ALWAYS_INLINE bool isRestrKeyword(JSTokenType token)
 {
-    return m_lastToken == CONTINUE || m_lastToken == BREAK || m_lastToken == RETURN || m_lastToken == THROW;
+    return token == CONTINUE || token == BREAK || token == RETURN || token == THROW;
 }
 
 template <typename T>
@@ -1998,10 +1996,9 @@ bool Lexer<T>::nextTokenIsColon()
 }
 
 template <typename T>
-void Lexer<T>::fillTokenInfo(JSToken* tokenRecord, JSTokenType token, JSTextPosition endPosition)
+void Lexer<T>::fillTokenInfo(JSToken* tokenRecord, JSTextPosition endPosition)
 {
     tokenRecord->m_endPosition = endPosition;
-    m_lastToken = token;
 }
 
 template <typename T>
@@ -2009,7 +2006,7 @@ JSTokenType Lexer<T>::lexWithoutClearingLineTerminator(JSToken* tokenRecord, Opt
 {
     JSTokenData* tokenData = &tokenRecord->m_data;
     ASSERT(!m_error);
-    m_lastTokenLocation = tokenRecord->location();
+
     ASSERT(m_buffer8.isEmpty());
     ASSERT(m_buffer16.isEmpty());
     JSTokenType token = ERRORTOK;
@@ -2021,12 +2018,6 @@ start:
     tokenRecord->m_startPosition = currentPosition();
 
     Latin1Character type = m_current;
-
-    if (atEnd()) {
-        token = EOFTOK;
-        goto returnToken;
-    }
-
     if constexpr (!std::is_same_v<T, Latin1Character>) {
         if (!isLatin1(m_current)) [[unlikely]] {
             char32_t codePoint;
@@ -2216,7 +2207,7 @@ start:
             m_lexErrorMessage = "Multiline comment was not closed properly"_s;
             token = UNTERMINATED_MULTILINE_COMMENT_ERRORTOK;
             m_error = true;
-            fillTokenInfo(tokenRecord, token, currentPosition());
+            fillTokenInfo(tokenRecord, currentPosition());
             return token;
         }
         if (m_current == '=') {
@@ -2674,13 +2665,13 @@ start:
         if (result != StringParsedSuccessfully) [[unlikely]] {
             token = result == StringUnterminated ? UNTERMINATED_STRING_LITERAL_ERRORTOK : INVALID_STRING_LITERAL_ERRORTOK;
             m_error = true;
-            fillTokenInfo(tokenRecord, token, currentPosition());
+            fillTokenInfo(tokenRecord, currentPosition());
             return token;
         }
         shift();
         token = STRING;
         m_atLineStart = false;
-        fillTokenInfo(tokenRecord, token, currentPosition());
+        fillTokenInfo(tokenRecord, currentPosition());
         return token;
     }
 
@@ -2889,7 +2880,6 @@ start:
     }
 
     case 183 /* 183 = Po category      CharacterOtherIdentifierPart */:
-    case   0 /*   0 = Null             CharacterInvalid */:
     case   1 /*   1 = Start of Heading CharacterInvalid */:
     case   2 /*   2 = Start of Text    CharacterInvalid */:
     case   3 /*   3 = End of Text      CharacterInvalid */:
@@ -2980,6 +2970,14 @@ start:
     case 247 /* 247 = Sm category      CharacterInvalid */: {
         goto invalidCharacter;
     }
+
+    case   0 /*   0 = Null             CharacterInvalid */: {
+        if (atEnd()) {
+            token = EOFTOK;
+            goto returnToken;
+        }
+        goto invalidCharacter;
+    }
     }
 
     m_atLineStart = false;
@@ -3025,7 +3023,7 @@ inSingleLineComment:
         if (m_code == m_codeEnd) {
             m_current = 0;
             token = EOFTOK;
-            fillTokenInfo(tokenRecord, token, endPosition);
+            fillTokenInfo(tokenRecord, endPosition);
             return token;
         }
 
@@ -3033,16 +3031,16 @@ inSingleLineComment:
         shiftLineTerminator();
         m_atLineStart = true;
         m_hasLineTerminatorBeforeToken = true;
-        if (!lastTokenWasRestrKeyword())
+        if (!isRestrKeyword(tokenRecord->m_type))
             goto start;
 
         token = SEMICOLON;
-        fillTokenInfo(tokenRecord, token, endPosition);
+        fillTokenInfo(tokenRecord, endPosition);
         return token;
     }
 
 returnToken:
-    fillTokenInfo(tokenRecord, token, currentPosition());
+    fillTokenInfo(tokenRecord, currentPosition());
     return token;
 
 invalidCharacter:
@@ -3052,7 +3050,7 @@ invalidCharacter:
 
 returnError:
     m_error = true;
-    fillTokenInfo(tokenRecord, token, currentPosition());
+    fillTokenInfo(tokenRecord, currentPosition());
     RELEASE_ASSERT(token & CanBeErrorTokenFlag);
     return token;
 }
@@ -3090,7 +3088,7 @@ JSTokenType Lexer<T>::scanRegExp(JSToken* tokenRecord, char16_t patternPrefix)
         if (isLineTerminator(m_current) || atEnd()) {
             m_buffer16.shrink(0);
             JSTokenType token = UNTERMINATED_REGEXP_LITERAL_ERRORTOK;
-            fillTokenInfo(tokenRecord, token, currentPosition());
+            fillTokenInfo(tokenRecord, currentPosition());
             m_error = true;
             m_lexErrorMessage = makeString("Unterminated regular expression literal '"_s, getToken(*tokenRecord), '\'');
             return token;
@@ -3139,7 +3137,7 @@ JSTokenType Lexer<T>::scanRegExp(JSToken* tokenRecord, char16_t patternPrefix)
     if (!isLatin1(m_current) && !isWhiteSpace(m_current) && !isLineTerminator(m_current)) [[unlikely]] {
         m_buffer8.shrink(0);
         JSTokenType token = INVALID_IDENTIFIER_UNICODE_ERRORTOK;
-        fillTokenInfo(tokenRecord, token, currentPosition());
+        fillTokenInfo(tokenRecord, currentPosition());
         m_error = true;
         String codePoint = String::fromCodePoint(currentCodePoint());
         if (!codePoint)
@@ -3155,7 +3153,7 @@ JSTokenType Lexer<T>::scanRegExp(JSToken* tokenRecord, char16_t patternPrefix)
     m_atLineStart = false;
 
     JSTokenType token = REGEXP;
-    fillTokenInfo(tokenRecord, token, currentPosition());
+    fillTokenInfo(tokenRecord, currentPosition());
     return token;
 }
 
@@ -3178,7 +3176,7 @@ JSTokenType Lexer<T>::scanTemplateString(JSToken* tokenRecord, RawStringsBuildMo
 
     // Since TemplateString always ends with ` or }, m_atLineStart always becomes false.
     m_atLineStart = false;
-    fillTokenInfo(tokenRecord, token, currentPosition());
+    fillTokenInfo(tokenRecord, currentPosition());
     return token;
 }
 

--- a/Source/JavaScriptCore/parser/Lexer.h
+++ b/Source/JavaScriptCore/parser/Lexer.h
@@ -79,9 +79,7 @@ public:
         return JSTextPosition(m_lineNumber, currentOffset(), currentLineStartOffset());
     }
     JSTextPosition positionBeforeLastNewline() const { return m_positionBeforeLastNewline; }
-    JSTokenLocation lastTokenLocation() const { return m_lastTokenLocation; }
-    void setLastLineNumber(int lastLineNumber) { m_lastLineNumber = lastLineNumber; }
-    int lastLineNumber() const { return m_lastLineNumber; }
+
     bool hasLineTerminatorBeforeToken() const { return m_hasLineTerminatorBeforeToken; }
     JSTokenType scanRegExp(JSToken*, char16_t patternPrefix = 0);
     enum class RawStringsBuildMode { BuildRawStrings, DontBuildRawStrings };
@@ -174,8 +172,6 @@ private:
     ALWAYS_INLINE const Identifier* makeRightSizedIdentifier(std::span<const char16_t>, char16_t orAllChars);
     ALWAYS_INLINE const Identifier* makeEmptyIdentifier();
 
-    ALWAYS_INLINE bool lastTokenWasRestrKeyword() const;
-    
     ALWAYS_INLINE void skipWhitespace();
 
     template <int shiftAmount> void internalShift();
@@ -209,12 +205,11 @@ private:
     template <unsigned length>
     ALWAYS_INLINE bool consume(const char (&input)[length]);
 
-    void fillTokenInfo(JSToken*, JSTokenType, JSTextPosition endPosition);
+    void fillTokenInfo(JSToken*, JSTextPosition endPosition);
 
     static constexpr size_t initialReadBufferCapacity = 32;
 
-    // Hot fields, grouped to share a cache line. Depending on sizeof(T),
-    // the line may or may not include m_lastLineNumber.
+    // Hot fields, grouped to share a cache line.
     VM& m_vm;
     IdentifierArena* m_arena;
     const T* m_code;
@@ -222,14 +217,12 @@ private:
     const T* m_codeEnd;
     const T* m_lineStart;
     int m_lineNumber;
-    int m_lastToken;
     T m_current;
     bool m_hasLineTerminatorBeforeToken;
     bool m_atLineStart;
     bool m_parsingBuiltinFunction;
-    int m_lastLineNumber;
 
-    JSTokenLocation m_lastTokenLocation;
+
     JSTextPosition m_positionBeforeLastNewline;
     JSParserScriptMode m_scriptMode;
     Vector<Latin1Character> m_buffer8;
@@ -402,7 +395,6 @@ ALWAYS_INLINE JSTokenType Lexer<T>::lexExpectIdentifier(JSToken* tokenRecord, Op
     }
 #endif
 
-    m_lastToken = IDENT;
     return IDENT;
     
 slowCase:

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -558,7 +558,7 @@ template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseGenerato
     info.parametersStartColumn = startColumn;
 
     auto functionExpr = context.createGeneratorFunctionBody(startLocation, info, name);
-    auto statement = context.createExprStatement(startLocation, functionExpr, start, m_lastTokenEndPosition.line);
+    auto statement = context.createExprStatement(startLocation, functionExpr, start, m_lastTokenLocation.line);
     context.appendStatement(sourceElements, statement);
 
     return sourceElements;
@@ -647,7 +647,7 @@ template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseAsyncFun
     info.parametersStartColumn = startColumn;
 
     auto functionExpr = context.createAsyncFunctionBody(startLocation, info, bodyParseMode, calleeName);
-    auto statement = context.createExprStatement(startLocation, functionExpr, start, m_lastTokenEndPosition.line);
+    auto statement = context.createExprStatement(startLocation, functionExpr, start, m_lastTokenLocation.line);
     context.appendStatement(sourceElements, statement);
 
     return sourceElements;
@@ -701,7 +701,7 @@ template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseAsyncGen
     info.parametersStartColumn = startColumn;
 
     auto functionExpr = context.createAsyncFunctionBody(startLocation, info, parseMode, calleeName);
-    auto statement = context.createExprStatement(startLocation, functionExpr, start, m_lastTokenEndPosition.line);
+    auto statement = context.createExprStatement(startLocation, functionExpr, start, m_lastTokenLocation.line);
     context.appendStatement(sourceElements, statement);
         
     return sourceElements;
@@ -730,7 +730,7 @@ template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseSingleFu
     }
 
     if (statement) {
-        context.setEndOffset(statement, m_lastTokenEndPosition.offset);
+        context.setEndOffset(statement, m_lastTokenLocation.endOffset);
         context.appendStatement(sourceElements, statement);
     }
 
@@ -866,7 +866,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseStatementList
 
     if (result) {
         if (shouldSetEndOffset)
-            context.setEndOffset(result, m_lastTokenEndPosition.offset);
+            context.setEndOffset(result, m_lastTokenLocation.endOffset);
         if (shouldSetPauseLocation)
             recordPauseLocation(context.breakpointLocation(result));
     }
@@ -1161,13 +1161,13 @@ template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseArrowFun
     TreeExpression expr = parseAssignmentExpression(context);
     failIfFalse(expr, "Cannot parse the arrow function expression");
     
-    context.setEndOffset(expr, m_lastTokenEndPosition.offset);
+    context.setEndOffset(expr, m_lastTokenLocation.endOffset);
 
     JSTextPosition end = tokenEndPosition();
     
     TreeSourceElements sourceElements = context.createSourceElements();
     TreeStatement body = context.createReturnStatement(location, expr, start, end);
-    context.setEndOffset(body, m_lastTokenEndPosition.offset);
+    context.setEndOffset(body, m_lastTokenLocation.endOffset);
     recordPauseLocation(context.breakpointLocation(body));
     context.appendStatement(sourceElements, body);
 
@@ -1984,7 +1984,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseTryStatement(
     tryBlock = parseBlockStatement(context);
     failIfFalse(tryBlock, "Cannot parse the body of try block");
     bool tryBlockContainsReturn = m_parserState.returnStatementCount != returnStatementCountBeforeTryBlock;
-    int lastLine = m_lastTokenEndPosition.line;
+    int lastLine = m_lastTokenLocation.line;
     VariableEnvironment catchEnvironment; 
     DeclarationStacks::FunctionStack functionStack;
     if (consume(CATCH)) {
@@ -2099,7 +2099,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseBlockStatemen
         next();
         if (shouldPushLexicalScope)
             std::tie(lexicalEnvironment, functionStack) = popScope(lexicalScope, TreeBuilder::NeedsFreeVariableInfo);
-        TreeStatement result = context.createBlockStatement(location, 0, start, m_lastTokenEndPosition.line, WTF::move(lexicalEnvironment), WTF::move(functionStack));
+        TreeStatement result = context.createBlockStatement(location, 0, start, m_lastTokenLocation.line, WTF::move(lexicalEnvironment), WTF::move(functionStack));
         context.setStartOffset(result, startOffset);
         context.setEndOffset(result, endOffset);
         return result;
@@ -2111,7 +2111,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseBlockStatemen
     next();
     if (shouldPushLexicalScope)
         std::tie(lexicalEnvironment, functionStack) = popScope(lexicalScope, TreeBuilder::NeedsFreeVariableInfo);
-    TreeStatement result = context.createBlockStatement(location, subtree, start, m_lastTokenEndPosition.line, WTF::move(lexicalEnvironment), WTF::move(functionStack));
+    TreeStatement result = context.createBlockStatement(location, subtree, start, m_lastTokenLocation.line, WTF::move(lexicalEnvironment), WTF::move(functionStack));
     context.setStartOffset(result, startOffset);
     context.setEndOffset(result, endOffset);
     return result;
@@ -2229,7 +2229,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseStatement(Tre
 
     if (result) {
         if (shouldSetEndOffset)
-            context.setEndOffset(result, m_lastTokenEndPosition.offset);
+            context.setEndOffset(result, m_lastTokenLocation.endOffset);
         if (shouldSetPauseLocation)
             recordPauseLocation(context.breakpointLocation(result));
     }
@@ -2266,7 +2266,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseFunctionDecla
     TreeSourceElements sourceElements = context.createSourceElements();
     context.appendStatement(sourceElements, function);
     auto [lexicalEnvironment, functionDeclarations] = popScope(blockScope, TreeBuilder::NeedsFreeVariableInfo);
-    return context.createBlockStatement(location, sourceElements, start, m_lastTokenEndPosition.line, WTF::move(lexicalEnvironment), WTF::move(functionDeclarations));
+    return context.createBlockStatement(location, sourceElements, start, m_lastTokenLocation.line, WTF::move(lexicalEnvironment), WTF::move(functionDeclarations));
 }
 
 template <typename LexerType>
@@ -2666,7 +2666,7 @@ template <class TreeBuilder> bool Parser<LexerType>::parseFunctionInfo(TreeBuild
                 next();
                 break;
             }
-            functionInfo.endLine = m_lastTokenEndPosition.line;
+            functionInfo.endLine = m_lastTokenLocation.line;
             return true;
         }
 
@@ -2909,7 +2909,7 @@ template <class TreeBuilder> bool Parser<LexerType>::parseFunctionInfo(TreeBuild
     if (newInfo)
         m_functionCache->add(functionInfo.startOffset, WTF::move(newInfo));
     
-    functionInfo.endLine = m_lastTokenEndPosition.line;
+    functionInfo.endLine = m_lastTokenLocation.line;
     return true;
 }
 
@@ -3446,7 +3446,14 @@ template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseClassFie
 
         TreeStatement statement;
         if (definition.kind == Kind::StaticInitializationBlock) {
-            restoreLexerState(LexerState { position.offset, static_cast<unsigned>(position.lineStartOffset), static_cast<unsigned>(position.line), static_cast<unsigned>(position.line), hasLineTerminatorBeforeToken });
+            {
+                JSTokenLocation loc;
+                loc.line = position.line;
+                loc.lineStartOffset = position.lineStartOffset;
+                loc.startOffset = position.offset;
+                loc.endOffset = position.offset;
+                restoreLexerState(LexerState { position.offset, static_cast<unsigned>(position.lineStartOffset), loc, static_cast<unsigned>(position.line), hasLineTerminatorBeforeToken, ERRORTOK });
+            }
             JSTokenLocation startLocation(tokenLocation());
             JSTextPosition startPosition = tokenStartPosition();
             unsigned expressionStart = tokenStart();
@@ -3461,7 +3468,7 @@ template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseClassFie
             TreeExpression expression = context.createFunctionExpr(startLocation, functionInfo);
 
             expression = context.makeStaticBlockFunctionCallNode(startLocation, expression, lastTokenEndPosition(), startPosition, lastTokenEndPosition());
-            statement = context.createExprStatement(startLocation, expression, startPosition, m_lastTokenEndPosition.line);
+            statement = context.createExprStatement(startLocation, expression, startPosition, m_lastTokenLocation.line);
         } else {
             JSTokenLocation location;
             location.line = position.line;
@@ -3470,7 +3477,14 @@ template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseClassFie
 
             TreeExpression initializer = 0;
             if (auto initializerPosition = definition.initializerPosition) {
-                restoreLexerState(LexerState { initializerPosition->offset, static_cast<unsigned>(initializerPosition->lineStartOffset), static_cast<unsigned>(initializerPosition->line), static_cast<unsigned>(initializerPosition->line), hasLineTerminatorBeforeToken });
+                {
+                    JSTokenLocation loc;
+                    loc.line = initializerPosition->line;
+                    loc.lineStartOffset = initializerPosition->lineStartOffset;
+                    loc.startOffset = initializerPosition->offset;
+                    loc.endOffset = initializerPosition->offset;
+                    restoreLexerState(LexerState { initializerPosition->offset, static_cast<unsigned>(initializerPosition->lineStartOffset), loc, static_cast<unsigned>(initializerPosition->line), hasLineTerminatorBeforeToken, ERRORTOK });
+                }
                 // parseExpression() is more permissive way to parse AssignmentExpression than parseAssignmentExpression() that is used in parseClass().
                 // This is very intentional: we need to fail for `foo = 1, 2` but support reparsing `foo = (1, 2)`, which is tricky because open paren
                 // is skipped (meaning start offset points to `1`) by parsePrimaryExpression().
@@ -3608,7 +3622,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseExpressionSta
     failIfFalse(expression, "Cannot parse expression statement");
     if (!autoSemiColon()) [[unlikely]]
         failDueToUnexpectedToken();
-    return context.createExprStatement(location, expression, start, m_lastTokenEndPosition.line);
+    return context.createExprStatement(location, expression, start, m_lastTokenLocation.line);
 }
 
 template <typename LexerType>
@@ -4212,7 +4226,7 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseExpression(T
     JSTokenLocation headLocation(tokenLocation());
     TreeExpression node = parseAssignmentExpression(context);
     failIfFalse(node, "Cannot parse expression");
-    context.setEndOffset(node, m_lastTokenEndPosition.offset);
+    context.setEndOffset(node, m_lastTokenLocation.endOffset);
     if (!match(COMMA))
         return node;
     recordPauseLocation(context.breakpointLocation(node));
@@ -4223,7 +4237,7 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseExpression(T
     TreeExpression right = parseAssignmentExpression(context);
     failIfFalse(right, "Cannot parse expression in a comma expression");
     recordPauseLocation(context.breakpointLocation(right));
-    context.setEndOffset(right, m_lastTokenEndPosition.offset);
+    context.setEndOffset(right, m_lastTokenLocation.endOffset);
     typename TreeBuilder::Comma head = context.createCommaExpr(headLocation, node);
     typename TreeBuilder::Comma tail = context.appendToCommaExpr(tailLocation, head, right);
     while (match(COMMA)) {
@@ -4231,11 +4245,11 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseExpression(T
         tailLocation = tokenLocation();
         right = parseAssignmentExpression(context);
         failIfFalse(right, "Cannot parse expression in a comma expression");
-        context.setEndOffset(right, m_lastTokenEndPosition.offset);
+        context.setEndOffset(right, m_lastTokenLocation.endOffset);
         recordPauseLocation(context.breakpointLocation(right));
         tail = context.appendToCommaExpr(tailLocation, tail, right);
     }
-    context.setEndOffset(head, m_lastTokenEndPosition.offset);
+    context.setEndOffset(head, m_lastTokenLocation.endOffset);
     return head;
 }
 
@@ -4492,12 +4506,12 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseConditionalE
         lhs = parseAssignmentExpression(context);
     }
     failIfFalse(lhs, "Cannot parse left hand side of ternary operator");
-    context.setEndOffset(lhs, m_lastTokenEndPosition.offset);
+    context.setEndOffset(lhs, m_lastTokenLocation.endOffset);
     consumeOrFailWithFlags(COLON, TreeBuilder::DontBuildStrings, "Expected ':' in ternary operator");
     
     TreeExpression rhs = parseAssignmentExpression(context);
     failIfFalse(rhs, "Cannot parse right hand side of ternary operator");
-    context.setEndOffset(rhs, m_lastTokenEndPosition.offset);
+    context.setEndOffset(rhs, m_lastTokenLocation.endOffset);
     return context.createConditionalExpr(location, cond, lhs, rhs);
 }
 
@@ -4774,7 +4788,7 @@ namedProperty:
         next();
         TreeExpression elem = parseAssignmentExpression(context);
         failIfFalse(elem, "Cannot parse subject of a spread operation");
-        auto node = context.createObjectSpreadExpression(spreadLocation, elem, start, divot, m_lastTokenEndPosition);
+        auto node = context.createObjectSpreadExpression(spreadLocation, elem, start, divot, lastTokenEndPosition());
         return context.createProperty(node, PropertyNode::Spread, SuperBinding::NotNeeded, ClassElementTag::No);
     }
     default:
@@ -4949,7 +4963,7 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseArrayLiteral
         next();
         auto spreadExpr = parseAssignmentExpression(context);
         failIfFalse(spreadExpr, "Cannot parse subject of a spread operation");
-        elem = context.createSpreadExpression(spreadLocation, spreadExpr, start, divot, m_lastTokenEndPosition);
+        elem = context.createSpreadExpression(spreadLocation, spreadExpr, start, divot, lastTokenEndPosition());
     } else
         elem = parseAssignmentExpression(context);
     failIfFalse(elem, "Cannot parse array literal element");
@@ -4973,7 +4987,7 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseArrayLiteral
             next();
             TreeExpression elem = parseAssignmentExpression(context);
             failIfFalse(elem, "Cannot parse subject of a spread operation");
-            auto spread = context.createSpreadExpression(spreadLocation, elem, start, divot, m_lastTokenEndPosition);
+            auto spread = context.createSpreadExpression(spreadLocation, elem, start, divot, lastTokenEndPosition());
             tail = context.createElementList(tail, elisions, spread);
             continue;
         }
@@ -5345,7 +5359,7 @@ template <class TreeBuilder> TreeArguments Parser<LexerType>::parseArguments(Tre
 
     handleProductionOrFail2(CLOSEPAREN, ")", "end", "argument list");
     if (hasSpread) {
-        TreeExpression spreadArray = context.createSpreadExpression(location, context.createArray(location, context.createElementList(argList)), argumentsStart, argumentsDivot, m_lastTokenEndPosition);
+        TreeExpression spreadArray = context.createSpreadExpression(location, context.createArray(location, context.createElementList(argList)), argumentsStart, argumentsDivot, lastTokenEndPosition());
         return context.createArguments(context.createArgumentsList(location, spreadArray), initialAssignments != m_parserState.assignmentCount);
     }
 
@@ -5362,7 +5376,7 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseArgument(Tre
         next();
         TreeExpression spreadExpr = parseAssignmentExpression(context);
         propagateError();
-        auto end = m_lastTokenEndPosition;
+        auto end = lastTokenEndPosition();
         type = ArgumentType::Spread;
         return context.createSpreadExpression(spreadLocation, spreadExpr, start, divot, end);
     }

--- a/Source/JavaScriptCore/parser/Parser.h
+++ b/Source/JavaScriptCore/parser/Parser.h
@@ -1051,7 +1051,7 @@ public:
     void overrideConstructorKindForTopLevelFunctionExpressions(ConstructorKind constructorKind) { m_constructorKindForTopLevelFunctionExpressions = constructorKind; }
 
     JSTextPosition positionBeforeLastNewline() const { return m_lexer->positionBeforeLastNewline(); }
-    JSTokenLocation locationBeforeLastToken() const { return m_lexer->lastTokenLocation(); }
+    JSTokenLocation locationBeforeLastToken() const { return m_lastTokenLocation; }
 
     struct CallOrApplyDepthScope {
         CallOrApplyDepthScope(Parser* parser)
@@ -1494,9 +1494,10 @@ private:
     struct LexerState {
         int startOffset;
         unsigned oldLineStartOffset;
-        unsigned oldLastLineNumber;
+        JSTokenLocation lastTokenLocation;
         unsigned oldLineNumber;
         bool hasLineTerminatorBeforeToken;
+        JSTokenType lastTokenType;
     };
 
     struct SavePoint {
@@ -1516,31 +1517,22 @@ private:
 
     ALWAYS_INLINE void next(OptionSet<LexerFlags> lexerFlags = { })
     {
-        int lastLine = m_token.m_startPosition.line;
-        int lastTokenEnd = m_token.m_endPosition.offset;
-        int lastTokenLineStart = m_token.m_startPosition.lineStartOffset;
-        m_lastTokenEndPosition = JSTextPosition(lastLine, lastTokenEnd, lastTokenLineStart);
-        m_lexer->setLastLineNumber(lastLine);
+        m_lastTokenLocation = m_token.location();
+        m_lastTokenType = m_token.m_type;
         m_token.m_type = m_lexer->lex(&m_token, lexerFlags, strictMode());
     }
 
     ALWAYS_INLINE void nextWithoutClearingLineTerminator(OptionSet<LexerFlags> lexerFlags = { })
     {
-        int lastLine = m_token.m_startPosition.line;
-        int lastTokenEnd = m_token.m_endPosition.offset;
-        int lastTokenLineStart = m_token.m_startPosition.lineStartOffset;
-        m_lastTokenEndPosition = JSTextPosition(lastLine, lastTokenEnd, lastTokenLineStart);
-        m_lexer->setLastLineNumber(lastLine);
+        m_lastTokenLocation = m_token.location();
+        m_lastTokenType = m_token.m_type;
         m_token.m_type = m_lexer->lexWithoutClearingLineTerminator(&m_token, lexerFlags, strictMode());
     }
 
     ALWAYS_INLINE void nextExpectIdentifier(OptionSet<LexerFlags> lexerFlags = { })
     {
-        int lastLine = m_token.m_startPosition.line;
-        int lastTokenEnd = m_token.m_endPosition.offset;
-        int lastTokenLineStart = m_token.m_startPosition.lineStartOffset;
-        m_lastTokenEndPosition = JSTextPosition(lastLine, lastTokenEnd, lastTokenLineStart);
-        m_lexer->setLastLineNumber(lastLine);
+        m_lastTokenLocation = m_token.location();
+        m_lastTokenType = m_token.m_type;
         m_token.m_type = m_lexer->lexExpectIdentifier(&m_token, lexerFlags, strictMode());
     }
 
@@ -1849,9 +1841,9 @@ private:
         return m_vm.isSafeToRecurse();
     }
     
-    const JSTextPosition& lastTokenEndPosition() const
+    JSTextPosition lastTokenEndPosition() const
     {
-        return m_lastTokenEndPosition;
+        return JSTextPosition(m_lastTokenLocation.line, m_lastTokenLocation.endOffset, m_lastTokenLocation.lineStartOffset);
     }
 
     bool hasError() const
@@ -1988,9 +1980,14 @@ private:
         LexerState result;
         result.startOffset = m_token.m_startPosition.offset;
         result.oldLineStartOffset = m_token.m_startPosition.lineStartOffset;
-        result.oldLastLineNumber = m_lexer->lastLineNumber();
-        result.oldLineNumber = m_lexer->lineNumber();
+        result.lastTokenLocation = m_lastTokenLocation;
+        result.oldLineNumber = m_token.m_startPosition.line;
+        // Why is this reading from Lexer fine while we are re-lexing the same token?
+        // This is because this flag is updated and indicating whether we have a line
+        // terminator before the lexed token, and based on that, we already moved startOffset.
+        // So getting this flag and setting it before lexing this token is right.
         result.hasLineTerminatorBeforeToken = m_lexer->hasLineTerminatorBeforeToken();
+        result.lastTokenType = m_lastTokenType;
         ASSERT(static_cast<unsigned>(result.startOffset) >= result.oldLineStartOffset);
         return result;
     }
@@ -2001,8 +1998,13 @@ private:
         m_lexer->setOffset(lexerState.startOffset, lexerState.oldLineStartOffset);
         m_lexer->setLineNumber(lexerState.oldLineNumber);
         m_lexer->setHasLineTerminatorBeforeToken(lexerState.hasLineTerminatorBeforeToken);
+        m_lastTokenType = lexerState.lastTokenType;
+        m_token.m_type = lexerState.lastTokenType;
+        m_token.m_startPosition.line = lexerState.lastTokenLocation.line;
+        m_token.m_startPosition.offset = lexerState.lastTokenLocation.startOffset;
+        m_token.m_startPosition.lineStartOffset = lexerState.lastTokenLocation.lineStartOffset;
+        m_token.m_endPosition.offset = lexerState.lastTokenLocation.endOffset;
         nextWithoutClearingLineTerminator();
-        m_lexer->setLastLineNumber(lexerState.oldLastLineNumber);
     }
 
     template <class TreeBuilder>
@@ -2061,7 +2063,8 @@ private:
     // Cache line 0 (hot)
     VM& m_vm;
     Scope* m_currentScope { nullptr };
-    JSTextPosition m_lastTokenEndPosition;
+    JSTokenLocation m_lastTokenLocation;
+    JSTokenType m_lastTokenType { ERRORTOK };
     bool m_allowsIn;
     bool m_immediateParentAllowsFunctionDeclarationInStatement;
     SourceParseMode m_parseMode;


### PR DESCRIPTION
#### a3940a0dde85b0183291661097506d5c96e249b5
<pre>
[JSC] Do not store m_lastToken
<a href="https://bugs.webkit.org/show_bug.cgi?id=310436">https://bugs.webkit.org/show_bug.cgi?id=310436</a>
<a href="https://rdar.apple.com/173075815">rdar://173075815</a>

Reviewed by Yijia Huang.

Remove m_lastToken and m_lastLineNumber from the Lexer — they were purely
Parser-managed state. Replace them with m_lastTokenType and m_lastTokenLocation
in the Parser, set consistently in the three next() variants before re-lexing.

This also fixes a staleness bug in restoreLexerState(): nextWithoutClearingLineTerminator()
was reading m_token.location() to set m_lastTokenLocation, but m_token had
not yet been re-lexed. The old code only patched m_lastLineNumber afterward,
leaving the rest of m_lastTokenLocation stale. Now we save the full
m_lastTokenLocation and m_lastTokenType in LexerState, and restore them
into m_token&apos;s position fields before re-lexing so the natural flow in
nextWithoutClearingLineTerminator() produces correct values.

Additionally, m_lastTokenEndPosition (a JSTextPosition) is replaced by
deriving it on demand from m_lastTokenLocation, and LexerState::oldLineNumber
is now saved from m_token.m_startPosition.line instead of m_lexer-&gt;lineNumber()
to stay consistent with setOffset repositioning to the token start.

* Source/JavaScriptCore/parser/Lexer.cpp:
(JSC::Lexer&lt;T&gt;::setCode):
(JSC::isRestrKeyword):
(JSC::Lexer&lt;T&gt;::fillTokenInfo):
(JSC::Lexer&lt;T&gt;::lexWithoutClearingLineTerminator):
(JSC::Lexer&lt;T&gt;::scanRegExp):
(JSC::Lexer&lt;T&gt;::scanTemplateString):
(JSC::Lexer&lt;T&gt;::lastTokenWasRestrKeyword const):
* Source/JavaScriptCore/parser/Lexer.h:
(JSC::Lexer&lt;T&gt;::lexExpectIdentifier):
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseGeneratorFunctionSourceElements):
(JSC::Parser&lt;LexerType&gt;::parseAsyncFunctionSourceElements):
(JSC::Parser&lt;LexerType&gt;::parseAsyncGeneratorFunctionSourceElements):
(JSC::Parser&lt;LexerType&gt;::parseSingleFunction):
(JSC::Parser&lt;LexerType&gt;::parseStatementListItem):
(JSC::Parser&lt;LexerType&gt;::parseArrowFunctionSingleExpressionBodySourceElements):
(JSC::Parser&lt;LexerType&gt;::parseTryStatement):
(JSC::Parser&lt;LexerType&gt;::parseBlockStatement):
(JSC::Parser&lt;LexerType&gt;::parseStatement):
(JSC::Parser&lt;LexerType&gt;::parseFunctionDeclarationStatement):
(JSC::Parser&lt;LexerType&gt;::parseFunctionInfo):
(JSC::Parser&lt;LexerType&gt;::parseClassFieldInitializerSourceElements):
(JSC::Parser&lt;LexerType&gt;::parseExpressionStatement):
(JSC::Parser&lt;LexerType&gt;::parseExpression):
(JSC::Parser&lt;LexerType&gt;::parseConditionalExpression):
(JSC::Parser&lt;LexerType&gt;::parseProperty):
(JSC::Parser&lt;LexerType&gt;::parseArrayLiteral):
(JSC::Parser&lt;LexerType&gt;::parseArguments):
(JSC::Parser&lt;LexerType&gt;::parseArgument):
* Source/JavaScriptCore/parser/Parser.h:

Canonical link: <a href="https://commits.webkit.org/309799@main">https://commits.webkit.org/309799@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d9e35beef2b61301d5f17bd6a3ea3ca300fbff5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151802 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24583 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/18153 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160544 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25076 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24878 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/117251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154762 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/136220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/97966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/18498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/16437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8379 "Failed to checkout and rebase branch from PR 61080") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/143807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/14123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163008 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/12603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/6157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/15715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/125271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/24382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/20496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/125452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/24383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/135919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/80958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23301 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/24383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/12694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/183413 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23999 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/88285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/46782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/23691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/23851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/23751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->