### PR TITLE
REGRESSION(309376@main): Crash in ResizeObserver::observeInternal

### DIFF
--- a/LayoutTests/resize-observer/resize-observer-observe-twice-expected.txt
+++ b/LayoutTests/resize-observer/resize-observer-observe-twice-expected.txt
@@ -1,0 +1,3 @@
+This tests observing a disconnected element twice. WebKit should not hit any assertions.
+
+PASS

--- a/LayoutTests/resize-observer/resize-observer-observe-twice.html
+++ b/LayoutTests/resize-observer/resize-observer-observe-twice.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<body>
+<p>This tests observing a disconnected element twice. WebKit should not hit any assertions.</p>
+<div id="result"></div>
+<script>
+
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+    requestAnimationFrame(() => {
+        setTimeout(() => {
+            testRunner.notifyDone();
+        }, 0);
+    })
+}
+
+let container = document.createElement('div');
+const observer = new ResizeObserver(() => {
+    result.textContent = 'PASS';
+});
+observer.observe(container);
+observer.observe(container, {box: 'border-box'});
+
+</script>

--- a/Source/WebCore/page/ResizeObserver.cpp
+++ b/Source/WebCore/page/ResizeObserver.cpp
@@ -74,16 +74,17 @@ void ResizeObserver::observeInternal(Element& target, const ResizeObserverBoxOpt
     auto addResult = m_observationMap.ensure(target, [&]() {
         return ResizeObservation::create(target, boxOptions);
     });
+    Ref observation = addResult.iterator->value;
     if (!addResult.isNewEntry) {
         // The spec suggests unconditionally unobserving here, but that causes a test failure:
         // https://github.com/web-platform-tests/wpt/issues/30708
-        if (addResult.iterator->value->observedBox() == boxOptions)
+        if (observation->observedBox() == boxOptions)
             return;
         unobserve(target);
     }
     auto& observerData = target.ensureResizeObserverData();
     observerData.observers.append(*this);
-    m_observations.add(addResult.iterator->value.copyRef());
+    m_observations.add(WTF::move(observation));
 
     // Per the specification, we should dispatch at least one observation for the target. For this reason, we make sure to keep the
     // target alive until this first observation. This, in turn, will keep the ResizeObserver's JS wrapper alive via


### PR DESCRIPTION
#### ce5c270171963802294b8050b40bf05d6f874eef
<pre>
REGRESSION(309376@main): Crash in ResizeObserver::observeInternal
<a href="https://bugs.webkit.org/show_bug.cgi?id=310608">https://bugs.webkit.org/show_bug.cgi?id=310608</a>
<a href="https://rdar.apple.com/173145739">rdar://173145739</a>

Reviewed by Anne van Kesteren.

The bug was caused by ResizeObserver::observeInternal calling ResizeObserver::unobserve,
which removes the entry from ListHashSet and invalidates the ListHashSet iterator.
Fixed the crash by storing the value in a local variable and avoid accessing it via
the invalidated iterator.

Test: resize-observer/resize-observer-observe-twice.html

* LayoutTests/resize-observer/resize-observer-observe-twice-expected.txt: Added.
* LayoutTests/resize-observer/resize-observer-observe-twice.html: Added.
* Source/WebCore/page/ResizeObserver.cpp:
(WebCore::ResizeObserver::observeInternal):

Canonical link: <a href="https://commits.webkit.org/309875@main">https://commits.webkit.org/309875@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fee507fd505f81fc44b8d14d06e6ee6bb0d480c1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151847 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24628 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18198 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160589 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105304 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/121f6378-234c-4897-a395-add8d663cfbd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153721 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25121 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24925 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117283 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83218 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154807 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19454 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136261 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97998 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/81091308-fdd7-4f21-8f2c-6b467934163e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18539 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16478 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8424 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128171 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14164 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163053 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6202 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15756 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125300 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24427 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20537 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125481 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24428 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135960 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81003 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23328 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20517 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12735 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24045 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88330 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23736 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23896 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23797 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->