### PR TITLE
AX: AXUIElementForTextMarker doesn't handle stitched text, meaning we can return references to objects not actually exposed in the tree

### DIFF
--- a/LayoutTests/accessibility/text-stitching-end-text-marker-expected.txt
+++ b/LayoutTests/accessibility/text-stitching-end-text-marker-expected.txt
@@ -1,0 +1,13 @@
+This test ensures the end-text-marker and UI-element-for-text-marker APIs correctly account for stitched text.
+
+PASS: initialFullText === 'Hello World'
+PASS: endElement.isEqual(startElement) === true
+PASS: endElement.stringValue.includes('Hello World') === true
+PASS: webArea.stringForTextMarkerRange(webArea.textMarkerRangeForMarkers(startMarker, webArea.endTextMarker)) === 'Hello World Goodbye'
+PASS: endElement.stringValue.includes('Goodbye') === true
+PASS: endElement.isEqual(startElement) === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Hello World Goodbye

--- a/LayoutTests/accessibility/text-stitching-end-text-marker.html
+++ b/LayoutTests/accessibility/text-stitching-end-text-marker.html
@@ -1,0 +1,54 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ runSingly=true AccessibilityTextStitchingEnabled=true ] -->
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<p id="paragraph">Hello <b>World</b></p>
+
+<script>
+var output = "This test ensures the end-text-marker and UI-element-for-text-marker APIs correctly account for stitched text.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var webArea = accessibilityController.rootElement.childAtIndex(0);
+
+    var startMarker = webArea.startTextMarker;
+    var endMarker = webArea.endTextMarker;
+    var fullRange = webArea.textMarkerRangeForMarkers(startMarker, endMarker);
+    var initialFullText = webArea.stringForTextMarkerRange(fullRange);
+    output += expect("initialFullText", "'Hello World'");
+
+    var startElement = webArea.accessibilityElementForTextMarker(startMarker)
+    var endElement = webArea.accessibilityElementForTextMarker(endMarker);
+    output += expect("endElement.isEqual(startElement)", "true");
+
+    // The end marker should resolve to an element whose string value includes
+    // all of the stitched text, not just an individual member's text.
+    output += expect("endElement.stringValue.includes('Hello World')", "true");
+
+    // Dynamically add more text to the paragraph and verify the end marker updates.
+    var span = document.createElement("span");
+    span.innerText = " Goodbye";
+    document.getElementById("paragraph").appendChild(span);
+
+    setTimeout(async function() {
+        startMarker = webArea.startTextMarker;
+        output += await expectAsync("webArea.stringForTextMarkerRange(webArea.textMarkerRangeForMarkers(startMarker, webArea.endTextMarker))", "'Hello World Goodbye'");
+
+        // After the dynamic update, the end element should still resolve to a visible
+        // element with the full stitched value.
+        endElement = webArea.accessibilityElementForTextMarker(webArea.endTextMarker);
+        output += expect("endElement.stringValue.includes('Goodbye')", "true");
+        output += expect("endElement.isEqual(startElement)", "true");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -853,6 +853,7 @@ accessibility/aria-owns-text-stitching.html [ Skip ]
 accessibility/dynamic-text-stitching.html [ Skip ]
 accessibility/hit-test-on-stitched-text.html [ Skip ]
 accessibility/list-marker-text-stitching.html [ Skip ]
+accessibility/text-stitching-end-text-marker.html [ Skip ]
 accessibility/text-stitching-inside-links.html [ Skip ]
 
 # Timed out since it was introduced.

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -3609,6 +3609,11 @@ static id handleUIElementForTextMarkerAttribute(WebAccessibilityObjectWrapper*, 
     if (!object)
         return nil;
 
+    if (std::optional<AXID> representativeID = object->stitchedIntoID(); representativeID && *representativeID != object->objectID()) {
+        if (RefPtr representative = AXTextMarker { object->treeID(), *representativeID, 0 }.object())
+            object = WTF::move(representative);
+    }
+
     RetainPtr wrapper = object->wrapper();
     if (!wrapper)
         return nil;


### PR DESCRIPTION
#### 907a8e427c17ddf47a813a00dab82aa9928a552d
<pre>
AX: AXUIElementForTextMarker doesn&apos;t handle stitched text, meaning we can return references to objects not actually exposed in the tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=310561">https://bugs.webkit.org/show_bug.cgi?id=310561</a>
<a href="https://rdar.apple.com/173173023">rdar://173173023</a>

Reviewed by Joshua Hoffman.

When text stitching is enabled, text markers can reference stitched-away
objects not exposed in the accessibility tree. Check for this in
handleUIElementForTextMarkerAttribute and redirect to the stitch group
representative so assistive technologies only receive objects actually
exposed in the tree.

* LayoutTests/accessibility/text-stitching-end-text-marker-expected.txt: Added.
* LayoutTests/accessibility/text-stitching-end-text-marker.html: Added.
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(handleUIElementForTextMarkerAttribute):

Canonical link: <a href="https://commits.webkit.org/309924@main">https://commits.webkit.org/309924@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c12b78866d5bc2832e059a6fe8ec0bd32bce8bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151987 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24769 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18344 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160730 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105444 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153861 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25261 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25074 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117407 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83278 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154947 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19577 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136391 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98122 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18659 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16599 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8564 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128292 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14291 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163194 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6342 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15883 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125430 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24567 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20656 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125607 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34121 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24568 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136087 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81150 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20619 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12863 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24185 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88470 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23876 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24036 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23937 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->