### PR TITLE
[JSC] Remove UB for truncate-double-to-int32 by injecting conversion inline asm

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -4888,7 +4888,7 @@ JSC_DEFINE_JIT_OPERATION(operationNewArrayWithSpecies, JSObject*, (JSGlobalObjec
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    uint64_t length = static_cast<uint64_t>(JSValue::decode(encodedLength).asNumber());
+    uint64_t length = truncateDoubleToUint64(JSValue::decode(encodedLength).asNumber());
     OPERATION_RETURN(scope, newArrayWithSpeciesImpl(globalObject, length, array, indexingType));
 }
 

--- a/Source/JavaScriptCore/runtime/CommonSlowPaths.cpp
+++ b/Source/JavaScriptCore/runtime/CommonSlowPaths.cpp
@@ -415,7 +415,7 @@ static void updateArithProfileForUnaryArithOp(UnaryArithProfile& profile, JSValu
                 // Therefore, we will get a false positive if the result is that value. This is intentionally
                 // done to simplify the checking algorithm.
                 static const int64_t int52OverflowPoint = (1ll << 51);
-                int64_t int64Val = static_cast<int64_t>(std::abs(doubleVal));
+                int64_t int64Val = truncateDoubleToInt64(std::abs(doubleVal));
                 if (int64Val >= int52OverflowPoint)
                     profile.setObservedInt52Overflow();
             }
@@ -481,7 +481,7 @@ static void updateArithProfileForBinaryArithOp(JSGlobalObject*, CodeBlock* codeB
                 // Therefore, we will get a false positive if the result is that value. This is intentionally
                 // done to simplify the checking algorithm.
                 static const int64_t int52OverflowPoint = (1ll << 51);
-                int64_t int64Val = static_cast<int64_t>(std::abs(doubleVal));
+                int64_t int64Val = truncateDoubleToInt64(std::abs(doubleVal));
                 if (int64Val >= int52OverflowPoint)
                     profile.setObservedInt52Overflow();
             }
@@ -1354,7 +1354,7 @@ JSC_DEFINE_COMMON_SLOW_PATH(slow_path_new_array_with_species)
     BEGIN();
     auto bytecode = pc->as<OpNewArrayWithSpecies>();
     JSObject* array = asObject(GET_C(bytecode.m_array).jsValue());
-    uint64_t length = static_cast<uint64_t>(GET_C(bytecode.m_length).jsValue().asNumber());
+    uint64_t length = truncateDoubleToUint64(GET_C(bytecode.m_length).jsValue().asNumber());
     auto& metadata = bytecode.metadata(codeBlock);
     auto& arrayAllocationProfile = metadata.m_arrayAllocationProfile;
     auto& arrayProfile = metadata.m_arrayProfile;

--- a/Source/JavaScriptCore/runtime/JSCJSValueInlines.h
+++ b/Source/JavaScriptCore/runtime/JSCJSValueInlines.h
@@ -125,7 +125,7 @@ inline std::optional<uint32_t> JSValue::tryGetAsUint32Index()
     }
     if (isNumber()) {
         double number = asNumber();
-        uint32_t asUint = static_cast<uint32_t>(number);
+        uint32_t asUint = static_cast<uint32_t>(truncateDoubleToUint64(number));
         if (static_cast<double>(asUint) == number && isIndex(asUint))
             return asUint;
     }
@@ -138,7 +138,7 @@ inline std::optional<int32_t> JSValue::tryGetAsInt32()
         return asInt32();
     if (isNumber()) {
         double number = asNumber();
-        int32_t asInt = static_cast<int32_t>(number);
+        int32_t asInt = truncateDoubleToInt32(number);
         if (static_cast<double>(asInt) == number)
             return asInt;
     }

--- a/Source/JavaScriptCore/runtime/MathCommon.cpp
+++ b/Source/JavaScriptCore/runtime/MathCommon.cpp
@@ -640,10 +640,10 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(i64_div_u, uint64_t, (uint64_t a, uint64_t b))
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(i64_rem_s, int64_t, (int64_t a, int64_t b)) { return a % b; }
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(i64_rem_u, uint64_t, (uint64_t a, uint64_t b)) { return a % b; }
 
-JSC_DEFINE_NOEXCEPT_JIT_OPERATION(i64_trunc_u_f32, uint64_t, (float operand)) { return static_cast<uint64_t>(operand); }
-JSC_DEFINE_NOEXCEPT_JIT_OPERATION(i64_trunc_s_f32, int64_t, (float operand)) { return static_cast<int64_t>(operand); }
-JSC_DEFINE_NOEXCEPT_JIT_OPERATION(i64_trunc_u_f64, uint64_t, (double operand)) { return static_cast<uint64_t>(operand); }
-JSC_DEFINE_NOEXCEPT_JIT_OPERATION(i64_trunc_s_f64, int64_t, (double operand)) { return static_cast<int64_t>(operand); }
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(i64_trunc_u_f32, uint64_t, (float operand)) { return truncateFloatToUint64(operand); }
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(i64_trunc_s_f32, int64_t, (float operand)) { return truncateFloatToInt64(operand); }
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(i64_trunc_u_f64, uint64_t, (double operand)) { return truncateDoubleToUint64(operand); }
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(i64_trunc_s_f64, int64_t, (double operand)) { return truncateDoubleToInt64(operand); }
 
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(f32_convert_u_i64, float, (uint64_t operand)) { return static_cast<float>(operand); }
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(f32_convert_s_i64, float, (int64_t operand)) { return static_cast<float>(operand); }

--- a/Source/JavaScriptCore/runtime/MathCommon.h
+++ b/Source/JavaScriptCore/runtime/MathCommon.h
@@ -31,6 +31,7 @@
 #include <climits>
 #include <cmath>
 #include <optional>
+#include <wtf/MathExtras.h>
 
 namespace JSC {
 
@@ -240,32 +241,6 @@ inline std::optional<double> safeReciprocalForDivByConst(double constant)
     return reciprocal;
 }
 
-ALWAYS_INLINE std::optional<int32_t> tryConvertToStrictInt32(double value)
-{
-#if HAVE(FJCVTZS_INSTRUCTION)
-    int32_t result;
-    bool isExact;
-    __asm__(
-        "fjcvtzs %w0, %d2"
-        : "=r" (result), "=@cceq" (isExact)
-        : "w" (value)
-        : "cc");
-    if (isExact)
-        return result;
-    return std::nullopt;
-#else
-    if (std::isinf(value) || std::isnan(value))
-        return std::nullopt;
-
-    // Note that -0.0 is not StrictInt32.
-    const int32_t asInt32 = static_cast<int32_t>(value);
-    if (!(asInt32 != value || (!asInt32 && std::signbit(value))))
-        return asInt32;
-
-    return std::nullopt;
-#endif
-}
-
 extern "C" {
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(jsRound, double, (double));
 }
@@ -377,6 +352,7 @@ JSC_DECLARE_NOEXCEPT_JIT_OPERATION(roundDouble, double, (double));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(jsRoundDouble, double, (double));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(roundFloat, float, (float));
 
+// FIXME: Remote them. These functions were only used in 32bit wasm.
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(f32_nearest, float, (float));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(f64_nearest, double, (double));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(f32_roundeven, float, (float));

--- a/Source/JavaScriptCore/runtime/NumberPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/NumberPrototype.cpp
@@ -375,7 +375,7 @@ String toStringWithRadix(double doubleValue, int32_t radix)
 {
     ASSERT(2 <= radix && radix <= 36);
 
-    int32_t integerValue = static_cast<int32_t>(doubleValue);
+    int32_t integerValue = truncateDoubleToInt32(doubleValue);
     if (integerValue == doubleValue)
         return toStringWithRadixInternal(integerValue, radix);
 
@@ -560,7 +560,7 @@ static ALWAYS_INLINE JSString* numberToStringInternal(VM& vm, double doubleValue
 {
     ASSERT(!(radix < 2 || radix > 36));
 
-    int32_t integerValue = static_cast<int32_t>(doubleValue);
+    int32_t integerValue = truncateDoubleToInt32(doubleValue);
     if (integerValue == doubleValue)
         return int32ToStringInternal(vm, integerValue, radix);
 

--- a/Source/JavaScriptCore/wasm/WasmFormat.h
+++ b/Source/JavaScriptCore/wasm/WasmFormat.h
@@ -555,7 +555,7 @@ inline size_t sizeOfType(TypeKind kind)
 inline JSValue internalizeExternref(JSValue value)
 {
     if (value.isDouble()) {
-        if (auto int32Value = JSC::tryConvertToStrictInt32(value.asDouble())) {
+        if (auto int32Value = tryConvertToStrictInt32(value.asDouble())) {
             if (int32Value.value() <= Wasm::maxI31ref && int32Value.value() >= Wasm::minI31ref)
                 return jsNumber(int32Value.value());
         }

--- a/Source/WTF/wtf/MathExtras.h
+++ b/Source/WTF/wtf/MathExtras.h
@@ -32,10 +32,15 @@
 #include <float.h>
 #include <limits>
 #include <numbers>
+#include <optional>
 #include <stdint.h>
 #include <stdlib.h>
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/StdLibExtras.h>
+
+#if CPU(ARM64)
+#include <arm_neon.h>
+#endif
 
 #if OS(OPENBSD)
 #include <sys/types.h>
@@ -846,6 +851,279 @@ constexpr T roundDownToMultipleOf(T x)
     return roundDownToMultipleOf(divisor, x);
 }
 
+// The following truncation helpers perform a direct hardware truncation of
+// floating-point values to integer types. Unlike ECMAScript ToInt32/ToInt64
+// (modular wrap-around), these produce architecture-defined results for
+// out-of-range inputs (e.g., NaN, infinity, values exceeding the target
+// range). They are intended for call sites that check the result after
+// conversion (e.g., round-trip comparison) or that are fine with a
+// deterministic but unspecified value on overflow. The inline-asm paths avoid
+// C++ undefined behaviour that a plain static_cast would trigger for
+// non-representable values.
+
+// Double-to-integer truncation helpers.
+
+#define WTF_PROVEN_TRUE(x) (__builtin_constant_p(x) && (x))
+
+ALWAYS_INLINE int32_t truncateDoubleToInt32(double number)
+{
+    if (WTF_PROVEN_TRUE(number > -2147483649.0 && number < 2147483648.0))
+        return static_cast<int32_t>(number);
+#if CPU(X86_64)
+    // cvttsd2si eax, xmm0
+    int32_t result;
+    __asm__("cvttsd2si %1, %0" : "=r"(result) : "x"(number));
+    return result;
+#elif CPU(ARM64)
+    // fcvtzs w0, d0
+    int32_t result;
+    __asm__("fcvtzs %w0, %d1" : "=r"(result) : "w"(number));
+    return result;
+#else
+    if (std::isnan(number) || !std::isfinite(number))
+        return 0;
+    if (number > 0) {
+        if (number >= static_cast<double>(INT32_MAX) + 1.0)
+            return INT32_MIN; // Saturate/wrap matching cvttsd2si overflow sentinel.
+        return static_cast<int32_t>(number);
+    }
+    if (number < static_cast<double>(INT32_MIN))
+        return INT32_MIN;
+    return static_cast<int32_t>(number);
+#endif
+}
+
+ALWAYS_INLINE int64_t truncateDoubleToInt64(double number)
+{
+#if CPU(ARM64)
+    return vcvtd_s64_f64(number);
+#else
+    if (WTF_PROVEN_TRUE(number >= -9223372036854775808.0 && number < 9223372036854775808.0))
+        return static_cast<int64_t>(number);
+#if CPU(X86_64)
+    // cvttsd2si rax, xmm0
+    int64_t result;
+    __asm__("cvttsd2si %1, %0" : "=r"(result) : "x"(number));
+    return result;
+#elif CPU(ARM64)
+    return vcvtd_s64_f64(number);
+#else
+    if (std::isnan(number) || !std::isfinite(number))
+        return 0;
+    if (number > 0) {
+        if (number >= static_cast<double>(INT64_MAX) + 1.0)
+            return INT64_MIN; // Saturate/wrap matching cvttsd2si overflow sentinel.
+        return static_cast<int64_t>(number);
+    }
+    if (number < static_cast<double>(INT64_MIN))
+        return INT64_MIN;
+    return static_cast<int64_t>(number);
+#endif
+#endif
+}
+
+ALWAYS_INLINE uint32_t truncateDoubleToUint32(double number)
+{
+    if (WTF_PROVEN_TRUE(number >= 0.0 && number < 4294967296.0))
+        return static_cast<uint32_t>(number);
+#if CPU(X86_64)
+    // cvttsd2si rax, xmm0 (64-bit signed, return low 32 bits)
+    int64_t result;
+    __asm__("cvttsd2si %1, %0" : "=r"(result) : "x"(number));
+    return static_cast<uint32_t>(result);
+#elif CPU(ARM64)
+    // fcvtzu w0, d0
+    uint32_t result;
+    __asm__("fcvtzu %w0, %d1" : "=r"(result) : "w"(number));
+    return result;
+#else
+    if (std::isnan(number) || !std::isfinite(number))
+        return 0;
+    // Mimic x86_64: cvttsd2si into int64, take low 32 bits.
+    int64_t wide = truncateDoubleToInt64(number);
+    return static_cast<uint32_t>(wide);
+#endif
+}
+
+ALWAYS_INLINE uint64_t truncateDoubleToUint64(double number)
+{
+#if CPU(ARM64)
+    return vcvtd_u64_f64(number);
+#else
+    if (WTF_PROVEN_TRUE(number >= 0.0 && number < 18446744073709551616.0))
+        return static_cast<uint64_t>(number);
+#if CPU(X86_64)
+    // Branchless conversion matching compiler codegen for static_cast<uint64_t>(double).
+    // cvttsd2si returns 0x8000000000000000 (negative) on overflow, including for
+    // values >= 2^63. When that happens, subtract 2^63 and convert again; the
+    // arithmetic-right-shift mask selects the adjusted result only on overflow.
+    constexpr double twoTo63 = 9223372036854775808.0; // 0x43e0000000000000
+    int64_t direct;
+    __asm__("cvttsd2si %1, %0" : "=r"(direct) : "x"(number));
+    double shifted = number - twoTo63;
+    int64_t fromShifted;
+    __asm__("cvttsd2si %1, %0" : "=r"(fromShifted) : "x"(shifted));
+    int64_t mask = direct >> 63;
+    return static_cast<uint64_t>((fromShifted & mask) | direct);
+#else
+    if (std::isnan(number) || !std::isfinite(number))
+        return 0;
+    if (number < 0.0)
+        return 0;
+    if (number >= 18446744073709551616.0)
+        return UINT64_MAX;
+    // For values >= 2^63, split into high and low halves to avoid UB.
+    constexpr double twoTo63 = 9223372036854775808.0;
+    if (number >= twoTo63) {
+        int64_t lo = static_cast<int64_t>(number - twoTo63);
+        return static_cast<uint64_t>(lo) + static_cast<uint64_t>(twoTo63);
+    }
+    return static_cast<uint64_t>(static_cast<int64_t>(number));
+#endif
+#endif
+}
+
+// Float-to-integer truncation helpers.
+
+ALWAYS_INLINE int32_t truncateFloatToInt32(float number)
+{
+#if CPU(ARM64)
+    return vcvts_s32_f32(number);
+#else
+    if (WTF_PROVEN_TRUE(number > -2147483649.0f && number < 2147483648.0f))
+        return static_cast<int32_t>(number);
+#if CPU(X86_64)
+    // cvttss2si eax, xmm0
+    int32_t result;
+    __asm__("cvttss2si %1, %0" : "=r"(result) : "x"(number));
+    return result;
+#else
+    if (std::isnan(number) || !std::isfinite(number))
+        return 0;
+    if (number > 0) {
+        if (number >= static_cast<float>(INT32_MAX) + 1.0f)
+            return INT32_MIN;
+        return static_cast<int32_t>(number);
+    }
+    if (number < static_cast<float>(INT32_MIN))
+        return INT32_MIN;
+    return static_cast<int32_t>(number);
+#endif
+#endif
+}
+
+ALWAYS_INLINE int64_t truncateFloatToInt64(float number)
+{
+    if (WTF_PROVEN_TRUE(number >= -9223372036854775808.0f && number < 9223372036854775808.0f))
+        return static_cast<int64_t>(number);
+#if CPU(X86_64)
+    // cvttss2si rax, xmm0
+    int64_t result;
+    __asm__("cvttss2si %1, %0" : "=r"(result) : "x"(number));
+    return result;
+#elif CPU(ARM64)
+    // fcvtzs x0, s0
+    int64_t result;
+    __asm__("fcvtzs %x0, %s1" : "=r"(result) : "w"(number));
+    return result;
+#else
+    if (std::isnan(number) || !std::isfinite(number))
+        return 0;
+    if (number > 0) {
+        if (number >= static_cast<float>(INT64_MAX) + 1.0f)
+            return INT64_MIN;
+        return static_cast<int64_t>(number);
+    }
+    if (number < static_cast<float>(INT64_MIN))
+        return INT64_MIN;
+    return static_cast<int64_t>(number);
+#endif
+}
+
+ALWAYS_INLINE uint32_t truncateFloatToUint32(float number)
+{
+    if (WTF_PROVEN_TRUE(number >= 0.0f && number < 4294967296.0f))
+        return static_cast<uint32_t>(number);
+#if CPU(X86_64)
+    // cvttss2si rax, xmm0 (64-bit signed, return low 32 bits)
+    int64_t result;
+    __asm__("cvttss2si %1, %0" : "=r"(result) : "x"(number));
+    return static_cast<uint32_t>(result);
+#elif CPU(ARM64)
+    return vcvts_u32_f32(number);
+#else
+    if (std::isnan(number) || !std::isfinite(number))
+        return 0;
+    int64_t wide = truncateFloatToInt64(number);
+    return static_cast<uint32_t>(wide);
+#endif
+}
+
+ALWAYS_INLINE uint64_t truncateFloatToUint64(float number)
+{
+    if (WTF_PROVEN_TRUE(number >= 0.0f && number < 18446744073709551616.0f))
+        return static_cast<uint64_t>(number);
+#if CPU(X86_64)
+    // Branchless conversion matching compiler codegen for static_cast<uint64_t>(float).
+    constexpr float twoTo63 = 9223372036854775808.0f; // 0x5f000000
+    int64_t direct;
+    __asm__("cvttss2si %1, %0" : "=r"(direct) : "x"(number));
+    float shifted = number - twoTo63;
+    int64_t fromShifted;
+    __asm__("cvttss2si %1, %0" : "=r"(fromShifted) : "x"(shifted));
+    int64_t mask = direct >> 63;
+    return static_cast<uint64_t>((fromShifted & mask) | direct);
+#elif CPU(ARM64)
+    // fcvtzu x0, s0
+    uint64_t result;
+    __asm__("fcvtzu %x0, %s1" : "=r"(result) : "w"(number));
+    return result;
+#else
+    if (std::isnan(number) || !std::isfinite(number))
+        return 0;
+    if (number < 0.0f)
+        return 0;
+    if (number >= 18446744073709551616.0f)
+        return UINT64_MAX;
+    constexpr float twoTo63 = 9223372036854775808.0f;
+    if (number >= twoTo63) {
+        int64_t lo = static_cast<int64_t>(number - twoTo63);
+        return static_cast<uint64_t>(lo) + static_cast<uint64_t>(twoTo63);
+    }
+    return static_cast<uint64_t>(static_cast<int64_t>(number));
+#endif
+}
+
+// tryConvertToStrictInt32: Attempts to convert a double to int32_t, returning
+// std::nullopt if the value is not exactly representable as int32 (including
+// -0.0, NaN, Infinity, non-integer values, and out-of-range values).
+ALWAYS_INLINE std::optional<int32_t> tryConvertToStrictInt32(double value)
+{
+#if HAVE(FJCVTZS_INSTRUCTION)
+    int32_t result;
+    bool isExact;
+    // Unlike other conversions on ARM, fjcvtzs sets the zero flag when no rounding occurred.
+    __asm__(
+        "fjcvtzs %w0, %d2"
+        : "=r" (result), "=@cceq" (isExact)
+        : "w" (value)
+        : "cc");
+    if (isExact)
+        return result;
+    return std::nullopt;
+#else
+    if (std::isinf(value) || std::isnan(value))
+        return std::nullopt;
+
+    // Note that -0.0 is not StrictInt32.
+    const int32_t asInt32 = truncateDoubleToInt32(value);
+    if (!(asInt32 != value || (!asInt32 && std::signbit(value))))
+        return asInt32;
+
+    return std::nullopt;
+#endif
+}
+
 } // namespace WTF
 
 using WTF::shuffleVector;
@@ -864,3 +1142,12 @@ using WTF::roundUpToPowerOfTwo;
 using WTF::isIdentical;
 using WTF::isRepresentableAs;
 using WTF::isPowerOfTwo;
+using WTF::truncateDoubleToInt32;
+using WTF::truncateDoubleToInt64;
+using WTF::truncateDoubleToUint32;
+using WTF::truncateDoubleToUint64;
+using WTF::truncateFloatToInt32;
+using WTF::truncateFloatToInt64;
+using WTF::truncateFloatToUint32;
+using WTF::truncateFloatToUint64;
+using WTF::tryConvertToStrictInt32;

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -130,6 +130,7 @@ set(TestWTF_SOURCES
     Tests/WTF/ThreadMessages.cpp
     Tests/WTF/Threading.cpp
     Tests/WTF/Time.cpp
+    Tests/WTF/TruncateFloat.cpp
     Tests/WTF/URL.cpp
     Tests/WTF/URLParser.cpp
     Tests/WTF/UTF8Conversion.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1538,6 +1538,7 @@
 		FE9CD7E42D10CE7500266FDD /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 574F55D0204D471C002948C6 /* Security.framework */; };
 		FEC2A85424CE975F00ADBC35 /* DisallowVMEntry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FEC2A85324CE974E00ADBC35 /* DisallowVMEntry.cpp */; };
 		FEC2A85624CEB65F00ADBC35 /* PropertySlot.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FEC2A85524CEB65F00ADBC35 /* PropertySlot.cpp */; };
+		FEC2A85826D0A00000ADBC35 /* TruncateFloat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FEC2A85726D0A00000ADBC35 /* TruncateFloat.cpp */; };
 		FF10AAF92831B1E600B9875B /* CompactPtr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FF10AAF82831B1E600B9875B /* CompactPtr.cpp */; };
 		FF41AC702A79CAA000AC0FA5 /* WYHash.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FF41AC682A79CAA000AC0FA5 /* WYHash.cpp */; };
 		FF5D0CB4283221AD00F3278A /* CompactRefPtr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FF5D0CB3283221AD00F3278A /* CompactRefPtr.cpp */; };
@@ -4542,6 +4543,7 @@
 		FEB6F74E1B2BA44E009E4922 /* NakedPtr.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NakedPtr.cpp; sourceTree = "<group>"; };
 		FEC2A85324CE974E00ADBC35 /* DisallowVMEntry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DisallowVMEntry.cpp; sourceTree = "<group>"; };
 		FEC2A85524CEB65F00ADBC35 /* PropertySlot.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PropertySlot.cpp; sourceTree = "<group>"; };
+		FEC2A85726D0A00000ADBC35 /* TruncateFloat.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TruncateFloat.cpp; sourceTree = "<group>"; };
 		FF10AAF82831B1E600B9875B /* CompactPtr.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CompactPtr.cpp; sourceTree = "<group>"; };
 		FF25942A2834B7A7006892D6 /* AlignedRefLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AlignedRefLogger.h; sourceTree = "<group>"; };
 		FF41AC682A79CAA000AC0FA5 /* WYHash.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WYHash.cpp; sourceTree = "<group>"; };
@@ -6647,6 +6649,7 @@
 				E38A0D341FD50CBC00E98C8B /* Threading.cpp */,
 				5311BD5D1EA9490D00525281 /* ThreadMessages.cpp */,
 				0F2C20B71DCD544800542D9E /* Time.cpp */,
+				FEC2A85726D0A00000ADBC35 /* TruncateFloat.cpp */,
 				E398BC0F2041C76300387136 /* UniqueArray.cpp */,
 				5C5E633D1D0B67940085A025 /* UniqueRef.cpp */,
 				3A1337AB28F9177600F29B73 /* UniqueRefVector.cpp */,
@@ -7851,6 +7854,7 @@
 				E38A0D351FD50CC300E98C8B /* Threading.cpp in Sources */,
 				5311BD5E1EA9490E00525281 /* ThreadMessages.cpp in Sources */,
 				0F2C20B81DCD545000542D9E /* Time.cpp in Sources */,
+				FEC2A85826D0A00000ADBC35 /* TruncateFloat.cpp in Sources */,
 				44CDE4D426EE6E4A009F6ACB /* TypeCastsCocoa.mm in Sources */,
 				44652CB726FCD405005EC272 /* TypeCastsCocoaARC.mm in Sources */,
 				4482E8E02D94710800754D28 /* TypeCastsOSObjectCF.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WTF/TruncateFloat.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/TruncateFloat.cpp
@@ -1,0 +1,500 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <cmath>
+#include <limits>
+#include <wtf/MathExtras.h>
+
+namespace TestWebKitAPI {
+
+// Prevent constant folding so we exercise the inline-asm path.
+template<typename T>
+NEVER_INLINE static T opaque(T value) { return value; }
+
+// ---- truncateDoubleToInt32 ----
+
+TEST(WTF_MathExtras, TruncateDoubleToInt32_InRange)
+{
+    EXPECT_EQ(truncateDoubleToInt32(0.0), 0);
+    EXPECT_EQ(truncateDoubleToInt32(-0.0), 0);
+    EXPECT_EQ(truncateDoubleToInt32(1.0), 1);
+    EXPECT_EQ(truncateDoubleToInt32(-1.0), -1);
+    EXPECT_EQ(truncateDoubleToInt32(0.5), 0);
+    EXPECT_EQ(truncateDoubleToInt32(-0.5), 0);
+    EXPECT_EQ(truncateDoubleToInt32(0.9), 0);
+    EXPECT_EQ(truncateDoubleToInt32(-0.9), 0);
+    EXPECT_EQ(truncateDoubleToInt32(100.7), 100);
+    EXPECT_EQ(truncateDoubleToInt32(-100.7), -100);
+    EXPECT_EQ(truncateDoubleToInt32(2147483647.0), INT32_MAX);
+    EXPECT_EQ(truncateDoubleToInt32(-2147483648.0), INT32_MIN);
+    EXPECT_EQ(truncateDoubleToInt32(std::numeric_limits<double>::epsilon()), 0);
+    EXPECT_EQ(truncateDoubleToInt32(std::numeric_limits<double>::denorm_min()), 0);
+    EXPECT_EQ(truncateDoubleToInt32(-std::numeric_limits<double>::denorm_min()), 0);
+}
+
+TEST(WTF_MathExtras, TruncateDoubleToInt32_InRange_Opaque)
+{
+    EXPECT_EQ(truncateDoubleToInt32(opaque(0.0)), 0);
+    EXPECT_EQ(truncateDoubleToInt32(opaque(-0.0)), 0);
+    EXPECT_EQ(truncateDoubleToInt32(opaque(1.0)), 1);
+    EXPECT_EQ(truncateDoubleToInt32(opaque(-1.0)), -1);
+    EXPECT_EQ(truncateDoubleToInt32(opaque(0.5)), 0);
+    EXPECT_EQ(truncateDoubleToInt32(opaque(-0.5)), 0);
+    EXPECT_EQ(truncateDoubleToInt32(opaque(0.9)), 0);
+    EXPECT_EQ(truncateDoubleToInt32(opaque(-0.9)), 0);
+    EXPECT_EQ(truncateDoubleToInt32(opaque(100.7)), 100);
+    EXPECT_EQ(truncateDoubleToInt32(opaque(-100.7)), -100);
+    EXPECT_EQ(truncateDoubleToInt32(opaque(2147483647.0)), INT32_MAX);
+    EXPECT_EQ(truncateDoubleToInt32(opaque(-2147483648.0)), INT32_MIN);
+    EXPECT_EQ(truncateDoubleToInt32(opaque(std::numeric_limits<double>::epsilon())), 0);
+    EXPECT_EQ(truncateDoubleToInt32(opaque(std::numeric_limits<double>::denorm_min())), 0);
+    EXPECT_EQ(truncateDoubleToInt32(opaque(-std::numeric_limits<double>::denorm_min())), 0);
+}
+
+TEST(WTF_MathExtras, TruncateDoubleToInt32_OutOfRange)
+{
+    (void)truncateDoubleToInt32(opaque(2147483648.0));
+    (void)truncateDoubleToInt32(opaque(-2147483649.0));
+    (void)truncateDoubleToInt32(opaque(std::numeric_limits<double>::quiet_NaN()));
+    (void)truncateDoubleToInt32(opaque(std::numeric_limits<double>::signaling_NaN()));
+    (void)truncateDoubleToInt32(opaque(-std::numeric_limits<double>::quiet_NaN()));
+    (void)truncateDoubleToInt32(opaque(std::numeric_limits<double>::infinity()));
+    (void)truncateDoubleToInt32(opaque(-std::numeric_limits<double>::infinity()));
+    (void)truncateDoubleToInt32(opaque(std::numeric_limits<double>::max()));
+    (void)truncateDoubleToInt32(opaque(std::numeric_limits<double>::lowest()));
+    (void)truncateDoubleToInt32(opaque(4294967296.0));
+    (void)truncateDoubleToInt32(opaque(static_cast<double>(1ULL << 52)));
+    (void)truncateDoubleToInt32(opaque(static_cast<double>(1ULL << 53)));
+}
+
+// ---- truncateDoubleToUint32 ----
+
+TEST(WTF_MathExtras, TruncateDoubleToUint32_InRange)
+{
+    EXPECT_EQ(truncateDoubleToUint32(0.0), 0u);
+    EXPECT_EQ(truncateDoubleToUint32(-0.0), 0u);
+    EXPECT_EQ(truncateDoubleToUint32(1.0), 1u);
+    EXPECT_EQ(truncateDoubleToUint32(0.5), 0u);
+    EXPECT_EQ(truncateDoubleToUint32(0.9), 0u);
+    EXPECT_EQ(truncateDoubleToUint32(100.7), 100u);
+    EXPECT_EQ(truncateDoubleToUint32(4294967295.0), UINT32_MAX);
+    EXPECT_EQ(truncateDoubleToUint32(2147483647.0), 2147483647u);
+    EXPECT_EQ(truncateDoubleToUint32(2147483648.0), 2147483648u);
+    EXPECT_EQ(truncateDoubleToUint32(std::numeric_limits<double>::epsilon()), 0u);
+    EXPECT_EQ(truncateDoubleToUint32(std::numeric_limits<double>::denorm_min()), 0u);
+}
+
+TEST(WTF_MathExtras, TruncateDoubleToUint32_InRange_Opaque)
+{
+    EXPECT_EQ(truncateDoubleToUint32(opaque(0.0)), 0u);
+    EXPECT_EQ(truncateDoubleToUint32(opaque(-0.0)), 0u);
+    EXPECT_EQ(truncateDoubleToUint32(opaque(1.0)), 1u);
+    EXPECT_EQ(truncateDoubleToUint32(opaque(0.5)), 0u);
+    EXPECT_EQ(truncateDoubleToUint32(opaque(0.9)), 0u);
+    EXPECT_EQ(truncateDoubleToUint32(opaque(100.7)), 100u);
+    EXPECT_EQ(truncateDoubleToUint32(opaque(4294967295.0)), UINT32_MAX);
+    EXPECT_EQ(truncateDoubleToUint32(opaque(2147483647.0)), 2147483647u);
+    EXPECT_EQ(truncateDoubleToUint32(opaque(2147483648.0)), 2147483648u);
+    EXPECT_EQ(truncateDoubleToUint32(opaque(std::numeric_limits<double>::epsilon())), 0u);
+    EXPECT_EQ(truncateDoubleToUint32(opaque(std::numeric_limits<double>::denorm_min())), 0u);
+}
+
+TEST(WTF_MathExtras, TruncateDoubleToUint32_OutOfRange)
+{
+    (void)truncateDoubleToUint32(opaque(-1.0));
+    (void)truncateDoubleToUint32(opaque(-0.5));
+    (void)truncateDoubleToUint32(opaque(4294967296.0));
+    (void)truncateDoubleToUint32(opaque(std::numeric_limits<double>::quiet_NaN()));
+    (void)truncateDoubleToUint32(opaque(std::numeric_limits<double>::signaling_NaN()));
+    (void)truncateDoubleToUint32(opaque(-std::numeric_limits<double>::quiet_NaN()));
+    (void)truncateDoubleToUint32(opaque(std::numeric_limits<double>::infinity()));
+    (void)truncateDoubleToUint32(opaque(-std::numeric_limits<double>::infinity()));
+    (void)truncateDoubleToUint32(opaque(std::numeric_limits<double>::max()));
+    (void)truncateDoubleToUint32(opaque(std::numeric_limits<double>::lowest()));
+}
+
+// ---- truncateDoubleToInt64 ----
+
+TEST(WTF_MathExtras, TruncateDoubleToInt64_InRange)
+{
+    EXPECT_EQ(truncateDoubleToInt64(0.0), 0LL);
+    EXPECT_EQ(truncateDoubleToInt64(-0.0), 0LL);
+    EXPECT_EQ(truncateDoubleToInt64(1.0), 1LL);
+    EXPECT_EQ(truncateDoubleToInt64(-1.0), -1LL);
+    EXPECT_EQ(truncateDoubleToInt64(0.5), 0LL);
+    EXPECT_EQ(truncateDoubleToInt64(-0.5), 0LL);
+    EXPECT_EQ(truncateDoubleToInt64(0.9), 0LL);
+    EXPECT_EQ(truncateDoubleToInt64(-0.9), 0LL);
+    EXPECT_EQ(truncateDoubleToInt64(2147483647.0), 2147483647LL);
+    EXPECT_EQ(truncateDoubleToInt64(-2147483648.0), -2147483648LL);
+    EXPECT_EQ(truncateDoubleToInt64(2147483648.0), 2147483648LL);
+    EXPECT_EQ(truncateDoubleToInt64(-2147483649.0), -2147483649LL);
+    EXPECT_EQ(truncateDoubleToInt64(4294967295.0), 4294967295LL);
+    EXPECT_EQ(truncateDoubleToInt64(4294967296.0), 4294967296LL);
+    EXPECT_EQ(truncateDoubleToInt64(static_cast<double>(1LL << 52)), (1LL << 52));
+    EXPECT_EQ(truncateDoubleToInt64(std::numeric_limits<double>::epsilon()), 0LL);
+    EXPECT_EQ(truncateDoubleToInt64(std::numeric_limits<double>::denorm_min()), 0LL);
+    EXPECT_EQ(truncateDoubleToInt64(-std::numeric_limits<double>::denorm_min()), 0LL);
+}
+
+TEST(WTF_MathExtras, TruncateDoubleToInt64_InRange_Opaque)
+{
+    EXPECT_EQ(truncateDoubleToInt64(opaque(0.0)), 0LL);
+    EXPECT_EQ(truncateDoubleToInt64(opaque(-0.0)), 0LL);
+    EXPECT_EQ(truncateDoubleToInt64(opaque(1.0)), 1LL);
+    EXPECT_EQ(truncateDoubleToInt64(opaque(-1.0)), -1LL);
+    EXPECT_EQ(truncateDoubleToInt64(opaque(0.5)), 0LL);
+    EXPECT_EQ(truncateDoubleToInt64(opaque(-0.5)), 0LL);
+    EXPECT_EQ(truncateDoubleToInt64(opaque(0.9)), 0LL);
+    EXPECT_EQ(truncateDoubleToInt64(opaque(-0.9)), 0LL);
+    EXPECT_EQ(truncateDoubleToInt64(opaque(2147483647.0)), 2147483647LL);
+    EXPECT_EQ(truncateDoubleToInt64(opaque(-2147483648.0)), -2147483648LL);
+    EXPECT_EQ(truncateDoubleToInt64(opaque(2147483648.0)), 2147483648LL);
+    EXPECT_EQ(truncateDoubleToInt64(opaque(-2147483649.0)), -2147483649LL);
+    EXPECT_EQ(truncateDoubleToInt64(opaque(4294967295.0)), 4294967295LL);
+    EXPECT_EQ(truncateDoubleToInt64(opaque(4294967296.0)), 4294967296LL);
+    EXPECT_EQ(truncateDoubleToInt64(opaque(static_cast<double>(1LL << 52))), (1LL << 52));
+    EXPECT_EQ(truncateDoubleToInt64(opaque(std::numeric_limits<double>::epsilon())), 0LL);
+    EXPECT_EQ(truncateDoubleToInt64(opaque(std::numeric_limits<double>::denorm_min())), 0LL);
+    EXPECT_EQ(truncateDoubleToInt64(opaque(-std::numeric_limits<double>::denorm_min())), 0LL);
+}
+
+TEST(WTF_MathExtras, TruncateDoubleToInt64_OutOfRange)
+{
+    (void)truncateDoubleToInt64(opaque(static_cast<double>(INT64_MAX)));
+    (void)truncateDoubleToInt64(opaque(static_cast<double>(INT64_MIN)));
+    (void)truncateDoubleToInt64(opaque(std::numeric_limits<double>::quiet_NaN()));
+    (void)truncateDoubleToInt64(opaque(std::numeric_limits<double>::signaling_NaN()));
+    (void)truncateDoubleToInt64(opaque(-std::numeric_limits<double>::quiet_NaN()));
+    (void)truncateDoubleToInt64(opaque(std::numeric_limits<double>::infinity()));
+    (void)truncateDoubleToInt64(opaque(-std::numeric_limits<double>::infinity()));
+    (void)truncateDoubleToInt64(opaque(std::numeric_limits<double>::max()));
+    (void)truncateDoubleToInt64(opaque(std::numeric_limits<double>::lowest()));
+    (void)truncateDoubleToInt64(opaque(static_cast<double>(1ULL << 53)));
+}
+
+// ---- truncateDoubleToUint64 ----
+
+TEST(WTF_MathExtras, TruncateDoubleToUint64_InRange)
+{
+    EXPECT_EQ(truncateDoubleToUint64(0.0), 0ULL);
+    EXPECT_EQ(truncateDoubleToUint64(-0.0), 0ULL);
+    EXPECT_EQ(truncateDoubleToUint64(1.0), 1ULL);
+    EXPECT_EQ(truncateDoubleToUint64(0.5), 0ULL);
+    EXPECT_EQ(truncateDoubleToUint64(0.9), 0ULL);
+    EXPECT_EQ(truncateDoubleToUint64(4294967295.0), 4294967295ULL);
+    EXPECT_EQ(truncateDoubleToUint64(4294967296.0), 4294967296ULL);
+    EXPECT_EQ(truncateDoubleToUint64(static_cast<double>(1ULL << 52)), (1ULL << 52));
+    EXPECT_EQ(truncateDoubleToUint64(std::numeric_limits<double>::epsilon()), 0ULL);
+    EXPECT_EQ(truncateDoubleToUint64(std::numeric_limits<double>::denorm_min()), 0ULL);
+}
+
+TEST(WTF_MathExtras, TruncateDoubleToUint64_InRange_Opaque)
+{
+    EXPECT_EQ(truncateDoubleToUint64(opaque(0.0)), 0ULL);
+    EXPECT_EQ(truncateDoubleToUint64(opaque(-0.0)), 0ULL);
+    EXPECT_EQ(truncateDoubleToUint64(opaque(1.0)), 1ULL);
+    EXPECT_EQ(truncateDoubleToUint64(opaque(0.5)), 0ULL);
+    EXPECT_EQ(truncateDoubleToUint64(opaque(0.9)), 0ULL);
+    EXPECT_EQ(truncateDoubleToUint64(opaque(4294967295.0)), 4294967295ULL);
+    EXPECT_EQ(truncateDoubleToUint64(opaque(4294967296.0)), 4294967296ULL);
+    EXPECT_EQ(truncateDoubleToUint64(opaque(static_cast<double>(1ULL << 52))), (1ULL << 52));
+    EXPECT_EQ(truncateDoubleToUint64(opaque(std::numeric_limits<double>::epsilon())), 0ULL);
+    EXPECT_EQ(truncateDoubleToUint64(opaque(std::numeric_limits<double>::denorm_min())), 0ULL);
+}
+
+TEST(WTF_MathExtras, TruncateDoubleToUint64_OutOfRange)
+{
+    (void)truncateDoubleToUint64(opaque(-1.0));
+    (void)truncateDoubleToUint64(opaque(-0.5));
+    (void)truncateDoubleToUint64(opaque(std::numeric_limits<double>::quiet_NaN()));
+    (void)truncateDoubleToUint64(opaque(std::numeric_limits<double>::signaling_NaN()));
+    (void)truncateDoubleToUint64(opaque(-std::numeric_limits<double>::quiet_NaN()));
+    (void)truncateDoubleToUint64(opaque(std::numeric_limits<double>::infinity()));
+    (void)truncateDoubleToUint64(opaque(-std::numeric_limits<double>::infinity()));
+    (void)truncateDoubleToUint64(opaque(std::numeric_limits<double>::max()));
+    (void)truncateDoubleToUint64(opaque(std::numeric_limits<double>::lowest()));
+}
+
+// ---- truncateFloatToInt32 ----
+
+TEST(WTF_MathExtras, TruncateFloatToInt32_InRange)
+{
+    EXPECT_EQ(truncateFloatToInt32(0.0f), 0);
+    EXPECT_EQ(truncateFloatToInt32(-0.0f), 0);
+    EXPECT_EQ(truncateFloatToInt32(1.0f), 1);
+    EXPECT_EQ(truncateFloatToInt32(-1.0f), -1);
+    EXPECT_EQ(truncateFloatToInt32(0.5f), 0);
+    EXPECT_EQ(truncateFloatToInt32(-0.5f), 0);
+    EXPECT_EQ(truncateFloatToInt32(0.9f), 0);
+    EXPECT_EQ(truncateFloatToInt32(-0.9f), 0);
+    EXPECT_EQ(truncateFloatToInt32(100.7f), 100);
+    EXPECT_EQ(truncateFloatToInt32(-100.7f), -100);
+    EXPECT_EQ(truncateFloatToInt32(std::numeric_limits<float>::epsilon()), 0);
+    EXPECT_EQ(truncateFloatToInt32(std::numeric_limits<float>::denorm_min()), 0);
+    EXPECT_EQ(truncateFloatToInt32(-std::numeric_limits<float>::denorm_min()), 0);
+}
+
+TEST(WTF_MathExtras, TruncateFloatToInt32_InRange_Opaque)
+{
+    EXPECT_EQ(truncateFloatToInt32(opaque(0.0f)), 0);
+    EXPECT_EQ(truncateFloatToInt32(opaque(-0.0f)), 0);
+    EXPECT_EQ(truncateFloatToInt32(opaque(1.0f)), 1);
+    EXPECT_EQ(truncateFloatToInt32(opaque(-1.0f)), -1);
+    EXPECT_EQ(truncateFloatToInt32(opaque(0.5f)), 0);
+    EXPECT_EQ(truncateFloatToInt32(opaque(-0.5f)), 0);
+    EXPECT_EQ(truncateFloatToInt32(opaque(0.9f)), 0);
+    EXPECT_EQ(truncateFloatToInt32(opaque(-0.9f)), 0);
+    EXPECT_EQ(truncateFloatToInt32(opaque(100.7f)), 100);
+    EXPECT_EQ(truncateFloatToInt32(opaque(-100.7f)), -100);
+    EXPECT_EQ(truncateFloatToInt32(opaque(std::numeric_limits<float>::epsilon())), 0);
+    EXPECT_EQ(truncateFloatToInt32(opaque(std::numeric_limits<float>::denorm_min())), 0);
+    EXPECT_EQ(truncateFloatToInt32(opaque(-std::numeric_limits<float>::denorm_min())), 0);
+}
+
+TEST(WTF_MathExtras, TruncateFloatToInt32_OutOfRange)
+{
+    (void)truncateFloatToInt32(opaque(static_cast<float>(INT32_MAX) + 1.0f));
+    (void)truncateFloatToInt32(opaque(static_cast<float>(INT32_MIN) - 1.0f));
+    (void)truncateFloatToInt32(opaque(std::numeric_limits<float>::quiet_NaN()));
+    (void)truncateFloatToInt32(opaque(std::numeric_limits<float>::signaling_NaN()));
+    (void)truncateFloatToInt32(opaque(-std::numeric_limits<float>::quiet_NaN()));
+    (void)truncateFloatToInt32(opaque(std::numeric_limits<float>::infinity()));
+    (void)truncateFloatToInt32(opaque(-std::numeric_limits<float>::infinity()));
+    (void)truncateFloatToInt32(opaque(std::numeric_limits<float>::max()));
+    (void)truncateFloatToInt32(opaque(std::numeric_limits<float>::lowest()));
+}
+
+// ---- truncateFloatToUint32 ----
+
+TEST(WTF_MathExtras, TruncateFloatToUint32_InRange)
+{
+    EXPECT_EQ(truncateFloatToUint32(0.0f), 0u);
+    EXPECT_EQ(truncateFloatToUint32(-0.0f), 0u);
+    EXPECT_EQ(truncateFloatToUint32(1.0f), 1u);
+    EXPECT_EQ(truncateFloatToUint32(0.5f), 0u);
+    EXPECT_EQ(truncateFloatToUint32(0.9f), 0u);
+    EXPECT_EQ(truncateFloatToUint32(100.7f), 100u);
+    EXPECT_EQ(truncateFloatToUint32(std::numeric_limits<float>::epsilon()), 0u);
+    EXPECT_EQ(truncateFloatToUint32(std::numeric_limits<float>::denorm_min()), 0u);
+}
+
+TEST(WTF_MathExtras, TruncateFloatToUint32_InRange_Opaque)
+{
+    EXPECT_EQ(truncateFloatToUint32(opaque(0.0f)), 0u);
+    EXPECT_EQ(truncateFloatToUint32(opaque(-0.0f)), 0u);
+    EXPECT_EQ(truncateFloatToUint32(opaque(1.0f)), 1u);
+    EXPECT_EQ(truncateFloatToUint32(opaque(0.5f)), 0u);
+    EXPECT_EQ(truncateFloatToUint32(opaque(0.9f)), 0u);
+    EXPECT_EQ(truncateFloatToUint32(opaque(100.7f)), 100u);
+    EXPECT_EQ(truncateFloatToUint32(opaque(std::numeric_limits<float>::epsilon())), 0u);
+    EXPECT_EQ(truncateFloatToUint32(opaque(std::numeric_limits<float>::denorm_min())), 0u);
+}
+
+TEST(WTF_MathExtras, TruncateFloatToUint32_OutOfRange)
+{
+    (void)truncateFloatToUint32(opaque(-1.0f));
+    (void)truncateFloatToUint32(opaque(-0.5f));
+    (void)truncateFloatToUint32(opaque(std::numeric_limits<float>::quiet_NaN()));
+    (void)truncateFloatToUint32(opaque(std::numeric_limits<float>::signaling_NaN()));
+    (void)truncateFloatToUint32(opaque(-std::numeric_limits<float>::quiet_NaN()));
+    (void)truncateFloatToUint32(opaque(std::numeric_limits<float>::infinity()));
+    (void)truncateFloatToUint32(opaque(-std::numeric_limits<float>::infinity()));
+    (void)truncateFloatToUint32(opaque(std::numeric_limits<float>::max()));
+    (void)truncateFloatToUint32(opaque(std::numeric_limits<float>::lowest()));
+}
+
+// ---- truncateFloatToInt64 ----
+
+TEST(WTF_MathExtras, TruncateFloatToInt64_InRange)
+{
+    EXPECT_EQ(truncateFloatToInt64(0.0f), 0LL);
+    EXPECT_EQ(truncateFloatToInt64(-0.0f), 0LL);
+    EXPECT_EQ(truncateFloatToInt64(1.0f), 1LL);
+    EXPECT_EQ(truncateFloatToInt64(-1.0f), -1LL);
+    EXPECT_EQ(truncateFloatToInt64(0.5f), 0LL);
+    EXPECT_EQ(truncateFloatToInt64(-0.5f), 0LL);
+    EXPECT_EQ(truncateFloatToInt64(100.7f), 100LL);
+    EXPECT_EQ(truncateFloatToInt64(-100.7f), -100LL);
+    EXPECT_EQ(truncateFloatToInt64(std::numeric_limits<float>::epsilon()), 0LL);
+    EXPECT_EQ(truncateFloatToInt64(std::numeric_limits<float>::denorm_min()), 0LL);
+    EXPECT_EQ(truncateFloatToInt64(-std::numeric_limits<float>::denorm_min()), 0LL);
+}
+
+TEST(WTF_MathExtras, TruncateFloatToInt64_InRange_Opaque)
+{
+    EXPECT_EQ(truncateFloatToInt64(opaque(0.0f)), 0LL);
+    EXPECT_EQ(truncateFloatToInt64(opaque(-0.0f)), 0LL);
+    EXPECT_EQ(truncateFloatToInt64(opaque(1.0f)), 1LL);
+    EXPECT_EQ(truncateFloatToInt64(opaque(-1.0f)), -1LL);
+    EXPECT_EQ(truncateFloatToInt64(opaque(0.5f)), 0LL);
+    EXPECT_EQ(truncateFloatToInt64(opaque(-0.5f)), 0LL);
+    EXPECT_EQ(truncateFloatToInt64(opaque(100.7f)), 100LL);
+    EXPECT_EQ(truncateFloatToInt64(opaque(-100.7f)), -100LL);
+    EXPECT_EQ(truncateFloatToInt64(opaque(std::numeric_limits<float>::epsilon())), 0LL);
+    EXPECT_EQ(truncateFloatToInt64(opaque(std::numeric_limits<float>::denorm_min())), 0LL);
+    EXPECT_EQ(truncateFloatToInt64(opaque(-std::numeric_limits<float>::denorm_min())), 0LL);
+}
+
+TEST(WTF_MathExtras, TruncateFloatToInt64_OutOfRange)
+{
+    (void)truncateFloatToInt64(opaque(static_cast<float>(INT64_MAX)));
+    (void)truncateFloatToInt64(opaque(static_cast<float>(INT64_MIN)));
+    (void)truncateFloatToInt64(opaque(std::numeric_limits<float>::quiet_NaN()));
+    (void)truncateFloatToInt64(opaque(std::numeric_limits<float>::signaling_NaN()));
+    (void)truncateFloatToInt64(opaque(-std::numeric_limits<float>::quiet_NaN()));
+    (void)truncateFloatToInt64(opaque(std::numeric_limits<float>::infinity()));
+    (void)truncateFloatToInt64(opaque(-std::numeric_limits<float>::infinity()));
+    (void)truncateFloatToInt64(opaque(std::numeric_limits<float>::max()));
+    (void)truncateFloatToInt64(opaque(std::numeric_limits<float>::lowest()));
+}
+
+// ---- truncateFloatToUint64 ----
+
+TEST(WTF_MathExtras, TruncateFloatToUint64_InRange)
+{
+    EXPECT_EQ(truncateFloatToUint64(0.0f), 0ULL);
+    EXPECT_EQ(truncateFloatToUint64(-0.0f), 0ULL);
+    EXPECT_EQ(truncateFloatToUint64(1.0f), 1ULL);
+    EXPECT_EQ(truncateFloatToUint64(0.5f), 0ULL);
+    EXPECT_EQ(truncateFloatToUint64(100.7f), 100ULL);
+    EXPECT_EQ(truncateFloatToUint64(std::numeric_limits<float>::epsilon()), 0ULL);
+    EXPECT_EQ(truncateFloatToUint64(std::numeric_limits<float>::denorm_min()), 0ULL);
+}
+
+TEST(WTF_MathExtras, TruncateFloatToUint64_InRange_Opaque)
+{
+    EXPECT_EQ(truncateFloatToUint64(opaque(0.0f)), 0ULL);
+    EXPECT_EQ(truncateFloatToUint64(opaque(-0.0f)), 0ULL);
+    EXPECT_EQ(truncateFloatToUint64(opaque(1.0f)), 1ULL);
+    EXPECT_EQ(truncateFloatToUint64(opaque(0.5f)), 0ULL);
+    EXPECT_EQ(truncateFloatToUint64(opaque(100.7f)), 100ULL);
+    EXPECT_EQ(truncateFloatToUint64(opaque(std::numeric_limits<float>::epsilon())), 0ULL);
+    EXPECT_EQ(truncateFloatToUint64(opaque(std::numeric_limits<float>::denorm_min())), 0ULL);
+}
+
+TEST(WTF_MathExtras, TruncateFloatToUint64_OutOfRange)
+{
+    (void)truncateFloatToUint64(opaque(-1.0f));
+    (void)truncateFloatToUint64(opaque(-0.5f));
+    (void)truncateFloatToUint64(opaque(std::numeric_limits<float>::quiet_NaN()));
+    (void)truncateFloatToUint64(opaque(std::numeric_limits<float>::signaling_NaN()));
+    (void)truncateFloatToUint64(opaque(-std::numeric_limits<float>::quiet_NaN()));
+    (void)truncateFloatToUint64(opaque(std::numeric_limits<float>::infinity()));
+    (void)truncateFloatToUint64(opaque(-std::numeric_limits<float>::infinity()));
+    (void)truncateFloatToUint64(opaque(std::numeric_limits<float>::max()));
+    (void)truncateFloatToUint64(opaque(std::numeric_limits<float>::lowest()));
+}
+
+// ---- tryConvertToStrictInt32 ----
+// This must produce identical results across all architectures.
+
+TEST(WTF_MathExtras, TryConvertToStrictInt32_ExactIntegers)
+{
+    EXPECT_EQ(tryConvertToStrictInt32(0.0), std::optional<int32_t>(0));
+    EXPECT_EQ(tryConvertToStrictInt32(1.0), std::optional<int32_t>(1));
+    EXPECT_EQ(tryConvertToStrictInt32(-1.0), std::optional<int32_t>(-1));
+    EXPECT_EQ(tryConvertToStrictInt32(42.0), std::optional<int32_t>(42));
+    EXPECT_EQ(tryConvertToStrictInt32(-42.0), std::optional<int32_t>(-42));
+    EXPECT_EQ(tryConvertToStrictInt32(static_cast<double>(INT32_MAX)), std::optional<int32_t>(INT32_MAX));
+    EXPECT_EQ(tryConvertToStrictInt32(static_cast<double>(INT32_MIN)), std::optional<int32_t>(INT32_MIN));
+}
+
+TEST(WTF_MathExtras, TryConvertToStrictInt32_ExactIntegers_Opaque)
+{
+    EXPECT_EQ(tryConvertToStrictInt32(opaque(0.0)), std::optional<int32_t>(0));
+    EXPECT_EQ(tryConvertToStrictInt32(opaque(1.0)), std::optional<int32_t>(1));
+    EXPECT_EQ(tryConvertToStrictInt32(opaque(-1.0)), std::optional<int32_t>(-1));
+    EXPECT_EQ(tryConvertToStrictInt32(opaque(42.0)), std::optional<int32_t>(42));
+    EXPECT_EQ(tryConvertToStrictInt32(opaque(-42.0)), std::optional<int32_t>(-42));
+    EXPECT_EQ(tryConvertToStrictInt32(opaque(static_cast<double>(INT32_MAX))), std::optional<int32_t>(INT32_MAX));
+    EXPECT_EQ(tryConvertToStrictInt32(opaque(static_cast<double>(INT32_MIN))), std::optional<int32_t>(INT32_MIN));
+}
+
+TEST(WTF_MathExtras, TryConvertToStrictInt32_NonIntegers)
+{
+    EXPECT_EQ(tryConvertToStrictInt32(0.5), std::nullopt);
+    EXPECT_EQ(tryConvertToStrictInt32(-0.5), std::nullopt);
+    EXPECT_EQ(tryConvertToStrictInt32(1.1), std::nullopt);
+    EXPECT_EQ(tryConvertToStrictInt32(-1.1), std::nullopt);
+    EXPECT_EQ(tryConvertToStrictInt32(0.1), std::nullopt);
+}
+
+TEST(WTF_MathExtras, TryConvertToStrictInt32_NonIntegers_Opaque)
+{
+    EXPECT_EQ(tryConvertToStrictInt32(opaque(0.5)), std::nullopt);
+    EXPECT_EQ(tryConvertToStrictInt32(opaque(-0.5)), std::nullopt);
+    EXPECT_EQ(tryConvertToStrictInt32(opaque(1.1)), std::nullopt);
+    EXPECT_EQ(tryConvertToStrictInt32(opaque(-1.1)), std::nullopt);
+    EXPECT_EQ(tryConvertToStrictInt32(opaque(0.1)), std::nullopt);
+}
+
+TEST(WTF_MathExtras, TryConvertToStrictInt32_SpecialValues)
+{
+    // -0.0 is not StrictInt32.
+    EXPECT_EQ(tryConvertToStrictInt32(-0.0), std::nullopt);
+    EXPECT_EQ(tryConvertToStrictInt32(std::numeric_limits<double>::quiet_NaN()), std::nullopt);
+    EXPECT_EQ(tryConvertToStrictInt32(std::numeric_limits<double>::signaling_NaN()), std::nullopt);
+    EXPECT_EQ(tryConvertToStrictInt32(-std::numeric_limits<double>::quiet_NaN()), std::nullopt);
+    EXPECT_EQ(tryConvertToStrictInt32(std::numeric_limits<double>::infinity()), std::nullopt);
+    EXPECT_EQ(tryConvertToStrictInt32(-std::numeric_limits<double>::infinity()), std::nullopt);
+    EXPECT_EQ(tryConvertToStrictInt32(std::numeric_limits<double>::denorm_min()), std::nullopt);
+    EXPECT_EQ(tryConvertToStrictInt32(-std::numeric_limits<double>::denorm_min()), std::nullopt);
+}
+
+TEST(WTF_MathExtras, TryConvertToStrictInt32_SpecialValues_Opaque)
+{
+    EXPECT_EQ(tryConvertToStrictInt32(opaque(-0.0)), std::nullopt);
+    EXPECT_EQ(tryConvertToStrictInt32(opaque(std::numeric_limits<double>::quiet_NaN())), std::nullopt);
+    EXPECT_EQ(tryConvertToStrictInt32(opaque(std::numeric_limits<double>::signaling_NaN())), std::nullopt);
+    EXPECT_EQ(tryConvertToStrictInt32(opaque(-std::numeric_limits<double>::quiet_NaN())), std::nullopt);
+    EXPECT_EQ(tryConvertToStrictInt32(opaque(std::numeric_limits<double>::infinity())), std::nullopt);
+    EXPECT_EQ(tryConvertToStrictInt32(opaque(-std::numeric_limits<double>::infinity())), std::nullopt);
+    EXPECT_EQ(tryConvertToStrictInt32(opaque(std::numeric_limits<double>::denorm_min())), std::nullopt);
+    EXPECT_EQ(tryConvertToStrictInt32(opaque(-std::numeric_limits<double>::denorm_min())), std::nullopt);
+}
+
+TEST(WTF_MathExtras, TryConvertToStrictInt32_OutOfRange)
+{
+    EXPECT_EQ(tryConvertToStrictInt32(static_cast<double>(INT32_MAX) + 1.0), std::nullopt);
+    EXPECT_EQ(tryConvertToStrictInt32(static_cast<double>(INT32_MIN) - 1.0), std::nullopt);
+    EXPECT_EQ(tryConvertToStrictInt32(static_cast<double>(1ULL << 53)), std::nullopt);
+    EXPECT_EQ(tryConvertToStrictInt32(-static_cast<double>(1ULL << 53)), std::nullopt);
+    EXPECT_EQ(tryConvertToStrictInt32(std::numeric_limits<double>::max()), std::nullopt);
+    EXPECT_EQ(tryConvertToStrictInt32(std::numeric_limits<double>::lowest()), std::nullopt);
+}
+
+TEST(WTF_MathExtras, TryConvertToStrictInt32_OutOfRange_Opaque)
+{
+    EXPECT_EQ(tryConvertToStrictInt32(opaque(static_cast<double>(INT32_MAX) + 1.0)), std::nullopt);
+    EXPECT_EQ(tryConvertToStrictInt32(opaque(static_cast<double>(INT32_MIN) - 1.0)), std::nullopt);
+    EXPECT_EQ(tryConvertToStrictInt32(opaque(static_cast<double>(1ULL << 53))), std::nullopt);
+    EXPECT_EQ(tryConvertToStrictInt32(opaque(-static_cast<double>(1ULL << 53))), std::nullopt);
+    EXPECT_EQ(tryConvertToStrictInt32(opaque(std::numeric_limits<double>::max())), std::nullopt);
+    EXPECT_EQ(tryConvertToStrictInt32(opaque(std::numeric_limits<double>::lowest())), std::nullopt);
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### bd8dde5e762e64ae6da62e1cce48d2223af62259
<pre>
[JSC] Remove UB for truncate-double-to-int32 by injecting conversion inline asm
<a href="https://bugs.webkit.org/show_bug.cgi?id=310490">https://bugs.webkit.org/show_bug.cgi?id=310490</a>
<a href="https://rdar.apple.com/173114293">rdar://173114293</a>

Reviewed by Keith Miller and Justin Michaud.

Recent clang does optimization based on this UB, breaking JSC when these
UB is used. But this is **really hot** code in JSC, thus we should not
use something slow-but-correct implementation. We should keep what we
are getting as a codegen as is while removing UB to prevent compilers
from breaking the meaning.

This patch introduces helper functions which convers fp to integers, and
just use these helper functions. They are just one inline asm in many
cases. The purpose is just making sure that we should have solid
semantics (not UB) for this one conversion. And the rest of code using
this is just fine if this is not UB. We move tryConvertToStrictInt32 to
WTF too, and make sure they are not having UB in slow path too. We
implemented optimized inline asm for x64 / ARM64 so that these
architectures do not see the difference from the currently generated code.

We also add WTF_PROVEN_TRUE. This leverages __builtin_constant_p to do
range analysis onto the input, so we do not lose the opportunities of
constant folding.

Tests: Tools/TestWebKitAPI/CMakeLists.txt
       Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
       Tools/TestWebKitAPI/Tests/WTF/TruncateFloat.cpp

* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/runtime/CommonSlowPaths.cpp:
(JSC::updateArithProfileForUnaryArithOp):
(JSC::updateArithProfileForBinaryArithOp):
(JSC::JSC_DEFINE_COMMON_SLOW_PATH):
* Source/JavaScriptCore/runtime/JSCJSValueInlines.h:
(JSC::JSValue::tryGetAsUint32Index):
(JSC::JSValue::tryGetAsInt32):
* Source/JavaScriptCore/runtime/MathCommon.cpp:
(JSC::Math::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/runtime/MathCommon.h:
(JSC::tryConvertToStrictInt32): Deleted.
* Source/JavaScriptCore/runtime/NumberPrototype.cpp:
(JSC::toStringWithRadix):
(JSC::numberToStringInternal):
* Source/JavaScriptCore/wasm/WasmFormat.h:
(JSC::Wasm::internalizeExternref):
* Source/WTF/wtf/MathExtras.h:
(WTF::truncateDoubleToInt32):
(WTF::truncateDoubleToInt64):
(WTF::truncateDoubleToUint32):
(WTF::truncateDoubleToUint64):
(WTF::truncateFloatToInt32):
(WTF::truncateFloatToInt64):
(WTF::truncateFloatToUint32):
(WTF::truncateFloatToUint64):
(WTF::tryConvertToStrictInt32):
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WTF/TruncateFloat.cpp: Added.
(TestWebKitAPI::opaque):
(TestWebKitAPI::TEST(WTF_MathExtras, TruncateDoubleToInt32_InRange)):
(TestWebKitAPI::TEST(WTF_MathExtras, TruncateDoubleToInt32_InRange_Opaque)):
(TestWebKitAPI::TEST(WTF_MathExtras, TruncateDoubleToInt32_OutOfRange)):
(TestWebKitAPI::TEST(WTF_MathExtras, TruncateDoubleToUint32_InRange)):
(TestWebKitAPI::TEST(WTF_MathExtras, TruncateDoubleToUint32_InRange_Opaque)):
(TestWebKitAPI::TEST(WTF_MathExtras, TruncateDoubleToUint32_OutOfRange)):
(TestWebKitAPI::TEST(WTF_MathExtras, TruncateDoubleToInt64_InRange)):
(TestWebKitAPI::TEST(WTF_MathExtras, TruncateDoubleToInt64_InRange_Opaque)):
(TestWebKitAPI::TEST(WTF_MathExtras, TruncateDoubleToInt64_OutOfRange)):
(TestWebKitAPI::TEST(WTF_MathExtras, TruncateDoubleToUint64_InRange)):
(TestWebKitAPI::TEST(WTF_MathExtras, TruncateDoubleToUint64_InRange_Opaque)):
(TestWebKitAPI::TEST(WTF_MathExtras, TruncateDoubleToUint64_OutOfRange)):
(TestWebKitAPI::TEST(WTF_MathExtras, TruncateFloatToInt32_InRange)):
(TestWebKitAPI::TEST(WTF_MathExtras, TruncateFloatToInt32_InRange_Opaque)):
(TestWebKitAPI::TEST(WTF_MathExtras, TruncateFloatToInt32_OutOfRange)):
(TestWebKitAPI::TEST(WTF_MathExtras, TruncateFloatToUint32_InRange)):
(TestWebKitAPI::TEST(WTF_MathExtras, TruncateFloatToUint32_InRange_Opaque)):
(TestWebKitAPI::TEST(WTF_MathExtras, TruncateFloatToUint32_OutOfRange)):
(TestWebKitAPI::TEST(WTF_MathExtras, TruncateFloatToInt64_InRange)):
(TestWebKitAPI::TEST(WTF_MathExtras, TruncateFloatToInt64_InRange_Opaque)):
(TestWebKitAPI::TEST(WTF_MathExtras, TruncateFloatToInt64_OutOfRange)):
(TestWebKitAPI::TEST(WTF_MathExtras, TruncateFloatToUint64_InRange)):
(TestWebKitAPI::TEST(WTF_MathExtras, TruncateFloatToUint64_InRange_Opaque)):
(TestWebKitAPI::TEST(WTF_MathExtras, TruncateFloatToUint64_OutOfRange)):
(TestWebKitAPI::TEST(WTF_MathExtras, TryConvertToStrictInt32_ExactIntegers)):
(TestWebKitAPI::TEST(WTF_MathExtras, TryConvertToStrictInt32_ExactIntegers_Opaque)):
(TestWebKitAPI::TEST(WTF_MathExtras, TryConvertToStrictInt32_NonIntegers)):
(TestWebKitAPI::TEST(WTF_MathExtras, TryConvertToStrictInt32_NonIntegers_Opaque)):
(TestWebKitAPI::TEST(WTF_MathExtras, TryConvertToStrictInt32_SpecialValues)):
(TestWebKitAPI::TEST(WTF_MathExtras, TryConvertToStrictInt32_SpecialValues_Opaque)):
(TestWebKitAPI::TEST(WTF_MathExtras, TryConvertToStrictInt32_OutOfRange)):
(TestWebKitAPI::TEST(WTF_MathExtras, TryConvertToStrictInt32_OutOfRange_Opaque)):

Canonical link: <a href="https://commits.webkit.org/309786@main">https://commits.webkit.org/309786@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b52a9df11eb9fb2f10acc3421ff353f20ce5b03a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151626 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24406 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17988 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160361 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105083 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ab4a7a73-7e34-4675-ab40-f7c15b596c89) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153500 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24886 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24701 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117116 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83134 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c01f7dcd-b265-435a-9e8b-2f303bb9b97e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154586 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19252 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136067 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97831 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/536590f7-5b4d-468d-901c-d9159194b239) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18340 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16286 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8203 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/143628 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127970 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13971 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162832 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/12427 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6000 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15561 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125133 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24206 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20344 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125315 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24208 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135767 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80782 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23294 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20354 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12542 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/183236 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23826 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88105 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46741 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23515 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23672 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23575 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->