### PR TITLE
Fix convertReplacingInvalidSequences silently corrupting valid supplementary characters

### DIFF
--- a/Source/WTF/wtf/unicode/UTF8Conversion.cpp
+++ b/Source/WTF/wtf/unicode/UTF8Conversion.cpp
@@ -40,7 +40,7 @@ static constexpr char32_t sentinelCodePoint = U_SENTINEL;
 enum class Replacement : bool { None, ReplaceInvalidSequences };
 
 template<Replacement = Replacement::None, typename CharacterType> static char32_t next(std::span<const CharacterType>, size_t& offset);
-template<Replacement = Replacement::None, typename CharacterType> static bool append(std::span<CharacterType>, size_t& offset, char32_t character);
+template<typename CharacterType> static bool append(std::span<CharacterType>, size_t& offset, char32_t character);
 
 template<> char32_t next<Replacement::None, Latin1Character>(std::span<const Latin1Character> characters, size_t& offset)
 {
@@ -75,30 +75,18 @@ template<> char32_t next<Replacement::ReplaceInvalidSequences, char16_t>(std::sp
     return character;
 }
 
-template<> bool append<Replacement::None, char8_t>(std::span<char8_t> characters, size_t& offset, char32_t character)
+template<> bool append<char8_t>(std::span<char8_t> characters, size_t& offset, char32_t character)
 {
     UBool sawError = false;
     U8_APPEND(characters, offset, characters.size(), character, sawError);
     return sawError;
 }
 
-template<> bool append<Replacement::ReplaceInvalidSequences, char8_t>(std::span<char8_t> characters, size_t& offset, char32_t character)
-{
-    return append(characters, offset, character)
-        && append(characters, offset, replacementCharacter);
-}
-
-template<> bool append<Replacement::None, char16_t>(std::span<char16_t> characters, size_t& offset, char32_t character)
+template<> bool append<char16_t>(std::span<char16_t> characters, size_t& offset, char32_t character)
 {
     UBool sawError = false;
     U16_APPEND(characters, offset, characters.size(), character, sawError);
     return sawError;
-}
-
-template<> bool append<Replacement::ReplaceInvalidSequences, char16_t>(std::span<char16_t> characters, size_t& offset, char32_t character)
-{
-    return append(characters, offset, character)
-        && append(characters, offset, replacementCharacter);
 }
 
 template<Replacement replacement = Replacement::None, typename SourceCharacterType, typename BufferCharacterType> static ConversionResult<BufferCharacterType> convertInternal(std::span<const SourceCharacterType> source, std::span<BufferCharacterType> buffer)
@@ -116,7 +104,7 @@ template<Replacement replacement = Replacement::None, typename SourceCharacterTy
             resultCode = ConversionResultCode::TargetExhausted;
             break;
         }
-        bool sawError = append<replacement>(buffer, bufferOffset, character);
+        bool sawError = append(buffer, bufferOffset, character);
         if (sawError) {
             resultCode = ConversionResultCode::TargetExhausted;
             break;

--- a/Tools/TestWebKitAPI/Tests/WTF/UTF8Conversion.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/UTF8Conversion.cpp
@@ -379,8 +379,8 @@ TEST(WTF_UTF8Conversion, UTF8ToUTF16ReplacingInvalidSequences)
     EXPECT_STREQ("0061 target exhausted", serialize(convertReplacingInvalidSequences(char8Array('a', 0), buffer1)));
     EXPECT_STREQ("D7FF target exhausted", serialize(convertReplacingInvalidSequences(char8Array(0xED, 0x9F, 0xBF, 0), buffer1)));
 
-    EXPECT_STREQ("FFFD", serialize(convertReplacingInvalidSequences(char8Array(0xF0, 0x90, 0x80, 0x80), buffer1)));
-    EXPECT_STREQ("FFFD", serialize(convertReplacingInvalidSequences(char8Array(0xF4, 0x8F, 0xBF, 0xBF), buffer1)));
+    EXPECT_STREQ("target exhausted", serialize(convertReplacingInvalidSequences(char8Array(0xF0, 0x90, 0x80, 0x80), buffer1)));
+    EXPECT_STREQ("target exhausted", serialize(convertReplacingInvalidSequences(char8Array(0xF4, 0x8F, 0xBF, 0xBF), buffer1)));
 
     EXPECT_STREQ("FFFD target exhausted", serialize(convertReplacingInvalidSequences(char8Array(0xF4, 0x90, 0x80, 0x80), buffer1)));
 
@@ -464,6 +464,28 @@ TEST(WTF_UTF8Conversion, UTF16ToUTF8ReplacingInvalidSequences)
     EXPECT_STREQ("target exhausted", serialize(convertReplacingInvalidSequences(char16Array(0xDC00, 0xDC00), buffer1)));
     EXPECT_STREQ("target exhausted", serialize(convertReplacingInvalidSequences(char16Array(0xD800, 0), buffer1)));
     EXPECT_STREQ("target exhausted", serialize(convertReplacingInvalidSequences(char16Array(0xD800, 0xE000), buffer1)));
+}
+
+TEST(WTF_UTF8Conversion, ReplaceInvalidSequencesShouldNotCorruptValidSupplementaryCharacters)
+{
+    using namespace WTF::Unicode;
+
+    // UTF-16 to UTF-8: valid U+10000 (surrogate pair) needs 4 UTF-8 bytes.
+    // A 3-byte buffer cannot hold it. Should report TargetExhausted, not silently write U+FFFD.
+    std::array<char8_t, 3> utf8Buffer3;
+    EXPECT_STREQ("target exhausted", serialize(convertReplacingInvalidSequences(char16Array(0xD800, 0xDC00), utf8Buffer3)));
+
+    // Same but with an ASCII prefix: 'a' takes 1 byte, leaving 2. U+10000 needs 4. Should stop after 'a'.
+    EXPECT_STREQ("61 target exhausted", serialize(convertReplacingInvalidSequences(char16Array('a', 0xD800, 0xDC00), utf8Buffer3)));
+
+    // UTF-8 to UTF-16: valid U+10000 (F0 90 80 80) needs 2 UTF-16 units.
+    // A 1-unit buffer cannot hold it. Should report TargetExhausted, not silently write U+FFFD.
+    std::array<char16_t, 1> utf16Buffer1;
+    EXPECT_STREQ("target exhausted", serialize(convertReplacingInvalidSequences(char8Array(0xF0, 0x90, 0x80, 0x80), utf16Buffer1)));
+
+    // Same but with an ASCII prefix: 'a' takes 1 unit, leaving 1. U+10000 needs 2. Should stop after 'a'.
+    std::array<char16_t, 2> utf16Buffer2;
+    EXPECT_STREQ("0061 target exhausted", serialize(convertReplacingInvalidSequences(char8Array('a', 0xF0, 0x90, 0x80, 0x80), utf16Buffer2)));
 }
 
 TEST(WTF_UTF8Conversion, CheckUTF8)


### PR DESCRIPTION
#### 5f4ef42ad97ee8c7f10731f6129d707006bfd9a8
<pre>
Fix convertReplacingInvalidSequences silently corrupting valid supplementary characters
<a href="https://bugs.webkit.org/show_bug.cgi?id=310525">https://bugs.webkit.org/show_bug.cgi?id=310525</a>

Reviewed by Darin Adler.

The `append&lt;ReplaceInvalidSequences&gt;` specializations had logic to fall back to
writing U+FFFD if the original character failed to append:
```
    return append(characters, offset, character)
        &amp;&amp; append(characters, offset, replacementCharacter);
```
append() returns true on error (sawError), so the `&amp;&amp;` means: &quot;if the character
failed to write, try writing U+FFFD instead.&quot; If U+FFFD succeeds, the overall
expression evaluates to true &amp;&amp; false = false (no error), and convertInternal
continues as if the character was written successfully.

This is a problem because U+FFFD is smaller than supplementary characters:
U+FFFD needs 3 bytes in UTF-8 vs 4 for supplementary characters (U+10000+),
and 1 code unit in UTF-16 vs 2 for supplementary characters. So there is a
window where the original character doesn&apos;t fit but U+FFFD does:

- char8_t output: supplementary character + exactly 3 bytes of buffer remaining.
  U8_APPEND fails for the 4-byte character (i+3 &lt; capacity is false), but
  U+FFFD takes the 3-byte path (i+2 &lt; capacity succeeds). The valid character
  is silently replaced with U+FFFD and Success is reported.

- char16_t output: supplementary character + exactly 1 unit of buffer remaining.
  U16_APPEND fails for the surrogate pair (i+1 &lt; capacity is false), but
  U+FFFD takes the BMP path (unconditional write). Same silent corruption.

The fix removes the append&lt;ReplaceInvalidSequences&gt; specializations entirely.
They were unnecessary because next&lt;ReplaceInvalidSequences&gt; already handles
replacement of *invalid input* sequences via U8_NEXT_OR_FFFD / U16_NEXT_OR_FFFD,
so append is only ever called with already-valid characters. Replacement of
invalid sequences should not be conflated with buffer exhaustion: when a valid
character doesn&apos;t fit, the correct result is TargetExhausted, not silent
substitution.

Test: Tools/TestWebKitAPI/Tests/WTF/UTF8Conversion.cpp

* Source/WTF/wtf/unicode/UTF8Conversion.cpp:
(WTF::Unicode::append&lt;char8_t&gt;):
(WTF::Unicode::append&lt;char16_t&gt;):
(WTF::Unicode::convertInternal):
* Tools/TestWebKitAPI/Tests/WTF/UTF8Conversion.cpp:
(TestWebKitAPI::TEST(WTF_UTF8Conversion, UTF8ToUTF16ReplacingInvalidSequences)):
(TestWebKitAPI::TEST(WTF_UTF8Conversion, ReplaceInvalidSequencesShouldNotCorruptValidSupplementaryCharacters)):

Canonical link: <a href="https://commits.webkit.org/309787@main">https://commits.webkit.org/309787@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f232753c85cfa8b9bd12b977713862030745d878

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151629 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24410 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17986 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160364 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105086 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/75f6ceab-35d5-4789-8379-ebb50a4410e2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153503 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24890 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24703 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117108 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83130 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c71ddfd5-6918-4008-9a7f-a76b35aa6231) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154589 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19265 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136060 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97823 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18352 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16283 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8206 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/143631 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127982 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13964 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162835 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/12430 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5989 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15554 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125124 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24209 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20341 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125306 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34023 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24205 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135760 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80785 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20350 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12535 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/183240 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23825 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88109 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46742 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23518 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23678 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23578 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->