### PR TITLE
[css-values-5 attr()] Rename CSSVariableReferenceValue and other related types

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1096,6 +1096,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     css/CSSStyleRule.h
     css/CSSStyleSheet.h
     css/CSSSubgridValue.h
+    css/CSSSubstitutionValue.h
     css/CSSToLengthConversionData.h
     css/CSSUnits.h
     css/CSSValue.h
@@ -1103,7 +1104,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     css/CSSValuePair.h
     css/CSSValuePool.h
     css/CSSVariableData.h
-    css/CSSVariableReferenceValue.h
     css/CSSWideKeyword.h
     css/ComputedStyleDependencies.h
     css/DOMCSSPaintWorklet.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -940,7 +940,7 @@ css/CSSPageDescriptors.cpp
 css/CSSPageRule.cpp
 css/CSSPaintImageValue.cpp
 css/CSSPathValue.cpp
-css/CSSPendingSubstitutionValue.cpp
+css/CSSShorthandSubstitutionValue.cpp
 css/CSSPositionTryDescriptors.cpp
 css/CSSPositionTryRule.cpp
 css/CSSPositionValue.cpp
@@ -981,7 +981,7 @@ css/CSSValueList.cpp
 css/CSSValuePair.cpp
 css/CSSValuePool.cpp
 css/CSSVariableData.cpp
-css/CSSVariableReferenceValue.cpp
+css/CSSSubstitutionValue.cpp
 css/CSSViewTransitionRule.cpp
 css/CSSViewValue.cpp
 css/ComputedStyleDependencies.cpp
@@ -1090,7 +1090,7 @@ css/parser/CSSSelectorParserContext.cpp
 css/parser/CSSSupportsParser.cpp
 css/parser/CSSTokenizer.cpp
 css/parser/CSSTokenizerInputStream.cpp
-css/parser/CSSVariableParser.cpp
+css/parser/CSSSubstitutionParser.cpp
 css/parser/MediaQueryBlockWatcher.cpp
 css/parser/MutableCSSSelector.cpp
 css/parser/SizesAttributeParser.cpp

--- a/Source/WebCore/animation/BlendingKeyframes.cpp
+++ b/Source/WebCore/animation/BlendingKeyframes.cpp
@@ -55,7 +55,7 @@ void BlendingKeyframes::clear()
     m_propertiesSetToInherit.clear();
     m_propertiesSetToCurrentColor.clear();
     m_usesRelativeFontWeight = false;
-    m_containsCSSVariableReferences = false;
+    m_containsSubstitutionFunctions = false;
     m_usesAnchorFunctions = false;
 }
 
@@ -314,8 +314,8 @@ void BlendingKeyframes::updatePropertiesMetadata(const StyleProperties& properti
         if (!cssValue)
             continue;
 
-        if (!m_containsCSSVariableReferences && cssValue->hasVariableReferences())
-            m_containsCSSVariableReferences = true;
+        if (!m_containsSubstitutionFunctions && cssValue->hasSubstitutionFunctions())
+            m_containsSubstitutionFunctions = true;
 
         if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(cssValue)) {
             auto propertyID = propertyReference.id();

--- a/Source/WebCore/animation/BlendingKeyframes.h
+++ b/Source/WebCore/animation/BlendingKeyframes.h
@@ -150,7 +150,7 @@ public:
 
     bool NODELETE usesContainerUnits() const;
     bool usesRelativeFontWeight() const { return m_usesRelativeFontWeight; }
-    bool hasCSSVariableReferences() const { return m_containsCSSVariableReferences; }
+    bool hasSubstitutionFunctions() const { return m_containsSubstitutionFunctions; }
     bool hasColorSetToCurrentColor() const;
     bool NODELETE hasPropertySetToCurrentColor() const;
     const HashSet<AnimatableCSSProperty>& NODELETE propertiesSetToInherit() const LIFETIME_BOUND;
@@ -182,7 +182,7 @@ private:
     HashSet<AnimatableCSSProperty> m_propertiesSetToInherit;
     HashSet<AnimatableCSSProperty> m_propertiesSetToCurrentColor;
     bool m_usesRelativeFontWeight { false };
-    bool m_containsCSSVariableReferences { false };
+    bool m_containsSubstitutionFunctions { false };
     bool m_usesAnchorFunctions { false };
     bool m_hasWidthDependentTransform { false };
     bool m_hasHeightDependentTransform { false };

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1017,13 +1017,13 @@ auto KeyframeEffect::getKeyframes() -> Vector<ComputedKeyframe>
             String styleString = emptyString();
             if (keyframeRule) {
                 if (auto cssValue = keyframeRule->properties().getPropertyCSSValue(cssPropertyId)) {
-                    if (!cssValue->hasVariableReferences())
+                    if (!cssValue->hasSubstitutionFunctions())
                         styleString = keyframeRule->properties().getPropertyValue(cssPropertyId);
                 }
             }
             if (styleString.isEmpty()) {
                 if (auto cssValue = styleProperties->getPropertyCSSValue(cssPropertyId)) {
-                    if (!cssValue->hasVariableReferences())
+                    if (!cssValue->hasSubstitutionFunctions())
                         styleString = styleProperties->getPropertyValue(cssPropertyId);
                 }
             }
@@ -1036,13 +1036,13 @@ auto KeyframeEffect::getKeyframes() -> Vector<ComputedKeyframe>
             String styleString = emptyString();
             if (keyframeRule) {
                 if (auto cssValue = keyframeRule->properties().getCustomPropertyCSSValue(customProperty)) {
-                    if (!cssValue->hasVariableReferences())
+                    if (!cssValue->hasSubstitutionFunctions())
                         styleString = keyframeRule->properties().getCustomPropertyValue(customProperty);
                 }
             }
             if (styleString.isEmpty()) {
                 if (auto cssValue = styleProperties->getCustomPropertyCSSValue(customProperty)) {
-                    if (!cssValue->hasVariableReferences())
+                    if (!cssValue->hasSubstitutionFunctions())
                         styleString = styleProperties->getCustomPropertyValue(customProperty);
                 }
             }
@@ -2188,7 +2188,7 @@ std::optional<KeyframeEffect::RecomputationReason> KeyframeEffect::recomputeKeyf
     };
 
     auto cssVariableChanged = [&]() {
-        if (previousUnanimatedStyle && m_blendingKeyframes.hasCSSVariableReferences()) {
+        if (previousUnanimatedStyle && m_blendingKeyframes.hasSubstitutionFunctions()) {
             if (!previousUnanimatedStyle->customPropertiesEqual(unanimatedStyle))
                 return true;
         }

--- a/Source/WebCore/css/CSSCustomPropertyValue.cpp
+++ b/Source/WebCore/css/CSSCustomPropertyValue.cpp
@@ -38,9 +38,9 @@ Ref<CSSCustomPropertyValue> CSSCustomPropertyValue::createEmpty(const AtomString
     return createSyntaxAll(name, Ref { empty.get() });
 }
 
-Ref<CSSCustomPropertyValue> CSSCustomPropertyValue::createUnresolved(const AtomString& name, Ref<CSSVariableReferenceValue>&& value)
+Ref<CSSCustomPropertyValue> CSSCustomPropertyValue::createUnresolved(const AtomString& name, Ref<CSSSubstitutionValue>&& value)
 {
-    return adoptRef(*new CSSCustomPropertyValue(name, VariantValue { WTF::InPlaceType<Ref<CSSVariableReferenceValue>>, WTF::move(value) }));
+    return adoptRef(*new CSSCustomPropertyValue(name, VariantValue { WTF::InPlaceType<Ref<CSSSubstitutionValue>>, WTF::move(value) }));
 }
 
 Ref<CSSCustomPropertyValue> CSSCustomPropertyValue::createSyntaxAll(const AtomString& name, Ref<CSSVariableData>&& value)
@@ -55,7 +55,7 @@ Ref<CSSCustomPropertyValue> CSSCustomPropertyValue::createWithCSSWideKeyword(con
 
 bool CSSCustomPropertyValue::isVariableReference() const
 {
-    return std::holds_alternative<Ref<CSSVariableReferenceValue>>(m_value);
+    return std::holds_alternative<Ref<CSSSubstitutionValue>>(m_value);
 }
 
 bool CSSCustomPropertyValue::isVariableData() const
@@ -81,8 +81,8 @@ bool CSSCustomPropertyValue::equals(const CSSCustomPropertyValue& other) const
         return false;
 
     return WTF::switchOn(m_value,
-        [&](const Ref<CSSVariableReferenceValue>& value) {
-            return arePointingToEqualData(value, std::get<Ref<CSSVariableReferenceValue>>(other.m_value));
+        [&](const Ref<CSSSubstitutionValue>& value) {
+            return arePointingToEqualData(value, std::get<Ref<CSSSubstitutionValue>>(other.m_value));
         },
         [&](const Ref<CSSVariableData>& value) {
             return arePointingToEqualData(value, std::get<Ref<CSSVariableData>>(other.m_value));
@@ -97,7 +97,7 @@ String CSSCustomPropertyValue::customCSSText(const CSS::SerializationContext& co
 {
     auto serialize = [&] {
         return WTF::switchOn(m_value,
-            [&](const Ref<CSSVariableReferenceValue>& value) {
+            [&](const Ref<CSSSubstitutionValue>& value) {
                 return value->cssText(context);
             },
             [&](const Ref<CSSVariableData>& value) {
@@ -120,7 +120,7 @@ const Vector<CSSParserToken>& CSSCustomPropertyValue::tokens() const
     static NeverDestroyed<Vector<CSSParserToken>> emptyTokens;
 
     return WTF::switchOn(m_value,
-        [&](const Ref<CSSVariableReferenceValue>&) -> const Vector<CSSParserToken>& {
+        [&](const Ref<CSSSubstitutionValue>&) -> const Vector<CSSParserToken>& {
             ASSERT_NOT_REACHED();
             return emptyTokens;
         },
@@ -137,7 +137,7 @@ const Vector<CSSParserToken>& CSSCustomPropertyValue::tokens() const
 Ref<const CSSVariableData> CSSCustomPropertyValue::asVariableData() const
 {
     return WTF::switchOn(m_value,
-        [&](const Ref<CSSVariableReferenceValue>& value) -> Ref<const CSSVariableData> {
+        [&](const Ref<CSSSubstitutionValue>& value) -> Ref<const CSSVariableData> {
             return value->data();
         },
         [&](const Ref<CSSVariableData>& value) -> Ref<const CSSVariableData> {
@@ -153,8 +153,8 @@ bool CSSCustomPropertyValue::isCurrentColor() const
 {
     // FIXME: Registered properties?
     auto tokenRange = switchOn(m_value,
-        [&](const Ref<CSSVariableReferenceValue>& variableReferenceValue) {
-            return variableReferenceValue->data().tokenRange();
+        [&](const Ref<CSSSubstitutionValue>& substitutionValue) {
+            return substitutionValue->data().tokenRange();
         },
         [&](const Ref<CSSVariableData>& data) {
             return data->tokenRange();
@@ -177,7 +177,7 @@ bool CSSCustomPropertyValue::isCurrentColor() const
 
 IterationStatus CSSCustomPropertyValue::customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>& func) const
 {
-    if (auto* value = std::get_if<Ref<CSSVariableReferenceValue>>(&m_value)) {
+    if (auto* value = std::get_if<Ref<CSSSubstitutionValue>>(&m_value)) {
         if (func(*value) == IterationStatus::Done)
             return IterationStatus::Done;
     }

--- a/Source/WebCore/css/CSSCustomPropertyValue.h
+++ b/Source/WebCore/css/CSSCustomPropertyValue.h
@@ -26,9 +26,9 @@
 
 #pragma once
 
+#include <WebCore/CSSSubstitutionValue.h>
 #include <WebCore/CSSValue.h>
 #include <WebCore/CSSVariableData.h>
-#include <WebCore/CSSVariableReferenceValue.h>
 #include <WebCore/CSSWideKeyword.h>
 
 namespace WebCore {
@@ -38,13 +38,13 @@ class CSSParserToken;
 class CSSCustomPropertyValue final : public CSSValue {
 public:
     using VariantValue = Variant<
-        Ref<CSSVariableReferenceValue>,
+        Ref<CSSSubstitutionValue>,
         Ref<CSSVariableData>,
         CSSWideKeyword
     >;
 
     static Ref<CSSCustomPropertyValue> createEmpty(const AtomString& name);
-    static Ref<CSSCustomPropertyValue> createUnresolved(const AtomString& name, Ref<CSSVariableReferenceValue>&&);
+    static Ref<CSSCustomPropertyValue> createUnresolved(const AtomString& name, Ref<CSSSubstitutionValue>&&);
     static Ref<CSSCustomPropertyValue> createSyntaxAll(const AtomString& name, Ref<CSSVariableData>&&);
     static Ref<CSSCustomPropertyValue> createWithCSSWideKeyword(const AtomString& name, CSSWideKeyword);
 

--- a/Source/WebCore/css/CSSShorthandSubstitutionValue.cpp
+++ b/Source/WebCore/css/CSSShorthandSubstitutionValue.cpp
@@ -24,17 +24,17 @@
  */
 
 #include "config.h"
-#include "CSSPendingSubstitutionValue.h"
+#include "CSSShorthandSubstitutionValue.h"
 
 namespace WebCore {
 
-Ref<CSSPendingSubstitutionValue> CSSPendingSubstitutionValue::create(CSSPropertyID shorthandPropertyId, Ref<CSSVariableReferenceValue>&& shorthandValue)
+Ref<CSSShorthandSubstitutionValue> CSSShorthandSubstitutionValue::create(CSSPropertyID shorthandPropertyId, Ref<CSSSubstitutionValue>&& shorthandValue)
 {
-    return adoptRef(*new CSSPendingSubstitutionValue(shorthandPropertyId, WTF::move(shorthandValue)));
+    return adoptRef(*new CSSShorthandSubstitutionValue(shorthandPropertyId, WTF::move(shorthandValue)));
 }
 
-CSSPendingSubstitutionValue::CSSPendingSubstitutionValue(CSSPropertyID shorthandPropertyId, Ref<CSSVariableReferenceValue>&& shorthandValue)
-    : CSSValue(ClassType::PendingSubstitutionValue)
+CSSShorthandSubstitutionValue::CSSShorthandSubstitutionValue(CSSPropertyID shorthandPropertyId, Ref<CSSSubstitutionValue>&& shorthandValue)
+    : CSSValue(ClassType::ShorthandSubstitution)
     , m_shorthandPropertyId(shorthandPropertyId)
     , m_shorthandValue(WTF::move(shorthandValue))
 {

--- a/Source/WebCore/css/CSSShorthandSubstitutionValue.h
+++ b/Source/WebCore/css/CSSShorthandSubstitutionValue.h
@@ -29,21 +29,25 @@
 
 #pragma once
 
+#include "CSSSubstitutionValue.h"
 #include "CSSValue.h"
-#include "CSSVariableReferenceValue.h"
 
 namespace WebCore {
 
 class CSSProperty;
 
-class CSSPendingSubstitutionValue final : public CSSValue {
+// Longhand placeholder for a shorthand value containing substitution functions.
+// Each longhand of the shorthand gets one of these; they share the CSSSubstitutionValue.
+// During style resolution, the shared value is resolved and parsed as the shorthand
+// to extract individual longhand values.
+class CSSShorthandSubstitutionValue final : public CSSValue {
 public:
-    static Ref<CSSPendingSubstitutionValue> create(CSSPropertyID shorthandPropertyId, Ref<CSSVariableReferenceValue>&&);
+    static Ref<CSSShorthandSubstitutionValue> create(CSSPropertyID shorthandPropertyId, Ref<CSSSubstitutionValue>&&);
 
-    CSSVariableReferenceValue& shorthandValue() const { return m_shorthandValue; }
+    CSSSubstitutionValue& shorthandValue() const { return m_shorthandValue; }
     CSSPropertyID shorthandPropertyId() const { return m_shorthandPropertyId; }
 
-    bool equals(const CSSPendingSubstitutionValue& other) const { return m_shorthandValue.ptr() == other.m_shorthandValue.ptr(); }
+    bool equals(const CSSShorthandSubstitutionValue& other) const { return m_shorthandValue.ptr() == other.m_shorthandValue.ptr(); }
     static String customCSSText(const CSS::SerializationContext&) { return emptyString(); }
 
     IterationStatus customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>& func) const
@@ -56,14 +60,14 @@ public:
 private:
     friend class Style::SubstitutionResolver;
 
-    CSSPendingSubstitutionValue(CSSPropertyID shorthandPropertyId, Ref<CSSVariableReferenceValue>&&);
+    CSSShorthandSubstitutionValue(CSSPropertyID shorthandPropertyId, Ref<CSSSubstitutionValue>&&);
 
     const CSSPropertyID m_shorthandPropertyId;
-    const Ref<CSSVariableReferenceValue> m_shorthandValue;
+    const Ref<CSSSubstitutionValue> m_shorthandValue;
 
     mutable Vector<CSSProperty> m_cachedPropertyValues;
 };
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_CSS_VALUE(CSSPendingSubstitutionValue, isPendingSubstitutionValue())
+SPECIALIZE_TYPE_TRAITS_CSS_VALUE(CSSShorthandSubstitutionValue, isShorthandSubstitutionValue())

--- a/Source/WebCore/css/CSSSubstitutionValue.cpp
+++ b/Source/WebCore/css/CSSSubstitutionValue.cpp
@@ -28,47 +28,47 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "config.h"
-#include "CSSVariableReferenceValue.h"
+#include "CSSSubstitutionValue.h"
 
 #include "CSSVariableData.h"
 
 namespace WebCore {
 
-CSSVariableReferenceValue::CSSVariableReferenceValue(Ref<CSSVariableData>&& data)
-    : CSSValue(ClassType::VariableReference)
+CSSSubstitutionValue::CSSSubstitutionValue(Ref<CSSVariableData>&& data)
+    : CSSValue(ClassType::Substitution)
     , m_data(WTF::move(data))
 {
     cacheSimpleReference();
 }
 
-Ref<CSSVariableReferenceValue> CSSVariableReferenceValue::create(const CSSParserTokenRange& range, const CSSParserContext& context)
+Ref<CSSSubstitutionValue> CSSSubstitutionValue::create(const CSSParserTokenRange& range, const CSSParserContext& context)
 {
-    return adoptRef(*new CSSVariableReferenceValue(CSSVariableData::create(range, context)));
+    return adoptRef(*new CSSSubstitutionValue(CSSVariableData::create(range, context)));
 }
 
-Ref<CSSVariableReferenceValue> CSSVariableReferenceValue::create(Ref<CSSVariableData>&& data)
+Ref<CSSSubstitutionValue> CSSSubstitutionValue::create(Ref<CSSVariableData>&& data)
 {
-    return adoptRef(*new CSSVariableReferenceValue(WTF::move(data)));
+    return adoptRef(*new CSSSubstitutionValue(WTF::move(data)));
 }
 
-bool CSSVariableReferenceValue::equals(const CSSVariableReferenceValue& other) const
+bool CSSSubstitutionValue::equals(const CSSSubstitutionValue& other) const
 {
     return arePointingToEqualData(m_data, other.m_data);
 }
 
-String CSSVariableReferenceValue::customCSSText(const CSS::SerializationContext&) const
+String CSSSubstitutionValue::customCSSText(const CSS::SerializationContext&) const
 {
     if (m_stringValue.isNull())
         m_stringValue = m_data->serialize();
     return m_stringValue;
 }
 
-const CSSParserContext& CSSVariableReferenceValue::context() const
+const CSSParserContext& CSSSubstitutionValue::context() const
 {
     return m_data->context();
 }
 
-void CSSVariableReferenceValue::cacheSimpleReference()
+void CSSSubstitutionValue::cacheSimpleReference()
 {
     ASSERT(!m_simpleReference);
 

--- a/Source/WebCore/css/CSSSubstitutionValue.h
+++ b/Source/WebCore/css/CSSSubstitutionValue.h
@@ -1,5 +1,5 @@
 // Copyright 2015 The Chromium Authors. All rights reserved.
-// Copyright (C) 2016 Apple Inc. All rights reserved.
+// Copyright (C) 2016-2021 Apple Inc. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -29,27 +29,62 @@
 
 #pragma once
 
-#include "CSSParserTokenRange.h"
-#include <wtf/RefPtr.h>
-#include <wtf/text/AtomString.h>
+#include <WebCore/CSSPropertyNames.h>
+#include <WebCore/CSSValue.h>
+#include <WebCore/CSSValueKeywords.h>
+#include <WebCore/CSSVariableData.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
-class CSSCustomPropertyValue;
+class CSSParserToken;
+class CSSParserTokenRange;
 struct CSSParserContext;
 
 namespace Style {
-class CustomProperty;
+class SubstitutionResolver;
 }
 
-class CSSVariableParser {
+// A property value containing arbitrary substitution functions (var(), env(), attr(), etc.)
+// that need to be resolved during style resolution.
+// https://drafts.csswg.org/css-values-5/#arbitrary-substitution
+class CSSSubstitutionValue final : public CSSValue {
 public:
-    static bool containsValidVariableReferences(CSSParserTokenRange, const CSSParserContext&);
+    static Ref<CSSSubstitutionValue> create(const CSSParserTokenRange&, const CSSParserContext&);
+    static Ref<CSSSubstitutionValue> create(Ref<CSSVariableData>&&);
 
-    static RefPtr<CSSCustomPropertyValue> parseDeclarationValue(const AtomString&, CSSParserTokenRange, const CSSParserContext&);
-    static RefPtr<const Style::CustomProperty> parseInitialValueForUniversalSyntax(const AtomString&, CSSParserTokenRange);
+    bool equals(const CSSSubstitutionValue&) const;
+    String customCSSText(const CSS::SerializationContext&) const;
 
-    static bool NODELETE isValidVariableName(const CSSParserToken&);
+    const CSSParserContext& NODELETE context() const;
+
+    const CSSVariableData& data() const { return m_data.get(); }
+
+private:
+    friend class Style::SubstitutionResolver;
+
+    explicit CSSSubstitutionValue(Ref<CSSVariableData>&&);
+
+    void cacheSimpleReference();
+
+    const Ref<CSSVariableData> m_data;
+    mutable String m_stringValue;
+
+    // For quickly resolving simple var(--foo) values.
+    struct SimpleReference {
+        AtomString name;
+        CSSValueID functionId;
+    };
+    std::optional<SimpleReference> m_simpleReference;
+
+    struct Cache {
+        RefPtr<CSSVariableData> dependencyData;
+        RefPtr<CSSValue> value;
+        CSSPropertyID propertyID { CSSPropertyInvalid };
+    };
+    mutable Cache m_cache;
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_CSS_VALUE(CSSSubstitutionValue, isSubstitutionValue())

--- a/Source/WebCore/css/CSSValue.cpp
+++ b/Source/WebCore/css/CSSValue.cpp
@@ -67,7 +67,6 @@
 #include "CSSOffsetRotateValue.h"
 #include "CSSPaintImageValue.h"
 #include "CSSPathValue.h"
-#include "CSSPendingSubstitutionValue.h"
 #include "CSSPositionValue.h"
 #include "CSSPrimitiveValue.h"
 #include "CSSProperty.h"
@@ -78,7 +77,9 @@
 #include "CSSReflectValue.h"
 #include "CSSScrollValue.h"
 #include "CSSSerializationContext.h"
+#include "CSSShorthandSubstitutionValue.h"
 #include "CSSSubgridValue.h"
+#include "CSSSubstitutionValue.h"
 #include "CSSTextShadowPropertyValue.h"
 #include "CSSToLengthConversionData.h"
 #include "CSSTransformListValue.h"
@@ -86,7 +87,6 @@
 #include "CSSUnicodeRangeValue.h"
 #include "CSSValueList.h"
 #include "CSSValuePair.h"
-#include "CSSVariableReferenceValue.h"
 #include "CSSViewValue.h"
 #include "ComputedStyleDependencies.h"
 #include "DeprecatedCSSOMPrimitiveValue.h"
@@ -187,8 +187,8 @@ template<typename Visitor> constexpr decltype(auto) CSSValue::visitDerived(Visit
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSOffsetRotateValue>(*this));
     case Path:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSPathValue>(*this));
-    case PendingSubstitutionValue:
-        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSPendingSubstitutionValue>(*this));
+    case ShorthandSubstitution:
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSShorthandSubstitutionValue>(*this));
     case Position:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSPositionValue>(*this));
     case PositionX:
@@ -223,8 +223,8 @@ template<typename Visitor> constexpr decltype(auto) CSSValue::visitDerived(Visit
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSValueList>(*this));
     case ValuePair:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSValuePair>(*this));
-    case VariableReference:
-        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSVariableReferenceValue>(*this));
+    case Substitution:
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSSubstitutionValue>(*this));
     case View:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSViewValue>(*this));
     case PaintImage:

--- a/Source/WebCore/css/CSSValue.h
+++ b/Source/WebCore/css/CSSValue.h
@@ -110,7 +110,7 @@ public:
     bool isOffsetRotateValue() const { return m_classType == ClassType::OffsetRotate; }
     bool isPair() const { return m_classType == ClassType::ValuePair; }
     bool isPath() const { return m_classType == ClassType::Path; }
-    bool isPendingSubstitutionValue() const { return m_classType == ClassType::PendingSubstitutionValue; }
+    bool isShorthandSubstitutionValue() const { return m_classType == ClassType::ShorthandSubstitution; }
     bool isPositionValue() const { return m_classType == ClassType::Position; }
     bool isPositionXValue() const { return m_classType == ClassType::PositionX; }
     bool isPositionYValue() const { return m_classType == ClassType::PositionY; }
@@ -127,11 +127,11 @@ public:
     bool isURL() const { return m_classType == ClassType::URL; }
     bool isUnicodeRangeValue() const { return m_classType == ClassType::UnicodeRange; }
     bool isValueList() const { return m_classType == ClassType::ValueList; }
-    bool isVariableReferenceValue() const { return m_classType == ClassType::VariableReference; }
+    bool isSubstitutionValue() const { return m_classType == ClassType::Substitution; }
     bool isViewValue() const { return m_classType == ClassType::View; }
     bool isPaintImageValue() const { return m_classType == ClassType::PaintImage; }
 
-    bool hasVariableReferences() const { return isVariableReferenceValue() || isPendingSubstitutionValue(); }
+    bool hasSubstitutionFunctions() const { return isSubstitutionValue() || isShorthandSubstitutionValue(); }
     bool isImageGeneratorValue() const { return m_classType >= ClassType::Canvas && m_classType <= ClassType::Gradient; }
     bool isImplicitInitialValue() const { return m_isImplicitInitialValue; }
     bool containsVector() const { return m_classType >= ClassType::ValueList; }
@@ -242,7 +242,7 @@ protected:
         GridTemplateAreas,
         OffsetRotate,
         Path,
-        PendingSubstitutionValue,
+        ShorthandSubstitution,
         Position,
         PositionX,
         PositionY,
@@ -256,7 +256,7 @@ protected:
         URL,
         UnicodeRange,
         ValuePair,
-        VariableReference,
+        Substitution,
         View,
 
         // Classes that contain vectors, which derive from CSSValueContainingVector.

--- a/Source/WebCore/css/ShorthandSerializer.cpp
+++ b/Source/WebCore/css/ShorthandSerializer.cpp
@@ -30,7 +30,6 @@
 #include "CSSGridLineNamesValue.h"
 #include "CSSGridTemplateAreasValue.h"
 #include "CSSParserIdioms.h"
-#include "CSSPendingSubstitutionValue.h"
 #include "CSSPropertyInitialValues.h"
 #include "CSSPropertyNames.h"
 #include "CSSPropertyParser.h"
@@ -38,10 +37,11 @@
 #include "CSSPropertyParserConsumer+Grid.h"
 #include "CSSPropertyParserConsumer+Ident.h"
 #include "CSSSerializationContext.h"
+#include "CSSShorthandSubstitutionValue.h"
+#include "CSSSubstitutionValue.h"
 #include "CSSValueKeywords.h"
 #include "CSSValueList.h"
 #include "CSSValuePair.h"
-#include "CSSVariableReferenceValue.h"
 #include "FontSelectionValueInlines.h"
 #include "Quad.h"
 #include "StyleExtractor.h"
@@ -230,7 +230,7 @@ bool ShorthandSerializer::commonSerializationChecks(const StyleProperties& prope
     std::optional<CSSValueID> specialKeyword;
     bool allSpecialKeywords = true;
     std::optional<bool> importance;
-    std::optional<CSSPendingSubstitutionValue*> firstValueFromShorthand;
+    std::optional<CSSShorthandSubstitutionValue*> firstValueFromShorthand;
     String commonValue;
     for (unsigned i = 0; i < length(); ++i) {
         auto longhand = longhandProperty(i);
@@ -264,7 +264,7 @@ bool ShorthandSerializer::commonSerializationChecks(const StyleProperties& prope
         }
 
         // Don't serialize if any longhand was set to a variable.
-        if (is<CSSVariableReferenceValue>(value))
+        if (is<CSSSubstitutionValue>(value))
             return true;
 
         // Don't serialize if any longhand was set to -internal-auto-base().
@@ -272,7 +272,7 @@ bool ShorthandSerializer::commonSerializationChecks(const StyleProperties& prope
             return true;
 
         // Don't serialize if any longhand was set by a different shorthand.
-        RefPtr valueFromShorthand = dynamicDowncast<CSSPendingSubstitutionValue>(value);
+        RefPtr valueFromShorthand = dynamicDowncast<CSSShorthandSubstitutionValue>(value);
         if (valueFromShorthand && valueFromShorthand->shorthandPropertyId() != m_shorthand.id())
             return true;
 

--- a/Source/WebCore/css/StyleProperties.cpp
+++ b/Source/WebCore/css/StyleProperties.cpp
@@ -25,13 +25,13 @@
 
 #include "CSSColorValue.h"
 #include "CSSCustomPropertyValue.h"
-#include "CSSPendingSubstitutionValue.h"
 #include "CSSPrimitiveValue.h"
 #include "CSSPropertyInitialValues.h"
 #include "CSSPropertyNames.h"
 #include "CSSPropertyParserConsumer+Color.h"
 #include "CSSPropertyParserConsumer+Font.h"
 #include "CSSSerializationContext.h"
+#include "CSSShorthandSubstitutionValue.h"
 #include "CSSStyleProperties.h"
 #include "CSSValueKeywords.h"
 #include "CSSValueList.h"
@@ -264,7 +264,7 @@ StringBuilder StyleProperties::asTextInternal(const CSS::SerializationContext& c
         ASSERT(isLonghand(propertyID) || propertyID == CSSPropertyCustom);
         Vector<CSSPropertyID, maxShorthandsForLonghand> shorthands;
 
-        if (RefPtr substitutionValue = dynamicDowncast<CSSPendingSubstitutionValue>(property.value()))
+        if (RefPtr substitutionValue = dynamicDowncast<CSSShorthandSubstitutionValue>(property.value()))
             shorthands.append(substitutionValue->shorthandPropertyId());
         else {
             for (auto& shorthand : matchingShorthandsForLonghand(propertyID)) {

--- a/Source/WebCore/css/parser/CSSParser.cpp
+++ b/Source/WebCore/css/parser/CSSParser.cpp
@@ -56,11 +56,11 @@
 #include "CSSPropertyParserConsumer+Timeline.h"
 #include "CSSSelectorParser.h"
 #include "CSSStyleSheet.h"
+#include "CSSSubstitutionParser.h"
 #include "CSSSupportsParser.h"
 #include "CSSTokenizer.h"
 #include "CSSValueList.h"
 #include "CSSValuePair.h"
-#include "CSSVariableParser.h"
 #include "CSSViewTransitionRule.h"
 #include "ComputedStyleDependencies.h"
 #include "ContainerQueryParser.h"
@@ -1425,7 +1425,7 @@ RefPtr<StyleRuleProperty> CSSParser::consumePropertyRule(CSSParserTokenRange pre
         auto dependencies = CSSPropertyParser::collectParsedCustomPropertyValueDependencies(*syntax, tokenRange, m_context);
         if (!dependencies.isComputationallyIndependent())
             return false;
-        auto containsVariable = CSSVariableParser::containsValidVariableReferences(descriptor.initialValue->tokenRange(), m_context);
+        auto containsVariable = CSSSubstitutionParser::containsSubstitutionFunctions(descriptor.initialValue->tokenRange(), m_context);
         if (containsVariable)
             return false;
         return true;
@@ -1787,7 +1787,7 @@ bool CSSParser::consumeDeclaration(CSSParserTokenRange range, StyleRuleType rule
 
     // @position-try doesn't allow custom properties.
     // FIXME: maybe make this logic more elegant?
-    if (propertyID == CSSPropertyInvalid && CSSVariableParser::isValidVariableName(token) && ruleType != StyleRuleType::PositionTry) {
+    if (propertyID == CSSPropertyInvalid && CSSSubstitutionParser::isValidCustomPropertyName(token) && ruleType != StyleRuleType::PositionTry) {
         AtomString variableName = token.value().toAtomString();
         consumeCustomPropertyValue(range, variableName, important);
     }
@@ -1809,7 +1809,7 @@ void CSSParser::consumeCustomPropertyValue(CSSParserTokenRange range, const Atom
 {
     if (range.atEnd())
         topContext().m_parsedProperties.append(CSSProperty(CSSPropertyCustom, CSSCustomPropertyValue::createEmpty(variableName), important));
-    else if (auto value = CSSVariableParser::parseDeclarationValue(variableName, range, m_context))
+    else if (auto value = CSSSubstitutionParser::parseDeclarationValue(variableName, range, m_context))
         topContext().m_parsedProperties.append(CSSProperty(CSSPropertyCustom, value.releaseNonNull(), important));
 }
 

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -38,7 +38,6 @@
 #include "CSSParserFastPaths.h"
 #include "CSSParserIdioms.h"
 #include "CSSParserTokenRange.h"
-#include "CSSPendingSubstitutionValue.h"
 #include "CSSPrimitiveValue.h"
 #include "CSSPropertyParserConsumer+AngleDefinitions.h"
 #include "CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h"
@@ -59,11 +58,12 @@
 #include "CSSPropertyParserResult.h"
 #include "CSSPropertyParserState.h"
 #include "CSSPropertyParsing.h"
+#include "CSSShorthandSubstitutionValue.h"
+#include "CSSSubstitutionParser.h"
+#include "CSSSubstitutionValue.h"
 #include "CSSTokenizer.h"
 #include "CSSTransformListValue.h"
 #include "CSSURLValue.h"
-#include "CSSVariableParser.h"
-#include "CSSVariableReferenceValue.h"
 #include "CSSWideKeyword.h"
 #include "ComputedStyleDependencies.h"
 #include "StyleBuilder.h"
@@ -442,7 +442,7 @@ std::optional<Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>> CSSProp
 RefPtr<const Style::CustomProperty> CSSPropertyParser::parseTypedCustomPropertyInitialValue(const AtomString& name, const CSSCustomPropertySyntax& syntax, CSSParserTokenRange range, Style::BuilderState& builderState, const CSSParserContext& context)
 {
     if (syntax.isUniversal())
-        return CSSVariableParser::parseInitialValueForUniversalSyntax(name, range);
+        return CSSSubstitutionParser::parseInitialValueForUniversalSyntax(name, range);
 
     auto state = CSS::PropertyParserState {
         .context = context,
@@ -688,8 +688,8 @@ bool consumeStyleProperty(CSSParserTokenRange& range, const CSSParserContext& co
         if (CSSPropertyParsing::parseStylePropertyShorthand(range, property, state, result))
             return true;
 
-        if (CSSVariableParser::containsValidVariableReferences(originalRange, context)) {
-            result.addPropertyForAllLonghandsOfCurrentShorthand(state, CSSPendingSubstitutionValue::create(property, CSSVariableReferenceValue::create(originalRange, context)));
+        if (CSSSubstitutionParser::containsSubstitutionFunctions(originalRange, context)) {
+            result.addPropertyForAllLonghandsOfCurrentShorthand(state, CSSShorthandSubstitutionValue::create(property, CSSSubstitutionValue::create(originalRange, context)));
             return true;
         }
     } else {
@@ -708,8 +708,8 @@ bool consumeStyleProperty(CSSParserTokenRange& range, const CSSParserContext& co
             return true;
         }
 
-        if (CSSVariableParser::containsValidVariableReferences(originalRange, context)) {
-            result.addProperty(state, property, CSSPropertyInvalid, CSSVariableReferenceValue::create(originalRange, context), important);
+        if (CSSSubstitutionParser::containsSubstitutionFunctions(originalRange, context)) {
+            result.addProperty(state, property, CSSPropertyInvalid, CSSSubstitutionValue::create(originalRange, context), important);
             return true;
         }
     }

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Syntax.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Syntax.cpp
@@ -29,7 +29,7 @@
 #include "CSSCustomPropertyValue.h"
 #include "CSSParserTokenRange.h"
 #include "CSSPropertyParserState.h"
-#include "CSSVariableParser.h"
+#include "CSSSubstitutionParser.h"
 #include <wtf/text/AtomString.h>
 
 namespace WebCore {
@@ -39,7 +39,7 @@ RefPtr<CSSValue> consumeDeclarationValue(CSSParserTokenRange& range, CSS::Proper
 {
     // https://drafts.csswg.org/css-syntax-3/#typedef-declaration-value
 
-    return CSSVariableParser::parseDeclarationValue(nullAtom(), range.consumeAll(), state.context);
+    return CSSSubstitutionParser::parseDeclarationValue(nullAtom(), range.consumeAll(), state.context);
 }
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/parser/CSSSubstitutionParser.cpp
+++ b/Source/WebCore/css/parser/CSSSubstitutionParser.cpp
@@ -28,7 +28,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "config.h"
-#include "CSSVariableParser.h"
+#include "CSSSubstitutionParser.h"
 
 #include "CSSCustomPropertyValue.h"
 #include "CSSParserContext.h"
@@ -43,7 +43,7 @@
 
 namespace WebCore {
 
-bool CSSVariableParser::isValidVariableName(const CSSParserToken& token)
+bool CSSSubstitutionParser::isValidCustomPropertyName(const CSSParserToken& token)
 {
     if (token.type() != IdentToken)
         return false;
@@ -181,7 +181,7 @@ static std::optional<ClassifyBlockResult> classifyBlock(CSSParserTokenRange rang
 bool isValidVariableReference(CSSParserTokenRange range, const CSSParserContext& parserContext)
 {
     range.consumeWhitespace();
-    if (!CSSVariableParser::isValidVariableName(range.consumeIncludingWhitespace()))
+    if (!CSSSubstitutionParser::isValidCustomPropertyName(range.consumeIncludingWhitespace()))
         return false;
     if (range.atEnd())
         return true;
@@ -286,7 +286,7 @@ static std::optional<VariableType> classifyVariableRange(CSSParserTokenRange ran
     return VariableType { { }, WTF::move(*classifyBlockResult) };
 }
 
-bool CSSVariableParser::containsValidVariableReferences(CSSParserTokenRange range, const CSSParserContext& parserContext)
+bool CSSSubstitutionParser::containsSubstitutionFunctions(CSSParserTokenRange range, const CSSParserContext& parserContext)
 {
     auto type = classifyVariableRange(range, parserContext);
     if (!type)
@@ -295,7 +295,7 @@ bool CSSVariableParser::containsValidVariableReferences(CSSParserTokenRange rang
     return type->classifyBlockResult.hasSubstitutionFunctions && !type->classifyBlockResult.hasTopLevelBraceBlockMixedWithOtherValues;
 }
 
-RefPtr<CSSCustomPropertyValue> CSSVariableParser::parseDeclarationValue(const AtomString& variableName, CSSParserTokenRange range, const CSSParserContext& parserContext)
+RefPtr<CSSCustomPropertyValue> CSSSubstitutionParser::parseDeclarationValue(const AtomString& variableName, CSSParserTokenRange range, const CSSParserContext& parserContext)
 {
     auto type = classifyVariableRange(range, parserContext);
     if (!type)
@@ -305,12 +305,12 @@ RefPtr<CSSCustomPropertyValue> CSSVariableParser::parseDeclarationValue(const At
         return CSSCustomPropertyValue::createWithCSSWideKeyword(variableName, *type->cssWideKeyword);
 
     if (type->classifyBlockResult.hasSubstitutionFunctions)
-        return CSSCustomPropertyValue::createUnresolved(variableName, CSSVariableReferenceValue::create(range, parserContext));
+        return CSSCustomPropertyValue::createUnresolved(variableName, CSSSubstitutionValue::create(range, parserContext));
 
     return CSSCustomPropertyValue::createSyntaxAll(variableName, CSSVariableData::create(range, parserContext));
 }
 
-RefPtr<const Style::CustomProperty> CSSVariableParser::parseInitialValueForUniversalSyntax(const AtomString& variableName, CSSParserTokenRange range)
+RefPtr<const Style::CustomProperty> CSSSubstitutionParser::parseInitialValueForUniversalSyntax(const AtomString& variableName, CSSParserTokenRange range)
 {
     auto type = classifyVariableRange(range, strictCSSParserContext());
 

--- a/Source/WebCore/css/parser/CSSSubstitutionParser.h
+++ b/Source/WebCore/css/parser/CSSSubstitutionParser.h
@@ -1,5 +1,5 @@
 // Copyright 2015 The Chromium Authors. All rights reserved.
-// Copyright (C) 2016-2021 Apple Inc. All rights reserved.
+// Copyright (C) 2016 Apple Inc. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -29,59 +29,27 @@
 
 #pragma once
 
-#include <WebCore/CSSPropertyNames.h>
-#include <WebCore/CSSValue.h>
-#include <WebCore/CSSValueKeywords.h>
-#include <WebCore/CSSVariableData.h>
-#include <wtf/text/WTFString.h>
+#include "CSSParserTokenRange.h"
+#include <wtf/RefPtr.h>
+#include <wtf/text/AtomString.h>
 
 namespace WebCore {
 
-class CSSParserToken;
-class CSSParserTokenRange;
+class CSSCustomPropertyValue;
 struct CSSParserContext;
 
 namespace Style {
-class SubstitutionResolver;
+class CustomProperty;
 }
 
-class CSSVariableReferenceValue final : public CSSValue {
+class CSSSubstitutionParser {
 public:
-    static Ref<CSSVariableReferenceValue> create(const CSSParserTokenRange&, const CSSParserContext&);
-    static Ref<CSSVariableReferenceValue> create(Ref<CSSVariableData>&&);
+    static bool containsSubstitutionFunctions(CSSParserTokenRange, const CSSParserContext&);
 
-    bool equals(const CSSVariableReferenceValue&) const;
-    String customCSSText(const CSS::SerializationContext&) const;
+    static RefPtr<CSSCustomPropertyValue> parseDeclarationValue(const AtomString&, CSSParserTokenRange, const CSSParserContext&);
+    static RefPtr<const Style::CustomProperty> parseInitialValueForUniversalSyntax(const AtomString&, CSSParserTokenRange);
 
-    const CSSParserContext& NODELETE context() const;
-
-    const CSSVariableData& data() const { return m_data.get(); }
-
-private:
-    friend class Style::SubstitutionResolver;
-
-    explicit CSSVariableReferenceValue(Ref<CSSVariableData>&&);
-
-    void cacheSimpleReference();
-
-    const Ref<CSSVariableData> m_data;
-    mutable String m_stringValue;
-
-    // For quickly resolving simple var(--foo) values.
-    struct SimpleReference {
-        AtomString name;
-        CSSValueID functionId;
-    };
-    std::optional<SimpleReference> m_simpleReference;
-
-    struct Cache {
-        RefPtr<CSSVariableData> dependencyData;
-        RefPtr<CSSValue> value;
-        CSSPropertyID propertyID { CSSPropertyInvalid };
-    };
-    mutable Cache m_cache;
+    static bool NODELETE isValidCustomPropertyName(const CSSParserToken&);
 };
 
 } // namespace WebCore
-
-SPECIALIZE_TYPE_TRAITS_CSS_VALUE(CSSVariableReferenceValue, isVariableReferenceValue())

--- a/Source/WebCore/css/query/GenericMediaQueryParser.cpp
+++ b/Source/WebCore/css/query/GenericMediaQueryParser.cpp
@@ -38,8 +38,8 @@
 #include "CSSPropertyParserConsumer+ResolutionDefinitions.h"
 #include "CSSPropertyParserState.h"
 #include "CSSRatioValue.h"
+#include "CSSSubstitutionParser.h"
 #include "CSSValue.h"
-#include "CSSVariableParser.h"
 #include "MediaQueryParserContext.h"
 #include <wtf/text/MakeString.h>
 
@@ -77,7 +77,7 @@ static RefPtr<CSSValue> consumeCustomPropertyValue(AtomString propertyName, CSSP
     if (valueRange.atEnd())
         return CSSCustomPropertyValue::createEmpty(propertyName);
 
-    return CSSVariableParser::parseDeclarationValue(propertyName, valueRange, context.context);
+    return CSSSubstitutionParser::parseDeclarationValue(propertyName, valueRange, context.context);
 }
 
 std::optional<Feature> FeatureParser::consumeBooleanOrPlainFeature(CSSParserTokenRange& range, const MediaQueryParserContext& context)

--- a/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
+++ b/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
@@ -39,11 +39,12 @@
 #include "CSSKeywordValue.h"
 #include "CSSNumericFactory.h"
 #include "CSSParser.h"
-#include "CSSPendingSubstitutionValue.h"
 #include "CSSPropertyParser.h"
 #include "CSSSerializationContext.h"
+#include "CSSShorthandSubstitutionValue.h"
 #include "CSSStyleImageValue.h"
 #include "CSSStyleValue.h"
+#include "CSSSubstitutionValue.h"
 #include "CSSTextShadowPropertyValue.h"
 #include "CSSTokenizer.h"
 #include "CSSTransformListValue.h"
@@ -54,7 +55,6 @@
 #include "CSSValueList.h"
 #include "CSSValuePool.h"
 #include "CSSVariableData.h"
-#include "CSSVariableReferenceValue.h"
 #include "ExceptionOr.h"
 #include "RenderStyle.h"
 #include "ScriptWrappableInlines.h"
@@ -78,7 +78,7 @@ RefPtr<CSSStyleValue> CSSStyleValueFactory::constructStyleValueForShorthandSeria
     CSSTokenizer tokenizer(serialization);
     if (serialization.contains("var("_s))
         return CSSUnparsedValue::create(tokenizer.tokenRange());
-    return CSSStyleValue::create(CSSVariableReferenceValue::create(tokenizer.tokenRange(), { document }));
+    return CSSStyleValue::create(CSSSubstitutionValue::create(tokenizer.tokenRange(), { document }));
 }
 
 ExceptionOr<RefPtr<CSSValue>> CSSStyleValueFactory::extractCSSValue(Document& document, const CSSPropertyID& propertyID, const String& cssText)
@@ -291,18 +291,18 @@ ExceptionOr<Ref<CSSStyleValue>> CSSStyleValueFactory::reifyValue(Document& docum
         }
     } else if (auto* imageValue = dynamicDowncast<CSSImageValue>(cssValue))
         return Ref<CSSStyleValue> { CSSStyleImageValue::create(const_cast<CSSImageValue&>(*imageValue), document) };
-    else if (auto* referenceValue = dynamicDowncast<CSSVariableReferenceValue>(cssValue)) {
+    else if (auto* referenceValue = dynamicDowncast<CSSSubstitutionValue>(cssValue)) {
         return Ref<CSSStyleValue> { CSSUnparsedValue::create(referenceValue->data().tokenRange()) };
-    } else if (auto* substitutionValue = dynamicDowncast<CSSPendingSubstitutionValue>(cssValue)) {
+    } else if (auto* substitutionValue = dynamicDowncast<CSSShorthandSubstitutionValue>(cssValue)) {
         return Ref<CSSStyleValue> { CSSUnparsedValue::create(substitutionValue->shorthandValue().data().tokenRange()) };
     } else if (auto* customPropertyValue = dynamicDowncast<CSSCustomPropertyValue>(cssValue)) {
         // FIXME: remove CSSStyleValue::create(WTF::move(cssValue)), add reification control flow
         return WTF::switchOn(customPropertyValue->value(),
-            [&](const Ref<CSSVariableReferenceValue>& value) {
+            [&](const Ref<CSSSubstitutionValue>& value) {
                 return reifyValue(document, value, propertyID);
             },
             [&](const Ref<CSSVariableData>& value) {
-                return reifyValue(document, CSSVariableReferenceValue::create(value.copyRef()), propertyID);
+                return reifyValue(document, CSSSubstitutionValue::create(value.copyRef()), propertyID);
             },
             [&](const CSSWideKeyword&) {
                 return ExceptionOr<Ref<CSSStyleValue>> { CSSStyleValue::create(Ref(const_cast<CSSValue&>(cssValue))) };

--- a/Source/WebCore/css/typedom/CSSUnparsedValue.cpp
+++ b/Source/WebCore/css/typedom/CSSUnparsedValue.cpp
@@ -33,8 +33,8 @@
 #include "CSSOMVariableReferenceValue.h"
 #include "CSSParserContext.h"
 #include "CSSParserTokenRange.h"
+#include "CSSSubstitutionValue.h"
 #include "CSSTokenizer.h"
-#include "CSSVariableReferenceValue.h"
 #include "ExceptionOr.h"
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
@@ -156,7 +156,7 @@ ExceptionOr<CSSUnparsedSegment> CSSUnparsedValue::setItem(size_t index, CSSUnpar
 RefPtr<CSSValue> CSSUnparsedValue::toCSSValue() const
 {
     CSSTokenizer tokenizer(toString());
-    return CSSVariableReferenceValue::create(tokenizer.tokenRange(), strictCSSParserContext());
+    return CSSSubstitutionValue::create(tokenizer.tokenRange(), strictCSSParserContext());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/DeclaredStylePropertyMap.cpp
+++ b/Source/WebCore/css/typedom/DeclaredStylePropertyMap.cpp
@@ -119,7 +119,7 @@ bool DeclaredStylePropertyMap::setProperty(CSSPropertyID propertyID, Ref<CSSValu
     return !didFailParsing;
 }
 
-bool DeclaredStylePropertyMap::setCustomProperty(Document&, const AtomString& property, Ref<CSSVariableReferenceValue>&& value)
+bool DeclaredStylePropertyMap::setCustomProperty(Document&, const AtomString& property, Ref<CSSSubstitutionValue>&& value)
 {
     RefPtr styleRule = this->styleRule();
     if (!styleRule)

--- a/Source/WebCore/css/typedom/DeclaredStylePropertyMap.h
+++ b/Source/WebCore/css/typedom/DeclaredStylePropertyMap.h
@@ -55,7 +55,7 @@ private:
     void removeCustomProperty(const AtomString&) final;
     bool setShorthandProperty(CSSPropertyID, const String&) final;
     bool setProperty(CSSPropertyID, Ref<CSSValue>&&) final;
-    bool setCustomProperty(Document&, const AtomString&, Ref<CSSVariableReferenceValue>&&) final;
+    bool setCustomProperty(Document&, const AtomString&, Ref<CSSSubstitutionValue>&&) final;
 
     WeakPtr<CSSStyleRule> m_ownerRule;
 };

--- a/Source/WebCore/css/typedom/InlineStylePropertyMap.cpp
+++ b/Source/WebCore/css/typedom/InlineStylePropertyMap.cpp
@@ -125,7 +125,7 @@ bool InlineStylePropertyMap::setProperty(CSSPropertyID propertyID, Ref<CSSValue>
     return !didFailParsing;
 }
 
-bool InlineStylePropertyMap::setCustomProperty(Document&, const AtomString& property, Ref<CSSVariableReferenceValue>&& value)
+bool InlineStylePropertyMap::setCustomProperty(Document&, const AtomString& property, Ref<CSSSubstitutionValue>&& value)
 {
     if (!m_element)
         return false;

--- a/Source/WebCore/css/typedom/InlineStylePropertyMap.h
+++ b/Source/WebCore/css/typedom/InlineStylePropertyMap.h
@@ -46,7 +46,7 @@ public:
     void removeProperty(CSSPropertyID) final;
     bool setShorthandProperty(CSSPropertyID, const String& value) final;
     bool setProperty(CSSPropertyID, Ref<CSSValue>&&) final;
-    bool setCustomProperty(Document&, const AtomString& property, Ref<CSSVariableReferenceValue>&&) final;
+    bool setCustomProperty(Document&, const AtomString& property, Ref<CSSSubstitutionValue>&&) final;
     void removeCustomProperty(const AtomString& property) final;
     void clear() final;
 

--- a/Source/WebCore/css/typedom/MainThreadStylePropertyMapReadOnly.cpp
+++ b/Source/WebCore/css/typedom/MainThreadStylePropertyMapReadOnly.cpp
@@ -26,10 +26,10 @@
 #include "config.h"
 #include "MainThreadStylePropertyMapReadOnly.h"
 
-#include "CSSPendingSubstitutionValue.h"
 #include "CSSProperty.h"
 #include "CSSPropertyNames.h"
 #include "CSSPropertyParser.h"
+#include "CSSShorthandSubstitutionValue.h"
 #include "CSSStyleValue.h"
 #include "CSSStyleValueFactory.h"
 #include "CSSTokenizer.h"

--- a/Source/WebCore/css/typedom/StylePropertyMap.cpp
+++ b/Source/WebCore/css/typedom/StylePropertyMap.cpp
@@ -31,10 +31,10 @@
 #include "CSSPropertyParser.h"
 #include "CSSQuadValue.h"
 #include "CSSStyleValueFactory.h"
+#include "CSSSubstitutionValue.h"
 #include "CSSUnparsedValue.h"
 #include "CSSValueList.h"
 #include "CSSValuePair.h"
-#include "CSSVariableReferenceValue.h"
 #include "Document.h"
 #include "ExceptionOr.h"
 #include "Settings.h"
@@ -78,7 +78,7 @@ ExceptionOr<void> StylePropertyMap::set(Document& document, const AtomString& pr
         auto value = protect(styleValues[0])->toCSSValue();
         if (!value)
             return Exception { ExceptionCode::TypeError, "Invalid values"_s };
-        setCustomProperty(document, property, downcast<CSSVariableReferenceValue>(value.releaseNonNull()));
+        setCustomProperty(document, property, downcast<CSSSubstitutionValue>(value.releaseNonNull()));
         return { };
     }
     auto propertyID = cssPropertyID(property);
@@ -181,7 +181,7 @@ ExceptionOr<void> StylePropertyMap::append(Document& document, const AtomString&
 
         if (!cssValue)
             continue;
-        if (is<CSSVariableReferenceValue>(*cssValue))
+        if (is<CSSSubstitutionValue>(*cssValue))
             return Exception { ExceptionCode::TypeError, "Values cannot contain a CSSVariableReferenceValue"_s };
 
         list.append(cssValue.releaseNonNull());

--- a/Source/WebCore/css/typedom/StylePropertyMap.h
+++ b/Source/WebCore/css/typedom/StylePropertyMap.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-class CSSVariableReferenceValue;
+class CSSSubstitutionValue;
 
 class StylePropertyMap : public MainThreadStylePropertyMapReadOnly {
 public:
@@ -43,7 +43,7 @@ protected:
     virtual void removeCustomProperty(const AtomString&) = 0;
     virtual bool setShorthandProperty(CSSPropertyID, const String&) = 0;
     virtual bool setProperty(CSSPropertyID, Ref<CSSValue>&&) = 0;
-    virtual bool setCustomProperty(Document&, const AtomString&, Ref<CSSVariableReferenceValue>&&) = 0;
+    virtual bool setCustomProperty(Document&, const AtomString&, Ref<CSSSubstitutionValue>&&) = 0;
 
 private:
     bool isStylePropertyMap() const final { return true; }

--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -1435,7 +1435,7 @@ static Vector<String> authoredGridTrackSizes(Node* node, Style::GridTrackSizingD
     }
 
     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=301874 add indication for developers that value originally auto
-    if (cssValue && cssValue->hasVariableReferences()) {
+    if (cssValue && cssValue->hasSubstitutionFunctions()) {
         Style::Extractor extractor(element);
         CheckedRef style = element->renderer()->style();
         if (auto computedValue = extractor.propertyValueInStyle(style, directionCSSPropertyID, CSSValuePool::singleton(), nullptr))

--- a/Source/WebCore/style/PropertyCascade.cpp
+++ b/Source/WebCore/style/PropertyCascade.cpp
@@ -363,7 +363,7 @@ bool PropertyCascade::shouldApplyAfterAnimation(const StyleProperties::PropertyR
         // We could check if the we are actually animating the referenced variable. Indirect cases would need to be taken into account.
         if (customProperty && customProperty->isVariableReference())
             return true;
-        if (property.value()->hasVariableReferences())
+        if (property.value()->hasSubstitutionFunctions())
             return true;
     }
 

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -34,9 +34,9 @@
 #include "CSSFontSelector.h"
 #include "CSSFunctionValue.h"
 #include "CSSPaintImageValue.h"
-#include "CSSPendingSubstitutionValue.h"
 #include "CSSPropertyParser.h"
 #include "CSSRegisteredCustomProperty.h"
+#include "CSSShorthandSubstitutionValue.h"
 #include "CSSValuePair.h"
 #include "CSSValuePool.h"
 #include "CSSWideKeyword.h"
@@ -603,15 +603,15 @@ Ref<CSSValue> Builder::resolveInternalAutoBaseFunction(CSSValue& value)
 
 Ref<CSSValue> Builder::resolveSubstitutionFunctions(CSSPropertyID propertyID, CSSValue& value)
 {
-    if (!value.hasVariableReferences())
+    if (!value.hasSubstitutionFunctions())
         return value;
 
     SubstitutionResolver substitutionResolver(*this);
 
     auto variableValue = [&]() -> RefPtr<CSSValue> {
-        if (auto* substitution = dynamicDowncast<CSSPendingSubstitutionValue>(value))
+        if (auto* substitution = dynamicDowncast<CSSShorthandSubstitutionValue>(value))
             return substitutionResolver.substituteAndParseShorthand(*substitution, propertyID);
-        return substitutionResolver.substituteAndParse(downcast<CSSVariableReferenceValue>(value), propertyID);
+        return substitutionResolver.substituteAndParse(downcast<CSSSubstitutionValue>(value), propertyID);
     }();
 
     // https://drafts.csswg.org/css-variables-2/#invalid-variables
@@ -684,7 +684,7 @@ std::optional<Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>> Builder
     auto* registered = m_state->document().customPropertyRegistry().get(name);
 
     auto preResolved = switchOn(value.value(),
-        [&](const Ref<CSSVariableReferenceValue>&) -> std::optional<Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>> {
+        [&](const Ref<CSSSubstitutionValue>&) -> std::optional<Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>> {
             return { };
         },
         [&](const Ref<CSSVariableData>& data) -> std::optional<Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>> {
@@ -702,9 +702,9 @@ std::optional<Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>> Builder
         return preResolved;
 
     auto resolvedData = switchOn(value.value(),
-        [&](const Ref<CSSVariableReferenceValue>& variableReferenceValue) -> RefPtr<CSSVariableData> {
+        [&](const Ref<CSSSubstitutionValue>& substitutionValue) -> RefPtr<CSSVariableData> {
             SubstitutionResolver substitutionResolver(*this);
-            return substitutionResolver.substitute(variableReferenceValue.get());
+            return substitutionResolver.substitute(substitutionValue.get());
         },
         [&](const Ref<CSSVariableData>& data) -> RefPtr<CSSVariableData> {
             return data.ptr();

--- a/Source/WebCore/style/StyleCustomProperty.cpp
+++ b/Source/WebCore/style/StyleCustomProperty.cpp
@@ -28,10 +28,10 @@
 #include "CSSCalcValue.h"
 #include "CSSPrimitiveValue.h"
 #include "CSSSerializationContext.h"
+#include "CSSSubstitutionValue.h"
 #include "CSSTokenizer.h"
 #include "CSSValueList.h"
 #include "CSSValuePool.h"
-#include "CSSVariableReferenceValue.h"
 #include "RenderStyle.h"
 #include "StyleCalculationValue.h"
 #include "StylePrimitiveNumericTypes+CSSValueCreation.h"
@@ -80,7 +80,7 @@ Ref<CSSValue> CustomProperty::propertyValue(CSSValuePool& pool, const RenderStyl
             return CSSPrimitiveValue::create(""_s);
         },
         [&](const Ref<CSSVariableData>& variableData) -> Ref<CSSValue> {
-            return CSSVariableReferenceValue::create(variableData.copyRef());
+            return CSSSubstitutionValue::create(variableData.copyRef());
         },
         [&](const Value& value) -> Ref<CSSValue> {
             return convertValue(value);

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -27,14 +27,14 @@
 #include "StyleSubstitutionResolver.h"
 
 #include "CSSCustomPropertyValue.h"
-#include "CSSPendingSubstitutionValue.h"
 #include "CSSPropertyNames.h"
 #include "CSSPropertyParser.h"
 #include "CSSPropertyParserConsumer+Primitives.h"
 #include "CSSRegisteredCustomProperty.h"
+#include "CSSShorthandSubstitutionValue.h"
+#include "CSSSubstitutionValue.h"
 #include "CSSValueKeywords.h"
 #include "CSSVariableData.h"
-#include "CSSVariableReferenceValue.h"
 #include "ConstantPropertyMap.h"
 #include "CustomFunctionRegistry.h"
 #include "Document.h"
@@ -240,7 +240,7 @@ std::optional<Vector<CSSParserToken>> SubstitutionResolver::substituteTokenRange
     return tokens;
 }
 
-RefPtr<CSSVariableData> SubstitutionResolver::trySimpleSubstitution(const CSSVariableReferenceValue& value) const
+RefPtr<CSSVariableData> SubstitutionResolver::trySimpleSubstitution(const CSSSubstitutionValue& value) const
 {
     if (!value.m_simpleReference)
         return nullptr;
@@ -254,7 +254,7 @@ RefPtr<CSSVariableData> SubstitutionResolver::trySimpleSubstitution(const CSSVar
     return std::get<Ref<CSSVariableData>>(property->value()).ptr();
 }
 
-RefPtr<CSSVariableData> SubstitutionResolver::substitute(const CSSVariableReferenceValue& value) const
+RefPtr<CSSVariableData> SubstitutionResolver::substitute(const CSSSubstitutionValue& value) const
 {
     if (auto data = trySimpleSubstitution(value))
         return data;
@@ -267,39 +267,39 @@ RefPtr<CSSVariableData> SubstitutionResolver::substitute(const CSSVariableRefere
     return CSSVariableData::create(*substitutedTokens, context);
 }
 
-RefPtr<CSSValue> SubstitutionResolver::substituteAndParse(const CSSVariableReferenceValue& variableRef, CSSPropertyID propertyID) const
+RefPtr<CSSValue> SubstitutionResolver::substituteAndParse(const CSSSubstitutionValue& substitutionValue, CSSPropertyID propertyID) const
 {
-    auto data = substitute(variableRef);
+    auto data = substitute(substitutionValue);
     if (!data)
         return nullptr;
 
-    if (!arePointingToEqualData(variableRef.m_cache.dependencyData, data) || variableRef.m_cache.propertyID != propertyID) {
-        variableRef.m_cache.value = CSSPropertyParser::parseStylePropertyLonghand(propertyID, data->tokens(), variableRef.context());
-        variableRef.m_cache.propertyID = propertyID;
+    if (!arePointingToEqualData(substitutionValue.m_cache.dependencyData, data) || substitutionValue.m_cache.propertyID != propertyID) {
+        substitutionValue.m_cache.value = CSSPropertyParser::parseStylePropertyLonghand(propertyID, data->tokens(), substitutionValue.context());
+        substitutionValue.m_cache.propertyID = propertyID;
     }
-    variableRef.m_cache.dependencyData = WTF::move(data);
+    substitutionValue.m_cache.dependencyData = WTF::move(data);
 
-    return variableRef.m_cache.value;
+    return substitutionValue.m_cache.value;
 }
 
-RefPtr<CSSValue> SubstitutionResolver::substituteAndParseShorthand(const CSSPendingSubstitutionValue& substitution, CSSPropertyID propertyID) const
+RefPtr<CSSValue> SubstitutionResolver::substituteAndParseShorthand(const CSSShorthandSubstitutionValue& substitution, CSSPropertyID propertyID) const
 {
     ASSERT(!CSSProperty::isDirectionAwareProperty(propertyID));
 
-    auto& variableRef = substitution.shorthandValue();
+    auto& substitutionValue = substitution.shorthandValue();
 
-    auto data = substitute(variableRef);
+    auto data = substitute(substitutionValue);
     if (!data)
         return nullptr;
 
-    if (!arePointingToEqualData(variableRef.m_cache.dependencyData, data)) {
+    if (!arePointingToEqualData(substitutionValue.m_cache.dependencyData, data)) {
         ParsedPropertyVector parsedProperties;
         if (!CSSPropertyParser::parseValue(substitution.m_shorthandPropertyId, IsImportant::No, data->tokens(), data->context(), parsedProperties, StyleRuleType::Style))
             substitution.m_cachedPropertyValues = { };
         else
             substitution.m_cachedPropertyValues = parsedProperties;
     }
-    variableRef.m_cache.dependencyData = WTF::move(data);
+    substitutionValue.m_cache.dependencyData = WTF::move(data);
 
     for (auto& property : substitution.m_cachedPropertyValues) {
         if (CSSProperty::resolveDirectionAwareProperty(property.id(), m_styleBuilder.state().style().writingMode()) == propertyID)

--- a/Source/WebCore/style/StyleSubstitutionResolver.h
+++ b/Source/WebCore/style/StyleSubstitutionResolver.h
@@ -29,10 +29,10 @@
 
 namespace WebCore {
 
-class CSSPendingSubstitutionValue;
+class CSSShorthandSubstitutionValue;
 class CSSValue;
 class CSSVariableData;
-class CSSVariableReferenceValue;
+class CSSSubstitutionValue;
 struct CSSParserContext;
 enum CSSPropertyID : uint16_t;
 enum CSSValueID : uint16_t;
@@ -47,9 +47,9 @@ class SubstitutionResolver {
 public:
     explicit SubstitutionResolver(Builder&);
 
-    RefPtr<CSSValue> substituteAndParse(const CSSVariableReferenceValue&, CSSPropertyID) const;
-    RefPtr<CSSValue> substituteAndParseShorthand(const CSSPendingSubstitutionValue&, CSSPropertyID) const;
-    RefPtr<CSSVariableData> substitute(const CSSVariableReferenceValue&) const;
+    RefPtr<CSSValue> substituteAndParse(const CSSSubstitutionValue&, CSSPropertyID) const;
+    RefPtr<CSSValue> substituteAndParseShorthand(const CSSShorthandSubstitutionValue&, CSSPropertyID) const;
+    RefPtr<CSSVariableData> substitute(const CSSSubstitutionValue&) const;
 
 private:
     std::optional<Vector<CSSParserToken>> substituteTokenRange(CSSParserTokenRange, const CSSParserContext&) const;
@@ -61,7 +61,7 @@ private:
     std::pair<FallbackResult, Vector<CSSParserToken>> substituteVariableFallback(const AtomString& variableName, CSSParserTokenRange, CSSValueID functionId, const CSSParserContext&) const;
 
     RefPtr<const CustomProperty> propertyValueForVariableName(const AtomString&, CSSValueID) const;
-    RefPtr<CSSVariableData> trySimpleSubstitution(const CSSVariableReferenceValue&) const;
+    RefPtr<CSSVariableData> trySimpleSubstitution(const CSSSubstitutionValue&) const;
 
     Builder& m_styleBuilder;
 };


### PR DESCRIPTION
#### 0b5a4b5b168699edb877a880bd257c79c00b6a32
<pre>
[css-values-5 attr()] Rename CSSVariableReferenceValue and other related types
<a href="https://bugs.webkit.org/show_bug.cgi?id=310483">https://bugs.webkit.org/show_bug.cgi?id=310483</a>
<a href="https://rdar.apple.com/173108760">rdar://173108760</a>

Reviewed by Alan Baradlay.

Rename CSSVariableReferenceValue, CSSPendingSubstitutionValue, and CSSVariableParser
to align with the CSS Values 5 spec term &quot;arbitrary substitution function&quot;.

- CSSVariableReferenceValue -&gt; CSSSubstitutionValue
- CSSPendingSubstitutionValue -&gt; CSSShorthandSubstitutionValue
- CSSVariableParser -&gt; CSSSubstitutionParser
- Related member functions and fields renamed accordingly

Canonical link: <a href="https://commits.webkit.org/309710@main">https://commits.webkit.org/309710@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2ec355cef7a4523e46383fa955e8a90522a19de

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151539 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24304 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17885 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160273 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104977 "Hash a2ec355c for PR 61119 does not build (failure)") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f9d0a5b5-4b0b-4d28-bc32-7965f8832bc4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153413 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24735 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24606 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117027 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/104977 "Hash a2ec355c for PR 61119 does not build (failure)") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0c0b36d0-d9b5-4d6a-a136-1e613bfca9d4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154499 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19173 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135983 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97743 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3e5a5aa7-62e8-4f41-a7cc-c8f003d87a98) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18263 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16209 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8115 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/127890 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13888 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162745 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5875 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15477 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125043 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24105 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20267 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125226 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33957 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24097 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135684 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80667 "Hash a2ec355c for PR 61119 does not build (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20286 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/12459 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23706 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88018 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23416 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23570 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23472 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->