### PR TITLE
Web Inspector: Remove obsolete per-resource content view settings after 308142@main

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Base/Setting.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Setting.js
@@ -60,9 +60,9 @@ WI.Setting = class Setting extends WI.Object
         return value;
     }
 
-    static reset()
+    static reset(options = {})
     {
-        let prefix = WI.Setting._localStorageKeyPrefix;
+        let prefix = WI.Setting._localStorageKeyPrefix + (options.keyPrefix || "");
 
         let keysToRemove = [];
         for (let i = 0; i < window.localStorage.length; ++i) {
@@ -148,6 +148,20 @@ WI.Setting.isFirstLaunch = !!window.InspectorTest || (window.localStorage && Obj
 WI.Setting.Event = {
     Changed: "setting-changed"
 };
+
+// COMPATIBILITY (macOS X.X, iOS X.X): Per-resource content view settings were removed in favor of per-mimeType settings. See <https://webkit.org/b/308310>
+WI.Setting._removeObsoleteResourceCurrentViewSettings = (function() {
+    if (window.InspectorTest || !window.localStorage)
+        return;
+
+    let didCleanupSetting = new WI.Setting("did-remove-obsolete-resource-current-view-settings", false);
+    if (didCleanupSetting.value)
+        return;
+
+    WI.Setting.reset({keyPrefix: "resource-current-view-"});
+
+    didCleanupSetting.value = true;
+})();
 
 WI.EngineeringSetting = class EngineeringSetting extends WI.Setting
 {


### PR DESCRIPTION
#### a6ff43363a20fa551dfb73dfe3c2d5b1418c91e3
<pre>
Web Inspector: Remove obsolete per-resource content view settings after <a href="https://commits.webkit.org/308142@main">308142@main</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=310558">https://bugs.webkit.org/show_bug.cgi?id=310558</a>
<a href="https://rdar.apple.com/173171572">rdar://173171572</a>

Reviewed by NOBODY (OOPS!).

Per-resource content view settings were removed in <a href="https://commits.webkit.org/308142@main">https://commits.webkit.org/308142@main</a>
in favor of per-MIME type settings. This patch removes the obsolete settings from Local Storage.

* Source/WebInspectorUI/UserInterface/Base/Setting.js:
(WI.Setting.prototype.reset):
(WI.Setting._removeObsoleteResourceCurrentViewSettings):
(WI.Setting.reset): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6ff43363a20fa551dfb73dfe3c2d5b1418c91e3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151722 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24503 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18073 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160462 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105179 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2352bc6f-2fad-4549-9a95-31947bd81322) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24976 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24796 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117188 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83172 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/46a1b40d-7c33-4d8f-bb68-13f8d65d1f01) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154682 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19328 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136143 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97903 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/193e2b13-9a2b-401e-abe8-ddeb017a3e56) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18414 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16368 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8299 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128044 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14047 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162928 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6077 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15638 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125210 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24302 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20427 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125386 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24303 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135843 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80878 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20417 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12618 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23919 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88204 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23611 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23771 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23671 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->