### PR TITLE
[run-benchmark] Fix typos and wording

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_browser_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_browser_driver.py
@@ -98,8 +98,8 @@ class LinuxBrowserDriver(BrowserDriver):
                     _log.info('Killing browser {browser_name} with pid {browser_pid}'.format(
                                browser_name=self.browser_name, browser_pid=self._browser_process.pid))
                     self._browser_process.kill()
-                    _log.warning('python psutil not found, cant check for '
-                                 'still-alive browser childs to kill.')
+                    _log.warning('python psutil not found, can\'t check for '
+                                 'still-alive browser children to kill.')
             else:
                 _log.error('Browser {browser_name} with pid {browser_pid} ended prematurely with return code {browser_retcode}.'.format(
                             browser_name=self.browser_name, browser_pid=self._browser_process.pid,

--- a/Tools/Scripts/webkitpy/benchmark_runner/http_server_driver/simple_http_server_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/http_server_driver/simple_http_server_driver.py
@@ -77,7 +77,7 @@ class SimpleHTTPServerDriver(HTTPServerDriver):
         self._ensure_http_server_dependencies()
 
     def serve(self, web_root):
-        _log.info('Launching an {} http server'.format(self._server_type))
+        _log.info('Launching a {} HTTP server'.format(self._server_type))
         http_server_file = 'http_server/{}_http_server.py'.format(self._server_type)
         http_server_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), http_server_file)
         extra_args = []
@@ -91,7 +91,7 @@ class SimpleHTTPServerDriver(HTTPServerDriver):
         max_attempt = 7
         retry_sequence = map(lambda attempt: attempt != max_attempt - 1, range(max_attempt))
         interval = 0.5
-        _log.info('Start to fetching the port number of the http server')
+        _log.info('Fetching HTTP server port number')
         for retry in retry_sequence:
             self._find_http_server_port()
             if self._server_port:
@@ -100,7 +100,7 @@ class SimpleHTTPServerDriver(HTTPServerDriver):
             assert self._server_process.poll() is None, 'HTTP Server Process is not running'
             if not retry:
                 continue
-            _log.info('Server port is not found this time, retry after {} seconds'.format(interval))
+            _log.info('Port not found yet, retrying in {} seconds'.format(interval))
             time.sleep(interval)
             interval *= 2
         else:
@@ -174,6 +174,6 @@ class SimpleHTTPServerDriver(HTTPServerDriver):
         self._server_type = server_type
 
     def _ensure_http_server_dependencies(self):
-        _log.info('Ensure dependencies of http server is satisfied')
+        _log.info('Ensure dependencies of http server are satisfied')
         if(self._server_type == 'twisted'):
             from webkitpy.autoinstalled import twisted


### PR DESCRIPTION
#### 7f095ce742903a1bec08920d122b96c3ee985815
<pre>
[run-benchmark] Fix typos and wording
<a href="https://bugs.webkit.org/show_bug.cgi?id=310536">https://bugs.webkit.org/show_bug.cgi?id=310536</a>

Reviewed by Carlos Alberto Lopez Perez.

Fixed a few typos and tightened the messages a bit.

* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_browser_driver.py:
(LinuxBrowserDriver.close_browsers):
* Tools/Scripts/webkitpy/benchmark_runner/http_server_driver/simple_http_server_driver.py:
(SimpleHTTPServerDriver.serve):
(SimpleHTTPServerDriver._ensure_http_server_dependencies):

Canonical link: <a href="https://commits.webkit.org/309779@main">https://commits.webkit.org/309779@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38382e1cdc5cdc9f93953d0aef932481b382a0a2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151650 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24431 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18001 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160385 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105107 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153524 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24903 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24724 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117126 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83140 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154610 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19259 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136079 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97841 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/150972 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18347 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16302 "Found 1 new API test failure: TestWebKitAPI.UnifiedPDF/PrintWithJSExecutionOptionTests.PDFWithWindowPrintEmbeddedJS/allowsContentJavascript_is_false (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8227 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127977 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13983 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162856 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15573 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125146 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24230 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20360 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125328 "Found 1 new API test failure: WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/itp (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34020 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24231 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135779 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80806 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20360 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12554 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23847 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23539 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23699 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23599 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->