### PR TITLE
AX: Focus resets to top of page when a focused button becomes disabled

### DIFF
--- a/LayoutTests/fast/events/sequential-focus-navigation-starting-point-after-disable-expected.txt
+++ b/LayoutTests/fast/events/sequential-focus-navigation-starting-point-after-disable-expected.txt
@@ -1,0 +1,10 @@
+After disabling a focused element, sequential focus navigation should start at the element's position.
+PASS container.innerHTML = '<input id=prev><button id=start>Start</button><input id=next>'; focusStart(); disableStart(); moveFocus('forward'); document.activeElement.id is 'next'
+PASS container.innerHTML = '<input id=prev><button id=start>Start</button><input id=next>'; focusStart(); disableStart(); moveFocus('backward'); document.activeElement.id is 'prev'
+PASS container.innerHTML = '<input id=prev><input id=start><input id=next>'; focusStart(); disableStart(); moveFocus('forward'); document.activeElement.id is 'next'
+PASS container.innerHTML = '<input id=prev><select id=start><option>A</option></select><input id=next>'; focusStart(); disableStart(); moveFocus('forward'); document.activeElement.id is 'next'
+PASS container.innerHTML = '<input id=prev><textarea id=start></textarea><input id=next>'; focusStart(); disableStart(); moveFocus('forward'); document.activeElement.id is 'next'
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/events/sequential-focus-navigation-starting-point-after-disable.html
+++ b/LayoutTests/fast/events/sequential-focus-navigation-starting-point-after-disable.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<body onload="runTest();">
+<script src="../../resources/js-test.js"></script>
+<div id="log"></div>
+<div id="container"></div>
+<script>
+if (!window.eventSender)
+    document.body.textContent = 'This test requires window.eventSender.';
+
+function moveFocus(direction) {
+    eventSender.keyDown('\t', direction == 'forward' ? [] : ['shiftKey']);
+}
+
+function focusStart() {
+    container.querySelector('#start').focus();
+}
+
+function disableStart() {
+    container.querySelector('#start').disabled = true;
+}
+
+function runTest() {
+    debug("After disabling a focused element, sequential focus navigation should start at the element's position.");
+    var container = document.querySelector('#container');
+
+    shouldBe("container.innerHTML = '<input id=prev><button id=start>Start</button><input id=next>'; focusStart(); disableStart(); moveFocus('forward'); document.activeElement.id", "'next'");
+    shouldBe("container.innerHTML = '<input id=prev><button id=start>Start</button><input id=next>'; focusStart(); disableStart(); moveFocus('backward'); document.activeElement.id", "'prev'");
+    shouldBe("container.innerHTML = '<input id=prev><input id=start><input id=next>'; focusStart(); disableStart(); moveFocus('forward'); document.activeElement.id", "'next'");
+    shouldBe("container.innerHTML = '<input id=prev><select id=start><option>A</option></select><input id=next>'; focusStart(); disableStart(); moveFocus('forward'); document.activeElement.id", "'next'");
+    shouldBe("container.innerHTML = '<input id=prev><textarea id=start></textarea><input id=next>'; focusStart(); disableStart(); moveFocus('forward'); document.activeElement.id", "'next'");
+}
+</script>
+</body>

--- a/Source/WebCore/html/HTMLFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLFormControlElement.cpp
@@ -158,6 +158,14 @@ void HTMLFormControlElement::finishParsingChildren()
 void HTMLFormControlElement::disabledStateChanged()
 {
     ValidatedFormListedElement::disabledStateChanged();
+
+    if (isDisabled()) {
+        if (document().focusedElement() == this) {
+            document().setFocusedElement(nullptr);
+            document().setFocusNavigationStartingNode(this);
+        }
+    }
+
     if (CheckedPtr renderer = this->renderer(); renderer && renderer->style().hasUsedAppearance())
         renderer->repaint();
 }


### PR DESCRIPTION
#### f9f0ac84aad581288eb0b4fcb3ad8fd35bdfc4d0
<pre>
AX: Focus resets to top of page when a focused button becomes disabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=309371">https://bugs.webkit.org/show_bug.cgi?id=309371</a>
<a href="https://rdar.apple.com/171926839">rdar://171926839</a>

Reviewed by NOBODY (OOPS!).

Prior to this commit, when a focused form control becomes disabled,
WebKit would restart the focus navigation start point to the top
of the page.

Fix by clearing focus and setting focusNavigationStartingNode in
HTMLFormControlElement::disabledStateChanged(), following the same pattern
used by Document::adjustFocusedNodeOnNodeRemoval() for removed nodes.

* LayoutTests/fast/events/sequential-focus-navigation-starting-point-after-disable-expected.txt: Added.
* LayoutTests/fast/events/sequential-focus-navigation-starting-point-after-disable.html: Added.
* Source/WebCore/html/HTMLFormControlElement.cpp:
(WebCore::HTMLFormControlElement::disabledStateChanged):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9f0ac84aad581288eb0b4fcb3ad8fd35bdfc4d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151464 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24229 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17810 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160196 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104902 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/de6c1dc3-d8aa-47cd-92a2-f66180f4bf4e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153338 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24660 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24531 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116954 "Found 1 new test failure: imported/w3c/web-platform-tests/html/interaction/focus/processing-model/focus-fixup-rule-one-no-dialogs.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83027 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ca1df091-8aa4-4ed2-bead-5429a35a818a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154424 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19102 "Found 1 new test failure: fast/events/sequential-focus-navigation-starting-point-after-disable.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135911 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97674 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8d392c78-e138-40f2-865c-8c50294e975b) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18193 "Found 1 new test failure: imported/w3c/web-platform-tests/html/interaction/focus/processing-model/focus-fixup-rule-one-no-dialogs.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16139 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8040 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127820 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13816 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162667 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5800 "Found 4 new failures in html/HTMLFormControlElement.cpp") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15404 "Found 1 new test failure: imported/w3c/web-platform-tests/html/interaction/focus/processing-model/focus-fixup-rule-one-no-dialogs.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124971 "Found 1 new test failure: imported/w3c/web-platform-tests/html/interaction/focus/processing-model/focus-fixup-rule-one-no-dialogs.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24030 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20196 "Found 1 new test failure: imported/w3c/web-platform-tests/html/interaction/focus/processing-model/focus-fixup-rule-one-no-dialogs.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125157 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24022 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135612 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80558 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20216 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12386 "Found 1 new test failure: imported/w3c/web-platform-tests/html/interaction/focus/processing-model/focus-fixup-rule-one-no-dialogs.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23631 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87943 "Found 4 new failures in html/HTMLFormControlElement.cpp") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23341 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23495 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23397 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->