### PR TITLE
Fix CSS absolute positioning on MathML elements by adding missing updateLogicalHeight() calls

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2161,7 +2161,6 @@ mathml/non-core/mathvariant/mathvariant-case-sensitivity.html [ ImageOnlyFailure
 imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-form-minus-plus.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-form.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-single-char-and-children.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/mathml/relations/css-styling/clip.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/relations/css-styling/presentational-hints-001.html [ ImageOnlyFailure Pass ]
 imported/w3c/web-platform-tests/mathml/relations/css-styling/transform.html [ ImageOnlyFailure ]
 

--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2086,7 +2086,6 @@ mathml/non-core/mathvariant/mathvariant-case-sensitivity.html [ ImageOnlyFailure
 imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-form-minus-plus.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-form.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-single-char-and-children.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/mathml/relations/css-styling/clip.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/relations/css-styling/presentational-hints-001.html [ ImageOnlyFailure Pass ]
 imported/w3c/web-platform-tests/mathml/relations/css-styling/transform.html [ ImageOnlyFailure ]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/out-of-flow/absolutely-positioned-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/out-of-flow/absolutely-positioned-002-expected.txt
@@ -1,0 +1,28 @@
+
+PASS position: absolute on <a> element itself
+PASS position: absolute on <maction> element itself
+PASS position: absolute on <menclose> element itself
+PASS position: absolute on <merror> element itself
+PASS position: absolute on <mfrac> element itself
+PASS position: absolute on <mi> element itself
+PASS position: absolute on <mmultiscripts> element itself
+PASS position: absolute on <mn> element itself
+PASS position: absolute on <mo> element itself
+PASS position: absolute on <mover> element itself
+PASS position: absolute on <mpadded> element itself
+PASS position: absolute on <mphantom> element itself
+PASS position: absolute on <mroot> element itself
+PASS position: absolute on <mrow> element itself
+PASS position: absolute on <ms> element itself
+PASS position: absolute on <mspace> element itself
+PASS position: absolute on <msqrt> element itself
+PASS position: absolute on <mstyle> element itself
+PASS position: absolute on <msub> element itself
+PASS position: absolute on <msubsup> element itself
+PASS position: absolute on <msup> element itself
+PASS position: absolute on <mtable> element itself
+PASS position: absolute on <mtext> element itself
+PASS position: absolute on <munder> element itself
+PASS position: absolute on <munderover> element itself
+PASS position: absolute on <semantics> element itself
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/out-of-flow/absolutely-positioned-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/out-of-flow/absolutely-positioned-002-expected.txt
@@ -1,0 +1,27 @@
+
+PASS position: absolute on <maction> element itself
+PASS position: absolute on <menclose> element itself
+PASS position: absolute on <merror> element itself
+PASS position: absolute on <mfrac> element itself
+PASS position: absolute on <mi> element itself
+PASS position: absolute on <mmultiscripts> element itself
+PASS position: absolute on <mn> element itself
+PASS position: absolute on <mo> element itself
+PASS position: absolute on <mover> element itself
+PASS position: absolute on <mpadded> element itself
+PASS position: absolute on <mphantom> element itself
+PASS position: absolute on <mroot> element itself
+PASS position: absolute on <mrow> element itself
+PASS position: absolute on <ms> element itself
+PASS position: absolute on <mspace> element itself
+PASS position: absolute on <msqrt> element itself
+PASS position: absolute on <mstyle> element itself
+PASS position: absolute on <msub> element itself
+PASS position: absolute on <msubsup> element itself
+PASS position: absolute on <msup> element itself
+PASS position: absolute on <mtable> element itself
+PASS position: absolute on <mtext> element itself
+PASS position: absolute on <munder> element itself
+PASS position: absolute on <munderover> element itself
+PASS position: absolute on <semantics> element itself
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/out-of-flow/absolutely-positioned-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/out-of-flow/absolutely-positioned-002.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Absolutely positioned MathML elements</title>
+<link rel="help" href="https://w3c.github.io/mathml-core/#layout-algorithms">
+<link rel="help" href="https://w3c.github.io/mathml-core/#css-styling">
+<meta name="assert" content="Verify that position:absolute with top/left works on MathML elements themselves.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/mathml/support/feature-detection.js"></script>
+<script src="/mathml/support/mathml-fragments.js"></script>
+<style>
+  /* override display: none on children of maction/semantics */
+  maction > *, semantics > * {
+    display: math;
+  }
+</style>
+<script>
+
+  window.addEventListener("DOMContentLoaded", _ => {
+      var targetTop = 200;
+      var targetLeft = 300;
+
+      for (tag in MathMLFragments) {
+          if (!FragmentHelper.isValidChildOfMrow(tag))
+              continue;
+
+          // Create a positioned container.
+          var container = document.createElement("div");
+          container.style.position = "absolute";
+          container.style.left = "0";
+          container.style.top = "0";
+          document.body.appendChild(container);
+
+          // Insert the MathML fragment inside a <math> element.
+          container.insertAdjacentHTML("beforeend", `<math>${MathMLFragments[tag]}</math>`);
+          var element = FragmentHelper.element(container.querySelector("math"));
+
+          // Give the element content so it has a nonzero size.
+          if (tag === "mspace") {
+              element.setAttribute("width", "50px");
+              element.setAttribute("height", "50px");
+          } else {
+              FragmentHelper.forceNonEmptyDescendants(element);
+          }
+
+          // Make the element itself absolutely positioned.
+          element.setAttribute("style",
+              `position: absolute; top: ${targetTop}px; left: ${targetLeft}px`);
+
+          var box = element.getBoundingClientRect();
+          var containerBox = container.getBoundingClientRect();
+          var epsilon = 1;
+
+          test(function() {
+              assert_true(MathMLFeatureDetection[`has_${tag}`](), `${tag} is supported`);
+              assert_greater_than(box.width, 0, "element has nonzero width");
+              assert_greater_than(box.height, 0, "element has nonzero height");
+              assert_approx_equals(box.left - containerBox.left, targetLeft, epsilon,
+                  "left position");
+              assert_approx_equals(box.top - containerBox.top, targetTop, epsilon,
+                  "top position");
+          }, `position: absolute on <${tag}> element itself`);
+
+          container.style.display = "none";
+      }
+  });
+</script>
+</head>
+<body>
+  <div id="log"></div>
+</body>
+</html>

--- a/Source/WebCore/rendering/mathml/RenderMathMLFraction.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLFraction.cpp
@@ -285,6 +285,8 @@ void RenderMathMLFraction::layoutBlock(RelayoutChildren relayoutChildren, Layout
 
     adjustLayoutForBorderAndPadding();
 
+    updateLogicalHeight();
+
     layoutOutOfFlowBoxes(relayoutChildren);
 }
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLFraction.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLFraction.cpp
@@ -283,6 +283,8 @@ void RenderMathMLFraction::layoutBlock(RelayoutChildren relayoutChildren, Layout
 
     adjustLayoutForBorderAndPadding();
 
+    updateLogicalHeight();
+
     layoutOutOfFlowBoxes(relayoutChildren);
 }
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLMenclose.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLMenclose.cpp
@@ -209,6 +209,8 @@ void RenderMathMLMenclose::layoutBlock(RelayoutChildren relayoutChildren, Layout
     adjustLayoutForBorderAndPadding();
     m_contentRect.moveBy(LayoutPoint(borderLeft() + paddingLeft(), borderAndPaddingBefore()));
 
+    updateLogicalHeight();
+
     layoutOutOfFlowBoxes(relayoutChildren);
 }
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLOperator.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLOperator.cpp
@@ -243,6 +243,8 @@ void RenderMathMLOperator::layoutBlock(RelayoutChildren relayoutChildren, Layout
         setLogicalWidth(leadingSpaceValue + m_mathOperator.width() + trailingSpaceValue + borderAndPaddingLogicalWidth());
         setLogicalHeight(m_mathOperator.ascent() + m_mathOperator.descent() + borderAndPaddingLogicalHeight());
 
+        updateLogicalHeight();
+
         layoutOutOfFlowBoxes(relayoutChildren);
     } else {
         // We first do the normal layout without spacing.

--- a/Source/WebCore/rendering/mathml/RenderMathMLPadded.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLPadded.cpp
@@ -146,6 +146,8 @@ void RenderMathMLPadded::layoutBlock(RelayoutChildren relayoutChildren, LayoutUn
 
     adjustLayoutForBorderAndPadding();
 
+    updateLogicalHeight();
+
     layoutOutOfFlowBoxes(relayoutChildren);
 }
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLRoot.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLRoot.cpp
@@ -284,6 +284,8 @@ void RenderMathMLRoot::layoutBlock(RelayoutChildren relayoutChildren, LayoutUnit
 
     adjustLayoutForBorderAndPadding();
 
+    updateLogicalHeight();
+
     layoutOutOfFlowBoxes(relayoutChildren);
 }
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLRoot.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLRoot.cpp
@@ -282,6 +282,8 @@ void RenderMathMLRoot::layoutBlock(RelayoutChildren relayoutChildren, LayoutUnit
 
     adjustLayoutForBorderAndPadding();
 
+    updateLogicalHeight();
+
     layoutOutOfFlowBoxes(relayoutChildren);
 }
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLRow.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLRow.cpp
@@ -189,6 +189,8 @@ void RenderMathMLRow::layoutBlock(RelayoutChildren relayoutChildren, LayoutUnit)
 
     adjustLayoutForBorderAndPadding();
 
+    updateLogicalHeight();
+
     layoutOutOfFlowBoxes(relayoutChildren);
 }
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLRow.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLRow.cpp
@@ -188,6 +188,8 @@ void RenderMathMLRow::layoutBlock(RelayoutChildren relayoutChildren, LayoutUnit)
 
     adjustLayoutForBorderAndPadding();
 
+    updateLogicalHeight();
+
     layoutOutOfFlowBoxes(relayoutChildren);
 }
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLScripts.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLScripts.cpp
@@ -507,6 +507,8 @@ void RenderMathMLScripts::layoutBlock(RelayoutChildren relayoutChildren, LayoutU
 
     adjustLayoutForBorderAndPadding();
 
+    updateLogicalHeight();
+
     layoutOutOfFlowBoxes(relayoutChildren);
 }
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLScripts.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLScripts.cpp
@@ -506,6 +506,8 @@ void RenderMathMLScripts::layoutBlock(RelayoutChildren relayoutChildren, LayoutU
 
     adjustLayoutForBorderAndPadding();
 
+    updateLogicalHeight();
+
     layoutOutOfFlowBoxes(relayoutChildren);
 }
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLSpace.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLSpace.cpp
@@ -107,6 +107,8 @@ void RenderMathMLSpace::layoutBlock(RelayoutChildren relayoutChildren, LayoutUni
     applySizeToMathContent(LayoutPhase::Layout, sizes);
 
     adjustLayoutForBorderAndPadding();
+
+    updateLogicalHeight();
 }
 
 std::optional<LayoutUnit> RenderMathMLSpace::firstLineBaseline() const

--- a/Source/WebCore/rendering/mathml/RenderMathMLToken.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLToken.cpp
@@ -186,6 +186,8 @@ void RenderMathMLToken::layoutBlock(RelayoutChildren relayoutChildren, LayoutUni
 
     adjustLayoutForBorderAndPadding();
 
+    updateLogicalHeight();
+
     layoutOutOfFlowBoxes(relayoutChildren);
 }
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLToken.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLToken.cpp
@@ -180,6 +180,8 @@ void RenderMathMLToken::layoutBlock(RelayoutChildren relayoutChildren, LayoutUni
 
     adjustLayoutForBorderAndPadding();
 
+    updateLogicalHeight();
+
     layoutOutOfFlowBoxes(relayoutChildren);
 }
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLUnderOver.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLUnderOver.cpp
@@ -384,6 +384,8 @@ void RenderMathMLUnderOver::layoutBlock(RelayoutChildren relayoutChildren, Layou
 
     adjustLayoutForBorderAndPadding();
 
+    updateLogicalHeight();
+
     layoutOutOfFlowBoxes(relayoutChildren);
 }
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLUnderOver.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLUnderOver.cpp
@@ -382,6 +382,8 @@ void RenderMathMLUnderOver::layoutBlock(RelayoutChildren relayoutChildren, Layou
 
     adjustLayoutForBorderAndPadding();
 
+    updateLogicalHeight();
+
     layoutOutOfFlowBoxes(relayoutChildren);
 }
 


### PR DESCRIPTION
#### d45ee7b421a1d3743bb20ebf663dd789fbc2de1a
<pre>
Fix CSS absolute positioning on MathML elements by adding missing updateLogicalHeight() calls
<a href="https://bugs.webkit.org/show_bug.cgi?id=310444">https://bugs.webkit.org/show_bug.cgi?id=310444</a>
<a href="https://rdar.apple.com/173088146">rdar://173088146</a>

Reviewed by Alan Baradlay.

This patch aligns WebKit with Blink / Chromium.

Most MathML renderers override layoutBlock() without calling updateLogicalHeight(),
which is responsible for computing logicalTop/logicalBottom from CSS top/bottom
properties on absolutely positioned elements via computeOutOfFlowPositionedLogicalHeight().

This means position:absolute with top/left on any MathML element (mspace, mrow, mfrac,
msqrt, msub, munder, mpadded, menclose, mo, mtext, etc.) silently ignores the
top/bottom properties, rendering the element at its default position instead.

Add updateLogicalHeight() to all MathML layoutBlock() overrides that were missing it:
RenderMathMLSpace, RenderMathMLRow, RenderMathMLFraction, RenderMathMLRoot,
RenderMathMLUnderOver, RenderMathMLScripts, RenderMathMLMenclose, RenderMathMLPadded,
RenderMathMLToken, and RenderMathMLOperator.

RenderMathMLBlock and RenderMathMLMath already had the call.

Test: imported/w3c/web-platform-tests/mathml/relations/css-styling/out-of-flow/absolutely-positioned-002.html

* LayoutTests/TestExpectations: Progression
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/out-of-flow/absolutely-positioned-002-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/out-of-flow/absolutely-positioned-002.html: Added.
* Source/WebCore/rendering/mathml/RenderMathMLFraction.cpp:
(WebCore::RenderMathMLFraction::layoutBlock):
* Source/WebCore/rendering/mathml/RenderMathMLMenclose.cpp:
(WebCore::RenderMathMLMenclose::layoutBlock):
* Source/WebCore/rendering/mathml/RenderMathMLOperator.cpp:
(WebCore::RenderMathMLOperator::layoutBlock):
* Source/WebCore/rendering/mathml/RenderMathMLPadded.cpp:
(WebCore::RenderMathMLPadded::layoutBlock):
* Source/WebCore/rendering/mathml/RenderMathMLRoot.cpp:
(WebCore::RenderMathMLRoot::layoutBlock):
* Source/WebCore/rendering/mathml/RenderMathMLRow.cpp:
(WebCore::RenderMathMLRow::layoutBlock):
* Source/WebCore/rendering/mathml/RenderMathMLScripts.cpp:
(WebCore::RenderMathMLScripts::layoutBlock):
* Source/WebCore/rendering/mathml/RenderMathMLSpace.cpp:
(WebCore::RenderMathMLSpace::layoutBlock):
* Source/WebCore/rendering/mathml/RenderMathMLToken.cpp:
(WebCore::RenderMathMLToken::layoutBlock):
* Source/WebCore/rendering/mathml/RenderMathMLUnderOver.cpp:
(WebCore::RenderMathMLUnderOver::layoutBlock):

Canonical link: <a href="https://commits.webkit.org/312905@main">https://commits.webkit.org/312905@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b291b7d64703602c4adae17916c809544cf7684

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161376 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34850 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27950 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170279 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a5465682-bda0-4a31-8696-0b0a8d666eb3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163245 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34950 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34851 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125188 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0052d437-44c7-41a4-bd38-dca630a16837) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164335 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27478 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144963 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105785 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/226211e9-e722-4328-87a8-e0cb0bc418d3) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17999 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136220 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22722 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172763 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19796 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24363 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133473 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34524 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29127 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133481 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36068 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34508 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144517 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96387 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28016 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/21336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34018 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101459 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33518 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33761 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33667 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->