### PR TITLE
Use explicit relaxed/acq_rel memory orderings in ThreadSafeRefCounted

### DIFF
--- a/Source/WTF/wtf/ThreadSafeRefCounted.h
+++ b/Source/WTF/wtf/ThreadSafeRefCounted.h
@@ -40,12 +40,12 @@ class WTF_EMPTY_BASE_CLASS ThreadSafeRefCountedBase {
 public:
     void ref() const
     {
-        m_refCountDebugger.willRef(m_refCount);
-        ++m_refCount;
+        m_refCountDebugger.willRef(m_refCount.load(std::memory_order_relaxed));
+        m_refCount.fetch_add(1, std::memory_order_relaxed);
     }
 
-    bool hasOneRef() const { return m_refCount == 1; }
-    uint32_t refCount() const { return m_refCount; }
+    bool hasOneRef() const { return m_refCount.load(std::memory_order_acquire) == 1; }
+    uint32_t refCount() const { return m_refCount.load(std::memory_order_relaxed); }
 
     // Debug APIs
     void adopted() { m_refCountDebugger.adopted(); }
@@ -63,20 +63,20 @@ protected:
 
     ~ThreadSafeRefCountedBase()
     {
-        m_refCountDebugger.willDestroy(m_refCount);
+        m_refCountDebugger.willDestroy(m_refCount.load(std::memory_order_relaxed));
         // Ideally we'd use a RELEASE_ASSERT() here but it is a 0.7-0.8% regression on Speedometer 3.
-        ASSERT_WITH_SECURITY_IMPLICATION(m_refCount == 1);
+        ASSERT_WITH_SECURITY_IMPLICATION(m_refCount.load(std::memory_order_relaxed) == 1);
     }
 
     // Returns true if the pointer should be freed.
     bool derefBase() const
     {
-        m_refCountDebugger.willDeref(m_refCount);
+        m_refCountDebugger.willDeref(m_refCount.load(std::memory_order_relaxed));
 
-        if (!--m_refCount) [[unlikely]] {
+        if (m_refCount.fetch_sub(1, std::memory_order_acq_rel) == 1) [[unlikely]] {
             m_refCountDebugger.willDelete();
 
-            m_refCount = 1;
+            m_refCount.store(1, std::memory_order_relaxed);
             return true;
         }
 

--- a/Source/WTF/wtf/ThreadSafeRefCountedWithSuppressingSaferCPPChecking.h
+++ b/Source/WTF/wtf/ThreadSafeRefCountedWithSuppressingSaferCPPChecking.h
@@ -42,12 +42,12 @@ class WTF_EMPTY_BASE_CLASS ThreadSafeRefCountedWithSuppressingSaferCPPCheckingBa
 public:
     void refSuppressingSaferCPPChecking() const
     {
-        m_refCountDebugger.willRef(m_refCount);
-        ++m_refCount;
+        m_refCountDebugger.willRef(m_refCount.load(std::memory_order_relaxed));
+        m_refCount.fetch_add(1, std::memory_order_relaxed);
     }
 
-    bool hasOneRef() const { return m_refCount == 1; }
-    uint32_t refCount() const { return m_refCount; }
+    bool hasOneRef() const { return m_refCount.load(std::memory_order_acquire) == 1; }
+    uint32_t refCount() const { return m_refCount.load(std::memory_order_relaxed); }
 
     // Debug APIs
     void adopted() { m_refCountDebugger.adopted(); }
@@ -65,20 +65,20 @@ protected:
 
     ~ThreadSafeRefCountedWithSuppressingSaferCPPCheckingBase()
     {
-        m_refCountDebugger.willDestroy(m_refCount);
+        m_refCountDebugger.willDestroy(m_refCount.load(std::memory_order_relaxed));
         // Ideally we'd use a RELEASE_ASSERT() here but it is a 0.7-0.8% regression on Speedometer 3.
-        ASSERT_WITH_SECURITY_IMPLICATION(m_refCount == 1);
+        ASSERT_WITH_SECURITY_IMPLICATION(m_refCount.load(std::memory_order_relaxed) == 1);
     }
 
     // Returns true if the pointer should be freed.
     bool derefBase() const
     {
-        m_refCountDebugger.willDeref(m_refCount);
+        m_refCountDebugger.willDeref(m_refCount.load(std::memory_order_relaxed));
 
-        if (!--m_refCount) [[unlikely]] {
+        if (m_refCount.fetch_sub(1, std::memory_order_acq_rel) == 1) [[unlikely]] {
             m_refCountDebugger.willDelete();
 
-            m_refCount = 1;
+            m_refCount.store(1, std::memory_order_relaxed);
             return true;
         }
 


### PR DESCRIPTION
#### 161bf30c172dda31f4ec79bd0af03ee3e9079215
<pre>
Use explicit relaxed/acq_rel memory orderings in ThreadSafeRefCounted
<a href="https://bugs.webkit.org/show_bug.cgi?id=310533">https://bugs.webkit.org/show_bug.cgi?id=310533</a>

Reviewed by Keith Miller.

Replace default sequentially-consistent atomic operations on m_refCount
with explicit memory orderings in ThreadSafeRefCountedBase and
ThreadSafeRefCountedWithSuppressingSaferCPPCheckingBase.

This follows the well-established pattern used by std::shared_ptr
(libc++ and libstdc++), boost::intrusive_ptr, Rust&apos;s Arc, and
Chromium&apos;s base::RefCountedThreadSafe. These implementations all use
the same memory orderings for the same reasons:

- ref(): Use fetch_add(1, relaxed) instead of operator++ (seq_cst).
  The caller must already hold a live reference in order to call ref(),
  so the object is guaranteed to be alive. No ordering is needed — there
  is no data the increment needs to synchronize with.
- derefBase(): Use fetch_sub(1, acq_rel) instead of operator--
  (seq_cst). The release on the decrement ensures that all prior accesses
  to the object happen-before the reference count reaches zero. The
  acquire on the load of the decremented value (implicit in acq_rel)
  ensures that when the final deref() observes a count of zero, it
  sees all accesses performed by every other thread that previously
  released its reference. This is the minimum ordering required for
  safe destruction.
- hasOneRef(): Use load(acquire) to ensure all prior modifications
  by other threads are visible before acting on the uniqueness check.
- Read-only accessors and debug assertions: Use load(relaxed) since
  these are advisory / diagnostic and don&apos;t guard critical decisions.

Sequential consistency is stronger than necessary here and results in
unnecessary full memory barriers on architectures like ARM64.

This shows as a 0.3% progression on Speedometer 3 on macOS.

* Source/WTF/wtf/ThreadSafeRefCounted.h:
* Source/WTF/wtf/ThreadSafeRefCountedWithSuppressingSaferCPPChecking.h:

Canonical link: <a href="https://commits.webkit.org/309801@main">https://commits.webkit.org/309801@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/afcefaab75d1d37bbcca99ebe7ea6db9cc856d7f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151651 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24432 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18002 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160386 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105108 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/770bbd29-3d78-46c3-93b1-6c1ae279a56e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24904 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24725 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117134 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83143 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154611 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19268 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136080 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97849 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e972a722-80e0-4d5d-ad3a-9a308f44abb5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18355 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16303 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8228 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/143654 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127985 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13984 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162857 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/12452 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6006 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15707 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125151 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24231 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20361 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125333 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34031 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24232 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135780 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80807 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20370 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12555 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/183262 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23848 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88133 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46748 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23540 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23700 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23600 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->