### PR TITLE
docs.github.com: Find in page scrolls to wrong location

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
@@ -52,6 +52,8 @@
 #include <WebCore/PageOverlayController.h>
 #include <WebCore/PathUtilities.h>
 #include <WebCore/PlatformMouseEvent.h>
+#include <WebCore/RenderLayer.h>
+#include <WebCore/RenderObject.h>
 #include <WebCore/SimpleRange.h>
 #include <WebCore/TextIterator.h>
 #include <ranges>
@@ -253,17 +255,20 @@ void WebFoundTextRangeController::scrollTextRangeToVisible(const WebFoundTextRan
             if (!simpleRange)
                 return;
 
-            RefPtr document = documentForFoundTextRange(range);
-            if (!document)
+            auto rects = WebCore::RenderObject::absoluteTextRects(*simpleRange);
+            if (rects.isEmpty())
                 return;
 
-            WebCore::VisibleSelection visibleSelection(*simpleRange);
-            OptionSet temporarySelectionOptions { WebCore::TemporarySelectionOption::DelegateMainFrameScroll, WebCore::TemporarySelectionOption::RevealSelectionBounds, WebCore::TemporarySelectionOption::DoNotSetFocus, WebCore::TemporarySelectionOption::UserTriggered };
+            CheckedPtr renderer = simpleRange->startContainer().renderer();
+            if (!renderer)
+                return;
 
-            if (document->isTopDocument())
-                temporarySelectionOptions.add(WebCore::TemporarySelectionOption::SmoothScroll);
+            WebCore::ScrollRectToVisibleOptions options;
+            RefPtr document = documentForFoundTextRange(range);
+            if (document && document->isTopDocument())
+                options.behavior = WebCore::ScrollBehavior::Smooth;
 
-            WebCore::TemporarySelectionChange selectionChange(*document, visibleSelection, temporarySelectionOptions);
+            WebCore::LocalFrameView::scrollRectToVisible(WebCore::LayoutRect(unionRect(rects)), *renderer, false, options);
         },
         [&] (const WebKit::WebFoundTextRange::PDFData& pdfData) {
 #if ENABLE(PDF_PLUGIN)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPage.mm
@@ -726,6 +726,32 @@ TEST(WebKit, ScrollToFoundRangeInNonScrollableIframe)
     EXPECT_WK_STREQ("771", [webView stringByEvaluatingJavaScript:@"document.getElementById('frame').contentWindow.scrollY"]);
 }
 
+TEST(WebKit, ScrollToUserSelectNoneFoundRange)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 300, 400)]);
+
+    [webView synchronouslyLoadHTMLString:@"<meta name='viewport' content='width=device-width,initial-scale=1'>"
+    "<p style='-webkit-user-select: none; height:500px'>findme</p>"
+    "<p style='-webkit-user-select: none; height:500px'>findme</p>"
+    "<p style='-webkit-user-select: none; height:500px'>findme</p>"
+    "<p style='-webkit-user-select: none; height:500px'>findme</p>"
+    "<p style='-webkit-user-select: none; height:500px'>findme</p>"
+    "<p style='-webkit-user-select: none; height:500px'>findme</p>"
+    ];
+
+    auto scrollViewDelegate = adoptNS([[TestScrollViewDelegate alloc] init]);
+    [webView scrollView].delegate = scrollViewDelegate.get();
+
+    EXPECT_TRUE(CGPointEqualToPoint([webView scrollView].contentOffset, CGPointMake(0, 0)));
+
+    RetainPtr ranges = textRangesForQueryString(webView.get(), @"findme");
+    [webView scrollRangeToVisible: [ranges lastObject] inDocument:nil];
+
+    TestWebKitAPI::Util::run(&scrollViewDelegate->_finishedScrolling);
+
+    EXPECT_TRUE(CGPointEqualToPoint([webView scrollView].contentOffset, CGPointMake(0, 2398)));
+}
+
 TEST(WebKit, CannotHaveMultipleFindOverlays)
 {
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);


### PR DESCRIPTION
#### ba1daf397dd0f84ee1d0a0ee18e442907659782b
<pre>
docs.github.com: Find in page scrolls to wrong location
<a href="https://rdar.apple.com/170477571">rdar://170477571</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=310575">https://bugs.webkit.org/show_bug.cgi?id=310575</a>

Reviewed by Ryosuke Niwa.

The problem is that WebFoundTextRangeController::scrollTextRangeToVisible
relies on VisualSelection to scroll. Some matches may not produce a valid
selection (typically due to elements styled with user-select: none), so during the canonicalization process, the range is collapsed,
and scrolling is broken.

The FindController uses FrameSelection::revealSelection, which calls
LocalFrameView::scrollRectToVisible. This approach does not rely on whether
we have a valid selection or not. The solution was to copy this approach
and call LocalFrameView::scrollRectToVisible directly in
WebFoundTextRangeController::scrollTextRangeToVisible.

* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp:
(WebKit::WebFoundTextRangeController::scrollTextRangeToVisible):
(WebKit::WebFoundTextRangeController::simpleRangeFromFoundTextRange):

I have added an API test, WebKit.ScrollToUserSelectNoneFoundRange to
exercise the new code path. Without my changes, the test times out
waiting for scroll.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPage.mm:
(TEST(WebKit, ScrollToUserSelectNoneFoundRange)):

Canonical link: <a href="https://commits.webkit.org/309923@main">https://commits.webkit.org/309923@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/117e66ba225c1e85f705b1667f42ba75903e151a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151937 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24718 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18314 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160679 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105394 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153811 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25211 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25022 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117365 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83257 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d321ef4a-0be7-40bb-b448-b6b0e2161edc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154897 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19537 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136364 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98080 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9c9cdef9-a420-4f5f-8dff-b739a7b4c139) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18619 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16556 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8514 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128252 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14266 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163144 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6292 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15858 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125385 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24517 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20615 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125565 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34120 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24518 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136062 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81100 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20591 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12837 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24135 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88420 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23826 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23986 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23887 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->