### PR TITLE
[Swift in WebKit] Use `CryptoDigestHashFunction` type directly in Swift instead of it's raw value

### DIFF
--- a/Source/WebCore/PAL/pal/PALSwift/CryptoKitShim.swift
+++ b/Source/WebCore/PAL/pal/PALSwift/CryptoKitShim.swift
@@ -406,17 +406,12 @@ public struct ECKey {
         return returnValue
     }
 
-    // FIXME: `hashFunction` should not be a raw value, but compilers < 6.0 do not understand C++ enums as parameters.
     // FIXME: PALSwift should have no public symbols.
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func sign(
         message: SpanConstUInt8,
-        hashFunction hashFunctionRawValue: PAL.CryptoDigestHashFunction.RawValue
+        hashFunction: PAL.CryptoDigestHashFunction
     ) -> CryptoOperationReturnValue {
-        // FIXME: This is safe because all callers use the enum type itself, and this is only temporary.
-        // swift-format-ignore: NeverForceUnwrap
-        let hashFunction = PAL.CryptoDigestHashFunction(rawValue: hashFunctionRawValue)!
-
         var returnValue = CryptoOperationReturnValue()
         do {
             switch try getInternalPrivate() {
@@ -445,12 +440,8 @@ public struct ECKey {
     public func verify(
         message: SpanConstUInt8,
         signature: SpanConstUInt8,
-        hashFunction hashFunctionRawValue: PAL.CryptoDigestHashFunction.RawValue
+        hashFunction: PAL.CryptoDigestHashFunction
     ) -> CryptoOperationReturnValue {
-        // FIXME: This is safe because all callers use the enum type itself, and this is only temporary.
-        // swift-format-ignore: NeverForceUnwrap
-        let hashFunction = PAL.CryptoDigestHashFunction(rawValue: hashFunctionRawValue)!
-
         var returnValue = CryptoOperationReturnValue()
         do {
             let internalPublic = try getInternalPublic()
@@ -772,12 +763,8 @@ public class HMAC {
     public static func sign(
         key: SpanConstUInt8,
         data: SpanConstUInt8,
-        hashFunction hashFunctionRawValue: PAL.CryptoDigestHashFunction.RawValue
+        hashFunction: PAL.CryptoDigestHashFunction
     ) -> VectorUInt8 {
-        // FIXME: This is safe because all callers use the enum type itself, and this is only temporary.
-        // swift-format-ignore: NeverForceUnwrap
-        let hashFunction = PAL.CryptoDigestHashFunction(rawValue: hashFunctionRawValue)!
-
         switch hashFunction {
         case .SHA_1:
             return unsafe CryptoKit.HMAC<Insecure.SHA1>.authenticationCode(data: data, key: key)
@@ -800,12 +787,8 @@ public class HMAC {
         mac: SpanConstUInt8,
         key: SpanConstUInt8,
         data: SpanConstUInt8,
-        hashFunction hashFunctionRawValue: PAL.CryptoDigestHashFunction.RawValue
+        hashFunction: PAL.CryptoDigestHashFunction
     ) -> Bool {
-        // FIXME: This is safe because all callers use the enum type itself, and this is only temporary.
-        // swift-format-ignore: NeverForceUnwrap
-        let hashFunction = PAL.CryptoDigestHashFunction(rawValue: hashFunctionRawValue)!
-
         switch hashFunction {
         case .SHA_1:
             return unsafe CryptoKit.HMAC<Insecure.SHA1>
@@ -844,12 +827,8 @@ public class HKDF {
         salt: SpanConstUInt8,
         info: SpanConstUInt8,
         outputBitCount: Int,
-        hashFunction hashFunctionRawValue: PAL.CryptoDigestHashFunction.RawValue
+        hashFunction: PAL.CryptoDigestHashFunction
     ) -> CryptoOperationReturnValue {
-        // FIXME: This is safe because all callers use the enum type itself, and this is only temporary.
-        // swift-format-ignore: NeverForceUnwrap
-        let hashFunction = PAL.CryptoDigestHashFunction(rawValue: hashFunctionRawValue)!
-
         var returnValue = CryptoOperationReturnValue()
         if outputBitCount <= 0 || outputBitCount % 8 != 0 {
             returnValue.errorCode = .InvalidArgument

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSACocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSACocoa.cpp
@@ -41,7 +41,7 @@ static ExceptionOr<Vector<uint8_t>> signECDSACryptoKit(CryptoAlgorithmIdentifier
 {
     if (!isValidHashParameter(hash))
         return Exception { ExceptionCode::OperationError };
-    auto rv = key->sign(data.span(), std::to_underlying(toCKHashFunction(hash)));
+    auto rv = key->sign(data.span(), toCKHashFunction(hash));
     if (rv.errorCode != Cpp::ErrorCodes::Success)
         return Exception { ExceptionCode::OperationError };
     return WTF::move(rv.result);
@@ -51,7 +51,7 @@ static ExceptionOr<bool> verifyECDSACryptoKit(CryptoAlgorithmIdentifier hash, co
 {
     if (!isValidHashParameter(hash))
         return Exception { ExceptionCode::OperationError };
-    return key->verify(data.span(), signature.span(), std::to_underlying(toCKHashFunction(hash))).errorCode == Cpp::ErrorCodes::Success;
+    return key->verify(data.span(), signature.span(), toCKHashFunction(hash)).errorCode == Cpp::ErrorCodes::Success;
 }
 
 ExceptionOr<Vector<uint8_t>> CryptoAlgorithmECDSA::platformSign(const CryptoAlgorithmEcdsaParams& parameters, const CryptoKeyEC& key, const Vector<uint8_t>& data)

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmHKDFCocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmHKDFCocoa.cpp
@@ -43,7 +43,7 @@ static ExceptionOr<Vector<uint8_t>> platformDeriveBitsCryptoKit(const CryptoAlgo
 {
     if (!isValidHashParameter(parameters.hashIdentifier))
         return Exception { ExceptionCode::OperationError };
-    auto rv = pal::HKDF::deriveBits(key.key().span(), parameters.saltVector().span(), parameters.infoVector().span(), length, std::to_underlying(toCKHashFunction(parameters.hashIdentifier)));
+    auto rv = pal::HKDF::deriveBits(key.key().span(), parameters.saltVector().span(), parameters.infoVector().span(), length, toCKHashFunction(parameters.hashIdentifier));
     if (rv.errorCode != Cpp::ErrorCodes::Success)
         return Exception { ExceptionCode::OperationError };
     return WTF::move(rv.result);

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmHMACCocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmHMACCocoa.cpp
@@ -38,14 +38,14 @@ static ExceptionOr<Vector<uint8_t>> platformSignCryptoKit(const CryptoKeyHMAC& k
 {
     if (!isValidHashParameter(key.hashAlgorithmIdentifier()))
         return Exception { ExceptionCode::OperationError };
-    return pal::HMAC::sign(key.key().span(), data.span(), std::to_underlying(toCKHashFunction(key.hashAlgorithmIdentifier())));
+    return pal::HMAC::sign(key.key().span(), data.span(), toCKHashFunction(key.hashAlgorithmIdentifier()));
 }
 
 static ExceptionOr<bool> platformVerifyCryptoKit(const CryptoKeyHMAC& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data)
 {
     if (!isValidHashParameter(key.hashAlgorithmIdentifier()))
         return Exception { ExceptionCode::OperationError };
-    return pal::HMAC::verify(signature.span(), key.key().span(), data.span(), std::to_underlying(toCKHashFunction(key.hashAlgorithmIdentifier())));
+    return pal::HMAC::verify(signature.span(), key.key().span(), data.span(), toCKHashFunction(key.hashAlgorithmIdentifier()));
 }
 
 ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHMAC::platformSign(const CryptoKeyHMAC& key, const Vector<uint8_t>& data)

--- a/Source/WebCore/workers/service/ServiceWorkerRoute.mm
+++ b/Source/WebCore/workers/service/ServiceWorkerRoute.mm
@@ -27,6 +27,7 @@
 #import "ServiceWorkerRoute.h"
 
 #import <pal/PALSwift.h>
+#import <pal/crypto/CryptoDigestHashFunction.h>
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunsafe-buffer-usage"


### PR DESCRIPTION
#### 8bc6fc32af2dca2990218be24212c1ae54723960
<pre>
[Swift in WebKit] Use `CryptoDigestHashFunction` type directly in Swift instead of it&apos;s raw value
<a href="https://bugs.webkit.org/show_bug.cgi?id=310455">https://bugs.webkit.org/show_bug.cgi?id=310455</a>
<a href="https://rdar.apple.com/173091954">rdar://173091954</a>

Reviewed by Abrar Rahman Protyasha.

All configurations now use &gt;= Swift 6.2, so this workaround is no longer needed.

* Source/WebCore/PAL/pal/PALSwift/CryptoKitShim.swift:
* Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSACocoa.cpp:
(WebCore::signECDSACryptoKit):
(WebCore::verifyECDSACryptoKit):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmHKDFCocoa.cpp:
(WebCore::platformDeriveBitsCryptoKit):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmHMACCocoa.cpp:
(WebCore::platformSignCryptoKit):
(WebCore::platformVerifyCryptoKit):
* Source/WebCore/workers/service/ServiceWorkerRoute.mm:

Canonical link: <a href="https://commits.webkit.org/309709@main">https://commits.webkit.org/309709@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7552a946eea3d523a0b60058f79ce28e7e990204

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151484 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24249 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17830 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160216 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104922 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1e76661b-4234-4417-b902-dc6fcb5ccdca) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153358 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24680 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24551 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116974 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83045 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4c5a0a52-f007-4b64-933e-4532cb13e2f0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154444 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19123 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135933 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97694 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f4e03ee3-94de-453e-bcb9-196f28484e7a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18213 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16158 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8060 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127840 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13838 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162687 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5820 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15427 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124992 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24050 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20215 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125177 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33956 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24042 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135634 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80589 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20239 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12409 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23651 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87963 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23361 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23515 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23417 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->