### PR TITLE
Upgrade ASSERT in ~ThreadSafeRefCountedBase() to ASSERT_WITH_SECURITY_IMPLICATION

### DIFF
--- a/Source/WTF/wtf/ThreadSafeRefCounted.h
+++ b/Source/WTF/wtf/ThreadSafeRefCounted.h
@@ -64,8 +64,8 @@ protected:
     ~ThreadSafeRefCountedBase()
     {
         m_refCountDebugger.willDestroy(m_refCount);
-        // FIXME: Test performance, then change this to RELEASE_ASSERT.
-        ASSERT(m_refCount == 1);
+        // Ideally we'd use a RELEASE_ASSERT() here but it is a 0.7-0.8% regression on Speedometer 3.
+        ASSERT_WITH_SECURITY_IMPLICATION(m_refCount == 1);
     }
 
     // Returns true if the pointer should be freed.

--- a/Source/WTF/wtf/ThreadSafeRefCountedWithSuppressingSaferCPPChecking.h
+++ b/Source/WTF/wtf/ThreadSafeRefCountedWithSuppressingSaferCPPChecking.h
@@ -66,8 +66,8 @@ protected:
     ~ThreadSafeRefCountedWithSuppressingSaferCPPCheckingBase()
     {
         m_refCountDebugger.willDestroy(m_refCount);
-        // FIXME: Test performance, then change this to RELEASE_ASSERT.
-        ASSERT(m_refCount == 1);
+        // Ideally we'd use a RELEASE_ASSERT() here but it is a 0.7-0.8% regression on Speedometer 3.
+        ASSERT_WITH_SECURITY_IMPLICATION(m_refCount == 1);
     }
 
     // Returns true if the pointer should be freed.


### PR DESCRIPTION
#### 12b050a6ea4769beeea87702eeccc4eb18e3f4fb
<pre>
Upgrade ASSERT in ~ThreadSafeRefCountedBase() to ASSERT_WITH_SECURITY_IMPLICATION
<a href="https://bugs.webkit.org/show_bug.cgi?id=310494">https://bugs.webkit.org/show_bug.cgi?id=310494</a>

Reviewed by Ryosuke Niwa.

Upgrade ASSERT in ~ThreadSafeRefCountedBase() to ASSERT_WITH_SECURITY_IMPLICATION.
Ideally we&apos;d use a RELEASE_ASSERT but I have confirmed that it would
regress Speedometer 3.

* Source/WTF/wtf/ThreadSafeRefCounted.h:
* Source/WTF/wtf/ThreadSafeRefCountedWithSuppressingSaferCPPChecking.h:

Canonical link: <a href="https://commits.webkit.org/309724@main">https://commits.webkit.org/309724@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd9755f8a9c774776fb79896dcefad2c68cdc2d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151567 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24332 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/17913 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160301 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24763 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24634 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/117052 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0e720abf-63b5-4d43-87a3-45fa9518584d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154527 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/136006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97767 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2b8daf3a-ba40-41b8-806a-8d02eb21bcd1) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/18289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/16231 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8144 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/143568 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/127918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/13911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162773 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/12368 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5903 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/15500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/125068 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24133 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/20289 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125251 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33967 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24125 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/135707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/80723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/20308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/12482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/183177 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23734 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/88046 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46718 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23444 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23598 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23500 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->