### PR TITLE
[JSC] Handle `Error.isError` in DFG/FTL with `IsCellWithType` node

### DIFF
--- a/JSTests/microbenchmarks/error-is-error-for-error.js
+++ b/JSTests/microbenchmarks/error-is-error-for-error.js
@@ -1,0 +1,9 @@
+function isError(e)
+{
+    return Error.isError(e);
+}
+noInline(isError);
+
+var err = new Error();
+for (var i = 0; i < 1e6; ++i)
+    isError(err);

--- a/JSTests/microbenchmarks/error-is-error-for-mixed.js
+++ b/JSTests/microbenchmarks/error-is-error-for-mixed.js
@@ -1,0 +1,9 @@
+function isError(e)
+{
+    return Error.isError(e);
+}
+noInline(isError);
+
+var inputs = [new Error(), new TypeError(), {}, undefined, null, 42, "str", []];
+for (var i = 0; i < 1e6; ++i)
+    isError(inputs[i & 7]);

--- a/JSTests/microbenchmarks/error-is-error-for-non-error.js
+++ b/JSTests/microbenchmarks/error-is-error-for-non-error.js
@@ -1,0 +1,9 @@
+function isError(e)
+{
+    return Error.isError(e);
+}
+noInline(isError);
+
+var obj = {};
+for (var i = 0; i < 1e6; ++i)
+    isError(obj);

--- a/JSTests/stress/error-is-error-intrinsic-errors.js
+++ b/JSTests/stress/error-is-error-intrinsic-errors.js
@@ -1,0 +1,44 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + " expected: " + expected);
+}
+
+function test(v) {
+    return Error.isError(v);
+}
+noInline(test);
+
+class MyError extends Error {}
+class MyTypeError extends TypeError {}
+class MyAggregateError extends AggregateError {}
+
+var inputs = [
+    new Error(),
+    new EvalError(),
+    new RangeError(),
+    new ReferenceError(),
+    new SyntaxError(),
+    new TypeError(),
+    new URIError(),
+    new AggregateError([]),
+    new MyError(),
+    new MyTypeError(),
+    new MyAggregateError([]),
+];
+
+for (var i = 0; i < testLoopCount; ++i) {
+    for (var j = 0; j < inputs.length; ++j)
+        shouldBe(test(inputs[j]), true);
+}
+
+function testThrown() {
+    try {
+        null.foo;
+    } catch (e) {
+        return Error.isError(e);
+    }
+}
+noInline(testThrown);
+
+for (var i = 0; i < testLoopCount; ++i)
+    shouldBe(testThrown(), true);

--- a/JSTests/stress/error-is-error-intrinsic-mixed.js
+++ b/JSTests/stress/error-is-error-intrinsic-mixed.js
@@ -1,0 +1,47 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + " expected: " + expected);
+}
+
+function test(v) {
+    return Error.isError(v);
+}
+noInline(test);
+
+class MyError extends Error {}
+
+var err = new Error();
+var typeErr = new TypeError();
+var myErr = new MyError();
+var obj = {};
+var arr = [];
+
+for (var i = 0; i < testLoopCount; ++i) {
+    shouldBe(test(err), true);
+    shouldBe(test(typeErr), true);
+    shouldBe(test(myErr), true);
+    shouldBe(test(obj), false);
+    shouldBe(test(arr), false);
+    shouldBe(test(undefined), false);
+    shouldBe(test(null), false);
+    shouldBe(test(42), false);
+    shouldBe(test("str"), false);
+}
+
+function testCellOnly(v) {
+    return Error.isError(v);
+}
+noInline(testCellOnly);
+
+for (var i = 0; i < testLoopCount; ++i) {
+    shouldBe(testCellOnly(err), true);
+    shouldBe(testCellOnly(obj), false);
+}
+
+function testNonCellOnly(v) {
+    return Error.isError(v);
+}
+noInline(testNonCellOnly);
+
+for (var i = 0; i < testLoopCount; ++i)
+    shouldBe(testNonCellOnly(i), false);

--- a/JSTests/stress/error-is-error-intrinsic-non-errors.js
+++ b/JSTests/stress/error-is-error-intrinsic-non-errors.js
@@ -1,0 +1,46 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + " expected: " + expected);
+}
+
+function test(v) {
+    return Error.isError(v);
+}
+noInline(test);
+
+var fakeError = {
+    __proto__: Error.prototype,
+    constructor: Error,
+    message: "",
+    [Symbol.toStringTag]: "Error",
+};
+
+var { proxy: revokedProxy, revoke } = Proxy.revocable(new Error(), {});
+revoke();
+
+var inputs = [
+    undefined, null, true, false,
+    0, -0, NaN, Infinity, 42,
+    "", "foo", 42n, Symbol(),
+    {}, [], function () {}, /a/g,
+    new Map(), new Set(),
+    Error, TypeError, AggregateError,
+    Error.prototype,
+    fakeError,
+    new Proxy(new Error(), {}),
+    new Proxy({}, {}),
+    revokedProxy,
+];
+
+for (var i = 0; i < testLoopCount; ++i) {
+    for (var j = 0; j < inputs.length; ++j)
+        shouldBe(test(inputs[j]), false);
+}
+
+function testNoArgs() {
+    return Error.isError();
+}
+noInline(testNoArgs);
+
+for (var i = 0; i < testLoopCount; ++i)
+    shouldBe(testNoArgs(), false);

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -2928,6 +2928,15 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             return CallOptimizationResult::Inlined;
         }
 
+        case ErrorIsErrorIntrinsic: {
+            if (argumentCountIncludingThis < 2)
+                return CallOptimizationResult::DidNothing;
+
+            insertChecks();
+            setResult(addToGraph(IsCellWithType, OpInfo(ErrorInstanceType), get(virtualRegisterForArgumentIncludingThis(1, registerOffset))));
+            return CallOptimizationResult::Inlined;
+        }
+
         case AtomicsAddIntrinsic:
         case AtomicsAndIntrinsic:
         case AtomicsCompareExchangeIntrinsic:

--- a/Source/JavaScriptCore/runtime/ErrorConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/ErrorConstructor.cpp
@@ -50,7 +50,7 @@ void ErrorConstructor::finishCreation(VM& vm, ErrorPrototype* errorPrototype)
     putDirectWithoutTransition(vm, vm.propertyNames->stackTraceLimit, jsNumber(globalObject->stackTraceLimit().value_or(Options::defaultErrorStackTraceLimit())), static_cast<unsigned>(PropertyAttribute::None));
 
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->captureStackTrace, errorConstructorCaptureStackTrace, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
-    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("isError"_s, errorConstructorIsError, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
+    JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("isError"_s, errorConstructorIsError, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, ErrorIsErrorIntrinsic);
 }
 
 // ECMA 15.9.3

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -87,6 +87,7 @@ namespace JSC {
     macro(DatePrototypeGetTimezoneOffsetIntrinsic) \
     macro(DatePrototypeGetYearIntrinsic) \
     macro(DatePrototypeSetTimeIntrinsic) \
+    macro(ErrorIsErrorIntrinsic) \
     macro(FromCharCodeIntrinsic) \
     macro(GlobalIsFiniteIntrinsic) \
     macro(GlobalIsNaNIntrinsic) \


### PR DESCRIPTION
#### 6c34b6a708cd6f77ceee7f4d181d23676ee4e286
<pre>
[JSC] Handle `Error.isError` in DFG/FTL with `IsCellWithType` node
<a href="https://bugs.webkit.org/show_bug.cgi?id=310610">https://bugs.webkit.org/show_bug.cgi?id=310610</a>

Reviewed by Yusuke Suzuki.

This patch changes to handle `Error.isError` in DFG/FTL with `IsCellWithType` node.

                                      TipOfTree                  Patched

error-is-error-for-error            4.0522+-0.0048     ^      1.8115+-0.0965        ^ definitely 2.2369x faster
error-is-error-for-mixed            4.3807+-0.2827     ^      2.5868+-0.0844        ^ definitely 1.6935x faster
error-is-error-for-non-error        4.1217+-0.1397     ^      1.7876+-0.0252        ^ definitely 2.3057x faster

Tests: JSTests/microbenchmarks/error-is-error-for-error.js
       JSTests/microbenchmarks/error-is-error-for-mixed.js
       JSTests/microbenchmarks/error-is-error-for-non-error.js
       JSTests/stress/error-is-error-intrinsic-errors.js
       JSTests/stress/error-is-error-intrinsic-mixed.js
       JSTests/stress/error-is-error-intrinsic-non-errors.js

* JSTests/microbenchmarks/error-is-error-for-error.js: Added.
(isError):
* JSTests/microbenchmarks/error-is-error-for-mixed.js: Added.
(isError):
(new.TypeError):
* JSTests/microbenchmarks/error-is-error-for-non-error.js: Added.
(isError):
* JSTests/stress/error-is-error-intrinsic-errors.js: Added.
(shouldBe):
(test):
(MyError):
(MyTypeError):
(MyAggregateError):
(testThrown):
* JSTests/stress/error-is-error-intrinsic-mixed.js: Added.
(shouldBe):
(test):
(MyError):
(testCellOnly):
(testNonCellOnly):
* JSTests/stress/error-is-error-intrinsic-non-errors.js: Added.
(shouldBe):
(test):
(Proxy.revocable.new.Error):
(Symbol):
(new.Proxy.new.Error):
(testNoArgs):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/runtime/ErrorConstructor.cpp:
(JSC::ErrorConstructor::finishCreation):
* Source/JavaScriptCore/runtime/Intrinsic.h:

Canonical link: <a href="https://commits.webkit.org/309887@main">https://commits.webkit.org/309887@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c2b92c686bc0a0a686f5da693b58845e6af561b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151850 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24631 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18201 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160592 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105307 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25124 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24928 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117293 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83222 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154810 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19460 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136270 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98008 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18545 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16484 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8427 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/143856 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128177 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14173 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163056 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/12651 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6205 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15765 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125309 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24430 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20543 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125490 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34091 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24431 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135969 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81006 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20521 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12744 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/183461 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24048 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88333 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46801 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23739 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23899 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23800 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->