### PR TITLE
JSValueInWrappedObject should store world of the lexical global object

### DIFF
--- a/Source/WebCore/Modules/paymentrequest/PaymentMethodChangeEvent.cpp
+++ b/Source/WebCore/Modules/paymentrequest/PaymentMethodChangeEvent.cpp
@@ -34,10 +34,10 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(PaymentMethodChangeEvent);
 
-PaymentMethodChangeEvent::PaymentMethodChangeEvent(const AtomString& type, Init&& eventInit)
+PaymentMethodChangeEvent::PaymentMethodChangeEvent(JSC::JSGlobalObject& globalObject, const AtomString& type, Init&& eventInit)
     : PaymentRequestUpdateEvent { EventInterfaceType::PaymentMethodChangeEvent, type, eventInit }
     , m_methodName { WTF::move(eventInit.methodName) }
-    , m_methodDetails { WTF::InPlaceTypeT<JSValueInWrappedObject>(), eventInit.methodDetails.get() }
+    , m_methodDetails { WTF::InPlaceTypeT<JSValueInWrappedObject>(), globalObject, eventInit.methodDetails.get() }
 {
 }
 

--- a/Source/WebCore/Modules/paymentrequest/PaymentMethodChangeEvent.h
+++ b/Source/WebCore/Modules/paymentrequest/PaymentMethodChangeEvent.h
@@ -59,7 +59,7 @@ public:
     };
 
 private:
-    PaymentMethodChangeEvent(const AtomString& type, Init&&);
+    PaymentMethodChangeEvent(JSC::JSGlobalObject&, const AtomString& type, Init&&);
     PaymentMethodChangeEvent(const AtomString& type, const String& methodName, MethodDetailsFunction&&);
 
     String m_methodName;

--- a/Source/WebCore/Modules/paymentrequest/PaymentMethodChangeEvent.idl
+++ b/Source/WebCore/Modules/paymentrequest/PaymentMethodChangeEvent.idl
@@ -30,7 +30,7 @@
     JSCustomMarkFunction,
     SecureContext,
 ] interface PaymentMethodChangeEvent : PaymentRequestUpdateEvent {
-    constructor([AtomString] DOMString type, optional PaymentMethodChangeEventInit eventInitDict = {});
+    [CallWith=CurrentGlobalObject] constructor([AtomString] DOMString type, optional PaymentMethodChangeEventInit eventInitDict = {});
 
     readonly attribute DOMString methodName;
     [CustomGetter] readonly attribute object? methodDetails;

--- a/Source/WebCore/Modules/streams/ReadableByteStreamController.cpp
+++ b/Source/WebCore/Modules/streams/ReadableByteStreamController.cpp
@@ -83,7 +83,7 @@ ReadableByteStreamController::ReadableByteStreamController(JSDOMGlobalObject& gl
         m_cancelAlgorithm = WTF::move(cancelAlgorithm);
     }
 
-    m_underlyingSource.set(globalObject.vm(), &globalObject, underlyingSource);
+    m_underlyingSource.set(globalObject, &globalObject, underlyingSource);
 
     m_pullAlgorithmWrapper =  [](auto& globalObject, auto& controller) {
         return getAlgorithmPromise(globalObject, controller.m_pullAlgorithm, controller.m_underlyingSource.getValue(), controller);
@@ -811,9 +811,8 @@ void ReadableByteStreamController::fillReadRequestFromQueue(JSDOMGlobalObject& g
 
 void ReadableByteStreamController::storeError(JSDOMGlobalObject& globalObject, JSC::JSValue error)
 {
-    Ref vm = globalObject.vm();
     auto thisValue = toJS(&globalObject, &globalObject, *this);
-    m_storedError.set(vm.get(), thisValue.getObject(), error);
+    m_storedError.set(globalObject, thisValue.getObject(), error);
 }
 
 JSC::JSValue ReadableByteStreamController::storedError() const

--- a/Source/WebCore/Modules/streams/StreamTeeUtilities.cpp
+++ b/Source/WebCore/Modules/streams/StreamTeeUtilities.cpp
@@ -78,13 +78,11 @@ public:
     JSC::JSValue NODELETE reason2() { return m_branch2Reason.getValue(); }
     void setReason1(JSDOMGlobalObject& globalObject, const JSC::JSCell* owner, JSC::JSValue value)
     {
-        Ref vm = globalObject.vm();
-        m_branch1Reason.set(vm, owner, value);
+        m_branch1Reason.set(globalObject, owner, value);
     }
     void setReason2(JSDOMGlobalObject& globalObject, const JSC::JSCell* owner, JSC::JSValue value)
     {
-        Ref vm = globalObject.vm();
-        m_branch2Reason.set(vm, owner, value);
+        m_branch2Reason.set(globalObject, owner, value);
     }
     void visit(JSC::AbstractSlotVisitor& visitor) final
     {

--- a/Source/WebCore/Modules/streams/TransformStream.cpp
+++ b/Source/WebCore/Modules/streams/TransformStream.cpp
@@ -65,16 +65,22 @@ ExceptionOr<Ref<TransformStream>> TransformStream::create(JSC::JSGlobalObject& g
         return result.releaseException();
 
     auto transformResult = result.releaseReturnValue();
-    return adoptRef(*new TransformStream(transformResult.transform, WTF::move(transformResult.readable), WTF::move(transformResult.writable)));
+    return adoptRef(*new TransformStream(*JSC::jsCast<JSDOMGlobalObject*>(&globalObject), transformResult.transform, WTF::move(transformResult.readable), WTF::move(transformResult.writable)));
 }
 
 Ref<TransformStream> TransformStream::create(Ref<ReadableStream>&& readable, Ref<WritableStream>&& writable)
 {
-    return adoptRef(*new TransformStream(JSC::jsUndefined(), WTF::move(readable), WTF::move(writable)));
+    return adoptRef(*new TransformStream(WTF::move(readable), WTF::move(writable)));
 }
 
-TransformStream::TransformStream(JSC::JSValue internalTransformStream, Ref<ReadableStream>&& readable, Ref<WritableStream>&& writable)
-    : m_internalTransformStream(internalTransformStream)
+TransformStream::TransformStream(Ref<ReadableStream>&& readable, Ref<WritableStream>&& writable)
+    : m_readable(WTF::move(readable))
+    , m_writable(WTF::move(writable))
+{
+}
+
+TransformStream::TransformStream(JSC::JSGlobalObject& globalObject, JSC::JSValue internalTransformStream, Ref<ReadableStream>&& readable, Ref<WritableStream>&& writable)
+    : m_internalTransformStream(globalObject, internalTransformStream)
     , m_readable(WTF::move(readable))
     , m_writable(WTF::move(writable))
 {

--- a/Source/WebCore/Modules/streams/TransformStream.h
+++ b/Source/WebCore/Modules/streams/TransformStream.h
@@ -63,7 +63,8 @@ public:
     static ExceptionOr<Ref<TransformStream>> runTransferReceivingSteps(JSDOMGlobalObject&, DetachedTransformStream&&);
 
 private:
-    TransformStream(JSC::JSValue, Ref<ReadableStream>&&, Ref<WritableStream>&&);
+    TransformStream(Ref<ReadableStream>&&, Ref<WritableStream>&&);
+    TransformStream(JSC::JSGlobalObject&, JSC::JSValue internalTransformStream, Ref<ReadableStream>&&, Ref<WritableStream>&&);
 
     JSValueInWrappedObject m_internalTransformStream;
     const Ref<ReadableStream> m_readable;

--- a/Source/WebCore/Modules/webaudio/AudioBuffer.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBuffer.cpp
@@ -192,7 +192,7 @@ ExceptionOr<JSC::JSValue> AudioBuffer::getChannelData(JSDOMGlobalObject& globalO
 
     if (globalObject.worldIsNormal()) {
         if (!m_channelWrappers[channelIndex])
-            m_channelWrappers[channelIndex].set(globalObject.vm(), wrapper(), constructJSArray());
+            m_channelWrappers[channelIndex].set(globalObject, wrapper(), constructJSArray());
         return m_channelWrappers[channelIndex].getValue();
     }
     return constructJSArray();

--- a/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
@@ -321,7 +321,7 @@ void AudioWorkletNode::fireProcessorErrorOnMainThread(ProcessorError error)
             errorMessage = "An error was thrown from AudioWorkletProcessor::process() method"_s;
             break;
         }
-        queueTaskToDispatchEvent(*this, TaskSource::MediaElement, ErrorEvent::create(eventNames().processorerrorEvent, errorMessage, { }, 0, 0, { }));
+        queueTaskToDispatchEvent(*this, TaskSource::MediaElement, ErrorEvent::create(eventNames().processorerrorEvent, errorMessage, { }, 0, 0));
     });
 }
 

--- a/Source/WebCore/Modules/webaudio/AudioWorkletProcessor.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletProcessor.cpp
@@ -273,7 +273,7 @@ void AudioWorkletProcessor::buildJSArguments(VM& vm, JSGlobalObject& globalObjec
     if (!success) {
         auto* array = constructFrozenJSArray(vm, globalObject, inputs, ShouldPopulateWithBusData::Yes);
         RETURN_IF_EXCEPTION(scope, void());
-        m_jsInputs.setWeakly(array);
+        m_jsInputs.setWeakly(globalObject, array);
     }
     args.append(m_jsInputs.getValue());
 
@@ -282,14 +282,14 @@ void AudioWorkletProcessor::buildJSArguments(VM& vm, JSGlobalObject& globalObjec
     if (!success) {
         auto* array = constructFrozenJSArray(vm, globalObject, outputs, ShouldPopulateWithBusData::No);
         RETURN_IF_EXCEPTION(scope, void());
-        m_jsOutputs.setWeakly(array);
+        m_jsOutputs.setWeakly(globalObject, array);
     }
     args.append(m_jsOutputs.getValue());
 
     success = copyDataFromParameterMapToJSObject(vm, globalObject, paramValuesMap, toJSObject(m_jsParamValues));
     RETURN_IF_EXCEPTION(scope, void());
     if (!success)
-        m_jsParamValues.setWeakly(constructFrozenKeyValueObject(vm, globalObject, paramValuesMap));
+        m_jsParamValues.setWeakly(globalObject, constructFrozenKeyValueObject(vm, globalObject, paramValuesMap));
 
     args.append(m_jsParamValues.getValue());
 }

--- a/Source/WebCore/bindings/js/DOMWrapperWorld.cpp
+++ b/Source/WebCore/bindings/js/DOMWrapperWorld.cpp
@@ -76,9 +76,4 @@ DOMWrapperWorld& mainThreadNormalWorldSingleton()
     return cachedNormalWorld->get();
 }
 
-bool isWorldCompatible(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value)
-{
-    return !value.isObject() || &worldForDOMObject(*value.getObject()) == &currentWorld(lexicalGlobalObject);
-}
-
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/DOMWrapperWorld.h
+++ b/Source/WebCore/bindings/js/DOMWrapperWorld.h
@@ -122,9 +122,6 @@ inline DOMWrapperWorld& pluginWorldSingleton() { return mainThreadNormalWorldSin
 DOMWrapperWorld& currentWorld(JSC::JSGlobalObject&);
 DOMWrapperWorld& worldForDOMObject(JSC::JSObject&);
 
-// Helper function for code paths that must not share objects across isolated DOM worlds.
-WEBCORE_EXPORT bool isWorldCompatible(JSC::JSGlobalObject&, JSC::JSValue);
-
 inline DOMWrapperWorld& currentWorld(JSC::JSGlobalObject& lexicalGlobalObject)
 {
     return JSC::jsCast<JSDOMGlobalObject*>(&lexicalGlobalObject)->world();

--- a/Source/WebCore/bindings/js/JSDOMWrapper.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWrapper.cpp
@@ -45,8 +45,16 @@ JSDOMObject::JSDOMObject(JSC::Structure* structure, JSC::JSGlobalObject& globalO
 
 JSC::JSValue cloneAcrossWorlds(JSC::JSGlobalObject& lexicalGlobalObject, const JSDOMObject& owner, JSC::JSValue value)
 {
-    if (isWorldCompatible(lexicalGlobalObject, value))
+    if (!value.isObject())
         return value;
+
+    // FIXME: Realmless objects (e.g. WebAssembly GC structs/arrays) are world-agnostic
+    // and should be returned as-is here.
+
+    // Same world — no cloning needed.
+    if (&worldForDOMObject(*value.getObject()) == &currentWorld(lexicalGlobalObject))
+        return value;
+
     // FIXME: Is it best to handle errors by returning null rather than throwing an exception?
     auto serializedValue = SerializedScriptValue::create(lexicalGlobalObject, value, SerializationForStorage::No, SerializationErrorMode::NonThrowing, SerializationContext::CloneAcrossWorlds);
     if (!serializedValue)

--- a/Source/WebCore/bindings/js/JSErrorEventCustom.cpp
+++ b/Source/WebCore/bindings/js/JSErrorEventCustom.cpp
@@ -27,12 +27,25 @@
 #include "config.h"
 #include "JSErrorEvent.h"
 
+#include "JSDOMGlobalObject.h"
+#include "JSValueInWrappedObject.h"
+
 namespace WebCore {
+using namespace JSC;
+
+JSValue JSErrorEvent::error(JSGlobalObject& lexicalGlobalObject) const
+{
+    auto throwScope = DECLARE_THROW_SCOPE(lexicalGlobalObject.vm());
+    return cachedPropertyValue(throwScope, lexicalGlobalObject, *this, wrapped().cachedError(), [this](ThrowScope&) {
+        return wrapped().originalError().getValue(jsNull());
+    });
+}
 
 template<typename Visitor>
 void JSErrorEvent::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     wrapped().originalError().visitInGCThread(visitor);
+    wrapped().cachedError().visitInGCThread(visitor);
 }
 
 DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSErrorEvent);

--- a/Source/WebCore/bindings/js/JSErrorHandler.cpp
+++ b/Source/WebCore/bindings/js/JSErrorHandler.cpp
@@ -38,6 +38,7 @@
 #include "JSDOMConvertNumbers.h"
 #include "JSDOMConvertStrings.h"
 #include "JSDOMWindow.h"
+#include "JSErrorEvent.h"
 #include "JSEvent.h"
 #include "JSExecState.h"
 #include "JSExecStateInstrumentation.h"
@@ -95,33 +96,53 @@ void JSErrorHandler::handleEvent(ScriptExecutionContext& scriptExecutionContext,
                 jsFunctionWindow->setCurrentEvent(errorEvent);
         }
 
-        MarkedArgumentBuffer args;
-        args.append(toJS<IDLDOMString>(*globalObject, errorEvent->message()));
-        args.append(toJS<IDLUSVString>(*globalObject, errorEvent->filename()));
-        args.append(toJS<IDLUnsignedLong>(errorEvent->lineno()));
-        args.append(toJS<IDLUnsignedLong>(errorEvent->colno()));
-        args.append(errorEvent->error(*globalObject));
-        ASSERT(!args.hasOverflowed());
+        auto exception = ([&] -> NakedPtr<JSC::Exception> {
+            VM& vm = globalObject->vm();
 
-        VM& vm = globalObject->vm();
-        VMEntryScope entryScope(vm, vm.entryScope ? vm.entryScope->globalObject() : globalObject);
+            MarkedArgumentBuffer args;
+            args.append(toJS<IDLDOMString>(*globalObject, errorEvent->message()));
+            args.append(toJS<IDLUSVString>(*globalObject, errorEvent->filename()));
+            args.append(toJS<IDLUnsignedLong>(errorEvent->lineno()));
+            args.append(toJS<IDLUnsignedLong>(errorEvent->colno()));
 
-        JSExecState::instrumentFunction(&scriptExecutionContext, callData);
+            {
+                auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+                auto* jsErrorEvent = jsCast<JSErrorEvent*>(toJS(globalObject, globalObject, *errorEvent));
+                if (auto* exception = scope.exception()) [[unlikely]] {
+                    scope.clearException();
+                    return exception;
+                }
+                auto error = jsErrorEvent->error(*globalObject);
+                if (auto* exception = scope.exception()) [[unlikely]] {
+                    scope.clearException();
+                    return exception;
+                }
+                args.append(error);
+                ASSERT(!args.hasOverflowed());
+            }
 
-        NakedPtr<JSC::Exception> exception;
-        JSValue returnValue = JSExecState::profiledCall(globalObject, JSC::ProfilingReason::Other, jsFunction, callData, globalObject, args, exception);
+            VMEntryScope entryScope(vm, vm.entryScope ? vm.entryScope->globalObject() : globalObject);
 
-        InspectorInstrumentation::didCallFunction(&scriptExecutionContext);
+            JSExecState::instrumentFunction(&scriptExecutionContext, callData);
 
-        if (exception)
-            reportException(jsFunction->globalObject(), exception);
-        else {
+            NakedPtr<JSC::Exception> exception;
+            JSValue returnValue = JSExecState::profiledCall(globalObject, JSC::ProfilingReason::Other, jsFunction, callData, globalObject, args, exception);
+
+            InspectorInstrumentation::didCallFunction(&scriptExecutionContext);
+
+            if (exception) [[unlikely]]
+                return exception;
+
             if (returnValue.isTrue())
                 errorEvent->preventDefault();
-        }
 
-        if (jsFunctionWindow)
-            jsFunctionWindow->setCurrentEvent(savedEvent.get());
+            if (jsFunctionWindow)
+                jsFunctionWindow->setCurrentEvent(savedEvent.get());
+
+            return nullptr;
+        }());
+        if (exception)
+            reportException(jsFunction->globalObject(), exception);
     }
 }
 

--- a/Source/WebCore/bindings/js/JSMediaControlsHostCustom.cpp
+++ b/Source/WebCore/bindings/js/JSMediaControlsHostCustom.cpp
@@ -40,7 +40,7 @@ JSC::JSValue JSMediaControlsHost::controller(JSC::JSGlobalObject& lexicalGlobalO
 
 void JSMediaControlsHost::setController(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value)
 {
-    wrapped().controllerWrapper().set(lexicalGlobalObject.vm(), this, value);
+    wrapped().controllerWrapper().set(lexicalGlobalObject, this, value);
 }
 
 template<typename Visitor>

--- a/Source/WebCore/bindings/js/JSPopStateEventCustom.cpp
+++ b/Source/WebCore/bindings/js/JSPopStateEventCustom.cpp
@@ -32,8 +32,8 @@
 #include "config.h"
 #include "JSPopStateEvent.h"
 
-#include "DOMWrapperWorld.h"
 #include "JSHistory.h"
+#include "JSValueInWrappedObject.h"
 #include <JavaScriptCore/HeapInlines.h>
 #include <JavaScriptCore/JSCJSValueInlines.h>
 
@@ -42,60 +42,32 @@ using namespace JSC;
 
 JSValue JSPopStateEvent::state(JSGlobalObject& lexicalGlobalObject) const
 {
-    if (m_state) {
-        // We cannot use a cached object if we are in a different world than the one it was created in.
-        if (isWorldCompatible(lexicalGlobalObject, m_state.get()))
-            return m_state.get();
-        ASSERT_NOT_REACHED();
-    }
+    auto throwScope = DECLARE_THROW_SCOPE(lexicalGlobalObject.vm());
+    return cachedPropertyValue(throwScope, lexicalGlobalObject, *this, wrapped().cachedState(), [this, &lexicalGlobalObject](ThrowScope&) {
+        PopStateEvent& event = wrapped();
 
-    // Save the lexicalGlobalObject value to the m_state member of a JSPopStateEvent, and return it, for convenience.
-    auto cacheState = [&lexicalGlobalObject, this] (JSC::JSValue eventState) {
-        m_state.set(lexicalGlobalObject.vm(), this, eventState);
-        return eventState;
-    };
+        if (event.state())
+            return event.state().getValue(jsNull());
 
-    PopStateEvent& event = wrapped();
+        History* history = event.history();
+        if (!history || !event.serializedState())
+            return jsNull();
 
-    if (event.state()) {
-        JSC::JSValue eventState = event.state().getValue();
-        // We need to make sure a PopStateEvent does not leak objects in its lexicalGlobalObject property across isolated DOM worlds.
-        // Ideally, we would check that the worlds have different privileges but that's not possible yet.
-        if (!isWorldCompatible(lexicalGlobalObject, eventState)) {
-            if (auto serializedValue = event.trySerializeState(lexicalGlobalObject))
-                eventState = serializedValue->deserialize(lexicalGlobalObject, globalObject());
-            else
-                eventState = jsNull();
+        // Share the same deserialization with history.state when the state is the current one.
+        if (history->isSameAsCurrentState(event.serializedState())) {
+            auto* jsHistory = jsCast<JSHistory*>(toJS(&lexicalGlobalObject, globalObject(), *history).asCell());
+            return jsHistory->state(lexicalGlobalObject);
         }
-        return cacheState(eventState);
-    }
-    
-    History* history = event.history();
-    if (!history || !event.serializedState())
-        return cacheState(jsNull());
 
-    // There's no cached value from a previous invocation, nor a lexicalGlobalObject value was provided by the
-    // event, but there is a history object, so first we need to see if the lexicalGlobalObject object has been
-    // deserialized through the history object already.
-    // The current history lexicalGlobalObject object might've changed in the meantime, so we need to take care
-    // of using the correct one, and always share the same deserialization with history.lexicalGlobalObject.
-
-    bool isSameState = history->isSameAsCurrentState(event.serializedState());
-    JSValue result;
-
-    if (isSameState) {
-        JSHistory* jsHistory = jsCast<JSHistory*>(toJS(&lexicalGlobalObject, globalObject(), *history).asCell());
-        result = jsHistory->state(lexicalGlobalObject);
-    } else
-        result = event.serializedState()->deserialize(lexicalGlobalObject, globalObject());
-
-    return cacheState(result);
+        return event.serializedState()->deserialize(lexicalGlobalObject, globalObject());
+    });
 }
 
 template<typename Visitor>
 void JSPopStateEvent::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     wrapped().state().visitInGCThread(visitor);
+    wrapped().cachedState().visitInGCThread(visitor);
 }
 
 DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSPopStateEvent);

--- a/Source/WebCore/bindings/js/JSValueInWrappedObject.h
+++ b/Source/WebCore/bindings/js/JSValueInWrappedObject.h
@@ -39,7 +39,8 @@ class JSValueInWrappedObject {
     WTF_MAKE_NONCOPYABLE(JSValueInWrappedObject);
     WTF_MAKE_NONMOVABLE(JSValueInWrappedObject);
 public:
-    JSValueInWrappedObject(JSC::JSValue = { });
+    JSValueInWrappedObject() = default;
+    JSValueInWrappedObject(JSC::JSGlobalObject&, JSC::JSValue);
 
     explicit operator bool() const;
     template<typename Visitor> void visitInGCThread(Visitor&) const;
@@ -48,23 +49,29 @@ public:
     // If you expect the value you store to be returned by getValue and not cleared under you, you *MUST* use set not setWeakly.
     // The owner parameter is typically the wrapper of the DOM node this class is embedded into but can be any GCed object that
     // will visit this JSValueInWrappedObject via visitAdditionalChildrenInGCThread/isReachableFromOpaqueRoots.
-    void set(JSC::VM&, const JSC::JSCell* owner, JSC::JSValue);
+    void set(JSC::JSGlobalObject&, const JSC::JSCell* owner, JSC::JSValue);
     // Only use this if you actually expect this value to be weakly held. If you call visitInGCThread on this value *DONT* set using setWeakly
     // use set instead. The GC might or might not keep your value around in that case.
-    void setWeakly(JSC::JSValue);
+    void setWeakly(JSC::JSGlobalObject&, JSC::JSValue);
     JSC::JSValue getValue(JSC::JSValue nullValue = JSC::jsUndefined()) const;
 
+    bool isWorldCompatible(JSC::JSGlobalObject& lexicalGlobalObject) const;
+
 private:
+    void setValueInternal(JSC::JSValue);
+    void setWorld(JSC::JSGlobalObject&);
+
     // Keep in mind that all of these fields are accessed concurrently without lock from concurrent GC thread.
     JSC::JSValue m_nonCell { };
     JSC::Weak<JSC::JSCell> m_cell { };
+    SingleThreadWeakPtr<DOMWrapperWorld> m_world;
 };
 
 JSC::JSValue cachedPropertyValue(JSC::ThrowScope&, JSC::JSGlobalObject&, const JSDOMObject& owner, JSValueInWrappedObject& cacheSlot, const auto&);
 
-inline JSValueInWrappedObject::JSValueInWrappedObject(JSC::JSValue value)
+inline JSValueInWrappedObject::JSValueInWrappedObject(JSC::JSGlobalObject& globalObject, JSC::JSValue value)
 {
-    setWeakly(value);
+    setWeakly(globalObject, value);
 }
 
 inline JSC::JSValue JSValueInWrappedObject::getValue(JSC::JSValue nullValue) const
@@ -88,8 +95,9 @@ inline void JSValueInWrappedObject::visitInGCThread(Visitor& visitor) const
 template void JSValueInWrappedObject::visitInGCThread(JSC::AbstractSlotVisitor&) const;
 template void JSValueInWrappedObject::visitInGCThread(JSC::SlotVisitor&) const;
 
-inline void JSValueInWrappedObject::setWeakly(JSC::JSValue value)
+inline void JSValueInWrappedObject::setValueInternal(JSC::JSValue value)
 {
+    m_world= nullptr;
     if (!value.isCell()) {
         m_nonCell = value;
         m_cell.clear();
@@ -101,28 +109,54 @@ inline void JSValueInWrappedObject::setWeakly(JSC::JSValue value)
     m_cell = WTF::move(weak);
 }
 
-inline void JSValueInWrappedObject::set(JSC::VM& vm, const JSC::JSCell* owner, JSC::JSValue value)
+inline void JSValueInWrappedObject::setWorld(JSC::JSGlobalObject& globalObject)
 {
-    setWeakly(value);
-    vm.writeBarrier(owner, value);
+    m_world = &currentWorld(globalObject);
+}
+
+inline void JSValueInWrappedObject::setWeakly(JSC::JSGlobalObject& globalObject, JSC::JSValue value)
+{
+    setValueInternal(value);
+    setWorld(globalObject);
+}
+
+inline void JSValueInWrappedObject::set(JSC::JSGlobalObject& globalObject, const JSC::JSCell* owner, JSC::JSValue value)
+{
+    setValueInternal(value);
+    globalObject.vm().writeBarrier(owner, value);
+    setWorld(globalObject);
 }
 
 inline void JSValueInWrappedObject::clear()
 {
     m_nonCell = { };
     m_cell.clear();
+    m_world = nullptr;
+}
+
+inline bool JSValueInWrappedObject::isWorldCompatible(JSC::JSGlobalObject& lexicalGlobalObject) const
+{
+    JSC::JSValue value = getValue();
+    if (!value.isObject())
+        return true;
+    // FIXME: For realmless objects (e.g. WebAssembly GC structs/arrays) that have no realm,
+    // this stored world is the only way to determine world compatibility.
+    auto* world = m_world.get();
+    if (!world)
+        return false;
+    return world == &currentWorld(lexicalGlobalObject);
 }
 
 inline JSC::JSValue cachedPropertyValue(JSC::ThrowScope& throwScope, JSC::JSGlobalObject& lexicalGlobalObject, const JSDOMObject& owner, JSValueInWrappedObject& cachedValue, const auto& function)
 {
-    if (cachedValue && isWorldCompatible(lexicalGlobalObject, cachedValue.getValue()))
+    if (cachedValue && cachedValue.isWorldCompatible(lexicalGlobalObject))
         return cachedValue.getValue();
 
     auto value = function(throwScope);
     RETURN_IF_EXCEPTION(throwScope, { });
 
-    cachedValue.set(lexicalGlobalObject.vm(), &owner, cloneAcrossWorlds(lexicalGlobalObject, owner, value));
-    ASSERT(isWorldCompatible(lexicalGlobalObject, cachedValue.getValue()));
+    cachedValue.set(lexicalGlobalObject, &owner, cloneAcrossWorlds(lexicalGlobalObject, owner, value));
+    ASSERT(cachedValue.isWorldCompatible(lexicalGlobalObject));
     return cachedValue.getValue();
 }
 

--- a/Source/WebCore/dom/AbortSignal.cpp
+++ b/Source/WebCore/dom/AbortSignal.cpp
@@ -35,6 +35,7 @@
 #include "EventTargetInlines.h"
 #include "JSDOMException.h"
 #include "ScriptExecutionContext.h"
+#include "ScriptWrappableInlines.h"
 #include "WebCoreOpaqueRoot.h"
 #include <JavaScriptCore/Exception.h>
 #include <JavaScriptCore/JSCast.h>
@@ -55,7 +56,7 @@ Ref<AbortSignal> AbortSignal::abort(JSDOMGlobalObject& globalObject, ScriptExecu
     ASSERT(reason);
     if (reason.isUndefined())
         reason = toJS(&globalObject, &globalObject, DOMException::create(ExceptionCode::AbortError));
-    return adoptRef(*new AbortSignal(&context, Aborted::Yes, reason));
+    return adoptRef(*new AbortSignal(globalObject, &context, Aborted::Yes, reason));
 }
 
 // https://dom.spec.whatwg.org/#dom-abortsignal-timeout
@@ -96,12 +97,17 @@ Ref<AbortSignal> AbortSignal::any(ScriptExecutionContext& context, const Vector<
     return resultSignal;
 }
 
-AbortSignal::AbortSignal(ScriptExecutionContext* context, Aborted aborted, JSC::JSValue reason)
+AbortSignal::AbortSignal(ScriptExecutionContext* context, Aborted aborted)
     : ContextDestructionObserver(context)
-    , m_reason(reason)
     , m_aborted(aborted == Aborted::Yes)
 {
-    ASSERT(reason);
+}
+
+AbortSignal::AbortSignal(JSC::JSGlobalObject& globalObject, ScriptExecutionContext* context, Aborted aborted, JSC::JSValue reason)
+    : ContextDestructionObserver(context)
+    , m_reason(globalObject, reason)
+    , m_aborted(aborted == Aborted::Yes)
+{
 }
 
 AbortSignal::~AbortSignal() = default;
@@ -127,27 +133,31 @@ void AbortSignal::addDependentSignal(AbortSignal& signal)
 // https://dom.spec.whatwg.org/#abortsignal-signal-abort
 void AbortSignal::signalAbort(JSC::JSValue reason)
 {
-    // 1. If signal's aborted flag is set, then return.
+    // 1. If signal’s aborted flag is set, then return.
     if (m_aborted)
+        return;
+
+    RefPtr context = scriptExecutionContext();
+    if (!context)
+        return;
+
+    auto* globalObject = JSC::jsCast<JSDOMGlobalObject*>(context->globalObject());
+    if (!globalObject)
         return;
 
     // 2. ... if the reason is not given, set it to a new "AbortError" DOMException.
     ASSERT(reason);
-    if (reason.isUndefined()) {
-        auto* globalObject = JSC::jsCast<JSDOMGlobalObject*>(protect(scriptExecutionContext())->globalObject());
-        if (!globalObject)
-            return;
+    if (reason.isUndefined())
         reason = toJS(globalObject, globalObject, DOMException::create(ExceptionCode::AbortError));
-    }
 
     // 2. Set signal’s abort reason to reason if it is given; otherwise to a new "AbortError" DOMException.
-    markAborted(reason);
+    markAborted(*globalObject, reason);
 
     Vector<Ref<AbortSignal>> dependentSignalsToAbort;
 
     for (Ref dependentSignal : std::exchange(m_dependentSignals, { })) {
         if (!dependentSignal->aborted()) {
-            dependentSignal->markAborted(reason);
+            dependentSignal->markAborted(*globalObject, reason);
             dependentSignalsToAbort.append(WTF::move(dependentSignal));
         }
     }
@@ -160,7 +170,7 @@ void AbortSignal::signalAbort(JSC::JSValue reason)
         dependentSignal->runAbortSteps();
 }
 
-void AbortSignal::markAborted(JSC::JSValue reason)
+void AbortSignal::markAborted(JSC::JSGlobalObject& globalObject, JSC::JSValue reason)
 {
     m_aborted = true;
     m_sourceSignals.clear();
@@ -168,7 +178,7 @@ void AbortSignal::markAborted(JSC::JSValue reason)
     // FIXME: This code is wrong: we should emit a write-barrier. Otherwise, GC can collect it.
     // https://bugs.webkit.org/show_bug.cgi?id=236353
     ASSERT(reason);
-    m_reason.setWeakly(reason);
+    m_reason.setWeakly(globalObject, reason);
 }
 
 void AbortSignal::runAbortSteps()

--- a/Source/WebCore/dom/AbortSignal.h
+++ b/Source/WebCore/dom/AbortSignal.h
@@ -84,7 +84,8 @@ public:
 
 private:
     enum class Aborted : bool { No, Yes };
-    AbortSignal(ScriptExecutionContext*, Aborted = Aborted::No, JSC::JSValue reason = JSC::jsUndefined());
+    AbortSignal(ScriptExecutionContext*, Aborted = Aborted::No);
+    AbortSignal(JSC::JSGlobalObject&, ScriptExecutionContext*, Aborted, JSC::JSValue reason);
 
     void setHasActiveTimeoutTimer(bool hasActiveTimeoutTimer) { m_hasActiveTimeoutTimer = hasActiveTimeoutTimer; }
 
@@ -92,7 +93,7 @@ private:
     void addSourceSignal(AbortSignal&);
     void addDependentSignal(AbortSignal&);
 
-    void markAborted(JSC::JSValue);
+    void markAborted(JSC::JSGlobalObject&, JSC::JSValue);
     void runAbortSteps();
 
     // EventTarget.

--- a/Source/WebCore/dom/CustomEvent.cpp
+++ b/Source/WebCore/dom/CustomEvent.cpp
@@ -27,6 +27,7 @@
 #include "config.h"
 #include "CustomEvent.h"
 
+#include "ScriptWrappableInlines.h"
 #include <JavaScriptCore/JSCInlines.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -39,9 +40,9 @@ inline CustomEvent::CustomEvent(IsTrusted isTrusted)
 {
 }
 
-inline CustomEvent::CustomEvent(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
+inline CustomEvent::CustomEvent(JSC::JSGlobalObject& globalObject, const AtomString& type, Init&& initializer, IsTrusted isTrusted)
     : Event(EventInterfaceType::CustomEvent, type, WTF::move(initializer), isTrusted)
-    , m_detail(initializer.detail)
+    , m_detail(globalObject, initializer.detail)
 {
 }
 
@@ -52,12 +53,12 @@ Ref<CustomEvent> CustomEvent::create(IsTrusted isTrusted)
     return adoptRef(*new CustomEvent(isTrusted));
 }
 
-Ref<CustomEvent> CustomEvent::create(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
+Ref<CustomEvent> CustomEvent::create(JSC::JSGlobalObject& globalObject, const AtomString& type, Init&& initializer, IsTrusted isTrusted)
 {
-    return adoptRef(*new CustomEvent(type, WTF::move(initializer), isTrusted));
+    return adoptRef(*new CustomEvent(globalObject, type, WTF::move(initializer), isTrusted));
 }
 
-void CustomEvent::initCustomEvent(const AtomString& type, bool canBubble, bool cancelable, JSC::JSValue detail)
+void CustomEvent::initCustomEvent(JSC::JSGlobalObject& globalObject, const AtomString& type, bool canBubble, bool cancelable, JSC::JSValue detail)
 {
     if (isBeingDispatched())
         return;
@@ -66,7 +67,7 @@ void CustomEvent::initCustomEvent(const AtomString& type, bool canBubble, bool c
 
     // FIXME: This code is wrong: we should emit a write-barrier. Otherwise, GC can collect it.
     // https://bugs.webkit.org/show_bug.cgi?id=236353
-    m_detail.setWeakly(detail);
+    m_detail.setWeakly(globalObject, detail);
     m_cachedDetail.clear();
 }
 

--- a/Source/WebCore/dom/CustomEvent.h
+++ b/Source/WebCore/dom/CustomEvent.h
@@ -43,16 +43,16 @@ public:
         JSC::JSValue detail;
     };
 
-    WEBCORE_EXPORT static Ref<CustomEvent> create(const AtomString& type, Init&&, IsTrusted = IsTrusted::No);
+    WEBCORE_EXPORT static Ref<CustomEvent> create(JSC::JSGlobalObject&, const AtomString& type, Init&&, IsTrusted = IsTrusted::No);
 
-    void initCustomEvent(const AtomString& type, bool canBubble, bool cancelable, JSC::JSValue detail = JSC::JSValue::JSUndefined);
+    void initCustomEvent(JSC::JSGlobalObject&, const AtomString& type, bool canBubble, bool cancelable, JSC::JSValue detail = JSC::JSValue::JSUndefined);
 
     const JSValueInWrappedObject& detail() const LIFETIME_BOUND { return m_detail; }
     JSValueInWrappedObject& cachedDetail() LIFETIME_BOUND { return m_cachedDetail; }
 
 private:
     CustomEvent(IsTrusted);
-    CustomEvent(const AtomString& type, Init&&, IsTrusted);
+    CustomEvent(JSC::JSGlobalObject&, const AtomString& type, Init&&, IsTrusted);
 
     JSValueInWrappedObject m_detail;
     JSValueInWrappedObject m_cachedDetail;

--- a/Source/WebCore/dom/CustomEvent.idl
+++ b/Source/WebCore/dom/CustomEvent.idl
@@ -29,11 +29,11 @@
     Exposed=*,
     JSCustomMarkFunction,
 ] interface CustomEvent : Event {
-    constructor([AtomString] DOMString type, optional CustomEventInit eventInitDict = {});
+    [CallWith=CurrentGlobalObject] constructor([AtomString] DOMString type, optional CustomEventInit eventInitDict = {});
 
     [CustomGetter] readonly attribute any detail;
 
-    undefined initCustomEvent([AtomString] DOMString type, optional boolean bubbles = false, optional boolean cancelable = false, optional any detail = null);
+    [CallWith=CurrentGlobalObject] undefined initCustomEvent([AtomString] DOMString type, optional boolean bubbles = false, optional boolean cancelable = false, optional any detail = null);
 };
 
 // https://dom.spec.whatwg.org/#dictdef-customeventinit

--- a/Source/WebCore/dom/ErrorEvent.cpp
+++ b/Source/WebCore/dom/ErrorEvent.cpp
@@ -32,7 +32,6 @@
 #include "config.h"
 #include "ErrorEvent.h"
 
-#include "DOMWrapperWorld.h"
 #include "EventNames.h"
 #include <JavaScriptCore/HeapInlines.h>
 #include <JavaScriptCore/StrongInlines.h>
@@ -43,59 +42,45 @@ using namespace JSC;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ErrorEvent);
 
-ErrorEvent::ErrorEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
+ErrorEvent::ErrorEvent(JSC::JSGlobalObject& globalObject, const AtomString& type, const Init& initializer, IsTrusted isTrusted)
     : Event(EventInterfaceType::ErrorEvent, type, initializer, isTrusted)
     , m_message(initializer.message)
     , m_fileName(initializer.filename)
     , m_lineNumber(initializer.lineno)
     , m_columnNumber(initializer.colno)
-    , m_error(initializer.error)
+    , m_error(globalObject, initializer.error)
 {
 }
 
-ErrorEvent::ErrorEvent(const AtomString& type, const String& message, const String& fileName, unsigned lineNumber, unsigned columnNumber, JSC::Strong<JSC::Unknown> error)
+ErrorEvent::ErrorEvent(JSC::JSGlobalObject& globalObject, const AtomString& type, const String& message, const String& fileName, unsigned lineNumber, unsigned columnNumber, JSC::Strong<JSC::Unknown> error)
     : Event(EventInterfaceType::ErrorEvent, type, CanBubble::No, IsCancelable::Yes)
     , m_message(message)
     , m_fileName(fileName)
     , m_lineNumber(lineNumber)
     , m_columnNumber(columnNumber)
-    , m_error(error.get())
+    , m_error(globalObject, error.get())
 {
 }
 
-ErrorEvent::ErrorEvent(const String& message, const String& fileName, unsigned lineNumber, unsigned columnNumber, JSC::Strong<JSC::Unknown> error)
-    : ErrorEvent(eventNames().errorEvent, message, fileName, lineNumber, columnNumber, error)
+ErrorEvent::ErrorEvent(JSC::JSGlobalObject& globalObject, const String& message, const String& fileName, unsigned lineNumber, unsigned columnNumber, JSC::Strong<JSC::Unknown> error)
+    : ErrorEvent(globalObject, eventNames().errorEvent, message, fileName, lineNumber, columnNumber, error)
+{
+}
+
+ErrorEvent::ErrorEvent(const String& message, const String& fileName, unsigned lineNumber, unsigned columnNumber)
+    : ErrorEvent(eventNames().errorEvent, message, fileName, lineNumber, columnNumber)
+{
+}
+
+ErrorEvent::ErrorEvent(const AtomString& type, const String& message, const String& fileName, unsigned lineNumber, unsigned columnNumber)
+    : Event(EventInterfaceType::ErrorEvent, type, CanBubble::No, IsCancelable::Yes)
+    , m_message(message)
+    , m_fileName(fileName)
+    , m_lineNumber(lineNumber)
+    , m_columnNumber(columnNumber)
 {
 }
 
 ErrorEvent::~ErrorEvent() = default;
-
-JSValue ErrorEvent::error(JSGlobalObject& globalObject)
-{    
-    if (!m_error)
-        return jsNull();
-
-    JSValue error = m_error.getValue();
-    if (!isWorldCompatible(globalObject, error)) {
-        // We need to make sure ErrorEvents do not leak their error property across isolated DOM worlds.
-        // Ideally, we would check that the worlds have different privileges but that's not possible yet.
-        auto serializedError = trySerializeError(globalObject);
-        if (!serializedError)
-            return jsNull();
-        return serializedError->deserialize(globalObject, &globalObject);
-    }
-
-    return error;
-}
-
-RefPtr<SerializedScriptValue> ErrorEvent::trySerializeError(JSGlobalObject& exec)
-{
-    if (!m_serializedError && !m_triedToSerialize) {
-        if (RefPtr error = SerializedScriptValue::create(exec, m_error.getValue(), SerializationForStorage::No, SerializationErrorMode::NonThrowing))
-            lazyInitialize(m_serializedError, error.releaseNonNull());
-        m_triedToSerialize = true;
-    }
-    return m_serializedError;
-}
 
 } // namespace WebCore

--- a/Source/WebCore/dom/ErrorEvent.h
+++ b/Source/WebCore/dom/ErrorEvent.h
@@ -33,7 +33,6 @@
 
 #include "Event.h"
 #include "JSValueInWrappedObject.h"
-#include "SerializedScriptValue.h"
 #include <JavaScriptCore/Strong.h>
 #include <wtf/text/WTFString.h>
 
@@ -42,14 +41,24 @@ namespace WebCore {
 class ErrorEvent final : public Event {
     WTF_MAKE_TZONE_ALLOCATED(ErrorEvent);
 public:
-    static Ref<ErrorEvent> create(const String& message, const String& fileName, unsigned lineNumber, unsigned columnNumber, JSC::Strong<JSC::Unknown> error)
+    static Ref<ErrorEvent> create(JSC::JSGlobalObject& globalObject, const String& message, const String& fileName, unsigned lineNumber, unsigned columnNumber, JSC::Strong<JSC::Unknown> error)
     {
-        return adoptRef(*new ErrorEvent(message, fileName, lineNumber, columnNumber, error));
+        return adoptRef(*new ErrorEvent(globalObject, message, fileName, lineNumber, columnNumber, error));
     }
 
-    static Ref<ErrorEvent> create(const AtomString& type, const String& message, const String& fileName, unsigned lineNumber, unsigned columnNumber, JSC::Strong<JSC::Unknown> error)
+    static Ref<ErrorEvent> create(const String& message, const String& fileName, unsigned lineNumber, unsigned columnNumber)
     {
-        return adoptRef(*new ErrorEvent(type, message, fileName, lineNumber, columnNumber, error));
+        return adoptRef(*new ErrorEvent(message, fileName, lineNumber, columnNumber));
+    }
+
+    static Ref<ErrorEvent> create(const AtomString& type, const String& message, const String& fileName, unsigned lineNumber, unsigned columnNumber)
+    {
+        return adoptRef(*new ErrorEvent(type, message, fileName, lineNumber, columnNumber));
+    }
+
+    static Ref<ErrorEvent> create(JSC::JSGlobalObject& globalObject, const AtomString& type, const String& message, const String& fileName, unsigned lineNumber, unsigned columnNumber, JSC::Strong<JSC::Unknown> error)
+    {
+        return adoptRef(*new ErrorEvent(globalObject, type, message, fileName, lineNumber, columnNumber, error));
     }
 
     struct Init : EventInit {
@@ -60,9 +69,9 @@ public:
         JSC::JSValue error { JSC::jsUndefined() };
     };
 
-    static Ref<ErrorEvent> create(const AtomString& type, const Init& initializer, IsTrusted isTrusted = IsTrusted::No)
+    static Ref<ErrorEvent> create(JSC::JSGlobalObject& globalObject, const AtomString& type, const Init& initializer, IsTrusted isTrusted = IsTrusted::No)
     {
-        return adoptRef(*new ErrorEvent(type, initializer, isTrusted));
+        return adoptRef(*new ErrorEvent(globalObject, type, initializer, isTrusted));
     }
 
     virtual ~ErrorEvent();
@@ -71,25 +80,23 @@ public:
     const String& filename() const LIFETIME_BOUND { return m_fileName; }
     unsigned lineno() const { return m_lineNumber; }
     unsigned colno() const { return m_columnNumber; }
-    JSC::JSValue error(JSC::JSGlobalObject&);
 
     const JSValueInWrappedObject& originalError() const LIFETIME_BOUND { return m_error; }
-    SerializedScriptValue* serializedError() const { return m_serializedError.get(); }
-
-    RefPtr<SerializedScriptValue> trySerializeError(JSC::JSGlobalObject&);
+    JSValueInWrappedObject& cachedError() LIFETIME_BOUND { return m_cachedError; }
 
 private:
-    ErrorEvent(const AtomString& type, const String& message, const String& fileName, unsigned lineNumber, unsigned columnNumber, JSC::Strong<JSC::Unknown> error);
-    ErrorEvent(const String& message, const String& fileName, unsigned lineNumber, unsigned columnNumber, JSC::Strong<JSC::Unknown> error);
-    ErrorEvent(const AtomString&, const Init&, IsTrusted);
+    ErrorEvent(JSC::JSGlobalObject&, const AtomString& type, const String& message, const String& fileName, unsigned lineNumber, unsigned columnNumber, JSC::Strong<JSC::Unknown> error);
+    ErrorEvent(JSC::JSGlobalObject&, const String& message, const String& fileName, unsigned lineNumber, unsigned columnNumber, JSC::Strong<JSC::Unknown> error);
+    ErrorEvent(const String& message, const String& fileName, unsigned lineNumber, unsigned columnNumber);
+    ErrorEvent(const AtomString& type, const String& message, const String& fileName, unsigned lineNumber, unsigned columnNumber);
+    ErrorEvent(JSC::JSGlobalObject&, const AtomString&, const Init&, IsTrusted);
 
     String m_message;
     String m_fileName;
     unsigned m_lineNumber;
     unsigned m_columnNumber;
     JSValueInWrappedObject m_error;
-    const RefPtr<SerializedScriptValue> m_serializedError;
-    bool m_triedToSerialize { false };
+    JSValueInWrappedObject m_cachedError;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/ErrorEvent.idl
+++ b/Source/WebCore/dom/ErrorEvent.idl
@@ -34,13 +34,13 @@
     Exposed=*,
     JSCustomMarkFunction,
 ] interface ErrorEvent : Event {
-    constructor([AtomString] DOMString type, optional ErrorEventInit eventInitDict = {});
+    [CallWith=CurrentGlobalObject] constructor([AtomString] DOMString type, optional ErrorEventInit eventInitDict = {});
 
     readonly attribute DOMString message;
     readonly attribute USVString filename;
     readonly attribute unsigned long lineno;
     readonly attribute unsigned long colno;
-    [CallWith=CurrentGlobalObject] readonly attribute any error;
+    [CustomGetter] readonly attribute any error;
 };
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#erroreventinit

--- a/Source/WebCore/dom/InternalObserverLast.cpp
+++ b/Source/WebCore/dom/InternalObserverLast.cpp
@@ -55,7 +55,13 @@ public:
 private:
     void next(JSC::JSValue value) final
     {
-        m_lastValue.setWeakly(value);
+        RefPtr context = scriptExecutionContext();
+        if (!context)
+            return;
+        auto* globalObject = context->globalObject();
+        if (!globalObject)
+            return;
+        m_lastValue.setWeakly(*globalObject, value);
     }
 
     void error(JSC::JSValue value) final

--- a/Source/WebCore/dom/InternalObserverReduce.cpp
+++ b/Source/WebCore/dom/InternalObserverReduce.cpp
@@ -56,14 +56,14 @@ public:
 private:
     void next(JSC::JSValue value) final
     {
-        if (!m_accumulator) {
-            m_index++;
-            m_accumulator.setWeakly(value);
-            return;
-        }
-
         auto* globalObject = protect(scriptExecutionContext())->globalObject();
         ASSERT(globalObject);
+
+        if (!m_accumulator) {
+            m_index++;
+            m_accumulator.setWeakly(*globalObject, value);
+            return;
+        }
 
         Ref vm = globalObject->vm();
 
@@ -81,7 +81,7 @@ private:
         }
 
         if (result.type() == CallbackResultType::Success)
-            m_accumulator.setWeakly(result.releaseReturnValue());
+            m_accumulator.setWeakly(*globalObject, result.releaseReturnValue());
     }
 
     void error(JSC::JSValue value) final
@@ -113,8 +113,10 @@ private:
         , m_callback(WTF::move(callback))
         , m_promise(WTF::move(promise))
     {
-        if (!initialValue.isUndefined()) [[unlikely]]
-            m_accumulator.setWeakly(initialValue);
+        if (!initialValue.isUndefined()) [[unlikely]] {
+            if (auto* globalObject = context.globalObject())
+                m_accumulator.setWeakly(*globalObject, initialValue);
+        }
     }
 
     uint64_t m_index { 0 };

--- a/Source/WebCore/dom/MessageEvent.cpp
+++ b/Source/WebCore/dom/MessageEvent.cpp
@@ -53,14 +53,14 @@ MessageEvent::MessageEvent()
 {
 }
 
-inline MessageEvent::MessageEvent(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
+inline MessageEvent::MessageEvent(JSC::JSGlobalObject& globalObject, const AtomString& type, Init&& initializer, IsTrusted isTrusted)
     : Event(EventInterfaceType::MessageEvent, type, initializer, isTrusted)
     , m_data(JSValueTag { })
     , m_origin(initializer.origin)
     , m_lastEventId(initializer.lastEventId)
     , m_source(WTF::move(initializer.source))
     , m_ports(WTF::move(initializer.ports))
-    , m_jsData(initializer.data)
+    , m_jsData(globalObject, initializer.data)
 {
 }
 
@@ -90,7 +90,7 @@ auto MessageEvent::create(JSC::JSGlobalObject& globalObject, Ref<SerializedScrip
     auto& eventType = didFail ? eventNames().messageerrorEvent : eventNames().messageEvent;
     Ref event = adoptRef(*new MessageEvent(eventType, MessageEvent::JSValueTag { }, WTF::move(origin), lastEventId, WTF::move(source), WTF::move(ports)));
     JSC::Strong<JSC::JSObject> strongWrapper(vm, JSC::jsCast<JSC::JSObject*>(toJS(&globalObject, JSC::jsCast<JSDOMGlobalObject*>(&globalObject), event.get())));
-    event->jsData().set(vm, strongWrapper.get(), deserialized);
+    event->jsData().set(globalObject, strongWrapper.get(), deserialized);
 
     return MessageEventWithStrongData { event, WTF::move(strongWrapper) };
 }
@@ -110,9 +110,9 @@ Ref<MessageEvent> MessageEvent::createForBindings()
     return adoptRef(*new MessageEvent);
 }
 
-Ref<MessageEvent> MessageEvent::create(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
+Ref<MessageEvent> MessageEvent::create(JSC::JSGlobalObject& globalObject, const AtomString& type, Init&& initializer, IsTrusted isTrusted)
 {
-    return adoptRef(*new MessageEvent(type, WTF::move(initializer), isTrusted));
+    return adoptRef(*new MessageEvent(globalObject, type, WTF::move(initializer), isTrusted));
 }
 
 MessageEvent::~MessageEvent() = default;
@@ -141,7 +141,7 @@ const RefPtr<SecurityOrigin> MessageEvent::securityOrigin() const
     );
 }
 
-void MessageEvent::initMessageEvent(const AtomString& type, bool canBubble, bool cancelable, JSValue data, const String& origin, const String& lastEventId, std::optional<MessageEventSource>&& source, Vector<Ref<MessagePort>>&& ports)
+void MessageEvent::initMessageEvent(JSC::JSGlobalObject& globalObject, const AtomString& type, bool canBubble, bool cancelable, JSValue data, const String& origin, const String& lastEventId, std::optional<MessageEventSource>&& source, Vector<Ref<MessagePort>>&& ports)
 {
     if (isBeingDispatched())
         return;
@@ -152,9 +152,9 @@ void MessageEvent::initMessageEvent(const AtomString& type, bool canBubble, bool
         Locker locker { m_concurrentDataAccessLock };
         m_data = JSValueTag { };
     }
-    // FIXME: This code is wrong: we should emit a write-barrier. Otherwise, GC can collect it.
-    // https://bugs.webkit.org/show_bug.cgi?id=236353
-    m_jsData.setWeakly(data);
+    auto* domGlobalObject = JSC::jsCast<JSDOMGlobalObject*>(&globalObject);
+    auto* wrapper = toJS(&globalObject, domGlobalObject, *this).getObject();
+    m_jsData.set(globalObject, wrapper, data);
     m_cachedData.clear();
     m_origin = origin;
     m_lastEventId = lastEventId;

--- a/Source/WebCore/dom/MessageEvent.h
+++ b/Source/WebCore/dom/MessageEvent.h
@@ -64,11 +64,11 @@ public:
         std::optional<MessageEventSource> source;
         Vector<Ref<MessagePort>> ports;
     };
-    static Ref<MessageEvent> create(const AtomString& type, Init&&, IsTrusted = IsTrusted::No);
+    static Ref<MessageEvent> create(JSC::JSGlobalObject&, const AtomString& type, Init&&, IsTrusted = IsTrusted::No);
 
     virtual ~MessageEvent();
 
-    void initMessageEvent(const AtomString& type, bool canBubble, bool cancelable, JSC::JSValue data, const String& origin, const String& lastEventId, std::optional<MessageEventSource>&&, Vector<Ref<MessagePort>>&&);
+    void initMessageEvent(JSC::JSGlobalObject&, const AtomString& type, bool canBubble, bool cancelable, JSC::JSValue data, const String& origin, const String& lastEventId, std::optional<MessageEventSource>&&, Vector<Ref<MessagePort>>&&);
 
     String origin() const;
     const RefPtr<SecurityOrigin> securityOrigin() const;
@@ -91,7 +91,7 @@ public:
 
 private:
     MessageEvent();
-    MessageEvent(const AtomString& type, Init&&, IsTrusted);
+    MessageEvent(JSC::JSGlobalObject&, const AtomString& type, Init&&, IsTrusted);
     MessageEvent(const AtomString& type, DataType&&, RefPtr<SecurityOrigin>&& origin, const String& lastEventId = { }, std::optional<MessageEventSource>&& = std::nullopt, Vector<Ref<MessagePort>>&& = { });
 
     DataType m_data WTF_GUARDED_BY_LOCK(m_concurrentDataAccessLock);

--- a/Source/WebCore/dom/MessageEvent.idl
+++ b/Source/WebCore/dom/MessageEvent.idl
@@ -35,7 +35,7 @@ typedef (WindowProxy or MessagePort or ServiceWorker) MessageEventSource;
     JSCustomMarkFunction,
     ReportExtraMemoryCost,
 ] interface MessageEvent : Event {
-    constructor([AtomString] DOMString type, optional MessageEventInit eventInitDict = {});
+    [CallWith=CurrentGlobalObject] constructor([AtomString] DOMString type, optional MessageEventInit eventInitDict = {});
 
     readonly attribute USVString origin;
     readonly attribute DOMString lastEventId;
@@ -43,7 +43,7 @@ typedef (WindowProxy or MessagePort or ServiceWorker) MessageEventSource;
     [CustomGetter] readonly attribute any data;
     [CustomGetter] readonly attribute FrozenArray<MessagePort> ports;
 
-    undefined initMessageEvent([AtomString] DOMString type, optional boolean bubbles = false, optional boolean cancelable = false,
+    [CallWith=CurrentGlobalObject] undefined initMessageEvent([AtomString] DOMString type, optional boolean bubbles = false, optional boolean cancelable = false,
         optional any data = null, optional USVString originArg = "", optional DOMString lastEventId = "", optional MessageEventSource? source = null,
         optional sequence<MessagePort> messagePorts = []);
 };

--- a/Source/WebCore/dom/PopStateEvent.cpp
+++ b/Source/WebCore/dom/PopStateEvent.cpp
@@ -41,9 +41,9 @@ PopStateEvent::PopStateEvent()
 {
 }
 
-PopStateEvent::PopStateEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
+PopStateEvent::PopStateEvent(JSC::JSGlobalObject& globalObject, const AtomString& type, const Init& initializer, IsTrusted isTrusted)
     : Event(EventInterfaceType::PopStateEvent, type, initializer, isTrusted)
-    , m_state(initializer.state)
+    , m_state(globalObject, initializer.state)
     , m_hasUAVisualTransition(initializer.hasUAVisualTransition)
 {
 }
@@ -62,26 +62,14 @@ Ref<PopStateEvent> PopStateEvent::create(RefPtr<SerializedScriptValue>&& seriali
     return adoptRef(*new PopStateEvent(WTF::move(serializedState), history));
 }
 
-Ref<PopStateEvent> PopStateEvent::create(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
+Ref<PopStateEvent> PopStateEvent::create(JSC::JSGlobalObject& globalObject, const AtomString& type, const Init& initializer, IsTrusted isTrusted)
 {
-    return adoptRef(*new PopStateEvent(type, initializer, isTrusted));
+    return adoptRef(*new PopStateEvent(globalObject, type, initializer, isTrusted));
 }
 
 Ref<PopStateEvent> PopStateEvent::createForBindings()
 {
     return adoptRef(*new PopStateEvent);
-}
-
-RefPtr<SerializedScriptValue> PopStateEvent::trySerializeState(JSC::JSGlobalObject& executionState)
-{
-    ASSERT(m_state);
-    
-    if (!m_serializedState && !m_triedToSerialize) {
-        m_serializedState = SerializedScriptValue::create(executionState, m_state.getValue(), SerializationForStorage::No, SerializationErrorMode::NonThrowing);
-        m_triedToSerialize = true;
-    }
-    
-    return m_serializedState;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/PopStateEvent.h
+++ b/Source/WebCore/dom/PopStateEvent.h
@@ -45,14 +45,13 @@ public:
         bool hasUAVisualTransition { false };
     };
 
-    static Ref<PopStateEvent> create(const AtomString&, const Init&, IsTrusted = IsTrusted::No);
+    static Ref<PopStateEvent> create(JSC::JSGlobalObject&, const AtomString&, const Init&, IsTrusted = IsTrusted::No);
     static Ref<PopStateEvent> createForBindings();
 
     const JSValueInWrappedObject& state() const LIFETIME_BOUND { return m_state; }
+    JSValueInWrappedObject& cachedState() LIFETIME_BOUND { return m_cachedState; }
     SerializedScriptValue* serializedState() const { return m_serializedState.get(); }
 
-    RefPtr<SerializedScriptValue> trySerializeState(JSC::JSGlobalObject&);
-    
     History* history() const { return m_history.get(); }
 
     bool hasUAVisualTransition() const { return m_hasUAVisualTransition; }
@@ -60,12 +59,12 @@ public:
 
 private:
     PopStateEvent();
-    PopStateEvent(const AtomString&, const Init&, IsTrusted);
+    PopStateEvent(JSC::JSGlobalObject&, const AtomString&, const Init&, IsTrusted);
     PopStateEvent(RefPtr<SerializedScriptValue>&&, History*);
 
     JSValueInWrappedObject m_state;
+    JSValueInWrappedObject m_cachedState;
     RefPtr<SerializedScriptValue> m_serializedState;
-    bool m_triedToSerialize { false };
     bool m_hasUAVisualTransition { false };
     RefPtr<History> m_history;
 };

--- a/Source/WebCore/dom/PopStateEvent.idl
+++ b/Source/WebCore/dom/PopStateEvent.idl
@@ -28,9 +28,9 @@
     JSCustomMarkFunction,
     Exposed=Window
 ] interface PopStateEvent : Event {
-    constructor([AtomString] DOMString type, optional PopStateEventInit eventInitDict = {});
+    [CallWith=CurrentGlobalObject] constructor([AtomString] DOMString type, optional PopStateEventInit eventInitDict = {});
 
-    [CachedAttribute, CustomGetter] readonly attribute any state;
+    [CustomGetter] readonly attribute any state;
     [EnabledBySetting=UAVisualTransitionDetectionEnabled] readonly attribute boolean hasUAVisualTransition;
 };
 

--- a/Source/WebCore/dom/PromiseRejectionEvent.cpp
+++ b/Source/WebCore/dom/PromiseRejectionEvent.cpp
@@ -37,10 +37,10 @@ using namespace JSC;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(PromiseRejectionEvent);
 
-PromiseRejectionEvent::PromiseRejectionEvent(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
+PromiseRejectionEvent::PromiseRejectionEvent(JSC::JSGlobalObject& globalObject, const AtomString& type, Init&& initializer, IsTrusted isTrusted)
     : Event(EventInterfaceType::PromiseRejectionEvent, type, initializer, isTrusted)
     , m_promise(WTF::move(initializer.promise))
-    , m_reason(initializer.reason)
+    , m_reason(globalObject, initializer.reason)
 {
 }
 

--- a/Source/WebCore/dom/PromiseRejectionEvent.h
+++ b/Source/WebCore/dom/PromiseRejectionEvent.h
@@ -40,9 +40,9 @@ public:
         JSC::JSValue reason;
     };
 
-    static Ref<PromiseRejectionEvent> create(const AtomString& type, Init&& initializer, IsTrusted isTrusted = IsTrusted::No)
+    static Ref<PromiseRejectionEvent> create(JSC::JSGlobalObject& globalObject, const AtomString& type, Init&& initializer, IsTrusted isTrusted = IsTrusted::No)
     {
-        return adoptRef(*new PromiseRejectionEvent(type, WTF::move(initializer), isTrusted));
+        return adoptRef(*new PromiseRejectionEvent(globalObject, type, WTF::move(initializer), isTrusted));
     }
 
     virtual ~PromiseRejectionEvent();
@@ -51,7 +51,7 @@ public:
     const JSValueInWrappedObject& reason() const LIFETIME_BOUND { return m_reason; }
 
 private:
-    PromiseRejectionEvent(const AtomString&, Init&&, IsTrusted);
+    PromiseRejectionEvent(JSC::JSGlobalObject&, const AtomString&, Init&&, IsTrusted);
 
     const Ref<DOMPromise> m_promise;
     JSValueInWrappedObject m_reason;

--- a/Source/WebCore/dom/PromiseRejectionEvent.idl
+++ b/Source/WebCore/dom/PromiseRejectionEvent.idl
@@ -27,7 +27,7 @@
     Exposed=*,
     JSCustomMarkFunction,
 ] interface PromiseRejectionEvent : Event {
-    constructor([AtomString] DOMString type, PromiseRejectionEventInit eventInitDict);
+    [CallWith=CurrentGlobalObject] constructor([AtomString] DOMString type, PromiseRejectionEventInit eventInitDict);
 
     readonly attribute Promise<any> promise;
     readonly attribute any reason;

--- a/Source/WebCore/dom/RejectedPromiseTracker.cpp
+++ b/Source/WebCore/dom/RejectedPromiseTracker.cpp
@@ -169,7 +169,7 @@ void RejectedPromiseTracker::reportUnhandledRejections(Vector<UnhandledPromise>&
             WTF::move(domPromise),
             promise.result(),
         };
-        Ref event = PromiseRejectionEvent::create(eventNames().unhandledrejectionEvent, WTF::move(initializer));
+        Ref event = PromiseRejectionEvent::create(lexicalGlobalObject, eventNames().unhandledrejectionEvent, WTF::move(initializer));
         RefPtr target = m_context->errorEventTarget();
         target->dispatchEvent(event);
 
@@ -191,6 +191,10 @@ void RejectedPromiseTracker::reportRejectionHandled(Ref<DOMPromise>&& rejectedPr
     if (rejectedPromise->isSuspended())
         return;
 
+    auto* globalObject = rejectedPromise->globalObject();
+    if (!globalObject)
+        return;
+
     auto& promise = *rejectedPromise->promise();
 
     auto initializer = PromiseRejectionEvent::Init {
@@ -198,7 +202,7 @@ void RejectedPromiseTracker::reportRejectionHandled(Ref<DOMPromise>&& rejectedPr
         WTF::move(rejectedPromise),
         promise.result(),
     };
-    Ref event = PromiseRejectionEvent::create(eventNames().rejectionhandledEvent, WTF::move(initializer));
+    Ref event = PromiseRejectionEvent::create(*globalObject, eventNames().rejectionhandledEvent, WTF::move(initializer));
     RefPtr target = m_context->errorEventTarget();
     target->dispatchEvent(event);
 }

--- a/Source/WebCore/dom/ScriptExecutionContext.cpp
+++ b/Source/WebCore/dom/ScriptExecutionContext.cpp
@@ -579,11 +579,15 @@ bool ScriptExecutionContext::dispatchErrorEvent(const String& errorMessage, int 
     if (!target)
         return false;
 
+    auto* jsGlobalObject = globalObject();
+    if (!jsGlobalObject)
+        return false;
+
     RefPtr<ErrorEvent> errorEvent;
     if (canIncludeErrorDetails(cachedScript, sourceURL, fromModule))
-        errorEvent = ErrorEvent::create(errorMessage, sourceURL, lineNumber, columnNumber, { vm(), exception ? exception->value() : JSC::jsNull() });
+        errorEvent = ErrorEvent::create(*jsGlobalObject, errorMessage, sourceURL, lineNumber, columnNumber, { vm(), exception ? exception->value() : JSC::jsNull() });
     else
-        errorEvent = ErrorEvent::create("Script error."_s, { }, 0, 0, { });
+        errorEvent = ErrorEvent::create(*jsGlobalObject, "Script error."_s, { }, 0, 0, { });
 
     ASSERT(!m_inDispatchErrorEvent);
     m_inDispatchErrorEvent = true;

--- a/Source/WebCore/page/NavigateEvent.cpp
+++ b/Source/WebCore/page/NavigateEvent.cpp
@@ -45,7 +45,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(NavigateEvent);
 
-NavigateEvent::NavigateEvent(const AtomString& type, Init&& init, EventIsTrusted isTrusted, AbortController* abortController)
+NavigateEvent::NavigateEvent(JSC::JSGlobalObject& globalObject, const AtomString& type, Init&& init, EventIsTrusted isTrusted, AbortController* abortController)
     : Event(EventInterfaceType::NavigateEvent, type, WTF::move(init), isTrusted)
     , m_navigationType(init.navigationType)
     , m_destination(WTF::move(init.destination))
@@ -60,18 +60,18 @@ NavigateEvent::NavigateEvent(const AtomString& type, Init&& init, EventIsTrusted
     , m_abortController(abortController)
 {
     Locker<JSC::JSLock> locker(commonVM().apiLock());
-    m_info.setWeakly(init.info);
+    m_info.setWeakly(globalObject, init.info);
 }
 
-Ref<NavigateEvent> NavigateEvent::create(const AtomString& type, Init&& init, AbortController* abortController)
+Ref<NavigateEvent> NavigateEvent::create(JSC::JSGlobalObject& globalObject, const AtomString& type, Init&& init, AbortController* abortController)
 {
-    return adoptRef(*new NavigateEvent(type, WTF::move(init), EventIsTrusted::Yes, abortController));
+    return adoptRef(*new NavigateEvent(globalObject, type, WTF::move(init), EventIsTrusted::Yes, abortController));
 }
 
-Ref<NavigateEvent> NavigateEvent::create(const AtomString& type, Init&& init)
+Ref<NavigateEvent> NavigateEvent::create(JSC::JSGlobalObject& globalObject, const AtomString& type, Init&& init)
 {
     // FIXME: AbortController is required but JS bindings need to create it without one.
-    return adoptRef(*new NavigateEvent(type, WTF::move(init), EventIsTrusted::No, nullptr));
+    return adoptRef(*new NavigateEvent(globalObject, type, WTF::move(init), EventIsTrusted::No, nullptr));
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigateevent-perform-shared-checks

--- a/Source/WebCore/page/NavigateEvent.h
+++ b/Source/WebCore/page/NavigateEvent.h
@@ -89,8 +89,8 @@ public:
         std::optional<NavigationScrollBehavior> scroll;
     };
 
-    static Ref<NavigateEvent> create(const AtomString& type, Init&&);
-    static Ref<NavigateEvent> create(const AtomString& type, Init&&, AbortController*);
+    static Ref<NavigateEvent> create(JSC::JSGlobalObject&, const AtomString& type, Init&&);
+    static Ref<NavigateEvent> create(JSC::JSGlobalObject&, const AtomString& type, Init&&, AbortController*);
 
     NavigationNavigationType navigationType() const { return m_navigationType; }
     bool canIntercept() const { return m_canIntercept; }
@@ -116,7 +116,7 @@ public:
     Vector<Ref<NavigationInterceptHandler>>& handlers() LIFETIME_BOUND { return m_handlers; }
 
 private:
-    NavigateEvent(const AtomString& type, Init&&, EventIsTrusted, AbortController*);
+    NavigateEvent(JSC::JSGlobalObject&, const AtomString& type, Init&&, EventIsTrusted, AbortController*);
 
     ExceptionOr<void> sharedChecks(Document&);
     void potentiallyProcessScrollBehavior(Document&);

--- a/Source/WebCore/page/NavigateEvent.idl
+++ b/Source/WebCore/page/NavigateEvent.idl
@@ -31,7 +31,7 @@
   EnabledBySetting=NavigationAPIEnabled,
   Exposed=Window
 ] interface NavigateEvent : Event {
-  constructor([AtomString] DOMString type, NavigateEventInit eventInitDict);
+  [CallWith=CurrentGlobalObject] constructor([AtomString] DOMString type, NavigateEventInit eventInitDict);
 
   readonly attribute NavigationNavigationType navigationType;
   readonly attribute NavigationDestination destination;

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -76,13 +76,13 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(Navigation);
 
-Ref<NavigationAPIMethodTracker> NavigationAPIMethodTracker::create(Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, JSC::JSValue&& info, RefPtr<SerializedScriptValue>&& serializedState)
+Ref<NavigationAPIMethodTracker> NavigationAPIMethodTracker::create(JSC::JSGlobalObject& globalObject, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, JSC::JSValue&& info, RefPtr<SerializedScriptValue>&& serializedState)
 {
-    return adoptRef(*new NavigationAPIMethodTracker(WTF::move(committed), WTF::move(finished), WTF::move(info), WTF::move(serializedState)));
+    return adoptRef(*new NavigationAPIMethodTracker(globalObject, WTF::move(committed), WTF::move(finished), WTF::move(info), WTF::move(serializedState)));
 }
 
-NavigationAPIMethodTracker::NavigationAPIMethodTracker(Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, JSC::JSValue&& infoValue, RefPtr<SerializedScriptValue>&& serializedStateValue)
-    : info(infoValue)
+NavigationAPIMethodTracker::NavigationAPIMethodTracker(JSC::JSGlobalObject& globalObject, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, JSC::JSValue&& infoValue, RefPtr<SerializedScriptValue>&& serializedStateValue)
+    : info(globalObject, infoValue)
     , serializedState(serializedStateValue)
     , committedPromise(WTF::move(committed))
     , finishedPromise(WTF::move(finished))
@@ -345,9 +345,9 @@ ExceptionOr<RefPtr<SerializedScriptValue>> Navigation::serializeState(JSC::JSVal
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#maybe-set-the-upcoming-non-traverse-api-method-tracker
-RefPtr<NavigationAPIMethodTracker> Navigation::maybeSetUpcomingNonTraversalTracker(Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, JSC::JSValue info, RefPtr<SerializedScriptValue>&& serializedState)
+RefPtr<NavigationAPIMethodTracker> Navigation::maybeSetUpcomingNonTraversalTracker(JSC::JSGlobalObject& globalObject, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, JSC::JSValue info, RefPtr<SerializedScriptValue>&& serializedState)
 {
-    RefPtr apiMethodTracker = NavigationAPIMethodTracker::create(WTF::move(committed), WTF::move(finished), WTF::move(info), WTF::move(serializedState));
+    RefPtr apiMethodTracker = NavigationAPIMethodTracker::create(globalObject, WTF::move(committed), WTF::move(finished), WTF::move(info), WTF::move(serializedState));
 
     apiMethodTracker->finishedPromise->markAsHandled();
 
@@ -361,9 +361,9 @@ RefPtr<NavigationAPIMethodTracker> Navigation::maybeSetUpcomingNonTraversalTrack
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#add-an-upcoming-traverse-api-method-tracker
-RefPtr<NavigationAPIMethodTracker> Navigation::addUpcomingTraverseAPIMethodTracker(Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, const String& key, JSC::JSValue info)
+RefPtr<NavigationAPIMethodTracker> Navigation::addUpcomingTraverseAPIMethodTracker(JSC::JSGlobalObject& globalObject, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, const String& key, JSC::JSValue info)
 {
-    RefPtr apiMethodTracker = NavigationAPIMethodTracker::create(WTF::move(committed), WTF::move(finished), WTF::move(info), nullptr);
+    RefPtr apiMethodTracker = NavigationAPIMethodTracker::create(globalObject, WTF::move(committed), WTF::move(finished), WTF::move(info), nullptr);
     apiMethodTracker->key = key;
 
     apiMethodTracker->finishedPromise->markAsHandled();
@@ -386,7 +386,7 @@ Navigation::Result Navigation::apiMethodTrackerDerivedResult(const NavigationAPI
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-reload
-Navigation::Result Navigation::reload(ReloadOptions&& options, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
+Navigation::Result Navigation::reload(JSC::JSGlobalObject& globalObject, ReloadOptions&& options, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
 {
     auto serializedState = serializeState(options.state);
     if (serializedState.hasException())
@@ -399,7 +399,7 @@ Navigation::Result Navigation::reload(ReloadOptions&& options, Ref<DeferredPromi
     if (!protect(window->document())->isFullyActive() || window->document()->unloadCounter())
         return createErrorResult(WTF::move(committed), WTF::move(finished), ExceptionCode::InvalidStateError, "Invalid state"_s);
 
-    RefPtr apiMethodTracker = maybeSetUpcomingNonTraversalTracker(WTF::move(committed), WTF::move(finished), WTF::move(options.info), WTF::move(state));
+    RefPtr apiMethodTracker = maybeSetUpcomingNonTraversalTracker(globalObject, WTF::move(committed), WTF::move(finished), WTF::move(options.info), WTF::move(state));
 
     RefPtr lexicalFrame = lexicalFrameFromCommonVM();
     auto initiatedByMainFrame = lexicalFrame && lexicalFrame->isMainFrame() ? InitiatedByMainFrame::Yes : InitiatedByMainFrame::Unknown;
@@ -417,7 +417,7 @@ Navigation::Result Navigation::reload(ReloadOptions&& options, Ref<DeferredPromi
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-navigate
-Navigation::Result Navigation::navigate(const String& url, NavigateOptions&& options, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
+Navigation::Result Navigation::navigate(JSC::JSGlobalObject& globalObject, const String& url, NavigateOptions&& options, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
 {
     RefPtr window = this->window();
     auto newURL = protect(window->document())->completeURL(url, ScriptExecutionContext::ForceUTF8::Yes);
@@ -440,7 +440,7 @@ Navigation::Result Navigation::navigate(const String& url, NavigateOptions&& opt
     if (!protect(window->document())->isFullyActive() || window->document()->unloadCounter())
         return createErrorResult(WTF::move(committed), WTF::move(finished), ExceptionCode::InvalidStateError, "Invalid state"_s);
 
-    RefPtr apiMethodTracker = maybeSetUpcomingNonTraversalTracker(WTF::move(committed), WTF::move(finished), WTF::move(options.info), serializedState.releaseReturnValue());
+    RefPtr apiMethodTracker = maybeSetUpcomingNonTraversalTracker(globalObject, WTF::move(committed), WTF::move(finished), WTF::move(options.info), serializedState.releaseReturnValue());
 
     auto request = FrameLoadRequest(*frame(), WTF::move(newURL));
     request.setNavigationHistoryBehavior(options.history);
@@ -460,7 +460,7 @@ Navigation::Result Navigation::navigate(const String& url, NavigateOptions&& opt
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#performing-a-navigation-api-traversal
-Navigation::Result Navigation::performTraversal(const String& key, Navigation::Options options, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
+Navigation::Result Navigation::performTraversal(JSC::JSGlobalObject& globalObject, const String& key, Navigation::Options options, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
 {
     RefPtr window = this->window();
     if (!protect(window->document())->isFullyActive() || window->document()->unloadCounter())
@@ -486,7 +486,7 @@ Navigation::Result Navigation::performTraversal(const String& key, Navigation::O
             return apiMethodTrackerDerivedResult(*existingMethodTracker);
     }
 
-    RefPtr apiMethodTracker = addUpcomingTraverseAPIMethodTracker(WTF::move(committed), WTF::move(finished), key, options.info);
+    RefPtr apiMethodTracker = addUpcomingTraverseAPIMethodTracker(globalObject, WTF::move(committed), WTF::move(finished), key, options.info);
 
     // FIXME: 11. Let sourceSnapshotParams be the result of snapshotting source snapshot params given document.
     protect(frame->navigationScheduler())->scheduleHistoryNavigationByKey(key, [apiMethodTracker] (ScheduleHistoryNavigationResult result) {
@@ -523,34 +523,34 @@ NavigationHistoryEntry* Navigation::findEntryByKey(const String& key) const
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-traverseto
-Navigation::Result Navigation::traverseTo(const String& key, Options&& options, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
+Navigation::Result Navigation::traverseTo(JSC::JSGlobalObject& globalObject, const String& key, Options&& options, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
 {
     if (!hasEntryWithKey(key))
         return createErrorResult(WTF::move(committed), WTF::move(finished), ExceptionCode::InvalidStateError, "Invalid key"_s);
 
-    return performTraversal(key, options, WTF::move(committed), WTF::move(finished));
+    return performTraversal(globalObject, key, options, WTF::move(committed), WTF::move(finished));
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-back
-Navigation::Result Navigation::back(Options&& options, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
+Navigation::Result Navigation::back(JSC::JSGlobalObject& globalObject, Options&& options, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
 {
     if (!canGoBack())
         return createErrorResult(WTF::move(committed), WTF::move(finished), ExceptionCode::InvalidStateError, "Cannot go back"_s);
 
     Ref previousEntry = m_entries[m_currentEntryIndex.value() - 1];
 
-    return performTraversal(previousEntry->key(), options, WTF::move(committed), WTF::move(finished));
+    return performTraversal(globalObject, previousEntry->key(), options, WTF::move(committed), WTF::move(finished));
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-forward
-Navigation::Result Navigation::forward(Options&& options, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
+Navigation::Result Navigation::forward(JSC::JSGlobalObject& globalObject, Options&& options, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
 {
     if (!canGoForward())
         return createErrorResult(WTF::move(committed), WTF::move(finished), ExceptionCode::InvalidStateError, "Cannot go forward"_s);
 
     Ref nextEntry = m_entries[m_currentEntryIndex.value() + 1];
 
-    return performTraversal(nextEntry->key(), options, WTF::move(committed), WTF::move(finished));
+    return performTraversal(globalObject, nextEntry->key(), options, WTF::move(committed), WTF::move(finished));
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-updatecurrententry
@@ -947,7 +947,7 @@ void Navigation::abortOngoingNavigation(NavigateEvent& event)
 
     m_ongoingNavigateEvent = nullptr;
 
-    dispatchEvent(ErrorEvent::create(eventNames().navigateerrorEvent, exception.message(), errorInformation.sourceURL, errorInformation.line, errorInformation.column, { globalObject->vm(), domException }));
+    dispatchEvent(ErrorEvent::create(*globalObject, eventNames().navigateerrorEvent, exception.message(), errorInformation.sourceURL, errorInformation.line, errorInformation.column, { globalObject->vm(), domException }));
 
     RefPtr<NavigationAPIMethodTracker> ongoingAPIMethodTracker;
     {
@@ -1118,7 +1118,7 @@ Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavi
     if (apiMethodTracker)
         apiMethodTracker->info.clear();
 
-    Ref event = NavigateEvent::create(eventNames().navigateEvent, WTF::move(init), abortController.get());
+    Ref event = NavigateEvent::create(*scriptExecutionContext->globalObject(), eventNames().navigateEvent, WTF::move(init), abortController.get());
     m_ongoingNavigateEvent = event.ptr();
     m_focusChangedDuringOngoingNavigation = FocusDidChange::No;
     m_suppressNormalScrollRestorationDuringOngoingNavigation = false;
@@ -1248,7 +1248,8 @@ Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavi
                     }
                 }
 
-                protectedThis->dispatchEvent(ErrorEvent::create(eventNames().navigateerrorEvent, errorMessage, errorInformation.sourceURL, errorInformation.line, errorInformation.column, { protect(protectedThis->scriptExecutionContext())->globalObject()->vm(), result }));
+                auto* navGlobalObject = protect(protectedThis->scriptExecutionContext())->globalObject();
+                protectedThis->dispatchEvent(ErrorEvent::create(*navGlobalObject, eventNames().navigateerrorEvent, errorMessage, errorInformation.sourceURL, errorInformation.line, errorInformation.column, { navGlobalObject->vm(), result }));
 
                 if (apiMethodTracker)
                     Ref { apiMethodTracker->finishedPromise }->reject<IDLAny>(result, RejectAsHandled::Yes);

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -58,7 +58,7 @@ using NavigationAPIMethodTrackerIdentifier = ObjectIdentifier<NavigationAPIMetho
 struct NavigationAPIMethodTracker : public RefCounted<NavigationAPIMethodTracker> {
     WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(NavigationAPIMethodTracker);
 
-    static Ref<NavigationAPIMethodTracker> create(Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, JSC::JSValue&& info, RefPtr<SerializedScriptValue>&& serializedState);
+    static Ref<NavigationAPIMethodTracker> create(JSC::JSGlobalObject&, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, JSC::JSValue&& info, RefPtr<SerializedScriptValue>&& serializedState);
     ~NavigationAPIMethodTracker();
 
     bool operator==(const NavigationAPIMethodTracker& other) const
@@ -76,7 +76,7 @@ struct NavigationAPIMethodTracker : public RefCounted<NavigationAPIMethodTracker
     Ref<DeferredPromise> finishedPromise;
 
 private:
-    NavigationAPIMethodTracker(Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, JSC::JSValue&& info, RefPtr<SerializedScriptValue>&& serializedState);
+    NavigationAPIMethodTracker(JSC::JSGlobalObject&, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, JSC::JSValue&& info, RefPtr<SerializedScriptValue>&& serializedState);
 
     NavigationAPIMethodTrackerIdentifier identifier;
 };
@@ -132,13 +132,13 @@ public:
 
     void initializeForNewWindow(std::optional<NavigationNavigationType>, LocalDOMWindow* previousWindow);
 
-    Result navigate(const String& url, NavigateOptions&&, Ref<DeferredPromise>&&, Ref<DeferredPromise>&&);
+    Result navigate(JSC::JSGlobalObject&, const String& url, NavigateOptions&&, Ref<DeferredPromise>&&, Ref<DeferredPromise>&&);
 
-    Result reload(ReloadOptions&&, Ref<DeferredPromise>&&, Ref<DeferredPromise>&&);
+    Result reload(JSC::JSGlobalObject&, ReloadOptions&&, Ref<DeferredPromise>&&, Ref<DeferredPromise>&&);
 
-    Result traverseTo(const String& key, Options&&, Ref<DeferredPromise>&&, Ref<DeferredPromise>&&);
-    Result back(Options&&, Ref<DeferredPromise>&&, Ref<DeferredPromise>&&);
-    Result forward(Options&&, Ref<DeferredPromise>&&, Ref<DeferredPromise>&&);
+    Result traverseTo(JSC::JSGlobalObject&, const String& key, Options&&, Ref<DeferredPromise>&&, Ref<DeferredPromise>&&);
+    Result back(JSC::JSGlobalObject&, Options&&, Ref<DeferredPromise>&&, Ref<DeferredPromise>&&);
+    Result forward(JSC::JSGlobalObject&, Options&&, Ref<DeferredPromise>&&, Ref<DeferredPromise>&&);
 
     ExceptionOr<void> updateCurrentEntry(UpdateCurrentEntryOptions&&);
 
@@ -242,14 +242,14 @@ private:
     void derefEventTarget() final { deref(); }
 
     bool hasEntriesAndEventsDisabled() const;
-    Result performTraversal(const String& key, Navigation::Options, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished);
+    Result performTraversal(JSC::JSGlobalObject&, const String& key, Navigation::Options, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished);
     ExceptionOr<RefPtr<SerializedScriptValue>> serializeState(JSC::JSValue state);
     DispatchResult innerDispatchNavigateEvent(NavigationNavigationType, Ref<NavigationDestination>&&, const String& downloadRequestFilename, FormState* = nullptr, SerializedScriptValue* classicHistoryAPIState = nullptr, Element* sourceElement = nullptr);
 
     void setActivation(HistoryItem* previousItem, std::optional<NavigationNavigationType>);
 
-    RefPtr<NavigationAPIMethodTracker> maybeSetUpcomingNonTraversalTracker(Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, JSC::JSValue info, RefPtr<SerializedScriptValue>&&);
-    RefPtr<NavigationAPIMethodTracker> addUpcomingTraverseAPIMethodTracker(Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, const String& key, JSC::JSValue info);
+    RefPtr<NavigationAPIMethodTracker> maybeSetUpcomingNonTraversalTracker(JSC::JSGlobalObject&, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, JSC::JSValue info, RefPtr<SerializedScriptValue>&&);
+    RefPtr<NavigationAPIMethodTracker> addUpcomingTraverseAPIMethodTracker(JSC::JSGlobalObject&, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, const String& key, JSC::JSValue info);
     void cleanupAPIMethodTracker(NavigationAPIMethodTracker*) WTF_EXCLUDES_LOCK(m_apiMethodTrackersLock);
     void resolveFinishedPromise(NavigationAPIMethodTracker*);
     void rejectFinishedPromise(NavigationAPIMethodTracker*, const Exception&, JSC::JSValue exceptionObject);

--- a/Source/WebCore/page/Navigation.idl
+++ b/Source/WebCore/page/Navigation.idl
@@ -40,12 +40,12 @@
   readonly attribute boolean canGoBack;
   readonly attribute boolean canGoForward;
 
-  [ReturnsPromisePair] NavigationResult navigate(USVString url, optional NavigationNavigateOptions options = {});
-  [ReturnsPromisePair] NavigationResult reload(optional NavigationReloadOptions options = {});
+  [CallWith=CurrentGlobalObject, ReturnsPromisePair] NavigationResult navigate(USVString url, optional NavigationNavigateOptions options = {});
+  [CallWith=CurrentGlobalObject, ReturnsPromisePair] NavigationResult reload(optional NavigationReloadOptions options = {});
 
-  [ReturnsPromisePair] NavigationResult traverseTo(DOMString key, optional NavigationOptions options = {});
-  [ReturnsPromisePair] NavigationResult back(optional NavigationOptions options = {});
-  [ReturnsPromisePair] NavigationResult forward(optional NavigationOptions options = {});
+  [CallWith=CurrentGlobalObject, ReturnsPromisePair] NavigationResult traverseTo(DOMString key, optional NavigationOptions options = {});
+  [CallWith=CurrentGlobalObject, ReturnsPromisePair] NavigationResult back(optional NavigationOptions options = {});
+  [CallWith=CurrentGlobalObject, ReturnsPromisePair] NavigationResult forward(optional NavigationOptions options = {});
 
   attribute EventHandler onnavigate;
   attribute EventHandler onnavigatesuccess;

--- a/Source/WebCore/testing/EventTargetForTesting.cpp
+++ b/Source/WebCore/testing/EventTargetForTesting.cpp
@@ -62,7 +62,11 @@ void EventTargetForTesting::sendInternalMessage(const MessageForTesting& message
 
     JSC::JSValue detail = jsNontrivialString(scriptExecutionContext->vm(), message.data);
 
-    dispatchEvent(CustomEvent::create(message.type, CustomEvent::Init {
+    auto* globalObject = scriptExecutionContext->globalObject();
+    if (!globalObject)
+        return;
+
+    dispatchEvent(CustomEvent::create(*globalObject, message.type, CustomEvent::Init {
         { },
         detail,
     }));

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -4570,8 +4570,12 @@ Ref<SerializedScriptValue> Internals::deserializeBuffer(ArrayBuffer& buffer) con
 
 bool Internals::isFromCurrentWorld(JSC::JSValue value) const
 {
+    if (!value.isObject())
+        return true;
+    // FIXME: Realmless objects (e.g. WebAssembly GC structs/arrays) have no realm
+    // and should be handled here.
     JSC::VM& vm = contextDocument()->vm();
-    return isWorldCompatible(*vm.topCallFrame->lexicalGlobalObject(vm), value);
+    return &worldForDOMObject(*value.getObject()) == &currentWorld(*vm.topCallFrame->lexicalGlobalObject(vm));
 }
 
 JSC::JSValue Internals::evaluateInWorldIgnoringException(const String& name, const String& source)

--- a/Source/WebCore/workers/WorkerMessagingProxy.cpp
+++ b/Source/WebCore/workers/WorkerMessagingProxy.cpp
@@ -346,7 +346,7 @@ void WorkerMessagingProxy::postExceptionToWorkerObject(const String& errorMessag
 
         // We don't bother checking the askedToTerminate() flag here, because exceptions should *always* be reported even if the thread is terminated.
         // This is intentionally different than the behavior in MessageWorkerTask, because terminated workers no longer deliver messages (section 4.6 of the WebWorker spec), but they do report exceptions.
-        ActiveDOMObject::queueTaskToDispatchEvent(*workerObject, TaskSource::DOMManipulation, ErrorEvent::create(errorMessage, sourceURL, lineNumber, columnNumber, { }));
+        ActiveDOMObject::queueTaskToDispatchEvent(*workerObject, TaskSource::DOMManipulation, ErrorEvent::create(errorMessage, sourceURL, lineNumber, columnNumber));
     });
 }
 

--- a/Source/WebCore/workers/service/ExtendableMessageEvent.cpp
+++ b/Source/WebCore/workers/service/ExtendableMessageEvent.cpp
@@ -44,7 +44,7 @@ static JSC::Strong<JSC::JSObject> createWrapperAndSetData(JSC::JSGlobalObject& g
 
     Locker<JSC::JSLock> locker(vm.apiLock());
     JSC::Strong<JSC::JSObject> strongWrapper(vm, JSC::jsCast<JSC::JSObject*>(toJSNewlyCreated<IDLInterface<ExtendableMessageEvent>>(globalObject,  *JSC::jsCast<JSDOMGlobalObject*>(&globalObject), Ref { event })));
-    event.data().set(vm, strongWrapper.get(), value);
+    event.data().set(globalObject, strongWrapper.get(), value);
 
     return strongWrapper;
 }

--- a/Source/WebCore/workers/shared/SharedWorkerObjectConnection.cpp
+++ b/Source/WebCore/workers/shared/SharedWorkerObjectConnection.cpp
@@ -89,7 +89,7 @@ void SharedWorkerObjectConnection::postErrorToWorkerObject(SharedWorkerObjectIde
     if (!workerObject)
         return;
 
-    auto event = isErrorEvent ? Ref<Event> { ErrorEvent::create(errorMessage, sourceURL, lineNumber, columnNumber, { }) } : Event::create(eventNames().errorEvent, Event::CanBubble::No, Event::IsCancelable::No);
+    auto event = isErrorEvent ? Ref<Event> { ErrorEvent::create(errorMessage, sourceURL, lineNumber, columnNumber) } : Event::create(eventNames().errorEvent, Event::CanBubble::No, Event::IsCancelable::No);
     ActiveDOMObject::queueTaskToDispatchEvent(*workerObject, TaskSource::DOMManipulation, WTF::move(event));
 }
 


### PR DESCRIPTION
#### 372ced794551688d9fc0c4552eca8b7c4ea07b8a
<pre>
JSValueInWrappedObject should store world of the lexical global object
<a href="https://bugs.webkit.org/show_bug.cgi?id=310622">https://bugs.webkit.org/show_bug.cgi?id=310622</a>
<a href="https://rdar.apple.com/173228040">rdar://173228040</a>

Reviewed by Keith Miller and Chris Dumez.

This is a preparation of introducing realm-less objects which is
introduced in V8 / blink. This patch improves JSValueInWrappedObject
by storing lexical global object&apos;s world, and using this world for
access control for this value. And threading lexical global object to
the places using JSValueInWrappedObject. This fixes
JSValueInWrappedObject: we would like to control the value access based
on which world sets this value. Not the world of the value itself as you
can create an object in the other world and setting it to the field from
the different realm still.

We also make sure that ErrorEvent / PopStateEvent are following to the
typical pattern of JSValueInWrappedObject so that we can easily
introduce the uniform approach for realm-less objects.

After this patch, we will introduce realm-less object, which does not
have tied realm (JSGlobalObject) in its Structure. This is Wasm GC
Struct / Array in V8 and this is necessary for the future thread-shared
objects in wasm.

* Source/WebCore/Modules/paymentrequest/PaymentMethodChangeEvent.cpp:
(WebCore::PaymentMethodChangeEvent::PaymentMethodChangeEvent):
* Source/WebCore/Modules/paymentrequest/PaymentMethodChangeEvent.h:
* Source/WebCore/Modules/paymentrequest/PaymentMethodChangeEvent.idl:
* Source/WebCore/Modules/streams/ReadableByteStreamController.cpp:
(WebCore::ReadableByteStreamController::ReadableByteStreamController):
(WebCore::ReadableByteStreamController::storeError):
* Source/WebCore/Modules/streams/StreamTeeUtilities.cpp:
* Source/WebCore/Modules/streams/TransformStream.cpp:
(WebCore::TransformStream::create):
(WebCore::TransformStream::TransformStream):
* Source/WebCore/Modules/streams/TransformStream.h:
* Source/WebCore/Modules/webaudio/AudioBuffer.cpp:
(WebCore::AudioBuffer::getChannelData):
* Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp:
(WebCore::AudioWorkletNode::fireProcessorErrorOnMainThread):
* Source/WebCore/Modules/webaudio/AudioWorkletProcessor.cpp:
(WebCore::AudioWorkletProcessor::buildJSArguments):
* Source/WebCore/bindings/js/DOMWrapperWorld.cpp:
(WebCore::isWorldCompatible): Deleted.
* Source/WebCore/bindings/js/DOMWrapperWorld.h:
* Source/WebCore/bindings/js/JSDOMWrapper.cpp:
(WebCore::cloneAcrossWorlds):
* Source/WebCore/bindings/js/JSErrorEventCustom.cpp:
(WebCore::JSErrorEvent::error const):
(WebCore::JSErrorEvent::visitAdditionalChildrenInGCThread):
* Source/WebCore/bindings/js/JSErrorHandler.cpp:
(WebCore::JSErrorHandler::handleEvent):
* Source/WebCore/bindings/js/JSMediaControlsHostCustom.cpp:
(WebCore::JSMediaControlsHost::setController):
* Source/WebCore/bindings/js/JSPopStateEventCustom.cpp:
(WebCore::JSPopStateEvent::state const):
(WebCore::JSPopStateEvent::visitAdditionalChildrenInGCThread):
* Source/WebCore/bindings/js/JSValueInWrappedObject.h:
(WebCore::JSValueInWrappedObject::JSValueInWrappedObject):
(WebCore::JSValueInWrappedObject::setValueInternal):
(WebCore::JSValueInWrappedObject::setWorld):
(WebCore::JSValueInWrappedObject::setWeakly):
(WebCore::JSValueInWrappedObject::set):
(WebCore::JSValueInWrappedObject::clear):
(WebCore::JSValueInWrappedObject::isWorldCompatible const):
(WebCore::cachedPropertyValue):
* Source/WebCore/dom/AbortSignal.cpp:
(WebCore::AbortSignal::abort):
(WebCore::AbortSignal::AbortSignal):
(WebCore::AbortSignal::signalAbort):
(WebCore::AbortSignal::markAborted):
* Source/WebCore/dom/AbortSignal.h:
* Source/WebCore/dom/CustomEvent.cpp:
(WebCore::CustomEvent::CustomEvent):
(WebCore::CustomEvent::create):
(WebCore::CustomEvent::initCustomEvent):
* Source/WebCore/dom/CustomEvent.h:
* Source/WebCore/dom/CustomEvent.idl:
* Source/WebCore/dom/ErrorEvent.cpp:
(WebCore::ErrorEvent::ErrorEvent):
(WebCore::ErrorEvent::error): Deleted.
(WebCore::ErrorEvent::trySerializeError): Deleted.
* Source/WebCore/dom/ErrorEvent.h:
* Source/WebCore/dom/ErrorEvent.idl:
* Source/WebCore/dom/InternalObserverLast.cpp:
* Source/WebCore/dom/InternalObserverReduce.cpp:
* Source/WebCore/dom/MessageEvent.cpp:
(WebCore::MessageEvent::MessageEvent):
(WebCore::m_jsData):
(WebCore::MessageEvent::create):
(WebCore::MessageEvent::initMessageEvent):
* Source/WebCore/dom/MessageEvent.h:
* Source/WebCore/dom/MessageEvent.idl:
* Source/WebCore/dom/PopStateEvent.cpp:
(WebCore::PopStateEvent::PopStateEvent):
(WebCore::PopStateEvent::create):
(WebCore::PopStateEvent::trySerializeState): Deleted.
* Source/WebCore/dom/PopStateEvent.h:
* Source/WebCore/dom/PopStateEvent.idl:
* Source/WebCore/dom/PromiseRejectionEvent.cpp:
(WebCore::PromiseRejectionEvent::PromiseRejectionEvent):
* Source/WebCore/dom/PromiseRejectionEvent.h:
* Source/WebCore/dom/PromiseRejectionEvent.idl:
* Source/WebCore/dom/RejectedPromiseTracker.cpp:
(WebCore::RejectedPromiseTracker::reportUnhandledRejections):
(WebCore::RejectedPromiseTracker::reportRejectionHandled):
* Source/WebCore/dom/ScriptExecutionContext.cpp:
(WebCore::ScriptExecutionContext::dispatchErrorEvent):
* Source/WebCore/page/NavigateEvent.cpp:
(WebCore::NavigateEvent::NavigateEvent):
(WebCore::NavigateEvent::create):
* Source/WebCore/page/NavigateEvent.h:
* Source/WebCore/page/NavigateEvent.idl:
* Source/WebCore/page/Navigation.cpp:
(WebCore::NavigationAPIMethodTracker::create):
(WebCore::NavigationAPIMethodTracker::NavigationAPIMethodTracker):
(WebCore::Navigation::maybeSetUpcomingNonTraversalTracker):
(WebCore::Navigation::addUpcomingTraverseAPIMethodTracker):
(WebCore::Navigation::reload):
(WebCore::Navigation::navigate):
(WebCore::Navigation::performTraversal):
(WebCore::Navigation::traverseTo):
(WebCore::Navigation::back):
(WebCore::Navigation::forward):
(WebCore::Navigation::abortOngoingNavigation):
(WebCore::Navigation::innerDispatchNavigateEvent):
* Source/WebCore/page/Navigation.h:
* Source/WebCore/page/Navigation.idl:
* Source/WebCore/testing/EventTargetForTesting.cpp:
(WebCore::EventTargetForTesting::sendInternalMessage):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::isFromCurrentWorld const):
* Source/WebCore/workers/WorkerMessagingProxy.cpp:
(WebCore::WorkerMessagingProxy::postExceptionToWorkerObject):
* Source/WebCore/workers/service/ExtendableMessageEvent.cpp:
(WebCore::createWrapperAndSetData):
* Source/WebCore/workers/shared/SharedWorkerObjectConnection.cpp:
(WebCore::SharedWorkerObjectConnection::postErrorToWorkerObject):

Canonical link: <a href="https://commits.webkit.org/309877@main">https://commits.webkit.org/309877@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed82dbb53cb2edfa09aabf72757b1e2035b9073f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151958 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24739 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18312 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160701 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105415 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153832 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25232 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25044 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117383 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a306271a-6656-455f-a297-cfcf3a8e5cc9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154918 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19560 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136362 "Found 1 new API test failure: TestWebKitAPI.UnifiedPDF.PasswordFormShouldDismissAfterNavigation (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98098 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/acf93a43-a2ab-4e91-9ade-ad4be844dad2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18642 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/16571 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8535 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128275 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14264 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163165 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6313 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15856 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125404 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24538 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20630 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125584 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24539 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136060 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81121 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23329 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20604 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12835 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24156 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88441 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23847 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24007 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23908 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->