### PR TITLE
Add WKTextEffectManager and associated plumbing for refactoring to use modern text effects.

### DIFF
--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1413,6 +1413,7 @@ def headers_for_type(type, for_implementation_file=False):
         'WebCore::TextCheckingResult': ['<WebCore/TextCheckerClient.h>'],
         'WebCore::TextCheckingType': ['<WebCore/TextChecking.h>'],
         'WebCore::TextDrawingModeFlags': ['<WebCore/GraphicsTypes.h>'],
+        'WebCore::TextEffectData': ['<WebCore/TextAnimationTypes.h>'],
         'WebCore::TextExtraction::Item': ['<WebCore/TextExtractionTypes.h>'],
         'WebCore::TextExtraction::Result': ['<WebCore/TextExtractionTypes.h>'],
         'WebCore::TextIndicatorData': ['<WebCore/TextIndicator.h>'],

--- a/Source/WebKit/Shared/TextAnimationTypes.serialization.in
+++ b/Source/WebKit/Shared/TextAnimationTypes.serialization.in
@@ -45,4 +45,9 @@ header: <WebCore/TextAnimationTypes.h>
     Markable<WTF::UUID> destinationAnimationUUID;
 };
 
+header: <WebCore/TextAnimationTypes.h>
+[CustomHeader] struct WebCore::TextEffectData {
+    WebCore::WritingDirection writingDirection;
+};
+
 #endif

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -488,6 +488,7 @@ UIProcess/Cocoa/WKEditCommand.mm @nonARC
 UIProcess/Cocoa/WKFullKeyboardAccessWatcher.mm @nonARC
 UIProcess/Cocoa/WKReloadFrameErrorRecoveryAttempter.mm @nonARC
 UIProcess/Cocoa/WKScreenTimeConfigurationObserver.mm @nonARC
+UIProcess/Cocoa/WKTextEffectManager.mm @nonARC
 UIProcess/Cocoa/WKTextPlaceholder.mm @nonARC
 UIProcess/Cocoa/WKTextSelectionRect.mm @nonARC
 UIProcess/Cocoa/WKWebViewContentProviderRegistry.mm @nonARC

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -3078,6 +3078,26 @@ static std::optional<WebCore::JSHandleIdentifier> jsHandleIdentifierInFrame(cons
 #endif
 }
 
+#if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+- (void)_addTextEffectForID:(NSUUID *)nsUUID withData:(const WebCore::TextEffectData&)data
+{
+#if PLATFORM(IOS_FAMILY)
+    [_contentView addTextEffectForID:nsUUID withData:data];
+#else
+    _impl->addTextEffectForID(nsUUID, data);
+#endif
+}
+
+- (void)_removeTextEffectForID:(NSUUID *)nsUUID
+{
+#if PLATFORM(IOS_FAMILY)
+    [_contentView removeTextEffectForID:nsUUID];
+#else
+    _impl->removeTextEffectForID(nsUUID);
+#endif
+}
+#endif // ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+
 #endif
 
 #if ENABLE(GAMEPAD)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -130,6 +130,7 @@ struct AppHighlight;
 struct ExceptionData;
 struct ExceptionDetails;
 struct TextAnimationData;
+struct TextEffectData;
 enum class BoxSide : uint8_t;
 enum class WheelScrollGestureState : uint8_t;
 
@@ -603,6 +604,11 @@ struct PerWebProcessState {
 
 - (void)_addTextAnimationForAnimationID:(NSUUID *)uuid withData:(const WebCore::TextAnimationData&)styleData;
 - (void)_removeTextAnimationForAnimationID:(NSUUID *)uuid;
+
+#if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+- (void)_addTextEffectForID:(NSUUID *)uuid withData:(const WebCore::TextEffectData&)data;
+- (void)_removeTextEffectForID:(NSUUID *)uuid;
+#endif
 
 - (void)_clearWritingToolsPreservedNodes;
 

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
@@ -47,6 +47,7 @@ class IntPoint;
 class IntSize;
 
 struct AppHighlight;
+struct TextEffectData;
 }
 
 namespace WebKit {
@@ -146,6 +147,11 @@ public:
 
     void addTextAnimationForAnimationID(const WTF::UUID&, const WebCore::TextAnimationData&) final;
     void removeTextAnimationForAnimationID(const WTF::UUID&) final;
+
+#if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+    void addTextEffectForID(const WTF::UUID&, const WebCore::TextEffectData&) final;
+    void removeTextEffectForID(const WTF::UUID&) final;
+#endif
 #endif
 
 #if ENABLE(SCREEN_TIME)

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
@@ -364,6 +364,18 @@ void PageClientImplCocoa::removeTextAnimationForAnimationID(const WTF::UUID& uui
     [webView() _removeTextAnimationForAnimationID:uuid.createNSUUID().get()];
 }
 
+#if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+void PageClientImplCocoa::addTextEffectForID(const WTF::UUID& uuid, const WebCore::TextEffectData& data)
+{
+    [webView() _addTextEffectForID:uuid.createNSUUID().get() withData:data];
+}
+
+void PageClientImplCocoa::removeTextEffectForID(const WTF::UUID& uuid)
+{
+    [webView() _removeTextEffectForID:uuid.createNSUUID().get()];
+}
+#endif // ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+
 #endif
 
 #if ENABLE(SCREEN_TIME)

--- a/Source/WebKit/UIProcess/Cocoa/WKTextEffectManager.h
+++ b/Source/WebKit/UIProcess/Cocoa/WKTextEffectManager.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+
+#import <Foundation/Foundation.h>
+
+namespace WebCore {
+struct TextEffectData;
+}
+
+OBJC_CLASS WKWebView;
+
+@interface WKTextEffectManager : NSObject
+
+- (instancetype)initWithWebView:(WKWebView *)webView;
+- (void)addTextEffectForID:(NSUUID *)uuid withData:(const WebCore::TextEffectData&)data;
+- (void)removeTextEffectForID:(NSUUID *)uuid;
+
+- (void)removeAllTextEffects;
+
+@end
+
+#endif // ENABLE(WRITING_TOOLS_TEXT_EFFECTS)

--- a/Source/WebKit/UIProcess/Cocoa/WKTextEffectManager.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKTextEffectManager.mm
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "WKTextEffectManager.h"
+
+#if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+
+#import "ImageOptions.h"
+#import "WKWebViewInternal.h"
+#import "WebPageProxy.h"
+#import <WebCore/NativeImage.h>
+#import <WebCore/TextAnimationTypes.h>
+#import <WebCore/TextIndicator.h>
+#import <WebCore/WritingDirection.h>
+#import <pal/spi/cocoa/WritingToolsUISPI.h>
+#import <wtf/WeakObjCPtr.h>
+
+#import <pal/cocoa/WritingToolsUISoftLink.h>
+
+
+static constexpr WTTextEffectManagerWritingDirection toTextEffectWritingDirection(WebCore::WritingDirection editorWritingDirection)
+{
+    switch (editorWritingDirection) {
+    case WebCore::WritingDirection::Natural:
+        return WTTextEffectManagerWritingDirectionLeftToRight;
+    case WebCore::WritingDirection::LeftToRight:
+        return WTTextEffectManagerWritingDirectionLeftToRight;
+    case WebCore::WritingDirection::RightToLeft:
+        return WTTextEffectManagerWritingDirectionRightToLeft;
+    default:
+        ASSERT_NOT_REACHED();
+        return WTTextEffectManagerWritingDirectionLeftToRight;
+    }
+}
+
+@interface WKTextEffectManager () <_WTTextEffectManagerDelegate>
+@end
+
+@implementation WKTextEffectManager {
+    WeakObjCPtr<WKWebView> _webView;
+    RetainPtr<_WTTextEffectManager> _textEffectManager;
+}
+
+- (instancetype)initWithWebView:(WKWebView *)webView
+{
+    if (!(self = [super init]))
+        return nil;
+
+    _webView = webView;
+    _textEffectManager = adoptNS([PAL::alloc_WTTextEffectManagerInstance() initWithDelegate:self]);
+
+    return self;
+}
+
+- (void)addTextEffectForID:(NSUUID *)uuid withData:(const WebCore::TextEffectData&)data
+{
+    [_textEffectManager startAnimationForSuggestionWithUUID:uuid writingDirection:toTextEffectWritingDirection(data.writingDirection) effectType:WTTextEffectManagerEffectTypeDefault completion:^(NSUUID *uuid) { }];
+}
+
+- (void)removeTextEffectForID:(NSUUID *)uuid
+{
+    [_textEffectManager cancelAnimationForSuggestionWithUUID:uuid];
+}
+
+- (void)removeAllTextEffects
+{
+    [_textEffectManager cancelAllAnimations];
+}
+
+#pragma mark _WTTextEffectManagerDelegate
+- (void)hideTextForSuggestionWithUUID:(NSUUID *)uuid completion:(void(^)(void))completionHandler
+{
+    RetainPtr webView = _webView.get();
+    if (!webView)
+        return completionHandler();
+
+    auto textEffectUUID = WTF::UUID::fromNSUUID(uuid);
+    if (!textEffectUUID)
+        return completionHandler();
+
+    [webView _page]->updateUnderlyingTextVisibilityForTextEffectID(*textEffectUUID, false, [completionHandler = makeBlockPtr(completionHandler)] {
+        if (completionHandler)
+            completionHandler();
+    });
+}
+- (void)showTextForSuggestionWithUUID:(NSUUID *)uuid completion:(void(^)(void))completionHandler
+{
+    RetainPtr webView = _webView.get();
+    if (!webView)
+        return completionHandler();
+
+    auto textEffectUUID = WTF::UUID::fromNSUUID(uuid);
+    if (!textEffectUUID)
+        return completionHandler();
+
+    [webView _page]->updateUnderlyingTextVisibilityForTextEffectID(*textEffectUUID, true, [completionHandler = makeBlockPtr(completionHandler)] {
+        if (completionHandler)
+            completionHandler();
+    });
+}
+
+- (void)containerViewForSuggestionWithUUID:(NSUUID *)uuid completion:(void(^)(CocoaView *containerView))completionHandler
+{
+    completionHandler(_webView.get());
+}
+
+static RetainPtr<NSArray<_WTTextPreview *>> textPreviewsFromIndicator(const RefPtr<WebCore::TextIndicator>& textIndicator)
+{
+    if (!textIndicator)
+        return nil;
+
+    RefPtr snapshot = textIndicator->contentImage();
+    if (!snapshot)
+        return nil;
+
+    RefPtr snapshotImage = snapshot->nativeImage();
+    if (!snapshotImage)
+        return nil;
+
+    RetainPtr previews = adoptNS([[NSMutableArray alloc] initWithCapacity:textIndicator->textRectsInBoundingRectCoordinates().size()]);
+    RetainPtr snapshotPlatformImage = snapshotImage->platformImage();
+
+    if (!snapshotPlatformImage)
+        return nil;
+
+    CGRect snapshotRectInBoundingRectCoordinates = textIndicator->textBoundingRectInRootViewCoordinates();
+
+    for (auto textRectInSnapshotCoordinates : textIndicator->textRectsInBoundingRectCoordinates()) {
+        CGRect textLineFrameInBoundingRectCoordinates = CGRectOffset(textRectInSnapshotCoordinates, snapshotRectInBoundingRectCoordinates.origin.x, snapshotRectInBoundingRectCoordinates.origin.y);
+        textRectInSnapshotCoordinates.scale(textIndicator->contentImageScaleFactor());
+        [previews addObject:adoptNS([PAL::alloc_WTTextPreviewInstance() initWithSnapshotImage:adoptCF(CGImageCreateWithImageInRect(snapshotPlatformImage.get(), textRectInSnapshotCoordinates)).get() presentationFrame:textLineFrameInBoundingRectCoordinates]).get()];
+    }
+
+    return previews;
+}
+
+- (void)previewsForSuggestionWithUUID:(NSUUID *)uuid completion:(void (^)(NSArray<_WTTextPreview *> * _Nullable textPreviews, NSArray<_WTTextPreview *> * _Nullable underlinePreviews))completionHandler
+{
+    RetainPtr webView = _webView.get();
+    if (!webView)
+        return completionHandler(nil, nil);
+
+    auto textEffectUUID = WTF::UUID::fromNSUUID(uuid);
+    if (!textEffectUUID)
+        return completionHandler(nil, nil);
+
+    [webView _page]->textIndicatorForTextEffectID(*textEffectUUID, [protectedSelf = retainPtr(self), textEffectUUID = *textEffectUUID, completionHandler = makeBlockPtr(completionHandler)](RefPtr<WebCore::TextIndicator> textIndicator) {
+        RetainPtr textPreviews = textPreviewsFromIndicator(textIndicator);
+        if (!textPreviews) {
+            completionHandler(nil, nil);
+            return;
+        }
+
+        RetainPtr webView = protectedSelf->_webView.get();
+        if (!webView) {
+            completionHandler(nil, nil);
+            return;
+        }
+
+        [webView _page]->decorationIndicatorForTextEffectID(textEffectUUID, [textPreviews = WTF::move(textPreviews), completionHandler](RefPtr<WebCore::TextIndicator> decorationIndicator) {
+            auto underlinePreviews = textPreviewsFromIndicator(decorationIndicator);
+            completionHandler(textPreviews.get(), underlinePreviews.get());
+        });
+    });
+}
+
+@end
+
+#endif // ENABLE(WRITING_TOOLS_TEXT_EFFECT)
+

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -1502,6 +1502,27 @@ void WebPageProxy::setSelectionForActiveWritingToolsSession(const WebCore::Chara
     protect(legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebPage::SetSelectionForActiveWritingToolsSession(rangeRelativeToSessionRange), WTF::move(completionHandler), webPageIDInMainFrameProcess());
 }
 
+#if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+void WebPageProxy::addTextEffectForID(IPC::Connection& connection, const WTF::UUID& uuid, const WebCore::TextEffectData& data, RefPtr<WebCore::TextIndicator>&& textIndicator, RefPtr<WebCore::TextIndicator>&& decorationIndicator)
+{
+    MESSAGE_CHECK(uuid.isValid(), connection);
+
+    internals().textIndicatorForAnimationID.add(uuid, textIndicator);
+    internals().decorationIndicatorForAnimationID.add(uuid, decorationIndicator);
+
+    if (RefPtr pageClient = this->pageClient())
+        pageClient->addTextEffectForID(uuid, data);
+}
+
+void WebPageProxy::removeTextEffectForID(IPC::Connection& connection, const WTF::UUID& uuid)
+{
+    MESSAGE_CHECK(uuid.isValid(), connection);
+
+    if (RefPtr pageClient = this->pageClient())
+        pageClient->removeTextEffectForID(uuid);
+}
+#endif // ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+
 void WebPageProxy::addTextAnimationForAnimationID(IPC::Connection& connection, const WTF::UUID& uuid, const WebCore::TextAnimationData& styleData, const RefPtr<WebCore::TextIndicator> textIndicator)
 {
     addTextAnimationForAnimationIDWithCompletionHandler(connection, uuid, styleData, textIndicator, { });
@@ -1597,6 +1618,46 @@ void WebPageProxy::didEndPartialIntelligenceTextAnimation(IPC::Connection&)
 {
     didEndPartialIntelligenceTextAnimationImpl();
 }
+
+#if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+void WebPageProxy::updateUnderlyingTextVisibilityForTextEffectID(const WTF::UUID& uuid, bool visible, CompletionHandler<void()>&& completionHandler)
+{
+    if (!hasRunningProcess()) {
+        completionHandler();
+        return;
+    }
+
+    protect(legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebPage::UpdateUnderlyingTextVisibilityForTextEffectID(uuid, visible), WTF::move(completionHandler), webPageIDInMainFrameProcess());
+}
+
+void WebPageProxy::textIndicatorForTextEffectID(const WTF::UUID& uuid, CompletionHandler<void(RefPtr<WebCore::TextIndicator>&&)>&& completionHandler)
+{
+    if (!hasRunningProcess()) {
+        completionHandler(nullptr);
+        return;
+    }
+
+    auto maybeTextIndicator = internals().textIndicatorForAnimationID.takeOptional(uuid);
+    if (RefPtr textIndicator = maybeTextIndicator.value_or(nullptr)) {
+        completionHandler(WTF::move(textIndicator));
+        return;
+    }
+
+    // Fallback if we are missing the indicator.
+    protect(legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebPage::CreateTextIndicatorForTextEffectID(uuid), WTF::move(completionHandler), webPageIDInMainFrameProcess());
+}
+
+void WebPageProxy::decorationIndicatorForTextEffectID(const WTF::UUID& uuid, CompletionHandler<void(RefPtr<WebCore::TextIndicator>&&)>&& completionHandler)
+{
+    if (!hasRunningProcess()) {
+        completionHandler(nullptr);
+        return;
+    }
+
+    RefPtr decorationIndicator = internals().decorationIndicatorForAnimationID.get(uuid);
+    completionHandler(WTF::move(decorationIndicator));
+}
+#endif // ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
 
 bool WebPageProxy::writingToolsTextReplacementsFinished()
 {

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -814,6 +814,11 @@ public:
 
     virtual void addTextAnimationForAnimationID(const WTF::UUID&, const WebCore::TextAnimationData&) = 0;
     virtual void removeTextAnimationForAnimationID(const WTF::UUID&) = 0;
+
+#if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+    virtual void addTextEffectForID(const WTF::UUID&, const WebCore::TextEffectData&) = 0;
+    virtual void removeTextEffectForID(const WTF::UUID&) = 0;
+#endif
 #endif
 
 #if ENABLE(DATA_DETECTION)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -344,6 +344,7 @@ struct SystemPreviewInfo;
 struct TargetedElementRequest;
 struct TextAlternativeWithRange;
 struct TextCheckingResult;
+struct TextEffectData;
 struct TextIndicatorData;
 struct TextManipulationControllerExclusionRule;
 struct TextManipulationControllerManipulationFailure;
@@ -2802,6 +2803,11 @@ public:
     void addTextAnimationForAnimationIDWithCompletionHandler(IPC::Connection&, const WTF::UUID&, const WebCore::TextAnimationData&, const RefPtr<WebCore::TextIndicator>, WTF::CompletionHandler<void(WebCore::TextAnimationRunMode)>&&);
     void removeTextAnimationForAnimationID(IPC::Connection&, const WTF::UUID&);
 
+#if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+    void addTextEffectForID(IPC::Connection&, const WTF::UUID&, const WebCore::TextEffectData&, RefPtr<WebCore::TextIndicator>&&, RefPtr<WebCore::TextIndicator>&& decorationIndicator);
+    void removeTextEffectForID(IPC::Connection&, const WTF::UUID&);
+#endif
+
     void callCompletionHandlerForAnimationID(const WTF::UUID&, WebCore::TextAnimationRunMode);
 #if PLATFORM(IOS_FAMILY)
     void storeDestinationCompletionHandlerForAnimationID(const WTF::UUID&, CompletionHandler<void(RefPtr<WebCore::TextIndicator>&&)>&&);
@@ -2814,6 +2820,12 @@ public:
 
     void didEndPartialIntelligenceTextAnimation(IPC::Connection&);
     void didEndPartialIntelligenceTextAnimationImpl();
+
+#if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+    void updateUnderlyingTextVisibilityForTextEffectID(const WTF::UUID&, bool, CompletionHandler<void()>&&);
+    void textIndicatorForTextEffectID(const WTF::UUID&, CompletionHandler<void(RefPtr<WebCore::TextIndicator>&&)>&&);
+    void decorationIndicatorForTextEffectID(const WTF::UUID&, CompletionHandler<void(RefPtr<WebCore::TextIndicator>&&)>&&);
+#endif
 #endif
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -284,6 +284,11 @@ messages -> WebPageProxy {
     DidEndPartialIntelligenceTextAnimation()
 #endif
 
+#if ENABLE(WRITING_TOOLS) && ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+    AddTextEffectForID(WTF::UUID uuid, struct WebCore::TextEffectData data, RefPtr<WebCore::TextIndicator> textIndicator, RefPtr<WebCore::TextIndicator> decorationIndicator)
+    RemoveTextEffectForID(WTF::UUID uuid)
+#endif
+
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
     [EnabledBy=MediaControlsContextMenusEnabled] ShowMediaControlsContextMenu(WebCore::FloatRect targetFrame, Vector<WebCore::MediaControlsContextMenuItem> items, struct WebKit::FrameInfoData frameInfoData, WebCore::MediaPlayerClientIdentifier identifier) -> (WebCore::MediaControlsContextMenuItem::ID selectedItemID)
 #endif // ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -399,6 +399,9 @@ public:
 
 #if ENABLE(WRITING_TOOLS)
     HashMap<WTF::UUID, RefPtr<WebCore::TextIndicator>> textIndicatorForAnimationID;
+#if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+    HashMap<WTF::UUID, RefPtr<WebCore::TextIndicator>> decorationIndicatorForAnimationID;
+#endif
     HashMap<WTF::UUID, CompletionHandler<void(WebCore::TextAnimationRunMode)>> completionHandlerForAnimationID;
     HashMap<WTF::UUID, CompletionHandler<void(RefPtr<WebCore::TextIndicator>)>> completionHandlerForDestinationTextIndicatorForSourceID;
     HashMap<WTF::UUID, WTF::UUID> sourceAnimationIDtoDestinationAnimationID;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -110,6 +110,7 @@ struct MediaPlayerClientIdentifierType;
 struct PromisedAttachmentInfo;
 struct ShareDataWithParsedURL;
 struct TextAnimationData;
+struct TextEffectData;
 struct TextRecognitionResult;
 enum class DOMPasteAccessCategory : uint8_t;
 enum class DOMPasteAccessResponse : uint8_t;
@@ -159,6 +160,7 @@ enum class PickerDismissalReason : uint8_t;
 @class _WKTextInputContext;
 
 @class WKTextAnimationManager;
+@class WKTextEffectManager;
 
 #if ENABLE(WEB_AUTHN)
 @class WKDigitalCredentialsPicker;
@@ -479,6 +481,9 @@ struct ImageAnalysisContextMenuActionData {
     BOOL _isPresentingWritingTools;
 
     RetainPtr<WKTextAnimationManager> _textAnimationManager;
+#if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+    RetainPtr<WKTextEffectManager> _textEffectManager;
+#endif
 #endif
 
     enum class SelectionInteractionType : uint8_t {
@@ -956,6 +961,11 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(DECLARE_WKCONTENTVIEW_ACTION_FOR_WEB_VIEW)
 #if ENABLE(WRITING_TOOLS)
 - (void)addTextAnimationForAnimationID:(NSUUID *)uuid withData:(const WebCore::TextAnimationData&)data;
 - (void)removeTextAnimationForAnimationID:(NSUUID *)uuid;
+
+#if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+- (void)addTextEffectForID:(NSUUID *)uuid withData:(const WebCore::TextEffectData&)data;
+- (void)removeTextEffectForID:(NSUUID *)uuid;
+#endif
 #endif
 
 @property (nonatomic, readonly) BOOL _shouldUseContextMenus;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -213,6 +213,7 @@
 
 #if ENABLE(WRITING_TOOLS)
 #import "WKTextAnimationManagerIOS.h"
+#import "WKTextEffectManager.h"
 #endif
 
 #if ENABLE(MODEL_PROCESS) || ENABLE(WRITING_TOOLS)
@@ -14326,6 +14327,33 @@ static inline WKTextAnimationType toWKTextAnimationType(WebCore::TextAnimationTy
 
     [_textAnimationManager removeTextAnimationForAnimationID:uuid];
 }
+
+#if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+- (void)addTextEffectForID:(NSUUID *)uuid withData:(const WebCore::TextEffectData&)data
+{
+    if (!protect(_page->preferences())->textEffectsEnabled())
+        return;
+
+    if (!_textEffectManager)
+        _textEffectManager = adoptNS([[WKTextEffectManager alloc] initWithWebView:self.webView]);
+
+    [_textEffectManager addTextEffectForID:uuid withData:data];
+}
+
+- (void)removeTextEffectForID:(NSUUID *)uuid
+{
+    if (!uuid)
+        return;
+
+    if (!protect(_page->preferences())->textEffectsEnabled())
+        return;
+
+    if (!_textEffectManager)
+        return;
+
+    [_textEffectManager removeTextEffectForID:uuid];
+}
+#endif // ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
 
 #endif
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -96,6 +96,7 @@ OBJC_CLASS WKTextSelectionController;
 OBJC_CLASS WKViewLayoutStrategy;
 OBJC_CLASS WKWebView;
 OBJC_CLASS WKWindowVisibilityObserver;
+OBJC_CLASS WKTextEffectManager;
 OBJC_CLASS _WKRemoteObjectRegistry;
 OBJC_CLASS _WKThumbnailView;
 
@@ -832,6 +833,11 @@ public:
     void removeTextAnimationForAnimationID(WTF::UUID);
 
     void hideTextAnimationView();
+
+#if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+    void addTextEffectForID(NSUUID *, const WebCore::TextEffectData&);
+    void removeTextEffectForID(NSUUID *);
+#endif
 #endif
 
 #if HAVE(INLINE_PREDICTIONS)
@@ -1119,6 +1125,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 #if ENABLE(WRITING_TOOLS)
     RetainPtr<WKTextAnimationManager> m_textAnimationTypeManager;
+#if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+    RetainPtr<WKTextEffectManager> m_textEffectManager;
+#endif
 #endif
 
     WebCore::IntPoint m_lastPageScrollPosition;

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -76,6 +76,7 @@
 #import "WKQuickLookPreviewController.h"
 #import "WKRevealItemPresenter.h"
 #import "WKTextAnimationManagerMac.h"
+#import "WKTextEffectManager.h"
 #import "WKTextPlaceholder.h"
 #import "WKTextSelectionController.h"
 #import "WKViewLayoutStrategy.h"
@@ -5108,6 +5109,27 @@ void WebViewImpl::hideTextAnimationView()
 {
     [m_textAnimationTypeManager hideTextAnimationView];
 }
+
+#if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+void WebViewImpl::addTextEffectForID(NSUUID *uuid, const WebCore::TextEffectData& data)
+{
+    if (!protect(m_page->preferences())->textEffectsEnabled())
+        return;
+
+    if (!m_textEffectManager)
+        m_textEffectManager = adoptNS([[WKTextEffectManager alloc] initWithWebView:view()]);
+
+    [m_textEffectManager addTextEffectForID:uuid withData:data];
+}
+
+void WebViewImpl::removeTextEffectForID(NSUUID *uuid)
+{
+    if (!protect(m_page->preferences())->textEffectsEnabled())
+        return;
+
+    [m_textEffectManager removeTextEffectForID:uuid];
+}
+#endif // ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
 
 #endif // ENABLE(WRITING_TOOLS)
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1092,6 +1092,7 @@
 		442E7BEB27B4586900C69AC1 /* RevealItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 442E7BEA27B4581300C69AC1 /* RevealItem.h */; };
 		4459984222833E8700E61373 /* SyntheticEditingCommandType.h in Headers */ = {isa = PBXBuildFile; fileRef = 4459984122833E6000E61373 /* SyntheticEditingCommandType.h */; };
 		4476EF0925BFC8B7004A0587 /* _WKAppHighlightDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 4476EF0825BFC8B7004A0587 /* _WKAppHighlightDelegate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		4481E6162F57C0A000C226A3 /* WKTextEffectManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 4481E6152F57C0A000C226A3 /* WKTextEffectManager.h */; };
 		4482734724528F6000A95493 /* CocoaImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 4482734624528F6000A95493 /* CocoaImage.h */; };
 		4486A15C2B730D0000E48068 /* CoreIPCNSShadow.h in Headers */ = {isa = PBXBuildFile; fileRef = 4486A15B2B730CF200E48068 /* CoreIPCNSShadow.h */; };
 		4486A15D2B730D0900E48068 /* CoreIPCNSShadow.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4486A1592B730CF100E48068 /* CoreIPCNSShadow.mm */; };
@@ -5708,6 +5709,8 @@
 		442E7BEA27B4581300C69AC1 /* RevealItem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RevealItem.h; sourceTree = "<group>"; };
 		4459984122833E6000E61373 /* SyntheticEditingCommandType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SyntheticEditingCommandType.h; sourceTree = "<group>"; };
 		4476EF0825BFC8B7004A0587 /* _WKAppHighlightDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKAppHighlightDelegate.h; sourceTree = "<group>"; };
+		4481E6152F57C0A000C226A3 /* WKTextEffectManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKTextEffectManager.h; sourceTree = "<group>"; };
+		4481E6172F57C0C300C226A3 /* WKTextEffectManager.mm */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; path = WKTextEffectManager.mm; sourceTree = "<group>"; };
 		4482734624528F6000A95493 /* CocoaImage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CocoaImage.h; sourceTree = "<group>"; };
 		4486A1592B730CF100E48068 /* CoreIPCNSShadow.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCNSShadow.mm; sourceTree = "<group>"; };
 		4486A15A2B730CF100E48068 /* CoreIPCNSShadow.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCNSShadow.serialization.in; sourceTree = "<group>"; };
@@ -10789,6 +10792,8 @@
 				1DBBB061211CC3CB00502ECC /* WKShareSheet.mm */,
 				7A78FF2E224191750096483E /* WKStorageAccessAlert.h */,
 				7A78FF2F224191760096483E /* WKStorageAccessAlert.mm */,
+				4481E6152F57C0A000C226A3 /* WKTextEffectManager.h */,
+				4481E6172F57C0C300C226A3 /* WKTextEffectManager.mm */,
 				CE21215D240EE571006ED443 /* WKTextPlaceholder.h */,
 				CE21215E240EE571006ED443 /* WKTextPlaceholder.mm */,
 				CE45945A240F85B90078019F /* WKTextSelectionRect.h */,
@@ -19453,6 +19458,7 @@
 				44DBDA502BB23DE9004E3712 /* WKTextAnimationManagerIOS.h in Headers */,
 				440C0BE52BBCAA3C0086046E /* WKTextAnimationManagerMac.h in Headers */,
 				31D755C11D91B81500843BD1 /* WKTextChecker.h in Headers */,
+				4481E6162F57C0A000C226A3 /* WKTextEffectManager.h in Headers */,
 				F48EC3582B75895800D1B886 /* WKTextExtractionUtilities.h in Headers */,
 				2DD67A351BD861060053B251 /* WKTextFinderClient.h in Headers */,
 				F4D5F51D206087A10038BBA8 /* WKTextInputListViewController.h in Headers */,

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -1393,6 +1393,18 @@ void WebPage::updateUnderlyingTextVisibilityForTextAnimationID(const WTF::UUID& 
     m_textAnimationController->updateUnderlyingTextVisibilityForTextAnimationID(uuid, visible, WTF::move(completionHandler));
 }
 
+#if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+void WebPage::updateUnderlyingTextVisibilityForTextEffectID(const WTF::UUID&, bool, CompletionHandler<void()>&& completionHandler)
+{
+    completionHandler();
+}
+
+void WebPage::createTextIndicatorForTextEffectID(const WTF::UUID&, CompletionHandler<void(RefPtr<WebCore::TextIndicator>&&)>&& completionHandler)
+{
+    completionHandler(nullptr);
+}
+#endif // ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+
 void WebPage::proofreadingSessionSuggestionTextRectsInRootViewCoordinates(const WebCore::CharacterRange& enclosingRangeRelativeToSessionRange, CompletionHandler<void(Vector<FloatRect>&&)>&& completionHandler) const
 {
     auto rects = protect(corePage())->proofreadingSessionSuggestionTextRectsInRootViewCoordinates(enclosingRangeRelativeToSessionRange);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2710,6 +2710,11 @@ private:
     void intelligenceTextAnimationsDidComplete();
 #endif
 
+#if ENABLE(WRITING_TOOLS) && ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+    void updateUnderlyingTextVisibilityForTextEffectID(const WTF::UUID&, bool, CompletionHandler<void()>&&);
+    void createTextIndicatorForTextEffectID(const WTF::UUID&, CompletionHandler<void(RefPtr<WebCore::TextIndicator>&&)>&&);
+#endif
+
     void remotePostMessage(WebCore::FrameIdentifier source, const WebCore::SecurityOriginData& sourceOrigin, WebCore::FrameIdentifier target, std::optional<WebCore::SecurityOriginData>&& targetOrigin, const WebCore::MessageWithMessagePorts&);
     void renderTreeAsTextForTesting(WebCore::FrameIdentifier, uint64_t baseIndent, OptionSet<WebCore::RenderAsTextFlag>, CompletionHandler<void(String&&)>&&);
     void layerTreeAsTextForTesting(WebCore::FrameIdentifier, uint64_t baseIndent, OptionSet<WebCore::LayerTreeAsTextOptions>, CompletionHandler<void(String&&)>&&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -910,6 +910,11 @@ messages -> WebPage WantsAsyncDispatchMessage {
     IntelligenceTextAnimationsDidComplete();
 #endif
 
+#if ENABLE(WRITING_TOOLS) && ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+    UpdateUnderlyingTextVisibilityForTextEffectID(WTF::UUID uuid, bool visible) -> ()
+    CreateTextIndicatorForTextEffectID(WTF::UUID uuid) -> (RefPtr<WebCore::TextIndicator> textIndicator)
+#endif
+
 #if PLATFORM(COCOA)
     CreateTextIndicatorForElementWithID(String elementID) -> (RefPtr<WebCore::TextIndicator> textIndicator)
 #endif


### PR DESCRIPTION
#### d34a8b84cbc1563a7c4547b9e93fc73fe862e560
<pre>
Add WKTextEffectManager and associated plumbing for refactoring to use modern text effects.
<a href="https://bugs.webkit.org/show_bug.cgi?id=310459">https://bugs.webkit.org/show_bug.cgi?id=310459</a>
<a href="https://rdar.apple.com/173093588">rdar://173093588</a>

Reviewed by Wenson Hsieh.

Refactoring to use the text effects that became
available after the first implementation of
writing tools.

* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/TextAnimationTypes.serialization.in:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _addTextEffectForID:withData:]):
(-[WKWebView _removeTextEffectForID:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm:
(WebKit::PageClientImplCocoa::addTextEffectForID):
(WebKit::PageClientImplCocoa::removeTextEffectForID):
* Source/WebKit/UIProcess/Cocoa/WKTextEffectManager.h: Added.
* Source/WebKit/UIProcess/Cocoa/WKTextEffectManager.mm: Added.
(toTextEffectWritingDirection):
(-[WKTextEffectManager initWithWebView:]):
(-[WKTextEffectManager addTextEffectForID:withData:]):
(-[WKTextEffectManager removeTextEffectForID:]):
(-[WKTextEffectManager removeAllTextEffects]):
(-[WKTextEffectManager hideTextForSuggestionWithUUID:completion:]):
(-[WKTextEffectManager showTextForSuggestionWithUUID:completion:]):
(-[WKTextEffectManager containerViewForSuggestionWithUUID:completion:]):
(textPreviewsFromIndicator):
(-[WKTextEffectManager previewsForSuggestionWithUUID:completion:]):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::addTextEffectForID):
(WebKit::WebPageProxy::removeTextEffectForID):
(WebKit::WebPageProxy::updateUnderlyingTextVisibilityForTextEffectID):
(WebKit::WebPageProxy::textIndicatorForTextEffectID):
(WebKit::WebPageProxy::decorationIndicatorForTextEffectID):
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/WebPageProxyInternals.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView addTextEffectForID:withData:]):
(-[WKContentView removeTextEffectForID:]):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::addTextEffectForID):
(WebKit::WebViewImpl::removeTextEffectForID):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::updateUnderlyingTextVisibilityForTextEffectID):
(WebKit::WebPage::createTextIndicatorForTextEffectID):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Canonical link: <a href="https://commits.webkit.org/309732@main">https://commits.webkit.org/309732@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad6e592d68faff2d83ecc3f255569c6b215ffd10

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151594 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24359 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17940 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160328 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5145e296-20bc-4939-b85d-9ff54a015bad) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24790 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24661 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/117077 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/243e89df-03c9-4725-b3ca-a4c0859fa9ea) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154554 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/136030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97792 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5b821757-491c-4bc1-97e3-b74fcdce8e40) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/150916 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/18314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/16256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8171 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/127943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162800 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5930 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15525 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/125090 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24160 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20314 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125273 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24152 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135731 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/80750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23272 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20327 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/12506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23761 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/88073 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23471 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23625 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/23527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->