### PR TITLE
dump-class-layout should support showing multiple classes

### DIFF
--- a/Tools/Scripts/dump-class-layout
+++ b/Tools/Scripts/dump-class-layout
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2011-2015 Apple Inc. All rights reserved.
+# Copyright (C) 2011-2026 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -46,12 +46,12 @@ def webkit_build_dir():
     scriptpath = os.path.dirname(os.path.realpath(__file__))
     return subprocess.check_output([os.path.join(scriptpath, "webkit-build-directory"), "--top-level"]).decode().strip()
 
-def main():
+def main(argv=None):
     parser = argparse.ArgumentParser(description='Dumps the in-memory layout of the given class or classes, showing padding holes.')
     parser.add_argument('framework', metavar='framework',
         help='name of the framework containing the class (e.g. "WebCore")')
-    parser.add_argument('classname', metavar='classname',
-        help='name of the class or struct to dump')
+    parser.add_argument('classname', metavar='classname', nargs='+',
+        help='name of the class or struct to dump (may specify multiple classes)')
 
     parser.add_argument('-b', '--build-directory', dest='build_directory', action='store',
         help='Path to the directory under which build files are kept (should not include configuration)')
@@ -68,7 +68,7 @@ def main():
     parser.add_argument('-s', '--skip-nested', dest='skip_nested', default=False, action='store_true',
         help='Do not traverse nested classes and structs')
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
     build_dir = webkit_build_dir()
 
     if args.config is None:
@@ -83,9 +83,17 @@ def main():
         target_path = os.path.join(build_dir, args.config, args.framework + ".framework", args.framework);
     
     lldb_instance = LLDBDebuggerInstance(target_path, args.arch)
-    class_layout = lldb_instance.layout_for_classname(args.classname, args.skip_nested)
-    if class_layout is not None:
-        class_layout.dump()
+
+    # Check if stdout is a TTY to determine if we should use colors
+    use_colors = sys.stdout.isatty()
+
+    for i, classname in enumerate(args.classname):
+        if i > 0:
+            print()  # Add blank line between multiple class dumps
+
+        class_layout = lldb_instance.layout_for_classname(classname, args.skip_nested)
+        if class_layout is not None:
+            class_layout.dump(colorize=use_colors)
 
 
 if __name__ == "__main__":

--- a/Tools/lldb/dump_class_layout_unittest.py
+++ b/Tools/lldb/dump_class_layout_unittest.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2018 Apple Inc. All rights reserved.
+# Copyright (C) 2018-2026 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -25,13 +25,28 @@
 
 import atexit
 import difflib
+import importlib.machinery
+import importlib.util
 import lldb
 import os
 import sys
 import unittest
+from unittest.mock import call, MagicMock, patch
 
 from lldb_dump_class_layout import LLDBDebuggerInstance, ClassLayoutBase
 from webkitpy.common.system.systemhost import SystemHost
+
+# Load the extensionless dump-class-layout script as a module.
+_test_dir = os.path.dirname(os.path.abspath(__file__))
+_scripts_dir = os.path.join(os.path.dirname(_test_dir), 'Scripts')
+_script_path = os.path.join(_scripts_dir, 'dump-class-layout')
+_spec = importlib.util.spec_from_file_location(
+    'dump_class_layout_script',
+    _script_path,
+    loader=importlib.machinery.SourceFileLoader('dump_class_layout_script', _script_path),
+)
+dump_class_layout_script = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(dump_class_layout_script)
 
 # Build for x86_64.
 # Run these tests with xcrun python3 Tools/Scripts/test-lldb-webkit
@@ -356,7 +371,7 @@ Padding percentage: 61.98 %"""
         self.assertEqual(EXPECTED_RESULT, actual_layout.as_string())
 
     def serial_test_InheritsFromClassWithPaddedBitfields(self):
-        EXPECTED_RESULT = """  +0 < 16> InheritsFromClassWithPaddedBitfields
+        EXPECTED_RESULT = """  +0 < 24> InheritsFromClassWithPaddedBitfields
   +0 < 16>     ClassWithPaddedBitfields ClassWithPaddedBitfields
   +0 <  1>         bool boolMember
   +1 < :1>         unsigned int bitfield1 : 1
@@ -371,11 +386,58 @@ Padding percentage: 61.98 %"""
   +8 < :9>         unsigned int bitfield8 : 9
   +9 < :1>         bool bitfield9 : 1
   +9 < :5>         <UNUSED BITS: 5 bits>
- +10 < :1>     bool derivedBitfield : 1
- +10 < :7>     <UNUSED BITS: 7 bits>
- +11 <  5>     <PADDING: 5 bytes>
-Total byte size: 16
-Total pad bytes: 6
-Padding percentage: 42.97 %"""
+ +10 <  6>     <PADDING: 6 bytes>
+ +16 < :1>     bool derivedBitfield : 1
+ +16 < :7>     <UNUSED BITS: 7 bits>
+ +17 <  7>     <PADDING: 7 bytes>
+Total byte size: 24
+Total pad bytes: 14
+Padding percentage: 61.98 %"""
         actual_layout = debugger_instance.layout_for_classname('InheritsFromClassWithPaddedBitfields')
         self.assertEqual(EXPECTED_RESULT, actual_layout.as_string())
+
+
+@unittest.skipUnless(SystemHost.get_default().platform.is_mac(), "macOS only")
+class TestDumpClassLayoutScript(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        mock_layout = MagicMock()
+        self._mock_instance = MagicMock()
+        self._mock_instance.layout_for_classname.return_value = mock_layout
+        self._lldb_patcher = patch.object(dump_class_layout_script, 'LLDBDebuggerInstance', return_value=self._mock_instance)
+        self._build_dir_patcher = patch.object(dump_class_layout_script, 'webkit_build_dir', return_value='/tmp/build')
+        self._lldb_patcher.start()
+        self._build_dir_patcher.start()
+
+    def tearDown(self):
+        self._lldb_patcher.stop()
+        self._build_dir_patcher.stop()
+        super().tearDown()
+
+    def test_single_classname_calls_layout_once(self):
+        dump_class_layout_script.main(['WebCore', 'ClassA'])
+        self._mock_instance.layout_for_classname.assert_called_once_with('ClassA', False)
+
+    def test_multiple_classnames_each_get_layout_called(self):
+        dump_class_layout_script.main(['WebCore', 'ClassA', 'ClassB', 'ClassC'])
+        self.assertEqual(self._mock_instance.layout_for_classname.call_count, 3)
+        self.assertEqual(
+            self._mock_instance.layout_for_classname.call_args_list,
+            [call('ClassA', False), call('ClassB', False), call('ClassC', False)],
+        )
+
+    def test_blank_line_printed_between_multiple_classes(self):
+        with patch('builtins.print') as mock_print:
+            dump_class_layout_script.main(['WebCore', 'ClassA', 'ClassB'])
+        # Exactly one blank line should be printed — between the two class dumps.
+        self.assertEqual(mock_print.call_args_list.count(call()), 1)
+
+    def test_blank_line_count_matches_class_count_minus_one(self):
+        with patch('builtins.print') as mock_print:
+            dump_class_layout_script.main(['WebCore', 'ClassA', 'ClassB', 'ClassC'])
+        self.assertEqual(mock_print.call_args_list.count(call()), 2)
+
+    def test_no_blank_line_for_single_class(self):
+        with patch('builtins.print') as mock_print:
+            dump_class_layout_script.main(['WebCore', 'ClassA'])
+        self.assertNotIn(call(), mock_print.call_args_list)

--- a/Tools/lldb/lldbWebKitTester/DumpClassLayoutTesting.cpp
+++ b/Tools/lldb/lldbWebKitTester/DumpClassLayoutTesting.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -505,9 +505,9 @@ class MemberHasBitfieldPadding {
      8:0-0 |     unsigned int bitfield7
      8:1-9 |     unsigned int bitfield8
      9:2-2 |     _Bool bitfield9
-    10:0-0 |   _Bool derivedBitfield
-           | [sizeof=16, dsize=11, align=8,
-           |  nvsize=11, nvalign=8]
+    16:0-0 |   _Bool derivedBitfield
+           | [sizeof=24, dsize=17, align=8,
+           |  nvsize=17, nvalign=8]
 */
 class InheritsFromClassWithPaddedBitfields : public ClassWithPaddedBitfields {
     bool derivedBitfield : 1;


### PR DESCRIPTION
#### ec3fb41c35f912de0ea2ff88d0d507df2fc5d1a7
<pre>
dump-class-layout should support showing multiple classes
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=310442">https://bugs.webkit.org/show_bug.cgi?id=310442</a>&gt;
&lt;<a href="https://rdar.apple.com/173085155">rdar://173085155</a>&gt;

Reviewed by Simon Fraser.

Accept multiple `classname` arguments in `dump-class-layout`,
printing each class layout with a blank line between them.
Also add `argv=None` to `main()` so tests can pass arguments directly
without patching `sys.argv`.

Add `TestDumpClassLayoutScript` to verify multi-class argument handling
via `unittest.mock`, loading the script as a Python module with
`importlib.machinery.SourceFileLoader`.

* Tools/Scripts/dump-class-layout:
(main):
* Tools/lldb/dump_class_layout_unittest.py:
- Load `dump-class-layout` as a module via `importlib` for script-level
  testing.
(TestDumpClassLayout.serial_test_InheritsFromClassWithPaddedBitfields):
- Drive-by fix to correct the expected output to match the current
  compiler-generated layout.
(TestDumpClassLayoutScript.setUp): Add.
(TestDumpClassLayoutScript.tearDown): Add.
(TestDumpClassLayoutScript.test_single_classname_calls_layout_once): Add.
(TestDumpClassLayoutScript.test_multiple_classnames_each_get_layout_called): Add.
(TestDumpClassLayoutScript.test_blank_line_printed_between_multiple_classes): Add.
(TestDumpClassLayoutScript.test_blank_line_count_matches_class_count_minus_one): Add.
(TestDumpClassLayoutScript.test_no_blank_line_for_single_class): Add.
* Tools/lldb/lldbWebKitTester/DumpClassLayoutTesting.cpp:
(InheritsFromClassWithPaddedBitfields):
- Drive-by fix to update the clang record layout comment to match the
  current compiler-generated layout.

Canonical link: <a href="https://commits.webkit.org/310262@main">https://commits.webkit.org/310262@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b05e1ce73422f12141025a9d009c40530a54bd0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153302 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/26086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/19684 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162047 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7c0a0bc3-794f-4d94-beb5-b2e6c8cd60d9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155175 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26612 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/26406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/118516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/15c72d3d-d254-4382-9c3c-aff3b37ec1a6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156261 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/20755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/137641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99228 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ecf6f138-148e-480e-b544-c3edd69f400d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/19832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/26406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9882 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/129479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/15511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164521 "Built successfully") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/17105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/126573 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/25882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/26406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126731 "Passed tests") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/25885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/137307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/82552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23451 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/25885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/14085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/25502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/25193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/25352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/25253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->