### PR TITLE
Window sometimes drifts during fullscreen animation on visionOS

### DIFF
--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -2163,6 +2163,16 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     return YES;
 }
 
+- (void)_updateFullscreenWindowOrigin
+{
+    CGRect originalWindowBounds = [_lastKnownParentWindow bounds];
+    CGRect fullscreenWindowBounds = [_window bounds];
+    CGRect adjustedFullscreenWindowFrame = fullscreenWindowBounds;
+    adjustedFullscreenWindowFrame.origin.x = (CGRectGetWidth(originalWindowBounds) - CGRectGetWidth(adjustedFullscreenWindowFrame)) / 2;
+    adjustedFullscreenWindowFrame.origin.y = (CGRectGetHeight(originalWindowBounds)  - CGRectGetHeight(adjustedFullscreenWindowFrame)) / 2;
+    [_window setFrame:adjustedFullscreenWindowFrame];
+}
+
 - (void)_performSpatialFullScreenTransition:(BOOL)enter completionHandler:(CompletionHandler<void()>&&)completionHandler
 {
     OBJC_ALWAYS_LOG(OBJC_LOGIDENTIFIER, enter);
@@ -2175,16 +2185,14 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     const BOOL shouldAnimateResizeScene = [self _shouldAnimateResizeScene];
 
-    // This is a workaround for the fact that the content in the window is anchored to the top left of the scene
-    // As a result, we need to apply an XY offset that animates as the inWindow comes in, such that it
-    // is centered while the animation happens during scene resize.
     CGFloat sceneWidthDifference = inWindowBounds.size.width - outWindowBounds.size.width;
     CGFloat sceneHeightDifference = inWindowBounds.size.height - outWindowBounds.size.height;
-    float inWindowXOffset = shouldAnimateResizeScene ? sceneWidthDifference / 2 : 0;
-    float inWindowYOffset = shouldAnimateResizeScene ? sceneHeightDifference / 2 : 0;
     CGSize targetSceneSize = [inWindow bounds].size;
 
-    inWindow.transform3D = CATransform3DTranslate(originalState.transform3D, -inWindowXOffset, -inWindowYOffset, kIncomingWindowZOffset);
+    if (shouldAnimateResizeScene && enter)
+        [self _updateFullscreenWindowOrigin];
+
+    inWindow.transform3D = CATransform3DTranslate(originalState.transform3D, 0, 0, kIncomingWindowZOffset);
 
     WKSurroundingsEffectType targetDarkness = enter ? (self.prefersSceneDimming ? WKSurroundingsEffectTypeDark : originalState.preferredSurroundingsEffect) : originalState.preferredSurroundingsEffect;
 
@@ -2234,16 +2242,19 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         completionHandler();
     });
 
-    auto animationCompletionBlock = makeBlockPtr([inWindow, targetSceneSize, shouldAnimateResizeScene, resizeCompletionBlock = WTF::move(resizeCompletionBlock)] (BOOL finished) mutable {
-        if (shouldAnimateResizeScene)
-            resizeCompletionBlock();
-        else
+    auto animationCompletionBlock = makeBlockPtr([enter, inWindow, targetSceneSize, shouldAnimateResizeScene, resizeCompletionBlock = WTF::move(resizeCompletionBlock)] (BOOL finished) mutable {
+        if (!shouldAnimateResizeScene || enter)
             WebKit::resizeScene([inWindow windowScene], targetSceneSize, 0, shouldAnimateResizeScene, WTF::move(resizeCompletionBlock));
+        else
+            resizeCompletionBlock();
     });
 
-    auto animationBlock = makeBlockPtr([inWindow, outWindow, originalState, enter, allowSceneGeometryUpdates, inWindowXOffset, inWindowYOffset, sceneWidthDifference, sceneHeightDifference, shouldAnimateResizeScene, self, weakSelf = WTF::move(weakSelf), animationCompletionBlock = WTF::move(animationCompletionBlock)] mutable {
+    auto animationBlock = makeBlockPtr([inWindow, outWindow, originalState, enter, allowSceneGeometryUpdates, sceneWidthDifference, sceneHeightDifference, shouldAnimateResizeScene, self, weakSelf = WTF::move(weakSelf), animationCompletionBlock = WTF::move(animationCompletionBlock)] mutable {
+        if (shouldAnimateResizeScene && !enter)
+            [self _updateFullscreenWindowOrigin];
+
 #if ENABLE(SCENE_GEOMETRY_UPDATE)
-        [UIView animateWithDuration:kWindowTranslationDuration delay:0 options:UIViewAnimationOptionCurveEaseInOut animations:^{
+        [UIView animateWithDuration:kOutgoingWindowFadeDuration delay:0 options:UIViewAnimationOptionCurveEaseInOut animations:^{
             if (allowSceneGeometryUpdates)
                 [[inWindow windowScene] setUsesDefaultGeometry:!enter];
         } completion:nil];
@@ -2259,7 +2270,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         } completion:nil];
 
         [UIView animateWithDuration:kWindowTranslationDuration delay:0 options:UIViewAnimationOptionCurveEaseInOut animations:^{
-            outWindow.transform3D = CATransform3DTranslate(outWindow.transform3D, inWindowXOffset, inWindowYOffset, kOutgoingWindowZOffset);
+            outWindow.transform3D = CATransform3DTranslate(outWindow.transform3D, 0, 0, kOutgoingWindowZOffset);
         } completion:nil];
 
         [UIView animateWithDuration:kWindowTranslationDuration delay:0 options:UIViewAnimationOptionCurveEaseInOut animations:^{
@@ -2304,10 +2315,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         } completion:animationCompletionBlock.get()];
     });
 
-    if (shouldAnimateResizeScene)
-        WebKit::resizeScene([inWindow windowScene], targetSceneSize, kWindowTranslationDuration, shouldAnimateResizeScene, WTF::move(animationBlock));
-    else
+    if (!shouldAnimateResizeScene || enter)
         animationBlock();
+    else
+        WebKit::resizeScene([inWindow windowScene], targetSceneSize, 0, shouldAnimateResizeScene, WTF::move(animationBlock));
 }
 
 - (void)toggleSceneDimming


### PR DESCRIPTION
#### 8f9fc27ff04c511bcb5c8a5c1392cf3bae40a504
<pre>
Window sometimes drifts during fullscreen animation on visionOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=310553">https://bugs.webkit.org/show_bug.cgi?id=310553</a>
<a href="https://rdar.apple.com/171182633">rdar://171182633</a>

Reviewed by Andy Estes.

In <a href="https://bugs.webkit.org/show_bug.cgi?id=306149">https://bugs.webkit.org/show_bug.cgi?id=306149</a> we previously introduced new behavior
for Fullscreen Animation in visionOS such that rather than using 2 scene resizes we limited
it to 1. The consequence of that was we needed to apply an XY animation for the windows as
they transitioned in and out to avoid the windows from drifting as they faded in and out.

From further testing we noticed that this XY animation may sometimes not synchronize with
the scene resize animation, so the issue may still occur. The solution is to remove this
workaround and instead do the following:

On entry: perform the scene resize with no animation at the end of the animation once the
fullscreen window settles

On exit: perform the scene resize with no animation at the beginning of the animation as
the fullscreen window fades out

In both cases, we adjust the origin point of the fullscreen window such that it does
not shift during the resize.

We introduce a `_updateFullscreenWindowOrigin` helper function for this purpose. It gets
called inside the scene resize animation block on exit such that it still synchronizes
with when the scene resize occurs.

* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController _updateFullscreenWindowOrigin]):
- Helper function to configure the origin point of the fullscreen window for animated
scene resize
(-[WKFullScreenWindowController _performSpatialFullScreenTransition:completionHandler:]):
- Removed the XY animation workaround in favor of the proposed above solution.

Canonical link: <a href="https://commits.webkit.org/310001@main">https://commits.webkit.org/310001@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7b24d697d5492b4bcd7a414fd767bb70c531db7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152426 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25208 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18807 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161169 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25736 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25514 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/117780 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155386 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136843 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98494 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/19066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9004 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163639 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/6781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/16311 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/125816 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25006 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/21042 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125987 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34173 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25008 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136513 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81608 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20981 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13292 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24624 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/88910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24315 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24475 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24376 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->