### PR TITLE
Add TextEffectController and associated plumbing to complete the refactor to use modern text effects.

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -262,6 +262,7 @@ page/scrolling/mac/ScrollingTreeMac.mm @nonARC
 page/scrolling/mac/ScrollingTreeOverflowScrollingNodeMac.mm @nonARC
 page/scrolling/mac/ScrollingTreePluginScrollingNodeMac.mm @nonARC
 page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm @nonARC
+page/writing-tools/TextEffectController.mm @nonARC
 page/writing-tools/WritingToolsController.mm @nonARC
 platform/VideoFrame.mm @nonARC
 platform/audio/AudioSession.cpp

--- a/Source/WebCore/dom/DocumentMarkerController.cpp
+++ b/Source/WebCore/dom/DocumentMarkerController.cpp
@@ -42,6 +42,10 @@
 #include "RenderObjectInlines.h"
 #include "RenderReplaced.h"
 #include "RenderText.h"
+#if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+#include "TextEffectController.h"
+#include "TextIndicator.h"
+#endif
 #include "RenderedDocumentMarker.h"
 #include "TextIterator.h"
 #include <stdio.h>
@@ -90,10 +94,26 @@ auto DocumentMarkerController::collectTextRanges(const SimpleRange& range) -> Ve
 bool DocumentMarkerController::addMarker(const SimpleRange& range, DocumentMarkerType type, const DocumentMarker::Data& data)
 {
     bool added = false;
+
+#if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+    RefPtr page = m_document->page();
+    bool needsTextEffect = type == DocumentMarkerType::Grammar && page;
+    RefPtr<TextIndicator> textIndicator;
+    if (needsTextEffect)
+        textIndicator = page->textEffectController().createTextIndicatorForRange(range);
+#endif
+
     for (auto& textPiece : collectTextRanges(range)) {
         if (addMarker(textPiece.node, { type, textPiece.range, DocumentMarker::Data { data } }))
             added = true;
     }
+
+#if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+    if (needsTextEffect) {
+        RefPtr decorationIndicator = page->textEffectController().createTextIndicatorForRange(range);
+        page->textEffectController().addTextEffect(range, WTF::move(textIndicator), WTF::move(decorationIndicator));
+    }
+#endif
     return added;
 }
 
@@ -146,6 +166,12 @@ void DocumentMarkerController::removeAllDictationStreamingOpacityMarkers()
 
 void DocumentMarkerController::removeMarkers(const SimpleRange& range, OptionSet<DocumentMarkerType> types, RemovePartiallyOverlappingMarker overlapRule)
 {
+#if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+    if (types.contains(DocumentMarkerType::Grammar)) {
+        if (RefPtr page = m_document->page())
+            page->textEffectController().removeTextEffect(range);
+    }
+#endif
     filterMarkers(range, nullptr, types, overlapRule);
 }
 

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -171,6 +171,7 @@ struct SimpleRange;
 struct StringWithDirection;
 struct SystemPreviewInfo;
 struct TextRecognitionOptions;
+struct TextEffectData;
 struct ViewportArguments;
 struct WindowFeatures;
 
@@ -784,6 +785,11 @@ public:
     virtual void saveSnapshotOfTextPlaceholderForAnimation(const SimpleRange&) { };
 
     virtual void clearAnimationsForActiveWritingToolsSession() { };
+
+#if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+    virtual void addTextEffectForID(const WTF::UUID&, TextEffectData&&, RefPtr<TextIndicator>&&, RefPtr<TextIndicator>&&) { }
+    virtual void removeTextEffectForID(const WTF::UUID&) { }
+#endif
 #endif
 
     virtual void setIsInRedo(bool) { }

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -247,6 +247,10 @@
 #include "AccessibilityRootAtspi.h"
 #endif
 
+#if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+#include "TextEffectController.h"
+#endif
+
 #if ENABLE(WRITING_TOOLS)
 #include "WritingToolsController.h"
 #endif
@@ -479,6 +483,9 @@ Page::Page(PageConfiguration&& pageConfiguration)
 #endif
 #if ENABLE(WRITING_TOOLS)
     , m_writingToolsController(makeUniqueRef<WritingToolsController>(*this))
+#endif
+#if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+    , m_textEffectController(makeUniqueRef<TextEffectController>(*this))
 #endif
     , m_activeNowPlayingSessionUpdateTimer(*this, &Page::updateActiveNowPlayingSessionNow)
     , m_topDocumentSyncData(DocumentSyncData::create())

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -207,6 +207,9 @@ class WheelEventDeltaFilter;
 class WheelEventTestMonitor;
 class WindowEventLoop;
 
+#if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+class TextEffectController;
+#endif
 #if ENABLE(WRITING_TOOLS)
 class WritingToolsController;
 
@@ -1300,6 +1303,9 @@ public:
     WEBCORE_EXPORT std::optional<SimpleRange> contextRangeForActiveWritingToolsSession() const;
     WEBCORE_EXPORT void intelligenceTextAnimationsDidComplete();
 #endif
+#if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+    TextEffectController& textEffectController() { return m_textEffectController.get(); }
+#endif
 
     bool hasActiveNowPlayingSession() const { return m_hasActiveNowPlayingSession; }
     void hasActiveNowPlayingSessionChanged();
@@ -1817,6 +1823,9 @@ private:
 
 #if ENABLE(WRITING_TOOLS)
     const UniqueRef<WritingToolsController> m_writingToolsController;
+#endif
+#if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+    const UniqueRef<TextEffectController> m_textEffectController;
 #endif
 
 #if HAVE(SUPPORT_HDR_DISPLAY)

--- a/Source/WebCore/page/writing-tools/TextEffectController.h
+++ b/Source/WebCore/page/writing-tools/TextEffectController.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+#if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+
+#include <WebCore/SimpleRange.h>
+#include <WebCore/TextAnimationTypes.h>
+#include <wtf/CompletionHandler.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/UUID.h>
+#include <wtf/Vector.h>
+#include <wtf/WeakPtr.h>
+
+namespace WebCore {
+
+class Document;
+class Page;
+class TextIndicator;
+
+struct SimpleRange;
+
+class TextEffectController final {
+    WTF_MAKE_TZONE_ALLOCATED(TextEffectController);
+    WTF_MAKE_NONCOPYABLE(TextEffectController);
+
+public:
+    explicit TextEffectController(Page&);
+
+    void addTextEffect(const SimpleRange&, RefPtr<TextIndicator>&&, RefPtr<TextIndicator>&& decorationIndicator);
+    void removeTextEffect(const SimpleRange&);
+    void removeAllTextEffects();
+
+    RefPtr<TextIndicator> createTextIndicatorForRange(const SimpleRange&);
+
+    WEBCORE_EXPORT void updateUnderlyingTextVisibilityForTextEffectID(const WTF::UUID&, bool visible, CompletionHandler<void()>&&);
+    WEBCORE_EXPORT void createTextIndicatorForTextEffectID(const WTF::UUID&, CompletionHandler<void(RefPtr<TextIndicator>&&)>&&);
+
+private:
+    RefPtr<Document> document() const;
+    std::optional<SimpleRange> rangeForTextEffectID(const WTF::UUID&) const;
+    void removeTransparentMarkersForTextEffectID(const WTF::UUID&);
+
+    struct ActiveEffect {
+        WTF::UUID uuid;
+        SimpleRange range;
+    };
+
+    WeakPtr<Page> m_page;
+    Vector<ActiveEffect> m_activeEffects;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(WRITING_TOOLS_TEXT_EFFECTS)

--- a/Source/WebCore/page/writing-tools/TextEffectController.mm
+++ b/Source/WebCore/page/writing-tools/TextEffectController.mm
@@ -1,0 +1,167 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "TextEffectController.h"
+
+#if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+
+#import "Chrome.h"
+#import "ChromeClient.h"
+#import "Document.h"
+#import "DocumentMarkerController.h"
+#import "FocusController.h"
+#import "Page.h"
+#import "SimpleRange.h"
+#import "TextIndicator.h"
+#import <WebCore/WritingDirection.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(TextEffectController);
+
+TextEffectController::TextEffectController(Page& page)
+    : m_page(page)
+{
+}
+
+void TextEffectController::addTextEffect(const SimpleRange& range, RefPtr<TextIndicator>&& textIndicator, RefPtr<TextIndicator>&& decorationIndicator)
+{
+    auto uuid = WTF::UUID::createVersion4();
+
+    m_activeEffects.append({ uuid, range });
+
+    TextEffectData data { WritingDirection::Natural };
+    m_page->chrome().client().addTextEffectForID(uuid, WTF::move(data), WTF::move(textIndicator), WTF::move(decorationIndicator));
+}
+
+void TextEffectController::removeTextEffect(const SimpleRange& range)
+{
+    m_activeEffects.removeAllMatching([&](auto& effect) {
+        if (!intersects(range, effect.range))
+            return false;
+        removeTransparentMarkersForTextEffectID(effect.uuid);
+        m_page->chrome().client().removeTextEffectForID(effect.uuid);
+        return true;
+    });
+}
+
+void TextEffectController::removeAllTextEffects()
+{
+    for (auto& effect : m_activeEffects) {
+        removeTransparentMarkersForTextEffectID(effect.uuid);
+        m_page->chrome().client().removeTextEffectForID(effect.uuid);
+    }
+
+    m_activeEffects.clear();
+}
+
+void TextEffectController::updateUnderlyingTextVisibilityForTextEffectID(const WTF::UUID& uuid, bool visible, CompletionHandler<void()>&& completionHandler)
+{
+    RefPtr document = this->document();
+    if (!document) {
+        ASSERT_NOT_REACHED();
+        completionHandler();
+        return;
+    }
+
+    if (visible)
+        removeTransparentMarkersForTextEffectID(uuid);
+    else {
+        auto range = rangeForTextEffectID(uuid);
+        if (!range) {
+            completionHandler();
+            return;
+        }
+        protect(document->markers())->addTransparentContentMarker(*range, uuid);
+    }
+
+    completionHandler();
+}
+
+void TextEffectController::createTextIndicatorForTextEffectID(const WTF::UUID& uuid, CompletionHandler<void(RefPtr<TextIndicator>&&)>&& completionHandler)
+{
+    auto range = rangeForTextEffectID(uuid);
+    if (!range) {
+        completionHandler(nullptr);
+        return;
+    }
+
+    completionHandler(createTextIndicatorForRange(*range));
+}
+
+RefPtr<Document> TextEffectController::document() const
+{
+    if (!m_page) {
+        ASSERT_NOT_REACHED();
+        return nullptr;
+    }
+
+    RefPtr frame = m_page->focusController().focusedOrMainFrame();
+    if (!frame) {
+        ASSERT_NOT_REACHED();
+        return nullptr;
+    }
+
+    return frame->document();
+}
+
+std::optional<SimpleRange> TextEffectController::rangeForTextEffectID(const WTF::UUID& uuid) const
+{
+    for (auto& effect : m_activeEffects) {
+        if (effect.uuid == uuid)
+            return effect.range;
+    }
+    return std::nullopt;
+}
+
+RefPtr<TextIndicator> TextEffectController::createTextIndicatorForRange(const SimpleRange& range)
+{
+    static constexpr OptionSet textIndicatorOptions {
+        TextIndicatorOption::IncludeSnapshotOfAllVisibleContentWithoutSelection,
+        TextIndicatorOption::ExpandClipBeyondVisibleRect,
+        TextIndicatorOption::SkipReplacedContent,
+        TextIndicatorOption::RespectTextColor,
+    };
+
+    return TextIndicator::createWithRange(range, textIndicatorOptions, TextIndicatorPresentationTransition::None, { });
+}
+
+void TextEffectController::removeTransparentMarkersForTextEffectID(const WTF::UUID& uuid)
+{
+    RefPtr document = this->document();
+    if (!document) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    protect(document->markers())->removeMarkers({ DocumentMarkerType::TransparentContent }, [&uuid](const DocumentMarker& marker) {
+        return std::get<DocumentMarker::TransparentContentData>(marker.data()).uuid == uuid ? FilterMarkerResult::Remove : FilterMarkerResult::Keep;
+    });
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WRITING_TOOLS_TEXT_EFFECTS)

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
@@ -149,7 +149,7 @@ public:
     void removeTextAnimationForAnimationID(const WTF::UUID&) final;
 
 #if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
-    void addTextEffectForID(const WTF::UUID&, const WebCore::TextEffectData&) final;
+    void addTextEffectForID(const WTF::UUID&, WebCore::TextEffectData&&) final;
     void removeTextEffectForID(const WTF::UUID&) final;
 #endif
 #endif

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
@@ -366,7 +366,7 @@ void PageClientImplCocoa::removeTextAnimationForAnimationID(const WTF::UUID& uui
 }
 
 #if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
-void PageClientImplCocoa::addTextEffectForID(const WTF::UUID& uuid, const WebCore::TextEffectData& data)
+void PageClientImplCocoa::addTextEffectForID(const WTF::UUID& uuid, WebCore::TextEffectData&& data)
 {
     [webView() _addTextEffectForID:uuid.createNSUUID().get() withData:data];
 }

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -1503,7 +1503,7 @@ void WebPageProxy::setSelectionForActiveWritingToolsSession(const WebCore::Chara
 }
 
 #if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
-void WebPageProxy::addTextEffectForID(IPC::Connection& connection, const WTF::UUID& uuid, const WebCore::TextEffectData& data, RefPtr<WebCore::TextIndicator>&& textIndicator, RefPtr<WebCore::TextIndicator>&& decorationIndicator)
+void WebPageProxy::addTextEffectForID(IPC::Connection& connection, const WTF::UUID& uuid, WebCore::TextEffectData&& data, RefPtr<WebCore::TextIndicator>&& textIndicator, RefPtr<WebCore::TextIndicator>&& decorationIndicator)
 {
     MESSAGE_CHECK(uuid.isValid(), connection);
 
@@ -1511,7 +1511,7 @@ void WebPageProxy::addTextEffectForID(IPC::Connection& connection, const WTF::UU
     internals().decorationIndicatorForAnimationID.add(uuid, decorationIndicator);
 
     if (RefPtr pageClient = this->pageClient())
-        pageClient->addTextEffectForID(uuid, data);
+        pageClient->addTextEffectForID(uuid, WTF::move(data));
 }
 
 void WebPageProxy::removeTextEffectForID(IPC::Connection& connection, const WTF::UUID& uuid)

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -816,7 +816,7 @@ public:
     virtual void removeTextAnimationForAnimationID(const WTF::UUID&) = 0;
 
 #if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
-    virtual void addTextEffectForID(const WTF::UUID&, const WebCore::TextEffectData&) = 0;
+    virtual void addTextEffectForID(const WTF::UUID&, WebCore::TextEffectData&&) = 0;
     virtual void removeTextEffectForID(const WTF::UUID&) = 0;
 #endif
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2804,7 +2804,7 @@ public:
     void removeTextAnimationForAnimationID(IPC::Connection&, const WTF::UUID&);
 
 #if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
-    void addTextEffectForID(IPC::Connection&, const WTF::UUID&, const WebCore::TextEffectData&, RefPtr<WebCore::TextIndicator>&&, RefPtr<WebCore::TextIndicator>&& decorationIndicator);
+    void addTextEffectForID(IPC::Connection&, const WTF::UUID&, WebCore::TextEffectData&&, RefPtr<WebCore::TextIndicator>&&, RefPtr<WebCore::TextIndicator>&& decorationIndicator);
     void removeTextEffectForID(IPC::Connection&, const WTF::UUID&);
 #endif
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -2380,6 +2380,20 @@ void WebChromeClient::clearAnimationsForActiveWritingToolsSession()
         page->clearAnimationsForActiveWritingToolsSession();
 }
 
+#if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+void WebChromeClient::addTextEffectForID(const WTF::UUID& uuid, WebCore::TextEffectData&& data, RefPtr<WebCore::TextIndicator>&& textIndicator, RefPtr<WebCore::TextIndicator>&& decorationIndicator)
+{
+    if (RefPtr page = m_page.get())
+        page->addTextEffectForID(uuid, WTF::move(data), WTF::move(textIndicator), WTF::move(decorationIndicator));
+}
+
+void WebChromeClient::removeTextEffectForID(const WTF::UUID& uuid)
+{
+    if (RefPtr page = m_page.get())
+        page->removeTextEffectForID(uuid);
+}
+#endif // ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+
 #endif
 
 void WebChromeClient::setIsInRedo(bool isInRedo)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -560,6 +560,11 @@ private:
     void saveSnapshotOfTextPlaceholderForAnimation(const WebCore::SimpleRange&);
 
     void clearAnimationsForActiveWritingToolsSession() final;
+
+#if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+    void addTextEffectForID(const WTF::UUID&, WebCore::TextEffectData&&, RefPtr<WebCore::TextIndicator>&&, RefPtr<WebCore::TextIndicator>&&) final;
+    void removeTextEffectForID(const WTF::UUID&) final;
+#endif
 #endif
 
     WebCore::HTMLFrameOwnerElement* frameOwnerElementForFrameID(WebCore::FrameIdentifier) const final;

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -179,6 +179,10 @@
 #include "WebExtensionControllerProxy.h"
 #endif
 
+#if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+#import <WebCore/TextEffectController.h>
+#endif
+
 #import "PDFKitSoftLink.h"
 
 #define WEBPAGE_RELEASE_LOG(channel, fmt, ...) RELEASE_LOG(channel, "%p - [webPageID=%" PRIu64 "] WebPage::" fmt, this, m_identifier.toUInt64(), ##__VA_ARGS__)
@@ -1353,6 +1357,18 @@ void WebPage::removeTextAnimationForAnimationID(const WTF::UUID& uuid)
     send(Messages::WebPageProxy::RemoveTextAnimationForAnimationID(uuid));
 }
 
+#if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+void WebPage::addTextEffectForID(const WTF::UUID& uuid, WebCore::TextEffectData&& data, RefPtr<WebCore::TextIndicator>&& textIndicator, RefPtr<WebCore::TextIndicator>&& decorationIndicator)
+{
+    send(Messages::WebPageProxy::AddTextEffectForID(uuid, WTF::move(data), WTF::move(textIndicator), WTF::move(decorationIndicator)));
+}
+
+void WebPage::removeTextEffectForID(const WTF::UUID& uuid)
+{
+    send(Messages::WebPageProxy::RemoveTextEffectForID(uuid));
+}
+#endif // ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+
 void WebPage::removeInitialTextAnimationForActiveWritingToolsSession()
 {
     m_textAnimationController->removeInitialTextAnimationForActiveWritingToolsSession();
@@ -1394,14 +1410,14 @@ void WebPage::updateUnderlyingTextVisibilityForTextAnimationID(const WTF::UUID& 
 }
 
 #if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
-void WebPage::updateUnderlyingTextVisibilityForTextEffectID(const WTF::UUID&, bool, CompletionHandler<void()>&& completionHandler)
+void WebPage::updateUnderlyingTextVisibilityForTextEffectID(const WTF::UUID& uuid, bool visible, CompletionHandler<void()>&& completionHandler)
 {
-    completionHandler();
+    protect(corePage())->textEffectController().updateUnderlyingTextVisibilityForTextEffectID(uuid, visible, WTF::move(completionHandler));
 }
 
-void WebPage::createTextIndicatorForTextEffectID(const WTF::UUID&, CompletionHandler<void(RefPtr<WebCore::TextIndicator>&&)>&& completionHandler)
+void WebPage::createTextIndicatorForTextEffectID(const WTF::UUID& uuid, CompletionHandler<void(RefPtr<WebCore::TextIndicator>&&)>&& completionHandler)
 {
-    completionHandler(nullptr);
+    protect(corePage())->textEffectController().createTextIndicatorForTextEffectID(uuid, WTF::move(completionHandler));
 }
 #endif // ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -347,6 +347,7 @@ struct TargetedElementInfo;
 struct TargetedElementRequest;
 struct TextAnimationData;
 struct TextCheckingResult;
+struct TextEffectData;
 struct TextManipulationControllerExclusionRule;
 struct TextManipulationControllerManipulationResult;
 struct TextManipulationItem;
@@ -2097,6 +2098,11 @@ public:
     void addTextAnimationForAnimationID(const WTF::UUID&, const WebCore::TextAnimationData&, const RefPtr<WebCore::TextIndicator>, CompletionHandler<void(WebCore::TextAnimationRunMode)>&& = { });
 
     void removeTextAnimationForAnimationID(const WTF::UUID&);
+
+#if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+    void addTextEffectForID(const WTF::UUID&, WebCore::TextEffectData&&, RefPtr<WebCore::TextIndicator>&&, RefPtr<WebCore::TextIndicator>&&);
+    void removeTextEffectForID(const WTF::UUID&);
+#endif
 
     void removeInitialTextAnimationForActiveWritingToolsSession();
     void addInitialTextAnimationForActiveWritingToolsSession();


### PR DESCRIPTION
#### abba7372a2d4ea3f68f652559d02cd680364dc5e
<pre>
Add TextEffectController and associated plumbing to complete the refactor to use modern text effects.
<a href="https://bugs.webkit.org/show_bug.cgi?id=310517">https://bugs.webkit.org/show_bug.cgi?id=310517</a>
<a href="https://rdar.apple.com/173129463">rdar://173129463</a>

Reviewed by Abrar Rahman Protyasha.

Refactoring to use the text effects that became
available after the first implementation of
writing tools.

* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/DocumentMarkerController.cpp:
(WebCore::DocumentMarkerController::addMarker):
(WebCore::DocumentMarkerController::removeMarkers):
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::addTextEffectForID):
(WebCore::ChromeClient::removeTextEffectForID):
* Source/WebCore/page/Page.cpp:
* Source/WebCore/page/Page.h:
(WebCore::Page::textEffectController):
* Source/WebCore/page/writing-tools/TextEffectController.h: Added.
* Source/WebCore/page/writing-tools/TextEffectController.mm: Added.
(WebCore::TextEffectController::TextEffectController):
(WebCore::TextEffectController::addTextEffect):
(WebCore::TextEffectController::removeTextEffect):
(WebCore::TextEffectController::removeAllTextEffects):
(WebCore::TextEffectController::updateUnderlyingTextVisibilityForTextEffectID):
(WebCore::TextEffectController::createTextIndicatorForTextEffectID):
(WebCore::TextEffectController::document const):
(WebCore::TextEffectController::rangeForTextEffectID const):
(WebCore::TextEffectController::createTextIndicatorForRange):
(WebCore::TextEffectController::removeTransparentMarkersForTextEffectID):
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm:
(WebKit::PageClientImplCocoa::addTextEffectForID):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::addTextEffectForID):
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::addTextEffectForID):
(WebKit::WebChromeClient::removeTextEffectForID):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::addTextEffectForID):
(WebKit::WebPage::removeTextEffectForID):
(WebKit::WebPage::updateUnderlyingTextVisibilityForTextEffectID):
(WebKit::WebPage::createTextIndicatorForTextEffectID):
* Source/WebKit/WebProcess/WebPage/WebPage.h:

Canonical link: <a href="https://commits.webkit.org/309794@main">https://commits.webkit.org/309794@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57bf19235309ea736e48e70e0d78cb7e69ec40e2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151760 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24541 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18111 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160502 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aa9264ff-5614-4f4c-9c36-c80733872bf2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153634 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25034 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24837 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117219 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/69e1e0ac-c868-400b-af10-0bcf37a8a400) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154720 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136181 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97934 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2076ecf3-9132-480c-968b-bcda12ff6af3) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/18471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/16400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8337 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14085 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162966 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/6115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15676 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125241 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24340 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/20459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125422 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34026 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24341 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135881 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/80916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20463 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12656 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23957 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/88243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/23649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23809 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/23709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->