### PR TITLE
[JSC] Remove rope suffix eval cache

### DIFF
--- a/Source/JavaScriptCore/bytecode/DirectEvalCodeCache.h
+++ b/Source/JavaScriptCore/bytecode/DirectEvalCodeCache.h
@@ -39,20 +39,14 @@ namespace JSC {
 
     class DirectEvalCodeCache {
     public:
-        enum class RopeSuffix : uint8_t {
-            None,
-            FunctionCall
-        };
-
         class CacheLookupKey;
 
         class CacheKey {
             friend class CacheLookupKey;
         public:
-            CacheKey(StringImpl* source, BytecodeIndex bytecodeIndex, RopeSuffix ropeSuffix)
+            CacheKey(StringImpl* source, BytecodeIndex bytecodeIndex)
                 : m_source(source)
                 , m_bytecodeIndex(bytecodeIndex)
-                , m_ropeSuffix(ropeSuffix)
             {
             }
 
@@ -63,13 +57,13 @@ namespace JSC {
 
             CacheKey() = default;
 
-            unsigned hash() const { return m_source->hash() + m_bytecodeIndex.asBits() + std::to_underlying(m_ropeSuffix); }
+            unsigned hash() const { return m_source->hash() + m_bytecodeIndex.asBits(); }
 
             bool isEmptyValue() const { return !m_source; }
 
             bool operator==(const CacheKey& other) const
             {
-                return m_bytecodeIndex == other.m_bytecodeIndex && m_ropeSuffix == other.m_ropeSuffix && WTF::equal(m_source.get(), other.m_source.get());
+                return m_bytecodeIndex == other.m_bytecodeIndex && WTF::equal(m_source.get(), other.m_source.get());
             }
 
             bool isHashTableDeletedValue() const { return m_source.isHashTableDeletedValue(); }
@@ -79,38 +73,35 @@ namespace JSC {
         private:
             RefPtr<StringImpl> m_source;
             BytecodeIndex m_bytecodeIndex;
-            RopeSuffix m_ropeSuffix;
         };
 
         class CacheLookupKey {
             void* operator new(size_t) = delete;
 
         public:
-            CacheLookupKey(StringImpl* source, BytecodeIndex bytecodeIndex, RopeSuffix ropeSuffix)
+            CacheLookupKey(StringImpl* source, BytecodeIndex bytecodeIndex)
                 : m_source(source)
                 , m_bytecodeIndex(bytecodeIndex)
-                , m_ropeSuffix(ropeSuffix)
             {
             }
 
             CacheLookupKey() = default;
 
-            unsigned hash() const { return m_source->hash() + m_bytecodeIndex.asBits() + std::to_underlying(m_ropeSuffix); }
+            unsigned hash() const { return m_source->hash() + m_bytecodeIndex.asBits(); }
 
             bool operator==(const CacheKey& other) const
             {
-                return m_bytecodeIndex == other.m_bytecodeIndex && m_ropeSuffix == other.m_ropeSuffix && WTF::equal(m_source, other.m_source.get());
+                return m_bytecodeIndex == other.m_bytecodeIndex && WTF::equal(m_source, other.m_source.get());
             }
 
             operator CacheKey() const
             {
-                return CacheKey(m_source, m_bytecodeIndex, m_ropeSuffix);
+                return CacheKey(m_source, m_bytecodeIndex);
             }
 
         private:
             SUPPRESS_UNCOUNTED_MEMBER StringImpl* m_source;
             BytecodeIndex m_bytecodeIndex;
-            RopeSuffix m_ropeSuffix;
         };
 
         struct CacheLookupKeyHashTranslator {

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -100,17 +100,6 @@
 
 namespace JSC {
 
-static inline DirectEvalCodeCache::CacheLookupKey directEvalCacheKey(JSGlobalObject* globalObject, JSString* string, BytecodeIndex bytecodeIndex)
-{
-    if (string->isRope()) {
-        auto rope = string->asRope();
-        if (auto source = rope->tryGetLHS("()"_s))
-            return DirectEvalCodeCache::CacheLookupKey(source, bytecodeIndex, DirectEvalCodeCache::RopeSuffix::FunctionCall);
-        return DirectEvalCodeCache::CacheLookupKey(rope->resolveRope(globalObject).impl(), bytecodeIndex, DirectEvalCodeCache::RopeSuffix::None);
-    }
-    return DirectEvalCodeCache::CacheLookupKey(string->getValueImpl(), bytecodeIndex, DirectEvalCodeCache::RopeSuffix::None);
-}
-
 JSValue eval(CallFrame* callFrame, JSValue thisValue, JSScope* callerScopeChain, CodeBlock* callerBaselineCodeBlock, BytecodeIndex bytecodeIndex, LexicallyScopedFeatures lexicallyScopedFeatures)
 {
     JSGlobalObject* globalObject = callerBaselineCodeBlock->globalObject();
@@ -170,11 +159,12 @@ JSValue eval(CallFrame* callFrame, JSValue thisValue, JSScope* callerScopeChain,
         return { };
     }
 
-    auto cacheKey = directEvalCacheKey(globalObject, programString, bytecodeIndex);
+    auto programStr = programString->value(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
+    auto cacheKey = DirectEvalCodeCache::CacheLookupKey(programStr.data.impl(), bytecodeIndex);
     DirectEvalExecutable* eval = callerBaselineCodeBlock->directEvalCodeCache().get(cacheKey);
     if (!eval) {
-        auto programSource = programString->value(globalObject).data;
+        auto programSource = programStr.data;
         if (SourceProfiler::g_profilerHook) [[unlikely]] {
             SourceTaintedOrigin sourceTaintedOrigin = computeNewSourceTaintedOriginFromStack(vm, callFrame);
             auto source = makeSource(programSource, callerBaselineCodeBlock->source().provider()->sourceOrigin(), sourceTaintedOrigin);

--- a/Source/JavaScriptCore/runtime/JSString.h
+++ b/Source/JavaScriptCore/runtime/JSString.h
@@ -526,8 +526,6 @@ public:
         return m_compactFibers.length();
     }
 
-    inline StringImpl* tryGetLHS(ASCIILiteral rhs) const;
-
 private:
     friend class LLIntOffsetsExtractor;
 

--- a/Source/JavaScriptCore/runtime/JSStringInlines.h
+++ b/Source/JavaScriptCore/runtime/JSStringInlines.h
@@ -280,31 +280,6 @@ inline void JSRopeString::convertToNonRope(String&& string) const
     notifyNeedsDestruction();
 }
 
-inline StringImpl* JSRopeString::tryGetLHS(ASCIILiteral rhs) const
-{
-    if (isSubstring())
-        return nullptr;
-
-    JSString* fiber2 = this->fiber2();
-    if (fiber2)
-        return nullptr;
-
-    JSString* fiber1 = this->fiber1();
-    ASSERT(fiber1);
-    if (fiber1->isRope())
-        return nullptr;
-
-    JSString* fiber0 = this->fiber0();
-    ASSERT(fiber0);
-    if (fiber0->isRope())
-        return nullptr;
-
-    if (fiber1->valueInternal() != rhs)
-        return nullptr;
-
-    return fiber0->valueInternal().impl();
-}
-
 // Overview: These functions convert a JSString from holding a string in rope form
 // down to a simple String representation. It does so by building up the string
 // backwards, since we want to avoid recursion, we expect that the tree structure


### PR DESCRIPTION
#### 0bd5df499e70892cd54cc93d617eada3d31ebb59
<pre>
[JSC] Remove rope suffix eval cache
<a href="https://bugs.webkit.org/show_bug.cgi?id=310499">https://bugs.webkit.org/show_bug.cgi?id=310499</a>
<a href="https://rdar.apple.com/173120111">rdar://173120111</a>

Reviewed by Yusuke Suzuki.

This was added as an optimization for a weird idiom in JS2 that has
since been changed for JS3. The date-format-tofte benchmark would do:
`eval(someFunctionText() + &quot;()&quot;)` and so we tried to avoid resolving the
rope for the eval cache.

That benchmark was changed in <a href="https://github.com/WebKit/JetStream/commit/d280391b7490e6a9e30dbeb9660bc5cbf5e30038">https://github.com/WebKit/JetStream/commit/d280391b7490e6a9e30dbeb9660bc5cbf5e30038</a>
and SunSpider is now a single line item in the overall JS3 workload.

Benchmarking appears neutral on JS3/SP3.

Canonical link: <a href="https://commits.webkit.org/309757@main">https://commits.webkit.org/309757@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14d299c4d53accc6fabf70838654d232ce59ccdc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151569 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24334 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17915 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160303 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105026 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a4d76da1-10c8-497b-bffb-0ec3f6c14f83) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24765 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24636 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117053 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83106 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1f60dc3e-2bd2-4977-9e5c-db84d1db0518) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154529 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19205 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136008 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97768 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18287 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16233 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8146 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/143570 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127916 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13913 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162775 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/12370 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5905 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15502 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125067 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24135 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20291 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125250 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24127 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135709 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80725 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23279 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20310 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12484 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/183179 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23736 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88048 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46720 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23446 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23600 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23502 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->