### PR TITLE
StringParsingBuffer::consume() incorrectly returns the whole buffer

### DIFF
--- a/Source/WTF/wtf/text/StringParsingBuffer.h
+++ b/Source/WTF/wtf/text/StringParsingBuffer.h
@@ -73,7 +73,7 @@ public:
     std::span<const CharacterType> consume(size_t count) LIFETIME_BOUND
     {
         ASSERT(count <= lengthRemaining());
-        auto result = m_data;
+        auto result = m_data.first(count);
         m_data = m_data.subspan(count);
         return result;
     }

--- a/Tools/TestWebKitAPI/Tests/WTF/StringParsingBuffer.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringParsingBuffer.cpp
@@ -167,6 +167,31 @@ TEST(WTF, StringParsingBufferStringView)
     EXPECT_EQ(viewRemaining[1], 'c');
 }
 
+TEST(WTF, StringParsingBufferConsumeCount)
+{
+    StringView string { "abcdef"_s };
+    StringParsingBuffer parsingBuffer { string.span8() };
+
+    // Consume 3 characters; the returned span should contain only the consumed characters.
+    auto consumed = parsingBuffer.consume(3);
+    EXPECT_EQ(consumed.size(), 3u);
+    EXPECT_EQ(consumed[0], 'a');
+    EXPECT_EQ(consumed[1], 'b');
+    EXPECT_EQ(consumed[2], 'c');
+
+    // The buffer should have advanced past the consumed characters.
+    EXPECT_EQ(parsingBuffer.lengthRemaining(), 3u);
+    EXPECT_EQ(*parsingBuffer, 'd');
+
+    // Consume the rest.
+    auto remaining = parsingBuffer.consume(3);
+    EXPECT_EQ(remaining.size(), 3u);
+    EXPECT_EQ(remaining[0], 'd');
+    EXPECT_EQ(remaining[1], 'e');
+    EXPECT_EQ(remaining[2], 'f');
+    EXPECT_TRUE(parsingBuffer.atEnd());
+}
+
 TEST(WTF, StringParsingBufferReadCharactersForParsing)
 {
     auto latin1 = StringView { "abc"_s };


### PR DESCRIPTION
#### 7e2a2b0030153b4484da13f3a062411083b9438a
<pre>
StringParsingBuffer::consume() incorrectly returns the whole buffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=310519">https://bugs.webkit.org/show_bug.cgi?id=310519</a>

Reviewed by Anne van Kesteren.

StringParsingBuffer::consume() incorrectly returns the whole buffer,
instead of just the consumed part.

Test: Tools/TestWebKitAPI/Tests/WTF/StringParsingBuffer.cpp

* Source/WTF/wtf/text/StringParsingBuffer.h:
* Tools/TestWebKitAPI/Tests/WTF/StringParsingBuffer.cpp:
(TestWebKitAPI::TEST(WTF, StringParsingBufferConsumeCount)):

Canonical link: <a href="https://commits.webkit.org/309749@main">https://commits.webkit.org/309749@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7d5071a24693b6d4f577002178433a2045b4c4c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151605 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24370 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17951 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160340 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105062 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c0b9060f-96b1-4838-8cd1-83406fd826ac) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153479 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24801 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24672 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117087 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/05f88f16-8cca-4e6a-bdfb-8fce6a0f9918) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154565 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19233 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136041 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97802 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/23cba2c0-5743-4746-b2e0-ccdba2a3d178) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18322 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16264 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8182 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/143607 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/127952 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13945 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162811 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/12406 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5941 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15535 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125102 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24171 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20322 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125285 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34000 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24163 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135741 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80761 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20337 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12516 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/183215 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23772 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88084 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46734 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23482 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23636 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23538 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->