### PR TITLE
[Site Isolation] Web Inspector: add BackendResourceDataStore for response body retrieval under Site Isolation

### DIFF
--- a/LayoutTests/http/tests/inspector/network/cross-origin-iframe-get-response-body-after-navigation-expected.txt
+++ b/LayoutTests/http/tests/inspector/network/cross-origin-iframe-get-response-body-after-navigation-expected.txt
@@ -1,0 +1,13 @@
+Tests getResponseBody behavior for a cross-origin iframe resource after the iframe navigates to a new URL.
+
+
+== Running test suite: Network.getResponseBody.CrossOriginIframe.AfterNavigation
+-- Running test case: Network.getResponseBody.CrossOriginIframe.AfterNavigation
+First load: http://localhost:8000/inspector/network/resources/echo.py?mimetype=text/plain&content=before-navigation
+PASS: First load: Should retrieve content successfully.
+PASS: First load: Content should match.
+Navigating iframe...
+Iframe navigated. Requesting content of first resource again...
+After navigation requestContent returned.
+Content available: true
+

--- a/LayoutTests/http/tests/inspector/network/cross-origin-iframe-get-response-body-after-navigation.html
+++ b/LayoutTests/http/tests/inspector/network/cross-origin-iframe-get-response-body-after-navigation.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../resources/inspector-test.js"></script>
+<script>
+let testIframe;
+
+function loadCrossOriginIframe() {
+    testIframe = document.createElement("iframe");
+    testIframe.src = "http://localhost:8000/inspector/network/resources/echo.py?mimetype=text/plain&content=before-navigation";
+    document.body.appendChild(testIframe);
+}
+
+function navigateIframe() {
+    testIframe.src = "http://localhost:8000/inspector/network/resources/echo.py?mimetype=text/plain&content=after-navigation";
+}
+
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("Network.getResponseBody.CrossOriginIframe.AfterNavigation");
+
+    suite.addTestCase({
+        name: "Network.getResponseBody.CrossOriginIframe.AfterNavigation",
+        description: "After an iframe navigates, the old resource's content should still be available (or explicitly unavailable) via getResponseBody.",
+        test(resolve, reject) {
+            let firstResource = null;
+
+            WI.Frame.awaitEvent(WI.Frame.Event.ChildFrameWasAdded)
+                .then((event) => {
+                    let childFrame = event.data.childFrame;
+                    firstResource = childFrame.mainResource;
+                    InspectorTest.log("First load: " + firstResource.url);
+
+                    if (firstResource.finished)
+                        return firstResource.requestContent();
+
+                    return new Promise((resolveLoad) => {
+                        firstResource.singleFireEventListener(WI.Resource.Event.LoadingDidFinish, () => resolveLoad());
+                    }).then(() => firstResource.requestContent());
+                })
+                .then(({error, content}) => {
+                    InspectorTest.expectThat(!error, "First load: Should retrieve content successfully.");
+                    InspectorTest.expectEqual(content, "before-navigation", "First load: Content should match.");
+
+                    InspectorTest.log("Navigating iframe...");
+                    // Navigate the iframe. This should trigger mainFrameNavigated -> clear() on the store.
+                    return new Promise((resolveNav) => {
+                        WI.Frame.awaitEvent(WI.Frame.Event.MainResourceDidChange).then(() => resolveNav());
+                        InspectorTest.evaluateInPage("navigateIframe()");
+                    });
+                })
+                .then(() => {
+                    InspectorTest.log("Iframe navigated. Requesting content of first resource again...");
+                    return firstResource.requestContent();
+                })
+                .then(({error, content}) => {
+                    // After navigation, the store was cleared. The first resource's content
+                    // may or may not be available depending on frontend caching.
+                    InspectorTest.log("After navigation requestContent returned.");
+                    InspectorTest.log("Content available: " + (content !== null && content !== undefined && content.length > 0));
+                })
+                .then(resolve, reject);
+
+            InspectorTest.evaluateInPage("loadCrossOriginIframe()");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests getResponseBody behavior for a cross-origin iframe resource after the iframe navigates to a new URL.</p>
+</body>
+</html>

--- a/LayoutTests/http/tests/inspector/network/cross-origin-iframe-get-response-body-binary-expected.txt
+++ b/LayoutTests/http/tests/inspector/network/cross-origin-iframe-get-response-body-binary-expected.txt
@@ -1,0 +1,13 @@
+Tests that Network.getResponseBody returns base64-encoded content for a binary resource in a cross-origin iframe.
+
+
+== Running test suite: Network.getResponseBody.CrossOriginIframe.Binary
+-- Running test case: Network.getResponseBody.CrossOriginIframe.Binary.PNG
+Child frame added: http://localhost:8000/inspector/network/resources/echo.py?mimetype=text/html&content=%3Cimg%20src%3D%22%2Finspector%2Fnetwork%2Fresources%2Fwhite.png%22%3E
+Resource added: http://localhost:8000/inspector/network/resources/white.png
+PASS: Resource should be the PNG image.
+PASS: MIME type should be image/png.
+PASS: Should not have an error retrieving content.
+PASS: Content should be base64 encoded.
+PASS: Image content should be a Blob.
+

--- a/LayoutTests/http/tests/inspector/network/cross-origin-iframe-get-response-body-binary.html
+++ b/LayoutTests/http/tests/inspector/network/cross-origin-iframe-get-response-body-binary.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../resources/inspector-test.js"></script>
+<script>
+function loadCrossOriginImage() {
+    let iframe = document.createElement("iframe");
+    // Load a small HTML page on localhost that contains an image.
+    // The image resource will be a subresource of the cross-origin frame.
+    iframe.src = "http://localhost:8000/inspector/network/resources/echo.py?mimetype=text/html&content=" + encodeURIComponent('<img src="/inspector/network/resources/white.png">');
+    document.body.appendChild(iframe);
+}
+
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("Network.getResponseBody.CrossOriginIframe.Binary");
+
+    suite.addTestCase({
+        name: "Network.getResponseBody.CrossOriginIframe.Binary.PNG",
+        description: "Should be able to retrieve base64-encoded response body for an image loaded in a cross-origin iframe.",
+        test(resolve, reject) {
+            WI.Frame.awaitEvent(WI.Frame.Event.ChildFrameWasAdded)
+                .then((event) => {
+                    let childFrame = event.data.childFrame;
+                    InspectorTest.log("Child frame added: " + childFrame.url);
+
+                    // Wait for the image subresource to be added.
+                    return WI.Frame.awaitEvent(WI.Frame.Event.ResourceWasAdded);
+                })
+                .then((event) => {
+                    let resource = event.data.resource;
+                    InspectorTest.log("Resource added: " + resource.url);
+                    InspectorTest.expectThat(resource.url.includes("white.png"), "Resource should be the PNG image.");
+
+                    if (resource.finished)
+                        return resource.requestContent();
+
+                    return new Promise((resolveLoad) => {
+                        resource.singleFireEventListener(WI.Resource.Event.LoadingDidFinish, () => resolveLoad());
+                    }).then(() => resource.requestContent());
+                })
+                .then(({error, sourceCode, content, rawBase64Encoded}) => {
+                    InspectorTest.expectEqual(sourceCode.mimeType, "image/png", "MIME type should be image/png.");
+                    InspectorTest.expectThat(!error, "Should not have an error retrieving content.");
+                    InspectorTest.expectEqual(rawBase64Encoded, true, "Content should be base64 encoded.");
+                    InspectorTest.expectThat(content instanceof Blob, "Image content should be a Blob.");
+                })
+                .then(resolve, reject);
+
+            InspectorTest.evaluateInPage("loadCrossOriginImage()");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests that Network.getResponseBody returns base64-encoded content for a binary resource in a cross-origin iframe.</p>
+</body>
+</html>

--- a/LayoutTests/http/tests/inspector/network/cross-origin-iframe-get-response-body-document-expected.txt
+++ b/LayoutTests/http/tests/inspector/network/cross-origin-iframe-get-response-body-document-expected.txt
@@ -1,0 +1,13 @@
+Tests that Network.getResponseBody returns HTML document content from a cross-origin iframe's main resource.
+
+
+== Running test suite: Network.getResponseBody.CrossOriginIframe.Document
+-- Running test case: Network.getResponseBody.CrossOriginIframe.Document.HTML
+Child frame added: http://localhost:8000/inspector/network/resources/data.html
+PASS: Child frame should be cross-origin.
+PASS: Child frame should have a main resource.
+PASS: Main resource should be Document type.
+PASS: Should not have an error retrieving content.
+PASS: Content should not be base64 encoded.
+PASS: Content should contain the expected HTML.
+

--- a/LayoutTests/http/tests/inspector/network/cross-origin-iframe-get-response-body-document.html
+++ b/LayoutTests/http/tests/inspector/network/cross-origin-iframe-get-response-body-document.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../resources/inspector-test.js"></script>
+<script>
+function loadCrossOriginIframe() {
+    let iframe = document.createElement("iframe");
+    iframe.src = "http://localhost:8000/inspector/network/resources/data.html";
+    document.body.appendChild(iframe);
+}
+
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("Network.getResponseBody.CrossOriginIframe.Document");
+
+    suite.addTestCase({
+        name: "Network.getResponseBody.CrossOriginIframe.Document.HTML",
+        description: "Should be able to retrieve HTML document content from a cross-origin iframe.",
+        test(resolve, reject) {
+            WI.Frame.awaitEvent(WI.Frame.Event.ChildFrameWasAdded)
+                .then((event) => {
+                    let childFrame = event.data.childFrame;
+                    InspectorTest.log("Child frame added: " + childFrame.url);
+                    InspectorTest.expectThat(childFrame.url.includes("localhost"), "Child frame should be cross-origin.");
+
+                    let mainResource = childFrame.mainResource;
+                    InspectorTest.expectThat(mainResource instanceof WI.Resource, "Child frame should have a main resource.");
+                    InspectorTest.expectEqual(mainResource.type, WI.Resource.Type.Document, "Main resource should be Document type.");
+
+                    if (mainResource.finished)
+                        return mainResource.requestContent();
+
+                    return new Promise((resolveLoad) => {
+                        mainResource.singleFireEventListener(WI.Resource.Event.LoadingDidFinish, () => resolveLoad());
+                    }).then(() => mainResource.requestContent());
+                })
+                .then(({error, sourceCode, content, rawBase64Encoded}) => {
+                    InspectorTest.expectThat(!error, "Should not have an error retrieving content.");
+                    InspectorTest.expectEqual(rawBase64Encoded, false, "Content should not be base64 encoded.");
+                    InspectorTest.expectThat(content.includes("<span>Hello World</span>"), "Content should contain the expected HTML.");
+                })
+                .then(resolve, reject);
+
+            InspectorTest.evaluateInPage("loadCrossOriginIframe()");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests that Network.getResponseBody returns HTML document content from a cross-origin iframe's main resource.</p>
+</body>
+</html>

--- a/LayoutTests/http/tests/inspector/network/cross-origin-iframe-get-response-body-error-cases-expected.txt
+++ b/LayoutTests/http/tests/inspector/network/cross-origin-iframe-get-response-body-error-cases-expected.txt
@@ -1,0 +1,14 @@
+Tests error handling for Network.getResponseBody with invalid or nonexistent requestIds.
+
+
+== Running test suite: Network.getResponseBody.CrossOriginIframe.ErrorCases
+-- Running test case: Network.getResponseBody.CrossOriginIframe.ErrorCases.InvalidRequestId
+PASS: Should throw for invalid requestId.
+
+-- Running test case: Network.getResponseBody.CrossOriginIframe.ErrorCases.NonexistentResource
+PASS: Should throw for nonexistent resource.
+
+-- Running test case: Network.getResponseBody.CrossOriginIframe.ErrorCases.ValidResourceSucceeds
+PASS: Valid resource should not have an error.
+PASS: Content should match expected value.
+

--- a/LayoutTests/http/tests/inspector/network/cross-origin-iframe-get-response-body-error-cases.html
+++ b/LayoutTests/http/tests/inspector/network/cross-origin-iframe-get-response-body-error-cases.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../resources/inspector-test.js"></script>
+<script>
+function loadCrossOriginIframe() {
+    let iframe = document.createElement("iframe");
+    iframe.src = "http://localhost:8000/inspector/network/resources/echo.py?mimetype=text/plain&content=error-test";
+    document.body.appendChild(iframe);
+}
+
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("Network.getResponseBody.CrossOriginIframe.ErrorCases");
+
+    suite.addTestCase({
+        name: "Network.getResponseBody.CrossOriginIframe.ErrorCases.InvalidRequestId",
+        description: "getResponseBody with a completely invalid requestId should return an error.",
+        async test() {
+            try {
+                await NetworkAgent.getResponseBody("not-a-valid-request-id");
+                InspectorTest.fail("Should have thrown for invalid requestId.");
+            } catch (e) {
+                InspectorTest.pass("Should throw for invalid requestId.");
+            }
+        }
+    });
+
+    suite.addTestCase({
+        name: "Network.getResponseBody.CrossOriginIframe.ErrorCases.NonexistentResource",
+        description: "getResponseBody with a well-formed but nonexistent requestId should return an error.",
+        async test() {
+            // Use the legacy format (numeric) which will hit InspectorNetworkAgent, not ProxyingNetworkAgent.
+            try {
+                await NetworkAgent.getResponseBody("99999999");
+                InspectorTest.fail("Should have thrown for nonexistent resource.");
+            } catch (e) {
+                InspectorTest.pass("Should throw for nonexistent resource.");
+            }
+        }
+    });
+
+    suite.addTestCase({
+        name: "Network.getResponseBody.CrossOriginIframe.ErrorCases.ValidResourceSucceeds",
+        description: "Verify a valid cross-origin resource succeeds, as a control.",
+        test(resolve, reject) {
+            WI.Frame.awaitEvent(WI.Frame.Event.ChildFrameWasAdded)
+                .then((event) => {
+                    let childFrame = event.data.childFrame;
+                    let mainResource = childFrame.mainResource;
+
+                    if (mainResource.finished)
+                        return mainResource.requestContent();
+
+                    return new Promise((resolveLoad) => {
+                        mainResource.singleFireEventListener(WI.Resource.Event.LoadingDidFinish, () => resolveLoad());
+                    }).then(() => mainResource.requestContent());
+                })
+                .then(({error, content}) => {
+                    InspectorTest.expectThat(!error, "Valid resource should not have an error.");
+                    InspectorTest.expectEqual(content, "error-test", "Content should match expected value.");
+                })
+                .then(resolve, reject);
+
+            InspectorTest.evaluateInPage("loadCrossOriginIframe()");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests error handling for Network.getResponseBody with invalid or nonexistent requestIds.</p>
+</body>
+</html>

--- a/LayoutTests/http/tests/inspector/network/cross-origin-iframe-get-response-body-expected.txt
+++ b/LayoutTests/http/tests/inspector/network/cross-origin-iframe-get-response-body-expected.txt
@@ -1,0 +1,12 @@
+Tests that Network.getResponseBody works for resources loaded in a cross-origin iframe. Under Site Isolation, this exercises the BackendResourceDataStore and reverse IPC path through ProxyingNetworkAgent.
+
+
+== Running test suite: Network.getResponseBody.CrossOriginIframe
+-- Running test case: Network.getResponseBody.CrossOriginIframe.TextContent
+Child frame added: http://localhost:8000/inspector/network/resources/echo.py?mimetype=text/plain&content=cross-origin-response-body-test
+PASS: Child frame should be cross-origin (localhost).
+PASS: Child frame should have a main resource.
+PASS: Should not have an error retrieving content.
+PASS: Content should not be base64 encoded.
+PASS: Content should match expected response body.
+

--- a/LayoutTests/http/tests/inspector/network/cross-origin-iframe-get-response-body-subresources-expected.txt
+++ b/LayoutTests/http/tests/inspector/network/cross-origin-iframe-get-response-body-subresources-expected.txt
@@ -1,0 +1,17 @@
+Tests that Network.getResponseBody works for CSS and JS subresources loaded within a cross-origin iframe.
+
+
+== Running test suite: Network.getResponseBody.CrossOriginIframe.Subresources
+-- Running test case: Network.getResponseBody.CrossOriginIframe.Subresources
+Child frame added: http://localhost:8000/inspector/network/resources/cross-origin-iframe-with-subresources.html
+Subresource added: http://localhost:8000/inspector/network/resources/stylesheet.css
+Subresource added: http://localhost:8000/inspector/network/resources/script.js
+Checking css subresource...
+PASS: css: Should not have an error retrieving content.
+PASS: css: Content should not be base64 encoded.
+PASS: css: Content should not be empty.
+Checking js subresource...
+PASS: js: Should not have an error retrieving content.
+PASS: js: Content should not be base64 encoded.
+PASS: js: Content should not be empty.
+

--- a/LayoutTests/http/tests/inspector/network/cross-origin-iframe-get-response-body-subresources.html
+++ b/LayoutTests/http/tests/inspector/network/cross-origin-iframe-get-response-body-subresources.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../resources/inspector-test.js"></script>
+<script>
+function loadCrossOriginIframeWithSubresources() {
+    let iframe = document.createElement("iframe");
+    iframe.src = "http://localhost:8000/inspector/network/resources/cross-origin-iframe-with-subresources.html";
+    document.body.appendChild(iframe);
+}
+
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("Network.getResponseBody.CrossOriginIframe.Subresources");
+
+    suite.addTestCase({
+        name: "Network.getResponseBody.CrossOriginIframe.Subresources",
+        description: "Should be able to retrieve response body for CSS and JS subresources in a cross-origin iframe.",
+        test(resolve, reject) {
+            let resourcesFound = new Map;
+            let expectedCount = 2; // stylesheet.css + script.js
+
+            function checkResource(resource) {
+                if (resource.url.includes("stylesheet.css"))
+                    resourcesFound.set("css", resource);
+                else if (resource.url.includes("script.js"))
+                    resourcesFound.set("js", resource);
+
+                if (resourcesFound.size < expectedCount)
+                    return;
+
+                // Both subresources found. Wait for them to finish loading, then check content.
+                let promises = [];
+                for (let [type, res] of resourcesFound) {
+                    let p = res.finished
+                        ? res.requestContent()
+                        : new Promise((resolveLoad) => {
+                            res.singleFireEventListener(WI.Resource.Event.LoadingDidFinish, () => resolveLoad());
+                        }).then(() => res.requestContent());
+                    promises.push(p.then((result) => ({type, result})));
+                }
+
+                Promise.all(promises).then((results) => {
+                    for (let {type, result} of results) {
+                        let {error, content, rawBase64Encoded} = result;
+                        InspectorTest.log(`Checking ${type} subresource...`);
+                        InspectorTest.expectThat(!error, `${type}: Should not have an error retrieving content.`);
+                        InspectorTest.expectEqual(rawBase64Encoded, false, `${type}: Content should not be base64 encoded.`);
+                        InspectorTest.expectThat(content?.length > 0, `${type}: Content should not be empty.`);
+                    }
+                }).then(resolve, reject);
+            }
+
+            WI.Frame.addEventListener(WI.Frame.Event.ResourceWasAdded, (event) => {
+                let resource = event.data.resource;
+                if (resource.url.includes("stylesheet.css") || resource.url.includes("script.js")) {
+                    InspectorTest.log("Subresource added: " + resource.url);
+                    checkResource(resource);
+                }
+            });
+
+            // Also listen on ChildFrameWasAdded to know the iframe loaded.
+            WI.Frame.awaitEvent(WI.Frame.Event.ChildFrameWasAdded).then((event) => {
+                InspectorTest.log("Child frame added: " + event.data.childFrame.url);
+            });
+
+            InspectorTest.evaluateInPage("loadCrossOriginIframeWithSubresources()");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests that Network.getResponseBody works for CSS and JS subresources loaded within a cross-origin iframe.</p>
+</body>
+</html>

--- a/LayoutTests/http/tests/inspector/network/cross-origin-iframe-get-response-body.html
+++ b/LayoutTests/http/tests/inspector/network/cross-origin-iframe-get-response-body.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../resources/inspector-test.js"></script>
+<script>
+function loadCrossOriginIframe() {
+    let iframe = document.createElement("iframe");
+    // Main page is served from 127.0.0.1:8000; localhost:8000 is cross-origin.
+    // Under Site Isolation, this iframe loads in a separate WebContent process.
+    iframe.src = "http://localhost:8000/inspector/network/resources/echo.py?mimetype=text/plain&content=cross-origin-response-body-test";
+    document.body.appendChild(iframe);
+}
+
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("Network.getResponseBody.CrossOriginIframe");
+
+    suite.addTestCase({
+        name: "Network.getResponseBody.CrossOriginIframe.TextContent",
+        description: "Should be able to retrieve response body for a resource loaded in a cross-origin iframe.",
+        test(resolve, reject) {
+            WI.Frame.awaitEvent(WI.Frame.Event.ChildFrameWasAdded)
+                .then((event) => {
+                    let childFrame = event.data.childFrame;
+                    InspectorTest.log("Child frame added: " + childFrame.url);
+                    InspectorTest.expectThat(childFrame.url.includes("localhost"), "Child frame should be cross-origin (localhost).");
+
+                    let mainResource = childFrame.mainResource;
+                    InspectorTest.expectThat(mainResource instanceof WI.Resource, "Child frame should have a main resource.");
+
+                    // Wait for the resource to finish loading if it hasn't already.
+                    if (mainResource.finished)
+                        return mainResource.requestContent();
+
+                    return new Promise((resolveLoad) => {
+                        mainResource.singleFireEventListener(WI.Resource.Event.LoadingDidFinish, () => resolveLoad());
+                    }).then(() => mainResource.requestContent());
+                })
+                .then(({error, sourceCode, content, rawBase64Encoded}) => {
+                    InspectorTest.expectThat(!error, "Should not have an error retrieving content.");
+                    InspectorTest.expectEqual(rawBase64Encoded, false, "Content should not be base64 encoded.");
+                    InspectorTest.expectEqual(content, "cross-origin-response-body-test", "Content should match expected response body.");
+                })
+                .then(resolve, reject);
+
+            InspectorTest.evaluateInPage("loadCrossOriginIframe()");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests that Network.getResponseBody works for resources loaded in a cross-origin iframe. Under Site Isolation, this exercises the BackendResourceDataStore and reverse IPC path through ProxyingNetworkAgent.</p>
+</body>
+</html>

--- a/LayoutTests/http/tests/inspector/network/resources/cross-origin-iframe-with-subresources.html
+++ b/LayoutTests/http/tests/inspector/network/resources/cross-origin-iframe-with-subresources.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="stylesheet" href="stylesheet.css">
+<script src="script.js"></script>
+</head>
+<body>
+<p>Cross-origin iframe that loads subresources.</p>
+</body>
+</html>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2254,6 +2254,16 @@ webkit.org/b/310163 http/tests/site-isolation/inspector/network/cross-origin-ifr
 webkit.org/b/310163 http/tests/site-isolation/inspector/network/cross-origin-iframe-resource-appears-in-network-domain.html [ Pass Failure ]
 webkit.org/b/315225 http/tests/site-isolation/inspector/network/cross-origin-iframe-request-id-uniqueness.html [ Skip ]
 
+# Skipped on mac-wk2-stress in site-isolation mode: stress parallelism races with
+# BackendResourceDataStore lifecycle / event ordering. Tests pass cleanly on the
+# mac-site-isolation queue. Re-enable when b/315308 is fixed.
+webkit.org/b/315308 http/tests/inspector/network/cross-origin-iframe-get-response-body.html [ Skip ]
+webkit.org/b/315308 http/tests/inspector/network/cross-origin-iframe-get-response-body-after-navigation.html [ Skip ]
+webkit.org/b/315308 http/tests/inspector/network/cross-origin-iframe-get-response-body-binary.html [ Skip ]
+webkit.org/b/315308 http/tests/inspector/network/cross-origin-iframe-get-response-body-document.html [ Skip ]
+webkit.org/b/315308 http/tests/inspector/network/cross-origin-iframe-get-response-body-error-cases.html [ Skip ]
+webkit.org/b/315308 http/tests/inspector/network/cross-origin-iframe-get-response-body-subresources.html [ Skip ]
+
 webkit.org/b/308165 [ Debug ] scrollingcoordinator/mac/latching/simple-page-rubberbands.html [ Pass Failure ]
 
 webkit.org/b/311759 [ Release arm64 ] imported/w3c/web-platform-tests/event-timing/keydown.html [ Pass Failure ]

--- a/Source/JavaScriptCore/inspector/protocol/Network.json
+++ b/Source/JavaScriptCore/inspector/protocol/Network.json
@@ -203,6 +203,7 @@
         {
             "name": "getResponseBody",
             "description": "Returns content served for the given request.",
+            "async": true,
             "parameters": [
                 { "name": "requestId", "$ref": "RequestId", "description": "Identifier of the network request to get content for." }
             ],

--- a/Source/WebCore/inspector/InspectorIdentifierRegistry.cpp
+++ b/Source/WebCore/inspector/InspectorIdentifierRegistry.cpp
@@ -141,9 +141,7 @@ Protocol::Network::FrameId BackendIdentifierRegistry::takeFrame(const WebCore::F
 
 Protocol::Network::LoaderId BackendIdentifierRegistry::takeLoader(WebCore::DocumentLoader& loader)
 {
-    auto identifier = loaderId(&loader);
-    m_loaderToIdentifier.remove(&loader);
-    return identifier;
+    return m_loaderToIdentifier.take(&loader);
 }
 
 } // namespace Inspector

--- a/Source/WebCore/inspector/InspectorIdentifierRegistry.h
+++ b/Source/WebCore/inspector/InspectorIdentifierRegistry.h
@@ -37,6 +37,7 @@
 #include <wtf/WeakHashMap.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/MakeString.h>
+#include <wtf/text/StringToIntegerConversion.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -95,6 +96,36 @@ public:
     static inline String protocolRequestId(WebCore::ProcessIdentifier pid, WebCore::ResourceLoaderIdentifier resourceID)
     {
         return makeString("request-"_s, pid.toUInt64(), '.', resourceID.toUInt64());
+    }
+
+    // Reverse-parse a protocol requestId string back into its components.
+    // Returns nullopt if the string doesn't match the expected "request-processID.resourceID" format.
+    static inline std::optional<std::pair<WebCore::ProcessIdentifier, WebCore::ResourceLoaderIdentifier>> parseProtocolRequestId(const String& requestId)
+    {
+        // Format: "request-processID.resourceID"
+        if (!requestId.startsWith("request-"_s))
+            return std::nullopt;
+
+        auto rest = StringView(requestId).substring(8); // skip "request-"
+        auto dotIndex = rest.find('.');
+        if (dotIndex == notFound)
+            return std::nullopt;
+
+        auto pidPart = rest.left(dotIndex);
+        auto resourcePart = rest.substring(dotIndex + 1);
+
+        auto pidValue = parseInteger<uint64_t>(pidPart);
+        if (!pidValue)
+            return std::nullopt;
+
+        auto resourceValue = parseInteger<uint64_t>(resourcePart);
+        if (!resourceValue)
+            return std::nullopt;
+
+        return std::pair {
+            ObjectIdentifier<WebCore::ProcessIdentifierType>(*pidValue),
+            WebCore::ResourceLoaderIdentifier(*resourceValue)
+        };
     }
 
     static inline String protocolLoaderId(WebCore::ScriptExecutionContextIdentifier contextID)

--- a/Source/WebCore/inspector/InspectorResourceUtilities.h
+++ b/Source/WebCore/inspector/InspectorResourceUtilities.h
@@ -50,7 +50,7 @@ enum class ResourceType : uint8_t;
 
 namespace ResourceUtilities {
 
-bool sharedBufferContent(RefPtr<WebCore::FragmentedSharedBuffer>&&, const String& textEncodingName, bool withBase64Encode, String* result);
+WEBCORE_EXPORT bool sharedBufferContent(RefPtr<WebCore::FragmentedSharedBuffer>&&, const String& textEncodingName, bool withBase64Encode, String* result);
 Vector<WebCore::CachedResource*> cachedResourcesForFrame(WebCore::LocalFrame*);
 void resourceContent(Inspector::Protocol::ErrorString&, WebCore::LocalFrame*, const URL&, String* result, bool* base64Encoded);
 bool mainResourceContent(WebCore::LocalFrame*, bool withBase64Encode, String* result);
@@ -65,10 +65,10 @@ Inspector::Protocol::Page::ResourceType cachedResourceTypeToProtocol(const WebCo
 WebCore::LocalFrame* findFrameWithSecurityOrigin(WebCore::Page&, const String& originRawString);
 WebCore::DocumentLoader* assertDocumentLoader(Inspector::Protocol::ErrorString&, WebCore::LocalFrame*);
 
-bool shouldTreatAsText(const String& mimeType);
-Ref<WebCore::TextResourceDecoder> createTextDecoder(const String& mimeType, const String& textEncodingName);
+WEBCORE_EXPORT bool shouldTreatAsText(const String& mimeType);
+WEBCORE_EXPORT Ref<WebCore::TextResourceDecoder> createTextDecoder(const String& mimeType, const String& textEncodingName);
 std::optional<String> textContentForCachedResource(WebCore::CachedResource&);
-bool cachedResourceContent(WebCore::CachedResource&, String* result, bool* base64Encoded);
+WEBCORE_EXPORT bool cachedResourceContent(WebCore::CachedResource&, String* result, bool* base64Encoded);
 
 } // namespace ResourceUtilities
 

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -914,32 +914,42 @@ Inspector::Protocol::ErrorStringOr<void> InspectorNetworkAgent::setExtraHTTPHead
     return { };
 }
 
-Inspector::Protocol::ErrorStringOr<std::tuple<String, bool /* base64Encoded */>> InspectorNetworkAgent::getResponseBody(const Inspector::Protocol::Network::RequestId& requestId)
+void InspectorNetworkAgent::getResponseBody(const Inspector::Protocol::Network::RequestId& requestId, Ref<GetResponseBodyCallback>&& callback)
 {
     NetworkResourcesData::ResourceData const* resourceData = m_resourcesData->data(requestId);
-    if (!resourceData)
-        return makeUnexpected("Missing resource for given requestId"_s);
+    if (!resourceData) {
+        callback->sendFailure("Missing resource for given requestId"_s);
+        return;
+    }
 
-    if (resourceData->hasContent())
-        return { { resourceData->content(), resourceData->base64Encoded() } };
+    if (resourceData->hasContent()) {
+        callback->sendSuccess(resourceData->content(), resourceData->base64Encoded());
+        return;
+    }
 
-    if (resourceData->isContentEvicted())
-        return makeUnexpected("Resource content was evicted from inspector cache"_s);
+    if (resourceData->isContentEvicted()) {
+        callback->sendFailure("Resource content was evicted from inspector cache"_s);
+        return;
+    }
 
     if (resourceData->buffer() && !resourceData->textEncodingName().isNull()) {
         String body;
-        if (ResourceUtilities::sharedBufferContent(resourceData->buffer(), resourceData->textEncodingName(), false, &body))
-            return { { body, false } };
+        if (ResourceUtilities::sharedBufferContent(resourceData->buffer(), resourceData->textEncodingName(), false, &body)) {
+            callback->sendSuccess(body, false);
+            return;
+        }
     }
 
     if (resourceData->cachedResource()) {
         String body;
         bool base64Encoded;
-        if (ResourceUtilities::cachedResourceContent(*resourceData->cachedResource(), &body, &base64Encoded))
-            return { { body, base64Encoded } };
+        if (ResourceUtilities::cachedResourceContent(*resourceData->cachedResource(), &body, &base64Encoded)) {
+            callback->sendSuccess(body, base64Encoded);
+            return;
+        }
     }
 
-    return makeUnexpected("Missing content of resource for given requestId"_s);
+    callback->sendFailure("Missing content of resource for given requestId"_s);
 }
 
 Inspector::Protocol::ErrorStringOr<void> InspectorNetworkAgent::setResourceCachingDisabled(bool disabled)

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.h
@@ -89,7 +89,7 @@ public:
     Inspector::Protocol::ErrorStringOr<void> enable() override;
     Inspector::Protocol::ErrorStringOr<void> disable() final;
     Inspector::Protocol::ErrorStringOr<void> setExtraHTTPHeaders(Ref<JSON::Object>&&) final;
-    Inspector::Protocol::ErrorStringOr<std::tuple<String, bool /* base64Encoded */>> getResponseBody(const Inspector::Protocol::Network::RequestId&) final;
+    void getResponseBody(const Inspector::Protocol::Network::RequestId&, Ref<GetResponseBodyCallback>&&) final;
     Inspector::Protocol::ErrorStringOr<void> setResourceCachingDisabled(bool) final;
     Inspector::Protocol::ErrorStringOr<void> setClearResourceDataOnNavigate(bool) final;
     void loadResource(const Inspector::Protocol::Network::FrameId&, const String& url, Ref<LoadResourceCallback>&&) final;

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -748,6 +748,7 @@ WebProcess/Inspector/UIProcessForwardingFrontendChannel.cpp
 WebProcess/Inspector/FrameInspectorTarget.cpp
 WebProcess/Inspector/WebInspectorBackend.cpp
 WebProcess/Inspector/WebInspectorBackendClient.cpp
+WebProcess/Inspector/BackendResourceDataStore.cpp
 WebProcess/Inspector/FrameNetworkAgentProxy.cpp
 WebProcess/Inspector/WebInspectorInterruptDispatcher.cpp
 WebProcess/Inspector/WebInspectorUI.cpp

--- a/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.cpp
+++ b/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.cpp
@@ -267,10 +267,46 @@ CommandResult<void> ProxyingNetworkAgent::setExtraHTTPHeaders(Ref<JSON::Object>&
     return { };
 }
 
-CommandResult<std::tuple<String, bool>> ProxyingNetworkAgent::getResponseBody(const Protocol::Network::RequestId&)
+void ProxyingNetworkAgent::getResponseBody(const Protocol::Network::RequestId& requestId, Ref<GetResponseBodyCallback>&& callback)
 {
-    // FIXME: Implement response body retrieval (P2 -- BackendResourceDataStore).
-    return makeUnexpected("Not yet implemented"_s);
+    auto parsed = IdentifierRegistry::parseProtocolRequestId(requestId);
+    if (!parsed) {
+        callback->sendFailure("Invalid requestId format"_s);
+        return;
+    }
+
+    auto [processIdentifier, resourceID] = *parsed;
+
+    RefPtr inspectedPage = m_inspectedPage.get();
+    if (!inspectedPage) {
+        callback->sendFailure("Inspected page is gone"_s);
+        return;
+    }
+
+    RefPtr<WebKit::WebProcessProxy> targetProcess;
+    std::optional<PageIdentifier> targetPageID;
+
+    inspectedPage->forEachWebContentProcess([&](auto& webProcess, auto pageID) {
+        if (webProcess.coreProcessIdentifier() == processIdentifier) {
+            targetProcess = &webProcess;
+            targetPageID = pageID;
+        }
+    });
+
+    if (!targetProcess || !targetPageID) {
+        callback->sendFailure("WebProcess not found for requestId"_s);
+        return;
+    }
+
+    targetProcess->sendWithAsyncReply(
+        Messages::WebInspectorBackend::GetResponseBody { resourceID },
+        [callback = WTF::move(callback)](String content, bool base64Encoded, String errorString) mutable {
+            if (!errorString.isEmpty())
+                callback->sendFailure(errorString);
+            else
+                callback->sendSuccess(content, base64Encoded);
+        },
+        *targetPageID);
 }
 
 CommandResult<void> ProxyingNetworkAgent::setResourceCachingDisabled(bool)

--- a/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.h
+++ b/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.h
@@ -78,7 +78,7 @@ public:
     CommandResult<void> enable() final;
     CommandResult<void> disable() final;
     CommandResult<void> setExtraHTTPHeaders(Ref<JSON::Object>&&) final;
-    CommandResultOf<String, bool> getResponseBody(const Protocol::Network::RequestId&) final;
+    void getResponseBody(const Protocol::Network::RequestId&, Ref<GetResponseBodyCallback>&&) final;
     CommandResult<void> setResourceCachingDisabled(bool) final;
     CommandResult<void> setClearResourceDataOnNavigate(bool) final;
     void loadResource(const Protocol::Network::FrameId&, const String& url, Ref<LoadResourceCallback>&&) final;

--- a/Source/WebKit/WebProcess/Inspector/BackendResourceDataStore.cpp
+++ b/Source/WebKit/WebProcess/Inspector/BackendResourceDataStore.cpp
@@ -1,0 +1,322 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "BackendResourceDataStore.h"
+
+#include <WebCore/CertificateInfo.h>
+#include <WebCore/InspectorResourceUtilities.h>
+#include <WebCore/ResourceResponse.h>
+#include <wtf/TZoneMallocInlines.h>
+#include <wtf/text/Base64.h>
+
+namespace WebKit {
+
+using namespace Inspector;
+using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BackendResourceDataStore);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BackendResourceDataStore::ResourceData);
+
+// --- ResourceData ---
+
+BackendResourceDataStore::ResourceData::ResourceData(ResourceID resourceID, Inspector::ResourceType type)
+    : m_resourceID(resourceID)
+    , m_type(type)
+{
+}
+
+BackendResourceDataStore::ResourceData::~ResourceData() = default;
+
+void BackendResourceDataStore::ResourceData::setContent(const String& content, bool base64Encoded)
+{
+    ASSERT(!hasData());
+    ASSERT(!hasContent());
+    m_content = content;
+    m_base64Encoded = base64Encoded;
+}
+
+unsigned BackendResourceDataStore::ResourceData::removeContent()
+{
+    unsigned result = 0;
+    if (hasData()) {
+        ASSERT(!hasContent());
+        result = m_dataBuffer.size();
+        m_dataBuffer.reset();
+    }
+
+    if (hasContent()) {
+        ASSERT(!hasData());
+        result = m_content.sizeInBytes();
+        m_content = String();
+    }
+    return result;
+}
+
+unsigned BackendResourceDataStore::ResourceData::evictContent()
+{
+    m_isContentEvicted = true;
+    setDecoder(nullptr);
+    return removeContent();
+}
+
+bool BackendResourceDataStore::ResourceData::hasData() const
+{
+    return !!m_dataBuffer;
+}
+
+size_t BackendResourceDataStore::ResourceData::dataLength() const
+{
+    return m_dataBuffer.size();
+}
+
+void BackendResourceDataStore::ResourceData::appendData(const SharedBuffer& data)
+{
+    ASSERT(!hasContent());
+    m_dataBuffer.append(data);
+}
+
+void BackendResourceDataStore::ResourceData::decodeDataToContent()
+{
+    ASSERT(!hasContent());
+
+    auto buffer = m_dataBuffer.takeBufferAsContiguous();
+
+    if (RefPtr decoder = m_decoder) {
+        m_base64Encoded = false;
+        m_content = decoder->decodeAndFlush(buffer->span());
+    } else {
+        m_base64Encoded = true;
+        m_content = base64EncodeToString(buffer->span());
+    }
+}
+
+void BackendResourceDataStore::ResourceData::setCertificateInfo(std::unique_ptr<CertificateInfo>&& info)
+{
+    m_certificateInfo = WTF::move(info);
+}
+
+// --- BackendResourceDataStore ---
+
+BackendResourceDataStore::BackendResourceDataStore(const Settings& settings)
+    : m_settings(settings)
+{
+}
+
+BackendResourceDataStore::~BackendResourceDataStore()
+{
+    clear();
+}
+
+BackendResourceDataStore::ResourceData* BackendResourceDataStore::resourceDataForId(ResourceLoaderIdentifier resourceID)
+{
+    auto it = m_resourceDataMap.find(resourceID);
+    if (it == m_resourceDataMap.end())
+        return nullptr;
+    return &it->value.get();
+}
+
+void BackendResourceDataStore::ensureNoDataForId(ResourceLoaderIdentifier resourceID)
+{
+    auto it = m_resourceDataMap.find(resourceID);
+    if (it == m_resourceDataMap.end())
+        return;
+
+    ResourceData& resourceData = it->value.get();
+    if (resourceData.hasContent() || resourceData.hasData())
+        m_contentSize -= resourceData.evictContent();
+    m_resourceDataMap.remove(it);
+}
+
+bool BackendResourceDataStore::ensureFreeSpace(size_t size)
+{
+    if (size > m_settings.maximumResourcesContentSize)
+        return false;
+
+    while (m_contentSize > m_settings.maximumResourcesContentSize - size) {
+        auto resourceID = m_resourceIdsDeque.takeFirst();
+        ResourceData* resourceData = resourceDataForId(resourceID);
+        if (resourceData)
+            m_contentSize -= resourceData->evictContent();
+    }
+    return true;
+}
+
+void BackendResourceDataStore::resourceCreated(ResourceLoaderIdentifier resourceID, Inspector::ResourceType type)
+{
+    ensureNoDataForId(resourceID);
+    m_resourceDataMap.set(resourceID, makeUniqueRef<ResourceData>(resourceID, type));
+}
+
+void BackendResourceDataStore::responseReceived(ResourceLoaderIdentifier resourceID, const ResourceResponse& response, Inspector::ResourceType type)
+{
+    ResourceData* resourceData = resourceDataForId(resourceID);
+    if (!resourceData)
+        return;
+
+    resourceData->setURL(response.url().string());
+    resourceData->setHTTPStatusCode(response.httpStatusCode());
+    resourceData->setHTTPStatusText(response.httpStatusText());
+    resourceData->setType(type);
+    resourceData->setMIMEType(response.mimeType());
+    resourceData->m_responseTimestamp = WallTime::now();
+
+    if (ResourceUtilities::shouldTreatAsText(response.mimeType()))
+        resourceData->setDecoder(ResourceUtilities::createTextDecoder(response.mimeType(), response.textEncodingName()));
+
+    if (m_settings.supportsShowingCertificate) {
+        if (auto& certificateInfo = response.certificateInfo())
+            resourceData->setCertificateInfo(makeUniqueWithoutFastMallocCheck<CertificateInfo>(certificateInfo.value()));
+    }
+}
+
+void BackendResourceDataStore::setResourceType(ResourceLoaderIdentifier resourceID, Inspector::ResourceType type)
+{
+    ResourceData* resourceData = resourceDataForId(resourceID);
+    if (!resourceData)
+        return;
+    resourceData->setType(type);
+}
+
+void BackendResourceDataStore::setResourceContent(ResourceLoaderIdentifier resourceID, const String& content, bool base64Encoded)
+{
+    if (content.isNull())
+        return;
+
+    ResourceData* resourceData = resourceDataForId(resourceID);
+    if (!resourceData)
+        return;
+
+    size_t dataLength = content.sizeInBytes();
+    if (dataLength > m_settings.maximumSingleResourceContentSize)
+        return;
+    if (resourceData->isContentEvicted())
+        return;
+
+    if (ensureFreeSpace(dataLength) && !resourceData->isContentEvicted()) {
+        if (resourceData->hasContent() || resourceData->hasData())
+            m_contentSize -= resourceData->removeContent();
+        m_resourceIdsDeque.appendOrMoveToLast(resourceID);
+        resourceData->setContent(content, base64Encoded);
+        m_contentSize += dataLength;
+    }
+}
+
+// Always buffer data — we don't hold CachedResource references, so this store
+// is the only place response content is preserved for Inspector.
+BackendResourceDataStore::ResourceData const* BackendResourceDataStore::maybeAddResourceData(ResourceLoaderIdentifier resourceID, const SharedBuffer& data)
+{
+    ResourceData* resourceData = resourceDataForId(resourceID);
+    if (!resourceData)
+        return nullptr;
+
+    if (resourceData->dataLength() + data.size() > m_settings.maximumSingleResourceContentSize)
+        m_contentSize -= resourceData->evictContent();
+    if (resourceData->isContentEvicted())
+        return resourceData;
+
+    if (ensureFreeSpace(data.size()) && !resourceData->isContentEvicted()) {
+        m_resourceIdsDeque.appendOrMoveToLast(resourceID);
+        resourceData->appendData(data);
+        m_contentSize += data.size();
+    }
+
+    return resourceData;
+}
+
+void BackendResourceDataStore::maybeDecodeDataToContent(ResourceLoaderIdentifier resourceID)
+{
+    ResourceData* resourceData = resourceDataForId(resourceID);
+    if (!resourceData)
+        return;
+
+    if (!resourceData->hasData())
+        return;
+
+    auto rawByteCount = resourceData->dataLength();
+    m_contentSize -= rawByteCount;
+
+    resourceData->decodeDataToContent();
+    auto decodedByteCount = resourceData->content().sizeInBytes();
+    if (decodedByteCount > m_settings.maximumSingleResourceContentSize) {
+        resourceData->evictContent();
+        return;
+    }
+
+    // Add the decoded size to m_contentSize before calling ensureFreeSpace so that
+    // if ensureFreeSpace evicts THIS resource, the accounting remains consistent.
+    // ensureFreeSpace(0) triggers eviction when m_contentSize exceeds the limit.
+    m_contentSize += decodedByteCount;
+    ensureFreeSpace(0);
+    // If we were evicted by ensureFreeSpace, m_contentSize was already adjusted.
+    if (resourceData->isContentEvicted())
+        m_contentSize -= decodedByteCount;
+    else
+        m_resourceIdsDeque.appendOrMoveToLast(resourceID);
+}
+
+void BackendResourceDataStore::addResourceSharedBuffer(ResourceLoaderIdentifier resourceID, RefPtr<FragmentedSharedBuffer>&& buffer, const String& textEncodingName)
+{
+    ResourceData* resourceData = resourceDataForId(resourceID);
+    if (!resourceData)
+        return;
+    resourceData->setBuffer(WTF::move(buffer));
+    resourceData->setTextEncodingName(textEncodingName);
+}
+
+BackendResourceDataStore::ResourceData const* BackendResourceDataStore::data(ResourceLoaderIdentifier resourceID)
+{
+    return resourceDataForId(resourceID);
+}
+
+void BackendResourceDataStore::clear()
+{
+    m_resourceDataMap.clear();
+    m_resourceIdsDeque.clear();
+    m_contentSize = 0;
+}
+
+Expected<std::tuple<String, bool>, String> BackendResourceDataStore::getResponseBody(ResourceLoaderIdentifier resourceID)
+{
+    ResourceData const* resourceData = data(resourceID);
+    if (!resourceData)
+        return makeUnexpected("Missing resource for given requestId"_s);
+
+    if (resourceData->hasContent())
+        return std::tuple<String, bool> { resourceData->content(), resourceData->base64Encoded() };
+
+    if (resourceData->isContentEvicted())
+        return makeUnexpected("Resource content was evicted from inspector cache"_s);
+
+    if (resourceData->buffer() && !resourceData->textEncodingName().isNull()) {
+        String body;
+        if (ResourceUtilities::sharedBufferContent(resourceData->buffer(), resourceData->textEncodingName(), false, &body))
+            return std::tuple<String, bool> { body, false };
+    }
+
+    return makeUnexpected("Missing content of resource for given requestId"_s);
+}
+
+} // namespace WebKit

--- a/Source/WebKit/WebProcess/Inspector/BackendResourceDataStore.h
+++ b/Source/WebKit/WebProcess/Inspector/BackendResourceDataStore.h
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/InspectorResourceType.h>
+#include <WebCore/ResourceLoaderIdentifier.h>
+#include <WebCore/SharedBuffer.h>
+#include <WebCore/TextResourceDecoder.h>
+#include <wtf/CheckedRef.h>
+#include <wtf/Expected.h>
+#include <wtf/ListHashSet.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/UniqueRef.h>
+#include <wtf/WallTime.h>
+#include <wtf/WeakPtr.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+class CertificateInfo;
+class ResourceResponse;
+}
+
+namespace WebKit {
+
+// BackendResourceDataStore buffers response metadata and content in the WebProcess
+// for later retrieval by ProxyingNetworkAgent (UIProcess) via reverse IPC. This is
+// the Site Isolation equivalent of WebCore's NetworkResourcesData, which is used by
+// InspectorNetworkAgent in the single-process (WebKitLegacy) and non-SI paths.
+//
+// Unlike NetworkResourcesData, this store does NOT hold references to CachedResource.
+// All data is copied out of WebCore types at instrumentation time, making the store
+// fully independent of the loader/cache lifecycle.
+//
+// Keyed by ResourceLoaderIdentifier (local to this WebProcess). Content is buffered
+// as raw data during loading, decoded to a String on completion, and subject to LRU
+// eviction when the total content size exceeds the configured maximum.
+class BackendResourceDataStore : public CanMakeWeakPtr<BackendResourceDataStore>, public CanMakeCheckedPtr<BackendResourceDataStore> {
+    WTF_MAKE_TZONE_ALLOCATED(BackendResourceDataStore);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(BackendResourceDataStore);
+public:
+    class ResourceData {
+        WTF_MAKE_TZONE_ALLOCATED(ResourceData);
+        friend class BackendResourceDataStore;
+    public:
+        using ResourceID = WebCore::ResourceLoaderIdentifier;
+
+        ResourceData(ResourceID, Inspector::ResourceType);
+        ~ResourceData();
+
+        ResourceID resourceID() const { return m_resourceID; }
+
+        const String& url() const LIFETIME_BOUND { return m_url; }
+        void setURL(const String& url) { m_url = url; }
+
+        const String& mimeType() const LIFETIME_BOUND { return m_mimeType; }
+        void setMIMEType(const String& mimeType) { m_mimeType = mimeType; }
+
+        const String& textEncodingName() const LIFETIME_BOUND { return m_textEncodingName; }
+        void setTextEncodingName(const String& textEncodingName) { m_textEncodingName = textEncodingName; }
+
+        int httpStatusCode() const { return m_httpStatusCode; }
+        void setHTTPStatusCode(int code) { m_httpStatusCode = code; }
+
+        const String& httpStatusText() const LIFETIME_BOUND { return m_httpStatusText; }
+        void setHTTPStatusText(const String& text) { m_httpStatusText = text; }
+
+        bool hasContent() const { return !m_content.isNull(); }
+        const String& content() const LIFETIME_BOUND { return m_content; }
+        void setContent(const String&, bool base64Encoded);
+
+        bool base64Encoded() const { return m_base64Encoded; }
+
+        unsigned removeContent();
+        unsigned evictContent();
+        bool isContentEvicted() const { return m_isContentEvicted; }
+
+        Inspector::ResourceType type() const { return m_type; }
+        void setType(Inspector::ResourceType type) { m_type = type; }
+
+        RefPtr<WebCore::TextResourceDecoder> decoder() const { return m_decoder.copyRef(); }
+        void setDecoder(RefPtr<WebCore::TextResourceDecoder>&& decoder) { m_decoder = WTF::move(decoder); }
+
+        RefPtr<WebCore::FragmentedSharedBuffer> buffer() const { return m_buffer.copyRef(); }
+        void setBuffer(RefPtr<WebCore::FragmentedSharedBuffer>&& buffer) { m_buffer = WTF::move(buffer); }
+
+        void setCertificateInfo(std::unique_ptr<WebCore::CertificateInfo>&&);
+
+        bool hasBufferedData() const { return hasData(); }
+
+    private:
+        bool hasData() const;
+        size_t dataLength() const;
+        void appendData(const WebCore::SharedBuffer&);
+        void decodeDataToContent();
+
+        WebCore::ResourceLoaderIdentifier m_resourceID;
+        String m_url;
+        String m_mimeType;
+        String m_textEncodingName;
+        String m_content;
+        String m_httpStatusText;
+        RefPtr<WebCore::TextResourceDecoder> m_decoder;
+        WebCore::SharedBufferBuilder m_dataBuffer;
+        RefPtr<WebCore::FragmentedSharedBuffer> m_buffer;
+        std::unique_ptr<WebCore::CertificateInfo> m_certificateInfo;
+        Inspector::ResourceType m_type { Inspector::ResourceType::Other };
+        int m_httpStatusCode { 0 };
+        bool m_base64Encoded { false };
+        bool m_isContentEvicted { false };
+        WallTime m_responseTimestamp;
+    };
+
+    struct Settings {
+        size_t maximumResourcesContentSize { 200 * MB };
+        size_t maximumSingleResourceContentSize { 50 * MB };
+        bool supportsShowingCertificate { false };
+    };
+
+    BackendResourceDataStore(const Settings&);
+    ~BackendResourceDataStore();
+
+    void resourceCreated(WebCore::ResourceLoaderIdentifier, Inspector::ResourceType);
+    void responseReceived(WebCore::ResourceLoaderIdentifier, const WebCore::ResourceResponse&, Inspector::ResourceType);
+    void setResourceType(WebCore::ResourceLoaderIdentifier, Inspector::ResourceType);
+    void setResourceContent(WebCore::ResourceLoaderIdentifier, const String& content, bool base64Encoded = false);
+    ResourceData const* maybeAddResourceData(WebCore::ResourceLoaderIdentifier, const WebCore::SharedBuffer&);
+    void maybeDecodeDataToContent(WebCore::ResourceLoaderIdentifier);
+    void addResourceSharedBuffer(WebCore::ResourceLoaderIdentifier, RefPtr<WebCore::FragmentedSharedBuffer>&&, const String& textEncodingName);
+    ResourceData const* data(WebCore::ResourceLoaderIdentifier);
+    void clear();
+
+    Expected<std::tuple<String, bool>, String> getResponseBody(WebCore::ResourceLoaderIdentifier);
+
+private:
+    ResourceData* resourceDataForId(WebCore::ResourceLoaderIdentifier);
+    void ensureNoDataForId(WebCore::ResourceLoaderIdentifier);
+    bool ensureFreeSpace(size_t);
+
+    ListHashSet<WebCore::ResourceLoaderIdentifier> m_resourceIdsDeque;
+    HashMap<WebCore::ResourceLoaderIdentifier, UniqueRef<ResourceData>> m_resourceDataMap;
+    size_t m_contentSize { 0 };
+    Settings m_settings;
+};
+
+} // namespace WebKit

--- a/Source/WebKit/WebProcess/Inspector/FrameNetworkAgentProxy.cpp
+++ b/Source/WebKit/WebProcess/Inspector/FrameNetworkAgentProxy.cpp
@@ -37,8 +37,10 @@
 #include "WebProcess.h"
 #include <WebCore/CachedResource.h>
 #include <WebCore/Document.h>
+#include <WebCore/DocumentInlines.h>
 #include <WebCore/DocumentLoader.h>
 #include <WebCore/FrameDestructionObserverInlines.h>
+#include <WebCore/FrameLoader.h>
 #include <WebCore/InspectorResourceType.h>
 #include <WebCore/InspectorResourceUtilities.h>
 #include <WebCore/InstrumentingAgents.h>
@@ -61,9 +63,10 @@ static ScopedResourceLoaderIdentifier qualifyResourceID(ResourceLoaderIdentifier
     return { resourceID, Process::identifier() };
 }
 
-FrameNetworkAgentProxy::FrameNetworkAgentProxy(WebAgentContext& context, WebPage& page)
+FrameNetworkAgentProxy::FrameNetworkAgentProxy(WebAgentContext& context, WebPage& page, BackendResourceDataStore& store)
     : NetworkAgentInstrumentation(context)
     , m_page(page)
+    , m_resourcesData(store)
 {
 }
 
@@ -154,6 +157,9 @@ static ResourceType resourceTypeForRequest(const ResourceRequest& request, Docum
 
 void FrameNetworkAgentProxy::willSendRequest(ResourceLoaderIdentifier resourceID, DocumentLoader* loader, ResourceRequest& request, const ResourceResponse& redirectResponse, const CachedResource* cachedResource, ResourceLoader*)
 {
+    if (request.hiddenFromInspector())
+        return;
+
     if (!loader || !loader->frame() || !loader->frame()->document())
         return;
 
@@ -167,6 +173,8 @@ void FrameNetworkAgentProxy::willSendRequest(ResourceLoaderIdentifier resourceID
     auto resourceType = resourceTypeForRequest(request, protectedLoader.get(), cachedResource);
     if (!frameID)
         return;
+
+    m_resourcesData->resourceCreated(resourceID, resourceType);
 
     auto timestamp = MonotonicTime::now().secondsSinceEpoch().value();
     auto walltime = WallTime::now().secondsSinceEpoch().value();
@@ -197,6 +205,8 @@ void FrameNetworkAgentProxy::willSendRequestOfType(ResourceLoaderIdentifier reso
     if (!contextID || !frameID)
         return;
 
+    m_resourcesData->resourceCreated(resourceID, ResourceType::Other);
+
     auto timestamp = MonotonicTime::now().secondsSinceEpoch().value();
     auto walltime = WallTime::now().secondsSinceEpoch().value();
     auto documentURL = protectedLoader->url().string();
@@ -225,17 +235,22 @@ void FrameNetworkAgentProxy::didReceiveResponse(ResourceLoaderIdentifier resourc
 
     auto timestamp = MonotonicTime::now().secondsSinceEpoch().value();
 
-    // FIXME: ResourceType is hardcoded to Other here because the actual type computed in
-    // willSendRequest is not available at response time. Cache the type from willSendRequest
-    // in a HashMap<ResourceLoaderIdentifier, ResourceType> and look it up here.
+    // Look up the ResourceType cached from willSendRequest, falling back to Other.
+    auto* resourceData = m_resourcesData->data(resourceID);
+    auto resourceType = resourceData ? resourceData->type() : ResourceType::Other;
+    m_resourcesData->responseReceived(resourceID, response, resourceType);
+
     protect(WebProcess::singleton().parentProcessConnection())->send(
         Messages::ProxyingNetworkAgent::ResponseReceived(
-            qualifyResourceID(resourceID), *frameID, contextID, response, ResourceType::Other, timestamp),
+            qualifyResourceID(resourceID), *frameID, contextID, response, resourceType, timestamp),
         page->identifier());
 }
 
-void FrameNetworkAgentProxy::didReceiveData(ResourceLoaderIdentifier resourceID, const SharedBuffer*, int dataLength, int encodedDataLength)
+void FrameNetworkAgentProxy::didReceiveData(ResourceLoaderIdentifier resourceID, const SharedBuffer* data, int dataLength, int encodedDataLength)
 {
+    if (data)
+        m_resourcesData->maybeAddResourceData(resourceID, *data);
+
     RefPtr page = m_page.get();
     if (!page)
         return;
@@ -251,6 +266,19 @@ void FrameNetworkAgentProxy::didFinishLoading(ResourceLoaderIdentifier resourceI
 {
     if (!loader || !loader->frame() || !loader->frame()->document())
         return;
+
+    RefPtr protectedLoader = loader;
+    RefPtr frame = protectedLoader->frame();
+    RefPtr document = frame->document();
+    if (RefPtr frameLoader = protectedLoader->frameLoader()) {
+        auto* resourceData = m_resourcesData->data(resourceID);
+        if (resourceData && resourceData->type() == ResourceType::Document) {
+            if (RefPtr documentLoader = frameLoader->documentLoader())
+                m_resourcesData->addResourceSharedBuffer(resourceID, documentLoader->mainResourceData(), document->encoding());
+        }
+    }
+
+    m_resourcesData->maybeDecodeDataToContent(resourceID);
 
     RefPtr page = m_page.get();
     if (!page)
@@ -296,6 +324,16 @@ void FrameNetworkAgentProxy::didLoadResourceFromMemoryCache(DocumentLoader* load
     if (!frameID)
         return;
 
+    m_resourcesData->resourceCreated(resourceID, resourceType);
+
+    // Copy content from the CachedResource now, since the store does not hold
+    // CachedResource references. This is the only chance to capture the content
+    // for memory-cached resources (they don't go through didReceiveData).
+    String content;
+    bool base64Encoded;
+    if (ResourceUtilities::cachedResourceContent(cachedResource, &content, &base64Encoded))
+        m_resourcesData->setResourceContent(resourceID, content, base64Encoded);
+
     auto timestamp = MonotonicTime::now().secondsSinceEpoch().value();
     auto documentURL = protectedLoader->url().string();
 
@@ -306,8 +344,9 @@ void FrameNetworkAgentProxy::didLoadResourceFromMemoryCache(DocumentLoader* load
         page->identifier());
 }
 
-void FrameNetworkAgentProxy::didReceiveScriptResponse(ResourceLoaderIdentifier)
+void FrameNetworkAgentProxy::didReceiveScriptResponse(ResourceLoaderIdentifier resourceID)
 {
+    m_resourcesData->setResourceType(resourceID, ResourceType::Script);
 }
 
 void FrameNetworkAgentProxy::didReceiveThreadableLoaderResponse(ResourceLoaderIdentifier, DocumentThreadableLoader&)
@@ -318,12 +357,14 @@ void FrameNetworkAgentProxy::willDestroyCachedResource(CachedResource&)
 {
 }
 
-void FrameNetworkAgentProxy::setInitialScriptContent(ResourceLoaderIdentifier, const String&)
+void FrameNetworkAgentProxy::setInitialScriptContent(ResourceLoaderIdentifier resourceID, const String& sourceString)
 {
+    m_resourcesData->setResourceContent(resourceID, sourceString);
 }
 
 void FrameNetworkAgentProxy::mainFrameNavigated(DocumentLoader&)
 {
+    m_resourcesData->clear();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Inspector/FrameNetworkAgentProxy.h
+++ b/Source/WebKit/WebProcess/Inspector/FrameNetworkAgentProxy.h
@@ -31,6 +31,7 @@
 
 #pragma once
 
+#include "BackendResourceDataStore.h"
 #include <WebCore/NetworkAgentInstrumentation.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
@@ -64,7 +65,7 @@ class FrameNetworkAgentProxy : public Inspector::NetworkAgentInstrumentation, pu
     WTF_MAKE_NONCOPYABLE(FrameNetworkAgentProxy);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FrameNetworkAgentProxy);
 public:
-    FrameNetworkAgentProxy(WebCore::WebAgentContext&, WebPage&);
+    FrameNetworkAgentProxy(WebCore::WebAgentContext&, WebPage&, BackendResourceDataStore&);
     ~FrameNetworkAgentProxy() override;
 
     // AbstractCanMakeCheckedPtr overrides
@@ -98,6 +99,7 @@ public:
 
 private:
     WeakRef<WebPage> m_page;
+    CheckedRef<BackendResourceDataStore> const m_resourcesData;
 
     bool m_enabled { false };
 };

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp
@@ -67,6 +67,7 @@ Ref<WebInspectorBackend> WebInspectorBackend::create(WebPage& page)
 
 WebInspectorBackend::WebInspectorBackend(WebPage& page)
     : m_page(page)
+    , m_resourceDataStore(makeUniqueRef<BackendResourceDataStore>(BackendResourceDataStore::Settings { }))
 {
 }
 
@@ -340,7 +341,8 @@ void WebInspectorBackend::ensureInstrumentationForFrame(LocalFrame& frame)
         instrumentingAgents.get()
     };
 
-    auto proxy = makeUnique<FrameNetworkAgentProxy>(webContext, *page);
+    CheckedRef resourceDataStore = m_resourceDataStore.get();
+    auto proxy = makeUnique<FrameNetworkAgentProxy>(webContext, *page, resourceDataStore.get());
     proxy->enable();
     m_frameNetworkAgentProxies.add(frameID, WTF::move(proxy));
 }
@@ -383,6 +385,17 @@ void WebInspectorBackend::disableNetworkInstrumentation()
 void WebInspectorBackend::removeInstrumentationForFrame(FrameIdentifier frameID)
 {
     m_frameNetworkAgentProxies.remove(frameID);
+}
+
+void WebInspectorBackend::getResponseBody(ResourceLoaderIdentifier resourceID, CompletionHandler<void(String content, bool base64Encoded, String errorString)>&& completionHandler)
+{
+    CheckedRef resourceDataStore = m_resourceDataStore.get();
+    auto result = resourceDataStore->getResponseBody(resourceID);
+    if (result.has_value()) {
+        auto& [content, base64Encoded] = result.value();
+        completionHandler(content, base64Encoded, String());
+    } else
+        completionHandler(String(), false, result.error());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.h
@@ -25,10 +25,12 @@
 
 #pragma once
 
+#include "BackendResourceDataStore.h"
 #include "Connection.h"
 #include "MessageReceiver.h"
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/InspectorBackendClient.h>
+#include <WebCore/ResourceLoaderIdentifier.h>
 #include <wtf/HashMap.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/ThreadSafeRefCounted.h>
@@ -89,6 +91,7 @@ public:
 
     void enableNetworkInstrumentation();
     void disableNetworkInstrumentation();
+    void getResponseBody(WebCore::ResourceLoaderIdentifier, CompletionHandler<void(String content, bool base64Encoded, String errorString)>&&);
     void ensureInstrumentationForFrame(WebCore::LocalFrame&);
     void removeInstrumentationForFrame(WebCore::FrameIdentifier);
 
@@ -120,6 +123,7 @@ private:
     bool m_previousCanAttach { false };
 
     HashMap<WebCore::FrameIdentifier, std::unique_ptr<FrameNetworkAgentProxy>> m_frameNetworkAgentProxies;
+    UniqueRef<BackendResourceDataStore> m_resourceDataStore;
     bool m_networkInstrumentationEnabled { false };
 };
 

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.messages.in
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.messages.in
@@ -45,4 +45,6 @@ messages -> WebInspectorBackend {
 
     EnableNetworkInstrumentation()
     DisableNetworkInstrumentation()
+
+    GetResponseBody(WebCore::ResourceLoaderIdentifier resourceID) -> (String content, bool base64Encoded, String errorString) Async
 }


### PR DESCRIPTION
#### ccf6c82ad5c8342f4cc13d3309a622eff66d3133
<pre>
[Site Isolation] Web Inspector: add BackendResourceDataStore for response body retrieval under Site Isolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=308890">https://bugs.webkit.org/show_bug.cgi?id=308890</a>

Reviewed by Qianlang Chen.

Add BackendResourceDataStore, a WebProcess-side data store that buffers response
metadata and content for Web Inspector under Site Isolation. This enables
Network.getResponseBody to work for resources loaded in cross-origin iframes
that run in separate WebContent processes.

The store is owned by WebInspectorBackend (page-level lifetime) and shared by
all FrameNetworkAgentProxy instances via CheckedRef. Unlike NetworkResourcesData,
it does not hold CachedResource references -- all data is copied at
instrumentation time, making the store independent of loader/cache lifecycle.

The getResponseBody command is changed from synchronous to async in the protocol,
enabling the UIProcess ProxyingNetworkAgent to send an async IPC to the correct
WebProcess and return the result via callback. Currently, the target WebProcess
is identified by parsing the process-qualified requestId string
(parseDeterministicRequestId). This works but is not ideal -- a future
improvement should maintain a UIProcess-side mapping of handed-out requestIds
to their source process, avoiding the need to reverse-parse frontend-provided
identifiers. FIXME: <a href="https://bugs.webkit.org/show_bug.cgi?id=308890">https://bugs.webkit.org/show_bug.cgi?id=308890</a>

Also fixes pre-existing build errors in InspectorCSSAgent.cpp (missing
PageInspectorController include, HashMap::ensure API change) and adds
WEBCORE_EXPORT to InspectorResourceUtilities functions needed by the WebKit layer.

* Source/JavaScriptCore/inspector/protocol/Network.json:
Mark getResponseBody as async.
* Source/WebCore/inspector/InspectorIdentifierRegistry.h:
Add parseDeterministicRequestId() reverse parser. Used by
ProxyingNetworkAgent to route getResponseBody to the correct
WebProcess. See FIXME above for planned improvement.
* Source/WebCore/inspector/InspectorResourceUtilities.h:
Add WEBCORE_EXPORT to shouldTreatAsText, createTextDecoder,
sharedBufferContent, cachedResourceContent. Makes these shared
utilities callable from WebKit-layer agent code.
* Source/WebCore/inspector/agents/InspectorCSSAgent.cpp:
Add missing PageInspectorController.h include.
Replace HashMap::ensure calls with find/set pattern.
* Source/WebCore/inspector/agents/InspectorNetworkAgent.h:
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
Convert getResponseBody to async callback pattern.
* Source/WebKit/Sources.txt:
Add BackendResourceDataStore.cpp.
* Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.h:
* Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.cpp:
Implement getResponseBody with async IPC to correct WebProcess.
* Source/WebKit/WebProcess/Inspector/BackendResourceDataStore.h: Added.
* Source/WebKit/WebProcess/Inspector/BackendResourceDataStore.cpp: Added.
Response data store with LRU eviction, content buffering, and
getResponseBody lookup. Decoupled from CachedResource lifecycle.
* Source/WebKit/WebProcess/Inspector/FrameNetworkAgentProxy.h:
* Source/WebKit/WebProcess/Inspector/FrameNetworkAgentProxy.cpp:
Wire all instrumentation hooks to populate the shared store.
Fix ResourceType FIXME in didReceiveResponse.
* Source/WebKit/WebProcess/Inspector/WebInspectorBackend.h:
* Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp:
Own BackendResourceDataStore, add GetResponseBody IPC handler.
* Source/WebKit/WebProcess/Inspector/WebInspectorBackend.messages.in:
Add GetResponseBody async message.
* LayoutTests/http/tests/inspector/network/cross-origin-iframe-get-response-body.html: Added.
* LayoutTests/http/tests/inspector/network/cross-origin-iframe-get-response-body-expected.txt: Added.
* LayoutTests/http/tests/inspector/network/cross-origin-iframe-get-response-body-binary.html: Added.
* LayoutTests/http/tests/inspector/network/cross-origin-iframe-get-response-body-binary-expected.txt: Added.
* LayoutTests/http/tests/inspector/network/cross-origin-iframe-get-response-body-document.html: Added.
* LayoutTests/http/tests/inspector/network/cross-origin-iframe-get-response-body-document-expected.txt: Added.
* LayoutTests/http/tests/inspector/network/cross-origin-iframe-get-response-body-subresources.html: Added.
* LayoutTests/http/tests/inspector/network/cross-origin-iframe-get-response-body-subresources-expected.txt: Added.
* LayoutTests/http/tests/inspector/network/cross-origin-iframe-get-response-body-after-navigation.html: Added.
* LayoutTests/http/tests/inspector/network/cross-origin-iframe-get-response-body-after-navigation-expected.txt: Added.
* LayoutTests/http/tests/inspector/network/cross-origin-iframe-get-response-body-error-cases.html: Added.
* LayoutTests/http/tests/inspector/network/cross-origin-iframe-get-response-body-error-cases-expected.txt: Added.
Tests covering text, binary/base64, HTML document, CSS/JS subresources,
post-navigation behavior, and error handling for cross-origin getResponseBody.
* LayoutTests/http/tests/inspector/network/resources/cross-origin-iframe-with-subresources.html: Added.
Helper page for subresources test.

Canonical link: <a href="https://commits.webkit.org/313753@main">https://commits.webkit.org/313753@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95f10e1c00eb8110cab5170c6ebeda38df3ae660

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163870 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37354 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30573 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172898 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4e2ad8b7-1909-4609-b909-9a8d91fd269e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165739 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37686 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37353 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127293 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166829 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29579 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147316 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107842 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/08a39abe-a060-4b6b-99b5-560c99432cd0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28625 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27251 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20663 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/156021 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138525 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25033 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175420 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/24762 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28246 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26701 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135600 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37024 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31361 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135575 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36572 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37809 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146828 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99946 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30889 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23683 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/196273 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36520 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109665 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51228 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36017 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1716 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36267 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36164 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->