### PR TITLE
Use multiplicative hashing in BloomFilter to reduce false positive rates for keyBits > 16

### DIFF
--- a/Source/WTF/wtf/BloomFilter.h
+++ b/Source/WTF/wtf/BloomFilter.h
@@ -34,7 +34,8 @@ namespace WTF {
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(BloomFilter);
 
 // Bloom filter with k=2. Uses 2^keyBits/8 bytes of memory.
-// False positive rate is approximately (1-e^(-2n/m))^2, where n is the number of unique 
+// The two hash functions are derived from a single unsigned hash using multiplicative hashing.
+// False positive rate is approximately (1-e^(-2n/m))^2, where n is the number of unique
 // keys and m is the table size (==2^keyBits).
 // See http://en.wikipedia.org/wiki/Bloom_filter
 template <unsigned keyBits>
@@ -66,6 +67,8 @@ public:
 private:
     static constexpr unsigned bitsPerPosition = 8 * sizeof(unsigned);
     static constexpr unsigned keyMask = (1 << keyBits) - 1;
+    // Golden ratio constant used for multiplicative hashing to derive the second hash function.
+    static constexpr unsigned goldenRatioHash = 0x9e3779b9u;
     static unsigned arrayIndex(unsigned key) { return key / bitsPerPosition; }
     static unsigned bitMask(unsigned key) { return 1 << (key % bitsPerPosition); }
     template <size_t hashSize> static std::pair<unsigned, unsigned> keysFromHash(const std::array<uint8_t, hashSize>&);
@@ -85,16 +88,14 @@ inline BloomFilter<keyBits>::BloomFilter()
 template <unsigned keyBits>
 inline bool BloomFilter<keyBits>::mayContain(unsigned hash) const
 {
-    // The top and bottom bits of the incoming hash are treated as independent bloom filter hash functions.
-    // This works well as long as the filter size is not much above 2^16.
-    return isBitSet(hash) && isBitSet(hash >> 16);
+    return isBitSet(hash) && isBitSet(hash * goldenRatioHash);
 }
 
 template <unsigned keyBits>
 inline void BloomFilter<keyBits>::add(unsigned hash)
 {
     setBit(hash);
-    setBit(hash >> 16);
+    setBit(hash * goldenRatioHash);
 }
 
 template <unsigned keyBits>
@@ -194,11 +195,13 @@ public:
 
 private:
     static constexpr unsigned keyMask = (1 << keyBits) - 1;
+    // Golden ratio constant used for multiplicative hashing to derive the second hash function.
+    static constexpr unsigned goldenRatioHash = 0x9e3779b9u;
 
     uint8_t& firstBucket(unsigned hash) { return m_buckets[hash & keyMask]; }
-    uint8_t& secondBucket(unsigned hash) { return m_buckets[(hash >> 16) & keyMask]; }
+    uint8_t& secondBucket(unsigned hash) { return m_buckets[(hash * goldenRatioHash) & keyMask]; }
     const uint8_t& firstBucket(unsigned hash) const { return m_buckets[hash & keyMask]; }
-    const uint8_t& secondBucket(unsigned hash) const { return m_buckets[(hash >> 16) & keyMask]; }
+    const uint8_t& secondBucket(unsigned hash) const { return m_buckets[(hash * goldenRatioHash) & keyMask]; }
 
     std::array<uint8_t, tableSize> m_buckets;
 };


### PR DESCRIPTION
#### e4b78baa616e56402c4e5afed35de9aef141a468
<pre>
Use multiplicative hashing in BloomFilter to reduce false positive rates for keyBits &gt; 16
<a href="https://bugs.webkit.org/show_bug.cgi?id=310469">https://bugs.webkit.org/show_bug.cgi?id=310469</a>

Reviewed by Darin Adler.

The second hash function was derived by shifting the hash right by 16
bits (hash &gt;&gt; 16). For keyBits &gt; 16 this meant the second hash could
only address a fraction of the bit array. For BloomFilter&lt;18&gt; (used by
NetworkCacheStorage), only 1/4 of the 262K positions were reachable,
roughly doubling the false positive rate vs the theoretical optimum.

Replace the bit shift with multiplicative hashing using the golden ratio
constant (0x9e3779b9). This ensures both hash functions distribute
uniformly across the full key space for any keyBits value. For
keyBits &lt;= 16 the false positive rate is unchanged; for keyBits = 18 it
is approximately halved.

* Source/WTF/wtf/BloomFilter.h:
(WTF::BloomFilter&lt;keyBits&gt;::mayContain const):
(WTF::BloomFilter&lt;keyBits&gt;::add):
(WTF::CountingBloomFilter::secondBucket):
(WTF::CountingBloomFilter::secondBucket const):

Canonical link: <a href="https://commits.webkit.org/309717@main">https://commits.webkit.org/309717@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5544739a924776da84ece7c07ff9293501ea8e82

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151559 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24324 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17905 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160293 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24755 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24626 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117044 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154519 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19191 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135999 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97759 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/63dd9848-300e-4a8f-87fc-06c49f433bea) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/18281 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/16224 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8136 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/143560 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/127909 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/13904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162765 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/12360 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5895 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15493 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/125060 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24125 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20282 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125243 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33961 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24117 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135700 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/80708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20303 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12475 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/183169 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23726 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88038 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46712 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23436 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23590 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23492 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->