### PR TITLE
Navigating away from the page can produce a stale immersive state

### DIFF
--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -595,10 +595,10 @@ void HTMLModelElement::deleteModelPlayer()
     };
 
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
-    if (immersive())
-        return protect(document().immersive())->exitRemovedImmersiveElement(this, WTF::move(deleteModelPlayerBlock));
+    // Let the document trigger the model player deletion after transitioning out the immersive element if needed
+    if (RefPtr documentImmersive = document().immersiveIfExists())
+        return documentImmersive->exitRemovedImmersiveElementIfNeeded(this, WTF::move(deleteModelPlayerBlock));
 #endif
-
     deleteModelPlayerBlock();
 }
 

--- a/Source/WebCore/dom/DocumentImmersive.cpp
+++ b/Source/WebCore/dom/DocumentImmersive.cpp
@@ -134,23 +134,24 @@ void DocumentImmersive::requestImmersive(HTMLModelElement* element, CompletionHa
 
 void DocumentImmersive::exitImmersive(CompletionHandler<void(ExceptionOr<void>)>&& completionHandler)
 {
-    RefPtr exitingImmersiveElement = immersiveElement();
-    if (!exitingImmersiveElement)
-        return completionHandler(Exception { ExceptionCode::TypeError, "Not in immersive"_s });
-
-    cancelActiveRequest([weakElement = WeakPtr { *exitingImmersiveElement }, weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler)]() mutable {
+    cancelActiveRequest([weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler)]() mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return completionHandler(Exception { ExceptionCode::AbortError });
 
         protectedThis->m_pendingImmersiveElement = nullptr;
+
+        RefPtr exitingImmersiveElement = protectedThis->immersiveElement();
+        if (!exitingImmersiveElement)
+            return completionHandler(Exception { ExceptionCode::TypeError, "Not in immersive"_s });
+
         protectedThis->m_pendingExitImmersive = true;
         auto resetPendingExitScope = makeScopeExit([weakThis] {
             if (RefPtr protectedThis = weakThis.get())
                 protectedThis->m_pendingExitImmersive = false;
         });
 
-        protectedThis->dismissClientImmersivePresentation([weakThis, weakElement, resetPendingExitScope = WTF::move(resetPendingExitScope), completionHandler = WTF::move(completionHandler)]() mutable {
+        protectedThis->dismissClientImmersivePresentation([weakThis, weakElement = WeakPtr { *exitingImmersiveElement }, resetPendingExitScope = WTF::move(resetPendingExitScope), completionHandler = WTF::move(completionHandler)]() mutable {
             RefPtr protectedThis = weakThis.get();
             RefPtr protectedElement = weakElement.get();
 
@@ -178,34 +179,47 @@ void DocumentImmersive::exitImmersive(CompletionHandler<void(ExceptionOr<void>)>
     });
 }
 
-void DocumentImmersive::exitImmersive()
+void DocumentImmersive::exitImmersiveIfNeeded()
 {
-    if (!immersiveElement())
+    if (immersiveElement()) {
+        exitImmersive([weakThis = WeakPtr { *this }](auto result) {
+            RefPtr protectedThis = weakThis.get();
+            if (!protectedThis)
+                return;
+
+            if (result.hasException())
+                RELEASE_LOG_ERROR(Immersive, "%p - DocumentImmersive: %s", protectedThis.get(), result.releaseException().message().utf8().data());
+        });
         return;
+    }
 
-    exitImmersive([weakThis = WeakPtr { *this }](auto result) {
-        RefPtr protectedThis = weakThis.get();
-        if (!protectedThis)
-            return;
-
-        if (result.hasException())
-            RELEASE_LOG_ERROR(Immersive, "%p - DocumentImmersive: %s", protectedThis.get(), result.releaseException().message().utf8().data());
-    });
+    m_pendingImmersiveElement = nullptr;
+    m_activeRequest.stage = ActiveRequest::Stage::None;
+    m_activeRequest.element = nullptr;
 }
 
-void DocumentImmersive::exitRemovedImmersiveElement(HTMLModelElement* element, CompletionHandler<void()>&& completionHandler)
+void DocumentImmersive::exitRemovedImmersiveElementIfNeeded(HTMLModelElement* element, CompletionHandler<void()>&& completionHandler)
 {
-    ASSERT(element->immersive());
-
     if (immersiveElement() == element) {
         exitImmersive([completionHandler = WTF::move(completionHandler)] (auto) mutable {
             completionHandler();
         });
-    } else {
-        element->exitImmersivePresentation([] { });
-        updateElementIsImmersive(element, false);
-        completionHandler();
+        return;
     }
+
+    if (m_pendingImmersiveElement == element || m_activeRequest.element == element) {
+        if (m_pendingImmersiveElement == element)
+            m_pendingImmersiveElement = nullptr;
+
+        if (m_activeRequest.element == element) {
+            m_activeRequest.stage = ActiveRequest::Stage::None;
+            m_activeRequest.element = nullptr;
+        }
+        completionHandler();
+        return;
+    }
+
+    completionHandler();
 }
 
 void DocumentImmersive::handleImmersiveError(HTMLModelElement* element, const String& message, EmitErrorEvent emitErrorEvent, ExceptionCode code, CompletionHandler<void(ExceptionOr<void>)>&& completionHandler)

--- a/Source/WebCore/dom/DocumentImmersive.h
+++ b/Source/WebCore/dom/DocumentImmersive.h
@@ -59,8 +59,8 @@ public:
 
     void requestImmersive(HTMLModelElement*, CompletionHandler<void(ExceptionOr<void>)>&&);
     void exitImmersive(CompletionHandler<void(ExceptionOr<void>)>&&);
-    WEBCORE_EXPORT void exitImmersive();
-    void exitRemovedImmersiveElement(HTMLModelElement*, CompletionHandler<void()>&&);
+    WEBCORE_EXPORT void exitImmersiveIfNeeded();
+    void exitRemovedImmersiveElementIfNeeded(HTMLModelElement*, CompletionHandler<void()>&&);
 
     enum class EventType : bool { Change, Error };
     void dispatchPendingEvents();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -7910,6 +7910,10 @@ void WebPage::didCommitLoad(WebFrame* frame)
 
     flushDeferredDidReceiveMouseEvent();
 
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    exitImmersive();
+#endif
+
     if (frame && frame->isMainFrame())
         m_networkResourceRequestIdentifiersForPageLoadTiming.clear();
 }
@@ -8123,7 +8127,7 @@ void WebPage::dismissImmersiveElement(CompletionHandler<void()>&& completion)
 void WebPage::exitImmersive() const
 {
     if (RefPtr localTopDocument = this->localTopDocument(); RefPtr protectedImmersive = localTopDocument->immersiveIfExists())
-        protectedImmersive->exitImmersive();
+        protectedImmersive->exitImmersiveIfNeeded();
 }
 
 bool WebPage::allowsImmersiveEnvironments() const


### PR DESCRIPTION
#### d9db6f38eff811fc082661ec2e820ea7e71c80e0
<pre>
Navigating away from the page can produce a stale immersive state
<a href="https://bugs.webkit.org/show_bug.cgi?id=310626">https://bugs.webkit.org/show_bug.cgi?id=310626</a>
<a href="https://rdar.apple.com/171750296">rdar://171750296</a>

Reviewed by Etienne Segonzac.

When navigating away and back via the nav bar, the webpage incorrectly
showed the environment as active because pending/in-flight immersive
request state was never cleaned up.

* Source/WebCore/dom/DocumentImmersive.h:
* Source/WebCore/dom/DocumentImmersive.cpp:
(WebCore::DocumentImmersive::exitImmersive):
Move the immersiveElement null check inside the cancelActiveRequest
callback so that any pending state (m_pendingImmersiveElement, m_activeRequest)
is always cleaned up, even when no element has fully entered immersive yet.

(WebCore::DocumentImmersive::exitImmersiveIfNeeded):
When there is no active immersive element, clear m_pendingImmersiveElement
and m_activeRequest to handle the case where a request was in-flight
but hadn&apos;t completed.

(WebCore::DocumentImmersive::exitRemovedImmersiveElementIfNeeded):
Remove the ASSERT since this is now called unconditionally.
Clean up m_pendingImmersiveElement and m_activeRequest when the removed
element was mid-request but not yet the active immersive element.
Any rollback action will be handled appropriately by the in-flight request.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::exitImmersive const):
(WebKit::WebPage::didCommitLoad):
Call exitImmersive() on commit load to tear down immersive state
when navigating to a new page.

* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::deleteModelPlayer):
Always route through exitRemovedImmersiveElementIfNeeded when
MODEL_ELEMENT_IMMERSIVE is enabled and an immersive document exists.

Canonical link: <a href="https://commits.webkit.org/310072@main">https://commits.webkit.org/310072@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/856f9374d23ed750a74284c3c4d23519c3b74d2a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152598 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25380 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18979 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161343 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106055 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154472 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25908 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25686 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117915 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155558 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20144 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136998 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98628 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19219 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17157 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9177 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128869 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14872 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163814 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6953 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16466 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125974 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25178 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21196 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126135 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34224 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25180 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136668 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81783 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21108 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13447 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24796 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89082 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24488 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24647 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24548 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->