### PR TITLE
[JSC] Fix completion value for bare/labeled/nested break and continue

### DIFF
--- a/JSTests/stress/completion-value.js
+++ b/JSTests/stress/completion-value.js
@@ -263,6 +263,56 @@ shouldBe(eval(`99; do { -99; try { [].x.x } catch (e) { 42; continue; } finally 
 shouldBe(eval(`99; do { -99; try { 42 } catch (e) { -1 } finally { -2; continue; -3 }; -77 } while (false);`), -2);
 shouldBe(eval(`99; do { -99; try { [].x.x } catch (e) { 42; } finally { -2; continue; -3 }; -77 } while (false);`), -2);
 
+// Bare break/continue (not wrapped in a block) as body of if/else/with.
+shouldBe(eval(`99; do { -99; if (true) break; } while (false);`), undefined);
+shouldBe(eval(`99; do { -99; if (true) break; -77 } while (false);`), undefined);
+shouldBe(eval(`99; do { -99; if (true) continue; } while (false);`), undefined);
+shouldBe(eval(`99; do { -99; if (true) continue; -77 } while (false);`), undefined);
+shouldBe(eval(`99; do { -99; if (false) -1; else break; } while (false);`), undefined);
+shouldBe(eval(`99; do { -99; if (false) -1; else break; -77 } while (false);`), undefined);
+shouldBe(eval(`99; do { -99; if (false) -1; else continue; } while (false);`), undefined);
+shouldBe(eval(`99; do { -99; if (false) -1; else continue; -77 } while (false);`), undefined);
+shouldBe(eval(`99; do { -99; with (true) break; } while (false);`), undefined);
+shouldBe(eval(`99; do { -99; with (true) break; -77 } while (false);`), undefined);
+shouldBe(eval(`99; do { -99; with (true) continue; } while (false);`), undefined);
+shouldBe(eval(`99; do { -99; with (true) continue; -77 } while (false);`), undefined);
+shouldBe(eval(`99; do { -99; do break; while (false); -77 } while (false);`), -77);
+shouldBe(eval(`99; do { -99; do continue; while (false); -77 } while (false);`), -77);
+shouldBe(eval(`99; for (;;) { -99; if (true) break; -77 }`), undefined);
+shouldBe(eval(`99; for (x of [1]) { -99; if (true) break; -77 }`), undefined);
+shouldBe(eval(`99; for (x in {a:1}) { -99; if (true) break; -77 }`), undefined);
+
+// break/continue wrapped in a label as body of if/else/with.
+shouldBe(eval(`99; do { -99; if (true) L: break; -77 } while (false);`), undefined);
+shouldBe(eval(`99; do { -99; if (true) L: continue; -77 } while (false);`), undefined);
+shouldBe(eval(`99; do { -99; if (false) -1; else L: break; -77 } while (false);`), undefined);
+shouldBe(eval(`99; do { -99; if (false) -1; else L: continue; -77 } while (false);`), undefined);
+shouldBe(eval(`99; do { -99; with ({}) L: break; -77 } while (false);`), undefined);
+shouldBe(eval(`99; do { -99; with ({}) L: continue; -77 } while (false);`), undefined);
+shouldBe(eval(`99; do { -99; if (true) L1: L2: L3: break; -77 } while (false);`), undefined);
+shouldBe(eval(`99; while (true) { -99; if (true) L: break; -77 }`), undefined);
+shouldBe(eval(`99; for (;;) { -99; if (true) L: break; -77 }`), undefined);
+shouldBe(eval(`99; for (x in {a:1}) { -99; if (true) L: break; -77 }`), undefined);
+shouldBe(eval(`99; for (x of [1]) { -99; if (true) L: break; -77 }`), undefined);
+shouldBe(eval(`99; switch (1) { case 1: -99; if (true) L: break; -77 }`), undefined);
+
+// break/continue wrapped in a nested block.
+shouldBe(eval(`99; do { -99; if (true) {{ break; }} -77 } while (false);`), undefined);
+shouldBe(eval(`99; do { -99; if (true) {{ continue; }} -77 } while (false);`), undefined);
+shouldBe(eval(`99; do { -99; try { { break; } } catch (e) {}; -77 } while (false);`), undefined);
+shouldBe(eval(`99; do { -99; try {} finally { { break; } }; -77 } while (false);`), undefined);
+shouldBe(eval(`99; switch (1) { case 1: -99; if (true) {{ break; }} -77 }`), undefined);
+
+// break/continue wrapped in a label inside a block.
+shouldBe(eval(`99; do { -99; if (true) { L: break; } -77 } while (false);`), undefined);
+shouldBe(eval(`99; do { -99; if (true) { L: continue; } -77 } while (false);`), undefined);
+shouldBe(eval(`99; do { -99; with ({}) { L: break; } -77 } while (false);`), undefined);
+shouldBe(eval(`99; do { -99; try { L: break; } catch (e) {}; -77 } while (false);`), undefined);
+shouldBe(eval(`99; do { -99; try {} finally { L: break; }; -77 } while (false);`), undefined);
+shouldBe(eval(`99; do { -99; if (true) { ; L: break; } -77 } while (false);`), undefined);
+shouldBe(eval(`99; do { -99; if (true) { var v; L: break; } -77 } while (false);`), undefined);
+shouldBe(eval(`99; do { -99; if (true) { L: { break; } } -77 } while (false);`), undefined);
+
 // Early break to a label.
 shouldBe(eval(`99; label: do { 1; if (true) { break label; 2; }; } while (false);`), undefined);
 shouldBe(eval(`99; label: do { 1; if (true) { break label; 2; }; 3; } while (false);`), undefined);

--- a/Source/JavaScriptCore/parser/Nodes.cpp
+++ b/Source/JavaScriptCore/parser/Nodes.cpp
@@ -85,7 +85,7 @@ bool SourceElements::hasCompletionValue() const
 bool SourceElements::hasEarlyBreakOrContinue() const
 {
     for (StatementNode* statement = m_head; statement; statement = statement->next()) {
-        if (statement->isBreak() || statement->isContinue())
+        if (statement->hasEarlyBreakOrContinue())
             return true;
         if (statement->hasCompletionValue())
             return false;

--- a/Source/JavaScriptCore/parser/Nodes.h
+++ b/Source/JavaScriptCore/parser/Nodes.h
@@ -1854,6 +1854,7 @@ namespace JSC {
         
     private:
         bool hasCompletionValue() const final { return false; }
+        bool hasEarlyBreakOrContinue() const final { return true; }
         bool isContinue() const final { return true; }
         void emitBytecode(BytecodeGenerator&, RegisterID* = nullptr) final;
 
@@ -1864,9 +1865,10 @@ namespace JSC {
     public:
         BreakNode(const JSTokenLocation&, const Identifier&);
         Label* trivialTarget(BytecodeGenerator&);
-        
+
     private:
         bool hasCompletionValue() const final { return false; }
+        bool hasEarlyBreakOrContinue() const final { return true; }
         bool isBreak() const final { return true; }
         void emitBytecode(BytecodeGenerator&, RegisterID* = nullptr) final;
 
@@ -1908,6 +1910,7 @@ namespace JSC {
 
     private:
         bool hasCompletionValue() const final { return m_statement->hasCompletionValue(); }
+        bool hasEarlyBreakOrContinue() const final { return m_statement->hasEarlyBreakOrContinue(); }
         void emitBytecode(BytecodeGenerator&, RegisterID* = nullptr) final;
 
         const Identifier& m_name;


### PR DESCRIPTION
#### 5412318e154cc80e65f284434e49fad5029972f0
<pre>
[JSC] Fix completion value for bare/labeled/nested break and continue
<a href="https://bugs.webkit.org/show_bug.cgi?id=310498">https://bugs.webkit.org/show_bug.cgi?id=310498</a>

Reviewed by Yusuke Suzuki.

eval(&quot;do { 6; if (true) break; 7; } while (false)&quot;) returned 6 instead
of undefined. Per spec, IfStatement calls UpdateEmpty(stmtCompletion,
undefined), which we implement by preloading undefined into dst when
hasEarlyBreakOrContinue() is true. Three cases were missed:

1. BreakNode/ContinueNode did not override hasEarlyBreakOrContinue(),
   so `if (cond) break;` without braces fell through to the default
   false.
2. LabelNode delegated hasCompletionValue() but not
   hasEarlyBreakOrContinue(), so `if (cond) L: break;` did the same.
3. SourceElements::hasEarlyBreakOrContinue() checked isBreak() /
   isContinue() directly instead of recursing, so `if (cond) {{break;}}`
   and `{ L: break; }` were not detected.

* JSTests/stress/completion-value.js:
(switch):
(catch):
(with):
* Source/JavaScriptCore/parser/Nodes.cpp:
(JSC::SourceElements::hasEarlyBreakOrContinue const):
* Source/JavaScriptCore/parser/Nodes.h:

Canonical link: <a href="https://commits.webkit.org/309826@main">https://commits.webkit.org/309826@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f52b27e52c7d0a6a69fea7e590e27ffc1db8d3c6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151566 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24331 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17912 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160300 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105023 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24762 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24633 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117051 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83104 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154526 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19198 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136005 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97766 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18288 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16230 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8143 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/143567 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127917 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13910 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162772 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/12367 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5902 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15499 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125066 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24132 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20288 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125249 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34047 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24124 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135706 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80722 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20307 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12481 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/183176 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23733 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88045 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46717 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23443 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23597 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23499 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->