### PR TITLE
serializeFontFamily: Quote font family names that match CSS keywords

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-family-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-family-computed-expected.txt
@@ -8,5 +8,5 @@ PASS Property font-family value 'serif, sans-serif, cursive, fantasy, monospace'
 PASS Property font-family value 'Helvetica, Verdana, sans-serif'
 FAIL Property font-family value '"New Century Schoolbook", serif' assert_equals: expected "New Century Schoolbook, serif" but got "\"New Century Schoolbook\", serif"
 PASS Property font-family value '"21st Century", fantasy'
-FAIL Property font-family value '"inherit", "serif"' assert_equals: expected "\"inherit\", \"serif\"" but got "inherit, serif"
+PASS Property font-family value '"inherit", "serif"'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-family-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-family-valid-expected.txt
@@ -9,5 +9,5 @@ PASS e.style['font-family'] = "serif, sans-serif, cursive, fantasy, monospace, s
 PASS e.style['font-family'] = "Helvetica, Verdana, sans-serif" should set the property value
 FAIL e.style['font-family'] = "\"New Century Schoolbook\", serif" should set the property value assert_equals: serialization should be canonical expected "New Century Schoolbook, serif" but got "\"New Century Schoolbook\", serif"
 PASS e.style['font-family'] = "'21st Century', fantasy" should set the property value
-FAIL e.style['font-family'] = "\"inherit\", \"serif\"" should set the property value assert_equals: serialization should be canonical expected "\"inherit\", \"serif\"" but got "inherit, serif"
+PASS e.style['font-family'] = "\"inherit\", \"serif\"" should set the property value
 

--- a/Source/WebCore/css/CSSMarkup.cpp
+++ b/Source/WebCore/css/CSSMarkup.cpp
@@ -28,6 +28,7 @@
 #include "CSSMarkup.h"
 
 #include "CSSParserIdioms.h"
+#include "CSSPropertyParser.h"
 #include <wtf/HexNumber.h>
 #include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/StringBuilder.h>
@@ -145,7 +146,24 @@ String serializeURL(const String& string)
 
 String serializeFontFamily(const String& string)
 {
-    return isCSSTokenizerIdentifier(string) ? string : serializeString(string);
+    if (!isCSSTokenizerIdentifier(string))
+        return serializeString(string);
+
+    // Font family names that match CSS-wide keywords, 'default', or generic
+    // family keywords must be quoted to prevent confusion with the keywords
+    // of the same names.
+    // https://www.w3.org/TR/css-fonts-4/#family-name-syntax
+    //
+    // Note: system-ui is excluded from quoting because the parser always
+    // stores it as a CSS_FONT_FAMILY string (not a CSSValueID), even when
+    // used as a generic keyword. Since we cannot distinguish the generic
+    // keyword from a quoted family name at this point, and the generic
+    // keyword is the common case, we leave it unquoted.
+    auto valueID = cssValueKeywordID(string);
+    if (valueID != CSSValueSystemUi && (!isValidCustomIdentifier(valueID) || isGenericFontFamilyKeyword(valueID)))
+        return serializeString(string);
+
+    return string;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSParserIdioms.h
+++ b/Source/WebCore/css/parser/CSSParserIdioms.h
@@ -67,6 +67,26 @@ inline bool isValidCustomIdentifier(CSSValueID valueID)
     return !isCSSWideKeyword(valueID) && valueID != CSSValueDefault;
 }
 
+// Unlike CSSPropertyParserHelpers::genericFontFamily, this does not access
+// NeverDestroyed objects that require main-thread access, making it
+// safe to call from OffscreenCanvas workers.
+inline bool isGenericFontFamilyKeyword(CSSValueID valueID)
+{
+    switch (valueID) {
+    case CSSValueSerif:
+    case CSSValueSansSerif:
+    case CSSValueCursive:
+    case CSSValueFantasy:
+    case CSSValueMonospace:
+    case CSSValueSystemUi:
+    case CSSValueWebkitPictograph:
+    case CSSValueMath:
+        return true;
+    default:
+        return false;
+    }
+}
+
 // https://drafts.csswg.org/css-conditional-5/#propdef-container-name
 inline bool isValidContainerNameIdentifier(CSSValueID valueID)
 {

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -37,8 +37,10 @@
 #include "ContainerNodeInlines.h"
 #include "CSSFontSelector.h"
 #include "CSSMarkup.h"
+#include "CSSParserIdioms.h"
 #include "CSSPrimitiveNumericTypes+Serialization.h"
 #include "CSSPropertyNames.h"
+#include "CSSPropertyParser.h"
 #include "CSSPropertyParserConsumer+LengthDefinitions.h"
 #include "CSSPropertyParserConsumer+MetaConsumer.h"
 #include "CSSPropertyParserState.h"
@@ -403,7 +405,13 @@ String CanvasRenderingContext2DBase::State::fontString() const
             family = family.substring(8);
 
         auto separator = i ? ", "_s : " "_s;
-        serializedFont.append(separator, serializeFontFamily(family.toString()));
+        auto familyString = family.toString();
+        // Generic font families should be emitted unquoted.
+        auto valueID = cssValueKeywordID(familyString);
+        if (isGenericFontFamilyKeyword(valueID))
+            serializedFont.append(separator, familyString);
+        else
+            serializedFont.append(separator, serializeFontFamily(familyString));
     }
 
     return serializedFont.toString();


### PR DESCRIPTION
#### d8a232e3b659fbd5ab4c08e3b71e510ecc07cd67
<pre>
serializeFontFamily: Quote font family names that match CSS keywords
<a href="https://bugs.webkit.org/show_bug.cgi?id=271626">https://bugs.webkit.org/show_bug.cgi?id=271626</a>
<a href="https://rdar.apple.com/125334960">rdar://125334960</a>

Reviewed by Dan Glastonbury.

Per CSS Fonts 4 [1], font family names that happen to match CSS-wide
keywords (inherit, initial, etc.) or generic family keywords (serif,
sans-serif, etc.) must be quoted during serialization to avoid confusion
with the actual keywords during re-parsing.

serializeFontFamily now checks for both CSS-wide keywords (via
isValidCustomIdentifier) and generic family keywords (via
isGenericFontFamilyKeyword). system-ui is excluded because the parser
always stores it as a CSS_FONT_FAMILY string rather than a CSSValueID,
so we cannot distinguish the generic keyword from a quoted family name.

We ahd to extract the generic font family check is extracted into a thread-safe
isGenericFontFamilyKeyword function in CSSParserIdioms.h, because
genericFontFamily accesses the a NeverDestroyed object only accessible
from the main thread. This is necessary because of OffscreenCanvas
workers.

[1] <a href="https://www.w3.org/TR/css-fonts-4/#family-name-syntax">https://www.w3.org/TR/css-fonts-4/#family-name-syntax</a>

* Source/WebCore/css/parser/CSSParserIdioms.h:
(WebCore::isGenericFontFamilyKeyword):
* Source/WebCore/css/CSSMarkup.cpp:
(WebCore::serializeFontFamily):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::State::fontString const):
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-family-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-family-valid-expected.txt:

Canonical link: <a href="https://commits.webkit.org/309959@main">https://commits.webkit.org/309959@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aae1c6de0269a47960cda937e32ba79fb8980089

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151932 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24713 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18285 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160674 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105389 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a1cecee6-f742-4833-bcea-b50313b2c9d0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153806 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25206 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25017 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117360 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83259 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f07795c4-aa44-4d2d-a1b2-45b6dd7c7cde) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154892 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19533 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136337 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98075 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cdb5a398-56eb-4dff-a91d-8e188a5e6846) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18615 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16551 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8509 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128248 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14240 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163139 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6287 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15832 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125381 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24512 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20610 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125561 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34142 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24513 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136036 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81095 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20586 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12811 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24130 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88415 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23821 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23981 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23882 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->