### PR TITLE
[WPE] WPE Platform: add overlay-scrollbars setting to allow applications to disable overlay scrollbars

### DIFF
--- a/Source/WebKit/UIProcess/wpe/SystemSettingsManagerProxyWPE.cpp
+++ b/Source/WebKit/UIProcess/wpe/SystemSettingsManagerProxyWPE.cpp
@@ -178,7 +178,7 @@ bool SystemSettingsManagerProxy::primaryButtonWarpsSlider() const
 
 bool SystemSettingsManagerProxy::overlayScrolling() const
 {
-    return true;
+    return getBool(m_settings, WPE_SETTING_OVERLAY_SCROLLBARS, true);
 }
 
 bool SystemSettingsManagerProxy::enableAnimations() const

--- a/Source/WebKit/WPEPlatform/wpe/WPESettings.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPESettings.cpp
@@ -104,6 +104,7 @@ struct _WPESettingsPrivate {
             { WPE_SETTING_DOUBLE_CLICK_TIME, G_VARIANT_TYPE_UINT32, g_variant_ref_sink(g_variant_new_uint32(400)) },
             { WPE_SETTING_DRAG_THRESHOLD, G_VARIANT_TYPE_UINT32, g_variant_ref_sink(g_variant_new_uint32(8)) },
             { WPE_SETTING_CREATE_VIEWS_WITH_A_TOPLEVEL, G_VARIANT_TYPE_BOOLEAN, g_variant_ref_sink(g_variant_new_boolean(true)) },
+            { WPE_SETTING_OVERLAY_SCROLLBARS, G_VARIANT_TYPE_BOOLEAN, g_variant_ref_sink(g_variant_new_boolean(true)) },
         };
 
         for (auto& setting : defaultSettings)

--- a/Source/WebKit/WPEPlatform/wpe/WPESettings.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPESettings.h
@@ -258,6 +258,18 @@ typedef enum {
 #define WPE_SETTING_CREATE_VIEWS_WITH_A_TOPLEVEL "/wpe-platform/create-views-with-a-toplevel"
 
 /**
+ * WPE_SETTING_OVERLAY_SCROLLBARS:
+ *
+ * Enables overlay scrollbars. When disabled, scrollbars are always
+ * visible (classic scrollbar mode).
+ *
+ * VariantType: boolean
+ *
+ * Default: true
+ */
+#define WPE_SETTING_OVERLAY_SCROLLBARS "/wpe-platform/overlay-scrollbars"
+
+/**
  * WPESettingsSource:
  * @WPE_SETTINGS_SOURCE_PLATFORM: Set by the platform
  * @WPE_SETTINGS_SOURCE_APPLICATION: Set by the application


### PR DESCRIPTION
#### 32f254e0b75758e833ebcc642716dfc7f116e406
<pre>
[WPE] WPE Platform: add overlay-scrollbars setting to allow applications to disable overlay scrollbars
<a href="https://bugs.webkit.org/show_bug.cgi?id=310479">https://bugs.webkit.org/show_bug.cgi?id=310479</a>

Reviewed by Adrian Perez de Castro.

Add WPE_SETTING_OVERLAY_SCROLLBARS to WPESettings so that applications
can control whether overlay scrollbars or classic (always visible)
scrollbars are used. Wire up SystemSettingsManagerProxyWPE to read
from it instead of returning a hardcoded value.

* Source/WebKit/UIProcess/wpe/SystemSettingsManagerProxyWPE.cpp:
(WebKit::SystemSettingsManagerProxy::overlayScrolling const):
* Source/WebKit/WPEPlatform/wpe/WPESettings.cpp:
(_WPESettingsPrivate::_WPESettingsPrivate):
* Source/WebKit/WPEPlatform/wpe/WPESettings.h:

Canonical link: <a href="https://commits.webkit.org/309811@main">https://commits.webkit.org/309811@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d504bc4e66c4618936404afd3a79d5664551d6a9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151648 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24429 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17999 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160383 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105105 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24901 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24722 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117128 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83139 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154608 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19258 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136077 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97843 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18346 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16299 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8225 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127976 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162854 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6003 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15571 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125142 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24228 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20357 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125324 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24229 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135777 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/80804 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23308 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20365 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12552 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23845 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88130 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23537 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23697 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23597 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->