### PR TITLE
[GTK] LayerTreeHost: Acquire a lock on zoom layer before manipulating it

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -490,6 +490,7 @@ void LayerTreeHost::applyTransientZoomToLayers(double scale, FloatPoint origin)
     transform.translate(constrainedOrigin.x(), constrainedOrigin.y());
     transform.scale(scale);
 
+    Locker locker { zoomLayer->lock() };
     zoomLayer->setTransform(transform);
     zoomLayer->setAnchorPoint(FloatPoint3D());
     zoomLayer->setPosition(FloatPoint());
@@ -512,7 +513,9 @@ void LayerTreeHost::commitTransientZoom(double scale, FloatPoint origin, FloatPo
         TransformationMatrix finalTransform;
         finalTransform.scale(scale);
 
-        layerForTransientZoom()->setTransform(finalTransform);
+        auto* zoomLayer = layerForTransientZoom();
+        Locker locker { zoomLayer->lock() };
+        zoomLayer->setTransform(finalTransform);
     }
 
     m_transientZoom = false;


### PR DESCRIPTION
#### 5e1e4b73d5babf39bdacc652674af8733b464362
<pre>
[GTK] LayerTreeHost: Acquire a lock on zoom layer before manipulating it
<a href="https://bugs.webkit.org/show_bug.cgi?id=310595">https://bugs.webkit.org/show_bug.cgi?id=310595</a>

Reviewed by Carlos Garcia Campos.

Fixes following assertions:

ASSERTION FAILED: m_lock.isHeld()
/WebKit/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp(274) : void WebCore::CoordinatedPlatformLayer::setTransform(const WebCore::TransformationMatrix&amp;)
1   0x7feca50e6702 WebCore::CoordinatedPlatformLayer::setTransform(WebCore::TransformationMatrix const&amp;)
2   0x7feca502a6fe WebKit::LayerTreeHost::applyTransientZoomToLayers(double, WebCore::FloatPoint)
3   0x7feca502ac70 WebKit::LayerTreeHost::adjustTransientZoom(double, WebCore::FloatPoint, WebCore::FloatPoint)
4   0x7feca50281cc WebKit::DrawingAreaCoordinatedGraphics::adjustTransientZoom(double, WebCore::FloatPoint)
(...)

ASSERTION FAILED: m_lock.isHeld()
/WebKit/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp(274) : void WebCore::CoordinatedPlatformLayer::setTransform(const WebCore::TransformationMatrix&amp;)
1   0x7fa913ce6702 WebCore::CoordinatedPlatformLayer::setTransform(WebCore::TransformationMatrix const&amp;)
2   0x7fa913c2886e WebKit::LayerTreeHost::commitTransientZoom(double, WebCore::FloatPoint, WebCore::FloatPoint)
3   0x7fa913c1c529 WebKit::DrawingAreaCoordinatedGraphics::commitTransientZoom(double, WebCore::FloatPoint, WTF::CompletionHandler&lt;void ()&gt;&amp;&amp;)
(...)

* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::applyTransientZoomToLayers):
(WebKit::LayerTreeHost::commitTransientZoom):

Canonical link: <a href="https://commits.webkit.org/309824@main">https://commits.webkit.org/309824@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4513dd343a009886b4093d069d71051b501776c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151859 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24640 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18210 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160601 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25133 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24938 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117294 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154819 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136274 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98009 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/18554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/16489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8436 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163065 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/6214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15769 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125311 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24439 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20548 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125492 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34045 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24440 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135973 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/81015 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20525 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12748 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24057 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88342 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23748 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23908 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23809 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->