### PR TITLE
[run-benchmark] Restore support to run MotionMark subtests

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner.py
@@ -154,6 +154,9 @@ class BenchmarkRunner(object):
     def _construct_subtest_url(self, subtests):
         if not subtests or not isinstance(subtests, collections.abc.Mapping) or 'subtest_url_format' not in self._plan:
             return ''
+        # As subtest URLs are concatenated directly, the format must account for this.
+        # MotionMark and JetStream start with '&', while Speedometer uses ',' separated values.
+        # If new plans are added, they must take this into account.
         subtest_url = ''
         for suite, tests in subtests.items():
             for test in tests:

--- a/Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner_unittest.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner_unittest.py
@@ -1,0 +1,101 @@
+# Copyright (C) 2026 Igalia S.L.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import collections
+import unittest
+
+from webkitpy.benchmark_runner.benchmark_runner import BenchmarkRunner
+
+
+class MockRunner:
+    def __init__(self, plan):
+        self._plan = plan
+
+
+class ConstructSubtestURLTest(unittest.TestCase):
+
+    def _load_plan(self, name):
+        _, plan = BenchmarkRunner._load_plan_data(name)
+        return plan
+
+    def _construct(self, plan, subtests):
+        runner = MockRunner(plan)
+        return BenchmarkRunner._construct_subtest_url(runner, subtests)
+
+    # Edge cases
+
+    def test_no_subtests_returns_empty(self):
+        plan = self._load_plan('speedometer3.0')
+        self.assertEqual(self._construct(plan, None), '')
+
+    def test_empty_subtests_returns_empty(self):
+        plan = self._load_plan('speedometer3.0')
+        self.assertEqual(self._construct(plan, {}), '')
+
+    def test_no_format_in_plan_returns_empty(self):
+        plan = {'timeout': 600}
+        subtests = collections.OrderedDict([('MotionMark', ['CanvasArcs'])])
+        self.assertEqual(self._construct(plan, subtests), '')
+
+    # Speedometer-style: comma-separated suite names
+
+    def test_speedometer_single_subtest(self):
+        plan = self._load_plan('speedometer3.0')
+        subtests = collections.OrderedDict([('TodoMVC-React', [''])])
+        self.assertEqual(self._construct(plan, subtests), 'TodoMVC-React,')
+
+    def test_speedometer_multiple_subtests(self):
+        plan = self._load_plan('speedometer3.0')
+        subtests = collections.OrderedDict([('TodoMVC-React', ['']), ('TodoMVC-Vue', [''])])
+        self.assertEqual(self._construct(plan, subtests), 'TodoMVC-React,TodoMVC-Vue,')
+
+    # MotionMark-style: URL parameters with suite-name and test-name
+
+    def test_motionmark_single_subtest(self):
+        plan = self._load_plan('motionmark1.3.1')
+        subtests = collections.OrderedDict([('MotionMark', ['CanvasArcs'])])
+        self.assertEqual(
+            self._construct(plan, subtests),
+            '&suite-name=MotionMark&test-name=CanvasArcs')
+
+    def test_motionmark_multiple_subtests(self):
+        plan = self._load_plan('motionmark1.3.1')
+        subtests = collections.OrderedDict([('MotionMark', ['CanvasArcs', 'Leaves'])])
+        self.assertEqual(
+            self._construct(plan, subtests),
+            '&suite-name=MotionMark&test-name=CanvasArcs&suite-name=MotionMark&test-name=Leaves')
+
+    # JetStream-style: leading & with test parameter
+
+    def test_jetstream_single_subtest(self):
+        plan = self._load_plan('jetstream3')
+        subtests = collections.OrderedDict([('default', ['HashSet-String'])])
+        self.assertEqual(
+            self._construct(plan, subtests),
+            '&test=HashSet-String')
+
+    def test_jetstream_multiple_subtests(self):
+        plan = self._load_plan('jetstream3')
+        subtests = collections.OrderedDict([('default', ['HashSet-String', 'bomb-workers'])])
+        self.assertEqual(
+            self._construct(plan, subtests),
+            '&test=HashSet-String&test=bomb-workers')

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.2.1.plan
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.2.1.plan
@@ -156,7 +156,7 @@
             {"path": "tests/text/design.js", "mode": "100644", "type": "blob"}
         ]
     },
-    "subtest_url_format": "suite-name=${SUITE}&test-name=${TEST}",
+    "subtest_url_format": "&suite-name=${SUITE}&test-name=${TEST}",
     "subtests": {
         "MotionMark": [
             "Multiply",

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.3.1.plan
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.3.1.plan
@@ -11,7 +11,7 @@
         "orientation": "landscape"
     },
     "output_file": "motionmark.result",
-    "subtest_url_format": "suite-name=${SUITE}&test-name=${TEST}",
+    "subtest_url_format": "&suite-name=${SUITE}&test-name=${TEST}",
     "subtests": {
         "MotionMark": [
             "Multiply",

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.3.plan
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.3.plan
@@ -11,7 +11,7 @@
         "orientation": "landscape"
     },
     "output_file": "motionmark.result",
-    "subtest_url_format": "suite-name=${SUITE}&test-name=${TEST}",
+    "subtest_url_format": "&suite-name=${SUITE}&test-name=${TEST}",
     "subtests": {
         "MotionMark": [
             "Multiply",


### PR DESCRIPTION
#### 41489acc0d94daedb1921a1ec2ffc7ef1ebaac22
<pre>
[run-benchmark] Restore support to run MotionMark subtests
<a href="https://bugs.webkit.org/show_bug.cgi?id=310633">https://bugs.webkit.org/show_bug.cgi?id=310633</a>

Reviewed by Carlos Alberto Lopez Perez.

Add a leading &amp; to MotionMark subtest_url_formats, so that when combined
creating a subset of tests they result in a valid URL. Added a note in
the code building the URL, to hint that plans need to stay up to date.

Added a new unit test that loads MotionMark, Speedometer and JetStream
plans to confirm that subtests can be properly formed.

* Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner.py:
(BenchmarkRunner._construct_subtest_url):
* Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner_unittest.py: Added.
(MockRunner):
(MockRunner.__init__):
(ConstructSubtestURLTest):
(ConstructSubtestURLTest._load_plan):
(ConstructSubtestURLTest._construct):
(ConstructSubtestURLTest.test_no_subtests_returns_empty):
(ConstructSubtestURLTest.test_empty_subtests_returns_empty):
(ConstructSubtestURLTest.test_no_format_in_plan_returns_empty):
(ConstructSubtestURLTest.test_speedometer_single_subtest):
(ConstructSubtestURLTest.test_speedometer_multiple_subtests):
(ConstructSubtestURLTest.test_motionmark_single_subtest):
(ConstructSubtestURLTest.test_motionmark_multiple_subtests):
(ConstructSubtestURLTest.test_jetstream_single_subtest):
(ConstructSubtestURLTest.test_jetstream_multiple_subtests):
* Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.2.1.plan:
* Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.3.1.plan:
* Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.3.plan:

Canonical link: <a href="https://commits.webkit.org/309974@main">https://commits.webkit.org/309974@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/347197163058398520ad1c11327007c1945a9032

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151901 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24682 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18254 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160643 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105358 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153775 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25175 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24984 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117335 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83243 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154861 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19507 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136310 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98050 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/151223 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18589 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16522 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8478 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128221 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14213 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163108 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15805 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125352 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24481 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20581 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125533 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34153 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24482 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136009 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81059 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20561 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12784 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24099 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23790 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23950 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23851 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->