### PR TITLE
media/modern-media-controls/tracks-support/sorted-by-user-preferred-languages.html is a constant TEXT failure

### DIFF
--- a/LayoutTests/media/modern-media-controls/tracks-support/sorted-by-user-preferred-languages-caption-display-settings-expected.txt
+++ b/LayoutTests/media/modern-media-controls/tracks-support/sorted-by-user-preferred-languages-caption-display-settings-expected.txt
@@ -1,0 +1,28 @@
+This test checks that tracks are sorted based on the user's preferred languages when caption display settings are enabled.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS shadowRoot.querySelector('button.tracks') became different from null
+PASS shadowRoot.querySelector('button.tracks').getBoundingClientRect().width became different from 0
+Tapping tracks button...
+Subtitles: [
+  "label-en",
+  "label-en Captions",
+  "Descriptions",
+  "Spanish",
+  "Spanish Captions",
+  "Spanish Descriptions",
+  "no-srclang",
+  "Chinese (China mainland)",
+  "French (label-fr)",
+  "French Captions (label-fr)",
+  "French Descriptions",
+  "German",
+  "German Captions",
+  "German Descriptions"
+]
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/media/modern-media-controls/tracks-support/sorted-by-user-preferred-languages-caption-display-settings.html
+++ b/LayoutTests/media/modern-media-controls/tracks-support/sorted-by-user-preferred-languages-caption-display-settings.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ CaptionDisplaySettingsEnabled=false language=en-US,zh-HK,es-US useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ CaptionDisplaySettingsEnabled=true language=en-US,zh-HK,es-US useFlexibleViewport=true ] -->
 <meta name="viewport" content="width=device-width">
 <script src="../resources/media-controls-utils.js"></script>
 <script src="../../../resources/ui-helper.js"></script>
@@ -24,7 +24,7 @@
 
 window.jsTestIsAsync = true;
 
-description(`This test checks that tracks are sorted based on the user's preferred languages.`);
+description(`This test checks that tracks are sorted based on the user's preferred languages when caption display settings are enabled.`);
 
 const media = document.querySelector("video");
 const shadowRoot = window.internals.shadowRoot(media);
@@ -42,10 +42,10 @@ media.addEventListener("play", () => {
             await pressOnElement(shadowRoot.querySelector("button.tracks"));
 
             let contextmenu = await getTracksContextMenu();
-            let items = contextmenu[0].children;
-            if (items[0].title === "Subtitles")
-                items = items.slice(1);
-            debug("Subtitles: " + JSON.stringify(items.map((item) => item.title), null, 2));
+            let items = contextmenu[0]?.children ?? [];
+            let languagesItem = items.find((item) => item.title === "Languages");
+            let tracks = languagesItem?.children ?? [];
+            debug("Subtitles: " + JSON.stringify(tracks.map((item) => item.title), null, 2));
 
             media.remove();
             finishJSTest();

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4055,6 +4055,7 @@ media/modern-media-controls/tracks-support/click-track-in-contextmenu.html [ Ski
 media/modern-media-controls/tracks-support/hidden-tracks.html [ Skip ]
 media/modern-media-controls/tracks-support/off-text-track.html [ Skip ]
 media/modern-media-controls/tracks-support/show-contextmenu-then-double-click-on-tracks-button.html [ Skip ]
+media/modern-media-controls/tracks-support/sorted-by-user-preferred-languages-caption-display-settings.html [ Skip ]
 media/modern-media-controls/tracks-support/sorted-by-user-preferred-languages.html [ Skip ]
 media/modern-media-controls/tracks-support/text-track-selected-via-media-api.html [ Skip ]
 media/modern-media-controls/volume-support/volume-support-drag-to-mute.html [ Skip ]


### PR DESCRIPTION
#### 3999e6e72e16f926af113e6f6595436f634410ff
<pre>
media/modern-media-controls/tracks-support/sorted-by-user-preferred-languages.html is a constant TEXT failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=310564">https://bugs.webkit.org/show_bug.cgi?id=310564</a>
<a href="https://rdar.apple.com/173034292">rdar://173034292</a>

Reviewed by Jer Noble.

Split the sorted-by-user-preferred-languages test into two variants, one with the runtime setting
CaptionDisplaySettingsEnabled turned off, and the other with it turned on. When the setting is on,
the structure of the subtitles context menu changes and we have to access a sub-menu to check
that the tracks are sorted by user preferences.

* LayoutTests/media/modern-media-controls/tracks-support/sorted-by-user-preferred-languages-caption-display-settings-expected.txt: Added.
* LayoutTests/media/modern-media-controls/tracks-support/sorted-by-user-preferred-languages-caption-display-settings.html: Added.
* LayoutTests/media/modern-media-controls/tracks-support/sorted-by-user-preferred-languages.html:
* LayoutTests/platform/glib/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/309998@main">https://commits.webkit.org/309998@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46b487765ee47215c8184bf74d903fa7d59fab9d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152178 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24960 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18579 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160921 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105635 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25542 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25266 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117566 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83384 "2 flakes 2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155138 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19845 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136637 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98279 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18907 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16783 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8755 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128558 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14511 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163387 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16103 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125592 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24758 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20824 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125768 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24759 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136307 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81358 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23363 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20777 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13084 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24376 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24067 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24227 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24128 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->