### PR TITLE
Optimize StringImpl::find()

### DIFF
--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -927,19 +927,24 @@ SUPPRESS_NODELETE size_t StringImpl::find(std::span<const Latin1Character> match
     // only call equal if the hashes match.
 
     auto findWithHash = [&](auto searchCharacters) -> size_t {
+        // Rabin-Karp style rolling hash with base 31.
+        constexpr unsigned base = 31;
         unsigned searchHash = 0;
         unsigned matchHash = 0;
+        unsigned basePower = 1; // base^(matchString.size()-1)
         for (size_t i = 0; i < matchString.size(); ++i) {
-            searchHash += searchCharacters[i];
-            matchHash += matchString[i];
+            searchHash = searchHash * base + searchCharacters[i];
+            matchHash = matchHash * base + matchString[i];
+            if (i)
+                basePower *= base;
         }
 
         for (size_t i = 0; i <= delta; ++i) {
             if (searchHash == matchHash && equal(searchCharacters.subspan(i, matchString.size()), matchString))
                 return start + i;
             if (i < delta) {
-                searchHash += searchCharacters[i + matchString.size()];
-                searchHash -= searchCharacters[i];
+                searchHash -= searchCharacters[i] * basePower;
+                searchHash = searchHash * base + searchCharacters[i + matchString.size()];
             }
         }
         return notFound;


### PR DESCRIPTION
#### 7f1c6a8c8a8cb18ddc21701761ee4ba6bdba4119
<pre>
Optimize StringImpl::find()
<a href="https://bugs.webkit.org/show_bug.cgi?id=310465">https://bugs.webkit.org/show_bug.cgi?id=310465</a>

Reviewed by Darin Adler.

Upgrade the rolling hash in StringImpl::find() from a naive additive
hash to a Rabin-Karp rolling hash. This hash is position-sensitive
(&quot;abc&quot; and &quot;cab&quot; now produce different hashes). This reduces false
positive collisions so that the expensive equal() comparison is called
less often.

The rolling update in the search loop remains O(1) per step. The overall
algorithm stays O(n) expected time, but with better constant factors due
to fewer unnecessary comparisons.

This results in a 0.2-0.4% progression on Speedometer 3.

* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::find):

Canonical link: <a href="https://commits.webkit.org/309713@main">https://commits.webkit.org/309713@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58edcb46ff4f6e4ecff62ff62486e0fb5ad59434

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151501 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24266 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17847 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160233 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104939 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d3687ecb-6591-4906-b3a2-504d386c7d2c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24697 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24568 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116991 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83061 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e4e02b2a-620c-4811-8fcc-19b490b6ebfa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154461 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19139 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135943 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97709 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a1460a34-9c87-43fc-9dfc-e3eaf1d2f5f9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18229 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16174 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8077 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/143498 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127856 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13848 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162705 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/12302 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5837 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15437 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125008 "Found 1 new test failure: imported/w3c/web-platform-tests/css/cssom-view/interrupt-hidden-smooth-scroll.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24067 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20232 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125192 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33959 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24059 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135644 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80609 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20249 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12419 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/183110 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23668 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87980 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46695 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23378 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23532 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23434 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->