### PR TITLE
ASSERTION FAILED: request.hasHTTPHeaderField(HTTPHeaderName::SecFetchDest)

### DIFF
--- a/LayoutTests/http/tests/navigation/post-basic-expected.txt
+++ b/LayoutTests/http/tests/navigation/post-basic-expected.txt
@@ -4,6 +4,7 @@ Parameters:
 
 the-input = input value goes here
 submitwithpost = Submit with POST
+Sec-Fetch-Site = 'same-origin'
 
 ============== Back Forward List ==============
         http://127.0.0.1:8000/navigation/resources/page-that-posts.html

--- a/LayoutTests/http/tests/navigation/post-frames-expected.txt
+++ b/LayoutTests/http/tests/navigation/post-frames-expected.txt
@@ -11,6 +11,7 @@ Parameters:
 
 the-input = input value goes here
 submitwithpost = Submit with POST
+Sec-Fetch-Site = 'same-origin'
 
 ============== Back Forward List ==============
         http://127.0.0.1:8000/navigation/post-frames.html

--- a/LayoutTests/http/tests/navigation/post-frames-goback1-expected.txt
+++ b/LayoutTests/http/tests/navigation/post-frames-goback1-expected.txt
@@ -11,6 +11,7 @@ This page was requested with the HTTP method POST.
 Parameters:
 
 the-input = input value goes here
+Sec-Fetch-Site = 'same-origin'
 
 ============== Back Forward List ==============
 curr->  http://127.0.0.1:8000/navigation/post-frames-goback1.html

--- a/LayoutTests/http/tests/navigation/post-goback1-expected.txt
+++ b/LayoutTests/http/tests/navigation/post-goback1-expected.txt
@@ -4,6 +4,7 @@ Parameters:
 
 the-input = input value goes here
 submitwithpost = Submit with POST
+Sec-Fetch-Site = 'same-origin'
 
 ============== Back Forward List ==============
         http://127.0.0.1:8000/navigation/resources/page-that-posts.html

--- a/LayoutTests/http/tests/navigation/resources/form-target.pl
+++ b/LayoutTests/http/tests/navigation/resources/form-target.pl
@@ -8,6 +8,7 @@ print "Content-type: text/html\r\n";
 print "\r\n";
 
 $method = $query->request_method();
+$secFetchSite = $ENV{"HTTP_SEC_FETCH_SITE"};
 
 print <<HEADER;
 <body>
@@ -26,6 +27,7 @@ foreach $paramName (@paramNames)
 
 print <<FOOTER
 </ul>
+<div id=logDiv></div>
 <script>
 var isDone = true;
 if (sessionStorage.formTargetShouldNavAndGoBack) {
@@ -51,8 +53,10 @@ if (sessionStorage.topShouldNavAndGoBack) {
   }
 }
 
-if (isDone && window.testRunner)
+if (isDone && window.testRunner) {
+    logDiv.innerHTML = "Sec-Fetch-Site = '$secFetchSite'";
     testRunner.notifyDone();
+}
 
 </script>
 </body>

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/form-action-src-allowed-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/form-action-src-allowed-expected.txt
@@ -3,6 +3,7 @@ This page was requested with the HTTP method POST.
 Parameters:
 
 fieldname = fieldvalue
+Sec-Fetch-Site = 'same-origin'
 
 ============== Back Forward List ==============
         http://127.0.0.1:8000/security/contentSecurityPolicy/1.1/form-action-src-allowed.html

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/form-action-src-default-ignored-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/form-action-src-default-ignored-expected.txt
@@ -3,6 +3,7 @@ This page was requested with the HTTP method POST.
 Parameters:
 
 fieldname = fieldvalue
+Sec-Fetch-Site = 'same-origin'
 
 ============== Back Forward List ==============
         http://127.0.0.1:8000/security/contentSecurityPolicy/1.1/form-action-src-default-ignored.html

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/form-action-src-get-allowed-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/form-action-src-get-allowed-expected.txt
@@ -3,6 +3,7 @@ This page was requested with the HTTP method GET.
 Parameters:
 
 fieldname = fieldvalue
+Sec-Fetch-Site = 'same-origin'
 
 ============== Back Forward List ==============
         http://127.0.0.1:8000/security/contentSecurityPolicy/1.1/form-action-src-get-allowed.html

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2498,8 +2498,3 @@ tiled-drawing/mac/margin-tiles-with-banner-view-overlay-repeat-y.html [ Skip ]
 # Cocoa platforms use data URLs for pasted images; blob URL tests are for Glib ports
 editing/pasteboard/paste-image-as-blob-url.html [ Skip ]
 editing/pasteboard/data-transfer-get-data-on-pasting-html-uses-blob-url.html [ Skip ]
-
-# webkit.org/b/310313 REGRESSION(309498@main): [iOS Debug] ASSERTION FAILED: request.hasHTTPHeaderField(HTTPHeaderName::SecFetchDest)
-[ Debug ] http/tests/navigation/post-frames-goback1.html [ Skip ]
-[ Debug ] http/tests/navigation/post-goback1.html [ Skip ]
-[ Debug ] http/tests/cache/subresource-failover-to-network.html [ Skip ]

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -974,9 +974,11 @@ static bool shouldReuseExistingFetchMetadata(const LocalFrame& frame, const Reso
     if (loader && loader->triggeringAction().type() != NavigationType::FormResubmitted)
         return false;
 
-    ASSERT_UNUSED(request, request.hasHTTPHeaderField(HTTPHeaderName::SecFetchDest));
+    if (!request.hasHTTPHeaderField(HTTPHeaderName::SecFetchSite))
+        return false;
+
+    ASSERT(request.hasHTTPHeaderField(HTTPHeaderName::SecFetchDest));
     ASSERT(request.hasHTTPHeaderField(HTTPHeaderName::SecFetchMode));
-    ASSERT(request.hasHTTPHeaderField(HTTPHeaderName::SecFetchSite));
 
     return true;
 }


### PR DESCRIPTION
#### d3b64505f94e4201b69833a0d13d9942ae945025
<pre>
ASSERTION FAILED: request.hasHTTPHeaderField(HTTPHeaderName::SecFetchDest)
<a href="https://rdar.apple.com/169836073">rdar://169836073</a>

Reviewed by Chris Dumez.

In <a href="https://rdar.apple.com/158416842">rdar://158416842</a>, we made sure to reuse Sec-Fetch headers in case of form resubmission, which happens when reloading for instance (FrameLoader::reload).
The other case where form resubmission happens is in FrameLoader::loadDifferentDocumentItem, where the request is recreated from scratch.
In that case, there is no Sec-Fetch headers in the request, and we should populate those headers.
We update shouldReuseExistingFetchMetadata to return false when there is no Sec-Fetch headers.
We update a test to cover this change.

Originally-landed-as: 305413.287@safari-7624-branch (41592221f73c). <a href="https://rdar.apple.com/173251752">rdar://173251752</a>
Canonical link: <a href="https://commits.webkit.org/309865@main">https://commits.webkit.org/309865@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a4ea5dffe48231846365f34f26eb96d25dc2dae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151927 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24708 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18280 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160669 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153801 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25201 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25012 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117355 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9fc3f2ac-0a41-4ebf-9b68-f893f67aeae7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154887 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19530 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136335 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98070 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eb6a8449-03c4-4934-a408-fc8cb31a8ce2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18612 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16545 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8504 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128245 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14238 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163134 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6282 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15830 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125377 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24507 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20604 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125557 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34075 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24508 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136034 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81090 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20583 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12809 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24125 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88410 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23816 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23976 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23877 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->