### PR TITLE
Use :focus-visible in SVG and MathML user agent style sheets

### DIFF
--- a/LayoutTests/mathml/focus-visible-mouse-and-keyboard-expected.txt
+++ b/LayoutTests/mathml/focus-visible-mouse-and-keyboard-expected.txt
@@ -1,0 +1,9 @@
+This test checks that the MathML UA stylesheet applies outline via :focus-visible, not :focus.
+
+1
++
+2
+
+PASS Mouse click on MathML element should not trigger UA focus outline
+PASS Keyboard focus on MathML element should trigger UA focus outline
+

--- a/LayoutTests/mathml/focus-visible-mouse-and-keyboard.html
+++ b/LayoutTests/mathml/focus-visible-mouse-and-keyboard.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>MathML: UA stylesheet uses :focus-visible for outline</title>
+  <script src="../resources/testharness.js"></script>
+  <script src="../resources/testharnessreport.js"></script>
+  <script src="../resources/ui-helper.js"></script>
+</head>
+<body>
+  <p>This test checks that the MathML UA stylesheet applies outline via :focus-visible, not :focus.</p>
+  <math>
+    <mn id="mouse-target" tabindex="0">1</mn>
+    <mo>+</mo>
+    <mn id="keyboard-target" tabindex="0">2</mn>
+  </math>
+  <script>
+    promise_test(async t => {
+      const target = document.getElementById("mouse-target");
+      const rect = target.getBoundingClientRect();
+      await UIHelper.activateAt(rect.x + rect.width / 2, rect.y + rect.height / 2);
+      assert_equals(document.activeElement, target);
+      assert_equals(getComputedStyle(target).outlineStyle, "none", "outlineStyle should be none after mouse click");
+    }, "Mouse click on MathML element should not trigger UA focus outline");
+
+    promise_test(async t => {
+      const target = document.getElementById("keyboard-target");
+      document.getElementById("mouse-target").focus();
+      await UIHelper.keyDown("\t");
+      assert_equals(document.activeElement, target);
+      assert_equals(getComputedStyle(target).outlineStyle, "auto", "outlineStyle should be auto after keyboard focus");
+    }, "Keyboard focus on MathML element should trigger UA focus outline");
+  </script>
+</body>
+</html>

--- a/LayoutTests/platform/ios/mathml/focus-visible-mouse-and-keyboard-expected.txt
+++ b/LayoutTests/platform/ios/mathml/focus-visible-mouse-and-keyboard-expected.txt
@@ -1,0 +1,9 @@
+This test checks that the MathML UA stylesheet applies outline via :focus-visible, not :focus.
+
+1
++
+2
+
+PASS Mouse click on MathML element should not trigger UA focus outline
+FAIL Keyboard focus on MathML element should trigger UA focus outline assert_equals: expected Element node <mn id="keyboard-target" tabindex="0">2</mn> but got Element node <mn id="mouse-target" tabindex="0">1</mn>
+

--- a/LayoutTests/platform/ios/svg/custom/focus-visible-mouse-and-keyboard-expected.txt
+++ b/LayoutTests/platform/ios/svg/custom/focus-visible-mouse-and-keyboard-expected.txt
@@ -1,0 +1,6 @@
+This test checks that the SVG UA stylesheet applies outline via :focus-visible, not :focus.
+
+
+PASS Mouse click on SVG element should not trigger UA focus outline
+FAIL Keyboard focus on SVG element should trigger UA focus outline assert_equals: expected Element node <rect id="keyboard-target" tabindex="0" x="80" y="10" wid... but got Element node <rect id="mouse-target" tabindex="0" x="10" y="10" width=...
+

--- a/LayoutTests/svg/custom/focus-visible-mouse-and-keyboard-expected.txt
+++ b/LayoutTests/svg/custom/focus-visible-mouse-and-keyboard-expected.txt
@@ -1,0 +1,6 @@
+This test checks that the SVG UA stylesheet applies outline via :focus-visible, not :focus.
+
+
+PASS Mouse click on SVG element should not trigger UA focus outline
+PASS Keyboard focus on SVG element should trigger UA focus outline
+

--- a/LayoutTests/svg/custom/focus-visible-mouse-and-keyboard.html
+++ b/LayoutTests/svg/custom/focus-visible-mouse-and-keyboard.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>SVG: UA stylesheet uses :focus-visible for outline</title>
+  <script src="../../resources/testharness.js"></script>
+  <script src="../../resources/testharnessreport.js"></script>
+  <script src="../../resources/ui-helper.js"></script>
+</head>
+<body>
+  <p>This test checks that the SVG UA stylesheet applies outline via :focus-visible, not :focus.</p>
+  <svg width="200" height="200">
+    <rect id="mouse-target" tabindex="0" x="10" y="10" width="50" height="50" fill="orange" />
+    <rect id="keyboard-target" tabindex="0" x="80" y="10" width="50" height="50" fill="orange" />
+  </svg>
+  <script>
+    promise_test(async t => {
+      const target = document.getElementById("mouse-target");
+      const rect = target.getBoundingClientRect();
+      await UIHelper.activateAt(rect.x + rect.width / 2, rect.y + rect.height / 2);
+      assert_equals(document.activeElement, target);
+      assert_equals(getComputedStyle(target).outlineStyle, "none", "outlineStyle should be none after mouse click");
+    }, "Mouse click on SVG element should not trigger UA focus outline");
+
+    promise_test(async t => {
+      const target = document.getElementById("keyboard-target");
+      document.getElementById("mouse-target").focus();
+      await UIHelper.keyDown("\t");
+      assert_equals(document.activeElement, target);
+      assert_equals(getComputedStyle(target).outlineStyle, "auto", "outlineStyle should be auto after keyboard focus");
+    }, "Keyboard focus on SVG element should trigger UA focus outline");
+  </script>
+</body>
+</html>

--- a/Source/WebCore/css/mathml.css
+++ b/Source/WebCore/css/mathml.css
@@ -37,7 +37,7 @@
     color: -webkit-activelink;
 }
 
-:focus {
+:focus-visible {
     outline-style: auto;
 }
 

--- a/Source/WebCore/css/svg.css
+++ b/Source/WebCore/css/svg.css
@@ -77,7 +77,7 @@ text, tspan, tref {
 
 /* states */
 
-:focus {
+:focus-visible {
     outline-style: auto;
 }
 


### PR DESCRIPTION
#### ecac1d7c657679e6b8aeb4712db698d3eac5e055
<pre>
Use :focus-visible in SVG and MathML user agent style sheets
<a href="https://bugs.webkit.org/show_bug.cgi?id=310614">https://bugs.webkit.org/show_bug.cgi?id=310614</a>

Reviewed by Frédéric Wang.

This aligns them with our HTML user agent style sheet. No
web-platform-tests as :focus-visible is up to user agents.

Tests: mathml/focus-visible-mouse-and-keyboard.html
       svg/custom/focus-visible-mouse-and-keyboard.html

Canonical link: <a href="https://commits.webkit.org/309912@main">https://commits.webkit.org/309912@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c161d2b5f2021f271f768eaccc4fa1415e46108c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152088 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24870 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18455 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160831 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105545 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153962 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25362 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25176 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117488 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155048 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19670 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136508 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98201 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18747 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16700 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8665 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14393 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163297 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6443 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15985 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125513 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24668 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20747 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125689 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24669 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136189 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81262 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23335 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20700 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12966 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24286 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88571 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23977 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24137 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24038 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->