### PR TITLE
[JSC] TypedArray `[[Set]]` should check receiver before writing to typed array

### DIFF
--- a/JSTests/stress/reflect-set.js
+++ b/JSTests/stress/reflect-set.js
@@ -687,11 +687,11 @@ var symbol = Symbol();
 
         var object = new TypedArray(64);
         var receiver = {};
-        // The receiver is ignored when the property name is an indexed one.
-        // shouldBe(Reflect.set(object, 0, 42, receiver), true);
+        // https://github.com/tc39/ecma262/pull/1556
         shouldBe(Reflect.set(object, 0, 42, receiver), true);
-        shouldBe(Reflect.get(object, 0), 42);
-        shouldBe(receiver.hasOwnProperty(0), false);
+        shouldBe(Reflect.get(object, 0), 0);
+        shouldBe(receiver.hasOwnProperty(0), true);
+        shouldBe(receiver[0], 42);
 
         var object = new TypedArray(1);
         transferArrayBuffer(object.buffer);

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -481,42 +481,6 @@ test/built-ins/TypedArrayConstructors/ctors/object-arg/iterated-array-changed-by
 test/built-ins/TypedArrayConstructors/ctors/typedarray-arg/throw-type-error-before-custom-proto-access.js:
   default: 'Test262Error: Expected a TypeError but got a Test262Error (Testing with Float64Array and makePassthrough.)'
   strict mode: 'Test262Error: Expected a TypeError but got a Test262Error (Testing with Float64Array and makePassthrough.)'
-test/built-ins/TypedArrayConstructors/internals/Set/BigInt/key-is-canonical-invalid-index-prototype-chain-set.js:
-  default: 'Test262Error: 1 setter should be unreachable! (Testing with BigInt64Array and makePassthrough.)'
-  strict mode: 'Test262Error: 1 setter should be unreachable! (Testing with BigInt64Array and makePassthrough.)'
-test/built-ins/TypedArrayConstructors/internals/Set/BigInt/key-is-canonical-invalid-index-reflect-set.js:
-  default: 'Test262Error: value should not be coerced Expected SameValue(«32», «0») to be true'
-  strict mode: 'Test262Error: value should not be coerced Expected SameValue(«32», «0») to be true'
-test/built-ins/TypedArrayConstructors/internals/Set/BigInt/key-is-valid-index-prototype-chain-set.js:
-  default: 'Test262Error: 0 setter should be unreachable! (Testing with BigInt64Array and makePassthrough.)'
-  strict mode: 'Test262Error: 0 setter should be unreachable! (Testing with BigInt64Array and makePassthrough.)'
-test/built-ins/TypedArrayConstructors/internals/Set/BigInt/key-is-valid-index-reflect-set.js:
-  default: 'Test262Error: target[0] should remain unchanged (receiver: empty object) Expected SameValue(«2n», «0n») to be true (Testing with BigInt64Array and makePassthrough.)'
-  strict mode: 'Test262Error: target[0] should remain unchanged (receiver: empty object) Expected SameValue(«2n», «0n») to be true (Testing with BigInt64Array and makePassthrough.)'
-test/built-ins/TypedArrayConstructors/internals/Set/key-is-canonical-invalid-index-prototype-chain-set.js:
-  default: 'Test262Error: 1 setter should be unreachable! (Testing with Float64Array and makePassthrough.)'
-  strict mode: 'Test262Error: 1 setter should be unreachable! (Testing with Float64Array and makePassthrough.)'
-test/built-ins/TypedArrayConstructors/internals/Set/key-is-canonical-invalid-index-reflect-set.js:
-  default: 'Test262Error: value should not be coerced Expected SameValue(«160», «0») to be true'
-  strict mode: 'Test262Error: value should not be coerced Expected SameValue(«160», «0») to be true'
-test/built-ins/TypedArrayConstructors/internals/Set/key-is-in-bounds-receiver-is-not-typed-array.js:
-  default: 'Test262Error: valueOf is not called Expected SameValue(«1», «0») to be true'
-  strict mode: 'Test262Error: valueOf is not called Expected SameValue(«1», «0») to be true'
-test/built-ins/TypedArrayConstructors/internals/Set/key-is-out-of-bounds-receiver-is-not-object.js:
-  default: 'Test262Error: valueOf is not called Expected SameValue(«1», «0») to be true'
-  strict mode: 'Test262Error: valueOf is not called Expected SameValue(«1», «0») to be true'
-test/built-ins/TypedArrayConstructors/internals/Set/key-is-out-of-bounds-receiver-is-not-typed-array.js:
-  default: 'Test262Error: valueOf is not called Expected SameValue(«1», «0») to be true'
-  strict mode: 'Test262Error: valueOf is not called Expected SameValue(«1», «0») to be true'
-test/built-ins/TypedArrayConstructors/internals/Set/key-is-out-of-bounds-receiver-is-proto.js:
-  default: 'Test262Error: [[Set]] succeeeds'
-  strict mode: 'Test262Error: [[Set]] succeeeds'
-test/built-ins/TypedArrayConstructors/internals/Set/key-is-valid-index-prototype-chain-set.js:
-  default: 'Test262Error: 0 setter should be unreachable! (Testing with Float64Array and makePassthrough.)'
-  strict mode: 'Test262Error: 0 setter should be unreachable! (Testing with Float64Array and makePassthrough.)'
-test/built-ins/TypedArrayConstructors/internals/Set/key-is-valid-index-reflect-set.js:
-  default: 'Test262Error: target[0] should remain unchanged (receiver: empty object) Expected SameValue(«2.3», «0») to be true (Testing with Float64Array and makePassthrough.)'
-  strict mode: 'Test262Error: target[0] should remain unchanged (receiver: empty object) Expected SameValue(«2.3», «0») to be true (Testing with Float64Array and makePassthrough.)'
 test/built-ins/Uint8Array/prototype/setFromBase64/trailing-garbage-empty.js:
   default: 'SyntaxError: Uint8Array.prototype.setFromBase64 requires a valid base64 string'
   strict mode: 'SyntaxError: Uint8Array.prototype.setFromBase64 requires a valid base64 string'
@@ -974,9 +938,6 @@ test/staging/sm/TypedArray/constructor-buffer-sequence.js:
 test/staging/sm/TypedArray/iterator-next-with-detached.js:
   default: 'TypeError: Underlying ArrayBuffer has been detached from the view or out-of-bounds'
   strict mode: 'TypeError: Underlying ArrayBuffer has been detached from the view or out-of-bounds'
-test/staging/sm/TypedArray/set-with-receiver.js:
-  default: 'Test262Error: Expected SameValue(«47», «0») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«47», «0») to be true'
 test/staging/sm/TypedArray/slice-memcpy.js:
   default: 'Test262Error: Actual [1, 2, 1, 2, 3, 4] and expected [1, 2, 1, 2, 1, 2] should have the same contents. '
   strict mode: 'Test262Error: Actual [1, 2, 1, 2, 3, 4] and expected [1, 2, 1, 2, 1, 2] should have the same contents. '

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
@@ -568,10 +568,19 @@ bool JSGenericTypedArrayView<Adaptor>::put(
 {
     JSGenericTypedArrayView* thisObject = jsCast<JSGenericTypedArrayView*>(cell);
 
-    if (std::optional<uint32_t> index = parseIndex(propertyName))
+    // https://tc39.es/ecma262/#sec-typedarray-set
+    if (std::optional<uint32_t> index = parseIndex(propertyName)) {
+        if (isThisValueAltered(slot, thisObject)) [[unlikely]] {
+            if (thisObject->isDetached() || !thisObject->inBounds(index.value()))
+                return true;
+            return ordinarySetSlow(globalObject, thisObject, propertyName, value, slot.thisValue(), slot.isStrictMode());
+        }
         return putByIndex(thisObject, globalObject, index.value(), value, slot.isStrictMode());
+    }
 
     if (isCanonicalNumericIndexString(propertyName.uid())) {
+        if (isThisValueAltered(slot, thisObject)) [[unlikely]]
+            return true;
         // Cases like '-0', '1.1', etc. are still obliged to give the RHS a chance to throw.
         toNativeFromValue<Adaptor>(globalObject, value);
         return true;

--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -683,6 +683,11 @@ bool ordinarySetWithOwnDescriptor(JSGlobalObject* globalObject, JSObject* object
             RELEASE_AND_RETURN(scope, proxy->ProxyObject::put(proxy, globalObject, propertyName, value, slot));
         }
 
+        if (current != object && isTypedArrayType(current->type())) {
+            PutPropertySlot slot(receiver, shouldThrow);
+            RELEASE_AND_RETURN(scope, current->methodTable()->put(current, globalObject, propertyName, value, slot));
+        }
+
         // 9.1.9.1-2 Let ownDesc be ? O.[[GetOwnProperty]](P).
         bool ownDescriptorFound;
         if (current == object)
@@ -3159,7 +3164,16 @@ bool JSObject::attemptToInterceptPutByIndexOnHoleForPrototype(JSGlobalObject* gl
             putResult = proxy->putByIndexCommon(globalObject, thisValue, i, value, shouldThrow);
             return true;
         }
-        
+
+        if (isTypedArrayType(current->type())) {
+            auto* typedArray = jsCast<JSArrayBufferView*>(current);
+            if (typedArray->isOutOfBounds() || i >= typedArray->length()) {
+                putResult = true;
+                return true;
+            }
+            return false;
+        }
+
         JSValue prototypeValue = current->getPrototype(globalObject);
         RETURN_IF_EXCEPTION(scope, false);
         if (prototypeValue.isNull())


### PR DESCRIPTION
#### 9654ed7d9e3db5a2d34b5b0de7e6ba054cd53dd5
<pre>
[JSC] TypedArray `[[Set]]` should check receiver before writing to typed array
<a href="https://bugs.webkit.org/show_bug.cgi?id=310457">https://bugs.webkit.org/show_bug.cgi?id=310457</a>

Reviewed by Yusuke Suzuki.

Implement the receiver check in TypedArray [[Set]] introduced by
<a href="https://github.com/tc39/ecma262/pull/1556.">https://github.com/tc39/ecma262/pull/1556.</a> When Receiver differs from
the typed array, we should fall back to OrdinarySet for valid indices
and return true without coercion for invalid indices.

This is the indexed [[Set]] follow-up to Bug 217916, which fixed
non-index property names.

1. JSGenericTypedArrayView::put checks isThisValueAltered and falls
   back to ordinarySetSlow for valid indices, or returns true for
   invalid indices.
2. ordinarySetWithOwnDescriptor delegates to the typed array&apos;s put
   when found in the prototype chain.
3. attemptToInterceptPutByIndexOnHoleForPrototype stops walking at
   a typed array, intercepting invalid indices and letting the caller
   write to the receiver for valid indices.

Also update JSTests/stress/reflect-set.js to the new spec behavior.

* JSTests/stress/reflect-set.js:
(set get Uint8Array):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h:
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::put):
* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::ordinarySetWithOwnDescriptor):
(JSC::JSObject::attemptToInterceptPutByIndexOnHoleForPrototype):

Canonical link: <a href="https://commits.webkit.org/309967@main">https://commits.webkit.org/309967@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2ff9a12726108cd811c6c1bde05a858b517cda1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151487 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24252 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17833 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160219 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104925 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24683 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24554 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116978 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83048 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154447 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19124 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135937 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97697 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18214 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16161 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8063 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/143484 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127841 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13842 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162690 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/12288 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5823 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15431 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124996 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24053 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20219 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125180 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34147 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24045 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135638 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80593 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20241 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12413 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/183096 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23654 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87966 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46692 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23364 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23518 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23420 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->