### PR TITLE
[JSC] Support inlined JIT functions in SourceCodeDump in JITDump

### DIFF
--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -699,6 +699,7 @@
 		141448CD13A1783700F5BA1A /* TinyBloomFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 141448CC13A1783700F5BA1A /* TinyBloomFilter.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		14150133154BB13F005D8C98 /* WeakSetInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 14150132154BB13F005D8C98 /* WeakSetInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		14201D591DECF26A00904BD3 /* SourceCode.h in Headers */ = {isa = PBXBuildFile; fileRef = 14201D581DECF26A00904BD3 /* SourceCode.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		5CD0000000000000000000A3 /* SourceCodeDumpUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CD0000000000000000000A2 /* SourceCodeDumpUtils.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1429D77C0ED20D7300B89619 /* Interpreter.h in Headers */ = {isa = PBXBuildFile; fileRef = 1429D77B0ED20D7300B89619 /* Interpreter.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1429D8DE0ED2205B00B89619 /* CallFrame.h in Headers */ = {isa = PBXBuildFile; fileRef = 1429D8DC0ED2205B00B89619 /* CallFrame.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1429D9300ED22D7000B89619 /* JIT.h in Headers */ = {isa = PBXBuildFile; fileRef = 1429D92E0ED22D7000B89619 /* JIT.h */; };
@@ -3771,6 +3772,8 @@
 		141448CC13A1783700F5BA1A /* TinyBloomFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TinyBloomFilter.h; sourceTree = "<group>"; };
 		14150132154BB13F005D8C98 /* WeakSetInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WeakSetInlines.h; sourceTree = "<group>"; };
 		14201D581DECF26A00904BD3 /* SourceCode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SourceCode.h; sourceTree = "<group>"; };
+		5CD0000000000000000000A1 /* SourceCodeDumpUtils.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SourceCodeDumpUtils.cpp; sourceTree = "<group>"; };
+		5CD0000000000000000000A2 /* SourceCodeDumpUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SourceCodeDumpUtils.h; sourceTree = "<group>"; };
 		1421359A0A677F4F00A8195E /* JSBase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSBase.cpp; sourceTree = "<group>"; };
 		142711380A460BBB0080EEEA /* JSBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSBase.h; sourceTree = "<group>"; };
 		1429D77B0ED20D7300B89619 /* Interpreter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Interpreter.h; sourceTree = "<group>"; };
@@ -10186,6 +10189,8 @@
 				865DA0C425B8957400875772 /* SetPrivateBrandVariant.h */,
 				E33B33352B9BA14E0011E80F /* SharedJITStubSet.cpp */,
 				E33B33342B9BA14E0011E80F /* SharedJITStubSet.h */,
+				5CD0000000000000000000A1 /* SourceCodeDumpUtils.cpp */,
+				5CD0000000000000000000A2 /* SourceCodeDumpUtils.h */,
 				5350356427147E5900EC1A7E /* SourceID.h */,
 				0FD82E84141F3FDA00179C94 /* SpeculatedType.cpp */,
 				0FD82E4F141DAEA100179C94 /* SpeculatedType.h */,
@@ -12353,6 +12358,7 @@
 				E3F23A801ECF13F500978D99 /* SnippetReg.h in Headers */,
 				E3F23A7F1ECF13EE00978D99 /* SnippetSlowPathCalls.h in Headers */,
 				14201D591DECF26A00904BD3 /* SourceCode.h in Headers */,
+				5CD0000000000000000000A3 /* SourceCodeDumpUtils.h in Headers */,
 				70B791911C024A13002481E2 /* SourceCodeKey.h in Headers */,
 				5350356527147E5A00EC1A7E /* SourceID.h in Headers */,
 				2D342F36F7244096804ADB24 /* SourceOrigin.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -289,6 +289,7 @@ bytecode/Repatch.cpp
 bytecode/SetPrivateBrandStatus.cpp
 bytecode/SetPrivateBrandVariant.cpp
 bytecode/SharedJITStubSet.cpp
+bytecode/SourceCodeDumpUtils.cpp
 bytecode/SpeculatedType.cpp
 bytecode/StructureSet.cpp
 bytecode/PropertyInlineCacheClearingWatchpoint.cpp

--- a/Source/JavaScriptCore/assembler/LinkBuffer.cpp
+++ b/Source/JavaScriptCore/assembler/LinkBuffer.cpp
@@ -34,6 +34,7 @@
 #include "JITCode.h"
 #include "Options.h"
 #include "PerfLog.h"
+#include "SourceCodeDumpUtils.h"
 #include "WasmCallee.h"
 #include "YarrJIT.h"
 #include <wtf/ScopedPrintStream.h>
@@ -88,42 +89,48 @@ void LinkBuffer::logJITCodeForJITDump(CodeRef<LinkBufferPtrTag>& codeRef, ASCIIL
             out.print(simpleName);
     };
 
-    StringPrintStream out;
-    out.print("JSC-", profileName(m_profile), ": ");
+    CString finalName;
     switch (m_profile) {
     case Profile::Baseline:
     case Profile::DFG:
     case Profile::FTL: {
-        if (m_ownerUID)
-            static_cast<CodeBlock*>(m_ownerUID)->dumpSimpleName(out);
-        else
-            dumpSimpleName(out, simpleName);
-        break;
+        if (m_ownerUID) {
+            finalName = functionNameForJITDump(m_profile, static_cast<CodeBlock*>(m_ownerUID));
+            break;
+        }
+        [[fallthrough]];
     }
+    default: {
+        StringPrintStream out;
+        out.print("JSC-", profileName(m_profile), ": ");
+        switch (m_profile) {
 #if ENABLE(WEBASSEMBLY)
-    case Profile::WasmOMG:
-    case Profile::WasmBBQ: {
-        if (m_ownerUID)
-            uncheckedDowncast<Wasm::Callee>(reinterpret_cast<NativeCallee*>(m_ownerUID))->dumpSimpleName(out);
-        else
-            dumpSimpleName(out, simpleName);
-        break;
-    }
+        case Profile::WasmOMG:
+        case Profile::WasmBBQ: {
+            if (m_ownerUID)
+                uncheckedDowncast<Wasm::Callee>(reinterpret_cast<NativeCallee*>(m_ownerUID))->dumpSimpleName(out);
+            else
+                dumpSimpleName(out, simpleName);
+            break;
+        }
 #endif
 #if ENABLE(YARR_JIT)
-    case Profile::YarrJIT: {
-        if (m_ownerUID)
-            static_cast<Yarr::YarrCodeBlock*>(m_ownerUID)->dumpSimpleName(out);
-        else
-            dumpSimpleName(out, simpleName);
-        break;
-    }
+        case Profile::YarrJIT: {
+            if (m_ownerUID)
+                static_cast<Yarr::YarrCodeBlock*>(m_ownerUID)->dumpSimpleName(out);
+            else
+                dumpSimpleName(out, simpleName);
+            break;
+        }
 #endif
-    default:
-        dumpSimpleName(out, simpleName);
+        default:
+            dumpSimpleName(out, simpleName);
+            break;
+        }
+        finalName = out.toCString();
         break;
     }
-    auto finalName = out.toCString();
+    }
 
     if (Options::useGdbJITInfo()) [[unlikely]]
         GdbJIT::log(finalName, codeRef);

--- a/Source/JavaScriptCore/assembler/LinkBuffer.h
+++ b/Source/JavaScriptCore/assembler/LinkBuffer.h
@@ -49,6 +49,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace JSC {
 
+class CodeBlock;
 class SourceProvider;
 
 class IRDumpDebugInfo {
@@ -82,10 +83,29 @@ class SourceCodeDumpDebugInfo {
     WTF_MAKE_TZONE_ALLOCATED(SourceCodeDumpDebugInfo);
     WTF_MAKE_NONCOPYABLE(SourceCodeDumpDebugInfo);
 public:
+    struct FrameInfo final : RefCounted<FrameInfo> {
+        static Ref<FrameInfo> create(CodeBlock* codeBlock, Ref<SourceProvider>&& sourceProvider, LineColumn lineColumn, LineColumn functionStartLineColumn, RefPtr<FrameInfo>&& parent)
+        {
+            return adoptRef(*new FrameInfo(codeBlock, WTF::move(sourceProvider), lineColumn, functionStartLineColumn, WTF::move(parent)));
+        }
+        SUPPRESS_FORWARD_DECL_MEMBER CodeBlock* codeBlock; // This is just used for dedup key. Not accessed actually.
+        Ref<SourceProvider> sourceProvider;
+        LineColumn lineColumn;
+        LineColumn functionStartLineColumn;
+        RefPtr<FrameInfo> parent;
+    private:
+        FrameInfo(CodeBlock* codeBlock, Ref<SourceProvider>&& sourceProvider, LineColumn lineColumn, LineColumn functionStartLineColumn, RefPtr<FrameInfo>&& parent)
+            : codeBlock(codeBlock)
+            , sourceProvider(WTF::move(sourceProvider))
+            , lineColumn(lineColumn)
+            , functionStartLineColumn(functionStartLineColumn)
+            , parent(WTF::move(parent))
+        { }
+    };
+
     struct CodeEntry {
         uint32_t codeOffset;
-        LineColumn lineColumn;
-        Ref<SourceProvider> sourceProvider;
+        Ref<FrameInfo> frameInfo;
     };
 
     SourceCodeDumpDebugInfo(CString&& name)
@@ -95,6 +115,7 @@ public:
 
     CString functionName;
     Vector<CodeEntry> codeEntries;
+    UncheckedKeyHashMap<CodeBlock*, CString> functionNames;
 };
 
 // LinkBuffer:

--- a/Source/JavaScriptCore/assembler/PerfLog.cpp
+++ b/Source/JavaScriptCore/assembler/PerfLog.cpp
@@ -123,6 +123,7 @@ enum class RecordType : uint32_t {
     JITCodeDebugInfo = 2,
     JITCodeClose = 3,
     JITCodeUnwindingInfo = 4,
+    SamplyJITCodeDebugInfo2 = 827346260,
 };
 
 struct RecordHeader {
@@ -159,6 +160,50 @@ struct DebugEntry {
     uint64_t codeAddress { 0 };
     uint32_t line { 0 };
     uint32_t discrim { 0 };
+};
+
+
+// samply's JITDump extension for inline call tree representation.
+// https://gist.github.com/mstange/8db7a7a0ec21ca1e93c5f7fc12077559
+
+struct SamplyDebugInfo2Record {
+    RecordHeader header {
+        RecordType::SamplyJITCodeDebugInfo2,
+        0,
+        0,
+    };
+    uint64_t codeAddress { 0 };
+    uint64_t codeOffsetCount { 0 };
+    uint64_t sourcePositionCount { 0 };
+    uint64_t stringCount { 0 };
+};
+
+struct CodeOffsetRecord {
+    // The code address offset, relative to the function start address.
+    // This record describes all instructions starting at this offset,
+    // up to the next code offset record's offset.
+    uint32_t codeOffset { 0 };
+    // The index of the source position.
+    uint32_t sourcePosition { 0 };
+};
+
+struct SourcePosition {
+    // The index of the caller source position, if this source position
+    // is within an inlined function. Otherwise -1.
+    int32_t callerIndex { -1 };
+    // The name of the function. This is an index into the string list.
+    uint32_t functionName { 0 };
+    // The name of the file which the function is declared in. This is
+    // an index into the string list. -1 if unknown.
+    int32_t file { -1 };
+    // The line number where the function starts, 1-based. 0 if unknown.
+    uint32_t functionStartLine { 0 };
+    // The column number where the function starts, 1-based. 0 if unknown.
+    uint32_t functionStartColumn { 0 };
+    // The line number, 1-based. 0 if unknown.
+    uint32_t line { 0 };
+    // The column number, 1-based. 0 if unknown.
+    uint32_t column { 0 };
 };
 
 } // namespace JITDump
@@ -230,13 +275,6 @@ void PerfLog::log(const CString& name, MacroAssemblerCodeRef<LinkBufferPtrTag> c
 
         CString irFilePath;
         Vector<std::pair<uint32_t, uint32_t>> lineEntries;
-        struct SourceEntry {
-            uint32_t codeOffset;
-            uint32_t line;
-            uint32_t column;
-            CString filePath;
-        };
-        Vector<SourceEntry> sourceEntries;
 
         if (irDebugInfo) {
             auto baseName = makeString("irdump-"_s, String::fromUTF8(irDebugInfo->functionName.span()), "-"_s, WTF::getCurrentProcessID(), "-"_s, timestamp);
@@ -272,15 +310,6 @@ void PerfLog::log(const CString& name, MacroAssemblerCodeRef<LinkBufferPtrTag> c
             }
         }
 
-        if (sourceCodeDebugInfo) {
-            const CString& sourceCodeDumpDir = logger.m_sourceCodeDumpDirectory;
-            for (auto& entry : sourceCodeDebugInfo->codeEntries) {
-                CString filePath = protect(entry.sourceProvider)->sourceCodeDumpFilePath(sourceCodeDumpDir);
-                if (!filePath.isNull())
-                    sourceEntries.append({ entry.codeOffset, entry.lineColumn.line, entry.lineColumn.column, WTF::move(filePath) });
-            }
-        }
-
         Locker locker { logger.m_lock };
 
         if (!irFilePath.isNull() && !lineEntries.isEmpty()) {
@@ -291,7 +320,7 @@ void PerfLog::log(const CString& name, MacroAssemblerCodeRef<LinkBufferPtrTag> c
 
             uint32_t totalSize = sizeof(JITDump::DebugInfoRecord);
             for (size_t i = 0; i < lineEntries.size(); ++i)
-                totalSize += sizeof(JITDump::DebugEntry) + (irFilePath.length() + 1);
+                totalSize += sizeof(JITDump::DebugEntry) + irFilePath.spanIncludingNullTerminator().size();
             debugRecord.header.totalSize = totalSize;
 
             logger.write(locker, unsafeMakeSpan(std::bit_cast<char*>(&debugRecord), sizeof(JITDump::DebugInfoRecord)));
@@ -306,32 +335,108 @@ void PerfLog::log(const CString& name, MacroAssemblerCodeRef<LinkBufferPtrTag> c
             }
         }
 
-        if (!sourceEntries.isEmpty()) {
-            JITDump::DebugInfoRecord debugRecord;
-            debugRecord.header.timestamp = timestamp;
-            debugRecord.codeAddress = std::bit_cast<uintptr_t>(executableAddress);
-            debugRecord.nrEntry = sourceEntries.size();
+        if (sourceCodeDebugInfo && !sourceCodeDebugInfo->codeEntries.isEmpty()) {
+            const CString& sourceCodeDumpDir = logger.m_sourceCodeDumpDirectory;
 
-            uint32_t totalSize = sizeof(JITDump::DebugInfoRecord);
-            for (auto& sourceEntry : sourceEntries)
-                totalSize += sizeof(JITDump::DebugEntry) + (sourceEntry.filePath.length() + 1);
-            debugRecord.header.totalSize = totalSize;
+            UncheckedKeyHashMap<CString, int32_t> stringIndexMap;
+            UncheckedKeyHashMap<SourceProvider*, int32_t> sourceProviderStringIndexMap;
+            Vector<CString> stringTable;
+            auto internString = [&](const CString& str) -> int32_t {
+                if (str.isNull())
+                    return -1;
+                auto result = stringIndexMap.add(str, stringTable.size());
+                if (result.isNewEntry)
+                    stringTable.append(str);
+                return result.iterator->value;
+            };
 
-            logger.write(locker, unsafeMakeSpan(std::bit_cast<char*>(&debugRecord), sizeof(JITDump::DebugInfoRecord)));
+            auto internSource = [&](SourceProvider& sourceProvider) -> int32_t {
+                auto result = sourceProviderStringIndexMap.find(&sourceProvider);
+                if (result != sourceProviderStringIndexMap.end())
+                    return result->value;
 
-            for (auto& sourceEntry : sourceEntries) {
-                JITDump::DebugEntry debugEntry;
-                debugEntry.codeAddress = std::bit_cast<uintptr_t>(executableAddress) + sourceEntry.codeOffset;
-                debugEntry.line = sourceEntry.line;
-                debugEntry.discrim = sourceEntry.column;
-                logger.write(locker, unsafeMakeSpan(std::bit_cast<char*>(&debugEntry), sizeof(JITDump::DebugEntry)));
-                logger.write(locker, sourceEntry.filePath.spanIncludingNullTerminator());
+                CString filePath = sourceProvider.sourceCodeDumpFilePath(sourceCodeDumpDir);
+                auto index = internString(filePath);
+                sourceProviderStringIndexMap.add(&sourceProvider, index);
+                return index;
+            };
+
+            UncheckedKeyHashMap<SourceCodeDumpDebugInfo::FrameInfo*, int32_t> frameToPositionIndex;
+            Vector<JITDump::SourcePosition> sourcePositions;
+
+            auto resolveFrame = [&](SourceCodeDumpDebugInfo::FrameInfo* innermost) -> uint32_t {
+                Vector<SourceCodeDumpDebugInfo::FrameInfo*, 8> chain;
+                for (SUPPRESS_UNCOUNTED_LOCAL auto* frame = innermost; frame; frame = frame->parent.get()) {
+                    if (frameToPositionIndex.contains(frame))
+                        continue;
+                    chain.append(frame);
+                }
+
+                for (SUPPRESS_UNCOUNTED_LOCAL auto* frame : chain | std::views::reverse) {
+                    int32_t callerIndex = -1;
+                    if (frame->parent) {
+                        auto it = frameToPositionIndex.find(frame->parent.get());
+                        ASSERT(it != frameToPositionIndex.end());
+                        callerIndex = it->value;
+                    }
+
+                    uint32_t functionNameIndex = internString(sourceCodeDebugInfo->functionNames.get(frame->codeBlock));
+                    int32_t fileIndex = internSource(frame->sourceProvider);
+
+                    int32_t index = sourcePositions.size();
+                    frameToPositionIndex.add(frame, index);
+
+                    JITDump::SourcePosition pos;
+                    pos.callerIndex = callerIndex;
+                    pos.functionName = functionNameIndex;
+                    pos.file = fileIndex;
+                    pos.functionStartLine = frame->functionStartLineColumn.line;
+                    pos.functionStartColumn = frame->functionStartLineColumn.column;
+                    pos.line = frame->lineColumn.line;
+                    pos.column = frame->lineColumn.column;
+                    sourcePositions.append(pos);
+                }
+
+                auto it = frameToPositionIndex.find(innermost);
+                ASSERT(it != frameToPositionIndex.end());
+                return it->value;
+            };
+
+            Vector<JITDump::CodeOffsetRecord> codeOffsetRecords;
+            for (auto& entry : sourceCodeDebugInfo->codeEntries) {
+                uint32_t index = resolveFrame(entry.frameInfo.ptr());
+                codeOffsetRecords.append({ entry.codeOffset, index });
             }
+
+            uint32_t totalSize = sizeof(JITDump::SamplyDebugInfo2Record);
+            totalSize += codeOffsetRecords.size() * sizeof(JITDump::CodeOffsetRecord);
+            totalSize += sourcePositions.size() * sizeof(JITDump::SourcePosition);
+            for (auto& str : stringTable)
+                totalSize += str.spanIncludingNullTerminator().size();
+
+            JITDump::SamplyDebugInfo2Record debugRecord;
+            debugRecord.header.timestamp = timestamp;
+            debugRecord.header.totalSize = totalSize;
+            debugRecord.codeAddress = std::bit_cast<uintptr_t>(executableAddress);
+            debugRecord.codeOffsetCount = codeOffsetRecords.size();
+            debugRecord.sourcePositionCount = sourcePositions.size();
+            debugRecord.stringCount = stringTable.size();
+
+            logger.write(locker, unsafeMakeSpan(std::bit_cast<char*>(&debugRecord), sizeof(JITDump::SamplyDebugInfo2Record)));
+
+            for (auto& record : codeOffsetRecords)
+                logger.write(locker, unsafeMakeSpan(std::bit_cast<char*>(&record), sizeof(JITDump::CodeOffsetRecord)));
+
+            for (auto& pos : sourcePositions)
+                logger.write(locker, unsafeMakeSpan(std::bit_cast<char*>(&pos), sizeof(JITDump::SourcePosition)));
+
+            for (auto& str : stringTable)
+                logger.write(locker, str.spanIncludingNullTerminator());
         }
 
         JITDump::CodeLoadRecord record;
         record.header.timestamp = timestamp;
-        record.header.totalSize = sizeof(JITDump::CodeLoadRecord) + (name.length() + 1) + size;
+        record.header.totalSize = sizeof(JITDump::CodeLoadRecord) + name.spanIncludingNullTerminator().size() + size;
         record.pid = getCurrentProcessID();
         record.tid = tid;
         record.vma = std::bit_cast<uintptr_t>(executableAddress);

--- a/Source/JavaScriptCore/bytecode/CodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.h
@@ -432,6 +432,7 @@ public:
     const SourceCode& source() const LIFETIME_BOUND { return m_ownerExecutable->source(); }
     unsigned sourceOffset() const { return m_ownerExecutable->source().startOffset(); }
     unsigned firstLineColumnOffset() const { return m_ownerExecutable->startColumn(); }
+    LineColumn functionStartLineColumn() const { return { static_cast<unsigned>(m_ownerExecutable->firstLine()), m_ownerExecutable->startColumn() }; }
 
     size_t numberOfJumpTargets() const { return m_unlinkedCode->numberOfJumpTargets(); }
     unsigned jumpTarget(int index) const { return m_unlinkedCode->jumpTarget(index); }

--- a/Source/JavaScriptCore/bytecode/SourceCodeDumpUtils.cpp
+++ b/Source/JavaScriptCore/bytecode/SourceCodeDumpUtils.cpp
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SourceCodeDumpUtils.h"
+
+#if ENABLE(ASSEMBLER)
+
+#include "CodeBlock.h"
+#include "InlineCallFrame.h"
+#include "Options.h"
+#include <wtf/StringPrintStream.h>
+
+namespace JSC {
+
+static const char* profileName(LinkBuffer::Profile profile)
+{
+#define RETURN_LINKBUFFER_PROFILE_NAME(name) case LinkBuffer::Profile::name: return #name;
+    switch (profile) {
+        FOR_EACH_LINKBUFFER_PROFILE(RETURN_LINKBUFFER_PROFILE_NAME)
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+#undef RETURN_LINKBUFFER_PROFILE_NAME
+    return "";
+}
+
+CString functionNameForJITDump(LinkBuffer::Profile profile, CodeBlock* codeBlock)
+{
+    StringPrintStream out;
+    out.print("JSC-", profileName(profile), ": ");
+    codeBlock->dumpSimpleName(out);
+    return out.toCString();
+}
+
+CString sourceCodeDumpFunctionName(LinkBuffer::Profile profile, CodeBlock* codeBlock)
+{
+    if (Options::useJITTiersInSourceCodeDump())
+        return functionNameForJITDump(profile, codeBlock);
+    StringPrintStream out;
+    codeBlock->dumpSimpleName(out);
+    return out.toCString();
+}
+
+RefPtr<SourceCodeDumpDebugInfo::FrameInfo> resolveSourceCodeDumpFrameInfo(CodeOrigin codeOrigin, CodeBlock* rootCodeBlock, LinkBuffer::Profile profile, UncheckedKeyHashMap<CodeOrigin, Ref<SourceCodeDumpDebugInfo::FrameInfo>>& frameInfoCache, UncheckedKeyHashMap<CodeBlock*, CString>& functionNames)
+{
+    Vector<CodeOrigin, 4> inlineStack;
+    codeOrigin.walkUpInlineStack([&](CodeOrigin origin) {
+        inlineStack.append(origin);
+    });
+
+    auto ensureFunctionName = [&](CodeBlock* codeBlock) {
+        auto result = functionNames.add(codeBlock, CString());
+        if (result.isNewEntry)
+            result.iterator->value = sourceCodeDumpFunctionName(profile, codeBlock);
+    };
+
+    RefPtr<SourceCodeDumpDebugInfo::FrameInfo> currentFrame;
+    for (auto stackOrigin : inlineStack | std::views::reverse) {
+        auto it = frameInfoCache.find(stackOrigin);
+        if (it != frameInfoCache.end()) {
+            currentFrame = it->value.ptr();
+            continue;
+        }
+
+        InlineCallFrame* inlineCallFrame = stackOrigin.inlineCallFrame();
+        CodeBlock* codeBlock = inlineCallFrame ? inlineCallFrame->baselineCodeBlock.get() : rootCodeBlock;
+        if (!codeBlock)
+            return nullptr;
+
+        BytecodeIndex bytecodeIndex = stackOrigin.bytecodeIndex();
+        if (bytecodeIndex.offset() >= codeBlock->instructionsSize())
+            return nullptr;
+
+        LineColumn lineColumn = codeBlock->lineColumnForBytecodeIndex(bytecodeIndex);
+        LineColumn functionStartLineColumn = codeBlock->functionStartLineColumn();
+        RefPtr provider = codeBlock->ownerExecutable()->source().provider();
+        if (!provider)
+            return nullptr;
+
+        ensureFunctionName(codeBlock);
+
+        auto frame = SourceCodeDumpDebugInfo::FrameInfo::create(codeBlock, provider.releaseNonNull(), lineColumn, functionStartLineColumn, RefPtr { currentFrame });
+        frameInfoCache.add(stackOrigin, frame.copyRef());
+        currentFrame = WTF::move(frame);
+    }
+
+    return currentFrame;
+}
+
+} // namespace JSC
+
+#endif // ENABLE(ASSEMBLER)

--- a/Source/JavaScriptCore/bytecode/SourceCodeDumpUtils.h
+++ b/Source/JavaScriptCore/bytecode/SourceCodeDumpUtils.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "LinkBuffer.h"
+#include <wtf/Forward.h>
+
+namespace JSC {
+
+class CodeBlock;
+class CodeOrigin;
+
+CString functionNameForJITDump(LinkBuffer::Profile, CodeBlock*);
+// Returns the function name to embed in a SamplyJitCodeDebugInfo2Record string table.
+// When Options::useJITTiersInSourceCodeDump is true, includes the tier prefix; otherwise tier-free.
+CString sourceCodeDumpFunctionName(LinkBuffer::Profile, CodeBlock*);
+
+RefPtr<SourceCodeDumpDebugInfo::FrameInfo> resolveSourceCodeDumpFrameInfo(CodeOrigin, CodeBlock* rootCodeBlock, LinkBuffer::Profile, UncheckedKeyHashMap<CodeOrigin, Ref<SourceCodeDumpDebugInfo::FrameInfo>>&, UncheckedKeyHashMap<CodeBlock*, CString>& functionNames);
+
+} // namespace JSC

--- a/Source/JavaScriptCore/dfg/DFGJITCompiler.cpp
+++ b/Source/JavaScriptCore/dfg/DFGJITCompiler.cpp
@@ -41,6 +41,7 @@
 #include "LinkBuffer.h"
 #include "Options.h"
 #include "ProbeContext.h"
+#include "SourceCodeDumpUtils.h"
 #include "ThunkGenerators.h"
 #include "VM.h"
 #include <wtf/TZoneMallocInlines.h>
@@ -398,32 +399,47 @@ void JITCompiler::collectSourceCodeDumpDebugInfo(LinkBuffer& linkBuffer)
     if (m_irDumpLabels.isEmpty())
         return;
 
-    auto debugInfo = makeUnique<SourceCodeDumpDebugInfo>(m_graph.m_codeBlock->inferredName());
+    auto debugInfo = makeUnique<SourceCodeDumpDebugInfo>(functionNameForJITDump(LinkBuffer::Profile::DFG, m_graph.m_codeBlock));
     void* codeStart = linkBuffer.entrypoint<DisassemblyPtrTag>().untaggedPtr();
+
+    UncheckedKeyHashMap<CodeOrigin, Ref<SourceCodeDumpDebugInfo::FrameInfo>> frameInfoCache;
+
+    CodeOrigin currentOrigin;
+    std::optional<uint32_t> currentCodeOffset;
+    RefPtr<SourceCodeDumpDebugInfo::FrameInfo> currentFrameInfo;
+    auto flush = [&] {
+        if (currentCodeOffset && currentFrameInfo)
+            debugInfo->codeEntries.append({ currentCodeOffset.value(), currentFrameInfo.releaseNonNull() });
+        currentOrigin = CodeOrigin();
+        currentCodeOffset = std::nullopt;
+        currentFrameInfo = nullptr;
+    };
 
     for (auto& entry : m_irDumpLabels) {
         CodeOrigin codeOrigin = entry.node->origin.semantic;
         if (!codeOrigin.isSet())
             continue;
 
-        InlineCallFrame* inlineCallFrame = codeOrigin.inlineCallFrame();
-        CodeBlock* codeBlock = inlineCallFrame ? inlineCallFrame->baselineCodeBlock.get() : m_graph.m_codeBlock;
-        if (!codeBlock)
+        if (currentOrigin == codeOrigin)
             continue;
 
-        BytecodeIndex bytecodeIndex = codeOrigin.bytecodeIndex();
-        if (bytecodeIndex.offset() >= codeBlock->instructionsSize())
+        flush();
+
+        auto frameInfo = resolveSourceCodeDumpFrameInfo(codeOrigin, m_graph.m_codeBlock, LinkBuffer::Profile::DFG, frameInfoCache, debugInfo->functionNames);
+        if (!frameInfo)
             continue;
 
-        LineColumn lineColumn = codeBlock->lineColumnForBytecodeIndex(bytecodeIndex);
-        RefPtr provider = codeBlock->ownerExecutable()->source().provider();
-        if (!provider)
-            continue;
+        currentOrigin = codeOrigin;
+        currentFrameInfo = WTF::move(frameInfo);
 
         auto location = linkBuffer.locationOf<DisassemblyPtrTag>(entry.label);
-        uint32_t codeOffset = static_cast<uint32_t>(location.dataLocation<uintptr_t>() - reinterpret_cast<uintptr_t>(codeStart));
-        debugInfo->codeEntries.append({ codeOffset, lineColumn, provider.releaseNonNull() });
+        currentCodeOffset = static_cast<uint32_t>(location.dataLocation<uintptr_t>() - reinterpret_cast<uintptr_t>(codeStart));
     }
+    flush();
+
+    // Ensure the first entry covers offset 0 so the initial code region is attributed.
+    if (!debugInfo->codeEntries.isEmpty())
+        debugInfo->codeEntries[0].codeOffset = 0;
 
     linkBuffer.setSourceCodeDumpDebugInfo(WTF::move(debugInfo));
 }

--- a/Source/JavaScriptCore/ftl/FTLCompile.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCompile.cpp
@@ -47,6 +47,7 @@
 #include "LinkBuffer.h"
 #include "Options.h"
 #include "PCToCodeOriginMap.h"
+#include "SourceCodeDumpUtils.h"
 #include "ThunkGenerators.h"
 #include <wtf/RecursableLambda.h>
 #include <wtf/SetForScope.h>
@@ -114,22 +115,22 @@ static void collectSourceCodeDumpDebugInfo(State& state, CodeBlock* codeBlock)
     if (!Options::useSourceCodeDump() || !state.proc->needsPCToOriginMap())
         return;
 
-    auto debugInfo = makeUnique<SourceCodeDumpDebugInfo>(codeBlock->inferredName());
+    auto debugInfo = makeUnique<SourceCodeDumpDebugInfo>(functionNameForJITDump(LinkBuffer::Profile::FTL, codeBlock));
 
     auto& originMap = state.proc->pcToOriginMap();
     void* codeStart = state.b3CodeLinkBuffer->entrypoint<DisassemblyPtrTag>().untaggedPtr();
 
+    UncheckedKeyHashMap<CodeOrigin, Ref<SourceCodeDumpDebugInfo::FrameInfo>> frameInfoCache;
+
     CodeOrigin currentOrigin;
     std::optional<uint32_t> currentCodeOffset;
-    LineColumn currentLineColumn;
-    SourceProvider* currentProvider = nullptr;
+    RefPtr<SourceCodeDumpDebugInfo::FrameInfo> currentFrameInfo;
     auto flush = [&] {
-        if (currentCodeOffset && currentProvider)
-            debugInfo->codeEntries.append({ currentCodeOffset.value(), currentLineColumn, *currentProvider });
+        if (currentCodeOffset && currentFrameInfo)
+            debugInfo->codeEntries.append({ currentCodeOffset.value(), currentFrameInfo.releaseNonNull() });
         currentOrigin = CodeOrigin();
         currentCodeOffset = std::nullopt;
-        currentLineColumn = { };
-        currentProvider = nullptr;
+        currentFrameInfo = nullptr;
     };
 
     for (auto& range : originMap.ranges()) {
@@ -149,25 +150,21 @@ static void collectSourceCodeDumpDebugInfo(State& state, CodeBlock* codeBlock)
 
         flush();
 
-        InlineCallFrame* inlineCallFrame = codeOrigin.inlineCallFrame();
-        CodeBlock* originCodeBlock = inlineCallFrame
-            ? inlineCallFrame->baselineCodeBlock.get()
-            : codeBlock;
-        if (!originCodeBlock)
-            continue;
-
-        BytecodeIndex bytecodeIndex = codeOrigin.bytecodeIndex();
-        if (bytecodeIndex.offset() >= originCodeBlock->instructionsSize())
+        auto frameInfo = resolveSourceCodeDumpFrameInfo(codeOrigin, codeBlock, LinkBuffer::Profile::FTL, frameInfoCache, debugInfo->functionNames);
+        if (!frameInfo)
             continue;
 
         currentOrigin = codeOrigin;
-        currentLineColumn = originCodeBlock->lineColumnForBytecodeIndex(bytecodeIndex);
-        currentProvider = originCodeBlock->ownerExecutable()->source().provider();
+        currentFrameInfo = WTF::move(frameInfo);
 
         auto location = state.b3CodeLinkBuffer->locationOf<DisassemblyPtrTag>(range.label);
         currentCodeOffset = static_cast<uint32_t>(location.dataLocation<uintptr_t>() - reinterpret_cast<uintptr_t>(codeStart));
     }
     flush();
+
+    // Ensure the first entry covers offset 0 so the initial code region is attributed.
+    if (!debugInfo->codeEntries.isEmpty())
+        debugInfo->codeEntries[0].codeOffset = 0;
 
     state.b3CodeLinkBuffer->setSourceCodeDumpDebugInfo(WTF::move(debugInfo));
 }

--- a/Source/JavaScriptCore/jit/JIT.cpp
+++ b/Source/JavaScriptCore/jit/JIT.cpp
@@ -48,6 +48,7 @@
 #include "ProfilerDatabase.h"
 #include "ProgramCodeBlock.h"
 #include "SlowPathCall.h"
+#include "SourceCodeDumpUtils.h"
 #include "StackAlignment.h"
 #include "ThunkGenerators.h"
 #include "TypeProfilerLog.h"
@@ -973,7 +974,8 @@ RefPtr<BaselineJITCode> JIT::link(LinkBuffer& patchBuffer)
         pcToCodeOriginMap = makeUnique<PCToCodeOriginMap>(WTF::move(m_pcToCodeOriginMapBuilder), patchBuffer);
 
     if (Options::useSourceCodeDump() && m_profiledCodeBlock) [[unlikely]] {
-        auto debugInfo = makeUnique<SourceCodeDumpDebugInfo>(m_profiledCodeBlock->inferredName());
+        auto debugInfo = makeUnique<SourceCodeDumpDebugInfo>(functionNameForJITDump(LinkBuffer::Profile::Baseline, m_profiledCodeBlock));
+        debugInfo->functionNames.add(m_profiledCodeBlock, sourceCodeDumpFunctionName(LinkBuffer::Profile::Baseline, m_profiledCodeBlock));
         if (RefPtr provider = m_profiledCodeBlock->ownerExecutable()->source().provider()) {
             void* codeStart = patchBuffer.entrypoint<DisassemblyPtrTag>().untaggedPtr();
             for (unsigned bytecodeOffset = 0; bytecodeOffset < m_labels.size(); ++bytecodeOffset) {
@@ -983,9 +985,11 @@ RefPtr<BaselineJITCode> JIT::link(LinkBuffer& patchBuffer)
                 if (bytecodeIndex.offset() >= m_profiledCodeBlock->instructionsSize())
                     continue;
                 LineColumn lineColumn = m_profiledCodeBlock->lineColumnForBytecodeIndex(bytecodeIndex);
+                LineColumn functionStartLineColumn = m_profiledCodeBlock->functionStartLineColumn();
                 auto location = patchBuffer.locationOf<DisassemblyPtrTag>(m_labels[bytecodeOffset]);
                 uint32_t codeOffset = static_cast<uint32_t>(location.dataLocation<uintptr_t>() - reinterpret_cast<uintptr_t>(codeStart));
-                debugInfo->codeEntries.append({ codeOffset, lineColumn, Ref { *provider } });
+                auto frame = SourceCodeDumpDebugInfo::FrameInfo::create(m_profiledCodeBlock, Ref { *provider }, lineColumn, functionStartLineColumn, nullptr);
+                debugInfo->codeEntries.append({ codeOffset, WTF::move(frame) });
             }
             patchBuffer.setSourceCodeDumpDebugInfo(WTF::move(debugInfo));
         }

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -152,6 +152,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useIRDump, false, Normal, "generates IR dump files and JIT_CODE_DEBUG_INFO in JITDump"_s) \
     v(OptionString, irDumpDirectory, nullptr, Normal, "Directory to place IR dump files"_s) \
     v(Bool, useSourceCodeDump, false, Normal, "generates source code debug info in JITDump"_s) \
+    v(Bool, useJITTiersInSourceCodeDump, true, Normal, "attaches JIT tier prefix to function names in SAMPLY_JIT_CODE_DEBUG_INFO2 records"_s) \
     v(OptionString, sourceCodeDumpDirectory, nullptr, Normal, "Directory to place dumped source files"_s) \
     v(OptionString, textMarkersDirectory, nullptr, Normal, "Directory to place MarkerTxt") \
     v(OptionRange, bytecodeRangeToJITCompile, nullptr, Normal, "bytecode size range to allow compilation on, e.g. 1:100"_s) \


### PR DESCRIPTION
#### 5649f0e8728201d5b54a00fc6084ca5e728869ce
<pre>
[JSC] Support inlined JIT functions in SourceCodeDump in JITDump
<a href="https://bugs.webkit.org/show_bug.cgi?id=310456">https://bugs.webkit.org/show_bug.cgi?id=310456</a>
<a href="https://rdar.apple.com/173092203">rdar://173092203</a>

Reviewed by NOBODY (OOPS!).

This patch adds samply&apos;s JITDebugInfo2 format in SourceCodeDump.
Previously we support JITCodeDebugInfo in JITDump, however, it cannot
handle inlined JIT functions: we cannot represent multiple functions &amp;
multiple source code for one function which includes multiple inlined functions.
JITCodeDebugInfo has a limitation that cannot represent this structured
inlined information, thus we need JITDump format&apos;s extension.

Based on discussion with Mozilla folks working on `samply`, we have an
extension to JITDump format which is samply&apos;s JITDebugInfo2. This can
have multiple benefits.

1. Originally JITCodeDebugInfo needs file name for each different range,
   which causes significant size increase for generated JITDump. New
   format has an interned string vector so that we can dedupe file names.
2. This interned strings are used for inlined function names too, so we
   can reduce JITDump size for SourceCodeDump.
3. New format adds SourcePosition, which can be a reversed tree of
   callsite information so that we can represent inlining function&apos;s tree.

samply&apos;s extension is in [1].

[1]: <a href="https://github.com/mstange/samply/commit/62a902cd222c21f3ca220546af02b78e74dedaf8">https://github.com/mstange/samply/commit/62a902cd222c21f3ca220546af02b78e74dedaf8</a>

* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/assembler/LinkBuffer.cpp:
(JSC::LinkBuffer::logJITCodeForJITDump):
* Source/JavaScriptCore/assembler/LinkBuffer.h:
* Source/JavaScriptCore/assembler/PerfLog.cpp:
(JSC::PerfLog::log):
* Source/JavaScriptCore/bytecode/CodeBlock.h:
(JSC::CodeBlock::functionStartLineColumn const):
* Source/JavaScriptCore/bytecode/SourceCodeDumpUtils.cpp: Added.
(JSC::profileName):
(JSC::functionNameForJITDump):
(JSC::sourceCodeDumpFunctionName):
(JSC::resolveSourceCodeDumpFrameInfo):
* Source/JavaScriptCore/bytecode/SourceCodeDumpUtils.h: Added.
* Source/JavaScriptCore/dfg/DFGJITCompiler.cpp:
(JSC::DFG::JITCompiler::collectSourceCodeDumpDebugInfo):
* Source/JavaScriptCore/ftl/FTLCompile.cpp:
(JSC::FTL::collectSourceCodeDumpDebugInfo):
* Source/JavaScriptCore/jit/JIT.cpp:
(JSC::JIT::link):
* Source/JavaScriptCore/runtime/OptionsList.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5649f0e8728201d5b54a00fc6084ca5e728869ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151754 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24535 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18105 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160496 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105211 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25028 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24828 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117222 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83188 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154714 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19375 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136175 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97937 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18461 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16395 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8331 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/143758 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128091 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14079 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162960 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/12555 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6109 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15670 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125238 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24334 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20454 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125419 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24335 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135875 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80910 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20451 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12650 "Found 4 new test failures: accessibility/mac/text-operation/text-operation-capitalize.html accessibility/mac/value-change/value-change-user-info-textarea.html accessibility/shadow-dom/reference-target/mac/aria-activedescendant.html animations/3d/animate-to-transform-perpective-to-none.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/183365 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23951 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88237 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46767 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23643 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23803 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23703 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->