### PR TITLE
[Swift in WebKit] Non-PAL targets should not access the internal PAL Swift bridging header (part 1)

### DIFF
--- a/Source/WebCore/Modules/webauthn/WebAuthenticationUtils.cpp
+++ b/Source/WebCore/Modules/webauthn/WebAuthenticationUtils.cpp
@@ -42,7 +42,7 @@ namespace WebCore {
 
 Vector<uint8_t> produceRpIdHash(const String& rpId)
 {
-    auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
+    auto crypto = PAL::Crypto::CryptoDigest::create(PAL::Crypto::CryptoDigest::Algorithm::SHA_256);
     auto rpIdUTF8 = rpId.utf8();
     crypto->addBytes(byteCast<uint8_t>(rpIdUTF8.span()));
     return crypto->computeHash();
@@ -179,7 +179,7 @@ Ref<ArrayBuffer> buildClientDataJson(ClientDataType type, const BufferSource& ch
 
 Vector<uint8_t> buildClientDataJsonHash(const ArrayBuffer& clientDataJson)
 {
-    auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
+    auto crypto = PAL::Crypto::CryptoDigest::create(PAL::Crypto::CryptoDigest::Algorithm::SHA_256);
     crypto->addBytes(clientDataJson.span());
     return crypto->computeHash();
 }

--- a/Source/WebCore/Modules/webauthn/fido/Pin.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/Pin.cpp
@@ -276,7 +276,7 @@ static Vector<uint8_t> deriveProtocolSharedSecret(PINUVAuthProtocol protocol, Ve
     // CTAP spec 6.5.6 (Protocol 1) and 6.5.7 (Protocol 2).
     Vector<uint8_t> sharedSecret;
     if (protocol == PINUVAuthProtocol::kPinProtocol1) {
-        auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
+        auto crypto = PAL::Crypto::CryptoDigest::create(PAL::Crypto::CryptoDigest::Algorithm::SHA_256);
         crypto->addBytes(ecdhResult.span());
         sharedSecret = crypto->computeHash();
     } else if (protocol == PINUVAuthProtocol::kPinProtocol2) {
@@ -375,7 +375,7 @@ std::optional<TokenRequest> TokenRequest::tryCreate(PINUVAuthProtocol protocol, 
     auto coseKey = encodeCOSEPublicKey(rawPublicKeyResult.returnValue());
 
     // The following calculates a SHA-256 digest of the PIN, and shrink to the left 16 bytes.
-    auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
+    auto crypto = PAL::Crypto::CryptoDigest::create(PAL::Crypto::CryptoDigest::Algorithm::SHA_256);
     crypto->addBytes(byteCast<uint8_t>(pin.span()));
     auto pinHash = crypto->computeHash();
     pinHash.shrink(16);

--- a/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
+++ b/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
@@ -11,13 +11,15 @@
 		071CFF4F2F0614FB00E07A47 /* pal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 071CFF4E2F0614FB00E07A47 /* pal.swift */; };
 		0721D32D2F709E930069239A /* RegexHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 0721D32A2F709E930069239A /* RegexHelper.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0721D3322F709F9F0069239A /* RegexHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0721D3312F709F9F0069239A /* RegexHelper.swift */; };
+		0721D3202F7082570069239A /* CryptoAlgorithmAESGCMCocoa.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0721D31F2F7082570069239A /* CryptoAlgorithmAESGCMCocoa.cpp */; };
+		0721D3212F7082570069239A /* CryptoAlgorithmAESGCMCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = 0721D31E2F7082570069239A /* CryptoAlgorithmAESGCMCocoa.h */; };
 		07611DB7243FA5BF00D80704 /* UsageTrackingSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 07611DB5243FA5BF00D80704 /* UsageTrackingSoftLink.mm */; };
 		077121B62C1E8B4400FACBF9 /* WritingToolsSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 077121B52C1E8B4400FACBF9 /* WritingToolsSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		077121BA2C1E8BE500FACBF9 /* WritingToolsUISPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 077121B92C1E8BE500FACBF9 /* WritingToolsUISPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		07789181273B14FF00E408D1 /* ScreenCaptureKitSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0778917F273B14FF00E408D1 /* ScreenCaptureKitSoftLink.mm */; };
 		077E87B1226A460200A2AFF0 /* AVFoundationSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 077E87AF226A460200A2AFF0 /* AVFoundationSoftLink.mm */; };
 		079D1D9826950DD700883577 /* SystemStatusSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 079D1D9626950DD700883577 /* SystemStatusSoftLink.mm */; };
-		07C9C8DC2EDAAABD007B579A /* CryptoDigestHashFunction.h in Headers */ = {isa = PBXBuildFile; fileRef = 07C9C8DB2EDAAABD007B579A /* CryptoDigestHashFunction.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		07C9C8DC2EDAAABD007B579A /* CryptoTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 07C9C8DB2EDAAABD007B579A /* CryptoTypes.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0CF99CA41F736375007EE793 /* MediaTimeAVFoundation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0C00CFD11F68CE4600AAC26D /* MediaTimeAVFoundation.cpp */; };
 		0CF99CA81F738437007EE793 /* CoreMediaSoftLink.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0CF99CA61F738436007EE793 /* CoreMediaSoftLink.cpp */; };
 		1C09D0561E31C46500725F18 /* CryptoDigestCommonCrypto.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C09D0551E31C46500725F18 /* CryptoDigestCommonCrypto.cpp */; };
@@ -92,7 +94,6 @@
 		7B47F2A428587B9700E793C8 /* CoreGraphicsSoftLink.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B47F2A228587B9700E793C8 /* CoreGraphicsSoftLink.cpp */; };
 		93B38EC025821CD800198E63 /* SpeechSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 93B38EBF25821CD700198E63 /* SpeechSoftLink.mm */; };
 		94A41E732BB1E10D00DA715C /* UnsafeOverlays.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94A41E702BB1E10D00DA715C /* UnsafeOverlays.swift */; };
-		94C759082B990D69000CC511 /* PALSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 94C759072B990D62000CC511 /* PALSwift.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		94F4AA022B730D2C006DFFDE /* CryptoKitShim.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94F4AA012B730D2C006DFFDE /* CryptoKitShim.swift */; };
 		A1038D332AB12BF100F57BA4 /* WebAVContentKeyGrouping.h in Headers */ = {isa = PBXBuildFile; fileRef = A1038D322AB12BF100F57BA4 /* WebAVContentKeyGrouping.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A1038D4F2AB21FBB00F57BA4 /* WebAVContentKeyReportGroupExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = A1038D4D2AB21FBB00F57BA4 /* WebAVContentKeyReportGroupExtras.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -461,6 +462,8 @@
 		071CFF4E2F0614FB00E07A47 /* pal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = pal.swift; sourceTree = "<group>"; };
 		0721D32A2F709E930069239A /* RegexHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RegexHelper.h; sourceTree = "<group>"; };
 		0721D3312F709F9F0069239A /* RegexHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegexHelper.swift; sourceTree = "<group>"; };
+		0721D31E2F7082570069239A /* CryptoAlgorithmAESGCMCocoa.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CryptoAlgorithmAESGCMCocoa.h; sourceTree = "<group>"; };
+		0721D31F2F7082570069239A /* CryptoAlgorithmAESGCMCocoa.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CryptoAlgorithmAESGCMCocoa.cpp; sourceTree = "<group>"; };
 		07611DB4243FA5BE00D80704 /* UsageTrackingSoftLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UsageTrackingSoftLink.h; sourceTree = "<group>"; };
 		07611DB5243FA5BF00D80704 /* UsageTrackingSoftLink.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = UsageTrackingSoftLink.mm; sourceTree = "<group>"; };
 		077121B52C1E8B4400FACBF9 /* WritingToolsSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WritingToolsSPI.h; sourceTree = "<group>"; };
@@ -471,7 +474,7 @@
 		077E87B0226A460200A2AFF0 /* AVFoundationSoftLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AVFoundationSoftLink.h; sourceTree = "<group>"; };
 		079D1D9526950DD700883577 /* SystemStatusSoftLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SystemStatusSoftLink.h; sourceTree = "<group>"; };
 		079D1D9626950DD700883577 /* SystemStatusSoftLink.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = SystemStatusSoftLink.mm; sourceTree = "<group>"; };
-		07C9C8DB2EDAAABD007B579A /* CryptoDigestHashFunction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CryptoDigestHashFunction.h; sourceTree = "<group>"; };
+		07C9C8DB2EDAAABD007B579A /* CryptoTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CryptoTypes.h; sourceTree = "<group>"; };
 		0C00CFD11F68CE4600AAC26D /* MediaTimeAVFoundation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MediaTimeAVFoundation.cpp; sourceTree = "<group>"; };
 		0C00CFD21F68CE4600AAC26D /* MediaTimeAVFoundation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MediaTimeAVFoundation.h; sourceTree = "<group>"; };
 		0C2D9E721EEF5AF600DBC317 /* ExportMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ExportMacros.h; sourceTree = "<group>"; };
@@ -683,7 +686,6 @@
 		93E5909C1F93BF1E0067F8CF /* UnencodableHandling.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UnencodableHandling.h; sourceTree = "<group>"; };
 		94A41E702BB1E10D00DA715C /* UnsafeOverlays.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UnsafeOverlays.swift; path = pal/PALSwift/UnsafeOverlays.swift; sourceTree = SOURCE_ROOT; };
 		94C759022B990D31000CC511 /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
-		94C759072B990D62000CC511 /* PALSwift.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PALSwift.h; sourceTree = "<group>"; };
 		94F4AA012B730D2C006DFFDE /* CryptoKitShim.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CryptoKitShim.swift; path = pal/PALSwift/CryptoKitShim.swift; sourceTree = SOURCE_ROOT; };
 		A10265881F56747A00B4C844 /* HIToolboxSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HIToolboxSPI.h; sourceTree = "<group>"; };
 		A102658D1F567E9D00B4C844 /* HIServicesSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HIServicesSPI.h; sourceTree = "<group>"; };
@@ -1083,7 +1085,6 @@
 				1C4876D71F8D7F4E00CCEEBD /* Logging.h */,
 				94C759022B990D31000CC511 /* module.modulemap */,
 				071CFF4E2F0614FB00E07A47 /* pal.swift */,
-				94C759072B990D62000CC511 /* PALSwift.h */,
 				FE62AC3C2CFE2E0300740A18 /* PALTZoneImpls.cpp */,
 				A3C66CDA1F462D6A009E6EE9 /* SessionID.cpp */,
 				A3C66CDB1F462D6A009E6EE9 /* SessionID.h */,
@@ -1097,8 +1098,10 @@
 			isa = PBXGroup;
 			children = (
 				1C09D0541E31C45200725F18 /* commoncrypto */,
+				0721D31F2F7082570069239A /* CryptoAlgorithmAESGCMCocoa.cpp */,
+				0721D31E2F7082570069239A /* CryptoAlgorithmAESGCMCocoa.h */,
 				1C09D0521E31C44100725F18 /* CryptoDigest.h */,
-				07C9C8DB2EDAAABD007B579A /* CryptoDigestHashFunction.h */,
+				07C9C8DB2EDAAABD007B579A /* CryptoTypes.h */,
 			);
 			path = crypto;
 			sourceTree = "<group>";
@@ -1457,10 +1460,11 @@
 				DD20DE1027BC90D80093D175 /* CoreUISPI.h in Headers */,
 				DD20DE1C27BC90D80093D175 /* CoreUISPI.h in Headers */,
 				DD20DDD127BC90D70093D175 /* CoreVideoSPI.h in Headers */,
+				0721D3212F7082570069239A /* CryptoAlgorithmAESGCMCocoa.h in Headers */,
 				DD20DD2727BC90D60093D175 /* CryptoDigest.h in Headers */,
-				07C9C8DC2EDAAABD007B579A /* CryptoDigestHashFunction.h in Headers */,
 				DD20DD1D27BC90D60093D175 /* CryptoKitPrivateSoftLink.h in Headers */,
 				DD20DDE327BC90D70093D175 /* CryptoKitPrivateSPI.h in Headers */,
+				07C9C8DC2EDAAABD007B579A /* CryptoTypes.h in Headers */,
 				DD20DD1E27BC90D60093D175 /* DataDetectorsCoreSoftLink.h in Headers */,
 				DD20DDE427BC90D70093D175 /* DataDetectorsCoreSPI.h in Headers */,
 				DD20DDC527BC90D70093D175 /* DataDetectorsSoftLink.h in Headers */,
@@ -1560,7 +1564,6 @@
 				DD20DD1827BC90D60093D175 /* OTSVGTable.h in Headers */,
 				DD20DD1327BC90D60093D175 /* OutputContext.h in Headers */,
 				DD20DD1427BC90D60093D175 /* OutputDevice.h in Headers */,
-				94C759082B990D69000CC511 /* PALSwift.h in Headers */,
 				DD20DE0227BC90D80093D175 /* PassKitInstallmentsSPI.h in Headers */,
 				DD20DD2227BC90D60093D175 /* PassKitSoftLink.h in Headers */,
 				DD20DE0327BC90D80093D175 /* PassKitSPI.h in Headers */,
@@ -1812,6 +1815,7 @@
 				F47221F4276FC2EB00B984C7 /* CoreMLSoftLink.mm in Sources */,
 				F43E89372AEDB8C800097D2D /* CoreTelephonySoftLink.mm in Sources */,
 				1C77C8C925D7972000635E0C /* CoreTextSoftLink.cpp in Sources */,
+				0721D3202F7082570069239A /* CryptoAlgorithmAESGCMCocoa.cpp in Sources */,
 				1C09D0561E31C46500725F18 /* CryptoDigestCommonCrypto.cpp in Sources */,
 				57F1C90A25DCF0CF00E8F6EA /* CryptoKitPrivateSoftLink.mm in Sources */,
 				94F4AA022B730D2C006DFFDE /* CryptoKitShim.swift in Sources */,

--- a/Source/WebCore/PAL/pal/CMakeLists.txt
+++ b/Source/WebCore/PAL/pal/CMakeLists.txt
@@ -7,7 +7,7 @@ set(PAL_PUBLIC_HEADERS
     ThreadGlobalData.h
 
     crypto/CryptoDigest.h
-    crypto/CryptoDigestHashFunction.h
+    crypto/CryptoTypes.h
 
     system/Clock.h
     system/ClockGeneric.h

--- a/Source/WebCore/PAL/pal/PALSwift/CryptoKitShim.swift
+++ b/Source/WebCore/PAL/pal/PALSwift/CryptoKitShim.swift
@@ -24,24 +24,23 @@
 public import CryptoKit
 public import Foundation
 
-public import pal.Core.PALSwift
-public import pal.Core.crypto.CryptoDigestHashFunction
+public import pal.Core.crypto.CryptoTypes
 
 // FIXME: PALSwift should have no public symbols.
 // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-public typealias CryptoOperationReturnValue = Cpp.CryptoOperationReturnValue
+public typealias CryptoOperationReturnValue = PAL.Crypto.CryptoOperationReturnValue
 
 // FIXME: PALSwift should have no public symbols.
 // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-public typealias ErrorCodes = Cpp.ErrorCodes
+public typealias ErrorCodes = PAL.Crypto.Error
 
 // FIXME: PALSwift should have no public symbols.
 // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-public typealias VectorUInt8 = Cpp.VectorUInt8
+public typealias VectorUInt8 = PAL.Crypto.VectorUInt8
 
 // FIXME: PALSwift should have no public symbols.
 // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-public typealias SpanConstUInt8 = Cpp.SpanConstUInt8
+public typealias SpanConstUInt8 = PAL.Crypto.SpanConstUInt8
 
 private enum LocalErrors: Error {
     case invalidArgument
@@ -200,7 +199,7 @@ public class Digest {
         unsafe Self.digest(data, t).copyToVectorUInt8()
     }
 
-    fileprivate static func digest(_ data: SpanConstUInt8, hashFunction: PAL.CryptoDigestHashFunction) -> any CryptoKit.Digest {
+    fileprivate static func digest(_ data: SpanConstUInt8, hashFunction: PAL.Crypto.CryptoDigestHashFunction) -> any CryptoKit.Digest {
         switch hashFunction {
         case .SHA_256:
             return unsafe digest(data, SHA256.self)
@@ -213,7 +212,7 @@ public class Digest {
         case .DEPRECATED_SHA_224:
             fatalError("DEPRECATED_SHA_224 is not supported")
         @unknown default:
-            fatalError("Unknown PAL.CryptoDigestHashFunction enum case value: \(hashFunction.rawValue)")
+            fatalError("Unknown PAL.Crypto.CryptoDigestHashFunction enum case value: \(hashFunction.rawValue)")
         }
     }
 }
@@ -410,7 +409,7 @@ public struct ECKey {
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func sign(
         message: SpanConstUInt8,
-        hashFunction: PAL.CryptoDigestHashFunction
+        hashFunction: PAL.Crypto.CryptoDigestHashFunction
     ) -> CryptoOperationReturnValue {
         var returnValue = CryptoOperationReturnValue()
         do {
@@ -440,7 +439,7 @@ public struct ECKey {
     public func verify(
         message: SpanConstUInt8,
         signature: SpanConstUInt8,
-        hashFunction: PAL.CryptoDigestHashFunction
+        hashFunction: PAL.Crypto.CryptoDigestHashFunction
     ) -> CryptoOperationReturnValue {
         var returnValue = CryptoOperationReturnValue()
         do {
@@ -763,7 +762,7 @@ public class HMAC {
     public static func sign(
         key: SpanConstUInt8,
         data: SpanConstUInt8,
-        hashFunction: PAL.CryptoDigestHashFunction
+        hashFunction: PAL.Crypto.CryptoDigestHashFunction
     ) -> VectorUInt8 {
         switch hashFunction {
         case .SHA_1:
@@ -777,7 +776,7 @@ public class HMAC {
         case .DEPRECATED_SHA_224:
             fatalError("DEPRECATED_SHA_224 is not supported")
         @unknown default:
-            fatalError("Unknown PAL.CryptoDigestHashFunction enum case value: \(hashFunction.rawValue)")
+            fatalError("Unknown PAL.Crypto.CryptoDigestHashFunction enum case value: \(hashFunction.rawValue)")
         }
     }
 
@@ -787,7 +786,7 @@ public class HMAC {
         mac: SpanConstUInt8,
         key: SpanConstUInt8,
         data: SpanConstUInt8,
-        hashFunction: PAL.CryptoDigestHashFunction
+        hashFunction: PAL.Crypto.CryptoDigestHashFunction
     ) -> Bool {
         switch hashFunction {
         case .SHA_1:
@@ -827,7 +826,7 @@ public class HKDF {
         salt: SpanConstUInt8,
         info: SpanConstUInt8,
         outputBitCount: Int,
-        hashFunction: PAL.CryptoDigestHashFunction
+        hashFunction: PAL.Crypto.CryptoDigestHashFunction
     ) -> CryptoOperationReturnValue {
         var returnValue = CryptoOperationReturnValue()
         if outputBitCount <= 0 || outputBitCount % 8 != 0 {

--- a/Source/WebCore/PAL/pal/PALSwift/UnsafeOverlays.swift
+++ b/Source/WebCore/PAL/pal/PALSwift/UnsafeOverlays.swift
@@ -24,7 +24,7 @@
 public import CryptoKit
 public import Foundation
 
-public import pal.Core.PALSwift
+public import pal.Core.crypto.CryptoTypes
 
 enum UnsafeErrors: Error {
     case invalidLength

--- a/Source/WebCore/PAL/pal/PALTZoneImpls.cpp
+++ b/Source/WebCore/PAL/pal/PALTZoneImpls.cpp
@@ -31,7 +31,12 @@
 
 namespace PAL {
 
+namespace Crypto {
+
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CryptoDigest);
+
+}
+
 WTF_MAKE_TZONE_ALLOCATED_IMPL(HysteresisActivity);
 
 } // namespace PAL

--- a/Source/WebCore/PAL/pal/crypto/CryptoAlgorithmAESGCMCocoa.cpp
+++ b/Source/WebCore/PAL/pal/crypto/CryptoAlgorithmAESGCMCocoa.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CryptoAlgorithmAESGCMCocoa.h"
+
+#include "CommonCryptoSPI.h"
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
+#include "PALSwift-Generated.h"
+#pragma clang diagnostic pop
+
+#include <wtf/CryptographicUtilities.h>
+
+namespace PAL::Crypto {
+
+Expected<VectorUInt8, Error> encryptAESGCM(const VectorUInt8& iv, const VectorUInt8& key, const VectorUInt8& plainText, const VectorUInt8& additionalData, size_t desiredTagLengthInBytes)
+{
+    Vector<uint8_t> cipherText(plainText.size() + desiredTagLengthInBytes); // Per section 5.2.1.2: http://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
+    Vector<uint8_t> tag(desiredTagLengthInBytes);
+    // tagLength is actual an input <rdar://problem/30660074>
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    CCCryptorStatus status = CCCryptorGCM(kCCEncrypt, kCCAlgorithmAES, key.span().data(), key.size(), iv.span().data(), iv.size(), additionalData.span().data(), additionalData.size(), plainText.span().data(), plainText.size(), cipherText.mutableSpan().data(), tag.mutableSpan().data(), &desiredTagLengthInBytes);
+    ALLOW_DEPRECATED_DECLARATIONS_END
+    if (status)
+        return makeUnexpected(Error::EncryptionFailed);
+    memcpySpan(cipherText.mutableSpan().subspan(plainText.size()), tag.span());
+
+    return WTF::move(cipherText);
+}
+
+Expected<VectorUInt8, Error> encryptCryptoKitAESGCM(const VectorUInt8& iv, const VectorUInt8& key, const VectorUInt8& plainText, const VectorUInt8& additionalData, size_t desiredTagLengthInBytes)
+{
+    auto rv = pal::AesGcm::encrypt(key.span(), iv.span(), additionalData.span(), plainText.span(), desiredTagLengthInBytes);
+    if (rv.errorCode != Error::Success)
+        return makeUnexpected(rv.errorCode);
+    return WTF::move(rv.result);
+}
+
+Expected<VectorUInt8, Error> decyptAESGCM(const VectorUInt8& iv, const VectorUInt8& key, const VectorUInt8& cipherText, const VectorUInt8& additionalData, size_t desiredTagLengthInBytes)
+{
+    Vector<uint8_t> plainText(cipherText.size()); // Per section 5.2.1.2: http://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
+    Vector<uint8_t> tag(desiredTagLengthInBytes);
+    size_t offset = cipherText.size() - desiredTagLengthInBytes;
+    // tagLength is actual an input <rdar://problem/30660074>
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    CCCryptorStatus status = CCCryptorGCM(kCCDecrypt, kCCAlgorithmAES, key.span().data(), key.size(), iv.span().data(), iv.size(), additionalData.span().data(), additionalData.size(), cipherText.span().data(), offset, plainText.mutableSpan().data(), tag.mutableSpan().data(), &desiredTagLengthInBytes);
+ALLOW_DEPRECATED_DECLARATIONS_END
+    if (status)
+        return makeUnexpected(Error::DecryptionFailed);
+
+    // Using a constant time comparison to prevent timing attacks.
+    if (constantTimeMemcmp(tag.span(), cipherText.subspan(offset)))
+        return makeUnexpected(Error::DecryptionFailed);
+
+    plainText.shrink(offset);
+    return WTF::move(plainText);
+}
+
+}

--- a/Source/WebCore/PAL/pal/crypto/CryptoAlgorithmAESGCMCocoa.h
+++ b/Source/WebCore/PAL/pal/crypto/CryptoAlgorithmAESGCMCocoa.h
@@ -25,14 +25,16 @@
 
 #pragma once
 
-namespace PAL {
+#include <pal/crypto/CryptoTypes.h>
+#include <wtf/Expected.h>
+#include <wtf/Unexpected.h>
 
-enum class CryptoDigestHashFunction : int {
-    SHA_1,
-    DEPRECATED_SHA_224,
-    SHA_256,
-    SHA_384,
-    SHA_512,
-};
+namespace PAL::Crypto {
 
-} // namespace PAL
+Expected<VectorUInt8, Error> encryptAESGCM(const VectorUInt8& iv, const VectorUInt8& key, const VectorUInt8& plainText, const VectorUInt8& additionalData, size_t desiredTagLengthInBytes);
+
+Expected<VectorUInt8, Error> encryptCryptoKitAESGCM(const VectorUInt8& iv, const Vector<uint8_t>& key, const VectorUInt8& plainText, const VectorUInt8& additionalData, size_t desiredTagLengthInBytes);
+
+Expected<VectorUInt8, Error> decyptAESGCM(const VectorUInt8& iv, const VectorUInt8& key, const VectorUInt8& cipherText, const VectorUInt8& additionalData, size_t desiredTagLengthInBytes);
+
+} // namespace PAL::Crypto

--- a/Source/WebCore/PAL/pal/crypto/CryptoDigest.h
+++ b/Source/WebCore/PAL/pal/crypto/CryptoDigest.h
@@ -25,13 +25,13 @@
 
 #pragma once
 
-#include <pal/crypto/CryptoDigestHashFunction.h>
+#include <pal/crypto/CryptoTypes.h>
 #include <wtf/HexNumber.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
-namespace PAL {
+namespace PAL::Crypto {
 
 struct CryptoDigestContext;
 
@@ -58,4 +58,4 @@ inline String CryptoDigest::toHexString()
     return WTF::toHexString(computeHash());
 }
 
-} // namespace PAL
+} // namespace PAL::Crypto

--- a/Source/WebCore/PAL/pal/crypto/CryptoTypes.h
+++ b/Source/WebCore/PAL/pal/crypto/CryptoTypes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,17 +26,24 @@
 #pragma once
 
 #include <cstdint>
-#include <optional>
 #include <span>
-#include <wtf/Forward.h>
 #include <wtf/Vector.h>
 
-namespace Cpp {
+namespace PAL::Crypto {
 
 using VectorUInt8 = WTF::Vector<uint8_t>;
+
 using SpanConstUInt8 = std::span<const uint8_t>;
 
-enum class ErrorCodes: int {
+enum class CryptoDigestHashFunction: int {
+    SHA_1,
+    DEPRECATED_SHA_224,
+    SHA_256,
+    SHA_384,
+    SHA_512,
+};
+
+enum class Error: int {
     Success = 0,
     WrongTagSize,
     EncryptionFailed,
@@ -55,9 +62,10 @@ enum class ErrorCodes: int {
     DefaultValue,
     UnsupportedAlgorithm,
 };
+
 struct CryptoOperationReturnValue {
-    ErrorCodes errorCode = ErrorCodes::DefaultValue;
+    Error errorCode = Error::DefaultValue;
     VectorUInt8 result;
 };
 
-} // Cpp
+} // namespace PAL::Crypto

--- a/Source/WebCore/PAL/pal/crypto/commoncrypto/CryptoDigestCommonCrypto.cpp
+++ b/Source/WebCore/PAL/pal/crypto/commoncrypto/CryptoDigestCommonCrypto.cpp
@@ -26,9 +26,9 @@
 #include "config.h"
 #include "CryptoDigest.h"
 
-#include "PALSwift.h"
 #include <CommonCrypto/CommonCrypto.h>
 #include <optional>
+#include <pal/crypto/CryptoTypes.h>
 #include <span>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -37,7 +37,7 @@
 #include "PALSwift-Generated.h"
 #pragma clang diagnostic pop
 
-namespace PAL {
+namespace PAL::Crypto {
 
 struct CryptoDigestContext {
     WTF_MAKE_STRUCT_TZONE_ALLOCATED(CryptoDigestContext);

--- a/Source/WebCore/PAL/pal/crypto/gcrypt/CryptoDigestGCrypt.cpp
+++ b/Source/WebCore/PAL/pal/crypto/gcrypt/CryptoDigestGCrypt.cpp
@@ -29,7 +29,7 @@
 
 #include <gcrypt.h>
 
-namespace PAL {
+namespace PAL::Crypto {
 
 struct CryptoDigestContext {
     WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(CryptoDigestContext);
@@ -95,4 +95,4 @@ Vector<uint8_t> CryptoDigest::computeHash()
     return result;
 }
 
-} // namespace PAL
+} // namespace PAL::Crypto

--- a/Source/WebCore/PAL/pal/crypto/openssl/CryptoDigestOpenSSL.cpp
+++ b/Source/WebCore/PAL/pal/crypto/openssl/CryptoDigestOpenSSL.cpp
@@ -57,7 +57,7 @@ struct SHA512Functions {
 };
 }
 
-namespace PAL {
+namespace PAL::Crypto {
 
 struct CryptoDigestContext {
     virtual ~CryptoDigestContext() = default;
@@ -136,4 +136,4 @@ Vector<uint8_t> CryptoDigest::computeHash()
     return m_context->computeHash();
 }
 
-} // namespace PAL
+} // namespace PAL::Crypto

--- a/Source/WebCore/crypto/CryptoAlgorithm.cpp
+++ b/Source/WebCore/crypto/CryptoAlgorithm.cpp
@@ -117,10 +117,10 @@ void CryptoAlgorithm::dispatchOperationInWorkQueue(WorkQueue& workQueue, ScriptE
     dispatchAlgorithmOperation(workQueue, context, WTF::move(callback), WTF::move(exceptionCallback), WTF::move(operation));
 }
 
-void CryptoAlgorithm::dispatchDigest(WorkQueue& workQueue, ScriptExecutionContext& context, VectorCallback&& callback, ExceptionCallback&&exceptionCallback, Vector<uint8_t>&& message, PAL::CryptoDigest::Algorithm algo)
+void CryptoAlgorithm::dispatchDigest(WorkQueue& workQueue, ScriptExecutionContext& context, VectorCallback&& callback, ExceptionCallback&&exceptionCallback, Vector<uint8_t>&& message, PAL::Crypto::CryptoDigest::Algorithm algo)
 {
     workQueue.dispatch([message = WTF::move(message), callback = WTF::move(callback), contextIdentifier = context.identifier(), exceptionCallback = WTF::move(exceptionCallback), algo]() mutable {
-        auto digest = PAL::CryptoDigest::create(algo);
+        auto digest = PAL::Crypto::CryptoDigest::create(algo);
         if (!digest) {
             exceptionCallback(ExceptionCode::OperationError);
             return;

--- a/Source/WebCore/crypto/CryptoAlgorithm.h
+++ b/Source/WebCore/crypto/CryptoAlgorithm.h
@@ -80,7 +80,7 @@ public:
 
     static void dispatchOperationInWorkQueue(WorkQueue&, ScriptExecutionContext&, VectorCallback&&, ExceptionCallback&&, Function<ExceptionOr<Vector<uint8_t>>()>&&);
     static void dispatchOperationInWorkQueue(WorkQueue&, ScriptExecutionContext&, BoolCallback&&, ExceptionCallback&&, Function<ExceptionOr<bool>()>&&);
-    static void dispatchDigest(WorkQueue&, ScriptExecutionContext&, VectorCallback&&, ExceptionCallback&&, Vector<uint8_t>&& message, PAL::CryptoDigest::Algorithm);
+    static void dispatchDigest(WorkQueue&, ScriptExecutionContext&, VectorCallback&&, ExceptionCallback&&, Vector<uint8_t>&& message, PAL::Crypto::CryptoDigest::Algorithm);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/crypto/CryptoAlgorithmIdentifier.h
+++ b/Source/WebCore/crypto/CryptoAlgorithmIdentifier.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <pal/crypto/CryptoDigestHashFunction.h>
+#include <pal/crypto/CryptoTypes.h>
 
 namespace WebCore {
 
@@ -54,20 +54,20 @@ enum class CryptoAlgorithmIdentifier : uint8_t {
     X25519
 };
 
-inline PAL::CryptoDigestHashFunction toCKHashFunction(CryptoAlgorithmIdentifier hash)
+inline PAL::Crypto::CryptoDigestHashFunction toCKHashFunction(CryptoAlgorithmIdentifier hash)
 {
     switch (hash) {
     case CryptoAlgorithmIdentifier::SHA_256:
-        return PAL::CryptoDigestHashFunction::SHA_256;
+        return PAL::Crypto::CryptoDigestHashFunction::SHA_256;
     case CryptoAlgorithmIdentifier::SHA_384:
-        return PAL::CryptoDigestHashFunction::SHA_384;
+        return PAL::Crypto::CryptoDigestHashFunction::SHA_384;
     case CryptoAlgorithmIdentifier::SHA_512:
-        return PAL::CryptoDigestHashFunction::SHA_512;
+        return PAL::Crypto::CryptoDigestHashFunction::SHA_512;
     case CryptoAlgorithmIdentifier::SHA_1:
-        return PAL::CryptoDigestHashFunction::SHA_1;
+        return PAL::Crypto::CryptoDigestHashFunction::SHA_1;
     default:
         ASSERT_NOT_REACHED();
-        return PAL::CryptoDigestHashFunction::SHA_512;
+        return PAL::Crypto::CryptoDigestHashFunction::SHA_512;
     }
 }
 

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmSHA1.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmSHA1.cpp
@@ -43,7 +43,7 @@ CryptoAlgorithmIdentifier CryptoAlgorithmSHA1::identifier() const
 
 void CryptoAlgorithmSHA1::digest(Vector<uint8_t>&& message, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
 {
-    CryptoAlgorithm::dispatchDigest(workQueue, context, WTF::move(callback), WTF::move(exceptionCallback), WTF::move(message), PAL::CryptoDigest::Algorithm::SHA_1);
+    CryptoAlgorithm::dispatchDigest(workQueue, context, WTF::move(callback), WTF::move(exceptionCallback), WTF::move(message), PAL::Crypto::CryptoDigest::Algorithm::SHA_1);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmSHA256.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmSHA256.cpp
@@ -43,7 +43,7 @@ CryptoAlgorithmIdentifier CryptoAlgorithmSHA256::identifier() const
 
 void CryptoAlgorithmSHA256::digest(Vector<uint8_t>&& message, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
 {
-    CryptoAlgorithm::dispatchDigest(workQueue, context, WTF::move(callback), WTF::move(exceptionCallback), WTF::move(message), PAL::CryptoDigest::Algorithm::SHA_256);
+    CryptoAlgorithm::dispatchDigest(workQueue, context, WTF::move(callback), WTF::move(exceptionCallback), WTF::move(message), PAL::Crypto::CryptoDigest::Algorithm::SHA_256);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmSHA384.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmSHA384.cpp
@@ -43,7 +43,7 @@ CryptoAlgorithmIdentifier CryptoAlgorithmSHA384::identifier() const
 
 void CryptoAlgorithmSHA384::digest(Vector<uint8_t>&& message, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
 {
-    CryptoAlgorithm::dispatchDigest(workQueue, context, WTF::move(callback), WTF::move(exceptionCallback), WTF::move(message), PAL::CryptoDigest::Algorithm::SHA_384);
+    CryptoAlgorithm::dispatchDigest(workQueue, context, WTF::move(callback), WTF::move(exceptionCallback), WTF::move(message), PAL::Crypto::CryptoDigest::Algorithm::SHA_384);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmSHA512.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmSHA512.cpp
@@ -43,7 +43,7 @@ CryptoAlgorithmIdentifier CryptoAlgorithmSHA512::identifier() const
 
 void CryptoAlgorithmSHA512::digest(Vector<uint8_t>&& message, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
 {
-    CryptoAlgorithm::dispatchDigest(workQueue, context, WTF::move(callback), WTF::move(exceptionCallback), WTF::move(message), PAL::CryptoDigest::Algorithm::SHA_512);
+    CryptoAlgorithm::dispatchDigest(workQueue, context, WTF::move(callback), WTF::move(exceptionCallback), WTF::move(message), PAL::Crypto::CryptoDigest::Algorithm::SHA_512);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESGCMCocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESGCMCocoa.cpp
@@ -29,71 +29,44 @@
 #include "CommonCryptoUtilities.h"
 #include "CryptoAlgorithmAesGcmParams.h"
 #include "CryptoKeyAES.h"
-#include <pal/PALSwift.h>
-#include <wtf/CryptographicUtilities.h>
-#include <wtf/StdLibExtras.h>
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
-#include "PALSwift-Generated.h"
-#pragma clang diagnostic pop
+#include <pal/crypto/CryptoAlgorithmAESGCMCocoa.h>
 
 namespace WebCore {
 
-static ExceptionOr<Vector<uint8_t>> encryptAESGCM(const Vector<uint8_t>& iv, const Vector<uint8_t>& key, const Vector<uint8_t>& plainText, const Vector<uint8_t>& additionalData, size_t desiredTagLengthInBytes)
+static std::optional<ExceptionCode> toExceptionCode(const PAL::Crypto::Error& error)
 {
-    Vector<uint8_t> cipherText(plainText.size() + desiredTagLengthInBytes); // Per section 5.2.1.2: http://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
-    Vector<uint8_t> tag(desiredTagLengthInBytes);
-    // tagLength is actual an input <rdar://problem/30660074>
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    CCCryptorStatus status = CCCryptorGCM(kCCEncrypt, kCCAlgorithmAES, key.span().data(), key.size(), iv.span().data(), iv.size(), additionalData.span().data(), additionalData.size(), plainText.span().data(), plainText.size(), cipherText.mutableSpan().data(), tag.mutableSpan().data(), &desiredTagLengthInBytes);
-ALLOW_DEPRECATED_DECLARATIONS_END
-    if (status)
-        return Exception { ExceptionCode::OperationError };
-    memcpySpan(cipherText.mutableSpan().subspan(plainText.size()), tag.span());
+    switch (error) {
+    case PAL::Crypto::Error::Success:
+        return std::nullopt;
 
-    return WTF::move(cipherText);
+    default:
+        return ExceptionCode::OperationError;
+    }
 }
 
-static ExceptionOr<Vector<uint8_t>> encryptCryptoKitAESGCM(const Vector<uint8_t>& iv, const Vector<uint8_t>& key, const Vector<uint8_t>& plainText, const Vector<uint8_t>& additionalData, size_t desiredTagLengthInBytes)
+static ExceptionOr<Vector<uint8_t>> toException(Expected<PAL::Crypto::VectorUInt8, PAL::Crypto::Error>&& expected)
 {
-    auto rv = pal::AesGcm::encrypt(key.span(), iv.span(), additionalData.span(), plainText.span(), desiredTagLengthInBytes);
-    if (rv.errorCode != Cpp::ErrorCodes::Success)
-        return Exception { ExceptionCode::OperationError };
-    return WTF::move(rv.result);
-}
+    if (expected)
+        return WTF::move(*expected);
 
-static ExceptionOr<Vector<uint8_t>> decyptAESGCM(const Vector<uint8_t>& iv, const Vector<uint8_t>& key, const Vector<uint8_t>& cipherText, const Vector<uint8_t>& additionalData, size_t desiredTagLengthInBytes)
-{
-    Vector<uint8_t> plainText(cipherText.size()); // Per section 5.2.1.2: http://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
-    Vector<uint8_t> tag(desiredTagLengthInBytes);
-    size_t offset = cipherText.size() - desiredTagLengthInBytes;
-    // tagLength is actual an input <rdar://problem/30660074>
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    CCCryptorStatus status = CCCryptorGCM(kCCDecrypt, kCCAlgorithmAES, key.span().data(), key.size(), iv.span().data(), iv.size(), additionalData.span().data(), additionalData.size(), cipherText.span().data(), offset, plainText.mutableSpan().data(), tag.mutableSpan().data(), &desiredTagLengthInBytes);
-ALLOW_DEPRECATED_DECLARATIONS_END
-    if (status)
-        return Exception { ExceptionCode::OperationError };
+    auto exceptionCode = toExceptionCode(expected.error());
+    if (exceptionCode)
+        return Exception { *exceptionCode };
 
-    // Using a constant time comparison to prevent timing attacks.
-    if (constantTimeMemcmp(tag.span(), cipherText.subspan(offset)))
-        return Exception { ExceptionCode::OperationError };
-
-    plainText.shrink(offset);
-    return WTF::move(plainText);
+    RELEASE_ASSERT_NOT_REACHED();
 }
 
 ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESGCM::platformEncrypt(const CryptoAlgorithmAesGcmParams& parameters, const CryptoKeyAES& key, const Vector<uint8_t>& plainText)
 {
     if (parameters.ivVector().size() >= 12)
-        return encryptCryptoKitAESGCM(parameters.ivVector(), key.key(), plainText, parameters.additionalDataVector(), parameters.tagLength.value_or(0) / 8);
-    return encryptAESGCM(parameters.ivVector(), key.key(), plainText, parameters.additionalDataVector(), parameters.tagLength.value_or(0) / 8);
+        return toException(PAL::Crypto::encryptCryptoKitAESGCM(parameters.ivVector(), key.key(), plainText, parameters.additionalDataVector(), parameters.tagLength.value_or(0) / 8));
+    return toException(PAL::Crypto::encryptAESGCM(parameters.ivVector(), key.key(), plainText, parameters.additionalDataVector(), parameters.tagLength.value_or(0) / 8));
 }
 
 ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESGCM::platformDecrypt(const CryptoAlgorithmAesGcmParams& parameters, const CryptoKeyAES& key, const Vector<uint8_t>& cipherText)
 {
     // FIXME: Add decrypt with CryptoKit once rdar://92701544 is resolved.
-    return decyptAESGCM(parameters.ivVector(), key.key(), cipherText, parameters.additionalDataVector(), parameters.tagLength.value_or(0) / 8);
+    return toException(PAL::Crypto::decyptAESGCM(parameters.ivVector(), key.key(), cipherText, parameters.additionalDataVector(), parameters.tagLength.value_or(0) / 8));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESKWCocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESKWCocoa.cpp
@@ -28,7 +28,7 @@
 
 #include "CryptoKeyAES.h"
 #include <CommonCrypto/CommonCrypto.h>
-#include <pal/PALSwift.h>
+#include <pal/crypto/CryptoTypes.h>
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
@@ -40,7 +40,7 @@ namespace WebCore {
 static ExceptionOr<Vector<uint8_t>> wrapKeyAESKWCryptoKit(const Vector<uint8_t>& key, const Vector<uint8_t>& data)
 {
     auto rv = pal::AesKw::wrap(data.span(), key.span());
-    if (rv.errorCode != Cpp::ErrorCodes::Success)
+    if (rv.errorCode != PAL::Crypto::Error::Success)
         return Exception { ExceptionCode::OperationError };
     return WTF::move(rv.result);
 }
@@ -48,7 +48,7 @@ static ExceptionOr<Vector<uint8_t>> wrapKeyAESKWCryptoKit(const Vector<uint8_t>&
 static ExceptionOr<Vector<uint8_t>> unwrapKeyAESKWCryptoKit(const Vector<uint8_t>& key, const Vector<uint8_t>& data)
 {
     auto rv = pal::AesKw::unwrap(data.span(), key.span());
-    if (rv.errorCode != Cpp::ErrorCodes::Success)
+    if (rv.errorCode != PAL::Crypto::Error::Success)
         return Exception { ExceptionCode::OperationError };
     return WTF::move(rv.result);
 }

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmECDHCocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmECDHCocoa.cpp
@@ -28,7 +28,7 @@
 
 #include "CommonCryptoUtilities.h"
 #include "CryptoKeyEC.h"
-#include <pal/PALSwift.h>
+#include <pal/crypto/CryptoTypes.h>
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
@@ -40,7 +40,7 @@ namespace WebCore {
 static std::optional<Vector<uint8_t>> platformDeriveBitsCryptoKit(const CryptoKeyEC& baseKey, const CryptoKeyEC& publicKey)
 {
     auto rv = baseKey.platformKey()->deriveBits(publicKey.platformKey());
-    if (rv.errorCode != Cpp::ErrorCodes::Success)
+    if (rv.errorCode != PAL::Crypto::Error::Success)
         return std::nullopt;
     return std::make_optional(WTF::move(rv.result));
 }

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSACocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSACocoa.cpp
@@ -32,7 +32,7 @@
 #include "CryptoDigestAlgorithm.h"
 #include "CryptoKeyEC.h"
 #include "ExceptionOr.h"
-#include <pal/PALSwift.h>
+#include <pal/crypto/CryptoTypes.h>
 #include <wtf/StdLibExtras.h>
 
 namespace WebCore {
@@ -42,7 +42,7 @@ static ExceptionOr<Vector<uint8_t>> signECDSACryptoKit(CryptoAlgorithmIdentifier
     if (!isValidHashParameter(hash))
         return Exception { ExceptionCode::OperationError };
     auto rv = key->sign(data.span(), toCKHashFunction(hash));
-    if (rv.errorCode != Cpp::ErrorCodes::Success)
+    if (rv.errorCode != PAL::Crypto::Error::Success)
         return Exception { ExceptionCode::OperationError };
     return WTF::move(rv.result);
 }
@@ -51,7 +51,7 @@ static ExceptionOr<bool> verifyECDSACryptoKit(CryptoAlgorithmIdentifier hash, co
 {
     if (!isValidHashParameter(hash))
         return Exception { ExceptionCode::OperationError };
-    return key->verify(data.span(), signature.span(), toCKHashFunction(hash)).errorCode == Cpp::ErrorCodes::Success;
+    return key->verify(data.span(), signature.span(), toCKHashFunction(hash)).errorCode == PAL::Crypto::Error::Success;
 }
 
 ExceptionOr<Vector<uint8_t>> CryptoAlgorithmECDSA::platformSign(const CryptoAlgorithmEcdsaParams& parameters, const CryptoKeyEC& key, const Vector<uint8_t>& data)

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmEd25519Cocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmEd25519Cocoa.cpp
@@ -28,7 +28,7 @@
 
 #include "CryptoKeyOKP.h"
 #include "ExceptionOr.h"
-#include <pal/PALSwift.h>
+#include <pal/crypto/CryptoTypes.h>
 #include <pal/spi/cocoa/CoreCryptoSPI.h>
 
 #pragma clang diagnostic push
@@ -43,7 +43,7 @@ static ExceptionOr<Vector<uint8_t>> signEd25519CryptoKit(const Vector<uint8_t>&s
     if (sk.size() != ed25519KeySize)
         return Exception { ExceptionCode::OperationError };
     auto rv = pal::EdKey::sign(pal::EdSigningAlgorithm::ed25519(), sk.span(), data.span());
-    if (rv.errorCode != Cpp::ErrorCodes::Success)
+    if (rv.errorCode != PAL::Crypto::Error::Success)
         return Exception { ExceptionCode::OperationError };
     return WTF::move(rv.result);
 }
@@ -53,7 +53,7 @@ static ExceptionOr<bool> verifyEd25519CryptoKit(const Vector<uint8_t>& pubKey, c
     if (pubKey.size() != ed25519KeySize || signature.size() != ed25519SignatureSize)
         return false;
     auto rv = pal::EdKey::verify(pal::EdSigningAlgorithm::ed25519(), pubKey.span(), signature.span(), data.span());
-    return rv.errorCode == Cpp::ErrorCodes::Success;
+    return rv.errorCode == PAL::Crypto::Error::Success;
 }
 
 ExceptionOr<Vector<uint8_t>> CryptoAlgorithmEd25519::platformSign(const CryptoKeyOKP& key, const Vector<uint8_t>& data)

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmHKDFCocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmHKDFCocoa.cpp
@@ -30,7 +30,7 @@
 #include "CryptoAlgorithmHkdfParams.h"
 #include "CryptoKeyRaw.h"
 #include "CryptoUtilitiesCocoa.h"
-#include <pal/PALSwift.h>
+#include <pal/crypto/CryptoTypes.h>
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
@@ -44,7 +44,7 @@ static ExceptionOr<Vector<uint8_t>> platformDeriveBitsCryptoKit(const CryptoAlgo
     if (!isValidHashParameter(parameters.hashIdentifier))
         return Exception { ExceptionCode::OperationError };
     auto rv = pal::HKDF::deriveBits(key.key().span(), parameters.saltVector().span(), parameters.infoVector().span(), length, toCKHashFunction(parameters.hashIdentifier));
-    if (rv.errorCode != Cpp::ErrorCodes::Success)
+    if (rv.errorCode != PAL::Crypto::Error::Success)
         return Exception { ExceptionCode::OperationError };
     return WTF::move(rv.result);
 }

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmHMACCocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmHMACCocoa.cpp
@@ -29,7 +29,7 @@
 #include "CryptoKeyHMAC.h"
 #include "CryptoUtilitiesCocoa.h"
 #include <CommonCrypto/CommonHMAC.h>
-#include <pal/PALSwift.h>
+#include <pal/crypto/CryptoTypes.h>
 #include <wtf/CryptographicUtilities.h>
 
 namespace WebCore {

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmRSASSA_PKCS1_v1_5Cocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmRSASSA_PKCS1_v1_5Cocoa.cpp
@@ -41,7 +41,7 @@ static ExceptionOr<Vector<uint8_t>> signRSASSA_PKCS1_v1_5(CryptoAlgorithmIdentif
     auto cryptoDigestAlgorithm = WebCore::cryptoDigestAlgorithm(hash);
     if (!cryptoDigestAlgorithm)
         return Exception { ExceptionCode::OperationError };
-    auto digest = PAL::CryptoDigest::create(*cryptoDigestAlgorithm);
+    auto digest = PAL::Crypto::CryptoDigest::create(*cryptoDigestAlgorithm);
     if (!digest)
         return Exception { ExceptionCode::OperationError };
     digest->addBytes(data.span());
@@ -66,7 +66,7 @@ static ExceptionOr<bool> verifyRSASSA_PKCS1_v1_5(CryptoAlgorithmIdentifier hash,
     auto cryptoDigestAlgorithm = WebCore::cryptoDigestAlgorithm(hash);
     if (!cryptoDigestAlgorithm)
         return Exception { ExceptionCode::OperationError };
-    auto digest = PAL::CryptoDigest::create(*cryptoDigestAlgorithm);
+    auto digest = PAL::Crypto::CryptoDigest::create(*cryptoDigestAlgorithm);
     if (!digest)
         return Exception { ExceptionCode::OperationError };
     digest->addBytes(data.span());

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmRSA_PSSCocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmRSA_PSSCocoa.cpp
@@ -45,7 +45,7 @@ static ExceptionOr<Vector<uint8_t>> signRSA_PSS(CryptoAlgorithmIdentifier hash, 
     auto cryptoDigestAlgorithm = WebCore::cryptoDigestAlgorithm(hash);
     if (!cryptoDigestAlgorithm)
         return Exception { ExceptionCode::OperationError };
-    auto digest = PAL::CryptoDigest::create(*cryptoDigestAlgorithm);
+    auto digest = PAL::Crypto::CryptoDigest::create(*cryptoDigestAlgorithm);
     if (!digest)
         return Exception { ExceptionCode::OperationError };
     digest->addBytes(data.span());
@@ -70,7 +70,7 @@ static ExceptionOr<bool> verifyRSA_PSS(CryptoAlgorithmIdentifier hash, const Pla
     auto cryptoDigestAlgorithm = WebCore::cryptoDigestAlgorithm(hash);
     if (!cryptoDigestAlgorithm)
         return Exception { ExceptionCode::OperationError };
-    auto digest = PAL::CryptoDigest::create(*cryptoDigestAlgorithm);
+    auto digest = PAL::Crypto::CryptoDigest::create(*cryptoDigestAlgorithm);
     if (!digest)
         return Exception { ExceptionCode::OperationError };
     digest->addBytes(data.span());

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmX25519Cocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmX25519Cocoa.cpp
@@ -21,7 +21,7 @@
 #include "CryptoAlgorithmX25519.h"
 
 #include "CryptoKeyOKP.h"
-#include <pal/PALSwift.h>
+#include <pal/crypto/CryptoTypes.h>
 #include <pal/spi/cocoa/CoreCryptoSPI.h>
 
 #pragma clang diagnostic push
@@ -36,7 +36,7 @@ static std::optional<Vector<uint8_t>> deriveBitsCryptoKit(const Vector<uint8_t>&
     if (baseKey.size() != ed25519KeySize || publicKey.size() != ed25519KeySize)
         return std::nullopt;
     auto rv = pal::EdKey::deriveBits(pal::EdKeyAgreementAlgorithm::x25519(), baseKey.span(), publicKey.span());
-    if (rv.errorCode != Cpp::ErrorCodes::Success)
+    if (rv.errorCode != PAL::Crypto::Error::Success)
         return std::nullopt;
     return WTF::move(rv.result);
 }

--- a/Source/WebCore/crypto/cocoa/CryptoDigestAlgorithm.h
+++ b/Source/WebCore/crypto/cocoa/CryptoDigestAlgorithm.h
@@ -31,17 +31,17 @@
 
 namespace WebCore {
 
-static std::optional<PAL::CryptoDigest::Algorithm> cryptoDigestAlgorithm(CryptoAlgorithmIdentifier hashFunction)
+static std::optional<PAL::Crypto::CryptoDigest::Algorithm> cryptoDigestAlgorithm(CryptoAlgorithmIdentifier hashFunction)
 {
     switch (hashFunction) {
     case CryptoAlgorithmIdentifier::SHA_1:
-        return PAL::CryptoDigest::Algorithm::SHA_1;
+        return PAL::Crypto::CryptoDigest::Algorithm::SHA_1;
     case CryptoAlgorithmIdentifier::SHA_256:
-        return PAL::CryptoDigest::Algorithm::SHA_256;
+        return PAL::Crypto::CryptoDigest::Algorithm::SHA_256;
     case CryptoAlgorithmIdentifier::SHA_384:
-        return PAL::CryptoDigest::Algorithm::SHA_384;
+        return PAL::Crypto::CryptoDigest::Algorithm::SHA_384;
     case CryptoAlgorithmIdentifier::SHA_512:
-        return PAL::CryptoDigest::Algorithm::SHA_512;
+        return PAL::Crypto::CryptoDigest::Algorithm::SHA_512;
     default:
         return std::nullopt;
     }

--- a/Source/WebCore/crypto/cocoa/CryptoKeyECCocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoKeyECCocoa.cpp
@@ -28,7 +28,7 @@
 
 #include "CommonCryptoDERUtilities.h"
 #include "JsonWebKey.h"
-#include <pal/PALSwift.h>
+#include <pal/crypto/CryptoTypes.h>
 #include <wtf/text/Base64.h>
 
 namespace WebCore {
@@ -138,7 +138,7 @@ Vector<uint8_t> CryptoKeyEC::platformExportRaw() const
 {
     size_t expectedSize = 2 * keySizeInBytes() + 1; // Per Section 2.3.4 of http://www.secg.org/sec1-v2.pdf
     auto rv = platformKey()->exportX963Pub();
-    if (rv.errorCode != Cpp::ErrorCodes::Success)
+    if (rv.errorCode != PAL::Crypto::Error::Success)
         return { };
     if (rv.result.size() != expectedSize)
         return { };
@@ -184,14 +184,14 @@ bool CryptoKeyEC::platformAddFieldElements(JsonWebKey& jwk) const
     switch (type()) {
     case CryptoKeyType::Public: {
         auto rv = platformKey()->exportX963Pub();
-        if (rv.errorCode != Cpp::ErrorCodes::Success)
+        if (rv.errorCode != PAL::Crypto::Error::Success)
             return false;
         result = WTF::move(rv.result);
         break;
     }
     case CryptoKeyType::Private: {
         auto rv = platformKey()->exportX963Private();
-        if (rv.errorCode != Cpp::ErrorCodes::Success)
+        if (rv.errorCode != PAL::Crypto::Error::Success)
             return false;
         result = WTF::move(rv.result);
         break;
@@ -272,7 +272,7 @@ Vector<uint8_t> CryptoKeyEC::platformExportSpki() const
     size_t keySize = keyBytes.size();
 
     auto rv = platformKey()->exportX963Pub();
-    if (rv.errorCode != Cpp::ErrorCodes::Success)
+    if (rv.errorCode != PAL::Crypto::Error::Success)
         return { };
     if (rv.result.size() != expectedKeySize)
         return { };
@@ -372,7 +372,7 @@ Vector<uint8_t> CryptoKeyEC::platformExportPkcs8() const
     Vector<uint8_t> keyBytes(expectedKeySize);
 
     auto rv = platformKey()->exportX963Private();
-    if (rv.errorCode != Cpp::ErrorCodes::Success)
+    if (rv.errorCode != PAL::Crypto::Error::Success)
         return { };
     if (rv.result.size() != expectedKeySize)
         return { };

--- a/Source/WebCore/crypto/cocoa/CryptoKeyOKPCocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoKeyOKPCocoa.cpp
@@ -30,7 +30,7 @@
 #include "ExceptionOr.h"
 #include "JsonWebKey.h"
 #include "Logging.h"
-#include <pal/PALSwift.h>
+#include <pal/crypto/CryptoTypes.h>
 #include <pal/spi/cocoa/CoreCryptoSPI.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/text/Base64.h>
@@ -52,7 +52,7 @@ std::optional<CryptoKeyPair> CryptoKeyOKP::platformGeneratePair(CryptoAlgorithmI
         auto privateKeyPlatform = pal::EdKey::generatePrivateKey(pal::EdSigningAlgorithm::ed25519());
         RELEASE_ASSERT(privateKeyPlatform.size() == 32);
         auto publicKeyPlatformRv = pal::EdKey::privateToPublic(pal::EdSigningAlgorithm::ed25519(), privateKeyPlatform.span());
-        if (publicKeyPlatformRv.errorCode != Cpp::ErrorCodes::Success)
+        if (publicKeyPlatformRv.errorCode != PAL::Crypto::Error::Success)
             return std::nullopt;
         bool isPublicKeyExtractable = true;
         auto publicKey = CryptoKeyOKP::create(identifier, namedCurve, CryptoKeyType::Public, WTF::move(publicKeyPlatformRv.result), isPublicKeyExtractable, usages);
@@ -65,7 +65,7 @@ std::optional<CryptoKeyPair> CryptoKeyOKP::platformGeneratePair(CryptoAlgorithmI
         auto privateKeyPlatform = pal::EdKey::generatePrivateKeyKeyAgreement(pal::EdKeyAgreementAlgorithm::x25519());
         RELEASE_ASSERT(privateKeyPlatform.size() == 32);
         auto publicKeyPlatformRv = pal::EdKey::privateToPublicKeyAgreement(pal::EdKeyAgreementAlgorithm::x25519(), privateKeyPlatform.span());
-        if (publicKeyPlatformRv.errorCode != Cpp::ErrorCodes::Success)
+        if (publicKeyPlatformRv.errorCode != PAL::Crypto::Error::Success)
             return std::nullopt;
         bool isPublicKeyExtractable = true;
         auto publicKey = CryptoKeyOKP::create(identifier, namedCurve, CryptoKeyType::Public, WTF::move(publicKeyPlatformRv.result), isPublicKeyExtractable, usages);
@@ -357,12 +357,12 @@ String CryptoKeyOKP::generateJwkX() const
     switch (namedCurve()) {
     case NamedCurve::Ed25519: {
         auto publicKeyPlatformRv = pal::EdKey::privateToPublic(pal::EdSigningAlgorithm::ed25519(), platformKey().span());
-        RELEASE_ASSERT(publicKeyPlatformRv.errorCode == Cpp::ErrorCodes::Success);
+        RELEASE_ASSERT(publicKeyPlatformRv.errorCode == PAL::Crypto::Error::Success);
         return base64URLEncodeToString(publicKeyPlatformRv.result.span());
     }
     case NamedCurve::X25519: {
         auto publicKeyPlatformRv = pal::EdKey::privateToPublicKeyAgreement(pal::EdKeyAgreementAlgorithm::x25519(), platformKey().span());
-        RELEASE_ASSERT(publicKeyPlatformRv.errorCode == Cpp::ErrorCodes::Success);
+        RELEASE_ASSERT(publicKeyPlatformRv.errorCode == PAL::Crypto::Error::Success);
         return base64URLEncodeToString(publicKeyPlatformRv.result.span());
     }
     default:

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmECDSAGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmECDSAGCrypt.cpp
@@ -70,7 +70,7 @@ static std::optional<Vector<uint8_t>> gcryptSign(gcry_sexp_t keySexp, const Vect
         if (!digestAlgorithm)
             return std::nullopt;
 
-        auto digest = PAL::CryptoDigest::create(*digestAlgorithm);
+        auto digest = PAL::Crypto::CryptoDigest::create(*digestAlgorithm);
         if (!digest)
             return std::nullopt;
 
@@ -130,7 +130,7 @@ static std::optional<bool> gcryptVerify(gcry_sexp_t keySexp, const Vector<uint8_
         if (!digestAlgorithm)
             return std::nullopt;
 
-        auto digest = PAL::CryptoDigest::create(*digestAlgorithm);
+        auto digest = PAL::Crypto::CryptoDigest::create(*digestAlgorithm);
         if (!digest)
             return std::nullopt;
 

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmRSASSA_PKCS1_v1_5GCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmRSASSA_PKCS1_v1_5GCrypt.cpp
@@ -43,7 +43,7 @@ static std::optional<Vector<uint8_t>> gcryptSign(gcry_sexp_t keySexp, const Vect
         if (!digestAlgorithm)
             return std::nullopt;
 
-        auto digest = PAL::CryptoDigest::create(*digestAlgorithm);
+        auto digest = PAL::Crypto::CryptoDigest::create(*digestAlgorithm);
         if (!digest)
             return std::nullopt;
 
@@ -94,7 +94,7 @@ static std::optional<bool> gcryptVerify(gcry_sexp_t keySexp, const Vector<uint8_
         if (!digestAlgorithm)
             return std::nullopt;
 
-        auto digest = PAL::CryptoDigest::create(*digestAlgorithm);
+        auto digest = PAL::Crypto::CryptoDigest::create(*digestAlgorithm);
         if (!digest)
             return std::nullopt;
 

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmRSA_PSSGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmRSA_PSSGCrypt.cpp
@@ -44,7 +44,7 @@ static std::optional<Vector<uint8_t>> gcryptSign(gcry_sexp_t keySexp, const Vect
         if (!digestAlgorithm)
             return std::nullopt;
 
-        auto digest = PAL::CryptoDigest::create(*digestAlgorithm);
+        auto digest = PAL::Crypto::CryptoDigest::create(*digestAlgorithm);
         if (!digest)
             return std::nullopt;
 
@@ -95,7 +95,7 @@ static std::optional<bool> gcryptVerify(gcry_sexp_t keySexp, const Vector<uint8_
         if (!digestAlgorithm)
             return std::nullopt;
 
-        auto digest = PAL::CryptoDigest::create(*digestAlgorithm);
+        auto digest = PAL::Crypto::CryptoDigest::create(*digestAlgorithm);
         if (!digest)
             return std::nullopt;
 

--- a/Source/WebCore/crypto/gcrypt/GCryptUtilities.cpp
+++ b/Source/WebCore/crypto/gcrypt/GCryptUtilities.cpp
@@ -88,20 +88,20 @@ std::optional<int> digestAlgorithm(CryptoAlgorithmIdentifier identifier)
     }
 }
 
-std::optional<PAL::CryptoDigest::Algorithm> hashCryptoDigestAlgorithm(CryptoAlgorithmIdentifier identifier)
+std::optional<PAL::Crypto::CryptoDigest::Algorithm> hashCryptoDigestAlgorithm(CryptoAlgorithmIdentifier identifier)
 {
     switch (identifier) {
     case CryptoAlgorithmIdentifier::SHA_1:
-        return PAL::CryptoDigest::Algorithm::SHA_1;
+        return PAL::Crypto::CryptoDigest::Algorithm::SHA_1;
     case CryptoAlgorithmIdentifier::DEPRECATED_SHA_224:
         RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE(sha224DeprecationMessage);
-        return PAL::CryptoDigest::Algorithm::SHA_256;
+        return PAL::Crypto::CryptoDigest::Algorithm::SHA_256;
     case CryptoAlgorithmIdentifier::SHA_256:
-        return PAL::CryptoDigest::Algorithm::SHA_256;
+        return PAL::Crypto::CryptoDigest::Algorithm::SHA_256;
     case CryptoAlgorithmIdentifier::SHA_384:
-        return PAL::CryptoDigest::Algorithm::SHA_384;
+        return PAL::Crypto::CryptoDigest::Algorithm::SHA_384;
     case CryptoAlgorithmIdentifier::SHA_512:
-        return PAL::CryptoDigest::Algorithm::SHA_512;
+        return PAL::Crypto::CryptoDigest::Algorithm::SHA_512;
     default:
         return std::nullopt;
     }

--- a/Source/WebCore/crypto/gcrypt/GCryptUtilities.h
+++ b/Source/WebCore/crypto/gcrypt/GCryptUtilities.h
@@ -77,7 +77,7 @@ ASCIILiteral hashAlgorithmName(CryptoAlgorithmIdentifier);
 
 std::optional<int> hmacAlgorithm(CryptoAlgorithmIdentifier);
 std::optional<int> digestAlgorithm(CryptoAlgorithmIdentifier);
-std::optional<PAL::CryptoDigest::Algorithm> hashCryptoDigestAlgorithm(CryptoAlgorithmIdentifier);
+std::optional<PAL::Crypto::CryptoDigest::Algorithm> hashCryptoDigestAlgorithm(CryptoAlgorithmIdentifier);
 
 std::optional<size_t> mpiLength(gcry_mpi_t);
 std::optional<size_t> mpiLength(gcry_sexp_t);

--- a/Source/WebCore/crypto/keys/CryptoKeyEC.cpp
+++ b/Source/WebCore/crypto/keys/CryptoKeyEC.cpp
@@ -32,7 +32,7 @@
 #include <wtf/text/Base64.h>
 
 #if OS(DARWIN) && !PLATFORM(GTK)
-#include <pal/PALSwift.h>
+#include <pal/crypto/CryptoTypes.h>
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
 #include "PALSwift-Generated.h"

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -1968,7 +1968,7 @@ static String computeContentSecurityPolicySHA256Hash(const Element& element)
     PAL::TextEncoding documentEncoding = element.document().textEncoding();
     const PAL::TextEncoding& encodingToUse = documentEncoding.isValid() ? documentEncoding : PAL::UTF8Encoding();
     auto content = encodingToUse.encode(TextNodeTraversal::contentsAsString(element), PAL::UnencodableHandling::Entities);
-    auto cryptoDigest = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
+    auto cryptoDigest = PAL::Crypto::CryptoDigest::create(PAL::Crypto::CryptoDigest::Algorithm::SHA_256);
     cryptoDigest->addBytes(content.span());
     auto digest = cryptoDigest->computeHash();
     return makeString("sha256-"_s, base64Encoded(digest));

--- a/Source/WebCore/loader/ResourceCryptographicDigest.cpp
+++ b/Source/WebCore/loader/ResourceCryptographicDigest.cpp
@@ -134,30 +134,30 @@ std::optional<ResourceCryptographicDigest> decodeEncodedResourceCryptographicDig
     return std::nullopt;
 }
 
-static PAL::CryptoDigest::Algorithm NODELETE toCryptoDigestAlgorithm(ResourceCryptographicDigest::Algorithm algorithm)
+static PAL::Crypto::CryptoDigest::Algorithm NODELETE toCryptoDigestAlgorithm(ResourceCryptographicDigest::Algorithm algorithm)
 {
     switch (algorithm) {
     case ResourceCryptographicDigest::Algorithm::SHA256:
-        return PAL::CryptoDigest::Algorithm::SHA_256;
+        return PAL::Crypto::CryptoDigest::Algorithm::SHA_256;
     case ResourceCryptographicDigest::Algorithm::SHA384:
-        return PAL::CryptoDigest::Algorithm::SHA_384;
+        return PAL::Crypto::CryptoDigest::Algorithm::SHA_384;
     case ResourceCryptographicDigest::Algorithm::SHA512:
-        return PAL::CryptoDigest::Algorithm::SHA_512;
+        return PAL::Crypto::CryptoDigest::Algorithm::SHA_512;
     }
     ASSERT_NOT_REACHED();
-    return PAL::CryptoDigest::Algorithm::SHA_512;
+    return PAL::Crypto::CryptoDigest::Algorithm::SHA_512;
 }
 
 ResourceCryptographicDigest cryptographicDigestForBytes(ResourceCryptographicDigest::Algorithm algorithm, std::span<const uint8_t> bytes)
 {
-    auto cryptoDigest = PAL::CryptoDigest::create(toCryptoDigestAlgorithm(algorithm));
+    auto cryptoDigest = PAL::Crypto::CryptoDigest::create(toCryptoDigestAlgorithm(algorithm));
     cryptoDigest->addBytes(bytes);
     return { algorithm, cryptoDigest->computeHash() };
 }
 
 ResourceCryptographicDigest cryptographicDigestForSharedBuffer(ResourceCryptographicDigest::Algorithm algorithm, const FragmentedSharedBuffer* buffer)
 {
-    auto cryptoDigest = PAL::CryptoDigest::create(toCryptoDigestAlgorithm(algorithm));
+    auto cryptoDigest = PAL::Crypto::CryptoDigest::create(toCryptoDigestAlgorithm(algorithm));
     if (buffer) {
         buffer->forEachSegment([&](auto segment) {
             cryptoDigest->addBytes(segment);

--- a/Source/WebCore/loader/cache/TrustedFonts.cpp
+++ b/Source/WebCore/loader/cache/TrustedFonts.cpp
@@ -872,7 +872,7 @@ static const MemoryCompactLookupOnlyRobinHoodHashSet<AtomString>& trustedFontHas
 
 static AtomString hashForFontData(std::span<const uint8_t> data)
 {
-    auto cryptoDigest = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
+    auto cryptoDigest = PAL::Crypto::CryptoDigest::create(PAL::Crypto::CryptoDigest::Algorithm::SHA_256);
     cryptoDigest->addBytes(data);
     auto digest = cryptoDigest->computeHash();
     return makeAtomString(base64Encoded(digest.span()));

--- a/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
+++ b/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
@@ -87,7 +87,7 @@ private:
         if (!certificateData)
             return String();
 
-        auto digest = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
+        auto digest = PAL::Crypto::CryptoDigest::create(PAL::Crypto::CryptoDigest::Algorithm::SHA_256);
         digest->addBytes(span(certificateData));
 
         return base64EncodeToString(digest->computeHash());

--- a/Source/WebCore/platform/sql/SQLiteFileSystem.cpp
+++ b/Source/WebCore/platform/sql/SQLiteFileSystem.cpp
@@ -148,7 +148,7 @@ std::optional<WallTime> SQLiteFileSystem::databaseModificationTime(const String&
     
 String SQLiteFileSystem::computeHashForFileName(StringView fileName)
 {
-    auto cryptoDigest = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
+    auto cryptoDigest = PAL::Crypto::CryptoDigest::create(PAL::Crypto::CryptoDigest::Algorithm::SHA_256);
     auto utf8FileName = fileName.utf8();
     cryptoDigest->addBytes(byteCast<uint8_t>(utf8FileName.span()));
     return cryptoDigest->toHexString();

--- a/Source/WebCore/storage/StorageUtilities.cpp
+++ b/Source/WebCore/storage/StorageUtilities.cpp
@@ -80,7 +80,7 @@ bool writeOriginToFile(const String& filePath, const ClientOrigin& origin)
 
 String encodeSecurityOriginForFileName(FileSystem::Salt salt, const SecurityOriginData& origin)
 {
-    auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
+    auto crypto = PAL::Crypto::CryptoDigest::create(PAL::Crypto::CryptoDigest::Algorithm::SHA_256);
     auto originString = origin.toString().utf8();
     crypto->addBytes(byteCast<uint8_t>(originString.span()));
     crypto->addBytes(salt);

--- a/Source/WebCore/workers/service/server/SWScriptStorage.cpp
+++ b/Source/WebCore/workers/service/server/SWScriptStorage.cpp
@@ -54,7 +54,7 @@ SWScriptStorage::SWScriptStorage(const String& directory)
 
 String SWScriptStorage::sha2Hash(const String& input) const
 {
-    auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
+    auto crypto = PAL::Crypto::CryptoDigest::create(PAL::Crypto::CryptoDigest::Algorithm::SHA_256);
     crypto->addBytes(m_salt);
     auto inputUTF8 = input.utf8();
     crypto->addBytes(byteCast<uint8_t>(inputUTF8.span()));

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.cpp
@@ -519,7 +519,7 @@ void PrivateClickMeasurementManager::fireConversionRequest(const PrivateClickMea
             if (!publicKeyData)
                 return;
 
-            auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
+            auto crypto = PAL::Crypto::CryptoDigest::create(PAL::Crypto::CryptoDigest::Algorithm::SHA_256);
             crypto->addBytes(publicKeyData->span());
 
             auto keyID = base64URLEncodeToString(crypto->computeHash());
@@ -539,7 +539,7 @@ void PrivateClickMeasurementManager::fireConversionRequest(const PrivateClickMea
                     if (!publicKeyData)
                         return;
 
-                    auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
+                    auto crypto = PAL::Crypto::CryptoDigest::create(PAL::Crypto::CryptoDigest::Algorithm::SHA_256);
                     crypto->addBytes(publicKeyData->span());
 
                     auto keyID = base64URLEncodeToString(crypto->computeHash());
@@ -565,7 +565,7 @@ void PrivateClickMeasurementManager::fireConversionRequest(const PrivateClickMea
         if (!publicKeyData)
             return;
 
-        auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
+        auto crypto = PAL::Crypto::CryptoDigest::create(PAL::Crypto::CryptoDigest::Algorithm::SHA_256);
         crypto->addBytes(publicKeyData->span());
 
         auto keyID = base64URLEncodeToString(crypto->computeHash());

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -91,7 +91,7 @@ static HashMap<String, ThreadSafeWeakPtr<NetworkStorageManager>>& NODELETE activ
 
 static String encode(const String& string, FileSystem::Salt salt)
 {
-    auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
+    auto crypto = PAL::Crypto::CryptoDigest::create(PAL::Crypto::CryptoDigest::Algorithm::SHA_256);
     auto utf8String = string.utf8();
     crypto->addBytes(byteCast<uint8_t>(utf8String.span()));
     crypto->addBytes(salt);

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
@@ -145,7 +145,7 @@ static RetainPtr<NSData> produceClientDataJson(_WKWebAuthenticationType type, NS
 
 static Vector<uint8_t> produceClientDataJsonHash(NSData *clientDataJson)
 {
-    auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
+    auto crypto = PAL::Crypto::CryptoDigest::create(PAL::Crypto::CryptoDigest::Algorithm::SHA_256);
     crypto->addBytes(span(clientDataJson));
     return crypto->computeHash();
 }
@@ -694,7 +694,7 @@ static void createNSErrorFromWKErrorIfNecessary(NSError **error, WKErrorCode err
         return nullptr;
     }
 
-    auto digest = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_1);
+    auto digest = PAL::Crypto::CryptoDigest::create(PAL::Crypto::CryptoDigest::Algorithm::SHA_1);
     digest->addBytes(span(nsPublicKeyData.get()));
     auto credentialId = digest->computeHash();
     RetainPtr nsCredentialId = toNSData(credentialId.span());

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
@@ -621,7 +621,7 @@ void LocalAuthenticator::continueMakeCredentialAfterUserVerification(SecAccessCo
     // of the key item. Instead we calculate that, and examine its equaity in DEBUG build.
     Vector<uint8_t> credentialId;
     {
-        auto digest = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_1);
+        auto digest = PAL::Crypto::CryptoDigest::create(PAL::Crypto::CryptoDigest::Algorithm::SHA_1);
         digest->addBytes(span(nsPublicKeyData.get()));
         credentialId = digest->computeHash();
         m_provisionalCredentialId = toNSData(credentialId);

--- a/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorUtils.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorUtils.mm
@@ -80,7 +80,7 @@ std::pair<Vector<uint8_t>, Vector<uint8_t>> credentialIdAndCosePubKeyForPrivateK
 
     Vector<uint8_t> credentialId;
     {
-        auto digest = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_1);
+        auto digest = PAL::Crypto::CryptoDigest::create(PAL::Crypto::CryptoDigest::Algorithm::SHA_1);
         digest->addBytes(span(nsPublicKeyData.get()));
         credentialId = digest->computeHash();
     }

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
@@ -124,7 +124,7 @@ static Vector<uint8_t> hashPRFInput(const BufferSource& input)
 {
     constexpr uint8_t prefix[] = { 'W', 'e', 'b', 'A', 'u', 't', 'h', 'n', ' ', 'P', 'R', 'F' };
     constexpr uint8_t nullByte = 0x00;
-    auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
+    auto crypto = PAL::Crypto::CryptoDigest::create(PAL::Crypto::CryptoDigest::Algorithm::SHA_256);
     crypto->addBytes(std::span { prefix });
     crypto->addBytes(std::span { &nullByte, 1 });
     crypto->addBytes(input.span());

--- a/Tools/TestWebKitAPI/Tests/WebCore/CryptoDigest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CryptoDigest.cpp
@@ -45,9 +45,9 @@ static CString toHex(WTF::Vector<uint8_t>&& hash)
     return buffer.span();
 }
 
-static void expect(PAL::CryptoDigest::Algorithm algorithm, const CString& input, int repeat, const CString& expected)
+static void expect(PAL::Crypto::CryptoDigest::Algorithm algorithm, const CString& input, int repeat, const CString& expected)
 {
-    auto cryptoDigest = PAL::CryptoDigest::create(algorithm);
+    auto cryptoDigest = PAL::Crypto::CryptoDigest::create(algorithm);
 
     for (int i = 0; i < repeat; ++i)
         cryptoDigest->addBytes(byteCast<uint8_t>(input.span()));
@@ -60,22 +60,22 @@ static void expect(PAL::CryptoDigest::Algorithm algorithm, const CString& input,
 
 static void expectSHA1(const CString& input, int repeat, const CString& expected)
 {
-    expect(PAL::CryptoDigest::Algorithm::SHA_1, input, repeat, expected);
+    expect(PAL::Crypto::CryptoDigest::Algorithm::SHA_1, input, repeat, expected);
 }
 
 static void expectSHA256(const CString& input, int repeat, const CString& expected)
 {
-    expect(PAL::CryptoDigest::Algorithm::SHA_256, input, repeat, expected);
+    expect(PAL::Crypto::CryptoDigest::Algorithm::SHA_256, input, repeat, expected);
 }
 
 static void expectSHA384(const CString& input, int repeat, const CString& expected)
 {
-    expect(PAL::CryptoDigest::Algorithm::SHA_384, input, repeat, expected);
+    expect(PAL::Crypto::CryptoDigest::Algorithm::SHA_384, input, repeat, expected);
 }
 
 static void expectSHA512(const CString& input, int repeat, const CString& expected)
 {
-    expect(PAL::CryptoDigest::Algorithm::SHA_512, input, repeat, expected);
+    expect(PAL::Crypto::CryptoDigest::Algorithm::SHA_512, input, repeat, expected);
 }
 
 TEST(CryptoDigest, SHA1Computation)

--- a/Tools/TestWebKitAPI/Tests/WebCore/CtapPinTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CtapPinTest.cpp
@@ -136,7 +136,7 @@ TEST(CtapPinTest, TestSetPinRequest)
     auto sharedKeyResult = CryptoAlgorithmECDH::platformDeriveBits(downcast<CryptoKeyEC>(*keyPair.privateKey), *cosePublicKey);
     EXPECT_TRUE(sharedKeyResult);
 
-    auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
+    auto crypto = PAL::Crypto::CryptoDigest::create(PAL::Crypto::CryptoDigest::Algorithm::SHA_256);
     crypto->addBytes(sharedKeyResult->span());
     auto sharedKeyHash = crypto->computeHash();
 
@@ -324,7 +324,7 @@ TEST(CtapPinTest, TestTokenRequest)
     auto sharedKeyResult = CryptoAlgorithmECDH::platformDeriveBits(downcast<CryptoKeyEC>(*keyPair.privateKey), *cosePublicKey);
     EXPECT_TRUE(sharedKeyResult);
 
-    auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
+    auto crypto = PAL::Crypto::CryptoDigest::create(PAL::Crypto::CryptoDigest::Algorithm::SHA_256);
     crypto->addBytes(sharedKeyResult->span());
     auto sharedKeyHash = crypto->computeHash();
 
@@ -531,7 +531,7 @@ TEST(CtapPinTest, TestProtocol2HKDFKeyDerivation)
         0xaa, 0xce, 0x11, 0x8e, 0x3e, 0x72, 0x49, 0xd2
     };
 
-    auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
+    auto crypto = PAL::Crypto::CryptoDigest::create(PAL::Crypto::CryptoDigest::Algorithm::SHA_256);
     crypto->addBytes(std::span { testECDHResult });
     auto protocol1Key = crypto->computeHash();
 


### PR DESCRIPTION
#### b93ab6c393f0df9594560251862b5637ef778c28
<pre>
[Swift in WebKit] Non-PAL targets should not access the internal PAL Swift bridging header (part 1)
<a href="https://bugs.webkit.org/show_bug.cgi?id=310489">https://bugs.webkit.org/show_bug.cgi?id=310489</a>
<a href="https://rdar.apple.com/173114104">rdar://173114104</a>

Reviewed by Abrar Rahman Protyasha.

There are many things currently wrong with the use of Swift in PAL currently. This starts
to address one of the issues, which is that projects should never be able to access each other&apos;s
internal Swift bridging headers. This is currently being violated by WebCore accessing PAL&apos;s
bridging header, causing a layering violation and build system issues. This only &quot;happens&quot; to
work out currently because WebCore&apos;s search paths are (incorrectly) customized to _also_ look in
PAL&apos;s source directory, which is a problem in itself.

Start to fix this by refactoring some of the crypto code by sinking it into PAL from WebCore, so
that it can then properly access the bridging header, where it belongs.

In doing this refactoring, several other changes are made to facilitate making this easier:

* A new `Crypto` nested namespace in `PAL` is introduced. This is done because previously, the
code organization within PAL was hard to read and maintain; in particular, types like
`Cpp::ErrorCodes` didn&apos;t really make sense, since that is all crypto specific and has nothing to
do with a language.

* `PALSwift.h` and `CryptoDigestHashFunction.h` are now merged into a `CryptoTypes.h` file.

Most of the changes in this are just renaming / moving.

* Source/WebCore/Modules/webauthn/WebAuthenticationUtils.cpp:
(WebCore::produceRpIdHash):
(WebCore::buildClientDataJsonHash):
* Source/WebCore/Modules/webauthn/fido/Pin.cpp:
(fido::pin::deriveProtocolSharedSecret):
(fido::pin::TokenRequest::tryCreate):
* Source/WebCore/PAL/pal/PALSwift/CryptoKitShim.swift:
(Digest.digest(_:hashFunction:)):
* Source/WebCore/PAL/pal/PALSwift/UnsafeOverlays.swift:
* Source/WebCore/PAL/pal/PALTZoneImpls.cpp:
* Source/WebCore/PAL/pal/crypto/CryptoDigest.h:
* Source/WebCore/PAL/pal/crypto/commoncrypto/CryptoDigestCommonCrypto.cpp:
* Source/WebCore/crypto/CryptoAlgorithm.cpp:
(WebCore::CryptoAlgorithm::dispatchDigest):
* Source/WebCore/crypto/CryptoAlgorithm.h:
* Source/WebCore/crypto/CryptoAlgorithmIdentifier.h:
(WebCore::toCKHashFunction):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmSHA1.cpp:
(WebCore::CryptoAlgorithmSHA1::digest):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmSHA256.cpp:
(WebCore::CryptoAlgorithmSHA256::digest):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmSHA384.cpp:
(WebCore::CryptoAlgorithmSHA384::digest):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmSHA512.cpp:
(WebCore::CryptoAlgorithmSHA512::digest):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmAESKWCocoa.cpp:
(WebCore::wrapKeyAESKWCryptoKit):
(WebCore::unwrapKeyAESKWCryptoKit):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmECDHCocoa.cpp:
(WebCore::platformDeriveBitsCryptoKit):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSACocoa.cpp:
(WebCore::signECDSACryptoKit):
(WebCore::verifyECDSACryptoKit):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmEd25519Cocoa.cpp:
(WebCore::signEd25519CryptoKit):
(WebCore::verifyEd25519CryptoKit):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmHKDFCocoa.cpp:
(WebCore::platformDeriveBitsCryptoKit):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmHMACCocoa.cpp:
* Source/WebCore/crypto/cocoa/CryptoAlgorithmRSASSA_PKCS1_v1_5Cocoa.cpp:
(WebCore::signRSASSA_PKCS1_v1_5):
(WebCore::verifyRSASSA_PKCS1_v1_5):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmRSA_PSSCocoa.cpp:
(WebCore::signRSA_PSS):
(WebCore::verifyRSA_PSS):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmX25519Cocoa.cpp:
(WebCore::deriveBitsCryptoKit):
* Source/WebCore/crypto/cocoa/CryptoDigestAlgorithm.h:
(WebCore::cryptoDigestAlgorithm):
* Source/WebCore/crypto/cocoa/CryptoKeyECCocoa.cpp:
(WebCore::CryptoKeyEC::platformExportRaw const):
(WebCore::CryptoKeyEC::platformAddFieldElements const):
(WebCore::CryptoKeyEC::platformExportSpki const):
(WebCore::CryptoKeyEC::platformExportPkcs8 const):
* Source/WebCore/crypto/cocoa/CryptoKeyOKPCocoa.cpp:
(WebCore::CryptoKeyOKP::platformGeneratePair):
(WebCore::CryptoKeyOKP::generateJwkX const):
* Source/WebCore/crypto/keys/CryptoKeyEC.cpp:
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::computeContentSecurityPolicySHA256Hash):
* Source/WebCore/loader/ResourceCryptographicDigest.cpp:
(WebCore::toCryptoDigestAlgorithm):
(WebCore::cryptographicDigestForBytes):
(WebCore::cryptographicDigestForSharedBuffer):
* Source/WebCore/loader/cache/TrustedFonts.cpp:
(WebCore::hashForFontData):
* Source/WebCore/platform/sql/SQLiteFileSystem.cpp:
(WebCore::SQLiteFileSystem::computeHashForFileName):
* Source/WebCore/storage/StorageUtilities.cpp:
(WebCore::StorageUtilities::encodeSecurityOriginForFileName):
* Source/WebCore/workers/service/ServiceWorkerRoute.mm:
* Source/WebCore/workers/service/server/SWScriptStorage.cpp:
(WebCore::SWScriptStorage::sha2Hash const):
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.cpp:
(WebKit::PrivateClickMeasurementManager::fireConversionRequest):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::encode):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm:
(produceClientDataJsonHash):
(+[_WKWebAuthenticationPanel importLocalAuthenticatorWithAccessGroup:credential:error:]):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm:
(WebKit::LocalAuthenticator::continueMakeCredentialAfterUserVerification):
* Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorUtils.mm:
(WebKit::credentialIdAndCosePubKeyForPrivateKey):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp:
* Tools/TestWebKitAPI/Tests/WebCore/CtapPinTest.cpp:
(TestWebKitAPI::TEST(CtapPinTest, TestSetPinRequest)):
(TestWebKitAPI::TEST(CtapPinTest, TestTokenRequest)):
(TestWebKitAPI::TEST(CtapPinTest, TestProtocol2HKDFKeyDerivation)):

- Update for new namespace
- Import `CryptoTypes` instead of `PALSwift`

* Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj:

- Xcode file changes

* Source/WebCore/PAL/pal/crypto/CryptoAlgorithmAESGCMCocoa.cpp: Copied from Source/WebCore/crypto/cocoa/CryptoAlgorithmAESGCMCocoa.cpp.
(PAL::Crypto::encryptAESGCM):
(PAL::Crypto::encryptCryptoKitAESGCM):
(PAL::Crypto::decyptAESGCM):
* Source/WebCore/PAL/pal/crypto/CryptoAlgorithmAESGCMCocoa.h: Renamed from Source/WebCore/PAL/pal/crypto/CryptoDigestHashFunction.h.

- Sink these functions into PAL so that they may properly access the bridging header. Use `Expected` and `PAL::Crypto::Error` since `ExceptionOr` is a WebCore type.

* Source/WebCore/PAL/pal/crypto/CryptoTypes.h: Renamed from Source/WebCore/PAL/pal/PALSwift.h.

- Switch to `CryptoTypes.h=

* Source/WebCore/PAL/pal/module.modulemap:

- Implement a silly workaround to ensure incremental builds work ok.

* Source/WebCore/crypto/cocoa/CryptoAlgorithmAESGCMCocoa.cpp:
(WebCore::toExceptionCode):
(WebCore::toException):
(WebCore::CryptoAlgorithmAESGCM::platformEncrypt):
(WebCore::CryptoAlgorithmAESGCM::platformDecrypt):
(WebCore::encryptAESGCM): Deleted.
(WebCore::encryptCryptoKitAESGCM): Deleted.
(WebCore::decyptAESGCM): Deleted.

- Implement a helper to convert between Expected and ExceptionOr
- Call the new functions in PAL

Canonical link: <a href="https://commits.webkit.org/309848@main">https://commits.webkit.org/309848@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d19a50068726b2568f5cc6e2bfe5791743905cd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151914 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24695 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18267 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160656 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c92c4a4f-86b6-41a3-bb9e-0997e5a87e02) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153788 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25188 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24998 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117346 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154874 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136322 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98061 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/18599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16532 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8491 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128232 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14225 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163121 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6269 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15817 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125364 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24494 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20591 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125545 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34066 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24495 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136021 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81076 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20571 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12796 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24112 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88397 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23803 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23963 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23864 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->