### PR TITLE
Cannot move to next item in playlist when in a background tab on music.apple.com

### DIFF
--- a/LayoutTests/media/encrypted-media/mock-navigator-requestMediaKeySystemAccess-in-background-expected.txt
+++ b/LayoutTests/media/encrypted-media/mock-navigator-requestMediaKeySystemAccess-in-background-expected.txt
@@ -6,8 +6,6 @@ RUN(capabilities.videoCapabilities = [{ contentType: 'video/mock; codecs="mock"'
 
 Call navigator.requestMediaKeySystemAccess() in a background tab
 RUN(promise = navigator.requestMediaKeySystemAccess("org.webkit.mock", [capabilities]))
-
-Switch the tab to foreground
 Promise resolved OK
 END OF TEST
 

--- a/LayoutTests/media/encrypted-media/mock-navigator-requestMediaKeySystemAccess-in-background.html
+++ b/LayoutTests/media/encrypted-media/mock-navigator-requestMediaKeySystemAccess-in-background.html
@@ -7,7 +7,7 @@
     var promise;
     var capabilities = {};
 
-    function runTest()
+    async function runTest()
     {
         if (!window.internals) {
             failTest("Internals is required for this test.")
@@ -24,16 +24,15 @@
         consoleWrite("Call navigator.requestMediaKeySystemAccess() in a background tab");
         internals.settings.setCanStartMedia(false);
         run('promise = navigator.requestMediaKeySystemAccess("org.webkit.mock", [capabilities])');
-
-        setTimeout(() => {
-            consoleWrite("");
-            consoleWrite("Switch the tab to foreground");
-            internals.settings.setCanStartMedia(true);
-            shouldResolve(promise).then(endTest, failTest);
-        }, 200);
+        await shouldResolve(promise);
+        internals.settings.setCanStartMedia(true);
     }
+
+    window.addEventListener('load', event => {
+        runTest().then(endTest).catch(failTest);
+    });
     </script>
 </head>
-<body onload="runTest()">
+<body>
 </body>
 </html>

--- a/Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.cpp
+++ b/Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.cpp
@@ -62,15 +62,7 @@ void MediaKeySystemPermissionRequestManager::startMediaKeySystemRequest(MediaKey
         return;
     }
 
-    if (document->page()->canStartMedia()) {
-        sendMediaKeySystemRequest(request);
-        return;
-    }
-
-    auto& pendingRequests = m_pendingMediaKeySystemRequests.add(*document, Vector<Ref<MediaKeySystemRequest>>()).iterator->value;
-    if (pendingRequests.isEmpty())
-        document->addMediaCanStartListener(*this);
-    pendingRequests.append(request);
+    sendMediaKeySystemRequest(request);
 }
 
 void MediaKeySystemPermissionRequestManager::sendMediaKeySystemRequest(MediaKeySystemRequest& userRequest)
@@ -97,36 +89,7 @@ void MediaKeySystemPermissionRequestManager::sendMediaKeySystemRequest(MediaKeyS
 
 void MediaKeySystemPermissionRequestManager::cancelMediaKeySystemRequest(MediaKeySystemRequest& request)
 {
-    if (auto removedRequest = m_ongoingMediaKeySystemRequests.take(request.identifier()))
-        return;
-
-    RefPtr document = request.document();
-    if (!document)
-        return;
-
-    auto iterator = m_pendingMediaKeySystemRequests.find(*document);
-    if (iterator == m_pendingMediaKeySystemRequests.end())
-        return;
-
-    auto& pendingRequests = iterator->value;
-    pendingRequests.removeFirstMatching([&request](auto& item) {
-        return &request == item.ptr();
-    });
-
-    if (!pendingRequests.isEmpty())
-        return;
-
-    document->removeMediaCanStartListener(*this);
-    m_pendingMediaKeySystemRequests.remove(iterator);
-}
-
-void MediaKeySystemPermissionRequestManager::mediaCanStart(Document& document)
-{
-    ASSERT(document.page()->canStartMedia());
-
-    auto pendingRequests = m_pendingMediaKeySystemRequests.take(document);
-    for (auto& pendingRequest : pendingRequests)
-        sendMediaKeySystemRequest(pendingRequest);
+    m_ongoingMediaKeySystemRequests.take(request.identifier());
 }
 
 void MediaKeySystemPermissionRequestManager::mediaKeySystemWasGranted(MediaKeySystemRequestIdentifier requestID, String&& mediaKeysHashSalt)

--- a/Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.h
+++ b/Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.h
@@ -28,9 +28,9 @@
 #if ENABLE(ENCRYPTED_MEDIA)
 
 #include "SandboxExtension.h"
-#include <WebCore/MediaCanStartListener.h>
 #include <WebCore/MediaKeySystemClient.h>
 #include <WebCore/MediaKeySystemRequest.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/Ref.h>
 #include <wtf/RefPtr.h>
@@ -41,7 +41,7 @@ namespace WebKit {
 
 class WebPage;
 
-class MediaKeySystemPermissionRequestManager : private WebCore::MediaCanStartListener {
+class MediaKeySystemPermissionRequestManager : public AbstractRefCountedAndCanMakeWeakPtr<MediaKeySystemPermissionRequestManager> {
     WTF_MAKE_TZONE_ALLOCATED(MediaKeySystemPermissionRequestManager);
 public:
     explicit MediaKeySystemPermissionRequestManager(WebPage&);
@@ -57,13 +57,9 @@ public:
 private:
     void sendMediaKeySystemRequest(WebCore::MediaKeySystemRequest&);
 
-    // WebCore::MediaCanStartListener
-    void mediaCanStart(WebCore::Document&) final;
-
     WeakRef<WebPage> m_page;
 
     HashMap<WebCore::MediaKeySystemRequestIdentifier, Ref<WebCore::MediaKeySystemRequest>> m_ongoingMediaKeySystemRequests;
-    HashMap<Ref<WebCore::Document>, Vector<Ref<WebCore::MediaKeySystemRequest>>> m_pendingMediaKeySystemRequests;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### 143423245cd98f8c6c58fcdac4ebe581245b6651
<pre>
Cannot move to next item in playlist when in a background tab on music.apple.com
<a href="https://rdar.apple.com/172676372">rdar://172676372</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=310577">https://bugs.webkit.org/show_bug.cgi?id=310577</a>

Reviewed by Eric Carlson.

In the original implementation of MediaKeySystemPermissionRequestManager in 233845@main prevented
requestMediaKeySystemAccess() from working when the WebPage was in the background, and a subsequent
change in 236448@main caused the requests to be stored and serviced when the page went back to the
foreground. However, this left the issue where when a page which was previously in the background,
and was able to play media requested key system access would have that access left pending, preventing
users from playing the next item in a playlist.

If a particular port wants to block MediaKeySystemAccess from working when a page is in the background
it seems the right way to do so would be at the client level, and not within WebKit. This patch removes
the &quot;canPlayMedia()&quot; check before issuing the key access request.

* LayoutTests/media/encrypted-media/mock-navigator-requestMediaKeySystemAccess-in-background-expected.txt:
* LayoutTests/media/encrypted-media/mock-navigator-requestMediaKeySystemAccess-in-background.html:
* Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.cpp:
(WebKit::MediaKeySystemPermissionRequestManager::startMediaKeySystemRequest):
(WebKit::MediaKeySystemPermissionRequestManager::cancelMediaKeySystemRequest):
(WebKit::MediaKeySystemPermissionRequestManager::mediaCanStart): Deleted.
* Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.h:

Canonical link: <a href="https://commits.webkit.org/309879@main">https://commits.webkit.org/309879@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f18bc1816799beb0a2f72b9185f43711382abced

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151748 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24529 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18099 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160490 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105205 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/859e4aa8-0338-4380-9f85-339066d0bc7c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25022 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24822 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117211 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83183 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154708 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19364 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136163 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97926 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18450 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16389 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8325 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128080 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14067 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162954 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6103 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15658 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125230 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24328 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20448 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125411 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34086 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24329 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135863 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80904 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20441 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12638 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23945 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88231 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23637 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23797 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23767 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->