### PR TITLE
Allow ::marker as a sub-pseudo-element of ::before and ::after

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/parsing/tree-abiding-pseudo-elements-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/parsing/tree-abiding-pseudo-elements-expected.txt
@@ -32,8 +32,8 @@ PASS "::before::after" should be an invalid selector
 PASS "::after::after" should be an invalid selector
 PASS "::marker::after" should be an invalid selector
 PASS "::placeholder::after" should be an invalid selector
-FAIL "::before::marker" should be a valid selector '::before::marker' is not a valid selector.
-FAIL "::after::marker" should be a valid selector '::after::marker' is not a valid selector.
+PASS "::before::marker" should be a valid selector
+PASS "::after::marker" should be a valid selector
 PASS "::marker::marker" should be an invalid selector
 PASS "::placeholder::marker" should be an invalid selector
 PASS "::before::placeholder" should be an invalid selector

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/text-selection-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/text-selection-expected.txt
@@ -6,6 +6,6 @@ PASS Selection ending in ::before
 PASS Selection contained in ::before
 PASS Selection ending in ::marker
 PASS Selection contained in ::marker
-FAIL Selection ending in ::before-marker assert_equals: toString expected "hello" but got "o"
-FAIL Selection contained in ::before-marker assert_equals: toString expected "" but got "llo"
+PASS Selection ending in ::before-marker
+PASS Selection contained in ::before-marker
 

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -346,10 +346,7 @@ dt {
     display: block;
 }
 
-/* FIXME: this should also match ::before::marker and ::after::marker but we don't support
-   this yet. When we do, we can remove the code specific to ::before and ::after in
-   RenderListItem::computeMarkerStyle(), see bugs.webkit.org/b/218897. */
-::marker {
+::marker, ::before::marker, ::after::marker {
     unicode-bidi: isolate;
     font-variant-numeric: tabular-nums;
     white-space: pre;

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -588,6 +588,11 @@ static bool isSimpleSelectorValidAfterPseudoElement(const MutableCSSSelector& si
         if (isTreeAbidingPseudoElement(simpleSelector))
             return true;
     }
+    if (compoundPseudoElement.pseudoElement() == CSSSelector::PseudoElement::Before
+        || compoundPseudoElement.pseudoElement() == CSSSelector::PseudoElement::After) {
+        if (simpleSelector.match() == CSSSelector::Match::PseudoElement && simpleSelector.pseudoElement() == CSSSelector::PseudoElement::Marker)
+            return true;
+    }
     if (simpleSelector.match() != CSSSelector::Match::PseudoClass)
         return false;
 

--- a/Source/WebCore/rendering/RenderListItem.cpp
+++ b/Source/WebCore/rendering/RenderListItem.cpp
@@ -39,7 +39,6 @@
 #include "RenderStyle+SettersInlines.h"
 #include "RenderTreeBuilder.h"
 #include "RenderView.h"
-#include "UnicodeBidi.h"
 #include <wtf/StackStats.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -65,26 +64,16 @@ RenderListItem::~RenderListItem()
 
 RenderStyle RenderListItem::computeMarkerStyle() const
 {
-    if (!is<PseudoElement>(element())) {
-        if (auto markerStyle = getCachedPseudoStyle({ PseudoElementType::Marker }, &style()))
-            return RenderStyle::clone(*markerStyle);
-    }
+    if (auto markerStyle = getCachedPseudoStyle({ PseudoElementType::Marker }, &style()))
+        return RenderStyle::clone(*markerStyle);
+
+    if (auto* markerStyle = style().getCachedPseudoStyle({ PseudoElementType::Marker }))
+        return RenderStyle::clone(*markerStyle);
 
     // The marker always inherits from the list item, regardless of where it might end
     // up (e.g., in some deeply nested line box). See CSS3 spec.
     auto markerStyle = RenderStyle::create();
     markerStyle.inheritFrom(style());
-
-    // In the case of a ::before or ::after pseudo-element, we manually apply the properties
-    // otherwise set in the user-agent stylesheet since we don't support ::before::marker or
-    // ::after::marker. See bugs.webkit.org/b/218897.
-    auto fontDescription = style().fontDescription();
-    fontDescription.setVariantNumericSpacing(FontVariantNumericSpacing::TabularNumbers);
-    markerStyle.setFontDescription(WTF::move(fontDescription));
-    markerStyle.setUnicodeBidi(UnicodeBidi::Isolate);
-    markerStyle.setWhiteSpaceCollapse(WhiteSpaceCollapse::Preserve);
-    markerStyle.setTextWrapMode(TextWrapMode::NoWrap);
-    markerStyle.setTextTransform({ });
     return markerStyle;
 }
 

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -915,9 +915,8 @@ void RenderTreeUpdater::tearDownRenderersInternal(Element& root, TeardownType te
             GeneratedContent::removeAfterPseudoElement(element.get(), builder);
 
             if (!is<PseudoElement>(element.get())) {
-                // ::before and ::after cannot have a ::marker pseudo-element addressable via
-                // CSS selectors, and as such cannot possibly have animations on them. Additionally,
-                // we cannot create a Styleable with a PseudoElement.
+                // FIXME: Now that ::before::marker and ::after::marker are supported,
+                // we should handle animations on them too. See webkit.org/b/218897.
                 if (auto* renderListItem = dynamicDowncast<RenderListItem>(element->renderer())) {
                     if (renderListItem->markerRenderer())
                         Styleable(element.get(), Style::PseudoElementIdentifier { PseudoElementType::Marker }).cancelStyleOriginatedAnimations();

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -565,6 +565,11 @@ std::optional<ElementUpdate> TreeResolver::resolvePseudoElement(Element& element
             if (auto firstLetterStyle = resolveAncestorFirstLetterPseudoElement(element, elementUpdate, beforeAfterContext))
                 animatedUpdate.style->addCachedPseudoStyle(WTF::move(firstLetterStyle->style));
         }
+        if (animatedUpdate.style->display() == DisplayType::BlockFlowListItem) {
+            auto markerContext = makeResolutionContextForPseudoElement(animatedUpdate, { PseudoElementType::Marker });
+            if (auto markerStyle = scope().resolver->styleForPseudoElement(element, PseudoElementType::Marker, markerContext))
+                animatedUpdate.style->addCachedPseudoStyle(WTF::move(markerStyle->style));
+        }
     }
 
     return animatedUpdate;


### PR DESCRIPTION
#### 69988905aea5df0328ea96641a5c52ac105e43c0
<pre>
Allow ::marker as a sub-pseudo-element of ::before and ::after
<a href="https://bugs.webkit.org/show_bug.cgi?id=310515">https://bugs.webkit.org/show_bug.cgi?id=310515</a>
<a href="https://rdar.apple.com/173127840">rdar://173127840</a>

Reviewed by NOBODY (OOPS!).

Per CSS Pseudo-Elements Level 4 §4.1 [1], ::before and ::after are fully
styleable pseudo-elements: &quot;there is no restriction on what properties
apply to them.&quot; Since all properties apply, including display: list-item,
they can generate a ::marker pseudo-element as a sub-pseudo-element.

Update isSimpleSelectorValidAfterPseudoElement() to accept ::marker
after ::before and ::after.

Extend the user-agent stylesheet rule for ::marker to also match
::before::marker and ::after::marker, so that the default marker
properties (unicode-bidi, font-variant-numeric, white-space,
text-transform, text-indent) apply uniformly.

In StyleTreeResolver::resolvePseudoElement(), after resolving ::before
or ::after, if the resulting style has display: list-item, resolve
::marker as a sub-pseudo-element and cache it on the ::before/::after
style. This follows the existing pattern for ::first-line and
::first-letter sub-pseudo resolution.

Remove the pseudo-element-specific hack in
RenderListItem::computeMarkerStyle() that manually applied UA stylesheet
properties for ::before/::after markers. Instead, fall back to checking
the directly cached pseudo style on the render style, bypassing the
hasPseudoStyle() guard that is not set for pseudo-element styles.

NOTE: The selector matching does not yet distinguish between bare ::marker
and ::before::marker / ::after::marker contexts. Animations on
::before::marker and ::after::marker are also not yet supported.

[1] <a href="https://drafts.csswg.org/css-pseudo-4/#generated-content">https://drafts.csswg.org/css-pseudo-4/#generated-content</a>

* Source/WebCore/css/html.css:
(::marker, ::before::marker, ::after::marker):
(::marker): Deleted.
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::isSimpleSelectorValidAfterPseudoElement):
* Source/WebCore/rendering/RenderListItem.cpp:
(WebCore::RenderListItem::computeMarkerStyle const):
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::RenderTreeUpdater::tearDownRenderersInternal):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolvePseudoElement):
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/parsing/tree-abiding-pseudo-elements-expected.txt: Progression
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/text-selection-expected.txt: Ditto
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69988905aea5df0328ea96641a5c52ac105e43c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160155 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33625 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26729 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169056 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114536 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162024 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33728 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33627 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124153 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-lists/nested-marker-dynamic.html imported/w3c/web-platform-tests/css/css-lists/nested-marker.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87079 "2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163113 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26395 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143854 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104754 "Found 1 new API test failure: WPE/TestWebKitFaviconDatabase:/webkit/WebKitFaviconDatabase/get-page-icons (failure)") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25448 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-lists/nested-marker-dynamic.html imported/w3c/web-platform-tests/css/css-lists/nested-marker.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23941 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16776 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135140 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21617 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171532 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17523 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23257 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-lists/nested-marker-dynamic.html imported/w3c/web-platform-tests/css/css-lists/nested-marker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132406 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33301 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28030 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-lists/nested-marker-dynamic.html imported/w3c/web-platform-tests/css/css-lists/nested-marker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132432 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33286 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143412 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91525 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27046 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20226 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-lists/nested-marker-dynamic.html imported/w3c/web-platform-tests/css/css-lists/nested-marker.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32795 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99192 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32293 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32539 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32443 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->