### PR TITLE
[GStreamer] GStreamer WebCore logs have incorrect filename and line number

### DIFF
--- a/Source/WTF/wtf/AggregateLogger.h
+++ b/Source/WTF/wtf/AggregateLogger.h
@@ -89,8 +89,8 @@ public:
 
     inline bool willLog(const WTFLogChannel& channel, WTFLogLevel level) const
     {
-        for (auto& loggers : m_loggers) {
-            if (!loggers->willLog(channel, level))
+        for (auto& logger : m_loggers) {
+            if (!logger->willLog(channel, level, { }))
                 return false;
         }
         return true;
@@ -112,7 +112,7 @@ private:
 
         for (const auto& logger : m_loggers) {
             for (Observer& observer : logger->observers())
-                observer.didLogMessage(channel, level, { ConsoleLogValue<Argument>::toValue(arguments)... });
+                observer.didLogMessage(channel, level, { }, { ConsoleLogValue<Argument>::toValue(arguments)... });
         }
     }
 

--- a/Source/WTF/wtf/Assertions.h
+++ b/Source/WTF/wtf/Assertions.h
@@ -182,6 +182,12 @@ typedef struct {
 #endif
 } WTFLogChannel;
 
+typedef struct {
+    const char* file;
+    const char* function;
+    int line;
+} WTFLogLocation;
+
 #define LOG_CHANNEL(name) JOIN_LOG_CHANNEL_WITH_PREFIX(LOG_CHANNEL_PREFIX, name)
 #define LOG_CHANNEL_ADDRESS(name) &LOG_CHANNEL(name),
 #define JOIN_LOG_CHANNEL_WITH_PREFIX(prefix, channel) JOIN_LOG_CHANNEL_WITH_PREFIX_LEVEL_2(prefix, channel)

--- a/Source/WTF/wtf/Logger.h
+++ b/Source/WTF/wtf/Logger.h
@@ -140,13 +140,13 @@ public:
     public:
         virtual ~Observer() = default;
         // Can be called on any thread.
-        virtual void didLogMessage(const WTFLogChannel&, WTFLogLevel, Vector<JSONLogValue>&&) = 0;
+        virtual void didLogMessage(const WTFLogChannel&, WTFLogLevel, std::optional<WTFLogLocation>, Vector<JSONLogValue>&&) = 0;
     };
 
     class MessageHandlerObserver {
     public:
         virtual ~MessageHandlerObserver() = default;
-        virtual void handleLogMessage(const WTFLogChannel&, WTFLogLevel, Vector<JSONLogValue>&&) = 0;
+        virtual void handleLogMessage(const WTFLogChannel&, WTFLogLevel, std::optional<WTFLogLocation>, Vector<JSONLogValue>&&) = 0;
     };
 
     static Ref<Logger> create(const void* owner)
@@ -162,7 +162,7 @@ public:
         //  on some systems, so don't allow it.
         UNUSED_PARAM(channel);
 #else
-        if (!willLog(channel, WTFLogLevel::Always, arguments...))
+        if (!willLog(channel, WTFLogLevel::Always, { }, arguments...))
             return;
 
         log(channel, WTFLogLevel::Always, arguments...);
@@ -172,7 +172,7 @@ public:
     template<typename... Arguments>
     inline void error(WTFLogChannel& channel, const Arguments&... arguments) const
     {
-        if (!willLog(channel, WTFLogLevel::Error, arguments...))
+        if (!willLog(channel, WTFLogLevel::Error, { }, arguments...))
             return;
 
         log(channel, WTFLogLevel::Error, arguments...);
@@ -181,7 +181,7 @@ public:
     template<typename... Arguments>
     inline void warning(WTFLogChannel& channel, const Arguments&... arguments) const
     {
-        if (!willLog(channel, WTFLogLevel::Warning, arguments...))
+        if (!willLog(channel, WTFLogLevel::Warning, { }, arguments...))
             return;
 
         log(channel, WTFLogLevel::Warning, arguments...);
@@ -190,7 +190,7 @@ public:
     template<typename... Arguments>
     inline void info(WTFLogChannel& channel, const Arguments&... arguments) const
     {
-        if (!willLog(channel, WTFLogLevel::Info, arguments...))
+        if (!willLog(channel, WTFLogLevel::Info, { }, arguments...))
             return;
 
         log(channel, WTFLogLevel::Info, arguments...);
@@ -199,7 +199,7 @@ public:
     template<typename... Arguments>
     inline void debug(WTFLogChannel& channel, const Arguments&... arguments) const
     {
-        if (!willLog(channel, WTFLogLevel::Debug, arguments...))
+        if (!willLog(channel, WTFLogLevel::Debug, { }, arguments...))
             return;
 
         log(channel, WTFLogLevel::Debug, arguments...);
@@ -216,7 +216,7 @@ public:
         UNUSED_PARAM(function);
         UNUSED_PARAM(line);
 #else
-        if (!willLog(channel, WTFLogLevel::Always, arguments...))
+        if (!willLog(channel, WTFLogLevel::Always, { { file, function, line } }, arguments...))
             return;
 
         logVerbose(channel, WTFLogLevel::Always, file, function, line, arguments...);
@@ -226,7 +226,7 @@ public:
     template<typename... Arguments>
     inline void errorVerbose(WTFLogChannel& channel, const char* file, const char* function, int line, const Arguments&... arguments) const
     {
-        if (!willLog(channel, WTFLogLevel::Error, arguments...))
+        if (!willLog(channel, WTFLogLevel::Error, { { file, function, line } }, arguments...))
             return;
 
         logVerbose(channel, WTFLogLevel::Error, file, function, line, arguments...);
@@ -235,7 +235,7 @@ public:
     template<typename... Arguments>
     inline void warningVerbose(WTFLogChannel& channel, const char* file, const char* function, int line, const Arguments&... arguments) const
     {
-        if (!willLog(channel, WTFLogLevel::Warning, arguments...))
+        if (!willLog(channel, WTFLogLevel::Warning, { { file, function, line } }, arguments...))
             return;
 
         logVerbose(channel, WTFLogLevel::Warning, file, function, line, arguments...);
@@ -244,7 +244,7 @@ public:
     template<typename... Arguments>
     inline void infoVerbose(WTFLogChannel& channel, const char* file, const char* function, int line, const Arguments&... arguments) const
     {
-        if (!willLog(channel, WTFLogLevel::Info, arguments...))
+        if (!willLog(channel, WTFLogLevel::Info, { { file, function, line } }, arguments...))
             return;
 
         logVerbose(channel, WTFLogLevel::Info, file, function, line, arguments...);
@@ -253,14 +253,14 @@ public:
     template<typename... Arguments>
     inline void debugVerbose(WTFLogChannel& channel, const char* file, const char* function, int line, const Arguments&... arguments) const
     {
-        if (!willLog(channel, WTFLogLevel::Debug, arguments...))
+        if (!willLog(channel, WTFLogLevel::Debug, { { file, function, line } }, arguments...))
             return;
 
         logVerbose(channel, WTFLogLevel::Debug, file, function, line, arguments...);
     }
 
     template<typename... Argument>
-    inline bool willLog(const WTFLogChannel& channel, WTFLogLevel level, const Argument&... arguments) const
+    inline bool willLog(const WTFLogChannel& channel, WTFLogLevel level, std::optional<WTFLogLocation> logLocation, const Argument&... arguments) const
     {
         {
             if (!messageHandlerObserverLock().tryLock())
@@ -268,7 +268,7 @@ public:
 
             Locker locker { AdoptLock, messageHandlerObserverLock() };
             for (MessageHandlerObserver& observer : messageHandlerObservers())
-                observer.handleLogMessage(channel, level, { ConsoleLogValue<Argument>::toValue(arguments)... });
+                observer.handleLogMessage(channel, level, logLocation, { ConsoleLogValue<Argument>::toValue(arguments)... });
         }
 
         if (!m_enabled)
@@ -289,12 +289,12 @@ public:
     }
 
     template<typename... Arguments>
-    inline void toObservers(WTFLogChannel& channel, WTFLogLevel level, const Arguments&... arguments) const
+    inline void toObservers(WTFLogChannel& channel, WTFLogLevel level, std::optional<WTFLogLocation> location, const Arguments&... arguments) const
     {
-        if (!willLog(channel, level, arguments...))
+        if (!willLog(channel, level, location, arguments...))
             return;
 
-        sendMessageToObservers(channel, level, arguments...);
+        sendMessageToObservers(channel, level, location, arguments...);
     }
 
     bool enabled() const { return m_enabled; }
@@ -383,11 +383,11 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         fprintf(stderr, "[" LOG_CHANNEL_WEBKIT_SUBSYSTEM ":%s:-] %s\n", channel.name, logMessage.utf8().data());
 #endif
 
-        sendMessageToObservers(channel, level, arguments...);
+        sendMessageToObservers(channel, level, { }, arguments...);
     }
 
     template<typename... Argument>
-    static inline void sendMessageToObservers(WTFLogChannel& channel, WTFLogLevel level, const Argument&... arguments)
+    static inline void sendMessageToObservers(WTFLogChannel& channel, WTFLogLevel level, std::optional<WTFLogLocation> location, const Argument&... arguments)
     {
         if (channel.state == WTFLogChannelState::Off || level > channel.level)
             return;
@@ -397,7 +397,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
         Locker locker { AdoptLock, observerLock() };
         for (Observer& observer : observers())
-            observer.didLogMessage(channel, level, { ConsoleLogValue<Argument>::toValue(arguments)... });
+            observer.didLogMessage(channel, level, location, { ConsoleLogValue<Argument>::toValue(arguments)... });
     }
 
     template<typename... Argument>
@@ -424,7 +424,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         fprintf(stderr, "[" LOG_CHANNEL_WEBKIT_SUBSYSTEM ":%s:-] %s FILE=%s:%d %s\n", channel.name, logMessage.utf8().data(), file, line, function);
 #endif
 
-        sendMessageToObservers(channel, level, arguments...);
+        sendMessageToObservers(channel, level, { { file, function, line } }, arguments...);
     }
 
     WTF_EXPORT_PRIVATE static Vector<std::reference_wrapper<Observer>>& NODELETE observers() WTF_REQUIRES_LOCK(observerLock());

--- a/Source/WTF/wtf/LoggerHelper.h
+++ b/Source/WTF/wtf/LoggerHelper.h
@@ -69,7 +69,7 @@ public:
 #define DEBUG_LOG_WITH_THIS(thisPtr, ...)      Ref { (thisPtr)->logger() }->debug((thisPtr)->logChannel(), __VA_ARGS__)
 #endif
 
-#define WILL_LOG(_level_)   Ref { logger() }->willLog(logChannel(), _level_)
+#define WILL_LOG(_level_)   Ref { logger() }->willLog(logChannel(), _level_, { })
 
 #define ALWAYS_LOG_IF(condition, ...)     if (condition) ALWAYS_LOG(__VA_ARGS__)
 #define ERROR_LOG_IF(condition, ...)      if (condition) ERROR_LOG(__VA_ARGS__)
@@ -82,7 +82,7 @@ public:
 #define WARNING_LOG_IF_POSSIBLE(...)    if (RefPtr logger = loggerPtr()) logger->warning(logChannel(), __VA_ARGS__)
 #define INFO_LOG_IF_POSSIBLE(...)       if (RefPtr logger = loggerPtr()) logger->info(logChannel(), __VA_ARGS__)
 #define DEBUG_LOG_IF_POSSIBLE(...)      if (RefPtr logger = loggerPtr()) logger->debug(logChannel(), __VA_ARGS__)
-#define WILL_LOG_IF_POSSIBLE(_level_)   if (RefPtr logger = loggerPtr()) logger->willLog(logChannel(), _level_)
+#define WILL_LOG_IF_POSSIBLE(_level_)   if (RefPtr logger = loggerPtr()) logger->willLog(logChannel(), _level_, { })
 
 #define ALWAYS_LOG_WITH_THIS_IF_POSSIBLE(thisPtr, ...)  if (RefPtr logger = thisPtr->loggerPtr()) ALWAYS_LOG_WITH_THIS(thisPtr, __VA_ARGS__)
 #define ERROR_LOG_WITH_THIS_IF_POSSIBLE(thisPtr, ...)   if (RefPtr logger = thisPtr->loggerPtr()) ERROR_LOG_WITH_THIS(thisPtr, __VA_ARGS__)

--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -256,7 +256,7 @@ Ref<Logger> MediaSource::logger(ScriptExecutionContext& context)
     return logger;
 }
 
-void MediaSource::didLogMessage(const WTFLogChannel&, WTFLogLevel, Vector<JSONLogValue>&&)
+void MediaSource::didLogMessage(const WTFLogChannel&, WTFLogLevel, std::optional<WTFLogLocation>, Vector<JSONLogValue>&&)
 {
     // FIXME: Add logging for when MediaSource is running in worker.
 }

--- a/Source/WebCore/Modules/mediasource/MediaSource.h
+++ b/Source/WebCore/Modules/mediasource/MediaSource.h
@@ -149,7 +149,7 @@ public:
     void setLogIdentifier(uint64_t);
 
     Ref<Logger> logger(ScriptExecutionContext&);
-    void NODELETE didLogMessage(const WTFLogChannel&, WTFLogLevel, Vector<JSONLogValue>&&) final;
+    void NODELETE didLogMessage(const WTFLogChannel&, WTFLogLevel, std::optional<WTFLogLocation>, Vector<JSONLogValue>&&) final;
 #endif
 
     virtual bool isManaged() const { return false; }

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
@@ -210,7 +210,7 @@ PeerConnectionBackend::~PeerConnectionBackend()
 }
 
 #if !RELEASE_LOG_DISABLED && (PLATFORM(WPE) || PLATFORM(GTK))
-void PeerConnectionBackend::handleLogMessage(const WTFLogChannel& channel, WTFLogLevel, Vector<JSONLogValue>&& values)
+void PeerConnectionBackend::handleLogMessage(const WTFLogChannel& channel, WTFLogLevel, std::optional<WTFLogLocation>, Vector<JSONLogValue>&& values)
 {
     auto name = StringView::fromLatin1(channel.name);
     if (name != "WebRTC"_s)
@@ -269,7 +269,7 @@ void PeerConnectionBackend::createOfferSucceeded(String&& sdp)
     ASSERT(isMainThread());
 
 #if !RELEASE_LOG_DISABLED
-    logger().toObservers(LogWebRTC, WTFLogLevel::Always, LOGIDENTIFIER, "SDP offer created:\n", sdp);
+    logger().toObservers(LogWebRTC, WTFLogLevel::Always, { }, LOGIDENTIFIER, "SDP offer created:\n", sdp);
     RELEASE_LOG_FORWARDABLE(WebRTC, PeerConnectionBackendCreateOfferSucceeded, logIdentifier(), sdp.utf8());
 #endif
 
@@ -305,7 +305,7 @@ void PeerConnectionBackend::createAnswerSucceeded(String&& sdp)
     ASSERT(isMainThread());
 
 #if !RELEASE_LOG_DISABLED
-    logger().toObservers(LogWebRTC, WTFLogLevel::Always, LOGIDENTIFIER, "SDP answer created:\n", sdp);
+    logger().toObservers(LogWebRTC, WTFLogLevel::Always, { }, LOGIDENTIFIER, "SDP answer created:\n", sdp);
     RELEASE_LOG_FORWARDABLE(WebRTC, PeerConnectionBackendCreateAnswerSucceeded, logIdentifier(), sdp.utf8());
 #endif
 

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.h
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.h
@@ -176,7 +176,7 @@ public:
     ASCIILiteral logClassName() const override { return "PeerConnectionBackend"_s; }
     WTFLogChannel& NODELETE logChannel() const final;
 #if PLATFORM(WPE) || PLATFORM(GTK)
-    void handleLogMessage(const WTFLogChannel&, WTFLogLevel, Vector<JSONLogValue>&&) final;
+    void handleLogMessage(const WTFLogChannel&, WTFLogLevel, std::optional<WTFLogLocation>, Vector<JSONLogValue>&&) final;
 #endif
 #endif
 

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
@@ -404,7 +404,7 @@ void RTCPeerConnection::setLocalDescription(std::optional<RTCLocalSessionDescrip
 
 #if !RELEASE_LOG_DISABLED
     String sdp = localDescription.value_or(RTCLocalSessionDescriptionInit { }).sdp;
-    logger().toObservers(LogWebRTC, WTFLogLevel::Always, LOGIDENTIFIER, "Setting local description to:\n", sdp);
+    logger().toObservers(LogWebRTC, WTFLogLevel::Always, { }, LOGIDENTIFIER, "Setting local description to:\n", sdp);
     RELEASE_LOG_FORWARDABLE(WebRTC, RtcPeerConnectionSetLocalDescription, logIdentifier(), sdp.utf8());
 #endif
 
@@ -437,7 +437,7 @@ void RTCPeerConnection::setRemoteDescription(RTCSessionDescriptionInit&& remoteD
     }
 
 #if !RELEASE_LOG_DISABLED
-    logger().toObservers(LogWebRTC, WTFLogLevel::Always, LOGIDENTIFIER, "Setting remote description to:\n", remoteDescription.sdp);
+    logger().toObservers(LogWebRTC, WTFLogLevel::Always, { }, LOGIDENTIFIER, "Setting remote description to:\n", remoteDescription.sdp);
     RELEASE_LOG_FORWARDABLE(WebRTC, RtcPeerConnectionSetRemoteDescription, logIdentifier(), remoteDescription.sdp.utf8());
 #endif
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -2686,7 +2686,7 @@ void GStreamerMediaEndpoint::processStatsItem(const GValue* value)
         peerConnectionBackend->provideStatLogs(WTF::move(event));
     }
 
-    if (logger().willLog(logChannel(), WTFLogLevel::Debug)) {
+    if (logger().willLog(logChannel(), WTFLogLevel::Debug, { })) {
         // Stats are very verbose, let's only display them in inspector console in verbose mode.
         logger().debug(LogWebRTC, Logger::LogSiteIdentifier("GStreamerMediaEndpoint"_s, "OnStatsDelivered"_s, logIdentifier()), statsLogger);
     } else
@@ -2730,7 +2730,7 @@ Seconds GStreamerMediaEndpoint::statsLogInterval(Seconds reportTimestamp) const
     if (m_isGatheringRTCLogs)
         return 1_s;
 
-    if (logger().willLog(logChannel(), WTFLogLevel::Info))
+    if (logger().willLog(logChannel(), WTFLogLevel::Info, { }))
         return 2_s;
 
     if (reportTimestamp - m_statsFirstDeliveredTimestamp > 15_s)

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp
@@ -905,7 +905,7 @@ void LibWebRTCMediaEndpoint::OnStatsDelivered(const webrtc::scoped_refptr<const 
 #endif
 
             // Stats are very verbose, let's only display them in inspector console in verbose mode.
-            logger().toObservers(LogWebRTC, WTFLogLevel::Debug, Logger::LogSiteIdentifier("LibWebRTCMediaEndpoint"_s, "OnStatsDelivered"_s, logIdentifier()), statsLogger);
+            logger().toObservers(LogWebRTC, WTFLogLevel::Debug, { }, Logger::LogSiteIdentifier("LibWebRTCMediaEndpoint"_s, "OnStatsDelivered"_s, logIdentifier()), statsLogger);
 
             RELEASE_LOG_FORWARDABLE(WebRTCStats, LibWebRtcMediaEndpointOnStatsDelivered, logIdentifier(), statsLogger.toJSONString().utf8());
         }
@@ -940,7 +940,7 @@ Seconds LibWebRTCMediaEndpoint::statsLogInterval(int64_t reportTimestamp) const
     if (m_isGatheringRTCLogs)
         return 1_s;
 
-    if (logger().willLog(logChannel(), WTFLogLevel::Info))
+    if (logger().willLog(logChannel(), WTFLogLevel::Info, { }))
         return 2_s;
 
     if (reportTimestamp - m_statsFirstDeliveredTimestamp > 15000000)

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -11183,12 +11183,12 @@ static inline Vector<JSONLogValue> crossThreadCopy(Vector<JSONLogValue>&& source
     return values;
 }
 
-void Document::didLogMessage(const WTFLogChannel& channel, WTFLogLevel level, Vector<JSONLogValue>&& logMessages)
+void Document::didLogMessage(const WTFLogChannel& channel, WTFLogLevel level, std::optional<WTFLogLocation> location, Vector<JSONLogValue>&& logMessages)
 {
     if (!isMainThread()) {
-        postTask([weakThis = WeakPtr<Document, WeakPtrImplWithEventTargetData> { *this }, channel, level, logMessages = crossThreadCopy(WTF::move(logMessages))](auto&) mutable {
+        postTask([weakThis = WeakPtr<Document, WeakPtrImplWithEventTargetData> { *this }, channel, level, location, logMessages = crossThreadCopy(WTF::move(logMessages))](auto&) mutable {
             if (RefPtr document = weakThis.get())
-                document->didLogMessage(channel, level, WTF::move(logMessages));
+                document->didLogMessage(channel, level, location, WTF::move(logMessages));
         });
         return;
     }

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -2233,7 +2233,7 @@ private:
 
     bool isBodyPotentiallyScrollable(HTMLBodyElement&);
 
-    void didLogMessage(const WTFLogChannel&, WTFLogLevel, Vector<JSONLogValue>&&) final;
+    void didLogMessage(const WTFLogChannel&, WTFLogLevel, std::optional<WTFLogLocation>, Vector<JSONLogValue>&&) final;
     static void configureSharedLogger();
 
     void addToDocumentsMap();

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -236,7 +236,7 @@ do { \
         if ((thisPtr)->logger().hasEnabledInspector()) { \
             std::array<char, 1024> buffer { }; \
             SAFE_SPRINTF(std::span { buffer }, MESSAGE_WITHOUT_PUBLIC_STRING_MODIFIER_HTMLMediaElement##formatString, (thisPtr)->logIdentifier(), ##__VA_ARGS__); \
-            (thisPtr)->logger().toObservers((thisPtr)->logChannel(), WTFLogLevel::Always, String::fromUTF8(buffer.data())); \
+            (thisPtr)->logger().toObservers((thisPtr)->logChannel(), WTFLogLevel::Always, { }, String::fromUTF8(buffer.data())); \
         } \
     } \
 } while (0)
@@ -9824,7 +9824,7 @@ WTFLogChannel& HTMLMediaElement::logChannel() const
 bool HTMLMediaElement::willLog(WTFLogLevel level) const
 {
 #if !RELEASE_LOG_DISABLED
-    return m_logger->willLog(logChannel(), level);
+    return m_logger->willLog(logChannel(), level, { });
 #else
     UNUSED_PARAM(level);
     return false;

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -77,7 +77,7 @@ do { \
         if (logger().hasEnabledInspector()) { \
             std::array<char, 1024> buffer { }; \
             SAFE_SPRINTF(std::span { buffer }, MESSAGE_HTMLVideoElement##formatString, logIdentifier(), ##__VA_ARGS__); \
-            logger().toObservers(logChannel(), WTFLogLevel::Always, String::fromUTF8(buffer.data())); \
+            logger().toObservers(logChannel(), WTFLogLevel::Always, { }, String::fromUTF8(buffer.data())); \
         } \
     } \
 } while (0)

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
@@ -44,7 +44,7 @@ do { \
         if (logger().developerExtrasEnabled()) { \
             std::array<char, 1024> buffer { }; \
             SAFE_SPRINTF(std::span { buffer }, MESSAGE_PLATFORMMEDIASESSIONMANAGER_##formatString, ##__VA_ARGS__); \
-            logger().toObservers(logChannel(), WTFLogLevel::Always, String::fromUTF8(buffer.data())); \
+            logger().toObservers(logChannel(), WTFLogLevel::Always, { }, String::fromUTF8(buffer.data())); \
         } \
     } \
 } while (0)

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -68,7 +68,7 @@ do { \
         if (logger().hasEnabledInspector()) { \
             char buffer[1024] = { 0 }; \
             SAFE_SPRINTF(std::span { buffer }, MESSAGE_MediaSessionManagerCocoa##formatString, ##__VA_ARGS__); \
-            logger().toObservers(logChannel(), WTFLogLevel::Always, String::fromUTF8(buffer)); \
+            logger().toObservers(logChannel(), WTFLogLevel::Always, { }, String::fromUTF8(buffer)); \
         } \
     } \
 } while (0)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -4493,7 +4493,7 @@ NSArray* playerKVOProperties()
 #endif
         }
 
-        if (player.logger().willLog(player.logChannel(), WTFLogLevel::Debug) && !([keyPath isEqualToString:@"loadedTimeRanges"] || [keyPath isEqualToString:@"seekableTimeRanges"])) {
+        if (player.logger().willLog(player.logChannel(), WTFLogLevel::Debug, { }) && !([keyPath isEqualToString:@"loadedTimeRanges"] || [keyPath isEqualToString:@"seekableTimeRanges"])) {
             auto identifier = Logger::LogSiteIdentifier("MediaPlayerPrivateAVFoundation"_s, "observeValueForKeyPath"_s, player.logIdentifier());
 
             if (shouldLogValue) {

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -664,7 +664,7 @@ void unregisterPipeline(const GRefPtr<GstElement>& pipeline)
     activePipelinesMap().remove(name.span());
 }
 
-void WebCoreLogObserver::didLogMessage(const WTFLogChannel& channel, WTFLogLevel level, Vector<JSONLogValue>&& values)
+void WebCoreLogObserver::didLogMessage(const WTFLogChannel& channel, WTFLogLevel level, std::optional<WTFLogLocation> location, Vector<JSONLogValue>&& values)
 {
 #ifndef GST_DISABLE_GST_DEBUG
     if (!shouldEmitLogMessage(channel))
@@ -676,7 +676,10 @@ void WebCoreLogObserver::didLogMessage(const WTFLogChannel& channel, WTFLogLevel
 
     auto logString = builder.toString();
     auto gstDebugLevel = gstDebugLevelFromWTFLogLevel(level);
-    gst_debug_log(debugCategory(), gstDebugLevel, __FILE__, __FUNCTION__, __LINE__, nullptr, "%s", logString.utf8().data());
+    const char* file = location ? location->file : __FILE__;
+    const char* function = location ? location->function : __FUNCTION__;
+    int line = location ? location->line : __LINE__;
+    gst_debug_log(debugCategory(), gstDebugLevel, file, function, line, nullptr, "%s", logString.utf8().data());
 #else
     UNUSED_PARAM(channel);
     UNUSED_PARAM(level);

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -350,7 +350,7 @@ class WebCoreLogObserver : public Logger::Observer {
     friend NeverDestroyed<WebCoreLogObserver>;
 public:
     explicit WebCoreLogObserver() = default;
-    void didLogMessage(const WTFLogChannel&, WTFLogLevel, Vector<JSONLogValue>&&) final;
+    void didLogMessage(const WTFLogChannel&, WTFLogLevel, std::optional<WTFLogLocation>, Vector<JSONLogValue>&&) final;
 
     virtual GstDebugCategory* debugCategory() const = 0;
     virtual bool shouldEmitLogMessage(const WTFLogChannel&) const = 0;

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
@@ -102,7 +102,7 @@ SourceBufferPrivateGStreamer::~SourceBufferPrivateGStreamer()
 }
 
 #if !RELEASE_LOG_DISABLED && !defined(GST_DISABLE_GST_DEBUG)
-void SourceBufferPrivateGStreamer::handleLogMessage(const WTFLogChannel& channel, WTFLogLevel level, Vector<JSONLogValue>&& values)
+void SourceBufferPrivateGStreamer::handleLogMessage(const WTFLogChannel& channel, WTFLogLevel level, std::optional<WTFLogLocation> location, Vector<JSONLogValue>&& values)
 {
     auto gstDebugLevel = gstDebugLevelFromWTFLogLevel(level);
     if (gstDebugLevel > gst_debug_category_get_threshold(GST_CAT_DEFAULT))
@@ -117,16 +117,16 @@ void SourceBufferPrivateGStreamer::handleLogMessage(const WTFLogChannel& channel
         return;
 
     // Parse "foo::bar(hexidentifier) "
-    auto& callSite = values[0].value;
-    auto leftParenthesisIndex = callSite.reverseFind('(');
+    auto& signature = values[0].value;
+    auto leftParenthesisIndex = signature.reverseFind('(');
     if (leftParenthesisIndex == notFound)
         return;
 
-    auto rightParenthesisIndex = callSite.reverseFind(')');
+    auto rightParenthesisIndex = signature.reverseFind(')');
     if (rightParenthesisIndex == notFound)
         return;
 
-    auto identifierString = callSite.substring(leftParenthesisIndex + 1, rightParenthesisIndex - leftParenthesisIndex - 1);
+    auto identifierString = signature.substring(leftParenthesisIndex + 1, rightParenthesisIndex - leftParenthesisIndex - 1);
     auto identifier = WTF::parseInteger<uint64_t>(identifierString, 16);
     if (!identifier)
         return;
@@ -141,14 +141,19 @@ void SourceBufferPrivateGStreamer::handleLogMessage(const WTFLogChannel& channel
 
     // Find the C++ method name, foo::bar() -> bar.
     auto methodName = emptyString();
-    auto methodNameSeparatorIndex = callSite.reverseFind(':');
-    if (methodNameSeparatorIndex != notFound)
-        methodName = callSite.substring(methodNameSeparatorIndex + 1, leftParenthesisIndex - methodNameSeparatorIndex - 1);
+    if (location)
+        methodName = String::fromUTF8(location->function);
+    else {
+        auto methodNameSeparatorIndex = signature.reverseFind(':');
+        if (methodNameSeparatorIndex != notFound)
+            methodName = signature.substring(methodNameSeparatorIndex + 1, leftParenthesisIndex - methodNameSeparatorIndex - 1);
+    }
 
     auto message = builder.toString();
     auto pipeline = m_appendPipeline ? m_appendPipeline->pipeline() : nullptr;
-    // FIXME: Filename and line number are inaccurate. https://bugs.webkit.org/show_bug.cgi?id=310526
-    gst_debug_log(GST_CAT_DEFAULT, gstDebugLevel, __FILE__, methodName.utf8().data(), __LINE__, G_OBJECT(pipeline), "%s", message.utf8().data());
+    const char* file = location ? location->file : __FILE__;
+    int line = location ? location->line : __LINE__;
+    gst_debug_log(GST_CAT_DEFAULT, gstDebugLevel, file, methodName.utf8().data(), line, G_OBJECT(pipeline), "%s", message.utf8().data());
 }
 #endif // !RELEASE_LOG_DISABLED && !defined(GST_DISABLE_GST_DEBUG)
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
@@ -101,7 +101,7 @@ public:
     const Logger& sourceBufferLogger() const final { return m_logger; }
     uint64_t sourceBufferLogIdentifier() final { return logIdentifier(); }
 #ifndef GST_DISABLE_GST_DEBUG
-    void handleLogMessage(const WTFLogChannel&, WTFLogLevel, Vector<JSONLogValue>&&) final;
+    void handleLogMessage(const WTFLogChannel&, WTFLogLevel, std::optional<WTFLogLocation>, Vector<JSONLogValue>&&) final;
 #endif
 #endif
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/Logging.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/Logging.cpp
@@ -284,7 +284,7 @@ TEST_F(LoggingTest, DISABLED_Logger)
     EXPECT_TRUE(logger->enabled());
 
     WTFSetLogChannelLevel(&TestChannel1, WTFLogLevel::Error);
-    EXPECT_TRUE(logger->willLog(TestChannel1, WTFLogLevel::Error));
+    EXPECT_TRUE(logger->willLog(TestChannel1, WTFLogLevel::Error, { }));
     logger->error(TestChannel1, "You're using coconuts!");
     EXPECT_TRUE(output().containsIgnoringASCIICase("You're using coconuts!"_s));
     logger->warning(TestChannel1, "You're using coconuts!");
@@ -318,10 +318,10 @@ TEST_F(LoggingTest, DISABLED_Logger)
     EXPECT_TRUE(output().containsIgnoringASCIICase("I shall taunt you a second time!"_s));
 
     logger->setEnabled(this, false);
-    EXPECT_FALSE(logger->willLog(TestChannel1, WTFLogLevel::Error));
-    EXPECT_FALSE(logger->willLog(TestChannel1, WTFLogLevel::Warning));
-    EXPECT_FALSE(logger->willLog(TestChannel1, WTFLogLevel::Info));
-    EXPECT_FALSE(logger->willLog(TestChannel1, WTFLogLevel::Debug));
+    EXPECT_FALSE(logger->willLog(TestChannel1, WTFLogLevel::Error, { }));
+    EXPECT_FALSE(logger->willLog(TestChannel1, WTFLogLevel::Warning, { }));
+    EXPECT_FALSE(logger->willLog(TestChannel1, WTFLogLevel::Info, { }));
+    EXPECT_FALSE(logger->willLog(TestChannel1, WTFLogLevel::Debug, { }));
     EXPECT_FALSE(logger->enabled());
     logger->logAlways(TestChannel1, "You've got two empty halves of coconuts");
     EXPECT_EQ(0u, output().length());
@@ -383,7 +383,7 @@ public:
     WTFLogLevel level() const { return m_lastLevel; }
 
 private:
-    void didLogMessage(const WTFLogChannel& channel, WTFLogLevel level, Vector<JSONLogValue>&& logMessage) final
+    void didLogMessage(const WTFLogChannel& channel, WTFLogLevel level, std::optional<WTFLogLocation>, Vector<JSONLogValue>&& logMessage) final
     {
         for (auto& item : logMessage)
             m_logBuffer.append(item.value);


### PR DESCRIPTION
#### ed2b48a0527a12430d16ae651f9d20844805ae5e
<pre>
[GStreamer] GStreamer WebCore logs have incorrect filename and line number
<a href="https://bugs.webkit.org/show_bug.cgi?id=310526">https://bugs.webkit.org/show_bug.cgi?id=310526</a>

Reviewed by Alicia Boya Garcia.

Forward log message location (file, function, line) to MessageHandlerObservers. The informations are
then re-used when generating GStreamer logs.

Canonical link: <a href="https://commits.webkit.org/309858@main">https://commits.webkit.org/309858@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06e8346100dcce835b2feef54958c1b60821c01d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151912 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24693 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18265 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160654 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105369 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153786 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25186 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24996 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117345 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154872 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19516 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136321 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98060 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18598 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16533 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8489 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/143918 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128231 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14224 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163119 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/12713 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6267 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15816 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125363 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24492 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20592 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125544 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34070 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24493 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136020 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81073 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20574 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12795 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/183536 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24110 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88395 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46814 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23801 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23961 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23862 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->