### PR TITLE
[iPadOS] fast/viewport/ios/shrink-to-fit-content-large-constant-width.html is a constant failure

### DIFF
--- a/LayoutTests/fast/viewport/ios/shrink-to-fit-content-large-constant-width-expected.txt
+++ b/LayoutTests/fast/viewport/ios/shrink-to-fit-content-large-constant-width-expected.txt
@@ -1,10 +1,10 @@
-This test verifies that a page with a constant width viewport smaller than the actual view width is scaled to fit the view. To test manually, load the page and verify that the bar spans the full width of the page.
+This test verifies that a page with a constant width viewport bigger than the actual view width is scaled to fit the view.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
 PASS minScale is expectedScale
-PASS innerWidth is 1000
+PASS innerWidth is expectedInnerWidth
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/viewport/ios/shrink-to-fit-content-large-constant-width.html
+++ b/LayoutTests/fast/viewport/ios/shrink-to-fit-content-large-constant-width.html
@@ -23,7 +23,7 @@ body, html {
 <script>
 jsTestIsAsync = true;
 
-description("This test verifies that a page with a constant width viewport smaller than the actual view width is scaled to fit the view. To test manually, load the page and verify that the bar spans the full width of the page.");
+description("This test verifies that a page with a constant width viewport bigger than the actual view width is scaled to fit the view.");
 
 addEventListener("load", async () => {
     if (!window.testRunner)
@@ -31,9 +31,20 @@ addEventListener("load", async () => {
 
     await UIHelper.ensurePresentationUpdate();
     minScale = (await UIHelper.minimumZoomScale()).toFixed(2);
-    expectedScale = (screen.width / 1000).toFixed(2);
+
+    const isEnhancedWindowingEnabled = await UIHelper.enhancedWindowingEnabled();
+    if (isEnhancedWindowingEnabled) {
+        // Since iOS 26, stage manager support has been introduced to all iPads.
+        // With this change, the innerWidth is now expected to be the screen.width / expectedScale rather than just 1000.
+        expectedScale = (Math.max(screen.width, Math.min(1000, internals.minimumShrinkToFitWidthWhenPreferringHorizontalScrolling())) / 1000).toFixed(2);
+        expectedInnerWidth = Math.round(screen.width / parseFloat(expectedScale));
+    } else {
+        expectedScale = (screen.width / 1000).toFixed(2);
+        expectedInnerWidth = 1000;
+    }
+
     shouldBe("minScale", "expectedScale");
-    shouldBe("innerWidth", "1000");
+    shouldBe("innerWidth", "expectedInnerWidth");
     finishJSTest();
 });
 </script>

--- a/LayoutTests/platform/ipad/TestExpectations
+++ b/LayoutTests/platform/ipad/TestExpectations
@@ -165,7 +165,4 @@ scrollingcoordinator/ios/fixed-scrolling-with-keyboard.html [ Skip ]
 # Failure only on iPad simulator 
 webkit.org/b/307451 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-keyboard-behavior.optional.html [ Pass Failure ]
 
-# webkit.org/b/307469 4x fast/viewport/iOS tests are constant text failures on iPad
-fast/viewport/ios/shrink-to-fit-content-large-constant-width.html [ Failure ]
-
 webkit.org/b/307488 media/volume-activate-audio-session.html [ Failure ]

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -1670,6 +1670,16 @@ window.UIHelper = class UIHelper {
         });
     }
 
+    static enhancedWindowingEnabled()
+    {
+        if (!this.isWebKit2() || !this.isIOSFamily())
+            return Promise.resolve(false);
+
+        return new Promise(resolve => {
+            testRunner.runUIScript("uiController.enhancedWindowingEnabled", result => resolve(result === "true"));
+        });
+    }
+
     static stylusTapAt(x, y, modifiers=[])
     {
         if (!this.isWebKit2())

--- a/Source/WebCore/page/ViewportConfiguration.cpp
+++ b/Source/WebCore/page/ViewportConfiguration.cpp
@@ -67,7 +67,6 @@ static inline void NODELETE ignoreViewportArgumentsToAvoidEnlargedView(ViewportA
 }
 
 constexpr double defaultDesktopViewportWidth = 980;
-constexpr double minimumShrinkToFitWidthWhenPreferringHorizontalScrolling = 820;
 
 #if ASSERT_ENABLED
 static bool constraintsAreAllRelative(const ViewportConfiguration::Parameters& configuration)

--- a/Source/WebCore/page/ViewportConfiguration.h
+++ b/Source/WebCore/page/ViewportConfiguration.h
@@ -67,6 +67,8 @@ public:
         friend bool operator==(const Parameters&, const Parameters&) = default;
     };
 
+    static constexpr double minimumShrinkToFitWidthWhenPreferringHorizontalScrolling = 820;
+
     WEBCORE_EXPORT ViewportConfiguration();
 
     const Parameters& defaultConfiguration() const LIFETIME_BOUND { return m_defaultConfiguration; }

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -262,6 +262,7 @@
 #include "UserMediaController.h"
 #include "VideoConfiguration.h"
 #include "ViewportArguments.h"
+#include "ViewportConfiguration.h"
 #include "VoidCallback.h"
 #include "WebAnimation.h"
 #include "WebAnimationUtilities.h"
@@ -3816,6 +3817,11 @@ ExceptionOr<Ref<DOMRectList>> Internals::nonFastScrollableRects() const
         return DOMRectList::create();
 
     return page->nonFastScrollableRectsForTesting();
+}
+
+double Internals::minimumShrinkToFitWidthWhenPreferringHorizontalScrolling() const
+{
+    return ViewportConfiguration::minimumShrinkToFitWidthWhenPreferringHorizontalScrolling;
 }
 
 ExceptionOr<void> Internals::setElementUsesDisplayListDrawing(Element& element, bool usesDisplayListDrawing)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -591,6 +591,8 @@ public:
     ExceptionOr<String> synchronousScrollingReasons() const;
     ExceptionOr<Ref<DOMRectList>> nonFastScrollableRects() const;
 
+    double minimumShrinkToFitWidthWhenPreferringHorizontalScrolling() const;
+
     ExceptionOr<void> setElementUsesDisplayListDrawing(Element&, bool usesDisplayListDrawing);
     ExceptionOr<void> setElementTracksDisplayListReplay(Element&, bool isTrackingReplay);
 

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -836,6 +836,8 @@ enum ContentsFormat {
 
     DOMString repaintRectsAsText();
 
+    double minimumShrinkToFitWidthWhenPreferringHorizontalScrolling();
+
     // These throw if the element does not have a compositing layer.
     undefined setElementUsesDisplayListDrawing(Element element, boolean usesDisplayListDrawing);
     undefined setElementTracksDisplayListReplay(Element element, boolean trackReplay);

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -361,6 +361,7 @@ interface UIScriptController {
     readonly attribute double minimumZoomScale;
     readonly attribute double maximumZoomScale;
     readonly attribute boolean isZoomingOrScrolling;
+    readonly attribute boolean enhancedWindowingEnabled;
 
     // Overides the "in stable state" behavior of WKWebView (only applies to iOS)
     // When false, content rect updates to the web process have inStableState=false, as if a scroll or zoom were in progress.

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -124,6 +124,7 @@ public:
     virtual double zoomScale() const { notImplemented(); return 1; }
     virtual double minimumZoomScale() const { notImplemented(); return 1; }
     virtual double maximumZoomScale() const { notImplemented(); return 1; }
+    virtual bool enhancedWindowingEnabled() const { notImplemented(); return false; }
 
     // Viewports
 

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
@@ -116,6 +116,7 @@ private:
     void applyAutocorrection(JSStringRef newString, JSStringRef oldString, JSValueRef, bool) override;
     double minimumZoomScale() const override;
     double maximumZoomScale() const override;
+    bool enhancedWindowingEnabled() const override;
     std::optional<bool> stableStateOverride() const override;
     void setStableStateOverride(std::optional<bool> overrideValue) override;
     JSObjectRef contentVisibleRect() const override;

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
@@ -931,6 +931,15 @@ double UIScriptControllerIOS::maximumZoomScale() const
     return webView().scrollView.maximumZoomScale;
 }
 
+bool UIScriptControllerIOS::enhancedWindowingEnabled() const
+{
+#if HAVE(UIKIT_RESIZABLE_WINDOWS)
+    return webView().window.windowScene._enhancedWindowingEnabled;
+#else
+    return false;
+#endif
+}
+
 std::optional<bool> UIScriptControllerIOS::stableStateOverride() const
 {
     TestRunnerWKWebView *webView = this->webView();


### PR DESCRIPTION
#### 55f386a3a3f7bafee75af3ccefbd7d29907cf432
<pre>
[iPadOS] fast/viewport/ios/shrink-to-fit-content-large-constant-width.html is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=307469">https://bugs.webkit.org/show_bug.cgi?id=307469</a>
<a href="https://rdar.apple.com/170088582">rdar://170088582</a>

Reviewed by Aditya Keerthi and Abrar Rahman Protyasha.

Stage Manager was extended to all iPads supported by iPadOS 26. When this
was introduced, iPad 9th gen (the simulator tests run on) was
one of the supported iPad models.

The expectedScale (calculated here as shrinkToFitWidth / width) used to
be the screen.width / 1000.

Due to stage manager support, m_prefersHorizontalScrollingBelowDesktopViewportWidths in ViewportConfiguration
is now true. So, shrinkToFitWidth changes from just m_viewLayoutSize.width() to the maximum of
m_viewLayoutSize.width() or a const minimumShrinkToFitWidthWhenPreferringHorizontalScrolling.
Here, the layout size width is less than minimumShrinkToFitWidthWhenPreferringHorizontalScrolling.
So, instead of simply having the expectedScale be the screen.size / 1000, change the test to
mirror the actual calculations that happen in ViewportConfiguration.

This upholds why after switching to run tests on iPad 9th gen, the test was not failing immediately:
only after the stage manager support was introduced did the simulator go down this code route of updating
shrinkToFitWidth to be a different value.

The test&apos;s original intent to ensure the content is shrunk to fit the screen in a reasonable manner
is still preserved.

Expose minimumShrinkToFitWidthWhenPreferringHorizontalScrolling in Internals to use in layout tests.
Also, add enhancedWindowingEnabled support to check if devices support stage manager in layout tests.

* LayoutTests/fast/viewport/ios/shrink-to-fit-content-large-constant-width-expected.txt:
* LayoutTests/fast/viewport/ios/shrink-to-fit-content-large-constant-width.html:
* LayoutTests/platform/ipad/TestExpectations:
* LayoutTests/resources/ui-helper.js:
(window.UIHelper.enhancedWindowingEnabled):
* Source/WebCore/page/ViewportConfiguration.cpp:
* Source/WebCore/page/ViewportConfiguration.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::minimumShrinkToFitWidthWhenPreferringHorizontalScrolling const):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
(WTR::UIScriptController::enhancedWindowingEnabled const):
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h:
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm:
(WTR::UIScriptControllerIOS::enhancedWindowingEnabled const):

Canonical link: <a href="https://commits.webkit.org/309938@main">https://commits.webkit.org/309938@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d01887c3f89268ad29a118a6d6044ca0cd9c90c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151952 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24733 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18396 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160695 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105409 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153826 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25226 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25037 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117378 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83263 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ffefbe9f-895f-472f-9c09-7b24f03cef78) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154912 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19545 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136443 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98093 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18627 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16563 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8529 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128260 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14336 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163159 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6307 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15928 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125398 "Passed tests") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24532 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20622 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125578 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34131 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24533 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136132 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81115 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20598 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12908 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24150 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88435 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23841 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24001 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23902 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->