### PR TITLE
[Android] Fall back when AHardwareBuffer EGL import is unavailable

### DIFF
--- a/Source/WebCore/platform/graphics/android/PlatformDisplayAndroid.cpp
+++ b/Source/WebCore/platform/graphics/android/PlatformDisplayAndroid.cpp
@@ -29,9 +29,59 @@
 #if OS(ANDROID)
 
 #include "GLContext.h"
+#include "Logging.h"
+#include <android/hardware_buffer.h>
 #include <epoxy/egl.h>
+#include <wtf/android/RefPtrAndroid.h>
 
 namespace WebCore {
+
+static bool supportsAndroidNativeBufferImport(const PlatformDisplayAndroid& display)
+{
+    const auto& extensions = display.eglExtensions();
+    auto supportsEGLImage = display.eglCheckVersion(1, 5) || extensions.KHR_image_base;
+    if (!(supportsEGLImage && extensions.ANDROID_get_native_client_buffer && extensions.ANDROID_image_native_buffer)) {
+        RELEASE_LOG_INFO(Compositing, "Android EGL display does not support required capabilities for AHardwareBuffer import (EGLImage=%d, ANDROID_get_native_client_buffer=%d, ANDROID_image_native_buffer=%d).",
+            supportsEGLImage, extensions.ANDROID_get_native_client_buffer, extensions.ANDROID_image_native_buffer);
+        return false;
+    }
+
+    auto getNativeClientBufferANDROID = reinterpret_cast<PFNEGLGETNATIVECLIENTBUFFERANDROIDPROC>(eglGetProcAddress("eglGetNativeClientBufferANDROID"));
+    if (!getNativeClientBufferANDROID) {
+        RELEASE_LOG_INFO(Compositing, "Android EGL display: eglGetNativeClientBufferANDROID not found.");
+        return false;
+    }
+
+    AHardwareBuffer_Desc description { };
+    description.width = 1;
+    description.height = 1;
+    description.layers = 1;
+    description.format = AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM;
+    description.usage = AHARDWAREBUFFER_USAGE_GPU_COLOR_OUTPUT | AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE;
+
+    AHardwareBuffer* hardwareBufferPtr { nullptr };
+    if (AHardwareBuffer_allocate(&description, &hardwareBufferPtr)) {
+        RELEASE_LOG_INFO(Compositing, "Android EGL display: AHardwareBuffer_allocate failed.");
+        return false;
+    }
+    auto hardwareBuffer = adoptRef(hardwareBufferPtr);
+
+    auto clientBuffer = getNativeClientBufferANDROID(hardwareBuffer.get());
+    if (!clientBuffer) {
+        RELEASE_LOG_INFO(Compositing, "Android EGL display: eglGetNativeClientBufferANDROID returned null.");
+        return false;
+    }
+
+    static const Vector<EGLAttrib> attributes { EGL_IMAGE_PRESERVED, EGL_TRUE, EGL_NONE };
+    auto image = display.createEGLImage(EGL_NO_CONTEXT, EGL_NATIVE_BUFFER_ANDROID, clientBuffer, attributes);
+    if (image == EGL_NO_IMAGE) {
+        RELEASE_LOG_INFO(Compositing, "Android EGL display: eglCreateImage for AHardwareBuffer failed with error %#04x.", eglGetError());
+        return false;
+    }
+
+    display.destroyEGLImage(image);
+    return true;
+}
 
 std::unique_ptr<PlatformDisplayAndroid> PlatformDisplayAndroid::create()
 {
@@ -52,8 +102,12 @@ std::unique_ptr<PlatformDisplayAndroid> PlatformDisplayAndroid::create()
         }();
 
     if (getPlatformDisplay) {
-        if (auto glDisplay = GLDisplay::create(getPlatformDisplay(EGL_PLATFORM_ANDROID_KHR, EGL_DEFAULT_DISPLAY, nullptr)))
-            return std::unique_ptr<PlatformDisplayAndroid>(new PlatformDisplayAndroid(glDisplay.releaseNonNull()));
+        if (auto glDisplay = GLDisplay::create(getPlatformDisplay(EGL_PLATFORM_ANDROID_KHR, EGL_DEFAULT_DISPLAY, nullptr))) {
+            auto display = std::unique_ptr<PlatformDisplayAndroid>(new PlatformDisplayAndroid(glDisplay.releaseNonNull()));
+            if (supportsAndroidNativeBufferImport(*display))
+                return display;
+            RELEASE_LOG_INFO(Compositing, "Android platform EGL display cannot import AHardwareBuffer objects; continuing with the normal fallback path.");
+        }
     }
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
@@ -722,6 +722,7 @@ AcceleratedSurface::SwapChain::SwapChain(uint64_t surfaceID, RenderingPurpose re
 #endif
 #if OS(ANDROID)
     case PlatformDisplay::Type::Android:
+    case PlatformDisplay::Type::Default:
         m_type = Type::EGLImage;
         break;
 #endif
@@ -731,10 +732,11 @@ AcceleratedSurface::SwapChain::SwapChain(uint64_t surfaceID, RenderingPurpose re
         m_type = Type::WPEBackend;
         break;
 #endif
-#if PLATFORM(GTK) || OS(ANDROID)
+#if PLATFORM(GTK)
     case PlatformDisplay::Type::Default:
         break;
-#endif // PLATFORM(GTK) || OS(ANDROID)
+#endif // PLATFORM(GTK)
+
     }
 }
 


### PR DESCRIPTION
#### 3b678c38be451b2ab6cfb82cf0b9232b5b2205fd
<pre>
[Android] Fall back when AHardwareBuffer EGL import is unavailable
<a href="https://bugs.webkit.org/show_bug.cgi?id=310475">https://bugs.webkit.org/show_bug.cgi?id=310475</a>

Reviewed by Adrian Perez de Castro.

Some Android EGL displays initialize successfully but cannot actually import
AHardwareBuffer objects as EGLImages. The Android coordinated graphics path
currently assumes that an Android display always supports that import path,
which can leave the swap chain without a valid rendering fallback.

Probe AHardwareBuffer import support when creating PlatformDisplayAndroid.
Prefer the Android platform display when it supports native-buffer import,
retry with eglGetDisplay() when it does not. Fallback to PlatformDisplayDefault
and handle Type::Default properly in Android in this case.

Also treat core EGL 1.5 image support as sufficient for the probe, matching
the existing EGL image creation logic instead of requiring the legacy
EGL_KHR_image_base extension string.

* Source/WebCore/platform/graphics/android/PlatformDisplayAndroid.cpp:
(WebCore::supportsAndroidNativeBufferImport):
(WebCore::PlatformDisplayAndroid::create):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp:
(WebKit::AcceleratedSurface::SwapChain::SwapChain):

Canonical link: <a href="https://commits.webkit.org/309983@main">https://commits.webkit.org/309983@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69ada29fb08fc17ce37b171cdcece6caeb2cd3b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152185 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24967 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18560 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160928 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105642 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154059 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25541 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25273 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117573 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83387 "10 flakes 2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155145 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19822 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136617 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98286 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18899 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16791 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8762 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128550 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14491 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163394 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6540 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16083 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125600 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24765 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20830 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125776 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34160 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24766 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136287 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81365 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20783 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13064 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24383 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88668 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24074 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24234 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24135 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->