### PR TITLE
[GStreamer] Video encrypted playback often stutters

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
@@ -61,6 +61,7 @@ struct _WebKitGLVideoSinkPrivate {
         GST_DEBUG_OBJECT(appSink.get(), "WebKitGLVideoSink finalized.");
     }
 
+    GRefPtr<GstElement> queue;
     GRefPtr<GstElement> appSink;
     WebKitVideoSinkSignalIdentifiers signalIdentifiers;
 };
@@ -130,7 +131,7 @@ static GstPadProbeReturn sinkPadProbeCallback(GstPad*, GstPadProbeInfo* info, gp
     gst_ghost_pad_set_target(GST_GHOST_PAD_CAST(sinkPad.get()), nullptr);
 
     gst_bin_add_many(GST_BIN_CAST(sink.get()), upload, colorconvert, nullptr);
-    gst_element_link_many(upload, colorconvert, priv->appSink.get(), nullptr);
+    gst_element_link_many(upload, colorconvert, priv->queue.get(), nullptr);
     auto target = adoptGRef(gst_element_get_static_pad(upload, "sink"));
 
     GstElement* imxVideoConvert = nullptr;
@@ -168,7 +169,14 @@ static void webKitGLVideoSinkConstructed(GObject* object)
 
     ASSERT(sink->priv->appSink);
     g_object_set(sink->priv->appSink.get(), "enable-last-sample", FALSE, "emit-signals", TRUE, "max-buffers", 1, nullptr);
-    gst_bin_add(GST_BIN_CAST(sink), sink->priv->appSink.get());
+
+    // Decouple upstream from the sink, otherwise the sink QoS would kick-in if the GL upload takes
+    // too long.
+    sink->priv->queue = gst_element_factory_make("queue", nullptr);
+    g_object_set(sink->priv->queue.get(), "max-size-buffers", 5, "max-size-time", static_cast<guint64>(0), "max-size-bytes", 0, nullptr);
+
+    gst_bin_add_many(GST_BIN_CAST(sink), sink->priv->queue.get(), sink->priv->appSink.get(), nullptr);
+    gst_element_link(sink->priv->queue.get(), sink->priv->appSink.get());
 
     GRefPtr<GstCaps> caps = adoptGRef(gst_caps_new_empty());
 
@@ -186,7 +194,7 @@ static void webKitGLVideoSinkConstructed(GObject* object)
     gst_caps_set_features(glCaps.get(), 0, gst_caps_features_new(GST_CAPS_FEATURE_MEMORY_GL_MEMORY, nullptr));
     gst_caps_append(caps.get(), glCaps.leakRef());
 
-    auto sinkPad = adoptGRef(gst_element_get_static_pad(sink->priv->appSink.get(), "sink"));
+    auto sinkPad = adoptGRef(gst_element_get_static_pad(sink->priv->queue.get(), "sink"));
 
     if (!quirkGLCaps) {
         auto upload = makeGStreamerElement("glupload"_s);
@@ -195,7 +203,7 @@ static void webKitGLVideoSinkConstructed(GObject* object)
         RELEASE_ASSERT(colorconvert);
 
         gst_bin_add_many(GST_BIN_CAST(sink), upload, colorconvert, nullptr);
-        gst_element_link_many(upload, colorconvert, sink->priv->appSink.get(), nullptr);
+        gst_element_link_many(upload, colorconvert, sink->priv->queue.get(), nullptr);
         sinkPad = adoptGRef(gst_element_get_static_pad(upload, "sink"));
 
         GstElement* imxVideoConvert = nullptr;


### PR DESCRIPTION
#### 32a99d26dbe9993e137e2e2ff9300edcd9024ced
<pre>
[GStreamer] Video encrypted playback often stutters
<a href="https://bugs.webkit.org/show_bug.cgi?id=310531">https://bugs.webkit.org/show_bug.cgi?id=310531</a>

Reviewed by Xabier Rodriguez-Calvar.

Decouple GL upload and conversion from the sink, otherwise the sink QoS would kick-in if
the GL upload takes too long.

* Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp:
(webKitGLVideoSinkConstructed):

Canonical link: <a href="https://commits.webkit.org/309897@main">https://commits.webkit.org/309897@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e54b8f024713932d0358f29b376737b4cadd023f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151897 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24678 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18250 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160639 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105354 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153771 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25171 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24980 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117331 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83242 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154857 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19504 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136309 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98046 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18586 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16520 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8474 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128218 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14212 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163103 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6252 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15804 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125349 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24477 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20579 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125530 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34102 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24478 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136008 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81055 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20559 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12783 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24095 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88380 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23786 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23946 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23847 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->