### PR TITLE
YouTube started autoplaying in background tab

### DIFF
--- a/LayoutTests/media/media-playback-in-background-after-pausing-expected.txt
+++ b/LayoutTests/media/media-playback-in-background-after-pausing-expected.txt
@@ -1,0 +1,21 @@
+
+RUN(internals.consumeTransientActivation())
+EVENT(canplay)
+RUN(video.play())
+Promise resolved OK
+RUN(internals.setMediaElementGracePeriodForResumingPlaybackInBackground(video, 20000))
+RUN(video.pause())
+EVENT(pause)
+Sleep 50ms:
+RUN(internals.setPageVisibility(false))
+RUN(video.play())
+Promise resolved OK
+-
+RUN(internals.setMediaElementGracePeriodForResumingPlaybackInBackground(video, 10))
+RUN(video.pause())
+Sleep 50ms:
+RUN(internals.setPageVisibility(false))
+RUN(video.play())
+Promise rejected correctly OK
+END OF TEST
+

--- a/LayoutTests/media/media-playback-in-background-after-pausing.html
+++ b/LayoutTests/media/media-playback-in-background-after-pausing.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>media-playback-in-background-after-pausing</title>
+	<script src="video-test.js"></script>
+	<script src="media-file.js"></script>
+	<script>
+	async function runTest() {
+		findMediaElement();
+		video.loop = true;
+		video.src = findMediaFile('video', 'content/test');
+
+		run('internals.consumeTransientActivation()');
+
+		await waitFor(video, 'canplay');
+		await shouldResolve(run('video.play()'));
+
+		run('internals.setMediaElementGracePeriodForResumingPlaybackInBackground(video, 20000)');
+		run('video.pause()');
+		await waitFor(video, 'pause');
+
+		consoleWrite('Sleep 50ms:')
+		await sleepFor(50);
+		run('internals.setPageVisibility(false)');
+		await shouldResolve(run('video.play()'));
+
+		consoleWrite('-');
+		run('internals.setMediaElementGracePeriodForResumingPlaybackInBackground(video, 10)');
+		run('video.pause()');
+		consoleWrite('Sleep 50ms:')
+		await sleepFor(50);
+		run('internals.setPageVisibility(false)');
+		await shouldReject(run('video.play()'));
+	}
+
+	window.addEventListener('load', event => {
+		runTest().then(endTest).catch(failTest);
+	})
+	</script>
+</head>
+<body>
+	<video></video>
+</body>
+</html>

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -695,6 +695,7 @@ void HTMLMediaElement::initializeMediaSession()
     m_mediaSession = mediaSession.copyRef();
     mediaSession->addBehaviorRestriction(MediaElementSession::RequireUserGestureForFullscreen);
     mediaSession->addBehaviorRestriction(MediaElementSession::RequirePageConsentToLoadMedia);
+    mediaSession->addBehaviorRestriction(MediaElementSession::RequiresUserGestureWhenPausedInBackground);
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
     mediaSession->addBehaviorRestriction(MediaElementSession::RequireUserGestureToAutoplayToExternalDevice);
 #endif

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -122,6 +122,7 @@ static String restrictionNames(MediaElementSession::BehaviorRestrictions restric
     CASE(RequirePlaybackToControlControlsManager)
     CASE(RequireUserGestureForVideoDueToLowPowerMode)
     CASE(RequireUserGestureForVideoDueToAggressiveThermalMitigation)
+    CASE(RequiresUserGestureWhenPausedInBackground)
 
     return restrictionBuilder.toString();
 }
@@ -489,6 +490,17 @@ Expected<void, MediaPlaybackDenialExplanation> MediaElementSession::playbackStat
     if (m_restrictions & RequireUserGestureForAudioRateChange && (!element->isVideo() || element->hasAudio()) && !element->muted() && element->volume() && !document->processingUserGestureForMedia())
         return makeUnexpectedDenial(MediaPlaybackDenialReason::UserGestureRequired, "User gesture required for audio rate change"_s);
 
+    if (m_restrictions & RequiresUserGestureWhenPausedInBackground
+        && state == MediaPlaybackState::Playing
+        && document->hidden()
+        && !document->processingUserGestureForMedia()) {
+        if (!m_mostRecentPlaybackEndedTime)
+            return makeUnexpectedDenial(MediaPlaybackDenialReason::UserGestureRequired, "User gesture required when not visible"_s);
+
+        auto durationSinceMostRecentPlaybackEnded = MonotonicTime::now() - *m_mostRecentPlaybackEndedTime;
+        if (durationSinceMostRecentPlaybackEnded > gracePeriodForResumingPlaybackInBackground())
+            return makeUnexpectedDenial(MediaPlaybackDenialReason::UserGestureRequired, "User gesture required when not visible"_s);
+    }
 
     if (m_restrictions & RequirePageVisibilityToPlayAudio && (!element->isVideo() || element->hasAudio()) && !element->muted() && element->volume() && element->elementIsHidden())
         return makeUnexpectedDenial(MediaPlaybackDenialReason::UserGestureRequired, "Page visibility required for audio rate change"_s);
@@ -1097,6 +1109,13 @@ void MediaElementSession::mediaEngineUpdated()
     client().setShouldPlayToPlaybackTarget(m_shouldPlayToPlaybackTarget);
 #endif
 
+}
+
+void MediaElementSession::setState(State state)
+{
+    if (this->state() == State::Playing && state != State::Playing)
+        m_mostRecentPlaybackEndedTime = MonotonicTime::now();
+    PlatformMediaSession::setState(state);
 }
 
 void MediaElementSession::resetPlaybackSessionState()

--- a/Source/WebCore/html/MediaElementSession.h
+++ b/Source/WebCore/html/MediaElementSession.h
@@ -123,6 +123,7 @@ public:
 
     void mediaEngineUpdated();
 
+    void setState(State) override;
     void resetPlaybackSessionState() override;
 
     void suspendBuffering() override;
@@ -153,6 +154,7 @@ public:
 #if ENABLE(REQUIRES_PAGE_VISIBILITY_FOR_NOW_PLAYING)
         RequirePageVisibilityForVideoToBeNowPlaying = 1 << 18,
 #endif
+        RequiresUserGestureWhenPausedInBackground = 1 << 19,
         AllRestrictions = ~NoRestrictions,
     };
     typedef unsigned BehaviorRestrictions;
@@ -206,6 +208,9 @@ public:
 
     bool hasNowPlayingInfo() const;
 
+    Seconds gracePeriodForResumingPlaybackInBackground() const { return m_gracePeriodForResumingPlaybackInBackground; }
+    void setGracePeriodForResumingPlaybackInBackground(Seconds period) { m_gracePeriodForResumingPlaybackInBackground = period; }
+
 private:
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
@@ -251,6 +256,8 @@ private:
 #endif
 
     Markable<MonotonicTime> m_mostRecentUserInteractionTime;
+    Markable<MonotonicTime> m_mostRecentPlaybackEndedTime;
+    Seconds m_gracePeriodForResumingPlaybackInBackground { 10_s };
 
     mutable bool m_isMainContent { false };
     Timer m_mainContentCheckTimer;

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -5329,6 +5329,8 @@ void Internals::setMediaElementRestrictions(HTMLMediaElement& element, StringVie
         if (equalLettersIgnoringASCIICase(restrictionString, "requirepagevisibilityforvideotobenowplaying"_s))
             restrictions |= MediaElementSession::RequirePageVisibilityForVideoToBeNowPlaying;
 #endif
+        if (equalLettersIgnoringASCIICase(restrictionString, "requiresusergesturewhenpausedinbackground"_s))
+            restrictions |= MediaElementSession::RequiresUserGestureWhenPausedInBackground;
     }
     element.mediaSession().addBehaviorRestriction(restrictions);
 }
@@ -5469,6 +5471,10 @@ void Internals::resumeAllMediaPlayback()
     page->resumeAllMediaPlayback();
 }
 
+void Internals::setMediaElementGracePeriodForResumingPlaybackInBackground(const HTMLMediaElement& element, long period)
+{
+    element.mediaSession().setGracePeriodForResumingPlaybackInBackground(Seconds::fromMilliseconds(period));
+}
 #endif // ENABLE(VIDEO)
 
 #if ENABLE(WEB_AUDIO)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -926,6 +926,7 @@ public:
     void suspendAllMediaBuffering();
     void suspendAllMediaPlayback();
     void resumeAllMediaPlayback();
+    void setMediaElementGracePeriodForResumingPlaybackInBackground(const HTMLMediaElement&, long period);
 #endif
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1096,6 +1096,7 @@ enum ContentsFormat {
     [Conditional=VIDEO] undefined suspendAllMediaBuffering();
     [Conditional=VIDEO] undefined suspendAllMediaPlayback();
     [Conditional=VIDEO] undefined resumeAllMediaPlayback();
+    [Conditional=VIDEO] undefined setMediaElementGracePeriodForResumingPlaybackInBackground(HTMLMediaElement element, long period);
 
     [Conditional=WIRELESS_PLAYBACK_TARGET] undefined setMockMediaPlaybackTargetPickerEnabled(boolean enabled);
     [Conditional=WIRELESS_PLAYBACK_TARGET] undefined setMockMediaPlaybackTargetPickerState(DOMString deviceName, DOMString deviceState);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/RequiresUserActionForPlayback.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/RequiresUserActionForPlayback.mm
@@ -29,6 +29,7 @@
 #import "PlatformUtilities.h"
 #import "Test.h"
 #import "TestNavigationDelegate.h"
+#import "TestWKWebView.h"
 #import <WebKit/WKWebViewConfigurationPrivate.h>
 #import <WebKit/WebKit.h>
 #import <wtf/RetainPtr.h>
@@ -65,21 +66,13 @@ public:
 
     void createWebView()
     {
-        webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-#if TARGET_OS_IPHONE
-        window = adoptNS([[UIWindow alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
-        [window addSubview:webView.get()];
-#else
-        window = adoptNS([[NSWindow alloc] initWithContentRect:webView.get().frame styleMask:NSBorderlessWindowMask backing:NSBackingStoreBuffered defer:NO]);
-        [window.get().contentView addSubview:webView.get()];
-#endif
+        webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
+        [webView setVisibility:YES];
     }
 
     void testVideoWithAudio()
     {
-        NSURL *fileURL = [NSBundle.test_resourcesBundle URLForResource:@"video-with-audio" withExtension:@"html"];
-        [webView loadFileURL:fileURL allowingReadAccessToURL:fileURL];
-        [webView _test_waitForDidFinishNavigation];
+        [webView synchronouslyLoadTestPageNamed:@"video-with-audio"];
 
         TestWebKitAPI::Util::run(&receivedScriptMessage);
         receivedScriptMessage = false;
@@ -87,9 +80,7 @@ public:
 
     void testVideoWithoutAudio()
     {
-        NSURL *fileURL = [NSBundle.test_resourcesBundle URLForResource:@"video-without-audio" withExtension:@"html"];
-        [webView loadFileURL:fileURL allowingReadAccessToURL:fileURL];
-        [webView _test_waitForDidFinishNavigation];
+        [webView synchronouslyLoadTestPageNamed:@"video-without-audio"];
 
         TestWebKitAPI::Util::run(&receivedScriptMessage);
         receivedScriptMessage = false;
@@ -97,9 +88,7 @@ public:
 
     void testAudioOnly()
     {
-        NSURL *fileURL = [NSBundle.test_resourcesBundle URLForResource:@"audio-only" withExtension:@"html"];
-        [webView loadFileURL:fileURL allowingReadAccessToURL:fileURL];
-        [webView _test_waitForDidFinishNavigation];
+        [webView synchronouslyLoadTestPageNamed:@"audio-only"];
 
         TestWebKitAPI::Util::run(&receivedScriptMessage);
         receivedScriptMessage = false;
@@ -107,12 +96,7 @@ public:
 
     RetainPtr<RequiresUserActionForPlaybackMessageHandler> handler;
     RetainPtr<WKWebViewConfiguration> configuration;
-    RetainPtr<WKWebView> webView;
-#if TARGET_OS_IPHONE
-    RetainPtr<UIWindow> window;
-#else
-    RetainPtr<NSWindow> window;
-#endif
+    RetainPtr<TestWKWebView> webView;
 };
 
 #if TARGET_OS_IPHONE


### PR DESCRIPTION
#### 4e392c1aa63f482e0671eed72d916651e89d92e3
<pre>
YouTube started autoplaying in background tab
<a href="https://rdar.apple.com/169468617">rdar://169468617</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=310600">https://bugs.webkit.org/show_bug.cgi?id=310600</a>

Reviewed by NOBODY (OOPS!).

Add a new behavior restrictions that prevents media elements in non-visible views
from starting playback without a user gesture. (Media elements already require a
visible view to start initial playback.) However, to support functionality such
as autoplay playlists, allow a 10s grace period to restart playback without a user
gesture when in a non-visible view.

To support testing this feature, add new methods to Internals to allow the grace
period to be configured.

Test: media/media-playback-in-background-after-pausing.html

* LayoutTests/media/media-playback-in-background-after-pausing-expected.txt: Added.
* LayoutTests/media/media-playback-in-background-after-pausing.html: Added.
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::initializeMediaSession):
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::restrictionNames):
(WebCore::MediaElementSession::playbackStateChangePermitted const):
(WebCore::MediaElementSession::setState):
* Source/WebCore/html/MediaElementSession.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::setMediaElementRestrictions):
(WebCore::Internals::setMediaElementGracePeriodForResumingPlaybackInBackground):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e392c1aa63f482e0671eed72d916651e89d92e3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152423 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25205 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18804 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161166 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105880 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1e3a4ec5-7bde-4282-a595-e270c8d7b328) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154297 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25733 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25511 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117778 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83490 "2 flakes 2 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/17744f3d-1693-4211-8065-32ece59ad611) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155383 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19988 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136841 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98492 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/35f5de99-364b-44a8-9d54-9330d446c175) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19065 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17000 "Found 3 new API test failures: TestWebKitAPI.RequiresUserActionForPlaybackTest.DeprecatedRequiresUserActionForAudioButNotVideoPlayback, TestWebKitAPI.RequiresUserActionForPlaybackTest.RequiresUserActionForVideoButNotAudioPlayback, TestWebKitAPI.RequiresUserActionForPlaybackTest.DeprecatedRequiresUserActionForVideoButNotAudioPlayback (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9001 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128715 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14715 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163636 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6778 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16309 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125814 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25003 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21039 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125985 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25005 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136511 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81605 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20980 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13290 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24621 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88907 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24312 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24472 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24373 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->