### PR TITLE
[JSC] Fix DFG crash when function with using declaration ends with return

### DIFF
--- a/JSTests/stress/using-declaration-return-last-statement-dfg.js
+++ b/JSTests/stress/using-declaration-return-last-statement-dfg.js
@@ -1,0 +1,28 @@
+//@ requireOptions("--useExplicitResourceManagement=true")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${String(actual)}, expected: ${String(expected)}`);
+}
+
+let shouldThrow = false;
+
+function test(val) {
+    using x = {
+        [Symbol.dispose]() {}
+    };
+    if (shouldThrow)
+        throw 1;
+    return val + 1;
+}
+
+noInline(test);
+
+shouldThrow = true;
+for (let i = 0; i < 20; i++) {
+    try { test(i); } catch {}
+}
+shouldThrow = false;
+
+for (let i = 0; i < testLoopCount; i++)
+    shouldBe(test(i), i + 1);

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -5730,7 +5730,9 @@ void FunctionNode::emitBytecode(BytecodeGenerator& generator, RegisterID*)
         ReturnNode* returnNode = nullptr;
 
         // Check for a return statement at the end of a function composed of a single block.
-        if (singleStatement && singleStatement->isBlock()) {
+        // With using declarations, emitUsingBodyScope ends with a `done` label that needs
+        // a terminal, otherwise it collides with the op_catch stubs appended by generate().
+        if (singleStatement && singleStatement->isBlock() && !usingDeclarationCount()) {
             StatementNode* lastStatementInBlock = static_cast<BlockNode*>(singleStatement)->lastStatement();
             if (lastStatementInBlock && lastStatementInBlock->isReturnNode())
                 returnNode = static_cast<ReturnNode*>(lastStatementInBlock);


### PR DESCRIPTION
#### 87b77483e7f4995bcb22a9702d2f316f8660b352
<pre>
[JSC] Fix DFG crash when function with using declaration ends with return
<a href="https://bugs.webkit.org/show_bug.cgi?id=310604">https://bugs.webkit.org/show_bug.cgi?id=310604</a>

Reviewed by Yusuke Suzuki.

FunctionNode::emitBytecode skips the implicit &quot;return undefined&quot; when the
last statement is a return. With using declarations, emitUsingBodyScope
ends with a `done` label that then shares a bytecode offset with the
deferred op_catch stubs appended by generate(). Jumps from
emitFinallyCompletion to `done` target the catch block, giving it
predecessors and violating the DFG invariant that catch entrypoints are
roots.

Skip this optimization when using declarations are present so the implicit
return terminates the `done` block.

Test: JSTests/stress/using-declaration-return-last-statement-dfg.js

* JSTests/stress/using-declaration-return-last-statement-dfg.js: Added.
(shouldBe):
(test):
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::FunctionNode::emitBytecode):

Canonical link: <a href="https://commits.webkit.org/309825@main">https://commits.webkit.org/309825@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41378b9d0f4aab24ecdec92676b4305fb0ce79b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151823 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24604 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18174 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160565 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25097 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24901 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117266 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154783 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19430 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136244 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97981 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18515 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16454 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8400 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/143829 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128147 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14147 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163029 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/12624 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6178 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15739 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125285 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24403 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20513 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125466 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34046 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24404 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135943 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80979 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20505 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12718 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/183434 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24021 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88306 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46787 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23712 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23872 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23773 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->