### PR TITLE
Fix Unicode::equal falsely returning true for strings with different invalid sequences

### DIFF
--- a/Source/WTF/wtf/unicode/UTF8Conversion.cpp
+++ b/Source/WTF/wtf/unicode/UTF8Conversion.cpp
@@ -181,7 +181,11 @@ template<typename CharacterTypeA, typename CharacterTypeB> bool equalInternal(st
     size_t offsetA = 0;
     size_t offsetB = 0;
     while (offsetA < a.size() && offsetB < b.size()) {
-        if (next(a, offsetA) != next(b, offsetB))
+        auto characterA = next(a, offsetA);
+        // sentinelCodePoint is U_SENTINEL (not U+FFFD), meaning decoding failed
+        // without producing any code point. Two unrelated decoding failures
+        // should not compare as equal.
+        if (characterA == sentinelCodePoint || characterA != next(b, offsetB))
             return false;
     }
     return offsetA == a.size() && offsetB == b.size();

--- a/Tools/TestWebKitAPI/Tests/WTF/UTF8Conversion.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/UTF8Conversion.cpp
@@ -298,6 +298,44 @@ TEST(WTF_UTF8Conversion, EqualUTF16ToUTF8)
     EXPECT_FALSE(equal(char16Array(0xDC00, 0xD800), char8Array(0xED, 0xB0, 0x80, 0xED, 0xA0, 0x80)));
     EXPECT_FALSE(equal(char16Array(0xDC00, 0xDC00), char8Array(0xED, 0xB0, 0x80, 0xED, 0xB0, 0x80)));
     EXPECT_FALSE(equal(char16Array(0xD800, 0), char8Array(0xED, 0xA0, 0x80, 0x00)));
+
+    // Properly encoded U+FFFD on both sides should compare as equal.
+    // This is a real code point, not a decoding error.
+    EXPECT_TRUE(equal(char16Array(0xFFFD), char8Array(0xEF, 0xBF, 0xBD)));
+
+    // Invalid sequences should not compare as equal, even if both sides fail.
+    // next() returns sentinelCodePoint (U_SENTINEL) for these, which is an
+    // internal error signal — not U+FFFD — so no code point was produced.
+
+    // Different invalid sequences (lone UTF-16 surrogate vs lone UTF-8 continuation byte).
+    EXPECT_FALSE(equal(char16Array(0xD800), char8Array(0x80)));
+    EXPECT_FALSE(equal(char16Array(0xDC00), char8Array(0x80)));
+    EXPECT_FALSE(equal(char16Array(0xD800), char8Array(0xFE)));
+
+    // Same invalid UTF-8 byte on both sides (via UTF-16 surrogates that map to same sentinel).
+    EXPECT_FALSE(equal(char16Array(0xD800), char8Array(0xED, 0xA0, 0x80)));
+    EXPECT_FALSE(equal(char16Array(0xDBFF), char8Array(0xED, 0xAF, 0xBF)));
+    EXPECT_FALSE(equal(char16Array(0xDC00), char8Array(0xED, 0xB0, 0x80)));
+
+    // Truncated UTF-8 multi-byte sequences.
+    EXPECT_FALSE(equal(char16Array(0xD800), char8Array(0xC2)));
+    EXPECT_FALSE(equal(char16Array(0xD800), char8Array(0xE0, 0x80)));
+    EXPECT_FALSE(equal(char16Array(0xD800), char8Array(0xF0, 0x90, 0x80)));
+
+    // Overlong UTF-8 encoding (2-byte encoding of a character that fits in 1 byte).
+    EXPECT_FALSE(equal(char16Array(0xD800), char8Array(0xC0, 0x80)));
+    EXPECT_FALSE(equal(char16Array(0xD800), char8Array(0xC1, 0xBF)));
+
+    // Out-of-range UTF-8 (above U+10FFFF).
+    EXPECT_FALSE(equal(char16Array(0xD800), char8Array(0xF4, 0x90, 0x80, 0x80)));
+
+    // Invalid sequence surrounded by valid data: "a" + invalid + "b" vs "a" + invalid + "b".
+    EXPECT_FALSE(equal(char16Array('a', 0xD800, 'b'), char8Array('a', 0x80, 'b')));
+    EXPECT_FALSE(equal(char16Array('a', 0xD800, 'b'), char8Array('a', 0xFE, 'b')));
+
+    // Valid data followed by invalid should not match valid data alone.
+    EXPECT_FALSE(equal(char16Array('a', 0xD800), char8Array('a')));
+    EXPECT_FALSE(equal(char16Array('a'), char8Array('a', 0x80)));
 }
 
 TEST(WTF_UTF8Conversion, EqualLatin1ToUTF8)
@@ -318,6 +356,12 @@ TEST(WTF_UTF8Conversion, EqualLatin1ToUTF8)
     EXPECT_FALSE(equal(latin1Array(0), char8Array(1)));
     EXPECT_FALSE(equal(latin1Array(0), char8Array(1)));
     EXPECT_FALSE(equal(latin1Array(1), char8Array(0)));
+
+    // Latin1 never produces sentinelCodePoint, but invalid UTF-8 does.
+    EXPECT_FALSE(equal(latin1Array(0x80), char8Array(0x80)));
+    EXPECT_FALSE(equal(latin1Array(0xFF), char8Array(0xFE)));
+    EXPECT_FALSE(equal(latin1Array('a'), char8Array(0x80)));
+    EXPECT_FALSE(equal(latin1Array('a', 'b'), char8Array('a', 0x80)));
 }
 
 TEST(WTF_UTF8Conversion, UTF8ToUTF16ReplacingInvalidSequences)


### PR DESCRIPTION
#### 2f6c85cf77b122f79b6008c8a630835a416f9899
<pre>
Fix Unicode::equal falsely returning true for strings with different invalid sequences
<a href="https://bugs.webkit.org/show_bug.cgi?id=310528">https://bugs.webkit.org/show_bug.cgi?id=310528</a>

Reviewed by Darin Adler and Anne van Kesteren.

equalInternal compared decoded code points from both sides using next(), which
returns sentinelCodePoint for invalid sequences (lone surrogates in UTF-16,
malformed bytes in UTF-8). Since sentinelCodePoint == sentinelCodePoint, two
strings with unrelated invalid data could compare as equal if the invalid
sequences happened to advance both offsets to the end simultaneously.

For example, `equal(char16Array(0xD800), char8Array(0x80))` returned true:
the UTF-16 side decoded the lone surrogate as sentinelCodePoint (offset 0-&gt;1),
the UTF-8 side decoded the lone continuation byte as sentinelCodePoint
(offset 0-&gt;1), the comparison passed, and both offsets reached their respective
ends.

Fix this by returning false immediately when either side produces
sentinelCodePoint. Note that sentinelCodePoint is U_SENTINEL, an internal error
signal meaning decoding failed without producing any code point. This is not
U+FFFD (the Unicode replacement character) — no decision has been made yet to
replace the invalid sequence with a replacement character. Since no actual code
point was decoded, comparing two decoding failures as equal is semantically wrong.
Properly encoded U+FFFD on both sides still compares as equal, as expected.

Test: Tools/TestWebKitAPI/Tests/WTF/UTF8Conversion.cpp

* Source/WTF/wtf/unicode/UTF8Conversion.cpp:
(WTF::Unicode::equalInternal):
* Tools/TestWebKitAPI/Tests/WTF/UTF8Conversion.cpp:
(TestWebKitAPI::TEST(WTF_UTF8Conversion, EqualUTF16ToUTF8)):
(TestWebKitAPI::TEST(WTF_UTF8Conversion, EqualLatin1ToUTF8)):

Canonical link: <a href="https://commits.webkit.org/309809@main">https://commits.webkit.org/309809@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2afe4e0a5477980e82437a4203c9532ff4f26cf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151800 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24581 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18151 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160542 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/38a59fcf-6db7-485a-8580-86c5324c6ce7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153674 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25074 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24876 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117248 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154760 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136217 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97963 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/18501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/16434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8377 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/143805 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14120 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163006 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/12601 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/6155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15712 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125268 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24380 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20493 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125449 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34036 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24381 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135916 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/80956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20478 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12691 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/183411 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23997 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/88283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46780 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23689 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23849 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/23749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->