### PR TITLE
NavigateEvent#navigationType should be "replace" when navigating to a URL that matches the active document's URL

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-same-url-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-same-url-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL <a> to identical url is a replace navigation assert_equals: expected "replace" but got "push"
+PASS <a> to identical url is a replace navigation
 

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -602,7 +602,7 @@ void HTMLAnchorElement::handleClick(Event& event)
     // Thus, URLs should be empty for now.
     ASSERT(!privateClickMeasurement || (privateClickMeasurement->attributionReportClickSourceURL().isNull() && privateClickMeasurement->attributionReportClickDestinationURL().isNull()));
     
-    frame->loader().changeLocation(completedURL, effectiveTarget, &event, referrerPolicy, document->shouldOpenExternalURLsPolicyToPropagate(), newFrameOpenerPolicy, downloadAttribute, WTF::move(privateClickMeasurement), NavigationHistoryBehavior::Push, this);
+    frame->loader().changeLocation(completedURL, effectiveTarget, &event, referrerPolicy, document->shouldOpenExternalURLsPolicyToPropagate(), newFrameOpenerPolicy, downloadAttribute, WTF::move(privateClickMeasurement), NavigationHistoryBehavior::Auto, this);
 
     sendPings(completedURL);
 

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1639,7 +1639,10 @@ void FrameLoader::loadURL(FrameLoadRequest&& frameLoadRequest, const String& ref
     bool isSameOrigin = protect(frameLoadRequest.requesterSecurityOrigin())->isSameOriginDomain(protect(document->securityOrigin()).get());
     if (!isReload(newLoadType)) {
         if (historyHandling == NavigationHistoryBehavior::Auto) {
-            if ((document->url() == newURL || document->readyState() != Document::ReadyState::Complete) && isSameOrigin)
+            // https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate (navigate-convert-to-replace)
+            // "If url equals navigable's active document's URL, and initiatorOriginSnapshot is
+            // same origin with navigable's active document's origin, then set historyHandling to 'replace'."
+            if (document->url() == newURL && isSameOrigin)
                 historyHandling = NavigationHistoryBehavior::Replace;
             else
                 historyHandling = NavigationHistoryBehavior::Push;


### PR DESCRIPTION
#### d56ef888827c41123460b958d32e1a135a81cd3f
<pre>
NavigateEvent#navigationType should be &quot;replace&quot; when navigating to a URL that matches the active document&apos;s URL
<a href="https://bugs.webkit.org/show_bug.cgi?id=306802">https://bugs.webkit.org/show_bug.cgi?id=306802</a>
<a href="https://rdar.apple.com/169999046">rdar://169999046</a>

Reviewed by Basuke Suzuki and Rupin Mittal.

When clicking an &lt;a&gt; element whose href matches the current document URL,
NavigateEvent.navigationType should be &quot;replace&quot; per the spec&apos;s
&quot;navigate-convert-to-replace&quot; step [1]. WebKit was returning &quot;push&quot; due
to two issues:

1. HTMLAnchorElement::handleClick() hardcoded NavigationHistoryBehavior::Push,
   bypassing the auto-resolution logic in FrameLoader that detects same-URL
   navigations and converts them to Replace.

2. The auto-resolution logic in FrameLoader also checked
   `document-&gt;readyState() != Complete`, which is unrelated to the spec&apos;s
   navigate-convert-to-replace step and is already handled at the call sites
   (e.g. Location.cpp).

Fix by changing HTMLAnchorElement to pass NavigationHistoryBehavior::Auto, and
simplifying the FrameLoader auto-resolution to match the spec: only convert
Auto to Replace when the URL equals the document URL and origins match.

[1] <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate-convert-to-replace">https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate-convert-to-replace</a>

No new tests, covered by the following rebaselined test:
- imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-same-url.html

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-same-url-expected.txt:
* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::HTMLAnchorElement::handleClick):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::loadURL):

Canonical link: <a href="https://commits.webkit.org/309871@main">https://commits.webkit.org/309871@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c1f10a49ced131a33c853b7972efdd54c418e10

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151827 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24608 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18178 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160569 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105284 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7130af25-bba3-457d-b755-a8f9594b049c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153701 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25101 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24905 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117269 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83213 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154787 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19433 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136252 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97984 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/809231bc-fefd-4bbb-8b24-f6fda5f33e8b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18518 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16459 "Found 3 new API test failures: TestWebKitAPI.WKWebExtensionAPIDOM.OpenOrClosedShadowRoot, TestWebKitAPI.TimeZoneOverrideTest.TimeZoneOverride, TestWebKitAPI.VerifyUserGesture.InvalidateAuthorizationTokensByPage (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8404 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128150 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14155 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163033 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6182 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15747 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125288 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24407 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20518 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125469 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34082 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24408 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135951 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80983 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20510 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12726 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24025 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88310 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23716 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23876 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23777 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->