### PR TITLE
[WTF] Clean up fp -> integer trunc implementations in x64

### DIFF
--- a/Source/WTF/wtf/MathExtras.h
+++ b/Source/WTF/wtf/MathExtras.h
@@ -41,6 +41,9 @@
 #if CPU(ARM64)
 #include <arm_neon.h>
 #endif
+#if CPU(X86_64)
+#include <emmintrin.h>
+#endif
 
 #if OS(OPENBSD)
 #include <sys/types.h>
@@ -867,19 +870,18 @@ constexpr T roundDownToMultipleOf(T x)
 
 ALWAYS_INLINE int32_t truncateDoubleToInt32(double number)
 {
+#if CPU(X86_64)
+    return _mm_cvttsd_si32(_mm_set_sd(number));
+#elif CPU(ARM64)
     if (WTF_PROVEN_TRUE(number > -2147483649.0 && number < 2147483648.0))
         return static_cast<int32_t>(number);
-#if CPU(X86_64)
-    // cvttsd2si eax, xmm0
-    int32_t result;
-    __asm__("cvttsd2si %1, %0" : "=r"(result) : "x"(number));
-    return result;
-#elif CPU(ARM64)
     // fcvtzs w0, d0
     int32_t result;
     __asm__("fcvtzs %w0, %d1" : "=r"(result) : "w"(number));
     return result;
 #else
+    if (WTF_PROVEN_TRUE(number > -2147483649.0 && number < 2147483648.0))
+        return static_cast<int32_t>(number);
     if (std::isnan(number) || !std::isfinite(number))
         return 0;
     if (number > 0) {
@@ -895,19 +897,13 @@ ALWAYS_INLINE int32_t truncateDoubleToInt32(double number)
 
 ALWAYS_INLINE int64_t truncateDoubleToInt64(double number)
 {
-#if CPU(ARM64)
+#if CPU(X86_64)
+    return _mm_cvttsd_si64(_mm_set_sd(number));
+#elif CPU(ARM64)
     return vcvtd_s64_f64(number);
 #else
     if (WTF_PROVEN_TRUE(number >= -9223372036854775808.0 && number < 9223372036854775808.0))
         return static_cast<int64_t>(number);
-#if CPU(X86_64)
-    // cvttsd2si rax, xmm0
-    int64_t result;
-    __asm__("cvttsd2si %1, %0" : "=r"(result) : "x"(number));
-    return result;
-#elif CPU(ARM64)
-    return vcvtd_s64_f64(number);
-#else
     if (std::isnan(number) || !std::isfinite(number))
         return 0;
     if (number > 0) {
@@ -919,24 +915,22 @@ ALWAYS_INLINE int64_t truncateDoubleToInt64(double number)
         return INT64_MIN;
     return static_cast<int64_t>(number);
 #endif
-#endif
 }
 
 ALWAYS_INLINE uint32_t truncateDoubleToUint32(double number)
 {
+#if CPU(X86_64)
+    return static_cast<uint32_t>(_mm_cvttsd_si64(_mm_set_sd(number)));
+#elif CPU(ARM64)
     if (WTF_PROVEN_TRUE(number >= 0.0 && number < 4294967296.0))
         return static_cast<uint32_t>(number);
-#if CPU(X86_64)
-    // cvttsd2si rax, xmm0 (64-bit signed, return low 32 bits)
-    int64_t result;
-    __asm__("cvttsd2si %1, %0" : "=r"(result) : "x"(number));
-    return static_cast<uint32_t>(result);
-#elif CPU(ARM64)
     // fcvtzu w0, d0
     uint32_t result;
     __asm__("fcvtzu %w0, %d1" : "=r"(result) : "w"(number));
     return result;
 #else
+    if (WTF_PROVEN_TRUE(number >= 0.0 && number < 4294967296.0))
+        return static_cast<uint32_t>(number);
     if (std::isnan(number) || !std::isfinite(number))
         return 0;
     // Mimic x86_64: cvttsd2si into int64, take low 32 bits.
@@ -947,25 +941,22 @@ ALWAYS_INLINE uint32_t truncateDoubleToUint32(double number)
 
 ALWAYS_INLINE uint64_t truncateDoubleToUint64(double number)
 {
-#if CPU(ARM64)
-    return vcvtd_u64_f64(number);
-#else
-    if (WTF_PROVEN_TRUE(number >= 0.0 && number < 18446744073709551616.0))
-        return static_cast<uint64_t>(number);
 #if CPU(X86_64)
     // Branchless conversion matching compiler codegen for static_cast<uint64_t>(double).
     // cvttsd2si returns 0x8000000000000000 (negative) on overflow, including for
     // values >= 2^63. When that happens, subtract 2^63 and convert again; the
     // arithmetic-right-shift mask selects the adjusted result only on overflow.
     constexpr double twoTo63 = 9223372036854775808.0; // 0x43e0000000000000
-    int64_t direct;
-    __asm__("cvttsd2si %1, %0" : "=r"(direct) : "x"(number));
+    int64_t direct = _mm_cvttsd_si64(_mm_set_sd(number));
     double shifted = number - twoTo63;
-    int64_t fromShifted;
-    __asm__("cvttsd2si %1, %0" : "=r"(fromShifted) : "x"(shifted));
+    int64_t fromShifted = _mm_cvttsd_si64(_mm_set_sd(shifted));
     int64_t mask = direct >> 63;
     return static_cast<uint64_t>((fromShifted & mask) | direct);
+#elif CPU(ARM64)
+    return vcvtd_u64_f64(number);
 #else
+    if (WTF_PROVEN_TRUE(number >= 0.0 && number < 18446744073709551616.0))
+        return static_cast<uint64_t>(number);
     if (std::isnan(number) || !std::isfinite(number))
         return 0;
     if (number < 0.0)
@@ -980,24 +971,19 @@ ALWAYS_INLINE uint64_t truncateDoubleToUint64(double number)
     }
     return static_cast<uint64_t>(static_cast<int64_t>(number));
 #endif
-#endif
 }
 
 // Float-to-integer truncation helpers.
 
 ALWAYS_INLINE int32_t truncateFloatToInt32(float number)
 {
-#if CPU(ARM64)
+#if CPU(X86_64)
+    return _mm_cvttss_si32(_mm_set_ss(number));
+#elif CPU(ARM64)
     return vcvts_s32_f32(number);
 #else
     if (WTF_PROVEN_TRUE(number > -2147483649.0f && number < 2147483648.0f))
         return static_cast<int32_t>(number);
-#if CPU(X86_64)
-    // cvttss2si eax, xmm0
-    int32_t result;
-    __asm__("cvttss2si %1, %0" : "=r"(result) : "x"(number));
-    return result;
-#else
     if (std::isnan(number) || !std::isfinite(number))
         return 0;
     if (number > 0) {
@@ -1009,24 +995,22 @@ ALWAYS_INLINE int32_t truncateFloatToInt32(float number)
         return INT32_MIN;
     return static_cast<int32_t>(number);
 #endif
-#endif
 }
 
 ALWAYS_INLINE int64_t truncateFloatToInt64(float number)
 {
+#if CPU(X86_64)
+    return _mm_cvttss_si64(_mm_set_ss(number));
+#elif CPU(ARM64)
     if (WTF_PROVEN_TRUE(number >= -9223372036854775808.0f && number < 9223372036854775808.0f))
         return static_cast<int64_t>(number);
-#if CPU(X86_64)
-    // cvttss2si rax, xmm0
-    int64_t result;
-    __asm__("cvttss2si %1, %0" : "=r"(result) : "x"(number));
-    return result;
-#elif CPU(ARM64)
     // fcvtzs x0, s0
     int64_t result;
     __asm__("fcvtzs %x0, %s1" : "=r"(result) : "w"(number));
     return result;
 #else
+    if (WTF_PROVEN_TRUE(number >= -9223372036854775808.0f && number < 9223372036854775808.0f))
+        return static_cast<int64_t>(number);
     if (std::isnan(number) || !std::isfinite(number))
         return 0;
     if (number > 0) {
@@ -1042,16 +1026,13 @@ ALWAYS_INLINE int64_t truncateFloatToInt64(float number)
 
 ALWAYS_INLINE uint32_t truncateFloatToUint32(float number)
 {
-    if (WTF_PROVEN_TRUE(number >= 0.0f && number < 4294967296.0f))
-        return static_cast<uint32_t>(number);
 #if CPU(X86_64)
-    // cvttss2si rax, xmm0 (64-bit signed, return low 32 bits)
-    int64_t result;
-    __asm__("cvttss2si %1, %0" : "=r"(result) : "x"(number));
-    return static_cast<uint32_t>(result);
+    return static_cast<uint32_t>(_mm_cvttss_si64(_mm_set_ss(number)));
 #elif CPU(ARM64)
     return vcvts_u32_f32(number);
 #else
+    if (WTF_PROVEN_TRUE(number >= 0.0f && number < 4294967296.0f))
+        return static_cast<uint32_t>(number);
     if (std::isnan(number) || !std::isfinite(number))
         return 0;
     int64_t wide = truncateFloatToInt64(number);
@@ -1061,24 +1042,24 @@ ALWAYS_INLINE uint32_t truncateFloatToUint32(float number)
 
 ALWAYS_INLINE uint64_t truncateFloatToUint64(float number)
 {
-    if (WTF_PROVEN_TRUE(number >= 0.0f && number < 18446744073709551616.0f))
-        return static_cast<uint64_t>(number);
 #if CPU(X86_64)
     // Branchless conversion matching compiler codegen for static_cast<uint64_t>(float).
     constexpr float twoTo63 = 9223372036854775808.0f; // 0x5f000000
-    int64_t direct;
-    __asm__("cvttss2si %1, %0" : "=r"(direct) : "x"(number));
+    int64_t direct = _mm_cvttss_si64(_mm_set_ss(number));
     float shifted = number - twoTo63;
-    int64_t fromShifted;
-    __asm__("cvttss2si %1, %0" : "=r"(fromShifted) : "x"(shifted));
+    int64_t fromShifted = _mm_cvttss_si64(_mm_set_ss(shifted));
     int64_t mask = direct >> 63;
     return static_cast<uint64_t>((fromShifted & mask) | direct);
 #elif CPU(ARM64)
+    if (WTF_PROVEN_TRUE(number >= 0.0f && number < 18446744073709551616.0f))
+        return static_cast<uint64_t>(number);
     // fcvtzu x0, s0
     uint64_t result;
     __asm__("fcvtzu %x0, %s1" : "=r"(result) : "w"(number));
     return result;
 #else
+    if (WTF_PROVEN_TRUE(number >= 0.0f && number < 18446744073709551616.0f))
+        return static_cast<uint64_t>(number);
     if (std::isnan(number) || !std::isfinite(number))
         return 0;
     if (number < 0.0f)


### PR DESCRIPTION
#### e5256d97edc289c5cd3160e7400d3fae68699993
<pre>
[WTF] Clean up fp -&gt; integer trunc implementations in x64
<a href="https://bugs.webkit.org/show_bug.cgi?id=310581">https://bugs.webkit.org/show_bug.cgi?id=310581</a>
<a href="https://rdar.apple.com/173192980">rdar://173192980</a>

Reviewed by Mark Lam.

Use x64 intrinsics instead. We intentional put WTF_PROVEN_TRUE check
duplicate for CPU(ARM64) and fallback cases to make sure that CPU(ARM64)
side code dense and concise. Once corresponding intrinsics are
introduced, just replace this part entirely in ARM64 too.

* Source/WTF/wtf/MathExtras.h:
(WTF::truncateDoubleToInt32):
(WTF::truncateDoubleToInt64):
(WTF::truncateDoubleToUint32):
(WTF::truncateDoubleToUint64):
(WTF::truncateFloatToInt32):
(WTF::truncateFloatToInt64):
(WTF::truncateFloatToUint32):
(WTF::truncateFloatToUint64):

Canonical link: <a href="https://commits.webkit.org/309806@main">https://commits.webkit.org/309806@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e86e020bc2fbe088ad8c19578e9e5afcd7b1ead

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151780 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24561 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18131 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160522 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2aee85c8-f608-4d86-9a83-1adfc4f5e4a2) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25054 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24855 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117236 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/61aacedb-cd6b-45ce-a497-9c1ddce1010c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154740 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136209 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97951 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ad3043c4-30e1-461f-9d82-1f93d6f83e3c) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/18492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/16416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8357 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/143785 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14112 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162986 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/12581 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/6135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15703 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125258 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24360 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20475 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125439 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24361 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135908 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80936 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23304 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20471 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12683 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/183391 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23977 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/88263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46772 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23669 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23829 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23729 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->