### PR TITLE
Fix reversed condition in StringView::reverseFind(StringView matchString, unsigned start)

### DIFF
--- a/Source/WTF/wtf/text/StringView.cpp
+++ b/Source/WTF/wtf/text/StringView.cpp
@@ -420,10 +420,10 @@ bool equalRespectingNullity(StringView a, StringView b)
 
 SUPPRESS_NODELETE size_t StringView::reverseFind(StringView matchString, unsigned start) const
 {
-    if (isNull())
+    if (isNull() || matchString.isNull())
         return notFound;
 
-    if (matchString.length())
+    if (matchString.isEmpty())
         return std::min(start, length());
 
     // Check start & matchLength are in range.

--- a/Tools/TestWebKitAPI/Tests/WTF/StringView.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringView.cpp
@@ -954,6 +954,38 @@ TEST(WTF, StringViewReverseFindBasic)
     EXPECT_EQ(reference.reverseFind('c', 4), notFound);
 }
 
+TEST(WTF, StringViewReverseFindStringView)
+{
+    auto reference = stringViewFromLiteral("Cappuccino");
+
+    // Basic substring search.
+    EXPECT_EQ(reference.reverseFind(stringViewFromLiteral("ccino")), 5U);
+    EXPECT_EQ(reference.reverseFind(stringViewFromLiteral("Cap")), 0U);
+    EXPECT_EQ(reference.reverseFind(stringViewFromLiteral("puc")), 3U);
+    EXPECT_EQ(reference.reverseFind(stringViewFromLiteral("xyz")), notFound);
+
+    // Search with start position.
+    EXPECT_EQ(reference.reverseFind(stringViewFromLiteral("cc"), 6), 5U);
+    EXPECT_EQ(reference.reverseFind(stringViewFromLiteral("cc"), 4), notFound);
+
+    // Empty match string returns clamped start position.
+    EXPECT_EQ(reference.reverseFind(stringViewFromLiteral("")), 10U);
+    EXPECT_EQ(reference.reverseFind(stringViewFromLiteral(""), 5), 5U);
+
+    // Match string longer than haystack.
+    EXPECT_EQ(reference.reverseFind(stringViewFromLiteral("Cappuccino!")), notFound);
+
+    // Null haystack.
+    StringView nullView;
+    EXPECT_EQ(nullView.reverseFind(stringViewFromLiteral("abc")), notFound);
+
+    // Null match string.
+    EXPECT_EQ(reference.reverseFind(nullView), notFound);
+
+    // Full string match.
+    EXPECT_EQ(reference.reverseFind(stringViewFromLiteral("Cappuccino")), 0U);
+}
+
 TEST(WTF, StringViewTrim)
 {
     auto isA = [] (char16_t c) { 


### PR DESCRIPTION
#### 8710df27792805fa1400cc6e067f6791fab91b7e
<pre>
Fix reversed condition in StringView::reverseFind(StringView matchString, unsigned start)
<a href="https://bugs.webkit.org/show_bug.cgi?id=310468">https://bugs.webkit.org/show_bug.cgi?id=310468</a>

Reviewed by Darin Adler and Ryosuke Niwa.

When matchString is non-empty (the normal case), matchString.length() is
truthy, so the function immediately returns std::min(start, length()),
a position, instead of actually searching.

Also update the function to return notFound when passed in a null
StringView, to be consistent with the behavior of
StringImpl::reverseFind().

Test: Tools/TestWebKitAPI/Tests/WTF/StringView.cpp

* Source/WTF/wtf/text/StringView.cpp:
(WTF::StringView::reverseFind const):
* Tools/TestWebKitAPI/Tests/WTF/StringView.cpp:
(TestWebKitAPI::TEST(WTF, StringViewReverseFindStringView)):

Canonical link: <a href="https://commits.webkit.org/309716@main">https://commits.webkit.org/309716@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e894345eee4a6dbe9b4c7c6e04d5fd76f9fb03d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151563 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24328 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17909 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160297 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/76bafbc3-dae4-4168-a5e0-3cf24afc8203) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153437 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24759 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24630 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/117047 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a082ff9e-d137-44e7-9fed-739354be0b86) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154523 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19190 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135998 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97762 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5ce65a25-8d42-49d1-bb80-c472fd7e99bf) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18280 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16226 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8140 "Built successfully") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/143564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/127908 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/13903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162769 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/12364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5899 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15492 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/125062 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24129 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20284 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125245 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33965 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24121 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135699 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/80719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20299 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/12474 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/183173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23730 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88042 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/183173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23440 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23594 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23496 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->