### PR TITLE
Add sandbox in Simulator

### DIFF
--- a/Source/WTF/wtf/spi/darwin/SandboxSPI.h
+++ b/Source/WTF/wtf/spi/darwin/SandboxSPI.h
@@ -92,7 +92,7 @@ sandbox_profile_t sandbox_compile_file(const char *path, sandbox_params_t, char 
 sandbox_profile_t sandbox_compile_string(const char *data, sandbox_params_t, char **error);
 void sandbox_free_profile(sandbox_profile_t);
 int sandbox_apply(sandbox_profile_t);
-
+int sandbox_apply_bytecode(const void *bytecode, size_t, const char *container);
 char *sandbox_extension_issue_iokit_registry_entry_class_to_process(const char *extension_class, const char *registry_entry_class, uint32_t flags, audit_token_t);
 char *sandbox_extension_issue_iokit_registry_entry_class(const char *extension_class, const char *registry_entry_class, uint32_t flags);
 

--- a/Source/WebKit/Configurations/WebKit.xcconfig
+++ b/Source/WebKit/Configurations/WebKit.xcconfig
@@ -152,6 +152,7 @@ WK_MOBILE_KEY_BAG_LDFLAGS_iphoneos = -framework MobileKeyBag;
 WK_LIBSANDBOX_LDFLAGS = $(WK_LIBSANDBOX_LDFLAGS_$(WK_PLATFORM_NAME));
 WK_LIBSANDBOX_LDFLAGS_macosx = -lsandbox;
 WK_LIBSANDBOX_LDFLAGS_maccatalyst = -lsandbox;
+WK_LIBSANDBOX_LDFLAGS_iphonesimulator = -W1,-hidden-lsandbox-static;
 
 WK_PDFKIT_LDFLAGS = $(WK_PDFKIT_LDFLAGS_$(WK_PLATFORM_NAME));
 WK_PDFKIT_LDFLAGS_iphoneos = -framework PDFKit;

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -145,11 +145,13 @@
     (allow network-outbound
         (literal "/private/var/run/syslog")))
 
+#if !PLATFORM(IOS_SIMULATOR)
 #if ENABLE(NOTIFY_BLOCKING)
 (with-filter (require-not (notify-blocking))
     (allow-notifyd))
 #else
 (allow-notifyd)
+#endif
 #endif
 
 (managed-configuration-read-public)
@@ -421,6 +423,7 @@
 (when (not (defined? 'process-codesigning*))
     (allow process-info-codesignature (target self)))
 
+#if !PLATFORM(IOS_SIMULATOR)
 (allow mach-bootstrap
     (apply-message-filter
         (deny mach-message-send NO_REPORT)
@@ -432,6 +435,7 @@
 #endif
         (with-filter (require-not (webcontent-process-launched))
             (allow mach-message-send (mach-bootstrap-message-numbers)))))
+#endif
 
 (deny syscall-mach (with telemetry))
 (allow syscall-mach

--- a/Source/WebKit/Scripts/compile-sandbox.sh
+++ b/Source/WebKit/Scripts/compile-sandbox.sh
@@ -11,6 +11,8 @@ if [ -z "$(xcrun --sdk $SDK_NAME -f sbutil 2> /dev/null)" ]; then
     exit 0;
 fi;
 
+SIMULATOR_SANDBOX_PATH="$SANDBOX_NAME.simulator"
+
 if [[ $SDK_NAME =~ "iphone" || $SDK_NAME =~ "watch" || $SDK_NAME =~ "appletv" || $SDK_NAME =~ "xr" ]]; then
     if [[ $SANDBOX_NAME == "com.apple.WebKit.adattributiond" || $SANDBOX_NAME == "com.apple.WebKit.webpushd" ]]; then
         if [ ! -e $SANDBOX_IMPORT_DIR ]; then
@@ -21,8 +23,9 @@ if [[ $SDK_NAME =~ "iphone" || $SDK_NAME =~ "watch" || $SDK_NAME =~ "appletv" ||
             exit 1;
         fi
     fi;
-    if [[ $SANDBOX_NAME == "com.apple.WebKit.GPU."* || $SANDBOX_NAME == "com.apple.WebKit.Networking."* || $SANDBOX_NAME == "com.apple.WebKit.WebContent."* ]]; then
-        xcrun --sdk $SDK_NAME sbutil compile $SANDBOX_PATH > /dev/null;
+    if [[ $SANDBOX_NAME == "com.apple.WebKit.GPU" || $SANDBOX_NAME == "com.apple.WebKit.GPU.Development" || $SANDBOX_NAME == "com.apple.WebKit.Networking"* || $SANDBOX_NAME == "com.apple.WebKit.WebContent"* ]]; then
+
+        xcrun --sdk $SDK_NAME sbutil compile $SANDBOX_PATH > $SIMULATOR_SANDBOX_PATH;
         if [[ $? != 0 ]]; then
             exit 1;
         fi

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -118,6 +118,7 @@
 #import <pal/spi/mac/NSApplicationSPI.h>
 #import <stdio.h>
 #import <wtf/BlockPtr.h>
+#import <wtf/FileHandle.h>
 #import <wtf/FileSystem.h>
 #import <wtf/Language.h>
 #import <wtf/LogInitialization.h>
@@ -1067,6 +1068,14 @@ void WebProcess::initializeSandbox(const AuxiliaryProcessInitializationParameter
     sandboxParameters.setOverrideSandboxProfilePath(makeString(String([webKitBundle resourcePath]), "/com.apple.WebProcess.sb"_s));
 
     AuxiliaryProcess::initializeSandbox(parameters, sandboxParameters);
+#elif ENABLE(SIMULATOR_SANDBOX)
+    auto webKitBundle = [NSBundle bundleForClass:NSClassFromString(@"WKWebView")];
+    String path = makeString(String([webKitBundle bundlePath]), "/com.apple.WebKit.WebContent.simulator"_s);
+    auto handle = FileSystem::openFile(path, FileSystem::FileOpenMode::Read, FileSystem::FileAccessPermission::All, { FileSystem::FileLockMode::Exclusive, FileSystem::FileLockMode::Nonblocking });
+    if (auto data = handle.readAll()) {
+        int rv = sandbox_apply_bytecode(data->mutableSpan().data(), data->size(), nullptr);
+        RELEASE_ASSERT(!rv);
+    }
 #endif
 }
 


### PR DESCRIPTION
#### 048baa0d76440569c87cb39642ad1da4a61cc5d6
<pre>
Add sandbox in Simulator
<a href="https://bugs.webkit.org/show_bug.cgi?id=310632">https://bugs.webkit.org/show_bug.cgi?id=310632</a>
<a href="https://rdar.apple.com/173235681">rdar://173235681</a>

Reviewed by Sihui Liu.

We can apply the sandbox at runtime in the Simulator, similar to how we do it on macOS.
This feature is not yet enabled.

* Source/WTF/wtf/PlatformEnableCocoa.h:
* Source/WTF/wtf/spi/darwin/SandboxSPI.h:
* Source/WebKit/Configurations/WebKit.xcconfig:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:
* Source/WebKit/Scripts/compile-sandbox.sh:
* Source/WebKit/Shared/AuxiliaryProcess.h:
* Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentProcessExtension.entitlements:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::accessibilityFocusedUIElement):

Canonical link: <a href="https://commits.webkit.org/310071@main">https://commits.webkit.org/310071@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0516cdd7fede666167c8bcb17bd688ec5fca0e78

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152427 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25209 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18808 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161170 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105884 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/25eeade7-710b-4692-95d0-4df79d963642) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25737 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25515 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117781 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83491 "8 flakes 2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155387 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20002 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136847 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98495 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/04cbb678-e705-45bb-a90f-69afcfae17af) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/151749 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19078 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17005 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9005 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144439 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128728 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14721 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163640 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13229 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6782 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16315 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125817 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25007 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21044 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125988 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25009 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136517 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81609 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23388 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20982 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13296 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184059 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24625 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88911 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46929 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24316 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24476 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24377 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->