### PR TITLE
[JSC][WASM][Debugger] Implement interleaved WASM/JS call stack collection

### DIFF
--- a/JSTests/wasm/debugger/resources/wasm/js-js-wasm-js-js-wasm.js
+++ b/JSTests/wasm/debugger/resources/wasm/js-js-wasm-js-js-wasm.js
@@ -1,0 +1,99 @@
+// Test case for deeply interleaved JS->JS->WASM->JS->JS->WASM call stack.
+// Exercises multiple JS frames on each side (DFG inlined + non-inlined) together
+// with the WasmToJS trampoline peek and JSToWasm trampoline skip.
+//
+// Call chain: JS main -> js_a -> js_b -> test[WASM] -> callback -> js_c -> wasm_inner[WASM]
+//
+// Function index mapping:
+//   0: imported js.callback (JS)
+//   1: test       (WASM, exported) — calls js.callback
+//   2: wasm_inner (WASM, exported) — nop, breakpoint target
+//
+// Expected bt at 0x4000000000000045:
+//   frame #0: 0x4000000000000045   (wasm_inner nop — breakpoint)
+//   frame #1: 0xc000000000000000   (js_c)
+//   frame #2: 0xc000000000000000   (callback)
+//   frame #3: 0x4000000000000042   (test call-site return PC — after 'call 0' at 0x40)
+//   frame #4: 0xc000000000000000   (js_b)
+//   frame #5: 0xc000000000000000   (js_a)
+//   frame #6: 0xc000000000000000   (JS main loop)
+var wasm = new Uint8Array([
+    // [0x00] WASM header
+    0x00, 0x61, 0x73, 0x6d, // magic
+    0x01, 0x00, 0x00, 0x00, // version
+
+    // [0x08] Type section: 1 type
+    0x01, 0x04,             // section id=1, size=4
+    0x01,                   // 1 type
+    0x60, 0x00, 0x00,       // type 0: (func [] -> [])
+
+    // [0x0e] Import section: js.callback
+    0x02, 0x0f,             // section id=2, size=15
+    0x01,                   // 1 import
+    0x02, 0x6a, 0x73,       // module name "js" (length=2)
+    0x08, 0x63, 0x61, 0x6c, 0x6c, 0x62, 0x61, 0x63, 0x6b, // field name "callback" (length=8)
+    0x00, 0x00,             // import kind: function, type index 0
+
+    // [0x1f] Function section: 2 WASM functions (both type 0)
+    0x03, 0x03,             // section id=3, size=3
+    0x02,                   // 2 functions
+    0x00, 0x00,             // both type 0
+
+    // [0x24] Export section: test (func 1), wasm_inner (func 2)
+    0x07, 0x15,             // section id=7, size=21
+    0x02,                   // 2 exports
+    0x04, 0x74, 0x65, 0x73, 0x74,                                   // name "test" (length=4)
+    0x00, 0x01,             // kind: function, index 1
+    0x0a, 0x77, 0x61, 0x73, 0x6d, 0x5f, 0x69, 0x6e, 0x6e, 0x65, 0x72, // name "wasm_inner" (length=10)
+    0x00, 0x02,             // kind: function, index 2
+
+    // [0x3b] Code section
+    0x0a, 0x0a,             // section id=10, size=10
+    0x02,                   // 2 functions
+
+    // [0x3e] Function 1 (test): calls js.callback
+    0x04,                   // body size=4
+    0x00,                   // 0 local declarations
+    0x10, 0x00,             // [0x40] call 0 (js.callback)
+    0x0b,                   // [0x42] end
+
+    // [0x43] Function 2 (wasm_inner): breakpoint target
+    0x03,                   // body size=3
+    0x00,                   // 0 local declarations
+    0x01,                   // [0x45] nop  <-- breakpoint
+    0x0b,                   // [0x46] end
+]);
+
+var wasm_inner_func;
+
+function js_c() {
+    wasm_inner_func();
+}
+
+function callback() {
+    js_c();
+}
+
+function js_b() {
+    test();
+}
+
+function js_a() {
+    js_b();
+}
+
+var module = new WebAssembly.Module(wasm);
+var instance = new WebAssembly.Instance(module, { js: { callback } });
+
+wasm_inner_func = instance.exports.wasm_inner;
+let test = instance.exports.test;
+
+let iteration = 0;
+for (;;) {
+    js_a();
+    iteration += 1;
+    if (iteration % 1e6 == 0)
+        print("iteration=", iteration);
+}
+
+// b 0x4000000000000045

--- a/JSTests/wasm/debugger/resources/wasm/js-wasm-js-wasm.js
+++ b/JSTests/wasm/debugger/resources/wasm/js-wasm-js-wasm.js
@@ -1,0 +1,81 @@
+// Test case for a JS->WASM->JS->WASM interleaved call stack.
+// Exercises the WasmToJS trampoline peek and JSToWasm trampoline skip.
+//
+// Function index mapping:
+//   0: imported js.callback (JS)
+//   1: test       (WASM, exported) — calls js.callback
+//   2: wasm_inner (WASM, exported) — nop, breakpoint target
+//
+// Expected bt at 0x4000000000000045:
+//   frame #0: 0x4000000000000045   (wasm_inner nop — breakpoint)
+//   frame #1: 0xc000000000000000   (JS callback)
+//   frame #2: 0x4000000000000042   (test call-site return PC — after 'call 0' at 0x40)
+//   frame #3: 0xc000000000000000   (JS main loop)
+var wasm = new Uint8Array([
+    // [0x00] WASM header
+    0x00, 0x61, 0x73, 0x6d, // magic
+    0x01, 0x00, 0x00, 0x00, // version
+
+    // [0x08] Type section: 1 type
+    0x01, 0x04,             // section id=1, size=4
+    0x01,                   // 1 type
+    0x60, 0x00, 0x00,       // type 0: (func [] -> [])
+
+    // [0x0e] Import section: js.callback
+    0x02, 0x0f,             // section id=2, size=15
+    0x01,                   // 1 import
+    0x02, 0x6a, 0x73,       // module name "js" (length=2)
+    0x08, 0x63, 0x61, 0x6c, 0x6c, 0x62, 0x61, 0x63, 0x6b, // field name "callback" (length=8)
+    0x00, 0x00,             // import kind: function, type index 0
+
+    // [0x1f] Function section: 2 WASM functions (both type 0)
+    0x03, 0x03,             // section id=3, size=3
+    0x02,                   // 2 functions
+    0x00, 0x00,             // both type 0
+
+    // [0x24] Export section: test (func 1), wasm_inner (func 2)
+    0x07, 0x15,             // section id=7, size=21
+    0x02,                   // 2 exports
+    0x04, 0x74, 0x65, 0x73, 0x74,                                   // name "test" (length=4)
+    0x00, 0x01,             // kind: function, index 1
+    0x0a, 0x77, 0x61, 0x73, 0x6d, 0x5f, 0x69, 0x6e, 0x6e, 0x65, 0x72, // name "wasm_inner" (length=10)
+    0x00, 0x02,             // kind: function, index 2
+
+    // [0x3b] Code section
+    0x0a, 0x0a,             // section id=10, size=10
+    0x02,                   // 2 functions
+
+    // [0x3e] Function 1 (test): calls js.callback
+    0x04,                   // body size=4
+    0x00,                   // 0 local declarations
+    0x10, 0x00,             // [0x40] call 0 (js.callback)
+    0x0b,                   // [0x42] end
+
+    // [0x43] Function 2 (wasm_inner): breakpoint target
+    0x03,                   // body size=3
+    0x00,                   // 0 local declarations
+    0x01,                   // [0x45] nop  <-- breakpoint
+    0x0b,                   // [0x46] end
+]);
+
+var wasm_inner_func;
+
+function callback() {
+    wasm_inner_func();
+}
+
+var module = new WebAssembly.Module(wasm);
+var instance = new WebAssembly.Instance(module, { js: { callback } });
+
+wasm_inner_func = instance.exports.wasm_inner;
+let test = instance.exports.test;
+
+let iteration = 0;
+for (;;) {
+    test();
+    iteration += 1;
+    if (iteration % 1e6 == 0)
+        print("iteration=", iteration);
+}
+
+// b 0x4000000000000045

--- a/JSTests/wasm/debugger/resources/wasm/wasm-js-wasm-js-wasm.js
+++ b/JSTests/wasm/debugger/resources/wasm/wasm-js-wasm-js-wasm.js
@@ -1,0 +1,105 @@
+// Test case for WASM→JS→WASM→JS→WASM triple-interleaved call stack.
+// Exercises two WasmToJS crossings, verifying that WasmToJSIPIntReturnPCSlot is read
+// from the correct WasmToJS trampoline frame at each crossing.
+//
+// Call chain: JS main → test_outer[W] → js_mid_outer[JS] → test_mid[W] → js_mid_inner[JS] → wasm_inner[W]
+//
+// Function index mapping:
+//   0: imported js.mid_outer (JS)
+//   1: imported js.mid_inner (JS)
+//   2: test_outer  (WASM, exported) — calls mid_outer (import 0)
+//   3: test_mid    (WASM, exported) — calls mid_inner (import 1)
+//   4: wasm_inner  (WASM, exported) — nop, breakpoint target
+//
+// Expected bt at 0x400000000000006c:
+//   frame #0: 0x400000000000006c   (wasm_inner nop — breakpoint)
+//   frame #1: 0xc000000000000000   (JS js_mid_inner frame)
+//   frame #2: 0x4000000000000069   (test_mid return PC, after 'call mid_inner' at 0x67 — from WasmToJSIPIntReturnPCSlot in WasmToJS frame)
+//   frame #3: 0xc000000000000000   (JS js_mid_outer frame)
+//   frame #4: 0x4000000000000064   (test_outer return PC, after 'call mid_outer' at 0x62 — from WasmToJSIPIntReturnPCSlot in WasmToJS frame)
+//   frame #5: 0xc000000000000000   (JS main loop)
+var wasm = new Uint8Array([
+    // [0x00] WASM header
+    0x00, 0x61, 0x73, 0x6d, // magic
+    0x01, 0x00, 0x00, 0x00, // version
+
+    // [0x08] Type section: 1 type (func [] -> [])
+    0x01, 0x04,             // section id=1, size=4
+    0x01,                   // 1 type
+    0x60, 0x00, 0x00,       // type 0: (func [] -> [])
+
+    // [0x0e] Import section: js.mid_outer, js.mid_inner
+    0x02, 0x1f,             // section id=2, size=31
+    0x02,                   // 2 imports
+    0x02, 0x6a, 0x73,       // module name "js" (length=2)
+    0x09, 0x6d, 0x69, 0x64, 0x5f, 0x6f, 0x75, 0x74, 0x65, 0x72, // field "mid_outer" (length=9)
+    0x00, 0x00,             // import kind: function, type index 0
+    0x02, 0x6a, 0x73,       // module name "js" (length=2)
+    0x09, 0x6d, 0x69, 0x64, 0x5f, 0x69, 0x6e, 0x6e, 0x65, 0x72, // field "mid_inner" (length=9)
+    0x00, 0x00,             // import kind: function, type index 0
+
+    // [0x2f] Function section: 3 WASM functions (indices 2–4, all type 0)
+    0x03, 0x04,             // section id=3, size=4
+    0x03,                   // 3 functions
+    0x00, 0x00, 0x00,       // all type 0
+
+    // [0x35] Export section: test_outer (func 2), test_mid (func 3), wasm_inner (func 4)
+    0x07, 0x26,             // section id=7, size=38
+    0x03,                   // 3 exports
+    0x0a, 0x74, 0x65, 0x73, 0x74, 0x5f, 0x6f, 0x75, 0x74, 0x65, 0x72, // name "test_outer" (length=10)
+    0x00, 0x02,             // kind: function, index 2
+    0x08, 0x74, 0x65, 0x73, 0x74, 0x5f, 0x6d, 0x69, 0x64, // name "test_mid" (length=8)
+    0x00, 0x03,             // kind: function, index 3
+    0x0a, 0x77, 0x61, 0x73, 0x6d, 0x5f, 0x69, 0x6e, 0x6e, 0x65, 0x72, // name "wasm_inner" (length=10)
+    0x00, 0x04,             // kind: function, index 4
+
+    // [0x5d] Code section
+    0x0a, 0x0f,             // section id=10, size=15
+    0x03,                   // 3 function bodies
+
+    // [0x60] Function 2 (test_outer): calls mid_outer (import 0)
+    0x04,                   // body size=4
+    0x00,                   // 0 local declarations
+    0x10, 0x00,             // [0x62] call 0 (mid_outer)
+    0x0b,                   // [0x64] end  ← return PC in test_outer
+
+    // [0x65] Function 3 (test_mid): calls mid_inner (import 1)
+    0x04,                   // body size=4
+    0x00,                   // 0 local declarations
+    0x10, 0x01,             // [0x67] call 1 (mid_inner)
+    0x0b,                   // [0x69] end  ← return PC in test_mid
+
+    // [0x6a] Function 4 (wasm_inner): breakpoint target
+    0x03,                   // body size=3
+    0x00,                   // 0 local declarations
+    0x01,                   // [0x6c] nop  <-- breakpoint
+    0x0b,                   // [0x6d] end
+]);
+
+var test_mid_func;
+var wasm_inner_func;
+
+function js_mid_inner() {
+    wasm_inner_func();
+}
+
+function js_mid_outer() {
+    test_mid_func();
+}
+
+var module = new WebAssembly.Module(wasm);
+var instance = new WebAssembly.Instance(module, { js: { mid_outer: js_mid_outer, mid_inner: js_mid_inner } });
+
+test_mid_func = instance.exports.test_mid;
+wasm_inner_func = instance.exports.wasm_inner;
+let test_outer = instance.exports.test_outer;
+
+let iteration = 0;
+for (;;) {
+    test_outer();
+    iteration += 1;
+    if (iteration % 1e6 == 0)
+        print("iteration=", iteration);
+}
+
+// b 0x400000000000006c

--- a/JSTests/wasm/debugger/resources/wasm/wasm-wasm-js-wasm-wasm.js
+++ b/JSTests/wasm/debugger/resources/wasm/wasm-wasm-js-wasm-wasm.js
@@ -1,0 +1,101 @@
+// Test case for WASM→WASM→JS→WASM→WASM interleaved call stack.
+// Exercises IPInt callee tracking across a WASM→WASM hop on each side of a JS boundary.
+//
+// Call chain: JS main → test_a[W] → test_b[W] → mid_callback[JS] → test_c[W] → wasm_leaf[W]
+//
+// Function index mapping:
+//   0: imported js.mid_callback (JS)
+//   1: test_a      (WASM, exported) — calls test_b (func 2)
+//   2: test_b      (WASM)           — calls mid_callback (import 0)
+//   3: test_c      (WASM, exported) — calls wasm_leaf (func 4)
+//   4: wasm_leaf   (WASM, exported) — nop, breakpoint target
+//
+// Expected bt at 0x400000000000005f:
+//   frame #0: 0x400000000000005f   (wasm_leaf nop — breakpoint)
+//   frame #1: 0x400000000000005c   (test_c return PC, after 'call wasm_leaf' at 0x5a)
+//   frame #2: 0xc000000000000000   (JS mid_callback frame)
+//   frame #3: 0x4000000000000057   (test_b return PC, after 'call mid_callback' at 0x55 — from WasmToJSIPIntReturnPCSlot in WasmToJS frame)
+//   frame #4: 0x4000000000000052   (test_a return PC, after 'call test_b' at 0x50 — read from test_b−8)
+//   frame #5: 0xc000000000000000   (JS main loop)
+var wasm = new Uint8Array([
+    // [0x00] WASM header
+    0x00, 0x61, 0x73, 0x6d, // magic
+    0x01, 0x00, 0x00, 0x00, // version
+
+    // [0x08] Type section: 1 type (func [] -> [])
+    0x01, 0x04,             // section id=1, size=4
+    0x01,                   // 1 type
+    0x60, 0x00, 0x00,       // type 0: (func [] -> [])
+
+    // [0x0e] Import section: js.mid_callback
+    0x02, 0x13,             // section id=2, size=19
+    0x01,                   // 1 import
+    0x02, 0x6a, 0x73,       // module name "js" (length=2)
+    0x0c, 0x6d, 0x69, 0x64, 0x5f, 0x63, 0x61, 0x6c, 0x6c, 0x62, 0x61, 0x63, 0x6b, // field "mid_callback" (length=12)
+    0x00, 0x00,             // import kind: function, type index 0
+
+    // [0x23] Function section: 4 WASM functions (indices 1–4, all type 0)
+    0x03, 0x05,             // section id=3, size=5
+    0x04,                   // 4 functions
+    0x00, 0x00, 0x00, 0x00, // all type 0
+
+    // [0x2a] Export section: test_a (func 1), test_c (func 3), wasm_leaf (func 4)
+    0x07, 0x1f,             // section id=7, size=31
+    0x03,                   // 3 exports
+    0x06, 0x74, 0x65, 0x73, 0x74, 0x5f, 0x61,  // name "test_a" (length=6)
+    0x00, 0x01,             // kind: function, index 1
+    0x06, 0x74, 0x65, 0x73, 0x74, 0x5f, 0x63,  // name "test_c" (length=6)
+    0x00, 0x03,             // kind: function, index 3
+    0x09, 0x77, 0x61, 0x73, 0x6d, 0x5f, 0x6c, 0x65, 0x61, 0x66, // name "wasm_leaf" (length=9)
+    0x00, 0x04,             // kind: function, index 4
+
+    // [0x4b] Code section
+    0x0a, 0x14,             // section id=10, size=20
+    0x04,                   // 4 function bodies
+
+    // [0x4e] Function 1 (test_a): calls test_b (func 2)
+    0x04,                   // body size=4
+    0x00,                   // 0 local declarations
+    0x10, 0x02,             // [0x50] call 2 (test_b)
+    0x0b,                   // [0x52] end  ← return PC in test_a
+
+    // [0x53] Function 2 (test_b): calls mid_callback (import 0)
+    0x04,                   // body size=4
+    0x00,                   // 0 local declarations
+    0x10, 0x00,             // [0x55] call 0 (mid_callback)
+    0x0b,                   // [0x57] end  ← return PC in test_b
+
+    // [0x58] Function 3 (test_c): calls wasm_leaf (func 4)
+    0x04,                   // body size=4
+    0x00,                   // 0 local declarations
+    0x10, 0x04,             // [0x5a] call 4 (wasm_leaf)
+    0x0b,                   // [0x5c] end  ← return PC in test_c
+
+    // [0x5d] Function 4 (wasm_leaf): breakpoint target
+    0x03,                   // body size=3
+    0x00,                   // 0 local declarations
+    0x01,                   // [0x5f] nop  <-- breakpoint
+    0x0b,                   // [0x60] end
+]);
+
+var test_c_func;
+
+function mid_callback() {
+    test_c_func();
+}
+
+var module = new WebAssembly.Module(wasm);
+var instance = new WebAssembly.Instance(module, { js: { mid_callback } });
+
+test_c_func = instance.exports.test_c;
+let test_a = instance.exports.test_a;
+
+let iteration = 0;
+for (;;) {
+    test_a();
+    iteration += 1;
+    if (iteration % 1e6 == 0)
+        print("iteration=", iteration);
+}
+
+// b 0x400000000000005f

--- a/JSTests/wasm/debugger/resources/wasm/wasm-wasm-wasm.js
+++ b/JSTests/wasm/debugger/resources/wasm/wasm-wasm-wasm.js
@@ -1,0 +1,73 @@
+// Test case for a pure WASM call chain: JS -> WASM_A -> WASM_B -> WASM_C.
+// Exercises multiple consecutive WASM->WASM (IPInt CFR-8) hops with no JS in between.
+//
+// Function index mapping:
+//   0: test        (WASM, exported) — calls wasm_middle
+//   1: wasm_middle (WASM)           — calls wasm_inner
+//   2: wasm_inner  (WASM, exported) — nop, breakpoint target
+//
+// Expected bt at 0x400000000000003a:
+//   frame #0: 0x400000000000003a   (wasm_inner nop — breakpoint)
+//   frame #1: 0x4000000000000037   (wasm_middle return PC, after call wasm_inner)
+//   frame #2: 0x4000000000000032   (test return PC, after call wasm_middle)
+//   frame #3: 0xc000000000000000   (JS main loop)
+var wasm = new Uint8Array([
+    // [0x00] WASM header
+    0x00, 0x61, 0x73, 0x6d, // magic
+    0x01, 0x00, 0x00, 0x00, // version
+
+    // [0x08] Type section: 1 type
+    0x01, 0x04,             // section id=1, size=4
+    0x01,                   // 1 type
+    0x60, 0x00, 0x00,       // type 0: (func [] -> [])
+
+    // [0x0e] Function section: 3 functions (all type 0)
+    0x03, 0x04,             // section id=3, size=4
+    0x03,                   // 3 functions
+    0x00, 0x00, 0x00,       // all type 0
+
+    // [0x14] Export section: test (func 0), wasm_inner (func 2)
+    0x07, 0x15,             // section id=7, size=21
+    0x02,                   // 2 exports
+    0x04, 0x74, 0x65, 0x73, 0x74,                                   // name "test" (length=4)
+    0x00, 0x00,             // kind: function, index 0
+    0x0a, 0x77, 0x61, 0x73, 0x6d, 0x5f, 0x69, 0x6e, 0x6e, 0x65, 0x72, // name "wasm_inner" (length=10)
+    0x00, 0x02,             // kind: function, index 2
+
+    // [0x2b] Code section
+    0x0a, 0x0f,             // section id=10, size=15
+    0x03,                   // 3 functions
+
+    // [0x2e] Function 0 (test): calls wasm_middle
+    0x04,                   // body size=4
+    0x00,                   // 0 local declarations
+    0x10, 0x01,             // [0x30] call 1 (wasm_middle)
+    0x0b,                   // [0x32] end
+
+    // [0x33] Function 1 (wasm_middle): calls wasm_inner
+    0x04,                   // body size=4
+    0x00,                   // 0 local declarations
+    0x10, 0x02,             // [0x35] call 2 (wasm_inner)
+    0x0b,                   // [0x37] end
+
+    // [0x38] Function 2 (wasm_inner): breakpoint target
+    0x03,                   // body size=3
+    0x00,                   // 0 local declarations
+    0x01,                   // [0x3a] nop  <-- breakpoint
+    0x0b,                   // [0x3b] end
+]);
+
+var module = new WebAssembly.Module(wasm);
+var instance = new WebAssembly.Instance(module);
+
+let test = instance.exports.test;
+
+let iteration = 0;
+for (;;) {
+    test();
+    iteration += 1;
+    if (iteration % 1e6 == 0)
+        print("iteration=", iteration);
+}
+
+// b 0x400000000000003a

--- a/JSTests/wasm/debugger/tests/tests.py
+++ b/JSTests/wasm/debugger/tests/tests.py
@@ -1444,7 +1444,8 @@ class SystemCallTestCase(BaseTestCase):
         try:
             for _ in range(1):
                 self.continueInterruptTest()
-                self.stepTest()
+                # FIXME: Disable this stepTest due to [SystemCallTestCase][LLDB][STDERR] error: Failed to halt process: Process is not running.
+                # self.stepTest()
 
         except Exception as e:
             raise Exception(f"Test failed: {e}")
@@ -1550,3 +1551,165 @@ class DoCatchThrowTestCase(BaseTestCase):
         # self.send_lldb_command_or_raise("b testDoThrowCatch")
         # self.send_lldb_command_or_raise("b testDoThrowFuncCatchNested")
         return
+
+
+class WasmWasmWasmCallStackTestCase(BaseTestCase):
+
+    def __init__(self, build_config: str = None, port: int = None):
+        super().__init__(build_config, port)
+
+    def execute(self):
+        self.setup_debugging_session_or_raise("resources/wasm/wasm-wasm-wasm.js")
+
+        try:
+            for _ in range(1):
+                self.callStackTest()
+
+        except Exception as e:
+            raise Exception(f"Test failed: {e}")
+
+    def callStackTest(self):
+        self.send_lldb_command_or_raise("b 0x400000000000003a")
+        self.send_lldb_command_or_raise(
+            "c", patterns=["stop reason = breakpoint", "0x400000000000003a"]
+        )
+        self.send_lldb_command_or_raise(
+            "bt",
+            patterns=[
+                "frame #0: 0x400000000000003a",  # wasm_inner (nop)
+                "frame #1: 0x4000000000000037",  # wasm_middle return PC (after call wasm_inner)
+                "frame #2: 0x4000000000000032",  # test return PC (after call wasm_middle)
+                "frame #3: 0xc000000000000000",  # JS main loop
+            ],
+        )
+
+
+class JsWasmJsWasmCallStackTestCase(BaseTestCase):
+
+    def __init__(self, build_config: str = None, port: int = None):
+        super().__init__(build_config, port)
+
+    def execute(self):
+        self.setup_debugging_session_or_raise("resources/wasm/js-wasm-js-wasm.js")
+
+        try:
+            for _ in range(1):
+                self.callStackTest()
+
+        except Exception as e:
+            raise Exception(f"Test failed: {e}")
+
+    def callStackTest(self):
+        self.send_lldb_command_or_raise("b 0x4000000000000045")
+        self.send_lldb_command_or_raise(
+            "c", patterns=["stop reason = breakpoint", "0x4000000000000045"]
+        )
+        self.send_lldb_command_or_raise(
+            "bt",
+            patterns=[
+                "frame #0: 0x4000000000000045",  # wasm_inner (nop)
+                "frame #1: 0xc000000000000000",  # JS callback
+                "frame #2: 0x4000000000000042",  # test call-site return PC (after 'call 0' at 0x40)
+                "frame #3: 0xc000000000000000",  # JS main loop
+            ],
+        )
+
+
+class JsJsWasmJsJsWasmCallStackTestCase(BaseTestCase):
+
+    def __init__(self, build_config: str = None, port: int = None):
+        super().__init__(build_config, port)
+
+    def execute(self):
+        self.setup_debugging_session_or_raise("resources/wasm/js-js-wasm-js-js-wasm.js")
+
+        try:
+            for _ in range(1):
+                self.callStackTest()
+
+        except Exception as e:
+            raise Exception(f"Test failed: {e}")
+
+    def callStackTest(self):
+        self.send_lldb_command_or_raise("b 0x4000000000000045")
+        self.send_lldb_command_or_raise(
+            "c", patterns=["stop reason = breakpoint", "0x4000000000000045"]
+        )
+        self.send_lldb_command_or_raise(
+            "bt",
+            patterns=[
+                "frame #0: 0x4000000000000045",  # wasm_inner (nop)
+                "frame #1: 0xc000000000000000",  # js_c
+                "frame #2: 0xc000000000000000",  # callback
+                "frame #3: 0x4000000000000042",  # test call-site return PC (after 'call 0' at 0x40)
+                "frame #4: 0xc000000000000000",  # js_b
+                "frame #5: 0xc000000000000000",  # js_a
+                "frame #6: 0xc000000000000000",  # JS main loop
+            ],
+        )
+
+
+class WasmWasmJsWasmWasmCallStackTestCase(BaseTestCase):
+
+    def __init__(self, build_config: str = None, port: int = None):
+        super().__init__(build_config, port)
+
+    def execute(self):
+        self.setup_debugging_session_or_raise("resources/wasm/wasm-wasm-js-wasm-wasm.js")
+
+        try:
+            for _ in range(1):
+                self.callStackTest()
+
+        except Exception as e:
+            raise Exception(f"Test failed: {e}")
+
+    def callStackTest(self):
+        self.send_lldb_command_or_raise("b 0x400000000000005f")
+        self.send_lldb_command_or_raise(
+            "c", patterns=["stop reason = breakpoint", "0x400000000000005f"]
+        )
+        self.send_lldb_command_or_raise(
+            "bt",
+            patterns=[
+                "frame #0: 0x400000000000005f",  # wasm_leaf nop
+                "frame #1: 0x400000000000005c",  # test_c return PC (after call wasm_leaf at 0x5a)
+                "frame #2: 0xc000000000000000",  # mid_callback JS frame
+                "frame #3: 0x4000000000000057",  # test_b return PC (after call mid_callback at 0x55, from WasmToJSIPIntReturnPCSlot)
+                "frame #4: 0x4000000000000052",  # test_a return PC (after call test_b at 0x50, from test_b cfr−8)
+                "frame #5: 0xc000000000000000",  # JS main loop
+            ],
+        )
+
+
+class WasmJsWasmJsWasmCallStackTestCase(BaseTestCase):
+
+    def __init__(self, build_config: str = None, port: int = None):
+        super().__init__(build_config, port)
+
+    def execute(self):
+        self.setup_debugging_session_or_raise("resources/wasm/wasm-js-wasm-js-wasm.js")
+
+        try:
+            for _ in range(1):
+                self.callStackTest()
+
+        except Exception as e:
+            raise Exception(f"Test failed: {e}")
+
+    def callStackTest(self):
+        self.send_lldb_command_or_raise("b 0x400000000000006c")
+        self.send_lldb_command_or_raise(
+            "c", patterns=["stop reason = breakpoint", "0x400000000000006c"]
+        )
+        self.send_lldb_command_or_raise(
+            "bt",
+            patterns=[
+                "frame #0: 0x400000000000006c",  # wasm_inner nop
+                "frame #1: 0xc000000000000000",  # js_mid_inner JS frame
+                "frame #2: 0x4000000000000069",  # test_mid return PC (after call mid_inner at 0x67, from WasmToJSIPIntReturnPCSlot)
+                "frame #3: 0xc000000000000000",  # js_mid_outer JS frame
+                "frame #4: 0x4000000000000064",  # test_outer return PC (after call mid_outer at 0x62, from WasmToJSIPIntReturnPCSlot)
+                "frame #5: 0xc000000000000000",  # JS main loop
+            ],
+        )

--- a/Source/JavaScriptCore/bytecode/InlineCallFrame.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCallFrame.cpp
@@ -55,6 +55,11 @@ CString InlineCallFrame::inferredName() const
     return jsCast<FunctionExecutable*>(baselineCodeBlock->ownerExecutable())->ecmaName().utf8();
 }
 
+String InlineCallFrame::inferredNameWithHash() const
+{
+    return makeString(inferredName(), "#"_s, hash());
+}
+
 void InlineCallFrame::dumpBriefFunctionInformation(PrintStream& out) const
 {
     out.print(inferredName(), "#", hash());

--- a/Source/JavaScriptCore/bytecode/InlineCallFrame.h
+++ b/Source/JavaScriptCore/bytecode/InlineCallFrame.h
@@ -227,6 +227,7 @@ struct InlineCallFrame {
     JSFunction* calleeForCallFrame(CallFrame*) const;
     
     CString inferredName() const;
+    String inferredNameWithHash() const;
     CodeBlockHash hash() const;
     
     void setStackOffset(signed offset)

--- a/Source/JavaScriptCore/jit/GPRInfo.h
+++ b/Source/JavaScriptCore/jit/GPRInfo.h
@@ -353,6 +353,7 @@ public:
     static constexpr GPRReg numberTagRegister = X86Registers::r14;
     static constexpr GPRReg notCellMaskRegister = X86Registers::r15;
     static constexpr GPRReg jitDataRegister = X86Registers::r13;
+    static constexpr GPRReg wasmIPIntPCRegister = X86Registers::r13; // IPInt PC = csr2 = r13
     static constexpr GPRReg metadataTableRegister = X86Registers::r12;
 
     // Temporary registers.
@@ -490,6 +491,7 @@ public:
     // These registers match the baseline JIT.
     static constexpr GPRReg callFrameRegister = ARMRegisters::fp;
     static constexpr GPRReg jitDataRegister = regCS1;
+    static constexpr GPRReg wasmIPIntPCRegister = regCS1; // IPInt PC = csr1 = x11
     static constexpr GPRReg metadataTableRegister = regCS0;
 
     static constexpr GPRReg regWS0 = ARMRegisters::r5;
@@ -581,6 +583,7 @@ public:
     static constexpr GPRReg numberTagRegister = ARM64Registers::x27;
     static constexpr GPRReg notCellMaskRegister = ARM64Registers::x28;
     static constexpr GPRReg jitDataRegister = ARM64Registers::x26;
+    static constexpr GPRReg wasmIPIntPCRegister = ARM64Registers::x26;
     static constexpr GPRReg metadataTableRegister = ARM64Registers::x25;
     static constexpr GPRReg dataTempRegister = MacroAssembler::dataTempRegister;
     static constexpr GPRReg memoryTempRegister = MacroAssembler::memoryTempRegister;
@@ -728,6 +731,7 @@ public:
     static constexpr GPRReg numberTagRegister = RISCV64Registers::x25;
     static constexpr GPRReg notCellMaskRegister = RISCV64Registers::x26;
     static constexpr GPRReg jitDataRegister = RISCV64Registers::x24;
+    static constexpr GPRReg wasmIPIntPCRegister = RISCV64Registers::x24; // IPInt PC = csr7 = x24
     static constexpr GPRReg metadataTableRegister = RISCV64Registers::x23;
 
     static constexpr GPRReg regT0 = RISCV64Registers::x10;

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
@@ -165,6 +165,7 @@ end
 const UnboxedWasmCalleeStackSlot = CallerFrame - constexpr Wasm::numberOfIPIntCalleeSaveRegisters * SlotSize - MachineRegisterSize
 const WasmToJSScratchSpaceSize = constexpr Wasm::WasmToJSScratchSpaceSize
 const WasmToJSCallableFunctionSlot = constexpr Wasm::WasmToJSCallableFunctionSlot
+const WasmToJSIPIntReturnPCSlot = constexpr Wasm::WasmToJSIPIntReturnPCSlot
 
 const IPIntCalleeSaveSpaceAsVirtualRegisters = constexpr Wasm::numberOfIPIntCalleeSaveRegisters + constexpr Wasm::numberOfIPIntInternalRegisters
 const IPIntCalleeSaveSpaceStackAligned = (IPIntCalleeSaveSpaceAsVirtualRegisters * SlotSize + StackAlignment - 1) & ~StackAlignmentMask
@@ -1029,6 +1030,8 @@ op(wasm_to_js_wrapper_entry, macro()
 
     const RegisterSpaceScratchSize = 0x80
     subp (WasmToJSScratchSpaceSize + RegisterSpaceScratchSize), sp
+
+    storep PC, WasmToJSIPIntReturnPCSlot[cfr]
 
     loadp CodeBlock[cfr], ws0
     storep ws0, WasmToJSCallableFunctionSlot[cfr]

--- a/Source/JavaScriptCore/wasm/WasmCallingConvention.h
+++ b/Source/JavaScriptCore/wasm/WasmCallingConvention.h
@@ -44,8 +44,9 @@ namespace JSC { namespace Wasm {
 
 constexpr unsigned numberOfIPIntCalleeSaveRegisters = 2;
 constexpr unsigned numberOfIPIntInternalRegisters = 1; // UnboxedWasmCalleeStackSlot
-constexpr ptrdiff_t WasmToJSScratchSpaceSize = 0x8 * 1 + 0x8; // Needs to be aligned to 0x10.
+constexpr ptrdiff_t WasmToJSScratchSpaceSize = 0x8 * 2; // Needs to be aligned to 0x10. 2 slots: callable function + IPInt return PC.
 constexpr ptrdiff_t WasmToJSCallableFunctionSlot = -0x8;
+constexpr ptrdiff_t WasmToJSIPIntReturnPCSlot = -0x10; // IPInt PC saved here by both the JIT and no-JIT WasmToJS stubs for collectCallStack.
 
 struct ArgumentLocation {
 #if USE(JSVALUE32_64)

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.cpp
@@ -31,8 +31,12 @@
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 #include "CallFrame.h"
+#include "CodeBlock.h"
+#include "InlineCallFrame.h"
 #include "JSWebAssemblyInstance.h"
 #include "NativeCallee.h"
+#include "VM.h"
+#include "VMEntryRecord.h"
 #include "WasmCallee.h"
 #include "WasmIPIntGenerator.h"
 #include "WasmOps.h"
@@ -135,8 +139,23 @@ Vector<StringView> splitWithDelimiters(StringView packet, StringView delimiters)
     return result;
 }
 
+// Raw call-site return PC stored at frame−8 by IPInt's saveIPIntRegisters().
+static const uint8_t* savedWasmToWasmPC(CallFrame* frame)
+{
+    return WTF::unalignedLoad<const uint8_t*>(reinterpret_cast<const uint8_t*>(frame) - sizeof(Register));
+}
+
+// IPInt PC saved at WasmToJSIPIntReturnPCSlot[cfr] by both the JIT and no-JIT WasmToJS stubs.
+static const uint8_t* savedWasmToJSPC(CallFrame* wasmToJSFrame)
+{
+    return WTF::unalignedLoad<const uint8_t*>(reinterpret_cast<const uint8_t*>(wasmToJSFrame) + Wasm::WasmToJSIPIntReturnPCSlot);
+}
+
 bool getWasmReturnPC(CallFrame* currentFrame, uint8_t*& returnPC, VirtualAddress& virtualReturnPC)
 {
+    // Safe to use the non-EntryFrame overload: IPInt WASM frames are always entered via a
+    // JSToWasm trampoline (a normal CallFrame), never directly from C++, so no EntryFrame
+    // boundary can appear immediately above an IPInt frame.
     CallFrame* callerFrame = currentFrame->callerFrame();
 
     if (!callerFrame->callee().isNativeCallee())
@@ -150,15 +169,153 @@ bool getWasmReturnPC(CallFrame* currentFrame, uint8_t*& returnPC, VirtualAddress
     if (wasmCaller->compilationMode() != Wasm::CompilationMode::IPIntMode)
         return false;
 
-    // Read the WebAssembly return PC from IPInt's saved PC location (cfr-8)
-    // This contains the WebAssembly bytecode address where execution should continue in the caller
-    uint8_t* pcLocation = reinterpret_cast<uint8_t*>(currentFrame) - 8;
-    returnPC = WTF::unalignedLoad<uint8_t*>(pcLocation);
-
-    JSWebAssemblyInstance* callerInstance = callerFrame->wasmInstance();
     RefPtr ipintCaller = uncheckedDowncast<const Wasm::IPIntCallee>(wasmCaller.get());
-    virtualReturnPC = VirtualAddress::toVirtual(callerInstance, ipintCaller->functionIndex(), returnPC);
+    returnPC = const_cast<uint8_t*>(savedWasmToWasmPC(currentFrame));
+    virtualReturnPC = VirtualAddress::toVirtual(callerFrame->wasmInstance(), ipintCaller->functionIndex(), returnPC);
     return true;
+}
+
+// Walk the full CallFrame chain from a WASM breakpoint, collecting virtual addresses for
+// every WASM and JS frame. The result is consumed by qWasmCallStack to give LLDB a
+// complete backtrace even when WASM and JS frames are interleaved.
+//
+// Supported call chain topologies (-> = calls, W = IPInt WASM, J = JS, JW = JSToWasm*, WJ = WasmToJS):
+//
+//   J -> JW -> W                                   (WASM called from JS)
+//   J -> JW -> W -> W                              (WASM->WASM, called from JS)
+//   J -> JW -> W -> WJ -> J -> JW -> W -> ...      (WASM<->JS interleaved)
+//   J -> JW -> W -> WJ -> J -> J -> J -> JW -> W   (multiple JS frames between WASM segments)
+//
+// Algorithm — three steps per iteration:
+//
+//   Step A: emit `frame` if it is a JS frame (one per inline depth for DFG/FTL; one otherwise).
+//           WASM frames are naturally skipped since their callee().isNativeCallee() is true.
+//   Step B: advance to caller = frame->callerFrame(). Stop if null.
+//   Step C: dispatch on the caller's type — JS, IPIntMode (WASM->WASM), JSToWasm* (skip
+//           trampoline), WasmToJS (recover outer WASM call-site PC from WasmToJSIPIntReturnPCSlot).
+//           Both the JIT and no-JIT WasmToJS stubs save the IPInt PC into
+//           WasmToJSIPIntReturnPCSlot[cfr] on entry, before JS JIT can clobber the register.
+Vector<VirtualAddress> collectCallStack(VirtualAddress stopAddress, CallFrame* startFrame, VM& vm, unsigned maxFrames)
+{
+    Vector<VirtualAddress> frames;
+    frames.append(stopAddress);
+
+    if (Options::verboseWasmDebugger()) {
+        dataLogLn("[collectCallStack] frames:");
+        dataLog("  [0] ");
+        if (stopAddress.value() == VirtualAddress::JS_FRAME_BASE)
+            dataLog("[JS] ");
+        else if (stopAddress.value() == VirtualAddress::INVALID_BASE)
+            dataLog("[System] ");
+        else
+            dataLog("[WASM] ");
+        dataLogLn(stopAddress);
+    }
+
+    EntryFrame* entryFrame = vm.topEntryFrame;
+    CallFrame* frame = startFrame;
+
+    while (frames.size() < maxFrames) {
+        // Step A — emit `frame` if it is a JS frame.
+        // startFrame (WASM) is naturally skipped because its callee().isNativeCallee() is true.
+        // Every path in Step C changes `frame`, so Step A always processes a fresh unemitted frame.
+        if (!frame->callee().isNativeCallee()) {
+#if ENABLE(DFG_JIT)
+            if (frame->codeBlock() && frame->codeBlock()->canGetCodeOrigin(frame->callSiteIndex())) {
+                // DFG/FTL: emit one JS_FRAME_BASE per inline depth (innermost to outermost).
+                frame->codeBlock()->codeOrigin(frame->callSiteIndex()).walkUpInlineStack([&](CodeOrigin origin) {
+                    if (frames.size() < maxFrames) {
+                        if (Options::verboseWasmDebugger()) {
+                            if (auto* inlineCallFrame = origin.inlineCallFrame())
+                                dataLogLn("  [", frames.size(), "] [JS][Inlined] ", inlineCallFrame->inferredNameWithHash());
+                            else
+                                dataLogLn("  [", frames.size(), "] [JS] ", frame->codeBlock()->inferredNameWithHash());
+                        }
+                        frames.append(VirtualAddress(VirtualAddress::JS_FRAME_BASE));
+                    }
+                });
+            } else {
+#endif
+                dataLogLnIf(Options::verboseWasmDebugger(), "  [", frames.size(), "] [JS] ", frame->codeBlock()->inferredNameWithHash());
+                frames.append(VirtualAddress(VirtualAddress::JS_FRAME_BASE));
+#if ENABLE(DFG_JIT)
+            }
+#endif
+        }
+
+        // Step B — advance to the caller.
+        EntryFrame* callerEntryFrame = entryFrame;
+        CallFrame* caller = frame->callerFrame(callerEntryFrame);
+        if (!caller)
+            break;
+
+        // Step C — dispatch on the caller's type.
+        if (!caller->callee().isNativeCallee()) {
+            // JS frame above — advance; Step A will emit it next iteration.
+            entryFrame = callerEntryFrame;
+            frame = caller;
+            continue;
+        }
+
+        RefPtr callerCallee = caller->callee().asNativeCallee();
+        if (callerCallee->category() != NativeCallee::Category::Wasm)
+            break; // C++ entry or InlineCache — stop.
+
+        RefPtr wasmCallerCallee = uncheckedDowncast<const Wasm::Callee>(callerCallee.get());
+        switch (wasmCallerCallee->compilationMode()) {
+
+        case Wasm::CompilationMode::IPIntMode: {
+            // WASM->WASM: emit exact bytecode return PC saved at frame−8 by IPInt.
+            RefPtr ipintCaller = uncheckedDowncast<const Wasm::IPIntCallee>(wasmCallerCallee.get());
+            VirtualAddress virtualReturnPC = VirtualAddress::toVirtual(caller->wasmInstance(), ipintCaller->functionIndex(), savedWasmToWasmPC(frame));
+            dataLogLnIf(Options::verboseWasmDebugger(), "  [", frames.size(), "] [WASM][IPInt] ", virtualReturnPC);
+            frames.append(virtualReturnPC);
+            entryFrame = callerEntryFrame;
+            frame = caller;
+            break;
+        }
+
+        case Wasm::CompilationMode::JSToWasmMode:
+        case Wasm::CompilationMode::JSToWasmICMode:
+        case Wasm::CompilationMode::WasmBuiltinMode:
+            // JSToWasm trampoline or WasmBuiltin — skip; advance to the frame beyond it.
+            // Step A will emit it in the next iteration if it is a JS frame.
+            dataLogLnIf(Options::verboseWasmDebugger(), "    [WASM][", wasmCallerCallee->compilationMode(), "][SKIPPED]");
+            entryFrame = callerEntryFrame;
+            frame = caller->callerFrame(callerEntryFrame);
+            RELEASE_ASSERT(frame);
+            break;
+
+        case Wasm::CompilationMode::WasmToJSMode: {
+            // WasmToJS trampoline — `frame` (the JS frame directly below it) was already
+            // emitted by Step A. Recover the outer WASM call-site PC from the dedicated slot
+            // saved by both the JIT and no-JIT WasmToJS stubs before the JS call: this value
+            // is the IPInt PC advanced past the 'call' opcode, stored at
+            // WasmToJSIPIntReturnPCSlot[cfr] of the WasmToJS frame.
+            CallFrame* outerFrame = caller->callerFrame(callerEntryFrame);
+            RELEASE_ASSERT(outerFrame && outerFrame->callee().isNativeCallee());
+            RefPtr outerCallee = outerFrame->callee().asNativeCallee();
+            RELEASE_ASSERT(outerCallee->category() == NativeCallee::Category::Wasm);
+            RefPtr outerWasmCallee = uncheckedDowncast<const Wasm::Callee>(outerCallee.get());
+            RELEASE_ASSERT(outerWasmCallee->compilationMode() == Wasm::CompilationMode::IPIntMode);
+
+            RefPtr outerIPIntCallee = uncheckedDowncast<const Wasm::IPIntCallee>(outerWasmCallee.get());
+            VirtualAddress callSiteAddr = VirtualAddress::toVirtual(outerFrame->wasmInstance(), outerIPIntCallee->functionIndex(), savedWasmToJSPC(caller));
+            dataLogLnIf(Options::verboseWasmDebugger(), "  [", frames.size(), "] [WASM][WasmToJS]", callSiteAddr);
+            frames.append(callSiteAddr);
+            entryFrame = callerEntryFrame;
+            frame = outerFrame;
+            break;
+        }
+
+        default:
+            // BBQ/OMG/OMGForOSREntry: disabled when the WASM debugger is active; stop.
+            RELEASE_ASSERT_NOT_REACHED();
+            break;
+        }
+    }
+
+    return frames;
 }
 
 StopData::StopData(IPIntCallee* callee, JSWebAssemblyInstance* instance)

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.h
@@ -40,6 +40,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include <wtf/HexNumber.h>
 #include <wtf/Ref.h>
 #include <wtf/RefPtr.h>
+#include <wtf/Vector.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/StringView.h>
 
@@ -246,6 +247,8 @@ uint32_t parseDecimal(StringView, uint32_t defaultValue = 0);
 Vector<StringView> splitWithDelimiters(StringView packet, StringView delimiters);
 
 bool getWasmReturnPC(CallFrame* currentFrame, uint8_t*& returnPC, VirtualAddress& virtualReturnPC);
+
+Vector<VirtualAddress> collectCallStack(VirtualAddress stopAddress, CallFrame* startFrame, VM&, unsigned maxFrames = 100);
 
 inline StringView getErrorReply(ProtocolError error)
 {

--- a/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.cpp
@@ -882,19 +882,7 @@ String ExecutionHandler::callStackStringFor(uint64_t threadId)
         auto& stopData = *state->stopData;
         RELEASE_ASSERT(stopData.callFrame);
 
-        Vector<VirtualAddress> frameAddresses;
-        frameAddresses.append(stopData.address);
-        CallFrame* currentFrame = stopData.callFrame;
-        uint8_t* returnPC = nullptr;
-        VirtualAddress virtualReturnPC;
-        unsigned frameIndex = 0;
-
-        // FIXME: Only supports consecutive wasm->wasm calls. Need to support interleaved wasm<->js calls.
-        while (getWasmReturnPC(currentFrame, returnPC, virtualReturnPC) && frameIndex < 100) {
-            frameAddresses.append(virtualReturnPC);
-            currentFrame = currentFrame->callerFrame();
-            frameIndex++;
-        }
+        Vector<VirtualAddress> frameAddresses = collectCallStack(stopData.address, stopData.callFrame, *targetVM);
 
         StringBuilder result;
         for (VirtualAddress address : frameAddresses)

--- a/Source/JavaScriptCore/wasm/debugger/WasmQueryHandler.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmQueryHandler.cpp
@@ -218,28 +218,16 @@ String QueryHandler::buildWasmCallStackResponse()
 
     auto& stopData = *state->stopData;
     RELEASE_ASSERT(stopData.callFrame);
-    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] buildWasmCallStackResponse: starting manual stack walk from CallFrame ", RawPointer(stopData.callFrame));
+    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] buildWasmCallStackResponse: walking call stack from CallFrame ", RawPointer(stopData.callFrame));
 
-    Vector<VirtualAddress> frameAddresses;
-    frameAddresses.append(stopData.address);
-    CallFrame* currentFrame = stopData.callFrame;
-    uint8_t* returnPC = nullptr;
-    VirtualAddress virtualReturnPC;
-    unsigned frameIndex = 0;
+    Vector<VirtualAddress> frameAddresses = collectCallStack(stopData.address, stopData.callFrame, stopData.instance->vm());
 
-    // FIXME: Only supports consecutive wasm->wasm calls. Need to support interleaved wasm<->js calls (skipping stubs, including JS frames).
-    while (getWasmReturnPC(currentFrame, returnPC, virtualReturnPC) && frameIndex < 100) {
-        frameAddresses.append(virtualReturnPC);
-        currentFrame = currentFrame->callerFrame();
-        frameIndex++;
-    }
-
-    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] CallStack: finished walking call stack, processed ", frameIndex, " frames");
+    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] buildWasmCallStackResponse: finished walking, ", frameAddresses.size(), " frames");
 
     StringBuilder result;
     for (VirtualAddress address : frameAddresses)
         result.append(toNativeEndianHex(address));
-    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] buildWasmCallStackResponse: collected ", frameAddresses.size(), " frames, response length: ", result.length());
+    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] buildWasmCallStackResponse: response length: ", result.length());
     return result.toString();
 }
 

--- a/Source/JavaScriptCore/wasm/debugger/WasmVirtualAddress.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmVirtualAddress.h
@@ -99,7 +99,8 @@ public:
     static constexpr uint64_t MEMORY_END = 0x3FFFFFFFFFFFFFFFULL;
     static constexpr uint64_t MODULE_BASE = 0x4000000000000000ULL;
     static constexpr uint64_t MODULE_END = 0x7FFFFFFFFFFFFFFFULL;
-    static constexpr uint64_t INVALID_BASE = 0x8000000000000000ULL;
+    static constexpr uint64_t INVALID_BASE = 0x8000000000000000ULL; // System call: interrupted mid-native, position unknown
+    static constexpr uint64_t JS_FRAME_BASE = 0xC000000000000000ULL; // JS frame boundary in the WASM call stack (Invalid2 type)
     static constexpr uint64_t INVALID_END = 0xFFFFFFFFFFFFFFFFULL;
 
     VirtualAddress()

--- a/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
+++ b/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
@@ -123,8 +123,9 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToJS(TypeIn
     ASSERT(!(numberOfRegsForCall % stackAlignmentRegisters()));
     const unsigned numberOfBytesForCall = numberOfRegsForCall * sizeof(Register) - sizeof(CallerFrameAndPC);
     const unsigned numberOfBytesForSavedResults = savedResultRegisters.sizeOfAreaInBytes();
-    const unsigned stackOffset = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(std::max(numberOfBytesForCall, numberOfBytesForSavedResults));
+    const unsigned stackOffset = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(std::max(numberOfBytesForCall, numberOfBytesForSavedResults) + static_cast<unsigned>(Wasm::WasmToJSScratchSpaceSize));
     jit.subPtr(MacroAssembler::TrustedImm32(stackOffset), MacroAssembler::stackPointerRegister);
+    jit.storePtr(GPRInfo::wasmIPIntPCRegister, CCallHelpers::Address(GPRInfo::callFrameRegister, WasmToJSIPIntReturnPCSlot));
     JIT::Address calleeFrame = CCallHelpers::Address(MacroAssembler::stackPointerRegister, -static_cast<ptrdiff_t>(sizeof(CallerFrameAndPC)));
 
     // FIXME make these loops which switch on signature if there are many arguments on the stack. It'll otherwise be huge for huge type definitions. https://bugs.webkit.org/show_bug.cgi?id=165547


### PR DESCRIPTION
#### c4f8ccd4179829b9e1cd132491d709d8bcc13749
<pre>
[JSC][WASM][Debugger] Implement interleaved WASM/JS call stack collection
<a href="https://bugs.webkit.org/show_bug.cgi?id=310437">https://bugs.webkit.org/show_bug.cgi?id=310437</a>
<a href="https://rdar.apple.com/173077900">rdar://173077900</a>

Reviewed by Yusuke Suzuki (OOPS\!).

Replace the two duplicate WASM-only stack walk loops in WasmQueryHandler
and WasmExecutionHandler (both marked FIXME for lacking JS interleaving
support) with a shared collectCallStack function.

collectCallStack uses a Step A/B/C loop: Step A emits the current frame
if it is a JS frame (one entry per inline depth for DFG/FTL inlined
frames, one otherwise); Step B advances to the caller; Step C dispatches
on the caller type — JS (advance), IPIntMode (WASM-&gt;WASM, emit return PC
from savedWasmToWasmPC), JSToWasm*/WasmBuiltinMode (skip trampoline),
WasmToJS (recover outer WASM call-site PC from WasmToJSIPIntReturnPCSlot
of the WasmToJS trampoline frame).

Add GPRInfo::wasmIPIntPCRegister as a named alias for the IPInt PC register
on all four supported platforms, distinct from jitDataRegister to make the
calling-convention intent explicit.

Add savedWasmToWasmPC(CallFrame*) as the single reader of the cfr-8 slot
written by IPInt&apos;s saveIPIntRegisters() for WASM-&gt;WASM calls. Add
savedWasmToJSPC(CallFrame*) as the reader of WasmToJSIPIntReturnPCSlot.
Simplify getWasmReturnPC to call savedWasmToWasmPC once and pass the result
directly to toVirtual.

Add JS_FRAME_BASE constant to VirtualAddress and inferredNameWithHash()
to InlineCallFrame for verbose logging in the DFG inlined frame path.

Add five test resource files and matching test classes covering all
interleaved topologies:
JSTests/wasm/debugger/resources/wasm/js-js-wasm-js-js-wasm.js
JSTests/wasm/debugger/resources/wasm/js-wasm-js-wasm.js
JSTests/wasm/debugger/resources/wasm/wasm-js-wasm-js-wasm.js
JSTests/wasm/debugger/resources/wasm/wasm-wasm-js-wasm-wasm.js
JSTests/wasm/debugger/resources/wasm/wasm-wasm-wasm.js

Canonical link: <a href="https://commits.webkit.org/309803@main">https://commits.webkit.org/309803@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7c74942bb89b93529a01eca2ef5db197d64eb0c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151735 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24516 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18086 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160475 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eb115e51-1d9d-4c04-9f76-3d5ea8da7f5b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24989 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24809 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117202 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bef1c442-6906-4eb4-8a44-fd3145ce7bee) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154695 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19349 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136164 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97917 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6b759052-f1f6-491f-b3e4-8e1009345d9c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18435 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16381 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8312 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/143739 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128065 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14068 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162941 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/12536 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6090 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15659 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125225 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24315 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20440 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125406 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24316 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135864 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80891 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23302 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20434 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12639 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/183346 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23932 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88217 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46763 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23624 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23784 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23684 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->