### PR TITLE
Showing or hiding banner view overlay occasionally causes crash

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
@@ -566,20 +566,28 @@ void RemoteScrollingTreeMac::scrollingTreeNodeScrollbarMinimumThumbLengthDidChan
 
 void RemoteScrollingTreeMac::triggerMainFrameRubberBandSnapBack()
 {
-    RefPtr rootScrollingNode = dynamicDowncast<ScrollingTreeFrameScrollingNodeMac>(rootNode());
-    if (!rootScrollingNode)
-        return;
+    ASSERT(isMainRunLoop());
+    ScrollingThread::dispatch([protectedThis = Ref { *this }]() {
+        Locker locker { protectedThis->m_treeLock };
+        RefPtr rootScrollingNode = dynamicDowncast<ScrollingTreeFrameScrollingNodeMac>(protectedThis->rootNode());
+        if (!rootScrollingNode)
+            return;
 
-    rootScrollingNode->startRubberBandSnapBack();
+        rootScrollingNode->startRubberBandSnapBack();
+    });
 }
 
 void RemoteScrollingTreeMac::mainFrameRubberBandTargetOffsetDidChange()
 {
-    RefPtr rootScrollingNode = dynamicDowncast<ScrollingTreeFrameScrollingNodeMac>(rootNode());
-    if (!rootScrollingNode)
-        return;
+    ASSERT(isMainRunLoop());
+    ScrollingThread::dispatch([protectedThis = Ref { *this }]() {
+        Locker locker { protectedThis->m_treeLock };
+        RefPtr rootScrollingNode = dynamicDowncast<ScrollingTreeFrameScrollingNodeMac>(protectedThis->rootNode());
+        if (!rootScrollingNode)
+            return;
 
-    rootScrollingNode->rubberBandTargetOffsetDidChange();
+        rootScrollingNode->rubberBandTargetOffsetDidChange();
+    });
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### ae3529e2117ae87d7ec94d1e62e6857f855ec570
<pre>
Showing or hiding banner view overlay occasionally causes crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=310568">https://bugs.webkit.org/show_bug.cgi?id=310568</a>
<a href="https://rdar.apple.com/173178942">rdar://173178942</a>

Reviewed by Abrar Rahman Protyasha.

`RemoteScrollingTreeMac::triggerMainFrameRubberBandSnapBack` or
`RemoteScrollingTreeMac::mainFrameRubberBandTargetOffsetDidChange`
are called when a banner view overlay is added or removed to the page.
However, they were called from the main thread instead of the scrolling
thread. The scrolling thread could destroy the in-progress animation,
leading to...

`if (CheckedPtr currentAnimation = m_currentAnimation.get())
     currentAnimation-&gt;stop();` &lt;-------------- a crash here!

Fix by acquiring `m_treeLock` and dispatching the call to the scrolling
thread.

* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::triggerMainFrameRubberBandSnapBack):
(WebKit::RemoteScrollingTreeMac::mainFrameRubberBandTargetOffsetDidChange):

Canonical link: <a href="https://commits.webkit.org/309889@main">https://commits.webkit.org/309889@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/403931d332b73ffcd3f44dce13953139d25c58de

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151938 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24719 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18291 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160680 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105395 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7484a9d5-18e6-4056-a670-090dc809d5f9) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25212 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25023 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117364 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83258 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a85aa4f0-ff65-4032-8b20-07960d27795e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154898 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19541 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136344 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98079 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3e3037cc-b34f-4596-af64-cffd4d2df87d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18623 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16554 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8515 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128256 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163145 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6293 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15839 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125386 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24518 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20613 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125566 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34092 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24519 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136043 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81101 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20587 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12818 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24136 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88421 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23827 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23987 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23888 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->