### PR TITLE
Add composedTreeLineage() and make composedTreeAncestors() work with const

### DIFF
--- a/Source/WebCore/dom/ComposedTreeAncestorIterator.h
+++ b/Source/WebCore/dom/ComposedTreeAncestorIterator.h
@@ -34,14 +34,15 @@ namespace WebCore {
 
 class HTMLSlotElement;
 
+template<typename ElementType = Element>
 class ComposedTreeAncestorIterator {
 public:
     ComposedTreeAncestorIterator();
-    ComposedTreeAncestorIterator(Element& current);
-    ComposedTreeAncestorIterator(Node& current);
+    ComposedTreeAncestorIterator(ElementType& current);
+    ComposedTreeAncestorIterator(const Node& current);
 
-    Element& operator*() { return get(); }
-    Element* operator->() { return &get(); }
+    ElementType& operator*() { return get(); }
+    ElementType* operator->() { return &get(); }
 
     friend bool operator==(ComposedTreeAncestorIterator, ComposedTreeAncestorIterator) = default;
 
@@ -51,31 +52,34 @@ public:
         return *this;
     }
 
-    Element& get() { return *m_current; }
+    ElementType& get() { return *m_current; }
 
 private:
-    void traverseParentInShadowTree();
-    static Element* NODELETE traverseParent(Node*);
+    static ElementType* NODELETE traverseParent(const Node*);
 
-    CheckedPtr<Element> m_current;
+    CheckedPtr<ElementType> m_current;
 };
 
-inline ComposedTreeAncestorIterator::ComposedTreeAncestorIterator()
+template<typename ElementType>
+inline ComposedTreeAncestorIterator<ElementType>::ComposedTreeAncestorIterator()
 {
 }
 
-inline ComposedTreeAncestorIterator::ComposedTreeAncestorIterator(Node& current)
+template<typename ElementType>
+inline ComposedTreeAncestorIterator<ElementType>::ComposedTreeAncestorIterator(const Node& current)
     : m_current(traverseParent(&current))
 {
     ASSERT(!is<ShadowRoot>(current));
 }
 
-inline ComposedTreeAncestorIterator::ComposedTreeAncestorIterator(Element& current)
+template<typename ElementType>
+inline ComposedTreeAncestorIterator<ElementType>::ComposedTreeAncestorIterator(ElementType& current)
     : m_current(&current)
 {
 }
 
-inline Element* ComposedTreeAncestorIterator::traverseParent(Node* current)
+template<typename ElementType>
+inline ElementType* ComposedTreeAncestorIterator<ElementType>::traverseParent(const Node* current)
 {
     auto* parent = current->parentNode();
     if (!parent)
@@ -90,11 +94,13 @@ inline Element* ComposedTreeAncestorIterator::traverseParent(Node* current)
     return parentElement;
 }
 
+template<typename ElementType = Element>
 class ComposedTreeAncestorAdapter {
 public:
-    using iterator = ComposedTreeAncestorIterator;
+    using iterator = ComposedTreeAncestorIterator<ElementType>;
+    using NodeType = std::conditional_t<std::is_const_v<ElementType>, const Node, Node>;
 
-    ComposedTreeAncestorAdapter(Node& node)
+    ComposedTreeAncestorAdapter(NodeType& node)
         : m_node(node)
     { }
 
@@ -110,7 +116,7 @@ public:
     {
         return iterator();
     }
-    Element* first()
+    ElementType* first()
     {
         auto it = begin();
         if (it == end())
@@ -119,13 +125,43 @@ public:
     }
 
 private:
-    const Ref<Node> m_node;
+    const Ref<NodeType> m_node;
 };
 
-// FIXME: We should have const versions too.
-inline ComposedTreeAncestorAdapter composedTreeAncestors(Node& node)
+inline ComposedTreeAncestorAdapter<Element> composedTreeAncestors(Node& node)
 {
-    return ComposedTreeAncestorAdapter(node);
+    return ComposedTreeAncestorAdapter<Element>(node);
+}
+
+inline ComposedTreeAncestorAdapter<const Element> composedTreeAncestors(const Node& node)
+{
+    return ComposedTreeAncestorAdapter<const Element>(node);
+}
+
+template<typename ElementType = Element>
+class ComposedTreeLineageAdapter {
+public:
+    using iterator = ComposedTreeAncestorIterator<ElementType>;
+
+    ComposedTreeLineageAdapter(ElementType& element)
+        : m_element(element)
+    { }
+
+    iterator begin() { return iterator(m_element.get()); }
+    iterator end() { return iterator(); }
+
+private:
+    const Ref<ElementType> m_element;
+};
+
+inline ComposedTreeLineageAdapter<Element> composedTreeLineage(Element& element)
+{
+    return ComposedTreeLineageAdapter<Element>(element);
+}
+
+inline ComposedTreeLineageAdapter<const Element> composedTreeLineage(const Element& element)
+{
+    return ComposedTreeLineageAdapter<const Element>(element);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -59,6 +59,7 @@
 #include "Comment.h"
 #include "CommonAtomStrings.h"
 #include "CommonVM.h"
+#include "ComposedTreeAncestorIterator.h"
 #include "ComposedTreeIterator.h"
 #include "CompositionEvent.h"
 #include "ConstantPropertyMap.h"
@@ -9645,9 +9646,9 @@ void Document::updateHoverActiveState(const HitTestRequest& request, Element* in
     RefPtr oldActiveElement = m_activeElement.get();
     if (oldActiveElement && !request.active()) {
         // We are clearing the :active chain because the mouse has been released.
-        for (RefPtr currentElement = oldActiveElement; currentElement; currentElement = currentElement->parentElementInComposedTree()) {
-            elementsToClearActive.append(*currentElement);
-            m_userActionElements.setInActiveChain(*currentElement, false);
+        for (Ref currentElement : composedTreeLineage(*oldActiveElement)) {
+            elementsToClearActive.append(currentElement);
+            m_userActionElements.setInActiveChain(currentElement, false);
             if (currentElement->isInTopLayer())
                 break;
         }

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -1020,7 +1020,7 @@ void Element::setFocus(bool value, FocusVisibility visibility)
         root->host()->invalidateStyle();
     }
 
-    for (RefPtr element = this; element; element = element->parentElementInComposedTree()) {
+    for (Ref element : composedTreeLineage(*this)) {
         element->setHasFocusWithin(value);
         if (element->isInTopLayer())
             break;
@@ -4727,14 +4727,14 @@ const RenderStyle* Element::resolveComputedStyle(ResolveComputedStyleMode mode)
 
         RefPtr<const Element> rootmost;
 
-        for (RefPtr element = this; element; element = element->parentElementInComposedTree()) {
+        for (Ref element : composedTreeLineage(*this)) {
             if (element->hasStateFlag(StateFlag::IsComputedStyleInvalidFlag)) {
-                rootmost = element;
+                rootmost = element.ptr();
                 continue;
             }
             CheckedPtr existing = element->existingComputedStyle();
             if (!existing) {
-                rootmost = element;
+                rootmost = element.ptr();
                 continue;
             }
             if (mode == ResolveComputedStyleMode::RenderedOnly && existing->display() == Style::DisplayType::None) {
@@ -5567,7 +5567,7 @@ bool Element::isWritingSuggestionsEnabled() const
     // not in the `default` state and the nearest such ancestor's `writingsuggestions` content attribute
     // is in the `false` state, then return `false`.
 
-    for (RefPtr ancestor = this; ancestor; ancestor = ancestor->parentElementInComposedTree()) {
+    for (Ref ancestor : composedTreeLineage(*this)) {
         auto& value = ancestor->attributeWithoutSynchronization(HTMLNames::writingsuggestionsAttr);
 
         if (value.isNull())
@@ -6374,7 +6374,7 @@ bool Element::checkVisibility(const CheckVisibilityOptions& options)
     if (options.contentVisibilityAuto && isSkippedContentWithReason(ContentVisibility::Auto))
         return false;
 
-    for (RefPtr ancestor = this; ancestor; ancestor = ancestor->parentElementInComposedTree()) {
+    for (Ref ancestor : composedTreeLineage(*this)) {
         CheckedPtr ancestorStyle = ancestor->computedStyle();
         if (ancestorStyle->display() == Style::DisplayType::None)
             return false;
@@ -6492,8 +6492,8 @@ RefPtr<HTMLElement> Element::topmostPopoverAncestor(TopLayerElementType topLayer
 
         // https://html.spec.whatwg.org/#nearest-inclusive-open-popover
         auto nearestInclusiveOpenPopover = [](Element& candidate) -> HTMLElement* {
-            for (auto* element = &candidate; element; element = element->parentElementInComposedTree()) {
-                if (auto* htmlElement = dynamicDowncast<HTMLElement>(element)) {
+            for (Ref element : composedTreeLineage(candidate)) {
+                if (auto* htmlElement = dynamicDowncast<HTMLElement>(element.get())) {
                     if (htmlElement->popoverState() == PopoverState::Auto && htmlElement->popoverData()->visibilityState() == PopoverVisibilityState::Showing)
                         return htmlElement;
                 }

--- a/Source/WebCore/editing/cocoa/EditingHTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/EditingHTMLConverter.mm
@@ -35,6 +35,7 @@
 #import "CharacterData.h"
 #import "ColorCocoa.h"
 #import "CommonAtomStrings.h"
+#import "ComposedTreeAncestorIterator.h"
 #import "ComposedTreeIterator.h"
 #import "ContainerNodeInlines.h"
 #import "Document.h"
@@ -261,19 +262,19 @@ static RefPtr<Element> enclosingElement(const Node& node, ElementCache<RefPtr<El
 {
     Vector<Ref<Element>> ancestors;
     RefPtr<Element> result;
-    for (RefPtr ancestor = node.parentElementInComposedTree(); ancestor; ancestor = ancestor->parentElementInComposedTree()) {
-        if (predicate(ancestor.get())) {
-            result = ancestor.get();
+    for (Ref ancestor : composedTreeAncestors(const_cast<Node&>(node))) {
+        if (predicate(ancestor.ptr())) {
+            result = ancestor.ptr();
             break;
         }
 
-        auto entry = cache.find(*ancestor);
+        auto entry = cache.find(ancestor);
         if (entry != cache.end()) {
             result = entry->value;
             break;
         }
 
-        ancestors.append(*ancestor);
+        ancestors.append(ancestor);
     }
 
     for (auto& ancestor : ancestors)

--- a/Source/WebCore/page/PointerCaptureController.cpp
+++ b/Source/WebCore/page/PointerCaptureController.cpp
@@ -27,6 +27,7 @@
 
 #include "Chrome.h"
 #include "ChromeClient.h"
+#include "ComposedTreeAncestorIterator.h"
 #include "DocumentPage.h"
 #include "Element.h"
 #include "EventHandler.h"
@@ -236,9 +237,9 @@ void PointerCaptureController::dispatchEnterOrLeaveEvent(const AtomString& type,
     }
 
     Vector<Ref<Element>, 32> targetChain;
-    for (RefPtr element = targetElement; element; element = element->parentElementInComposedTree()) {
+    for (Ref element : composedTreeLineage(targetElement)) {
         if (hasCapturingListenerInHierarchy || element->hasEventListeners(type))
-            targetChain.append(*element);
+            targetChain.append(element);
     }
 
     if (type == eventNames().pointerenterEvent) {

--- a/Source/WebCore/style/ContainerQueryEvaluator.cpp
+++ b/Source/WebCore/style/ContainerQueryEvaluator.cpp
@@ -182,9 +182,9 @@ RefPtr<const Element> ContainerQueryEvaluator::selectContainer(OptionSet<CQ::Axi
         // query containers can be established by flat tree ancestors of those elements.
         // For other pseudo-elements, query containers can be established by inclusive flat tree ancestors of their originating element.
         // https://drafts.csswg.org/css-conditional-5/#container-queries
-        for (RefPtr ancestor = originatingElement; ancestor; ancestor = ancestor->parentElementInComposedTree()) {
-            if (isContainerForQuery(*ancestor.get(), originatingElement.get()))
-                return ancestor;
+        for (Ref ancestor : composedTreeLineage(*originatingElement)) {
+            if (isContainerForQuery(ancestor, originatingElement.get()))
+                return ancestor.ptr();
         }
         return nullptr;
     }
@@ -197,9 +197,9 @@ RefPtr<const Element> ContainerQueryEvaluator::selectContainer(OptionSet<CQ::Axi
         return { };
     }
 
-    for (RefPtr ancestor = element.parentElementInComposedTree(); ancestor; ancestor = ancestor->parentElementInComposedTree()) {
-        if (isContainerForQuery(*ancestor.get()))
-            return ancestor;
+    for (Ref ancestor : composedTreeAncestors(element)) {
+        if (isContainerForQuery(ancestor))
+            return ancestor.ptr();
     }
     return { };
 }


### PR DESCRIPTION
#### 95957858e3fd9c97d1a1d8c7373f05db8b4d34ab
<pre>
Add composedTreeLineage() and make composedTreeAncestors() work with const
<a href="https://bugs.webkit.org/show_bug.cgi?id=310554">https://bugs.webkit.org/show_bug.cgi?id=310554</a>

Reviewed by Ryosuke Niwa.

It seems we have sufficient callers now to add some niceness.

Canonical link: <a href="https://commits.webkit.org/309807@main">https://commits.webkit.org/309807@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c75101f9c69d1f1e5a8c4cd90fdd64f5872177af

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151713 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24494 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18064 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160453 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105170 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c17daae8-0a6e-4fad-82ed-41221d391213) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153587 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24967 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24787 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117179 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83164 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154673 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19320 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136142 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97894 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9d7ebdac-ac7a-4b47-8740-271038751851) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18406 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16358 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8290 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128036 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14046 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162919 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6068 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15637 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125196 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24293 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20417 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125378 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24294 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135842 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80869 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23305 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20411 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12617 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23910 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88195 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23602 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23762 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23662 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->