### PR TITLE
SpeechSynthesis: empty utterances don't fire start/end events, causing WPT test timeout

### DIFF
--- a/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
@@ -62,6 +62,7 @@ SpeechSynthesis::SpeechSynthesis(ScriptExecutionContext& context)
     , m_isPaused(false)
     , m_restrictions({ })
     , m_speechSynthesisClient(nullptr)
+    , m_emptyUtteranceTimer(RunLoop::mainSingleton(), "SpeechSynthesis::EmptyUtteranceTimer"_s, this, &SpeechSynthesis::emptyUtteranceTimerFired)
 {
     if (auto* document = dynamicDowncast<Document>(context)) {
 #if PLATFORM(IOS_FAMILY)
@@ -153,6 +154,12 @@ void SpeechSynthesis::startSpeakingImmediately(SpeechSynthesisUtterance& utteran
     m_currentSpeechUtterance = makeUnique<SpeechSynthesisUtteranceActivity>(Ref { utterance });
     m_isPaused = false;
 
+    // Use RunLoop::Timer for empty utterances to fire start/end events reliably (rdar://81465164).
+    if (utterance.text().isEmpty()) {
+        m_emptyUtteranceTimer.startOneShot(0_s);
+        return;
+    }
+
     if (RefPtr speechSynthesisClient = m_speechSynthesisClient.get())
         speechSynthesisClient->speak(&utterance.platformUtterance());
     else
@@ -177,6 +184,8 @@ void SpeechSynthesis::speak(SpeechSynthesisUtterance& utterance)
 
 void SpeechSynthesis::cancel()
 {
+    m_emptyUtteranceTimer.stop();
+
     // Remove all the items from the utterance queue.
     // Hold on to the current utterance so the platform synthesizer can have a chance to clean up.
     RefPtr current = currentSpeechUtterance();
@@ -223,6 +232,15 @@ void SpeechSynthesis::resumeSynthesis()
         else if (RefPtr platformSpeechSynthesizer = m_platformSpeechSynthesizer)
             platformSpeechSynthesizer->resume();
     }
+}
+
+void SpeechSynthesis::emptyUtteranceTimerFired()
+{
+    if (!m_currentSpeechUtterance)
+        return;
+    Ref utterance = m_currentSpeechUtterance->utterance();
+    didStartSpeaking(utterance->platformUtterance());
+    handleSpeakingCompleted(utterance.get(), false);
 }
 
 void SpeechSynthesis::handleSpeakingCompleted(SpeechSynthesisUtterance& utterance, bool errorOccurred)

--- a/Source/WebCore/Modules/speech/SpeechSynthesis.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.h
@@ -36,6 +36,7 @@
 #include "SpeechSynthesisVoice.h"
 #include <wtf/Deque.h>
 #include <wtf/RefCounted.h>
+#include <wtf/RunLoop.h>
 
 namespace WebCore {
 
@@ -104,6 +105,7 @@ private:
 
     void startSpeakingImmediately(SpeechSynthesisUtterance&);
     void handleSpeakingCompleted(SpeechSynthesisUtterance&, bool errorOccurred);
+    void emptyUtteranceTimerFired();
 
     // EventTarget
     ScriptExecutionContext* NODELETE scriptExecutionContext() const final;
@@ -124,6 +126,7 @@ private:
     BehaviorRestrictions m_restrictions;
     WeakPtr<SpeechSynthesisClient> m_speechSynthesisClient;
     bool m_hasEventListener { false };
+    RunLoop::Timer m_emptyUtteranceTimer;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 09769dce41ea7c52332cd8c8dadebcf0164a761c
<pre>
SpeechSynthesis: empty utterances don&apos;t fire start/end events, causing WPT test timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=310602">https://bugs.webkit.org/show_bug.cgi?id=310602</a>
<a href="https://rdar.apple.com/173190750">rdar://173190750</a>

Reviewed by NOBODY (OOPS\!).

SpeechSynthesis::startSpeakingImmediately() uses queueTaskKeepingObjectAlive to
asynchronously fire start/end events for empty utterances. The queued task never
executes, so empty utterances hang indefinitely. Replace with a RunLoop::Timer
which fires reliably.

* Source/WebCore/Modules/speech/SpeechSynthesis.cpp:
(WebCore::m_emptyUtteranceTimer):
(WebCore::SpeechSynthesis::startSpeakingImmediately):
(WebCore::SpeechSynthesis::cancel):
(WebCore::SpeechSynthesis::emptyUtteranceTimerFired):
* Source/WebCore/Modules/speech/SpeechSynthesis.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09769dce41ea7c52332cd8c8dadebcf0164a761c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151825 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24606 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18176 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160567 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105282 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153699 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25099 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24903 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117264 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83211 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fb7af922-ae8b-469a-b681-481aa3dff01a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154785 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19431 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136246 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97979 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18516 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16457 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8402 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128148 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14149 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163031 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6180 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15741 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125286 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24405 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20516 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125467 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24406 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135945 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80981 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20493 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12720 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24023 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88308 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23714 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23874 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23775 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->