### PR TITLE
[macOS iOS] imported/w3c/web-platform-tests/webrtc/transfer-datachannel.html is a flaky text/timeout failure.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-helper.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-helper.js
@@ -15,7 +15,10 @@ async function maybeWrapChannel(channel, shim = null) {
     await shim.init(channel);
     channel = shim;
   }
-  await new Promise(r => channel.addEventListener("open", r, {once: true}));
+  // The channel may already be open if the connection was established while
+  // it was being transferred to a worker.
+  if (channel.readyState !== "open")
+    await new Promise(r => channel.addEventListener("open", r, {once: true}));
   if (shim) {
     await shim.updateState();
   }

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-worker.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-worker.js
@@ -40,6 +40,10 @@ try {
           }
           channels.set(channel.label, channel);
           wireEvents(channel);
+          // The channel may already be open if the connection was established
+          // while it was being transferred to this worker.
+          if (channel.readyState === "open")
+            self.postMessage({type: 'open', label: channel.label});
           self.postMessage({
             type: 'initResponse',
             label: channel.label,

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/transfer-datachannel-worker.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/transfer-datachannel-worker.js
@@ -2,10 +2,22 @@ let channel;
 onmessage = (event) => {
     if (event.data.channel) {
         channel = event.data.channel;
-        channel.onopen = () => self.postMessage("opened");
+        let didOpen = false;
+        channel.onopen = () => {
+            if (!didOpen) {
+                didOpen = true;
+                self.postMessage("opened");
+            }
+        };
         channel.onerror = () => self.postMessage("errored");
         channel.onclose = () => self.postMessage("closed");
         channel.onmessage = event => self.postMessage(event.data);
+        // The channel may already be open if the connection was established
+        // while the channel was being transferred to this worker.
+        if (channel.readyState === "open" && !didOpen) {
+            didOpen = true;
+            self.postMessage("opened");
+        }
     }
     if (event.data.message) {
         if (channel)

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8381,8 +8381,6 @@ imported/w3c/web-platform-tests/css/CSS2/box-display/display-013.xht [ ImageOnly
 fast/images/page-wide-animation-toggle.html [ Pass Timeout ]
 fast/images/individual-animation-toggle.html [ Pass Timeout ]
 
-webkit.org/b/310569 imported/w3c/web-platform-tests/webrtc/transfer-datachannel.html [ Pass Failure ]
-
 webkit.org/b/301175 editing/selection/ios/become-first-responder-after-relinquishing-focus.html [ Pass Timeout ]
 
 webkit.org/b/302893 imported/w3c/web-platform-tests/html/interaction/focus/focus-input-type-switch.html [ Failure ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2428,8 +2428,6 @@ webkit.org/b/306570 [ Tahoe arm64 ] http/tests/webcodecs/video-decoder-callbacks
 
 webkit.org/b/306629 [ Release arm64 ] imported/w3c/web-platform-tests/media-source/mediasource-config-change-webm-av-video-bitrate.html [ Pass Failure ]
 
-webkit.org/b/310569 imported/w3c/web-platform-tests/webrtc/transfer-datachannel.html [ Pass Failure ]
-
 webkit.org/b/306301 [ x86_64 ] http/tests/webgpu/webgpu/api/validation/state/device_lost/destroy.html [ Failure ]
 
 webkit.org/b/306663 [ Debug arm64 ] webaudio/silent-audio-interrupted-in-background.html [ Pass Failure ]


### PR DESCRIPTION
#### 22d617a3f599031a5e8ae026dabfa85410a1067c
<pre>
[macOS iOS] imported/w3c/web-platform-tests/webrtc/transfer-datachannel.html is a flaky text/timeout failure.
<a href="https://rdar.apple.com/173179225">rdar://173179225</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=310569">https://bugs.webkit.org/show_bug.cgi?id=310569</a>

Reviewed by NOBODY (OOPS!).

This test is a flaky timeout due to the following:
    - transfer-datachannel-worker.js. When an RTCDataChannel is transferred to a Web Worker via postMessage,
    the connection may complete while the channel is in-flight. This causes the channel to arrive at the worker
    with readyState === &quot;open&quot; and a buffered open event. The worker&apos;s onopen handler was set too late to catch
    the state transition, so &quot;opened&quot; was never sent back to the test, causing a timeout.
    - When both the buffered open event fires AND the readyState check triggers, &quot;opened&quot; gets sent twice,
    corrupting the subsequent message sequence (the second test&apos;s &quot;OK&quot; assert received &quot;opened&quot; instead).

This patch fixes 3 files:
    1. transfer-datachannel-worker.js (primary fix): Added a readyState === &quot;open&quot; check after setting event
    handlers, with a didOpen guard to prevent duplicate &quot;opened&quot; messages when the buffered event also fires.
    2. RTCDataChannel-worker.js: Added the same readyState === &quot;open&quot; check in the init handler after wireEvents(),
    for the shim-based tests.
    3. RTCDataChannel-helper.js: Made maybeWrapChannel() skip waiting for the &quot;open&quot; event if readyState is already &quot;open&quot;.

* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-helper.js:
(async maybeWrapChannel):
* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-worker.js:
(try.onmessage):
* LayoutTests/imported/w3c/web-platform-tests/webrtc/transfer-datachannel-worker.js:
(onmessage):
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22d617a3f599031a5e8ae026dabfa85410a1067c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152224 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25006 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18601 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160967 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105681 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25498 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25312 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117606 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83400 "7 flakes 2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155184 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19793 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136657 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98319 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18870 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16826 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8801 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128520 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14531 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163434 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16124 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125632 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24804 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20865 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125808 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24805 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136327 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81404 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20814 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13104 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24422 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88707 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24113 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24273 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24174 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->