### PR TITLE
[JSC] Add missing NodeMustGenerate to RegExpExecNonGlobalOrSticky and DataViewGetByteLength

### DIFF
--- a/JSTests/stress/dataview-byte-length-dce-resizable.js
+++ b/JSTests/stress/dataview-byte-length-dce-resizable.js
@@ -1,0 +1,19 @@
+function shouldThrow(f) {
+    let threw = false;
+    try { f(); } catch (e) { threw = e instanceof TypeError; }
+    if (!threw) throw new Error("should have thrown TypeError");
+}
+
+const rab = new ArrayBuffer(16, {maxByteLength: 32});
+const dv = new DataView(rab, 8, 8);
+
+function byteLength() {
+    dv.byteLength;
+}
+noInline(byteLength);
+
+for (let i = 0; i < testLoopCount; i++)
+    byteLength();
+
+rab.resize(4);
+shouldThrow(byteLength);

--- a/JSTests/stress/regexp-exec-nongs-dce-lastmatch.js
+++ b/JSTests/stress/regexp-exec-nongs-dce-lastmatch.js
@@ -1,0 +1,16 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + " expected: " + expected);
+}
+
+function t(s) {
+    /h(el)lo/.exec(s);
+}
+noInline(t);
+
+for (let i = 0; i < testLoopCount; i++) {
+    /s(ee)d/.exec("seed");
+    t("hello");
+    shouldBe(RegExp.$1, "el");
+    shouldBe(RegExp.lastMatch, "hello");
+}

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -4911,6 +4911,8 @@ bool ByteCodeParser::handleIntrinsicGetter(Operand result, SpeculatedType predic
 
         NodeType op = mayBeLargeArrayBuffer ? DataViewGetByteLengthAsInt52 : DataViewGetByteLength;
         Node* lengthNode = addToGraph(op, OpInfo(mayBeResizableOrGrowableSharedArrayBuffer), Edge(thisNode, DataViewObjectUse));
+        if (mayBeResizableOrGrowableSharedArrayBuffer)
+            lengthNode->mergeFlags(NodeMustGenerate);
         m_exitOK = true;
         addToGraph(ExitOK);
 

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -349,7 +349,7 @@ namespace JSC { namespace DFG {
     \
     /* Optimizations for regular expression matching. */\
     macro(RegExpExec, NodeResultJS | NodeMustGenerate) \
-    macro(RegExpExecNonGlobalOrSticky, NodeResultJS) \
+    macro(RegExpExecNonGlobalOrSticky, NodeResultJS | NodeMustGenerate) \
     macro(RegExpTest, NodeResultJS | NodeMustGenerate) \
     macro(RegExpTestInline, NodeResultJS | NodeMustGenerate) \
     macro(RegExpMatchFast, NodeResultJS | NodeMustGenerate) \


### PR DESCRIPTION
#### 6f0008f50e579f1b5e004f3e8698ed5674527d29
<pre>
[JSC] Add missing NodeMustGenerate to RegExpExecNonGlobalOrSticky and DataViewGetByteLength
<a href="https://bugs.webkit.org/show_bug.cgi?id=310502">https://bugs.webkit.org/show_bug.cgi?id=310502</a>

Reviewed by Yusuke Suzuki.

RegExpExecNonGlobalOrSticky was missing NodeMustGenerate, the same pattern
fixed for RegExpMatchFastGlobal in 309953. DFGStrengthReductionPhase
converts RegExpExec to this node via setOpAndDefaultFlags, dropping the
flag. DFGClobberize.h declares write(RegExpState) but FTL DCE only checks
NodeMustGenerate, so unused exec results leave RegExp.$1 stale.

DataViewGetByteLength and DataViewGetByteLengthAsInt52 also lacked
NodeMustGenerate. When the backing ArrayBuffer is resizable and the
DataView goes out of bounds, the node emits an OSR exit that leads to a
TypeError in baseline. FTL DCE eliminates the node when the result is
unused, suppressing the required throw. The flag is added conditionally in
DFGByteCodeParser only when mayBeResizableOrGrowableSharedArrayBuffer, so
non-resizable DataViews remain DCE-eligible.

Tests: JSTests/stress/dataview-byte-length-dce-resizable.js
       JSTests/stress/regexp-exec-nongs-dce-lastmatch.js

* JSTests/stress/dataview-byte-length-dce-resizable.js: Added.
(shouldThrow):
(byteLength):
* JSTests/stress/regexp-exec-nongs-dce-lastmatch.js: Added.
(shouldBe):
(t):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicGetter):
* Source/JavaScriptCore/dfg/DFGNodeType.h:

Canonical link: <a href="https://commits.webkit.org/309903@main">https://commits.webkit.org/309903@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0cb3fcbc46083c5f75e98e11019e3551e50659eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151572 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24337 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17918 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160306 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105029 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24768 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24639 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117056 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83108 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154532 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19203 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136011 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97771 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18293 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16235 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8149 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/143573 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127922 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13916 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162778 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/12373 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5908 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15505 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125071 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24138 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20293 "Found 1 new test failure: http/tests/webgpu/webgpu/api/validation/gpu_external_texture_expiration.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125254 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34106 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24130 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135712 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80728 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20313 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12487 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/183182 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23739 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88051 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46722 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23449 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23603 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23505 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->