### PR TITLE
[IndexedDB API] Add IDL and stub for IDBIndex::getAllRecords()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAll-options.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAll-options.any-expected.txt
@@ -1,28 +1,28 @@
 
-FAIL Single item get assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Empty object store assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get all assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get all with generated keys assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get all with large values assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL maxCount=10 assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get bound range assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get bound range with maxCount assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get upper excluded assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get lower excluded assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get bound range (generated) with maxCount assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Non existent key assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL maxCount=0 assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Max value count assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Query with empty range where  first key < upperBound assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Query with empty range where lowerBound < last key assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Retrieve multiEntry key assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Retrieve one key multiple values assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction: next assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction: prev assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction: nextunique assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction: prevunique assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction and query assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction, query and count assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
+FAIL Single item get Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Empty object store Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get all Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get all with generated keys Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get all with large values Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL maxCount=10 Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get bound range Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get bound range with maxCount Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get upper excluded Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get lower excluded Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get bound range (generated) with maxCount Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Non existent key Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL maxCount=0 Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Max value count Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Query with empty range where  first key < upperBound Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Query with empty range where lowerBound < last key Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Retrieve multiEntry key Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Retrieve one key multiple values Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction: next Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction: prev Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction: nextunique Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction: prevunique Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction and query Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction, query and count Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
 FAIL Get all values with both options and count Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
 PASS Get all values with invalid query keys
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAll-options.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAll-options.any.serviceworker-expected.txt
@@ -1,28 +1,28 @@
 
-FAIL Single item get assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Empty object store assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get all assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get all with generated keys assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get all with large values assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL maxCount=10 assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get bound range assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get bound range with maxCount assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get upper excluded assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get lower excluded assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get bound range (generated) with maxCount assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Non existent key assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL maxCount=0 assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Max value count assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Query with empty range where  first key < upperBound assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Query with empty range where lowerBound < last key assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Retrieve multiEntry key assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Retrieve one key multiple values assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction: next assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction: prev assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction: nextunique assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction: prevunique assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction and query assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction, query and count assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
+FAIL Single item get Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Empty object store Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get all Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get all with generated keys Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get all with large values Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL maxCount=10 Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get bound range Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get bound range with maxCount Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get upper excluded Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get lower excluded Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get bound range (generated) with maxCount Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Non existent key Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL maxCount=0 Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Max value count Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Query with empty range where  first key < upperBound Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Query with empty range where lowerBound < last key Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Retrieve multiEntry key Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Retrieve one key multiple values Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction: next Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction: prev Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction: nextunique Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction: prevunique Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction and query Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction, query and count Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
 FAIL Get all values with both options and count Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
 PASS Get all values with invalid query keys
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAll-options.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAll-options.any.sharedworker-expected.txt
@@ -1,28 +1,28 @@
 
-FAIL Single item get assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Empty object store assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get all assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get all with generated keys assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get all with large values assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL maxCount=10 assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get bound range assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get bound range with maxCount assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get upper excluded assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get lower excluded assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get bound range (generated) with maxCount assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Non existent key assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL maxCount=0 assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Max value count assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Query with empty range where  first key < upperBound assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Query with empty range where lowerBound < last key assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Retrieve multiEntry key assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Retrieve one key multiple values assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction: next assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction: prev assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction: nextunique assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction: prevunique assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction and query assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction, query and count assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
+FAIL Single item get Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Empty object store Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get all Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get all with generated keys Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get all with large values Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL maxCount=10 Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get bound range Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get bound range with maxCount Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get upper excluded Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get lower excluded Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get bound range (generated) with maxCount Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Non existent key Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL maxCount=0 Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Max value count Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Query with empty range where  first key < upperBound Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Query with empty range where lowerBound < last key Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Retrieve multiEntry key Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Retrieve one key multiple values Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction: next Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction: prev Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction: nextunique Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction: prevunique Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction and query Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction, query and count Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
 FAIL Get all values with both options and count Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
 PASS Get all values with invalid query keys
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAll-options.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAll-options.any.worker-expected.txt
@@ -1,28 +1,28 @@
 
-FAIL Single item get assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Empty object store assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get all assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get all with generated keys assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get all with large values assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL maxCount=10 assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get bound range assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get bound range with maxCount assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get upper excluded assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get lower excluded assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get bound range (generated) with maxCount assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Non existent key assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL maxCount=0 assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Max value count assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Query with empty range where  first key < upperBound assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Query with empty range where lowerBound < last key assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Retrieve multiEntry key assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Retrieve one key multiple values assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction: next assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction: prev assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction: nextunique assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction: prevunique assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction and query assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction, query and count assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
+FAIL Single item get Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Empty object store Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get all Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get all with generated keys Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get all with large values Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL maxCount=10 Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get bound range Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get bound range with maxCount Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get upper excluded Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get lower excluded Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get bound range (generated) with maxCount Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Non existent key Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL maxCount=0 Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Max value count Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Query with empty range where  first key < upperBound Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Query with empty range where lowerBound < last key Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Retrieve multiEntry key Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Retrieve one key multiple values Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction: next Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction: prev Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction: nextunique Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction: prevunique Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction and query Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction, query and count Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
 FAIL Get all values with both options and count Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
 PASS Get all values with invalid query keys
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllKeys-options.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllKeys-options.any-expected.txt
@@ -1,27 +1,27 @@
 
-FAIL Single item get assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Empty object store assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get all keys assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get all generated keys assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL maxCount=10 assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get bound range assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get bound range with maxCount assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get upper excluded assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get lower excluded assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get bound range (generated) with maxCount assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Non existent key assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL maxCount=0 assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Max value count assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Query with empty range where  first key < upperBound assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Query with empty range where lowerBound < last key assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Retrieve multiEntry key assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Retrieve one key multiple values assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction: next assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction: prev assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction: nextunique assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction: prevunique assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction and query assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction, query and count assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
+FAIL Single item get Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Empty object store Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get all keys Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get all generated keys Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL maxCount=10 Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get bound range Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get bound range with maxCount Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get upper excluded Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get lower excluded Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get bound range (generated) with maxCount Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Non existent key Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL maxCount=0 Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Max value count Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Query with empty range where  first key < upperBound Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Query with empty range where lowerBound < last key Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Retrieve multiEntry key Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Retrieve one key multiple values Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction: next Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction: prev Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction: nextunique Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction: prevunique Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction and query Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction, query and count Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
 FAIL Get all keys with both options and count Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
 PASS Get all keys with invalid query keys
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllKeys-options.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllKeys-options.any.serviceworker-expected.txt
@@ -1,27 +1,27 @@
 
-FAIL Single item get assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Empty object store assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get all keys assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get all generated keys assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL maxCount=10 assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get bound range assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get bound range with maxCount assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get upper excluded assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get lower excluded assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get bound range (generated) with maxCount assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Non existent key assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL maxCount=0 assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Max value count assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Query with empty range where  first key < upperBound assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Query with empty range where lowerBound < last key assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Retrieve multiEntry key assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Retrieve one key multiple values assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction: next assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction: prev assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction: nextunique assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction: prevunique assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction and query assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction, query and count assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
+FAIL Single item get Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Empty object store Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get all keys Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get all generated keys Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL maxCount=10 Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get bound range Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get bound range with maxCount Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get upper excluded Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get lower excluded Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get bound range (generated) with maxCount Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Non existent key Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL maxCount=0 Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Max value count Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Query with empty range where  first key < upperBound Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Query with empty range where lowerBound < last key Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Retrieve multiEntry key Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Retrieve one key multiple values Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction: next Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction: prev Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction: nextunique Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction: prevunique Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction and query Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction, query and count Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
 FAIL Get all keys with both options and count Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
 PASS Get all keys with invalid query keys
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllKeys-options.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllKeys-options.any.sharedworker-expected.txt
@@ -1,27 +1,27 @@
 
-FAIL Single item get assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Empty object store assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get all keys assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get all generated keys assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL maxCount=10 assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get bound range assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get bound range with maxCount assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get upper excluded assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get lower excluded assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get bound range (generated) with maxCount assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Non existent key assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL maxCount=0 assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Max value count assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Query with empty range where  first key < upperBound assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Query with empty range where lowerBound < last key assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Retrieve multiEntry key assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Retrieve one key multiple values assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction: next assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction: prev assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction: nextunique assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction: prevunique assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction and query assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction, query and count assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
+FAIL Single item get Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Empty object store Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get all keys Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get all generated keys Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL maxCount=10 Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get bound range Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get bound range with maxCount Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get upper excluded Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get lower excluded Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get bound range (generated) with maxCount Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Non existent key Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL maxCount=0 Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Max value count Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Query with empty range where  first key < upperBound Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Query with empty range where lowerBound < last key Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Retrieve multiEntry key Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Retrieve one key multiple values Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction: next Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction: prev Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction: nextunique Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction: prevunique Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction and query Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction, query and count Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
 FAIL Get all keys with both options and count Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
 PASS Get all keys with invalid query keys
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllKeys-options.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllKeys-options.any.worker-expected.txt
@@ -1,27 +1,27 @@
 
-FAIL Single item get assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Empty object store assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get all keys assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get all generated keys assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL maxCount=10 assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get bound range assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get bound range with maxCount assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get upper excluded assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get lower excluded assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get bound range (generated) with maxCount assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Non existent key assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL maxCount=0 assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Max value count assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Query with empty range where  first key < upperBound assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Query with empty range where lowerBound < last key assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Retrieve multiEntry key assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Retrieve one key multiple values assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction: next assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction: prev assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction: nextunique assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction: prevunique assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction and query assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction, query and count assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
+FAIL Single item get Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Empty object store Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get all keys Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get all generated keys Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL maxCount=10 Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get bound range Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get bound range with maxCount Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get upper excluded Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get lower excluded Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Get bound range (generated) with maxCount Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Non existent key Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL maxCount=0 Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Max value count Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Query with empty range where  first key < upperBound Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Query with empty range where lowerBound < last key Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Retrieve multiEntry key Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Retrieve one key multiple values Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction: next Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction: prev Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction: nextunique Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction: prevunique Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction and query Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+FAIL Direction, query and count Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
 FAIL Get all keys with both options and count Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
 PASS Get all keys with invalid query keys
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllRecords.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllRecords.any-expected.txt
@@ -1,29 +1,29 @@
 
-FAIL Single item assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Empty index queryTarget[getAllFunctionName] is not a function. (In 'queryTarget[getAllFunctionName]()', 'queryTarget[getAllFunctionName]' is undefined)
-FAIL Get all records queryTarget[getAllFunctionName] is not a function. (In 'queryTarget[getAllFunctionName]()', 'queryTarget[getAllFunctionName]' is undefined)
-FAIL Get all records with empty options assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Get all records with large value queryTarget[getAllFunctionName] is not a function. (In 'queryTarget[getAllFunctionName]()', 'queryTarget[getAllFunctionName]' is undefined)
-FAIL Count assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with bound range assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with bound range and count assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with upper excluded bound range assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with lower excluded bound range assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with bound range and count for generated keys assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with Nonexistent key assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Zero count assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Max value count assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with empty range where first key < upperBound assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with empty range where lowerBound < last key assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query index key that matches multiple records assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with multiEntry index assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction: next assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction: prev assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction: nextunique assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction: prevunique assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction and query assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction, query and count assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
+FAIL Single item getAllRecords is not yet supported
+FAIL Empty index getAllRecords is not yet supported
+FAIL Get all records getAllRecords is not yet supported
+FAIL Get all records with empty options getAllRecords is not yet supported
+FAIL Get all records with large value getAllRecords is not yet supported
+FAIL Count getAllRecords is not yet supported
+FAIL Query with bound range getAllRecords is not yet supported
+FAIL Query with bound range and count getAllRecords is not yet supported
+FAIL Query with upper excluded bound range getAllRecords is not yet supported
+FAIL Query with lower excluded bound range getAllRecords is not yet supported
+FAIL Query with bound range and count for generated keys getAllRecords is not yet supported
+FAIL Query with Nonexistent key getAllRecords is not yet supported
+FAIL Zero count getAllRecords is not yet supported
+FAIL Max value count getAllRecords is not yet supported
+FAIL Query with empty range where first key < upperBound getAllRecords is not yet supported
+FAIL Query with empty range where lowerBound < last key getAllRecords is not yet supported
+FAIL Query index key that matches multiple records getAllRecords is not yet supported
+FAIL Query with multiEntry index getAllRecords is not yet supported
+FAIL Direction: next getAllRecords is not yet supported
+FAIL Direction: prev getAllRecords is not yet supported
+FAIL Direction: nextunique getAllRecords is not yet supported
+FAIL Direction: prevunique getAllRecords is not yet supported
+FAIL Direction and query getAllRecords is not yet supported
+FAIL Direction, query and count getAllRecords is not yet supported
 FAIL Get all records with invalid query keys assert_throws_dom: An invalid Date(NaN) key must throw an exception. function "() => {
         queryTarget[getAllFunctionName](argument);
-      }" threw object "TypeError: queryTarget[getAllFunctionName] is not a function. (In 'queryTarget[getAllFunctionName](argument)', 'queryTarget[getAllFunctionName]' is undefined)" that is not a DOMException DataError: property "code" is equal to undefined, expected 0
+      }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllRecords.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllRecords.any.serviceworker-expected.txt
@@ -1,29 +1,29 @@
 
-FAIL Single item assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Empty index queryTarget[getAllFunctionName] is not a function. (In 'queryTarget[getAllFunctionName]()', 'queryTarget[getAllFunctionName]' is undefined)
-FAIL Get all records queryTarget[getAllFunctionName] is not a function. (In 'queryTarget[getAllFunctionName]()', 'queryTarget[getAllFunctionName]' is undefined)
-FAIL Get all records with empty options assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Get all records with large value queryTarget[getAllFunctionName] is not a function. (In 'queryTarget[getAllFunctionName]()', 'queryTarget[getAllFunctionName]' is undefined)
-FAIL Count assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with bound range assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with bound range and count assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with upper excluded bound range assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with lower excluded bound range assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with bound range and count for generated keys assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with Nonexistent key assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Zero count assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Max value count assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with empty range where first key < upperBound assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with empty range where lowerBound < last key assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query index key that matches multiple records assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with multiEntry index assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction: next assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction: prev assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction: nextunique assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction: prevunique assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction and query assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction, query and count assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
+FAIL Single item getAllRecords is not yet supported
+FAIL Empty index getAllRecords is not yet supported
+FAIL Get all records getAllRecords is not yet supported
+FAIL Get all records with empty options getAllRecords is not yet supported
+FAIL Get all records with large value getAllRecords is not yet supported
+FAIL Count getAllRecords is not yet supported
+FAIL Query with bound range getAllRecords is not yet supported
+FAIL Query with bound range and count getAllRecords is not yet supported
+FAIL Query with upper excluded bound range getAllRecords is not yet supported
+FAIL Query with lower excluded bound range getAllRecords is not yet supported
+FAIL Query with bound range and count for generated keys getAllRecords is not yet supported
+FAIL Query with Nonexistent key getAllRecords is not yet supported
+FAIL Zero count getAllRecords is not yet supported
+FAIL Max value count getAllRecords is not yet supported
+FAIL Query with empty range where first key < upperBound getAllRecords is not yet supported
+FAIL Query with empty range where lowerBound < last key getAllRecords is not yet supported
+FAIL Query index key that matches multiple records getAllRecords is not yet supported
+FAIL Query with multiEntry index getAllRecords is not yet supported
+FAIL Direction: next getAllRecords is not yet supported
+FAIL Direction: prev getAllRecords is not yet supported
+FAIL Direction: nextunique getAllRecords is not yet supported
+FAIL Direction: prevunique getAllRecords is not yet supported
+FAIL Direction and query getAllRecords is not yet supported
+FAIL Direction, query and count getAllRecords is not yet supported
 FAIL Get all records with invalid query keys assert_throws_dom: An invalid Date(NaN) key must throw an exception. function "() => {
         queryTarget[getAllFunctionName](argument);
-      }" threw object "TypeError: queryTarget[getAllFunctionName] is not a function. (In 'queryTarget[getAllFunctionName](argument)', 'queryTarget[getAllFunctionName]' is undefined)" that is not a DOMException DataError: property "code" is equal to undefined, expected 0
+      }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllRecords.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllRecords.any.sharedworker-expected.txt
@@ -1,29 +1,29 @@
 
-FAIL Single item assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Empty index queryTarget[getAllFunctionName] is not a function. (In 'queryTarget[getAllFunctionName]()', 'queryTarget[getAllFunctionName]' is undefined)
-FAIL Get all records queryTarget[getAllFunctionName] is not a function. (In 'queryTarget[getAllFunctionName]()', 'queryTarget[getAllFunctionName]' is undefined)
-FAIL Get all records with empty options assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Get all records with large value queryTarget[getAllFunctionName] is not a function. (In 'queryTarget[getAllFunctionName]()', 'queryTarget[getAllFunctionName]' is undefined)
-FAIL Count assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with bound range assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with bound range and count assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with upper excluded bound range assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with lower excluded bound range assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with bound range and count for generated keys assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with Nonexistent key assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Zero count assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Max value count assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with empty range where first key < upperBound assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with empty range where lowerBound < last key assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query index key that matches multiple records assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with multiEntry index assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction: next assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction: prev assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction: nextunique assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction: prevunique assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction and query assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction, query and count assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
+FAIL Single item getAllRecords is not yet supported
+FAIL Empty index getAllRecords is not yet supported
+FAIL Get all records getAllRecords is not yet supported
+FAIL Get all records with empty options getAllRecords is not yet supported
+FAIL Get all records with large value getAllRecords is not yet supported
+FAIL Count getAllRecords is not yet supported
+FAIL Query with bound range getAllRecords is not yet supported
+FAIL Query with bound range and count getAllRecords is not yet supported
+FAIL Query with upper excluded bound range getAllRecords is not yet supported
+FAIL Query with lower excluded bound range getAllRecords is not yet supported
+FAIL Query with bound range and count for generated keys getAllRecords is not yet supported
+FAIL Query with Nonexistent key getAllRecords is not yet supported
+FAIL Zero count getAllRecords is not yet supported
+FAIL Max value count getAllRecords is not yet supported
+FAIL Query with empty range where first key < upperBound getAllRecords is not yet supported
+FAIL Query with empty range where lowerBound < last key getAllRecords is not yet supported
+FAIL Query index key that matches multiple records getAllRecords is not yet supported
+FAIL Query with multiEntry index getAllRecords is not yet supported
+FAIL Direction: next getAllRecords is not yet supported
+FAIL Direction: prev getAllRecords is not yet supported
+FAIL Direction: nextunique getAllRecords is not yet supported
+FAIL Direction: prevunique getAllRecords is not yet supported
+FAIL Direction and query getAllRecords is not yet supported
+FAIL Direction, query and count getAllRecords is not yet supported
 FAIL Get all records with invalid query keys assert_throws_dom: An invalid Date(NaN) key must throw an exception. function "() => {
         queryTarget[getAllFunctionName](argument);
-      }" threw object "TypeError: queryTarget[getAllFunctionName] is not a function. (In 'queryTarget[getAllFunctionName](argument)', 'queryTarget[getAllFunctionName]' is undefined)" that is not a DOMException DataError: property "code" is equal to undefined, expected 0
+      }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllRecords.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllRecords.any.worker-expected.txt
@@ -1,29 +1,29 @@
 
-FAIL Single item assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Empty index queryTarget[getAllFunctionName] is not a function. (In 'queryTarget[getAllFunctionName]()', 'queryTarget[getAllFunctionName]' is undefined)
-FAIL Get all records queryTarget[getAllFunctionName] is not a function. (In 'queryTarget[getAllFunctionName]()', 'queryTarget[getAllFunctionName]' is undefined)
-FAIL Get all records with empty options assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Get all records with large value queryTarget[getAllFunctionName] is not a function. (In 'queryTarget[getAllFunctionName]()', 'queryTarget[getAllFunctionName]' is undefined)
-FAIL Count assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with bound range assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with bound range and count assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with upper excluded bound range assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with lower excluded bound range assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with bound range and count for generated keys assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with Nonexistent key assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Zero count assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Max value count assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with empty range where first key < upperBound assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with empty range where lowerBound < last key assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query index key that matches multiple records assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with multiEntry index assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction: next assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction: prev assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction: nextunique assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction: prevunique assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction and query assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction, query and count assert_true: "[object IDBIndex]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
+FAIL Single item getAllRecords is not yet supported
+FAIL Empty index getAllRecords is not yet supported
+FAIL Get all records getAllRecords is not yet supported
+FAIL Get all records with empty options getAllRecords is not yet supported
+FAIL Get all records with large value getAllRecords is not yet supported
+FAIL Count getAllRecords is not yet supported
+FAIL Query with bound range getAllRecords is not yet supported
+FAIL Query with bound range and count getAllRecords is not yet supported
+FAIL Query with upper excluded bound range getAllRecords is not yet supported
+FAIL Query with lower excluded bound range getAllRecords is not yet supported
+FAIL Query with bound range and count for generated keys getAllRecords is not yet supported
+FAIL Query with Nonexistent key getAllRecords is not yet supported
+FAIL Zero count getAllRecords is not yet supported
+FAIL Max value count getAllRecords is not yet supported
+FAIL Query with empty range where first key < upperBound getAllRecords is not yet supported
+FAIL Query with empty range where lowerBound < last key getAllRecords is not yet supported
+FAIL Query index key that matches multiple records getAllRecords is not yet supported
+FAIL Query with multiEntry index getAllRecords is not yet supported
+FAIL Direction: next getAllRecords is not yet supported
+FAIL Direction: prev getAllRecords is not yet supported
+FAIL Direction: nextunique getAllRecords is not yet supported
+FAIL Direction: prevunique getAllRecords is not yet supported
+FAIL Direction and query getAllRecords is not yet supported
+FAIL Direction, query and count getAllRecords is not yet supported
 FAIL Get all records with invalid query keys assert_throws_dom: An invalid Date(NaN) key must throw an exception. function "() => {
         queryTarget[getAllFunctionName](argument);
-      }" threw object "TypeError: queryTarget[getAllFunctionName] is not a function. (In 'queryTarget[getAllFunctionName](argument)', 'queryTarget[getAllFunctionName]' is undefined)" that is not a DOMException DataError: property "code" is equal to undefined, expected 0
+      }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idlharness.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idlharness.any-expected.txt
@@ -121,7 +121,7 @@ PASS IDBIndex interface: operation get(any)
 PASS IDBIndex interface: operation getKey(any)
 PASS IDBIndex interface: operation getAll(optional any, optional unsigned long)
 PASS IDBIndex interface: operation getAllKeys(optional any, optional unsigned long)
-FAIL IDBIndex interface: operation getAllRecords(optional IDBGetAllOptions) assert_own_property: interface prototype object missing non-static operation expected property "getAllRecords" missing
+PASS IDBIndex interface: operation getAllRecords(optional IDBGetAllOptions)
 PASS IDBIndex interface: operation count(optional any)
 PASS IDBIndex interface: operation openCursor(optional any, optional IDBCursorDirection)
 PASS IDBIndex interface: operation openKeyCursor(optional any, optional IDBCursorDirection)

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idlharness.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idlharness.any.serviceworker-expected.txt
@@ -121,7 +121,7 @@ PASS IDBIndex interface: operation get(any)
 PASS IDBIndex interface: operation getKey(any)
 PASS IDBIndex interface: operation getAll(optional any, optional unsigned long)
 PASS IDBIndex interface: operation getAllKeys(optional any, optional unsigned long)
-FAIL IDBIndex interface: operation getAllRecords(optional IDBGetAllOptions) assert_own_property: interface prototype object missing non-static operation expected property "getAllRecords" missing
+PASS IDBIndex interface: operation getAllRecords(optional IDBGetAllOptions)
 PASS IDBIndex interface: operation count(optional any)
 PASS IDBIndex interface: operation openCursor(optional any, optional IDBCursorDirection)
 PASS IDBIndex interface: operation openKeyCursor(optional any, optional IDBCursorDirection)

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idlharness.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idlharness.any.sharedworker-expected.txt
@@ -121,7 +121,7 @@ PASS IDBIndex interface: operation get(any)
 PASS IDBIndex interface: operation getKey(any)
 PASS IDBIndex interface: operation getAll(optional any, optional unsigned long)
 PASS IDBIndex interface: operation getAllKeys(optional any, optional unsigned long)
-FAIL IDBIndex interface: operation getAllRecords(optional IDBGetAllOptions) assert_own_property: interface prototype object missing non-static operation expected property "getAllRecords" missing
+PASS IDBIndex interface: operation getAllRecords(optional IDBGetAllOptions)
 PASS IDBIndex interface: operation count(optional any)
 PASS IDBIndex interface: operation openCursor(optional any, optional IDBCursorDirection)
 PASS IDBIndex interface: operation openKeyCursor(optional any, optional IDBCursorDirection)

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idlharness.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idlharness.any.worker-expected.txt
@@ -121,7 +121,7 @@ PASS IDBIndex interface: operation get(any)
 PASS IDBIndex interface: operation getKey(any)
 PASS IDBIndex interface: operation getAll(optional any, optional unsigned long)
 PASS IDBIndex interface: operation getAllKeys(optional any, optional unsigned long)
-FAIL IDBIndex interface: operation getAllRecords(optional IDBGetAllOptions) assert_own_property: interface prototype object missing non-static operation expected property "getAllRecords" missing
+PASS IDBIndex interface: operation getAllRecords(optional IDBGetAllOptions)
 PASS IDBIndex interface: operation count(optional any)
 PASS IDBIndex interface: operation openCursor(optional any, optional IDBCursorDirection)
 PASS IDBIndex interface: operation openKeyCursor(optional any, optional IDBCursorDirection)

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any-expected.txt
@@ -23,7 +23,13 @@ PASS IDBIndex openKeyCursor() method with throwing/invalid keys
 PASS IDBObjectStore getAll() method with throwing/invalid keys
 PASS IDBObjectStore getAllKeys() method with throwing/invalid keys
 PASS IDBObjectStore getAllRecords() method with throwing/invalid keys
-PASS IDBIndex getAll() method with throwing/invalid keys
-PASS IDBIndex getAllKeys() method with throwing/invalid keys
-PASS IDBIndex getAllRecords() method with throwing/invalid keys
+FAIL IDBIndex getAll() method with throwing/invalid keys assert_throws_exactly: options query key conversion with throwing getter should rethrow function "() => {
+    receiver[method]({query: key});
+  }" threw object "DataError: Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key." but we expected it to throw object "getter: throwing from getter"
+FAIL IDBIndex getAllKeys() method with throwing/invalid keys assert_throws_exactly: options query key conversion with throwing getter should rethrow function "() => {
+    receiver[method]({query: key});
+  }" threw object "DataError: Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key." but we expected it to throw object "getter: throwing from getter"
+FAIL IDBIndex getAllRecords() method with throwing/invalid keys assert_throws_dom: options query key conversion with invalid key should throw DataError function "() => {
+    receiver[method]({query: invalid_key});
+  }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.serviceworker-expected.txt
@@ -23,7 +23,13 @@ PASS IDBIndex openKeyCursor() method with throwing/invalid keys
 PASS IDBObjectStore getAll() method with throwing/invalid keys
 PASS IDBObjectStore getAllKeys() method with throwing/invalid keys
 PASS IDBObjectStore getAllRecords() method with throwing/invalid keys
-PASS IDBIndex getAll() method with throwing/invalid keys
-PASS IDBIndex getAllKeys() method with throwing/invalid keys
-PASS IDBIndex getAllRecords() method with throwing/invalid keys
+FAIL IDBIndex getAll() method with throwing/invalid keys assert_throws_exactly: options query key conversion with throwing getter should rethrow function "() => {
+    receiver[method]({query: key});
+  }" threw object "DataError: Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key." but we expected it to throw object "getter: throwing from getter"
+FAIL IDBIndex getAllKeys() method with throwing/invalid keys assert_throws_exactly: options query key conversion with throwing getter should rethrow function "() => {
+    receiver[method]({query: key});
+  }" threw object "DataError: Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key." but we expected it to throw object "getter: throwing from getter"
+FAIL IDBIndex getAllRecords() method with throwing/invalid keys assert_throws_dom: options query key conversion with invalid key should throw DataError function "() => {
+    receiver[method]({query: invalid_key});
+  }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.sharedworker-expected.txt
@@ -23,7 +23,13 @@ PASS IDBIndex openKeyCursor() method with throwing/invalid keys
 PASS IDBObjectStore getAll() method with throwing/invalid keys
 PASS IDBObjectStore getAllKeys() method with throwing/invalid keys
 PASS IDBObjectStore getAllRecords() method with throwing/invalid keys
-PASS IDBIndex getAll() method with throwing/invalid keys
-PASS IDBIndex getAllKeys() method with throwing/invalid keys
-PASS IDBIndex getAllRecords() method with throwing/invalid keys
+FAIL IDBIndex getAll() method with throwing/invalid keys assert_throws_exactly: options query key conversion with throwing getter should rethrow function "() => {
+    receiver[method]({query: key});
+  }" threw object "DataError: Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key." but we expected it to throw object "getter: throwing from getter"
+FAIL IDBIndex getAllKeys() method with throwing/invalid keys assert_throws_exactly: options query key conversion with throwing getter should rethrow function "() => {
+    receiver[method]({query: key});
+  }" threw object "DataError: Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key." but we expected it to throw object "getter: throwing from getter"
+FAIL IDBIndex getAllRecords() method with throwing/invalid keys assert_throws_dom: options query key conversion with invalid key should throw DataError function "() => {
+    receiver[method]({query: invalid_key});
+  }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.worker-expected.txt
@@ -23,7 +23,13 @@ PASS IDBIndex openKeyCursor() method with throwing/invalid keys
 PASS IDBObjectStore getAll() method with throwing/invalid keys
 PASS IDBObjectStore getAllKeys() method with throwing/invalid keys
 PASS IDBObjectStore getAllRecords() method with throwing/invalid keys
-PASS IDBIndex getAll() method with throwing/invalid keys
-PASS IDBIndex getAllKeys() method with throwing/invalid keys
-PASS IDBIndex getAllRecords() method with throwing/invalid keys
+FAIL IDBIndex getAll() method with throwing/invalid keys assert_throws_exactly: options query key conversion with throwing getter should rethrow function "() => {
+    receiver[method]({query: key});
+  }" threw object "DataError: Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key." but we expected it to throw object "getter: throwing from getter"
+FAIL IDBIndex getAllKeys() method with throwing/invalid keys assert_throws_exactly: options query key conversion with throwing getter should rethrow function "() => {
+    receiver[method]({query: key});
+  }" threw object "DataError: Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key." but we expected it to throw object "getter: throwing from getter"
+FAIL IDBIndex getAllRecords() method with throwing/invalid keys assert_throws_dom: options query key conversion with invalid key should throw DataError function "() => {
+    receiver[method]({query: invalid_key});
+  }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0
 

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3914,6 +3914,22 @@ IndexedDBAPIEnabled:
   sharedPreferenceForWebProcess: true
   richJavaScript: true
 
+IndexedDBGetAllRecordsEnabled:
+  type: bool
+  category: dom
+  status: testable
+  humanReadableName: "IndexedDB getAllRecords() API"
+  humanReadableDescription: "Enable getAllRecords() on IDBIndex"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+  sharedPreferenceForWebProcess: true
+  richJavaScript: true
+
 IndexedDBSQLiteMemoryBackingStoreEnabled:
   type: bool
   status: stable

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -460,6 +460,7 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/indexeddb/IDBCursorWithValue.idl
     Modules/indexeddb/IDBDatabase.idl
     Modules/indexeddb/IDBFactory.idl
+    Modules/indexeddb/IDBGetAllOptions.idl
     Modules/indexeddb/IDBIndex.idl
     Modules/indexeddb/IDBKeyRange.idl
     Modules/indexeddb/IDBObjectStore.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -524,6 +524,7 @@ $(PROJECT_DIR)/Modules/indexeddb/IDBCursorDirection.idl
 $(PROJECT_DIR)/Modules/indexeddb/IDBCursorWithValue.idl
 $(PROJECT_DIR)/Modules/indexeddb/IDBDatabase.idl
 $(PROJECT_DIR)/Modules/indexeddb/IDBFactory.idl
+$(PROJECT_DIR)/Modules/indexeddb/IDBGetAllOptions.idl
 $(PROJECT_DIR)/Modules/indexeddb/IDBIndex.idl
 $(PROJECT_DIR)/Modules/indexeddb/IDBKeyRange.idl
 $(PROJECT_DIR)/Modules/indexeddb/IDBObjectStore.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -1725,6 +1725,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIDBDatabase.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIDBDatabase.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIDBFactory.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIDBFactory.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIDBGetAllOptions.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIDBGetAllOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIDBIndex.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIDBIndex.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIDBKeyRange.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -385,6 +385,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/indexeddb/IDBCursorWithValue.idl \
     $(WebCore)/Modules/indexeddb/IDBDatabase.idl \
     $(WebCore)/Modules/indexeddb/IDBFactory.idl \
+    $(WebCore)/Modules/indexeddb/IDBGetAllOptions.idl \
     $(WebCore)/Modules/indexeddb/IDBIndex.idl \
     $(WebCore)/Modules/indexeddb/IDBKeyRange.idl \
     $(WebCore)/Modules/indexeddb/IDBObjectStore.idl \

--- a/Source/WebCore/Modules/indexeddb/IDBGetAllOptions.h
+++ b/Source/WebCore/Modules/indexeddb/IDBGetAllOptions.h
@@ -1,0 +1,40 @@
+/*
+* Copyright (C) 2026 Apple Inc. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+* THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+* PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+* BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+* THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#pragma once
+
+#include "IDBCursorDirection.h"
+#include <JavaScriptCore/JSCJSValue.h>
+#include <optional>
+
+namespace WebCore {
+
+struct IDBGetAllOptions {
+    JSC::JSValue query;
+    std::optional<uint32_t> count;
+    IDBCursorDirection direction { IDBCursorDirection::Next };
+};
+
+}

--- a/Source/WebCore/Modules/indexeddb/IDBGetAllOptions.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBGetAllOptions.idl
@@ -1,0 +1,32 @@
+/*
+* Copyright (C) 2026 Apple Inc. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+* THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+* PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+* BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+* THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+[
+    EnabledBySetting=IndexedDBGetAllRecordsEnabled
+] dictionary IDBGetAllOptions {
+    any query = null;
+    [EnforceRange] unsigned long count;
+    IDBCursorDirection direction = "next";
+};

--- a/Source/WebCore/Modules/indexeddb/IDBIndex.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBIndex.cpp
@@ -31,6 +31,7 @@
 #include "IDBBindingUtilities.h"
 #include "IDBCursor.h"
 #include "IDBDatabase.h"
+#include "IDBGetAllOptions.h"
 #include "IDBKeyRangeData.h"
 #include "IDBObjectStore.h"
 #include "IDBRequest.h"
@@ -418,6 +419,11 @@ ExceptionOr<Ref<IDBRequest>> IDBIndex::getAllKeys(JSGlobalObject& execState, JSV
 
         return ExceptionOr<RefPtr<IDBKeyRange>> { onlyResult.releaseReturnValue() };
     });
+}
+
+ExceptionOr<Ref<IDBRequest>> IDBIndex::getAllRecords(JSGlobalObject&, IDBGetAllOptions&&)
+{
+    return Exception { ExceptionCode::NotSupportedError, "getAllRecords is not yet supported"_s };
 }
 
 void IDBIndex::markAsDeleted()

--- a/Source/WebCore/Modules/indexeddb/IDBIndex.h
+++ b/Source/WebCore/Modules/indexeddb/IDBIndex.h
@@ -40,6 +40,7 @@ namespace WebCore {
 class IDBKeyRange;
 class WebCoreOpaqueRoot;
 
+struct IDBGetAllOptions;
 struct IDBKeyRangeData;
 
 class IDBIndex final : public ActiveDOMObject {
@@ -75,6 +76,8 @@ public:
     ExceptionOr<Ref<IDBRequest>> getAll(JSC::JSGlobalObject&, JSC::JSValue key, std::optional<uint32_t> count);
     ExceptionOr<Ref<IDBRequest>> getAllKeys(RefPtr<IDBKeyRange>&&, std::optional<uint32_t> count);
     ExceptionOr<Ref<IDBRequest>> getAllKeys(JSC::JSGlobalObject&, JSC::JSValue key, std::optional<uint32_t> count);
+
+    ExceptionOr<Ref<IDBRequest>> getAllRecords(JSC::JSGlobalObject&, IDBGetAllOptions&&);
 
     const IDBIndexInfo& info() const LIFETIME_BOUND { return m_info; }
 

--- a/Source/WebCore/Modules/indexeddb/IDBIndex.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBIndex.idl
@@ -49,6 +49,7 @@ typedef (DOMString or sequence<DOMString>) IDBKeyPath;
     [NewObject, CallWith=CurrentGlobalObject] IDBRequest getAll(any key, optional [EnforceRange] unsigned long count);
     [NewObject] IDBRequest getAllKeys(optional IDBKeyRange? range = null, optional [EnforceRange] unsigned long count);
     [NewObject, CallWith=CurrentGlobalObject] IDBRequest getAllKeys(any key, optional [EnforceRange] unsigned long count);
+    [NewObject, CallWith=CurrentGlobalObject, EnabledBySetting=IndexedDBGetAllRecordsEnabled] IDBRequest getAllRecords(optional IDBGetAllOptions options = {});
     [NewObject] IDBRequest count(optional IDBKeyRange? range = null);
     [NewObject, CallWith=CurrentGlobalObject] IDBRequest count(any key);
 

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(VIDEO)
 
+#include "HTMLMediaElementEnums.h"
 #include "JSValueInWrappedObject.h"
 #include "MediaSession.h"
 #include <wtf/Ref.h>
@@ -52,8 +53,6 @@ class VTTCue;
 class VoidCallback;
 
 struct MediaControlsContextMenuItem;
-
-enum class HTMLMediaElementSourceType : uint8_t;
 
 class MediaControlsHost final
     : public CanMakeWeakPtr<MediaControlsHost>

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -4410,6 +4410,7 @@ JSIDBCursorDirection.cpp
 JSIDBCursorWithValue.cpp
 JSIDBDatabase.cpp
 JSIDBFactory.cpp
+JSIDBGetAllOptions.cpp
 JSIDBIndex.cpp
 JSIDBKeyRange.cpp
 JSIDBObjectStore.cpp


### PR DESCRIPTION
#### d6ceec146cc55b00cdecd66993d08158ce60f1d3
<pre>
[IndexedDB API] Add IDL and stub for IDBIndex::getAllRecords()
<a href="https://bugs.webkit.org/show_bug.cgi?id=310594">https://bugs.webkit.org/show_bug.cgi?id=310594</a>
<a href="https://rdar.apple.com/173205766">rdar://173205766</a>

Reviewed by Sihui Liu and Brady Eidson.

This adds the IDL for IDBIndex::getAllRecords() and a stub that returns a
NotSupportedError. It is gated behind a new feature flag IndexedDBGetAllRecordsEnabled.

The implementation will come in future patches.

* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAll-options.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAll-options.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAll-options.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAll-options.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllKeys-options.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllKeys-options.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllKeys-options.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllKeys-options.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllRecords.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllRecords.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllRecords.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllRecords.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idlharness.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idlharness.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idlharness.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idlharness.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.worker-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Modules/indexeddb/IDBGetAllOptions.h: Added.
* Source/WebCore/Modules/indexeddb/IDBGetAllOptions.idl: Added.
* Source/WebCore/Modules/indexeddb/IDBIndex.cpp:
(WebCore::IDBIndex::getAllRecords):
* Source/WebCore/Modules/indexeddb/IDBIndex.h:
* Source/WebCore/Modules/indexeddb/IDBIndex.idl:
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.h:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/309868@main">https://commits.webkit.org/309868@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e084479db3a16fab29c8177358c4c33d3962172

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151842 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24623 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18193 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160584 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105299 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153716 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25116 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24920 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117286 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83220 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b981e5aa-9956-444d-a56b-5cfa62dd29cb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154802 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19458 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136265 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98001 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18543 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16477 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8419 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/143848 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128175 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14168 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163048 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/12643 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6197 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15760 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125303 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24422 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20536 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125484 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24423 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135964 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80998 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23327 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20515 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12739 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/183453 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24040 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88325 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46788 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23731 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23891 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23792 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->