### PR TITLE
Add missing threading assertions to WeakRef::get() and WeakRef::ptr()

### DIFF
--- a/Source/WTF/wtf/WeakPtr.h
+++ b/Source/WTF/wtf/WeakPtr.h
@@ -167,7 +167,6 @@ public:
             !IsDeprecatedWeakRefSmartPointerException<std::remove_cv_t<T>>::value || (!HasRefPtrMemberFunctions<T>::value && !HasCheckedPtrMemberFunctions<T>::value),
             "IsDeprecatedWeakRefSmartPointerException specialization is no longer needed for this class, please remove it.");
 
-        ASSERT_WITH_SECURITY_IMPLICATION(canSafelyBeUsed());
         auto* result = get();
         RELEASE_ASSERT(result);
         return result;
@@ -183,7 +182,6 @@ public:
             !IsDeprecatedWeakRefSmartPointerException<std::remove_cv_t<T>>::value || (!HasRefPtrMemberFunctions<T>::value && !HasCheckedPtrMemberFunctions<T>::value),
             "IsDeprecatedWeakRefSmartPointerException specialization is no longer needed for this class, please remove it.");
 
-        ASSERT_WITH_SECURITY_IMPLICATION(canSafelyBeUsed());
         auto* result = get();
         RELEASE_ASSERT(result);
         return *result;

--- a/Source/WTF/wtf/WeakRef.h
+++ b/Source/WTF/wtf/WeakRef.h
@@ -98,6 +98,7 @@ public:
             HasRefPtrMemberFunctions<T>::value || HasCheckedPtrMemberFunctions<T>::value || IsDeprecatedWeakRefSmartPointerException<std::remove_cv_t<T>>::value,
             "Classes that offer weak pointers should also offer RefPtr or CheckedPtr. Please do not add new exceptions.");
 
+        ASSERT_WITH_SECURITY_IMPLICATION(canSafelyBeUsed());
         auto* ptr = static_cast<T*>(m_impl->template get<T>());
         RELEASE_ASSERT(ptr);
         return ptr;
@@ -110,6 +111,7 @@ public:
             HasRefPtrMemberFunctions<T>::value || HasCheckedPtrMemberFunctions<T>::value || IsDeprecatedWeakRefSmartPointerException<std::remove_cv_t<T>>::value,
             "Classes that offer weak pointers should also offer RefPtr or CheckedPtr. Please do not add new exceptions.");
 
+        ASSERT_WITH_SECURITY_IMPLICATION(canSafelyBeUsed());
         auto* ptr = static_cast<T*>(m_impl->template get<T>());
         RELEASE_ASSERT(ptr);
         return *ptr;
@@ -117,11 +119,7 @@ public:
 
     operator T&() const { return get(); }
 
-    T* operator->() const
-    {
-        ASSERT_WITH_SECURITY_IMPLICATION(canSafelyBeUsed());
-        return ptr();
-    }
+    T* operator->() const { return ptr(); }
 
     EnableWeakPtrThreadingAssertions enableWeakPtrThreadingAssertions() const
     {

--- a/Source/WebKit/Platform/IPC/MessageReceiveQueues.h
+++ b/Source/WebKit/Platform/IPC/MessageReceiveQueues.h
@@ -38,7 +38,7 @@ class FunctionDispatcherQueue final : public MessageReceiveQueue {
 public:
     FunctionDispatcherQueue(FunctionDispatcher& dispatcher, MessageReceiver& receiver)
         : m_dispatcher(dispatcher)
-        , m_receiver(receiver)
+        , m_receiver(receiver, EnableWeakPtrThreadingAssertions::No) // FIXME: Re-enable threading assertions when possible.
     {
     }
     ~FunctionDispatcherQueue() final = default;


### PR DESCRIPTION
#### 89b787e9884b589ad8aff91e8cb426e1f31757cc
<pre>
Add missing threading assertions to WeakRef::get() and WeakRef::ptr()
<a href="https://bugs.webkit.org/show_bug.cgi?id=310523">https://bugs.webkit.org/show_bug.cgi?id=310523</a>

Reviewed by Darin Adler and Ryosuke Niwa.

Add missing threading assertions to WeakRef::get() and WeakRef::ptr(),
to match WeakPtr::get().

Also drop redundant assertions in WeakPtr because `get()` already
includes this assertion.

* Source/WTF/wtf/WeakPtr.h:
(WTF::WeakPtr::operator-&gt; const):
(WTF::WeakPtr::operator* const):
* Source/WTF/wtf/WeakRef.h:
(WTF::WeakRef::ptr const):
(WTF::WeakRef::get const):
(WTF::WeakRef::operator-&gt; const):
* Source/WebKit/Platform/IPC/MessageReceiveQueues.h:

Canonical link: <a href="https://commits.webkit.org/309800@main">https://commits.webkit.org/309800@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52c9ef909e9aaf24b8eb4ccec7cf3529a5ab707c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151638 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24419 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17989 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160373 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105095 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7b4e4d71-cfbc-435d-b503-e34644749eb9) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24884 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24712 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117121 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83135 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154598 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19261 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136068 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97836 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7acd522c-9e24-475b-b80a-704776b1c2e9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18339 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16291 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8215 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/143641 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127969 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13972 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162844 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/12439 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5986 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15562 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125135 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24218 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20349 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125317 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34029 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24219 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135768 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80794 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20361 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12543 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/183249 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23835 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88120 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46745 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23527 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23687 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23587 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->