### PR TITLE
Value returned by Deque::removeAllMatching() is incorrect

### DIFF
--- a/Source/WTF/wtf/Deque.h
+++ b/Source/WTF/wtf/Deque.h
@@ -574,7 +574,7 @@ inline size_t Deque<T, inlineCapacity>::removeAllMatching(const Predicate& predi
         if (!predicate(value))
             append(WTF::move(value));
     }
-    return size() - oldSize;
+    return oldSize - size();
 }
 
 template<typename T, size_t inlineCapacity>

--- a/Tools/TestWebKitAPI/Tests/WTF/Deque.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Deque.cpp
@@ -295,4 +295,77 @@ TEST(WTF_Deque, StressAppendPrepend)
     EXPECT_TRUE(deque.isEmpty());
 }
 
+TEST(WTF_Deque, RemoveAllMatching)
+{
+    Deque<int> deque = { 1, 2, 3, 4, 5, 6, 7, 8 };
+
+    // Remove even numbers.
+    size_t removed = deque.removeAllMatching([](int value) { return !(value % 2); });
+    EXPECT_EQ(4u, removed);
+    EXPECT_EQ(4u, deque.size());
+
+    // Verify remaining elements and their order.
+    auto it = deque.begin();
+    EXPECT_EQ(1, *it);
+    ++it;
+    EXPECT_EQ(3, *it);
+    ++it;
+    EXPECT_EQ(5, *it);
+    ++it;
+    EXPECT_EQ(7, *it);
+    ++it;
+    EXPECT_TRUE(it == deque.end());
+}
+
+TEST(WTF_Deque, RemoveAllMatchingNone)
+{
+    Deque<int> deque = { 1, 2, 3 };
+
+    size_t removed = deque.removeAllMatching([](int) { return false; });
+    EXPECT_EQ(0u, removed);
+    EXPECT_EQ(3u, deque.size());
+}
+
+TEST(WTF_Deque, RemoveAllMatchingAll)
+{
+    Deque<int> deque = { 1, 2, 3, 4 };
+
+    size_t removed = deque.removeAllMatching([](int) { return true; });
+    EXPECT_EQ(4u, removed);
+    EXPECT_TRUE(deque.isEmpty());
+}
+
+TEST(WTF_Deque, RemoveAllMatchingSingleElement)
+{
+    Deque<int> deque = { 42 };
+
+    size_t removed = deque.removeAllMatching([](int value) { return value == 42; });
+    EXPECT_EQ(1u, removed);
+    EXPECT_TRUE(deque.isEmpty());
+}
+
+TEST(WTF_Deque, RemoveFirstMatching)
+{
+    Deque<int> deque = { 1, 2, 3, 2, 4 };
+
+    bool found = deque.removeFirstMatching([](int value) { return value == 2; });
+    EXPECT_TRUE(found);
+    EXPECT_EQ(4u, deque.size());
+
+    // Only the first 2 should be removed.
+    auto it = deque.begin();
+    EXPECT_EQ(1, *it);
+    ++it;
+    EXPECT_EQ(3, *it);
+    ++it;
+    EXPECT_EQ(2, *it);
+    ++it;
+    EXPECT_EQ(4, *it);
+
+    // No match.
+    found = deque.removeFirstMatching([](int value) { return value == 99; });
+    EXPECT_FALSE(found);
+    EXPECT_EQ(4u, deque.size());
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 18b2f1f3724b8f1d7b12ad3bea62f90695bd0350
<pre>
Value returned by Deque::removeAllMatching() is incorrect
<a href="https://bugs.webkit.org/show_bug.cgi?id=310473">https://bugs.webkit.org/show_bug.cgi?id=310473</a>

Reviewed by Darin Adler and Ryosuke Niwa.

The logic was reversed in Deque::removeAllMatching() when computing the
number of items removed. The substraction would underflow.

Test: Tools/TestWebKitAPI/Tests/WTF/Deque.cpp

* Source/WTF/wtf/Deque.h:
* Tools/TestWebKitAPI/Tests/WTF/Deque.cpp:
(TestWebKitAPI::TEST(WTF_Deque, RemoveAllMatching)):
(TestWebKitAPI::TEST(WTF_Deque, RemoveAllMatchingNone)):
(TestWebKitAPI::TEST(WTF_Deque, RemoveAllMatchingAll)):
(TestWebKitAPI::TEST(WTF_Deque, RemoveAllMatchingSingleElement)):
(TestWebKitAPI::TEST(WTF_Deque, RemoveFirstMatching)):

Canonical link: <a href="https://commits.webkit.org/309715@main">https://commits.webkit.org/309715@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ca9e166ac558748e676a747e24e5293b72283ae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151515 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24280 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17861 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160249 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104953 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153389 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24711 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24582 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117007 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83076 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154475 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19152 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135960 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97723 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cd961bc0-a795-44ac-b8e7-10c64da9c41c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18242 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16187 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8091 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/143513 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127869 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13865 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162721 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/12316 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5851 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15454 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125023 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24081 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20245 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125206 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33964 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24073 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135661 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80631 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20264 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12436 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/183125 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23682 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87994 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46700 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23392 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23546 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23448 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->