### PR TITLE
Rseync `css-animations` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-range-shorthand-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-range-shorthand-expected.txt
@@ -8,6 +8,7 @@ PASS e.style['animation-range'] = "entry-crossing" should set the property value
 PASS e.style['animation-range'] = "exit" should set the property value
 PASS e.style['animation-range'] = "exit-crossing" should set the property value
 PASS e.style['animation-range'] = "entry, exit" should set the property value
+FAIL e.style['animation-range'] = "0% 100%" should set the property value assert_equals: serialization should be canonical expected "0%" but got "0% 100%"
 PASS e.style['animation-range'] = "entry 0% entry 100%" should set the property value
 PASS e.style['animation-range'] = "entry-crossing 0% entry-crossing 100%" should set the property value
 PASS e.style['animation-range'] = "exit 0% exit 100%" should set the property value
@@ -30,6 +31,7 @@ PASS e.style['animation-range'] = "normal 100px" should set the property value
 PASS e.style['animation-range'] = "100px" should set the property value
 PASS e.style['animation-range'] = "100px normal" should set the property value
 PASS e.style['animation-range'] = "10% normal" should set the property value
+FAIL e.style['animation-range'] = "entry normal" should set the property value assert_equals: serialization should be canonical expected "entry normal" but got "entry"
 PASS Property animation-range value 'normal'
 PASS Property animation-range value 'normal normal'
 PASS Property animation-range value 'cover'
@@ -39,6 +41,7 @@ PASS Property animation-range value 'entry-crossing'
 PASS Property animation-range value 'exit'
 PASS Property animation-range value 'exit-crossing'
 PASS Property animation-range value 'entry, exit'
+PASS Property animation-range value '0% 100%'
 PASS Property animation-range value 'entry 0% entry 100%'
 PASS Property animation-range value 'entry-crossing 0% entry-crossing 100%'
 PASS Property animation-range value 'exit 0% exit 100%'
@@ -62,6 +65,7 @@ PASS Property animation-range value 'normal 100px'
 PASS Property animation-range value '100px'
 PASS Property animation-range value '100px normal'
 PASS Property animation-range value '10% normal'
+FAIL Property animation-range value 'entry normal' assert_equals: expected "entry normal" but got "entry"
 PASS Property animation-range value '10% calc(70% + 10% * sign(100em - 1px))'
 PASS e.style['animation-range'] = "entry 50% 0s" should not set the property value
 PASS e.style['animation-range'] = "0s entry 50%" should not set the property value

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-range-shorthand.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-range-shorthand.html
@@ -18,6 +18,7 @@ test_valid_value("animation-range", "exit");
 test_valid_value("animation-range", "exit-crossing");
 test_valid_value("animation-range", "entry, exit");
 
+test_valid_value("animation-range", "0% 100%", "0%");
 test_valid_value("animation-range", "entry 0% entry 100%", "entry");
 test_valid_value("animation-range", "entry-crossing 0% entry-crossing 100%",
                  "entry-crossing");
@@ -45,6 +46,7 @@ test_valid_value("animation-range", "normal 100px");
 test_valid_value("animation-range", "100px");
 test_valid_value("animation-range", "100px normal", "100px");
 test_valid_value("animation-range", "10% normal", "10%");
+test_valid_value("animation-range", "entry normal");
 
 test_computed_value("animation-range", "normal");
 test_computed_value("animation-range", "normal normal", "normal");
@@ -56,6 +58,7 @@ test_computed_value("animation-range", "exit");
 test_computed_value("animation-range", "exit-crossing");
 test_computed_value("animation-range", "entry, exit");
 
+test_computed_value("animation-range", "0% 100%", "0%");
 test_computed_value("animation-range", "entry 0% entry 100%", "entry");
 test_computed_value("animation-range", "entry-crossing 0% entry-crossing 100%",
                  "entry-crossing");
@@ -85,6 +88,7 @@ test_computed_value("animation-range", "normal 100px");
 test_computed_value("animation-range", "100px");
 test_computed_value("animation-range", "100px normal", "100px");
 test_computed_value("animation-range", "10% normal", "10%");
+test_computed_value("animation-range", "entry normal");
 test_computed_value("animation-range", "10% calc(70% + 10% * sign(100em - 1px))", "10% 80%");
 
 test_invalid_value("animation-range", "entry 50% 0s", "entry 50%");

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-range-start-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-range-start-computed-expected.txt
@@ -1,6 +1,7 @@
 
 PASS Property animation-range-start value 'initial'
 PASS Property animation-range-start value 'normal'
+PASS Property animation-range-start value 'cover 0px'
 PASS Property animation-range-start value 'cover 0%'
 PASS Property animation-range-start value 'cover 100%'
 PASS Property animation-range-start value 'COVER 0%'

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-range-start-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-range-start-computed.html
@@ -7,6 +7,7 @@
 <script>
 test_computed_value("animation-range-start", "initial", "normal");
 test_computed_value("animation-range-start", "normal");
+test_computed_value("animation-range-start", "cover 0px");
 test_computed_value("animation-range-start", "cover 0%", "cover");
 test_computed_value("animation-range-start", "cover 100%");
 test_computed_value("animation-range-start", "COVER 0%", "cover");

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-range-start-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-range-start-valid-expected.txt
@@ -1,5 +1,6 @@
 
 PASS e.style['animation-range-start'] = "normal" should set the property value
+PASS e.style['animation-range-start'] = "cover 0px" should set the property value
 PASS e.style['animation-range-start'] = "cover 0%" should set the property value
 PASS e.style['animation-range-start'] = "cover 100%" should set the property value
 PASS e.style['animation-range-start'] = "cover 120%" should set the property value

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-range-start-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-range-start-valid.html
@@ -6,6 +6,7 @@
 <script>
 // https://drafts.csswg.org/scroll-animations-1/#view-timelines-ranges
 test_valid_value("animation-range-start", "normal");
+test_valid_value("animation-range-start", "cover 0px");
 test_valid_value("animation-range-start", "cover 0%", "cover");
 test_valid_value("animation-range-start", "cover 100%");
 test_valid_value("animation-range-start", "cover 120%");


### PR DESCRIPTION
#### 68a76b6b806c7ac16c209a302c9cc023821262be
<pre>
Rseync `css-animations` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=310462">https://bugs.webkit.org/show_bug.cgi?id=310462</a>

Reviewed by Antoine Quint.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/b2b605ce8662b1dd6f92f56e4857d7904c19132f">https://github.com/web-platform-tests/wpt/commit/b2b605ce8662b1dd6f92f56e4857d7904c19132f</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-range-shorthand-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-range-shorthand.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-range-start-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-range-start-computed.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-range-start-valid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-range-start-valid.html:

Canonical link: <a href="https://commits.webkit.org/309745@main">https://commits.webkit.org/309745@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d409e073f8343911127ebff78f844b40ee565476

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151496 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24261 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17842 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160228 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104934 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/18aa5269-462a-4c91-bf81-174f99cab6f9) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24692 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24563 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116994 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83056 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/96f09de5-6b8f-42c5-8626-2ec1f3bdac98) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154456 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19131 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135945 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97705 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1656f428-c316-4be6-9521-0af6ad9497af) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18221 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16168 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8072 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127848 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13850 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162699 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15439 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125004 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24062 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20226 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125188 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33996 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24054 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135646 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80603 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20245 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12421 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23663 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23373 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23527 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23429 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->