### PR TITLE
AX: UI-process scrolls should update FrameGeometry

### DIFF
--- a/LayoutTests/accessibility/ios-simulator/frame-geometry-update-after-uiscroll-expected.txt
+++ b/LayoutTests/accessibility/ios-simulator/frame-geometry-update-after-uiscroll-expected.txt
@@ -1,0 +1,9 @@
+This test verifies that the when scroll happens in the UI process, frame geometry is updated.
+
+PASS: accessibilityController.accessibleElementById('target').y < initialY === true
+PASS: delta > 400 && delta < 600 === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Target

--- a/LayoutTests/accessibility/ios-simulator/frame-geometry-update-after-uiscroll.html
+++ b/LayoutTests/accessibility/ios-simulator/frame-geometry-update-after-uiscroll.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<style>
+body {
+    height: 5000px;
+    margin: 0;
+}
+#target {
+    position: absolute;
+    top: 200px;
+    left: 10px;
+    width: 100px;
+    height: 50px;
+}
+</style>
+</head>
+<body>
+
+<button id="target">Target</button>
+
+<script>
+var output = "This test verifies that the when scroll happens in the UI process, frame geometry is updated.\n\n";
+var initialY, scrolledY, delta;
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    setTimeout(async function() {
+        var target = accessibilityController.accessibleElementById("target");
+
+        // Wait for initial FrameGeometry to arrive via async IPC.
+        await waitForFrameGeometryReady();
+        initialY = target.y;
+
+        // Scroll via UIHelper, which scrolls the real UIScrollView (animated).
+        await UIHelper.scrollTo(0, 500);
+
+        // Wait for the frame geometry update to propagate asynchronously.
+        output += await expectAsync("accessibilityController.accessibleElementById('target').y < initialY", "true");
+
+        scrolledY = accessibilityController.accessibleElementById("target").y;
+        delta = initialY - scrolledY;
+        output += expect("delta > 400 && delta < 600", "true");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+
+</body>
+</html>

--- a/LayoutTests/accessibility/ios-simulator/unobscured-content-rect-expected.txt
+++ b/LayoutTests/accessibility/ios-simulator/unobscured-content-rect-expected.txt
@@ -1,12 +1,9 @@
-test
 This tests that unobscured content rect is exposed to accessibility.
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+button visible rect: { x: 0, y: 0, w: 800, h: 600 }
+iframe visible rect: { x: 58, y: 10, w: 200, h: 200 }
 
-
-PASS button.stringAttributeValue('AXVisibleContentRect') is '{0.00, 0.00, 800.00, 600.00}'
-PASS frameButton.stringAttributeValue('AXVisibleContentRect') is '{58.00, 10.00, 200.00, 200.00}'
 PASS successfullyParsed is true
 
 TEST COMPLETE
-
+test

--- a/LayoutTests/accessibility/ios-simulator/unobscured-content-rect.html
+++ b/LayoutTests/accessibility/ios-simulator/unobscured-content-rect.html
@@ -1,38 +1,53 @@
-
 <!DOCTYPE html>
 <html>
 <body id="body">
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
 <div id="content">
 <button id="button">test</button>
 
-<iframe id="iframe" onload="startTest();" width="200" height="200" src="data:text/html,<body><button id='frame-button'>Click me</button><a href='%23' id='frame-link'>a</a></body>"></iframe>
+<iframe id="iframe" width="200" height="200" src="data:text/html,<body><button id='frame-button'>Click me</button><a href='%23' id='frame-link'>a</a></body>"></iframe>
 
 </div>
 
-<p id="description"></p>
-<div id="console"></div>
-
 <script>
+var output = "This tests that unobscured content rect is exposed to accessibility.\n\n";
 
-    description("This tests that unobscured content rect is exposed to accessibility.");
+function visibleContentRectValues(element) {
+    var parts = element.stringAttributeValue("AXVisibleContentRect").replace("{", "").replace("}", "").split(",");
+    return { x: parseFloat(parts[0]), y: parseFloat(parts[1]), w: parseFloat(parts[2]), h: parseFloat(parts[3]) };
+}
 
-    if (window.accessibilityController) {
-        window.jsTestIsAsync = true;
+function formatRect(rect, offsetX, offsetY) {
+    return `{ x: ${rect.x - offsetX}, y: ${rect.y - offsetY}, w: ${Math.round(rect.w)}, h: ${Math.round(rect.h)} }`;
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    document.getElementById("iframe").addEventListener("load", async function() {
+        await waitForFrameGeometryReady();
+
+        var iframeScrollView = accessibilityController.accessibleElementById("iframe").childAtIndex(0);
+        await waitFor(() => iframeScrollView.isFrameGeometryInitialized);
+
+        // Compute screen offset from root to normalize coordinates.
+        var rootRect = visibleContentRectValues(accessibilityController.rootElement);
+        var offsetX = rootRect.x;
+        var offsetY = rootRect.y;
+
         var button = accessibilityController.accessibleElementById("button");
-        shouldBe("button.stringAttributeValue('AXVisibleContentRect')", "'{0.00, 0.00, 800.00, 600.00}'");
+        output += `button visible rect: ${formatRect(visibleContentRectValues(button), offsetX, offsetY)}\n`;
 
-        var frameButton;
-        function startTest() {
-        	var iframe = document.getElementById("iframe");
-        	frameButton = iframe.contentWindow.accessibilityController.accessibleElementById("frame-button");
-		shouldBe("frameButton.stringAttributeValue('AXVisibleContentRect')", "'{58.00, 10.00, 200.00, 200.00}'");
-        	finishJSTest();
-        }
-    }
+        var iframe = document.getElementById("iframe");
+        var frameButton = iframe.contentWindow.accessibilityController.accessibleElementById("frame-button");
+        output += `iframe visible rect: ${formatRect(visibleContentRectValues(frameButton), offsetX, offsetY)}\n`;
+
+        debug(output);
+        finishJSTest();
+    });
+}
 </script>
 
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>
-

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -5643,6 +5643,8 @@ fast/block/positioning/vertical-rl/fixed-positioning.html [ Failure ]
 fast/forms/indeterminate-progress-inline-height.html [ Failure ]
 fast/forms/input-appearance-spinbutton.html [ Failure ]
 accessibility/ios-simulator/press-fires-touch-events.html [ Skip ]
+# Requires ENABLE(ACCESSIBILITY_LOCAL_FRAME) for FrameGeometry support.
+accessibility/ios-simulator/frame-geometry-update-after-uiscroll.html [ Skip ]
 
 fast/text/combining-character-sequence-vertical.html [ ImageOnlyFailure ]
 fast/text/vertical-quotation-marks.html [ ImageOnlyFailure ]

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -2055,6 +2055,12 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
     [self _scheduleVisibleContentRectUpdate];
     [_contentView didFinishScrolling];
 
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    // After scrolling completes, recompute the screen position for each frame
+    // so accessibility clients get up-to-date screen coordinates.
+    _page->updateAccessibilityFrameGeometry();
+#endif
+
     if (CheckedPtr coordinator = _page->scrollingCoordinatorProxy())
         coordinator->setRootNodeIsInUserScroll(false);
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -6581,8 +6581,7 @@ void WebPageProxy::pageScaleFactorDidChange(IPC::Connection& connection, double 
 
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     // If the page's scale factor changes, the UI process needs to send an updated AffineTransform to each frame.
-    for (RefPtr frame = m_mainFrame; frame; frame = frame->traverseNext().frame)
-        requestFrameScreenPosition(frame->frameID());
+    updateAccessibilityFrameGeometry();
 #endif
 }
 
@@ -10047,6 +10046,12 @@ void WebPageProxy::requestFrameScreenPosition(FrameIdentifier frameID)
 
         protectedThis->sendToProcessContainingFrame(frameID, Messages::WebPage::UpdateRemotePageAccessibilityScreenPosition(frameID, geometry));
     });
+}
+
+void WebPageProxy::updateAccessibilityFrameGeometry()
+{
+    for (RefPtr frame = m_mainFrame; frame; frame = frame->traverseNext().frame)
+        requestFrameScreenPosition(frame->frameID());
 }
 #endif // ENABLE(ACCESSIBILITY_LOCAL_FRAME)
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1574,6 +1574,9 @@ public:
     void setCustomDeviceScaleFactor(float, CompletionHandler<void()>&&);
 
     void accessibilitySettingsDidChange();
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    void updateAccessibilityFrameGeometry();
+#endif
     void enableAccessibilityForAllProcesses();
 
 #if PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -33,6 +33,7 @@
 #import "APIPageConfiguration.h"
 #import "APIUIClient.h"
 #import "ApplicationStateTracker.h"
+#import "DefaultWebBrowserChecks.h"
 #import "DrawingAreaProxy.h"
 #import "EndowmentStateTracker.h"
 #import "FrameInfoData.h"
@@ -592,6 +593,14 @@ IntRect PageClientImpl::rootViewToAccessibilityScreen(const IntRect& rect)
     auto contentView = this->contentView();
     if ([contentView respondsToSelector:@selector(accessibilityConvertRectToSceneReferenceCoordinates:)])
         rootViewRect = [contentView accessibilityConvertRectToSceneReferenceCoordinates:rootViewRect];
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    else if (isRunningTest(applicationBundleIdentifier())) [[unlikely]] {
+        // accessibilityConvertRectToSceneReferenceCoordinates is a no-op when running tests,
+        // so fall back to standard UIKit coordinate conversion.
+        if (UIWindow *window = [contentView window])
+            rootViewRect = [contentView convertRect:rootViewRect toCoordinateSpace:window.screen.coordinateSpace];
+    }
+#endif
     return enclosingIntRect(rootViewRect);
 }
     


### PR DESCRIPTION
#### f015f2e2b556798e6d5579e5912a791e56607701
<pre>
AX: UI-process scrolls should update FrameGeometry
<a href="https://bugs.webkit.org/show_bug.cgi?id=310518">https://bugs.webkit.org/show_bug.cgi?id=310518</a>
<a href="https://rdar.apple.com/173129711">rdar://173129711</a>

Reviewed by Tyler Wilcock.

After a UI-process scroll, we were not updating all frames&apos; FrameGeometry. This PR fixes that,
hooking into the WKWebView&apos;s _didFinishScrolling to trigger a recomputation from the UI process.

To enable testing this on the simulator, a new fallback was added to rootViewToAccessibilityScreen.
The issue was that on the simulator, accessibilityConvertRectToSceneReferenceCoordinates, which is
used in that method, was a no-op. Now, we fallback (in the test runner only) to using standard
UIKit coordinate conversion. This provides adequate behavior for testing, allowing us to verify
that FrameGeometry updates. The new test, frame-geometry-update-after-uiscroll.html, exercises
this.

One simulator test (accessibility/ios-simulator/unobscured-content-rect.html) was updated so that
the screen positions are normalized.

Test: accessibility/ios-simulator/frame-geometry-update-after-uiscroll.html

* LayoutTests/accessibility/ios-simulator/frame-geometry-update-after-uiscroll-expected.txt: Added.
* LayoutTests/accessibility/ios-simulator/frame-geometry-update-after-uiscroll.html: Added.
* LayoutTests/accessibility/ios-simulator/unobscured-content-rect-expected.txt:
* LayoutTests/accessibility/ios-simulator/unobscured-content-rect.html:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _didFinishScrolling:]):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::pageScaleFactorDidChange):
(WebKit::WebPageProxy::updateAccessibilityFrameGeometry):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::rootViewToAccessibilityScreen):

Canonical link: <a href="https://commits.webkit.org/309834@main">https://commits.webkit.org/309834@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9cd296dd891e7cb2dccbc79977a58dbf737ee77c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151783 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24564 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18134 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160525 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105240 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3bf1d640-955b-4091-a0b7-81245c87d6fe) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25057 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24858 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117235 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83200 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a3f028d7-d312-4071-848e-fa1c3a4be876) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154743 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19394 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136199 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97950 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/896529b1-b2b4-495c-829c-17f7366a6702) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18479 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16419 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8360 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128109 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14102 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162989 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6138 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15693 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125255 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24363 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20478 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125436 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34054 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24364 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135898 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80939 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20465 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12673 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23980 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88266 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23672 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23832 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23732 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->