### PR TITLE
Can't analyze HEIC images on web app, force converts to JPEG

### DIFF
--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -870,6 +870,10 @@ bool Quirks::shouldTranscodeHeicImagesForURL(const URL& url)
     if (quirksDomain.string() == "canva.com"_s)
         return true;
 
+    // uhc.com rdar://173206598
+    if (quirksDomain.string() == "uhc.com"_s)
+        return true;
+
     return false;
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm
@@ -49,6 +49,7 @@
 #import <WebCore/Pasteboard.h>
 #import <WebCore/PasteboardItemInfo.h>
 #import <WebCore/PlatformPasteboard.h>
+#import <WebCore/Quirks.h>
 #import <WebCore/SharedBuffer.h>
 #import <WebCore/UTIUtilities.h>
 #import <wtf/URL.h>
@@ -69,6 +70,18 @@ static PasteboardDataLifetime determineDataLifetime(std::optional<WebPageProxyId
         return page->sessionID().isEphemeral() ? PasteboardDataLifetime::Ephemeral : PasteboardDataLifetime::Persistent;
 
     return PasteboardDataLifetime::Persistent;
+}
+
+static bool shouldTranscodeHEICImagesForPage(std::optional<WebPageProxyIdentifier> pageID)
+{
+    if (!pageID)
+        return false;
+
+    RefPtr page = WebProcessProxy::webPage(*pageID);
+    if (!page)
+        return false;
+
+    return protect(page->preferences())->needsSiteSpecificQuirks() && Quirks::shouldTranscodeHeicImagesForURL(URL { page->currentURL() });
 }
 
 void WebPasteboardProxy::grantAccessToCurrentTypes(WebProcessProxy& process, const String& pasteboardName)
@@ -225,10 +238,12 @@ void WebPasteboardProxy::getPasteboardPathnamesForType(IPC::Connection& connecti
 
 #if PLATFORM(MAC)
         Vector<size_t> indicesToTranscode;
-        for (size_t i = 0; i < pathnames.size(); ++i) {
-            auto mimeType = WebCore::MIMETypeRegistry::mimeTypeForPath(pathnames[i]);
-            if (mimeType == "image/heic"_s || mimeType == "image/heif"_s)
-                indicesToTranscode.append(i);
+        if (shouldTranscodeHEICImagesForPage(pageID)) {
+            for (size_t i = 0; i < pathnames.size(); ++i) {
+                auto mimeType = WebCore::MIMETypeRegistry::mimeTypeForPath(pathnames[i]);
+                if (mimeType == "image/heic"_s || mimeType == "image/heif"_s)
+                    indicesToTranscode.append(i);
+            }
         }
 
         if (indicesToTranscode.isEmpty()) {
@@ -587,9 +602,12 @@ static void notifyNetworkProcessOfTranscodedFiles(RefPtr<WebProcessProxy>& proce
         protect(protect(process->websiteDataStore())->networkProcess())->sendWithAsyncReply(Messages::NetworkProcess::AllowFilesAccessFromWebProcess(process->coreProcessIdentifier(), nonEmptyPaths), [] { });
 }
 
-static Vector<HEICTranscodingInfo> findHEICPathsForTranscoding(Vector<PasteboardItemInfo>& allInfo)
+static Vector<HEICTranscodingInfo> findHEICPathsForTranscoding(Vector<PasteboardItemInfo>& allInfo, std::optional<WebPageProxyIdentifier> pageID)
 {
     Vector<HEICTranscodingInfo> transcodingInfo;
+    if (!shouldTranscodeHEICImagesForPage(pageID))
+        return transcodingInfo;
+
     for (size_t infoIndex = 0; infoIndex < allInfo.size(); ++infoIndex) {
         auto& info = allInfo[infoIndex];
         for (size_t pathIndex = 0; pathIndex < info.pathsForFileUpload.size(); ++pathIndex) {
@@ -604,10 +622,10 @@ static Vector<HEICTranscodingInfo> findHEICPathsForTranscoding(Vector<Pasteboard
     return transcodingInfo;
 }
 
-static Vector<HEICTranscodingInfo> findHEICPathsForTranscoding(PasteboardItemInfo& info)
+static Vector<HEICTranscodingInfo> findHEICPathsForTranscoding(PasteboardItemInfo& info, std::optional<WebPageProxyIdentifier> pageID)
 {
     Vector<PasteboardItemInfo> items { info };
-    return findHEICPathsForTranscoding(items);
+    return findHEICPathsForTranscoding(items, pageID);
 }
 #endif
 
@@ -630,7 +648,7 @@ void WebPasteboardProxy::allPasteboardItemInfo(IPC::Connection& connection, cons
             return;
         }
 
-        auto transcodingInfo = findHEICPathsForTranscoding(*allInfo);
+        auto transcodingInfo = findHEICPathsForTranscoding(*allInfo, pageID);
         if (transcodingInfo.isEmpty()) {
             completionHandler(WTF::move(allInfo));
             return;
@@ -680,7 +698,7 @@ void WebPasteboardProxy::informationForItemAtIndex(IPC::Connection& connection, 
             return;
         }
 
-        auto transcodingInfo = findHEICPathsForTranscoding(*info);
+        auto transcodingInfo = findHEICPathsForTranscoding(*info, pageID);
         if (transcodingInfo.isEmpty()) {
             completionHandler(WTF::move(info));
             return;


### PR DESCRIPTION
#### b5cac067b0db51def1bd4da3ec45a76bc35bafcf
<pre>
Can&apos;t analyze HEIC images on web app, force converts to JPEG
<a href="https://bugs.webkit.org/show_bug.cgi?id=310605">https://bugs.webkit.org/show_bug.cgi?id=310605</a>
<a href="https://rdar.apple.com/173206598">rdar://173206598</a>

Reviewed by Aditya Keerthi and Tim Horton.

Moved the change implemented here: <a href="https://bugs.webkit.org/show_bug.cgi?id=292350">https://bugs.webkit.org/show_bug.cgi?id=292350</a>
to a quirk specifically for uhc.com.

Uhc.com was the original domain that the radar was filed for: <a href="https://rdar.apple.com/97210206">rdar://97210206</a>

* Source/WebCore/page/Quirks.cpp:
* Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm:
(WebKit::shouldTranscodeHeicImagesForPage):
(WebKit::WebPasteboardProxy::getPasteboardPathnamesForType):
(WebKit::WebPasteboardProxy::allPasteboardItemInfo):
(WebKit::WebPasteboardProxy::informationForItemAtIndex):

Canonical link: <a href="https://commits.webkit.org/309872@main">https://commits.webkit.org/309872@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f61e9900516d8a4d4a0c873e085992a9db5476d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151924 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24705 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18277 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160666 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105381 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153798 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25198 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25009 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117357 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83255 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154884 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19525 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136333 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98072 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18607 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16541 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8501 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128240 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14236 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163131 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6279 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15828 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125375 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24504 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20600 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125555 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34083 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24505 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136032 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/81087 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20582 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12807 "Passed tests") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24122 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88407 "Built successfully") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23813 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23973 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23874 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->