### PR TITLE
[AutoFill Debugging] request(Container)JSHandleForNodeIdentifier should fall back to the nodeID if searchText is not found

### DIFF
--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -2353,11 +2353,11 @@ InteractionDescription interactionDescription(const Interaction& interaction, Lo
 
 RefPtr<Element> elementForExtractedText(const LocalFrame& frame, ExtractedText&& extractedText)
 {
+    auto nodeIdentifier = extractedText.nodeIdentifier;
     auto range = rangeForExtractedText(frame, WTF::move(extractedText));
-    if (!range)
-        return { };
-
-    RefPtr node = commonInclusiveAncestor<ComposedTree>(*range);
+    RefPtr node = range.transform([](auto& range) -> RefPtr<Node> {
+        return commonInclusiveAncestor<ComposedTree>(range);
+    }).value_or(nodeIdentifier ? Node::fromIdentifier(WTF::move(*nodeIdentifier)) : nullptr);
     if (!node)
         return { };
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm
@@ -617,6 +617,10 @@ TEST(TextExtractionTests, RequestJSHandleForNodeIdentifier)
     }()];
 
     EXPECT_WK_STREQ(debugTextForBody.get(), @"root,'“The quick brown fox jumped over the lazy dog”'");
+
+    RetainPtr nodeID = extractNodeIdentifier([extractionResult textContent], @"Compose a new message");
+    EXPECT_NOT_NULL([extractionResult jsHandleForNodeIdentifier:nodeID.get() searchText:@"text that does not exist"]);
+    EXPECT_NULL([extractionResult jsHandleForNodeIdentifier:nil searchText:@"text that does not exist"]);
 }
 
 TEST(TextExtractionTests, RequestJSHandleForNodeIdentifierCaseSensitive)
@@ -704,6 +708,10 @@ TEST(TextExtractionTests, RequestContainerJSHandleForNodeIdentifier)
     EXPECT_TRUE([debugText1 containsString:@"Sale - 20% Off"]);
     EXPECT_TRUE([debugText1 containsString:@"In Stock - Ships within 24 hours"]);
     EXPECT_FALSE([debugText1 containsString:@"Customers Also Bought"]);
+
+    RetainPtr nodeID = extractNodeIdentifier([extractionResult textContent], @"$99.99");
+    EXPECT_NOT_NULL([extractionResult containerJSHandleForNodeIdentifier:nodeID.get() searchText:@"text that does not exist"]);
+    EXPECT_NULL([extractionResult containerJSHandleForNodeIdentifier:nil searchText:@"text that does not exist"]);
 }
 
 TEST(TextExtractionTests, ResolveTargetNodeFromSelectorData)


### PR DESCRIPTION
#### 159b6e9fb7ce49f1a81656ee453e23134027a438
<pre>
[AutoFill Debugging] request(Container)JSHandleForNodeIdentifier should fall back to the nodeID if searchText is not found
<a href="https://bugs.webkit.org/show_bug.cgi?id=310487">https://bugs.webkit.org/show_bug.cgi?id=310487</a>
<a href="https://rdar.apple.com/172953055">rdar://172953055</a>

Reviewed by Richard Robinson and Abrar Rahman Protyasha.

Make these methods fall back to the node corresponding to the `nodeIdentifier` (if found), in the
case where `searchText` doesn&apos;t match any text in the document.

Test:   TextExtractionTests.RequestJSHandleForNodeIdentifier
        TextExtractionTests.RequestContainerJSHandleForNodeIdentifier

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::elementForExtractedText):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm:
(TestWebKitAPI::TEST(TextExtractionTests, RequestJSHandleForNodeIdentifier)):
(TestWebKitAPI::TEST(TextExtractionTests, RequestContainerJSHandleForNodeIdentifier)):

Augment a couple of test cases to cover this scenario.

Canonical link: <a href="https://commits.webkit.org/309727@main">https://commits.webkit.org/309727@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/27f3188225ea7e34b350c8986e885cdb0d539ce1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151548 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24313 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17894 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160282 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105005 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6a0dc17f-6fd0-4de4-8854-f4a9905799d4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153422 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24744 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24615 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117037 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83099 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/16c49e7c-48b5-4701-9575-aabedab442fd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154508 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19183 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135989 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97751 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c26b3814-a91f-4579-8d57-7e7595cdd6d9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18273 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16216 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8124 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/127913 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13894 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162754 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5884 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15483 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125051 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24114 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20274 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125234 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33970 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24106 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135690 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80717 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20292 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12465 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23715 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88027 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23425 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23579 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23481 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->