### PR TITLE
[JSC] Remove unused link-time constants

### DIFF
--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -93,7 +93,6 @@ namespace JSC {
     macro(promiseReject) \
     macro(performPromiseThen) \
     macro(push) \
-    macro(repeatCharacter) \
     macro(starDefault) \
     macro(starNamespace) \
     macro(then) \
@@ -132,20 +131,15 @@ namespace JSC {
     macro(importInRealm) \
     macro(evalFunction) \
     macro(evalInRealm) \
-    macro(moveFunctionToRealm) \
     macro(newTargetLocal) \
     macro(derivedConstructor) \
     macro(isTypedArrayView) \
-    macro(isSharedTypedArrayView) \
-    macro(isResizableOrGrowableSharedTypedArrayView) \
     macro(isDetached) \
     macro(typedArrayFromFast) \
     macro(isBoundFunction) \
     macro(hasInstanceBoundFunction) \
     macro(instanceOf) \
-    macro(isArraySlow) \
     macro(isArray) \
-    macro(sameValue) \
     macro(regExpCreate) \
     macro(isRegExp) \
     macro(isFinite) \
@@ -180,11 +174,8 @@ namespace JSC {
     macro(regExpProtoUnicodeGetter) \
     macro(regExpProtoUnicodeSetsGetter) \
     macro(regExpPrototypeSymbolMatch) \
-    macro(regExpPrototypeSymbolReplace) \
-    macro(regExpSearchFast) \
     macro(regExpSplitFast) \
     macro(stringIncludesInternal) \
-    macro(stringIndexOfInternal) \
     macro(stringSplitFast) \
     macro(stringSubstring) \
     macro(handleNegativeProxyHasTrapResult) \
@@ -206,7 +197,6 @@ namespace JSC {
     macro(emptyPropertyNameEnumerator) \
     macro(sentinelString) \
     macro(createRemoteFunction) \
-    macro(isRemoteFunction) \
     macro(arrayFromFastWithoutMapFn) \
     macro(jsonParse) \
     macro(jsonStringify) \
@@ -221,7 +211,6 @@ namespace JSC {
     macro(pop) \
     macro(wrapForValidIteratorCreate) \
     macro(asyncFromSyncIteratorCreate) \
-    macro(regExpStringIteratorCreate) \
     macro(iteratorHelperCreate) \
     macro(syncIterator) \
     macro(includes) \

--- a/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
+++ b/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
@@ -73,13 +73,10 @@ class JSGlobalObject;
     v(promiseReject, nullptr) \
     v(performPromiseThen, nullptr) \
     v(makeTypeError, nullptr) \
-    v(AggregateError, nullptr) \
     v(typedArrayLength, nullptr) \
     v(toIntegerOrInfinity, nullptr) \
     v(toLength, nullptr) \
     v(isTypedArrayView, nullptr) \
-    v(isSharedTypedArrayView, nullptr) \
-    v(isResizableOrGrowableSharedTypedArrayView, nullptr) \
     v(typedArrayFromFast, nullptr) \
     v(isDetached, nullptr) \
     v(isBoundFunction, nullptr) \
@@ -90,21 +87,16 @@ class JSGlobalObject;
     v(BuiltinDescribe, nullptr) \
     v(RegExp, nullptr) \
     v(Iterator, nullptr) \
-    v(min, nullptr) \
     v(Promise, nullptr) \
     v(InternalPromise, nullptr) \
     v(defaultPromiseThen, nullptr) \
-    v(repeatCharacter, nullptr) \
     v(isArray, nullptr) \
-    v(isArraySlow, nullptr) \
     v(Set, nullptr) \
     v(Map, nullptr) \
     v(importInRealm, nullptr) \
     v(evalFunction, nullptr) \
     v(evalInRealm, nullptr) \
-    v(moveFunctionToRealm, nullptr) \
     v(isConstructor, nullptr) \
-    v(sameValue, nullptr) \
     v(regExpProtoFlagsGetter, nullptr) \
     v(regExpProtoGlobalGetter, nullptr) \
     v(regExpProtoHasIndicesGetter, nullptr) \
@@ -119,12 +111,9 @@ class JSGlobalObject;
     v(regExpCreate, nullptr) \
     v(isRegExp, nullptr) \
     v(regExpMatchFast, nullptr) \
-    v(regExpSearchFast, nullptr) \
     v(regExpSplitFast, nullptr) \
     v(regExpPrototypeSymbolMatch, nullptr) \
-    v(regExpPrototypeSymbolReplace, nullptr) \
     v(stringIncludesInternal, nullptr) \
-    v(stringIndexOfInternal, nullptr) \
     v(stringSplitFast, nullptr) \
     v(stringSubstring, nullptr) \
     v(handleNegativeProxyHasTrapResult, nullptr) \
@@ -141,26 +130,12 @@ class JSGlobalObject;
     v(emptyPropertyNameEnumerator, nullptr) \
     v(sentinelString, nullptr) \
     v(createRemoteFunction, nullptr) \
-    v(isRemoteFunction, nullptr) \
     v(arrayFromFastWithoutMapFn, nullptr) \
     v(jsonParse, nullptr) \
     v(jsonStringify, nullptr) \
     v(String, nullptr) \
-    v(Int8Array, nullptr) \
-    v(Uint8Array, nullptr) \
-    v(Uint8ClampedArray, nullptr) \
-    v(Int16Array, nullptr) \
-    v(Uint16Array, nullptr) \
-    v(Int32Array, nullptr) \
-    v(Uint32Array, nullptr) \
-    v(Float16Array, nullptr) \
-    v(Float32Array, nullptr) \
-    v(Float64Array, nullptr) \
-    v(BigInt64Array, nullptr) \
-    v(BigUint64Array, nullptr) \
     v(wrapForValidIteratorCreate, nullptr) \
     v(asyncFromSyncIteratorCreate, nullptr) \
-    v(regExpStringIteratorCreate, nullptr) \
     v(iteratorHelperCreate, nullptr) \
     v(ReferenceError, nullptr) \
     v(SuppressedError, nullptr) \

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -4622,28 +4622,6 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             return CallOptimizationResult::Inlined;
         }
 
-        case RegExpStringIteratorCreateIntrinsic: {
-            if (argumentCountIncludingThis < 5)
-                return CallOptimizationResult::DidNothing;
-
-            insertChecks();
-            JSGlobalObject* globalObject = m_graph.globalObjectFor(currentNodeOrigin().semantic);
-            Node* regExp = get(virtualRegisterForArgumentIncludingThis(1, registerOffset));
-            Node* string = get(virtualRegisterForArgumentIncludingThis(2, registerOffset));
-            Node* global = get(virtualRegisterForArgumentIncludingThis(3, registerOffset));
-            Node* fullUnicode = get(virtualRegisterForArgumentIncludingThis(4, registerOffset));
-            Node* regExpStringIterator = addToGraph(NewInternalFieldObject, OpInfo(m_graph.registerStructure(globalObject->regExpStringIteratorStructure())));
-            addToGraph(PutInternalField, OpInfo(static_cast<uint32_t>(JSRegExpStringIterator::Field::RegExp)), regExpStringIterator, regExp);
-            addToGraph(PutInternalField, OpInfo(static_cast<uint32_t>(JSRegExpStringIterator::Field::String)), regExpStringIterator, string);
-            // Combine global and fullUnicode into a single flags field: flags = global | (fullUnicode << 1)
-            Node* one = addToGraph(JSConstant, OpInfo(m_graph.freeze(jsNumber(1))));
-            Node* fullUnicodeShifted = addToGraph(ArithBitLShift, fullUnicode, one);
-            Node* flags = addToGraph(ArithBitOr, global, fullUnicodeShifted);
-            addToGraph(PutInternalField, OpInfo(static_cast<uint32_t>(JSRegExpStringIterator::Field::Flags)), regExpStringIterator, flags);
-            setResult(regExpStringIterator);
-            return CallOptimizationResult::Inlined;
-        }
-
         case ResolvePromiseWithFirstResolvingFunctionCallCheckIntrinsic: {
             if (argumentCountIncludingThis < 3)
                 return CallOptimizationResult::DidNothing;

--- a/Source/JavaScriptCore/runtime/ArrayConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayConstructor.cpp
@@ -161,14 +161,6 @@ bool isArraySlow(JSGlobalObject* globalObject, ProxyObject* argument)
     return isArraySlowInline(globalObject, argument);
 }
 
-// ES6 7.2.2
-// https://tc39.github.io/ecma262/#sec-isarray
-JSC_DEFINE_HOST_FUNCTION(arrayConstructorPrivateFuncIsArraySlow, (JSGlobalObject* globalObject, CallFrame* callFrame))
-{
-    ASSERT_UNUSED(globalObject, jsDynamicCast<ProxyObject*>(callFrame->argument(0)));
-    return JSValue::encode(jsBoolean(isArraySlowInline(globalObject, jsCast<ProxyObject*>(callFrame->uncheckedArgument(0)))));
-}
-
 ALWAYS_INLINE JSArray* fastArrayOf(JSGlobalObject* globalObject, CallFrame* callFrame, size_t length)
 {
     VM& vm = globalObject->vm();

--- a/Source/JavaScriptCore/runtime/ArrayConstructor.h
+++ b/Source/JavaScriptCore/runtime/ArrayConstructor.h
@@ -58,7 +58,6 @@ JSArray* constructArrayWithSizeQuirk(JSGlobalObject*, ArrayAllocationProfile*, J
 
 JSC_DECLARE_HOST_FUNCTION(arrayConstructorIsArray);
 JSC_DECLARE_HOST_FUNCTION(arrayConstructorPrivateFromFastWithoutMapFn);
-JSC_DECLARE_HOST_FUNCTION(arrayConstructorPrivateFuncIsArraySlow);
 bool isArraySlow(JSGlobalObject*, ProxyObject* argument);
 
 // ES6 7.2.2

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -204,7 +204,6 @@ namespace JSC {
     macro(IteratorHelperCreateIntrinsic) \
     macro(WrapForValidIteratorCreateIntrinsic) \
     macro(AsyncFromSyncIteratorCreateIntrinsic) \
-    macro(RegExpStringIteratorCreateIntrinsic) \
     macro(ResolvePromiseWithFirstResolvingFunctionCallCheckIntrinsic) \
     macro(RejectPromiseWithFirstResolvingFunctionCallCheckIntrinsic) \
     macro(FulfillPromiseWithFirstResolvingFunctionCallCheckIntrinsic) \

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -1186,9 +1186,6 @@ void JSGlobalObject::init(VM& vm)
         [] (const Initializer<Structure>& init) { \
             init.set(JSResizableOrGrowableShared ## type ## Array::createStructure(init.vm, init.owner, init.owner->typedArrayPrototype(Type##type))); \
             init.owner->typedArrayStructure(Type##type, /* isResizableOrGrowableShared */ false); /* Initialize non-resizable Structure too */ \
-        }); \
-    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::type##Array)].initLater([](const Initializer<JSCell>& init) { \
-            init.set(jsCast<JSGlobalObject*>(init.owner)->typedArrayConstructor(TypedArrayType::Type##type)); \
         });
     FOR_EACH_TYPED_ARRAY_TYPE_EXCLUDING_DATA_VIEW(INIT_TYPED_ARRAY_LATER)
 #undef INIT_TYPED_ARRAY_LATER
@@ -1809,7 +1806,6 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     m_regExpProtoSymbolReplace.set(vm, this, regExpSymbolReplace);
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::regExpBuiltinExec)].set(vm, this, jsCast<JSFunction*>(m_regExpPrototype->getDirect(vm, vm.propertyNames->exec)));
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::regExpPrototypeSymbolMatch)].set(vm, this, m_regExpPrototype->getDirect(vm, vm.propertyNames->matchSymbol).asCell());
-    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::regExpPrototypeSymbolReplace)].set(vm, this, m_regExpPrototype->getDirect(vm, vm.propertyNames->replaceSymbol).asCell());
 
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::isArray)].initLater([] (const Initializer<JSCell>& init) {
         init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "isArray"_s, arrayConstructorIsArray, ImplementationVisibility::Public, ArrayIsArrayIntrinsic));
@@ -1835,11 +1831,6 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     // AsyncFromSyncIterator Helpers
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::asyncFromSyncIteratorCreate)].initLater([](const Initializer<JSCell>& init) {
         init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "asyncFromSyncIteratorCreate"_s, asyncFromSyncIteratorPrivateFuncCreate, ImplementationVisibility::Private, AsyncFromSyncIteratorCreateIntrinsic));
-    });
-
-    // RegExpStringIteratorHelpers
-    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::regExpStringIteratorCreate)].initLater([](const Initializer<JSCell>& init) {
-        init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 4, "regExpStringIteratorCreate"_s, regExpStringIteratorPrivateFuncCreate, ImplementationVisibility::Private, RegExpStringIteratorCreateIntrinsic));
     });
 
     // WrapForValidIterator Helpers
@@ -1970,10 +1961,6 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::makeTypeError)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "makeTypeError"_s, globalFuncMakeTypeError, ImplementationVisibility::Private));
         });
-    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::AggregateError)].initLater([] (const Initializer<JSCell>& init) {
-            JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(init.owner);
-            init.set(globalObject->m_aggregateErrorStructure.constructor(globalObject));
-        });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::ReferenceError)].initLater([] (const Initializer<JSCell>& init) {
         JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(init.owner);
         init.set(globalObject->m_referenceErrorStructure.constructor(globalObject));
@@ -1996,12 +1983,6 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::isTypedArrayView)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "typedArrayViewIsTypedArrayView"_s, typedArrayViewPrivateFuncIsTypedArrayView, ImplementationVisibility::Private, IsTypedArrayViewIntrinsic));
-        });
-    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::isSharedTypedArrayView)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "typedArrayViewIsSharedTypedArrayView"_s, typedArrayViewPrivateFuncIsSharedTypedArrayView, ImplementationVisibility::Private));
-        });
-    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::isResizableOrGrowableSharedTypedArrayView)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "typedArrayViewPrivateFuncIsResizableOrGrowableSharedTypedArrayView"_s, typedArrayViewPrivateFuncIsResizableOrGrowableSharedTypedArrayView, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::typedArrayFromFast)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "typedArrayViewTypedArrayFromFast"_s, typedArrayViewPrivateFuncTypedArrayFromFast, ImplementationVisibility::Private));
@@ -2027,15 +2008,6 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::BuiltinDescribe)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "BuiltinDescribe"_s, globalFuncBuiltinDescribe, ImplementationVisibility::Private));
         });
-    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::min)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "min"_s, mathProtoFuncMin, ImplementationVisibility::Private, MinIntrinsic));
-        });
-    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::repeatCharacter)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "repeatCharacter"_s, stringProtoFuncRepeatCharacter, ImplementationVisibility::Private));
-        });
-    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::isArraySlow)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "isArraySlow"_s, arrayConstructorPrivateFuncIsArraySlow, ImplementationVisibility::Private));
-        });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::importInRealm)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "importInRealm"_s, importInRealm, ImplementationVisibility::Private));
         });
@@ -2044,12 +2016,6 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::evalInRealm)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "evalInRealm"_s, evalInRealm, ImplementationVisibility::Private));
-        });
-    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::moveFunctionToRealm)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "moveFunctionToRealm"_s, moveFunctionToRealm, ImplementationVisibility::Private));
-        });
-    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::sameValue)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "is"_s, objectConstructorIs, ImplementationVisibility::Private, ObjectIsIntrinsic));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::setPrototypeDirect)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "setPrototypeDirect"_s, globalFuncSetPrototypeDirect, ImplementationVisibility::Private));
@@ -2081,9 +2047,6 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     // String.prototype helpers.
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::stringIncludesInternal)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "stringIncludesInternal"_s, builtinStringIncludesInternal, ImplementationVisibility::Private));
-        });
-    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::stringIndexOfInternal)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "stringIndexOfInternal"_s, builtinStringIndexOfInternal, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::stringSplitFast)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "stringSplitFast"_s, stringProtoFuncSplitFast, ImplementationVisibility::Private));
@@ -2118,9 +2081,6 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     // ShadowRealms
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::createRemoteFunction)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "createRemoteFunction"_s, createRemoteFunction, ImplementationVisibility::Private));
-        });
-    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::isRemoteFunction)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "isRemoteFunction"_s, isRemoteFunction, ImplementationVisibility::Private));
         });
 
 #if ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/runtime/JSRegExpStringIterator.cpp
+++ b/Source/JavaScriptCore/runtime/JSRegExpStringIterator.cpp
@@ -60,22 +60,4 @@ void JSRegExpStringIterator::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 
 DEFINE_VISIT_CHILDREN(JSRegExpStringIterator);
 
-JSC_DEFINE_HOST_FUNCTION(regExpStringIteratorPrivateFuncCreate, (JSGlobalObject* globalObject, CallFrame* callFrame))
-{
-    ASSERT(callFrame->argument(0).isCell());
-    ASSERT(callFrame->argument(1).isString());
-    ASSERT(callFrame->argument(2).isBoolean());
-    ASSERT(callFrame->argument(3).isBoolean());
-
-    VM& vm = globalObject->vm();
-
-    auto* regExpStringIterator = JSRegExpStringIterator::createWithInitialValues(vm, globalObject->regExpStringIteratorStructure());
-
-    regExpStringIterator->setRegExp(vm, asObject(callFrame->uncheckedArgument(0)));
-    regExpStringIterator->setString(vm, callFrame->uncheckedArgument(1));
-    regExpStringIterator->setFlags(callFrame->argument(2).asBoolean(), callFrame->argument(3).asBoolean());
-
-    return JSValue::encode(regExpStringIterator);
-}
-
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSRegExpStringIterator.h
+++ b/Source/JavaScriptCore/runtime/JSRegExpStringIterator.h
@@ -117,6 +117,4 @@ private:
 
 STATIC_ASSERT_IS_TRIVIALLY_DESTRUCTIBLE(JSRegExpStringIterator);
 
-JSC_DECLARE_HOST_FUNCTION(regExpStringIteratorPrivateFuncCreate);
-
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSRemoteFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSRemoteFunction.cpp
@@ -158,13 +158,6 @@ JSC_DEFINE_HOST_FUNCTION(remoteFunctionCallGeneric, (JSGlobalObject* globalObjec
     RELEASE_AND_RETURN(scope, JSValue::encode(wrapReturnValue(globalObject, targetGlobalObject, result)));
 }
 
-JSC_DEFINE_HOST_FUNCTION(isRemoteFunction, (JSGlobalObject*, CallFrame* callFrame))
-{
-    ASSERT(callFrame->argumentCount() == 1);
-    JSValue value = callFrame->uncheckedArgument(0);
-    return JSValue::encode(jsBoolean(JSC::isRemoteFunction(value)));
-}
-
 JSC_DEFINE_HOST_FUNCTION(createRemoteFunction, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();

--- a/Source/JavaScriptCore/runtime/JSRemoteFunction.h
+++ b/Source/JavaScriptCore/runtime/JSRemoteFunction.h
@@ -37,7 +37,6 @@ namespace JSC {
 
 JSC_DECLARE_HOST_FUNCTION(remoteFunctionCallForJSFunction);
 JSC_DECLARE_HOST_FUNCTION(remoteFunctionCallGeneric);
-JSC_DECLARE_HOST_FUNCTION(isRemoteFunction);
 JSC_DECLARE_HOST_FUNCTION(createRemoteFunction);
 
 // JSRemoteFunction creates a bridge between its native Realm and a remote one.

--- a/Source/JavaScriptCore/runtime/JSTypedArrayViewPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSTypedArrayViewPrototype.cpp
@@ -115,26 +115,6 @@ JSC_DEFINE_HOST_FUNCTION(typedArrayViewPrivateFuncIsTypedArrayView, (JSGlobalObj
     return JSValue::encode(jsBoolean(value.isCell() && isTypedView(value.asCell()->type())));
 }
 
-JSC_DEFINE_HOST_FUNCTION(typedArrayViewPrivateFuncIsSharedTypedArrayView, (JSGlobalObject*, CallFrame* callFrame))
-{
-    JSValue value = callFrame->uncheckedArgument(0);
-    if (!value.isCell())
-        return JSValue::encode(jsBoolean(false));
-    if (!isTypedView(value.asCell()->type()))
-        return JSValue::encode(jsBoolean(false));
-    return JSValue::encode(jsBoolean(jsCast<JSArrayBufferView*>(value)->isShared()));
-}
-
-JSC_DEFINE_HOST_FUNCTION(typedArrayViewPrivateFuncIsResizableOrGrowableSharedTypedArrayView, (JSGlobalObject*, CallFrame* callFrame))
-{
-    JSValue value = callFrame->uncheckedArgument(0);
-    if (!value.isCell())
-        return JSValue::encode(jsBoolean(false));
-    if (!isTypedView(value.asCell()->type()))
-        return JSValue::encode(jsBoolean(false));
-    return JSValue::encode(jsBoolean(jsCast<JSArrayBufferView*>(value)->isResizableOrGrowableShared()));
-}
-
 static inline std::optional<JSType> isTypedArrayViewConstructor(JSValue value)
 {
     if (!value.isCell()) [[unlikely]]

--- a/Source/JavaScriptCore/runtime/JSTypedArrayViewPrototype.h
+++ b/Source/JavaScriptCore/runtime/JSTypedArrayViewPrototype.h
@@ -52,8 +52,6 @@ private:
 };
 
 JSC_DECLARE_HOST_FUNCTION(typedArrayViewPrivateFuncIsTypedArrayView);
-JSC_DECLARE_HOST_FUNCTION(typedArrayViewPrivateFuncIsSharedTypedArrayView);
-JSC_DECLARE_HOST_FUNCTION(typedArrayViewPrivateFuncIsResizableOrGrowableSharedTypedArrayView);
 JSC_DECLARE_HOST_FUNCTION(typedArrayViewPrivateFuncTypedArrayFromFast);
 JSC_DECLARE_HOST_FUNCTION(typedArrayViewPrivateFuncIsDetached);
 JSC_DECLARE_HOST_FUNCTION(typedArrayViewPrivateFuncLength);

--- a/Source/JavaScriptCore/runtime/ShadowRealmPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ShadowRealmPrototype.cpp
@@ -134,22 +134,4 @@ JSC_DEFINE_HOST_FUNCTION(evalInRealm, (JSGlobalObject* globalObject, CallFrame* 
     RELEASE_AND_RETURN(scope, JSValue::encode(result));
 }
 
-JSC_DEFINE_HOST_FUNCTION(moveFunctionToRealm, (JSGlobalObject* globalObject, CallFrame* callFrame))
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    JSValue wrappedFnArg = callFrame->argument(0);
-    JSFunction* wrappedFn = jsDynamicCast<JSFunction*>(wrappedFnArg);
-    JSValue targetRealmArg = callFrame->argument(1);
-    ShadowRealmObject* targetRealm = jsDynamicCast<ShadowRealmObject*>(targetRealmArg);
-    ASSERT(targetRealm);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    bool isBuiltin = false;
-    JSGlobalObject* targetGlobalObj = targetRealm->globalObject();
-    wrappedFn->setPrototype(vm, targetGlobalObj, targetGlobalObj->strictFunctionStructure(isBuiltin)->storedPrototype());
-    RELEASE_AND_RETURN(scope, JSValue::encode(jsUndefined()));
-}
-
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/ShadowRealmPrototype.h
+++ b/Source/JavaScriptCore/runtime/ShadowRealmPrototype.h
@@ -60,6 +60,5 @@ private:
 
 JSC_DECLARE_HOST_FUNCTION(importInRealm);
 JSC_DECLARE_HOST_FUNCTION(evalInRealm);
-JSC_DECLARE_HOST_FUNCTION(moveFunctionToRealm);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -298,39 +298,6 @@ void substituteBackreferences(StringBuilder& result, const String& replacement, 
     return substituteBackreferencesInline(result, replacement, source, ovector, reg);
 }
 
-JSC_DEFINE_HOST_FUNCTION(stringProtoFuncRepeatCharacter, (JSGlobalObject* globalObject, CallFrame* callFrame))
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    // For a string which length is single, instead of creating ropes,
-    // allocating a sequential buffer and fill with the repeated string for efficiency.
-    ASSERT(callFrame->argumentCount() == 2);
-
-    ASSERT(callFrame->uncheckedArgument(0).isString());
-    JSString* string = asString(callFrame->uncheckedArgument(0));
-    ASSERT(string->length() == 1);
-
-    JSValue repeatCountValue = callFrame->uncheckedArgument(1);
-    RELEASE_ASSERT(repeatCountValue.isNumber());
-    int32_t repeatCount;
-    double value = repeatCountValue.asNumber();
-    if (value > JSString::MaxLength)
-        return JSValue::encode(throwOutOfMemoryError(globalObject, scope));
-    repeatCount = static_cast<int32_t>(value);
-    ASSERT(repeatCount >= 0);
-    ASSERT(!repeatCountValue.isDouble() || repeatCountValue.asDouble() == repeatCount);
-
-    auto view = string->view(globalObject);
-    ASSERT(view->length() == 1);
-    scope.assertNoException();
-    char16_t character = view[0];
-    scope.release();
-    if (isLatin1(character))
-        return JSValue::encode(repeatCharacter(globalObject, static_cast<Latin1Character>(character), repeatCount));
-    return JSValue::encode(repeatCharacter(globalObject, character, repeatCount));
-}
-
 // 22.1.3.19 String.prototype.replace ( searchValue, replaceValue )
 // https://tc39.es/ecma262/#sec-string.prototype.replace
 JSC_DEFINE_HOST_FUNCTION(stringProtoFuncReplace, (JSGlobalObject* globalObject, CallFrame* callFrame))
@@ -616,14 +583,6 @@ static EncodedJSValue stringIndexOfImpl(JSGlobalObject* globalObject, CallFrame*
 
 JSC_DEFINE_HOST_FUNCTION(stringProtoFuncIndexOf, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    return stringIndexOfImpl(globalObject, callFrame);
-}
-
-JSC_DEFINE_HOST_FUNCTION(builtinStringIndexOfInternal, (JSGlobalObject* globalObject, CallFrame* callFrame))
-{
-    ASSERT(callFrame->thisValue().isString());
-    ASSERT(callFrame->argument(0).isString());
-    ASSERT(callFrame->argument(1).isNumber() || callFrame->argument(1).isUndefined());
     return stringIndexOfImpl(globalObject, callFrame);
 }
 

--- a/Source/JavaScriptCore/runtime/StringPrototype.h
+++ b/Source/JavaScriptCore/runtime/StringPrototype.h
@@ -53,11 +53,9 @@ STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(StringPrototype, StringObject);
 void substituteBackreferences(StringBuilder& result, const String& replacement, StringView source, const int* ovector, RegExp*);
 void substituteBackreferencesSlow(StringBuilder& result, StringView replacement, StringView source, const int* ovector, RegExp*, size_t firstDollarSignPosition);
 
-JSC_DECLARE_HOST_FUNCTION(stringProtoFuncRepeatCharacter);
 JSC_DECLARE_HOST_FUNCTION(stringProtoFuncSplitFast);
 JSC_DECLARE_HOST_FUNCTION(stringProtoFuncSubstring);
 
 JSC_DECLARE_HOST_FUNCTION(builtinStringIncludesInternal);
-JSC_DECLARE_HOST_FUNCTION(builtinStringIndexOfInternal);
 
 } // namespace JSC


### PR DESCRIPTION
#### dbcf7c2835439a6cdef549e7518a5a4f067ff878
<pre>
[JSC] Remove unused link-time constants
<a href="https://bugs.webkit.org/show_bug.cgi?id=310613">https://bugs.webkit.org/show_bug.cgi?id=310613</a>

Reviewed by NOBODY (OOPS!).

This patch changes to remove unused LinkTimeConstant entries.

* Source/JavaScriptCore/builtins/BuiltinNames.h:
* Source/JavaScriptCore/bytecode/LinkTimeConstant.h:
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/runtime/ArrayConstructor.cpp:
* Source/JavaScriptCore/runtime/ArrayConstructor.h:
* Source/JavaScriptCore/runtime/Intrinsic.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
* Source/JavaScriptCore/runtime/JSRegExpStringIterator.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION): Deleted.
* Source/JavaScriptCore/runtime/JSRegExpStringIterator.h:
* Source/JavaScriptCore/runtime/JSRemoteFunction.cpp:
* Source/JavaScriptCore/runtime/JSRemoteFunction.h:
* Source/JavaScriptCore/runtime/JSTypedArrayViewPrototype.cpp:
* Source/JavaScriptCore/runtime/JSTypedArrayViewPrototype.h:
* Source/JavaScriptCore/runtime/ShadowRealmPrototype.cpp:
* Source/JavaScriptCore/runtime/ShadowRealmPrototype.h:
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
* Source/JavaScriptCore/runtime/StringPrototype.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbcf7c2835439a6cdef549e7518a5a4f067ff878

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151854 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24635 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18205 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160596 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105311 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25128 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24932 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117289 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83223 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154814 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19465 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136271 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98004 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18550 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16485 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8431 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/143860 "Found 38 new JSC stress test failures: stress/same-value-intrinsic.js.bytecode-cache, stress/same-value-intrinsic.js.default, stress/same-value-intrinsic.js.dfg-eager, stress/same-value-intrinsic.js.dfg-eager-no-cjit-validate, stress/same-value-intrinsic.js.eager-jettison-no-cjit, stress/same-value-intrinsic.js.ftl-eager, stress/same-value-intrinsic.js.ftl-eager-no-cjit, stress/same-value-intrinsic.js.ftl-eager-no-cjit-b3o1, stress/same-value-intrinsic.js.ftl-no-cjit-b3o0, stress/same-value-intrinsic.js.ftl-no-cjit-no-inline-validate ... (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128182 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14174 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163060 "Built successfully") | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/12655 "Found 34 new JSC stress test failures: stress/same-value-intrinsic.js.bytecode-cache, stress/same-value-intrinsic.js.default, stress/same-value-intrinsic.js.dfg-eager, stress/same-value-intrinsic.js.dfg-eager-no-cjit-validate, stress/same-value-intrinsic.js.eager-jettison-no-cjit, stress/same-value-intrinsic.js.ftl-eager, stress/same-value-intrinsic.js.ftl-eager-no-cjit-b3o1, stress/same-value-intrinsic.js.ftl-no-cjit-b3o0, stress/same-value-intrinsic.js.ftl-no-cjit-no-inline-validate, stress/same-value-intrinsic.js.ftl-no-cjit-no-put-stack-validate ... (failure)") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6209 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15766 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125310 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24434 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20544 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125491 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24435 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135970 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81010 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20522 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12745 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/183477 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24052 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88337 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46802 "Found 4 new JSC stress test failures: stress/same-value-intrinsic.js.bytecode-cache, stress/same-value-intrinsic.js.default, stress/typed-array-builtin-names.js.bytecode-cache, stress/typed-array-builtin-names.js.default (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23743 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23903 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23804 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->