### PR TITLE
[JSC] `String#repeat` should not resolve rope when building a rope result

### DIFF
--- a/JSTests/microbenchmarks/string-repeat-rope-not-resolving.js
+++ b/JSTests/microbenchmarks/string-repeat-rope-not-resolving.js
@@ -1,0 +1,10 @@
+function test(str, count)
+{
+    return str.repeat(count);
+}
+noInline(test);
+
+let a = "a".repeat(50000);
+let b = "b".repeat(50000);
+for (let i = 0; i < 1e4; ++i)
+    test(a + b, 2);

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -1996,33 +1996,35 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncRepeat, (JSGlobalObject* globalObject, C
     if (repeatCount == 1)
         return JSValue::encode(thisString);
 
-    auto view = thisString->view(globalObject);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    if (stringLength == 1) {
-        // For a string which length is single, instead of creating ropes,
-        // allocating a sequential buffer and fill with the repeated string for efficiency.
-        char16_t character = view[0];
-        scope.release();
-        if (isLatin1(character))
-            return JSValue::encode(repeatCharacter(globalObject, static_cast<Latin1Character>(character), repeatCount));
-        return JSValue::encode(repeatCharacter(globalObject, character, repeatCount));
-    }
-
     auto checkedResultLength = checkedProduct<unsigned>(stringLength, static_cast<unsigned>(repeatCount));
     if (checkedResultLength.hasOverflowed() || static_cast<unsigned>(checkedResultLength) > JSString::MaxLength) [[unlikely]]
         return JSValue::encode(throwOutOfMemoryError(globalObject, scope));
-
-    // Even if the string length is not single, if the resulting string length is small,
-    // allocating a sequential buffer and fill with the repeated string for efficiency.
     unsigned resultLength = checkedResultLength;
+
     constexpr unsigned maxStringLength = 8;
     constexpr unsigned maxResultLength = 1024;
-    if (stringLength <= maxStringLength && resultLength <= maxResultLength) {
-        scope.release();
-        if (view->is8Bit())
-            return JSValue::encode(repeatString<Latin1Character>(globalObject, view, repeatCount));
-        return JSValue::encode(repeatString<char16_t>(globalObject, view, repeatCount));
+    if (stringLength <= maxStringLength) {
+        auto view = thisString->view(globalObject);
+        RETURN_IF_EXCEPTION(scope, { });
+
+        if (stringLength == 1) {
+            // For a string which length is single, instead of creating ropes,
+            // allocating a sequential buffer and fill with the repeated string for efficiency.
+            char16_t character = view[0];
+            scope.release();
+            if (isLatin1(character))
+                return JSValue::encode(repeatCharacter(globalObject, static_cast<Latin1Character>(character), repeatCount));
+            return JSValue::encode(repeatCharacter(globalObject, character, repeatCount));
+        }
+
+        // Even if the string length is not single, if the resulting string length is small,
+        // allocating a sequential buffer and fill with the repeated string for efficiency.
+        if (resultLength <= maxResultLength) {
+            scope.release();
+            if (view->is8Bit())
+                return JSValue::encode(repeatString<Latin1Character>(globalObject, view, repeatCount));
+            return JSValue::encode(repeatString<char16_t>(globalObject, view, repeatCount));
+        }
     }
 
     RELEASE_AND_RETURN(scope, JSValue::encode(repeatRope(globalObject, thisString, repeatCount)));


### PR DESCRIPTION
#### 00aa2fb09f21e9a1600f8c5d8375a4b10dbe83e1
<pre>
[JSC] `String#repeat` should not resolve rope when building a rope result
<a href="https://bugs.webkit.org/show_bug.cgi?id=310451">https://bugs.webkit.org/show_bug.cgi?id=310451</a>

Reviewed by Yusuke Suzuki.

stringProtoFuncRepeat unconditionally called view() which resolves the
rope, but the resolved view is only needed when the source string is
short enough to fill a sequential buffer (stringLength &lt;= 8). For longer
strings, the result is built via repeatRope which keeps the source as a
rope fiber, so the flatten is wasted work.

This patch moves the view() call inside the stringLength &lt;= maxStringLength
guard. The overflow check is hoisted before the length-1 fast path; this
is observably equivalent since repeatCount &lt;= MaxLength is already ensured
by the earlier argument validation.

                                          Baseline              Patched

string-repeat-rope-not-resolving    11.7956+-0.5261  ^  0.4885+-0.0391  ^ definitely 24.1453x faster

Test: JSTests/microbenchmarks/string-repeat-rope-not-resolving.js

* JSTests/microbenchmarks/string-repeat-rope-not-resolving.js: Added.
(test):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/309902@main">https://commits.webkit.org/309902@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5735828ce5fe7f8e6e7ee007672065846f99dc37

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151479 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24244 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17825 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160211 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104917 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24675 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24546 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116969 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83041 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154439 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19118 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135927 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97689 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18209 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16154 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8055 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/143476 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127836 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13832 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162682 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/12280 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5815 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15420 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124988 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24045 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20211 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125173 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34107 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24037 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135628 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80584 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20231 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12402 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/183088 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23646 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87958 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46688 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23356 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23510 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23412 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->