### PR TITLE
Fix UB in equalSpans() and inconsistent null/empty semantics in CStringView

### DIFF
--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -1016,6 +1016,8 @@ bool equalSpans(std::span<T, TExtent> a, std::span<U, UExtent> b)
     static_assert(ignoreTypeChecks == IgnoreTypeChecks::Yes || std::has_unique_object_representations_v<U>);
     if (a.size() != b.size())
         return false;
+    if (!a.size())
+        return true;
     return !memcmp(a.data(), b.data(), a.size_bytes()); // NOLINT
 }
 

--- a/Source/WTF/wtf/text/CStringView.h
+++ b/Source/WTF/wtf/text/CStringView.h
@@ -68,11 +68,8 @@ public:
         : CStringView()
     { }
     CStringView(ASCIILiteral literal LIFETIME_BOUND)
-    {
-        if (!literal.length())
-            return;
-        m_spanWithNullTerminator = byteCast<char8_t>(literal.spanIncludingNullTerminator());
-    }
+        : m_spanWithNullTerminator(byteCast<char8_t>(literal.spanIncludingNullTerminator()))
+    { }
 
     bool isNull() const { return m_spanWithNullTerminator.empty(); }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/CStringView.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CStringView.cpp
@@ -49,9 +49,9 @@ TEST(WTF, CStringViewNullAndEmpty)
     EXPECT_FALSE(string);
 
     string = CStringView(""_s);
-    EXPECT_TRUE(string.isNull());
+    EXPECT_FALSE(string.isNull());
     EXPECT_TRUE(string.isEmpty());
-    EXPECT_EQ(string.utf8(), nullptr);
+    EXPECT_TRUE(string.utf8());
     EXPECT_TRUE(!string);
     EXPECT_FALSE(string);
 
@@ -69,6 +69,11 @@ TEST(WTF, CStringViewSize)
     EXPECT_EQ(string.lengthInBytes(), 0UZ);
     EXPECT_EQ(string.span().size(), 0UZ);
     EXPECT_EQ(string.spanIncludingNullTerminator().size(), 0UZ);
+
+    string = CStringView(""_s);
+    EXPECT_EQ(string.lengthInBytes(), 0UZ);
+    EXPECT_EQ(string.span().size(), 0UZ);
+    EXPECT_EQ(string.spanIncludingNullTerminator().size(), 1UZ);
 
     string = CStringView("test"_s);
     EXPECT_EQ(string.lengthInBytes(), 4UZ);
@@ -106,10 +111,12 @@ TEST(WTF, CStringViewFrom)
     stringPtr = "";
     string = CStringView::unsafeFromUTF8(stringPtr);
     EXPECT_EQ(string.lengthInBytes(), 0UZ);
+    EXPECT_FALSE(string.isNull());
     EXPECT_FALSE(string);
     EXPECT_EQ(string.utf8(), stringPtr);
     string = CStringView::fromUTF8(byteCast<char8_t>(unsafeSpanIncludingNullTerminator(stringPtr)));
     EXPECT_EQ(string.lengthInBytes(), 0UZ);
+    EXPECT_FALSE(string.isNull());
     EXPECT_FALSE(string);
     EXPECT_EQ(string.utf8(), stringPtr);
 
@@ -129,21 +136,38 @@ TEST(WTF, CStringViewEquality)
     CStringView string("Test"_s);
     CStringView sameString("Test"_s);
     CStringView anotherString("another test"_s);
-    CStringView emptyString;
-    CStringView nullString(nullptr);
-    EXPECT_TRUE(string != emptyString);
+    CStringView nullString;
+    CStringView nullString2(nullptr);
+    CStringView emptyLiteral(""_s);
+
     EXPECT_EQ(string, string);
     EXPECT_EQ(string, sameString);
     EXPECT_TRUE(string != anotherString);
-    EXPECT_EQ(emptyString, nullString);
+    EXPECT_TRUE(string != nullString);
 
+    // Null vs null.
+    EXPECT_EQ(nullString, nullString2);
+
+    // Null vs empty (both have zero lengthInBytes).
+    EXPECT_EQ(nullString, emptyLiteral);
+
+    // Empty from unsafeFromUTF8 vs null and vs empty literal.
     char* bareEmptyString = strdup("");
     char* bareEmptyString2 = strdup("");
-    emptyString = CStringView::unsafeFromUTF8(bareEmptyString);
-    auto emptyString2 = CStringView::unsafeFromUTF8(bareEmptyString2);
-    EXPECT_EQ(emptyString, emptyString2);
+    auto emptyFromUTF8 = CStringView::unsafeFromUTF8(bareEmptyString);
+    auto emptyFromUTF8_2 = CStringView::unsafeFromUTF8(bareEmptyString2);
+    EXPECT_EQ(emptyFromUTF8, emptyFromUTF8_2);
+    EXPECT_EQ(emptyFromUTF8, nullString);
+    EXPECT_EQ(emptyFromUTF8, emptyLiteral);
     free(bareEmptyString);
     free(bareEmptyString2);
+
+    // CStringView vs ASCIILiteral.
+    EXPECT_EQ(string, "Test"_s);
+    EXPECT_EQ("Test"_s, string);
+    EXPECT_TRUE(string != "Other"_s);
+    EXPECT_EQ(nullString, ""_s);
+    EXPECT_EQ(emptyLiteral, ""_s);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### b416e36fff4608fc03b8213d55e7daa27821a3fa
<pre>
Fix UB in equalSpans() and inconsistent null/empty semantics in CStringView
<a href="https://bugs.webkit.org/show_bug.cgi?id=310514">https://bugs.webkit.org/show_bug.cgi?id=310514</a>

Reviewed by Anne van Kesteren.

equalSpans() calls memcmp() without guarding against zero-size spans.
However, passing nullptr to memcmp() is undefined behavior, even when
the count is zero. This was triggered when comparing null or
empty CStringViews via operator==.

Additionally, CStringView&apos;s ASCIILiteral constructor was collapsing
empty strings to null (`CStringView(&quot;&quot;_s).isNull()` was true), while
`unsafeFromUTF8(&quot;&quot;)` and `fromUTF8({&apos;\0&apos;})` correctly preserved the
non-null empty state. Fix the ASCIILiteral constructor to stop
special-casing empty strings, making all construction paths consistent.

Test: Tools/TestWebKitAPI/Tests/WTF/CStringView.cpp

* Source/WTF/wtf/StdLibExtras.h:
(WTF::equalSpans): Add early return when both spans have size zero
to avoid calling memcmp() with potentially-null pointers.

* Source/WTF/wtf/text/CStringView.h:
* Tools/TestWebKitAPI/Tests/WTF/CStringView.cpp:
(TestWebKitAPI::TEST(WTF, CStringViewNullAndEmpty)):
(TestWebKitAPI::TEST(WTF, CStringViewSize)):
(TestWebKitAPI::TEST(WTF, CStringViewFrom)):
(TestWebKitAPI::TEST(WTF, CStringViewEquality)):

Canonical link: <a href="https://commits.webkit.org/309766@main">https://commits.webkit.org/309766@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d98e84c218a8278aafbee9ec2b08c24134abadf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151639 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24420 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17990 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160374 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105096 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2d1e4fa4-5038-4467-9133-bd6996c9119c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153513 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24888 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24713 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117120 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83136 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/336a58d2-cda3-4f1d-90c5-9771f84c8f5e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154599 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19254 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136069 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97835 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5664723e-b67d-45a2-9f1a-33d4ec22f605) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18342 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16292 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8216 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/143642 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127972 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13973 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162845 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/12440 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5987 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15563 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125139 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24219 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20350 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125321 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34013 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24220 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135769 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80795 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20362 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12544 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/183250 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23836 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88121 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46746 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23528 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23688 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23588 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->