### PR TITLE
Align object-fit computation between ModelPlayers

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift
@@ -98,7 +98,7 @@ class Renderer {
 
         let aspect = Float(texture.width) / Float(texture.height)
         let projection = _Proto_LowLevelRenderer_v1.Camera.Projection.perspective(
-            fovYRadians: 90 * .pi / 180,
+            fovYRadians: 60 * .pi / 180,
             aspectRatio: aspect,
             nearZ: modelDistance * 0.01,
             farZ: modelDistance * 100,

--- a/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.cpp
@@ -121,15 +121,6 @@ RemoteMeshProxy::~RemoteMeshProxy()
 #endif
 }
 
-#if ENABLE(GPU_PROCESS_MODEL)
-static WebModel::Float4x4 buildTranslation(float x, float y, float z)
-{
-    WebModel::Float4x4 result = matrix_identity_float4x4;
-    result.column3 = simd_make_float4(x, y, z, 1.f);
-    return result;
-}
-#endif
-
 void RemoteMeshProxy::update(const WebModel::UpdateMeshDescriptor& descriptor)
 {
 #if ENABLE(GPU_PROCESS_MODEL)
@@ -141,15 +132,11 @@ void RemoteMeshProxy::update(const WebModel::UpdateMeshDescriptor& descriptor)
         m_maxCorner = simd_max(m_maxCorner, maxCorner);
     }
 
-    auto [center, extents] = getCenterAndExtents();
-    if (boundingBoxChanged)
-        setCameraDistance(std::max(extents.x, extents.y) * .5f);
-
     auto sendResult = sendWithAsyncReply(Messages::RemoteMesh::Update(descriptor), [](auto) mutable {
     });
     UNUSED_VARIABLE(sendResult);
     if (boundingBoxChanged)
-        setStageMode(m_stageMode);
+        computeTransform();
 
 #else
     UNUSED_PARAM(descriptor);
@@ -332,22 +319,59 @@ void RemoteMeshProxy::setScale(float scale)
 #endif
 }
 
+void RemoteMeshProxy::setViewportSize(float width, float height)
+{
+#if ENABLE(GPU_PROCESS_MODEL)
+    m_viewportWidth = width;
+    m_viewportHeight = height;
+    computeTransform();
+#endif
+}
+
 void RemoteMeshProxy::setStageMode(WebCore::StageModeOperation stageMode)
 {
 #if ENABLE(GPU_PROCESS_MODEL)
     m_stageMode = stageMode;
+    computeTransform();
+#else
+    UNUSED_PARAM(stageMode);
+#endif
+}
+
+
+static constexpr float kCSSPixelsPerMeter = 96 / 2.54 * 100;
+// Based on the 60° fovYRadians in ModelRenderer.swift
+static constexpr float kVerticalFOVScale = 1.1547;
+
+#if ENABLE(GPU_PROCESS_MODEL)
+void RemoteMeshProxy::computeTransform()
+{
     auto [center, extents] = getCenterAndExtents();
-    if (stageMode == WebCore::StageModeOperation::None) {
-        setEntityTransformInternal(buildTranslation(-center.x, -center.y, -center.z - .5f * extents.z));
-        return;
+
+    float viewportWidth = m_viewportWidth / kCSSPixelsPerMeter;
+    float viewportHeight = m_viewportHeight / kCSSPixelsPerMeter;
+
+    float scale = 0;
+    float depth = 0;
+
+    if (m_stageMode == WebCore::StageModeOperation::None) {
+        if (std::fmin(extents.x, extents.y) > FLT_EPSILON)
+            scale = std::fmin(viewportWidth / extents.x, viewportHeight / extents.y);
+        depth = extents.z;
+    } else {
+        float boundingDiameter = std::max(
+            { simd_length(simd_make_float2(extents.x, extents.y))
+            , simd_length(simd_make_float2(extents.x, extents.z))
+            , simd_length(simd_make_float2(extents.y, extents.z)) }
+        );
+        if (boundingDiameter > FLT_EPSILON)
+            scale = std::fmin(viewportWidth, viewportHeight) / boundingDiameter;
+        depth = boundingDiameter;
     }
 
     WebModel::Float4x4 result = matrix_identity_float4x4;
     if (auto existingTransform = entityTransform())
         result = *existingTransform;
-
-    float maxExtent = simd_reduce_max(extents.xyz);
-    float scale = m_cameraDistance / maxExtent;
 
     result.column0 = scale * simd_normalize(result.column0);
     result.column1 = scale * simd_normalize(result.column1);
@@ -355,14 +379,13 @@ void RemoteMeshProxy::setStageMode(WebCore::StageModeOperation stageMode)
     result.column3 = simd_make_float4(
         -simd_dot(center.xyz, simd_make_float3(result.column0.x, result.column1.x, result.column2.x)),
         -simd_dot(center.xyz, simd_make_float3(result.column0.y, result.column1.y, result.column2.y)),
-        -simd_dot(center.xyz, simd_make_float3(result.column0.z, result.column1.z, result.column2.z)),
+        -simd_dot(center.xyz, simd_make_float3(result.column0.z, result.column1.z, result.column2.z)) - scale * depth / 2,
         1.f);
 
+    setCameraDistance(viewportHeight / kVerticalFOVScale);
     setEntityTransformInternal(result);
-#else
-    UNUSED_PARAM(stageMode);
-#endif
 }
+#endif
 
 #if ENABLE(GPU_PROCESS_MODEL)
 static simd_float4x4 buildRotation(float azimuth, float elevation)

--- a/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.h
@@ -108,8 +108,10 @@ private:
     void setScale(float) final;
     void setCameraDistance(float) final;
     void setBackgroundColor(const WebModel::Float3&) final;
+    void setViewportSize(float, float) final;
     void setStageMode(WebCore::StageModeOperation) final;
 #if ENABLE(GPU_PROCESS_MODEL)
+    void computeTransform();
     void setRotation(float yaw, float pitch, float roll) final;
 #endif
     void setEnvironmentMap(const WebModel::ImageAsset&) final;
@@ -124,6 +126,8 @@ private:
 #endif
 #if ENABLE(GPU_PROCESS_MODEL)
     float m_cameraDistance { 1.f };
+    float m_viewportWidth { 0.f };
+    float m_viewportHeight { 0.f };
     WebCore::StageModeOperation m_stageMode;
 #endif
 };

--- a/Source/WebKit/WebProcess/Model/Mesh.h
+++ b/Source/WebKit/WebProcess/Model/Mesh.h
@@ -81,6 +81,7 @@ public:
     virtual void setScale(float) { }
     virtual void setCameraDistance(float) = 0;
     virtual void setBackgroundColor(const WebModel::Float3&) { }
+    virtual void setViewportSize(float, float) { }
     virtual void setStageMode(WebCore::StageModeOperation) { }
     virtual void setRotation(float, float = 0.f, float = 0.f) { }
     virtual void play(bool) = 0;

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
@@ -295,6 +295,7 @@ void WebModelPlayer::load(WebCore::Model& modelSource, WebCore::LayoutSize size)
         if (surfaceHandles.size())
             protectedThis->m_displayBuffers = WTF::move(surfaceHandles);
     });
+    m_currentModel->setViewportSize(size.width().toFloat(), size.height().toFloat());
 
     m_modelLoader = adoptNS([allocWKBridgeModelLoaderInstance() init]);
     Ref protectedThis = Ref { *this };
@@ -392,6 +393,8 @@ void WebModelPlayer::sizeDidChange(WebCore::LayoutSize size)
     });
 
     m_currentScale = static_cast<float>(size.minDimension());
+    if (RefPtr model = m_currentModel)
+        model->setViewportSize(size.width().toFloat(), size.height().toFloat());
     notifyEntityTransformUpdated();
 }
 


### PR DESCRIPTION
#### be5da49765e0a0675596fbef536ea75bbe2d2ac3
<pre>
Align object-fit computation between ModelPlayers
<a href="https://bugs.webkit.org/show_bug.cgi?id=310574">https://bugs.webkit.org/show_bug.cgi?id=310574</a>
&lt;<a href="https://rdar.apple.com/172387167">rdar://172387167</a>&gt;

Reviewed by Mike Wyrzykowski.

Align the WebModelPlayer on the ModelProcessModelPlayer for both stage
modes.

* Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift:
Switch FoV to 60 degrees.

* Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.cpp:
(WebKit::RemoteMeshProxy::update):
(WebKit::RemoteMeshProxy::setViewportSize):
(WebKit::RemoteMeshProxy::setStageMode):
(WebKit::RemoteMeshProxy::computeTransform):
(WebKit::buildTranslation): Deleted.
Introduce a computeTransform method matching the behavior of the
ModelProcessModelPlayer for stagemode None and Orbit.

* Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.h:
* Source/WebKit/WebProcess/Model/Mesh.h:
(WebKit::Mesh::setViewportSize):
* Source/WebKit/WebProcess/Model/WebModelPlayer.mm:
(WebKit::WebModelPlayer::load):
(WebKit::WebModelPlayer::sizeDidChange):
Pass viewport information down to the Mesh.

Canonical link: <a href="https://commits.webkit.org/309847@main">https://commits.webkit.org/309847@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fbbee6abf60582f9342169aab5866fd223fbd2b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151879 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24660 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18231 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160621 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105336 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/feb3695e-84c5-4a83-bfef-d6ee36b0f257) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25153 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24959 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117312 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83232 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c718568d-ae66-4d8a-bc07-ce4cf58b069e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154839 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19493 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136294 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98027 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eca0a839-76b0-44d1-be72-3eca126e4ac5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18572 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16506 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8456 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128204 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163085 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6234 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15789 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125330 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24459 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20565 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125511 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34067 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24460 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135993 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81035 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20542 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12768 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24077 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88362 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23768 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23928 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23829 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->