### PR TITLE
Revert "Align LocalFrameView::documentBackgroundColor() with CSS"

### DIFF
--- a/LayoutTests/compositing/contents-opaque/body-background-painted.html
+++ b/LayoutTests/compositing/contents-opaque/body-background-painted.html
@@ -28,7 +28,7 @@
     </head>
     <!-- Composited body over the child div. -->
     <!-- Root <html> element has a background-color. -->
-    <!-- Background for the html element is painted in this case. -->
+    <!-- Background for the body element is painted in this case. -->
     <!-- GraphicsLayer::contentsOpaque for the body layer should be false. -->
     <body>
         <!-- Box under the body. -->

--- a/LayoutTests/fast/scrolling/mac/wheel-event-listener-region-window-scrollable-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/wheel-event-listener-region-window-scrollable-expected.txt
@@ -6,7 +6,7 @@
       (bounds 785.00 2000.00)
       (contentsOpaque 1)
       (drawsContent 1)
-      (backgroundColor #FFFFFF)
+      (backgroundColor #C0C0C0)
       (event region
         (rect (0,0) width=785 height=2000)
       (wheel event listener region

--- a/LayoutTests/platform/glib/compositing/contents-opaque/body-background-painted-expected.txt
+++ b/LayoutTests/platform/glib/compositing/contents-opaque/body-background-painted-expected.txt
@@ -5,7 +5,7 @@
     (GraphicsLayer
       (bounds 800.00 600.00)
       (contentsOpaque 1)
-      (backgroundColor #D3D3D3)
+      (backgroundColor #0000FF)
       (children 1
         (GraphicsLayer
           (bounds 800.00 600.00)

--- a/LayoutTests/platform/ios/compositing/contents-opaque/body-background-painted-expected.txt
+++ b/LayoutTests/platform/ios/compositing/contents-opaque/body-background-painted-expected.txt
@@ -5,7 +5,7 @@
     (GraphicsLayer
       (bounds 800.00 600.00)
       (contentsOpaque 1)
-      (backgroundColor #D3D3D3)
+      (backgroundColor #0000FF)
       (children 1
         (GraphicsLayer
           (bounds 800.00 600.00)

--- a/LayoutTests/platform/mac-wk2/compositing/contents-opaque/body-background-painted-expected.txt
+++ b/LayoutTests/platform/mac-wk2/compositing/contents-opaque/body-background-painted-expected.txt
@@ -5,7 +5,7 @@
     (GraphicsLayer
       (bounds 800.00 600.00)
       (contentsOpaque 1)
-      (backgroundColor #D3D3D3)
+      (backgroundColor #0000FF)
       (children 1
         (GraphicsLayer
           (bounds 800.00 600.00)

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -138,7 +138,6 @@ enum class SDKAlignedBehavior {
     DataURLForPastedImages,
     SuppressKeypressForModifierShortcuts,
     ScrollColorExtensionGrowsDuringRubberBanding,
-    DocumentBackgroundColorFromCanvas,
     ManagedRefreshControlAppearance,
 
     NumberOfBehaviors

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -150,10 +150,6 @@
 #include <wtf/text/MakeString.h>
 #include <wtf/text/TextStream.h>
 
-#if PLATFORM(COCOA)
-#include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
-#endif
-
 #if PLATFORM(IOS_FAMILY)
 #include "DocumentLoader.h"
 #include "LegacyTileCache.h"
@@ -5436,6 +5432,10 @@ void LocalFrameView::paintScrollbar(GraphicsContext& context, Scrollbar& bar, co
 
 Color LocalFrameView::documentBackgroundColor() const
 {
+    // <https://bugs.webkit.org/show_bug.cgi?id=59540> We blend the background color of
+    // the document and the body against the base background color of the frame view.
+    // Background images are unfortunately impractical to include.
+
     // Return invalid Color objects whenever there is insufficient information.
     RefPtr backgroundDocument = [&] {
 #if ENABLE(FULLSCREEN_API)
@@ -5450,8 +5450,19 @@ Color LocalFrameView::documentBackgroundColor() const
     if (!backgroundDocument)
         return Color();
 
+    RefPtr htmlElement = backgroundDocument->documentElement();
+    RefPtr bodyElement = backgroundDocument->bodyOrFrameset();
+
+    // Start with invalid colors.
+    Color htmlBackgroundColor;
+    Color bodyBackgroundColor;
+    if (htmlElement && htmlElement->renderer())
+        htmlBackgroundColor = htmlElement->renderer()->style().visitedDependentBackgroundColorApplyingColorFilter();
+    if (bodyElement && bodyElement->renderer())
+        bodyBackgroundColor = bodyElement->renderer()->style().visitedDependentBackgroundColorApplyingColorFilter();
+
 #if ENABLE(FULLSCREEN_API)
-    auto fullscreenBackgroundColor = [&] -> Color {
+    Color fullscreenBackgroundColor = [&] () -> Color {
         RefPtr documentFullscreen = backgroundDocument->fullscreenIfExists();
         if (!documentFullscreen)
             return { };
@@ -5474,74 +5485,33 @@ Color LocalFrameView::documentBackgroundColor() const
         // intentionally be visible underneath (and around) the fullscreen element.
         return backdropRenderer->style().visitedDependentBackgroundColorApplyingColorFilter();
     }();
-#endif
 
-#if PLATFORM(COCOA)
-    // <https://bugs.webkit.org/show_bug.cgi?id=59540> We blend the background color of
-    // the document and the body against the base background color of the frame view.
-    // Background images are unfortunately impractical to include.
-    if (!linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::DocumentBackgroundColorFromCanvas)) {
-        RefPtr htmlElement = backgroundDocument->documentElement();
-        RefPtr bodyElement = backgroundDocument->bodyOrFrameset();
-
-        // Start with invalid colors.
-        Color htmlBackgroundColor;
-        Color bodyBackgroundColor;
-        if (htmlElement && htmlElement->renderer())
-            htmlBackgroundColor = htmlElement->renderer()->style().visitedDependentBackgroundColorApplyingColorFilter();
-        if (bodyElement && bodyElement->renderer())
-            bodyBackgroundColor = bodyElement->renderer()->style().visitedDependentBackgroundColorApplyingColorFilter();
-
-#if ENABLE(FULLSCREEN_API)
-        // Replace or blend the fullscreen background color with the body background color, if present.
-        if (fullscreenBackgroundColor.isValid()) {
-            if (!bodyBackgroundColor.isValid())
-                bodyBackgroundColor = fullscreenBackgroundColor;
-            else
-                bodyBackgroundColor = blendSourceOver(bodyBackgroundColor, fullscreenBackgroundColor);
-        }
-#endif
-
-        if (!bodyBackgroundColor.isValid()) {
-            if (!htmlBackgroundColor.isValid())
-                return Color();
-            return blendSourceOver(baseBackgroundColor(), htmlBackgroundColor);
-        }
-
-        if (!htmlBackgroundColor.isValid())
-            return blendSourceOver(baseBackgroundColor(), bodyBackgroundColor);
-
-        // We take the aggregate of the base background color
-        // the <html> background color, and the <body>
-        // background color to find the document color. The
-        // addition of the base background color is not
-        // technically part of the document background, but it
-        // otherwise poses problems when the aggregate is not
-        // fully opaque.
-        return blendSourceOver(blendSourceOver(baseBackgroundColor(), htmlBackgroundColor), bodyBackgroundColor);
-    }
-#endif
-
-    CheckedPtr renderView = backgroundDocument->renderView();
-    Color result;
-    if (renderView) {
-        if (CheckedPtr canvasRenderer = renderView->rendererForRootBackground()) {
-            auto canvasColor = canvasRenderer->style().visitedDependentBackgroundColorApplyingColorFilter();
-            if (canvasColor.isValid())
-                result = blendSourceOver(baseBackgroundColor(), canvasColor);
-        }
-    }
-
-#if ENABLE(FULLSCREEN_API)
+    // Replace or blend the fullscreen background color with the body background color, if present.
     if (fullscreenBackgroundColor.isValid()) {
-        if (result.isValid())
-            result = blendSourceOver(result, fullscreenBackgroundColor);
+        if (!bodyBackgroundColor.isValid())
+            bodyBackgroundColor = fullscreenBackgroundColor;
         else
-            result = blendSourceOver(baseBackgroundColor(), fullscreenBackgroundColor);
+            bodyBackgroundColor = blendSourceOver(bodyBackgroundColor, fullscreenBackgroundColor);
     }
 #endif
 
-    return result;
+    if (!bodyBackgroundColor.isValid()) {
+        if (!htmlBackgroundColor.isValid())
+            return Color();
+        return blendSourceOver(baseBackgroundColor(), htmlBackgroundColor);
+    }
+
+    if (!htmlBackgroundColor.isValid())
+        return blendSourceOver(baseBackgroundColor(), bodyBackgroundColor);
+
+    // We take the aggregate of the base background color
+    // the <html> background color, and the <body>
+    // background color to find the document color. The
+    // addition of the base background color is not
+    // technically part of the document background, but it
+    // otherwise poses problems when the aggregate is not
+    // fully opaque.
+    return blendSourceOver(blendSourceOver(baseBackgroundColor(), htmlBackgroundColor), bodyBackgroundColor);
 }
 
 bool LocalFrameView::hasCustomScrollbars() const

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewUnderPageBackgroundColor.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewUnderPageBackgroundColor.mm
@@ -90,13 +90,13 @@ TEST(WKWebViewUnderPageBackgroundColor, SingleBlendedColor)
 TEST(WKWebViewUnderPageBackgroundColor, MultipleSolidColors)
 {
     auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
-    auto blueColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), blueColorComponents));
+    auto redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     EXPECT_TRUE(CGColorEqualToColor([webView underPageBackgroundColor].CGColor, defaultBackgroundColor().get()));
 
     [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:@"<style> html { background-color: blue; } body { background-color: red; } </style>"];
-    EXPECT_TRUE(CGColorEqualToColor([webView underPageBackgroundColor].CGColor, blueColor.get()));
+    EXPECT_TRUE(CGColorEqualToColor([webView underPageBackgroundColor].CGColor, redColor.get()));
 }
 
 TEST(WKWebViewUnderPageBackgroundColor, MultipleBlendedColors)
@@ -106,9 +106,9 @@ TEST(WKWebViewUnderPageBackgroundColor, MultipleBlendedColors)
 
     [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:@"<style> html { background-color: rgba(255, 0, 0, 0.5); } body { background-color: rgba(0, 0, 255, 0.5); } </style>"];
     auto components = CGColorGetComponents([webView underPageBackgroundColor].CGColor);
-    EXPECT_EQ(components[0], 1);
-    EXPECT_IN_RANGE(components[1], 0.45, 0.55);
-    EXPECT_IN_RANGE(components[2], 0.45, 0.55);
+    EXPECT_IN_RANGE(components[0], 0.45, 0.55);
+    EXPECT_IN_RANGE(components[1], 0.2, 0.25);
+    EXPECT_IN_RANGE(components[2], 0.7, 0.75);
     EXPECT_EQ(components[3], 1);
 }
 


### PR DESCRIPTION
#### dc03d48b0c35ef9a7323ab4cf9500a1ad64248ef
<pre>
Revert &quot;Align LocalFrameView::documentBackgroundColor() with CSS&quot;
<a href="https://rdar.apple.com/172980732">rdar://172980732</a>

Unreviewed.

This reverts 309332@main for causing a bad regression.

Canonical link: <a href="https://commits.webkit.org/309817@main">https://commits.webkit.org/309817@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0bac37250e8c9685b376b0a6c53c4a4475dd03e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151853 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24634 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/18204 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160595 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153727 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25127 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24931 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/117288 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154813 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/136268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98003 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/91e18ae7-34dc-49a9-a879-4cfd24d68bd5) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/18546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/16483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8430 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/143859 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/14171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163059 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/12654 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/6208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/15763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/125305 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24433 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20542 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125486 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24434 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/135967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/81009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23313 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/20520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/12742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/183476 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24051 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/88336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/183476 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23742 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23902 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/23803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->