### PR TITLE
[JSC][WASM][Debugger] Implement qWasmGlobal GDB remote packet handler

### DIFF
--- a/JSTests/wasm/debugger/resources/swift-wasm/globals-test/Package.swift
+++ b/JSTests/wasm/debugger/resources/swift-wasm/globals-test/Package.swift
@@ -1,0 +1,15 @@
+// swift-tools-version: 6.2
+import PackageDescription
+
+let package = Package(
+    name: "globals-test",
+    targets: [
+        .executableTarget(
+            name: "globals-test",
+            path: "Sources/globals-test",
+            linkerSettings: [
+                .unsafeFlags(["-Xlinker", "--export=increment_globals"])
+            ]
+        )
+    ]
+)

--- a/JSTests/wasm/debugger/resources/swift-wasm/globals-test/Sources/globals-test/main.swift
+++ b/JSTests/wasm/debugger/resources/swift-wasm/globals-test/Sources/globals-test/main.swift
@@ -1,0 +1,24 @@
+nonisolated(unsafe) var globalCounter1: Int32 = 0
+nonisolated(unsafe) var globalCounter2: Int32 = 0
+nonisolated(unsafe) var globalCounter3: Int32 = 0
+nonisolated(unsafe) var globalCounter4: Int32 = 0
+
+func helper() {
+    globalCounter2 = 2
+    globalCounter3 = 3
+}
+
+@_cdecl("increment_globals")
+public func incrementGlobals(_ x: Int32) -> Int32 {
+    globalCounter1 = 1
+    helper()
+    globalCounter4 &+= x
+    return globalCounter4
+}
+
+@main
+struct GlobalsTest {
+    static func main() {
+        _ = incrementGlobals
+    }
+}

--- a/JSTests/wasm/debugger/resources/swift-wasm/globals-test/main.js
+++ b/JSTests/wasm/debugger/resources/swift-wasm/globals-test/main.js
@@ -1,0 +1,37 @@
+var wasm_code = read('globals-test.wasm', 'binary');
+var wasm_module = new WebAssembly.Module(wasm_code);
+var imports = {
+    wasi_snapshot_preview1: {
+        proc_exit: function (code) {
+            print("Program exited with code:", code);
+        },
+        args_get: function () { return 0; },
+        args_sizes_get: function () { return 0; },
+        environ_get: function () { return 0; },
+        environ_sizes_get: function () { return 0; },
+        fd_write: function () { return 0; },
+        fd_read: function () { return 0; },
+        fd_close: function () { return 0; },
+        fd_seek: function () { return 0; },
+        fd_fdstat_get: function () { return 0; },
+        fd_prestat_get: function () { return 8; },
+        fd_prestat_dir_name: function () { return 8; },
+        path_open: function () { return 8; },
+        random_get: function () { return 0; },
+        clock_time_get: function () { return 0; }
+    }
+};
+
+var instance = new WebAssembly.Instance(wasm_module, imports);
+
+print("Available exports:", Object.keys(instance.exports));
+
+let incrementGlobals = instance.exports.increment_globals;
+
+let iteration = 0;
+for (; ;) {
+    incrementGlobals(iteration);
+    iteration += 1;
+    if (iteration % 1e5 == 0)
+        print("iteration=", iteration);
+}

--- a/JSTests/wasm/debugger/tests/tests.py
+++ b/JSTests/wasm/debugger/tests/tests.py
@@ -510,6 +510,45 @@ class SwiftWasmTestCase(BaseTestCase):
         ])
 
 
+class SwiftWasmGlobalTestCase(BaseTestCase):
+
+    def __init__(self, build_config: str = None, port: int = None):
+        super().__init__(build_config, port)
+
+    def execute(self):
+        self.setup_debugging_session_or_raise("resources/swift-wasm/globals-test/main.js")
+
+        try:
+            for _ in range(1):
+                self.globalVariableTest()
+
+        except Exception as e:
+            raise Exception(f"Test failed: {e}")
+
+    def globalVariableTest(self):
+        self.send_lldb_command_or_raise("b helper")
+        self.send_lldb_command_or_raise(
+            "c",
+            patterns=[
+                "Process 1 stopped",
+                "stop reason = breakpoint",
+                "-> 7   	    globalCounter2 = 2",
+            ],
+        )
+
+        self.send_lldb_command_or_raise("n", patterns=["-> 8   	    globalCounter3 = 3"])
+        self.send_lldb_command_or_raise("n", patterns=["-> 9   	}"])
+
+        self.send_lldb_command_or_raise("p globalCounter2", patterns=["(Int32) 2"])
+        self.send_lldb_command_or_raise("p globalCounter3", patterns=["(Int32) 3"])
+
+        self.send_lldb_command_or_raise("up", patterns=["-> 14  	    helper()"])
+
+        self.send_lldb_command_or_raise("p globalCounter1", patterns=["(Int32) 1"])
+
+        self.send_lldb_command_or_raise("br del -f", patterns=["All breakpoints removed."])
+
+
 class NopDropSelectEndTestCase(BaseTestCase):
 
     def __init__(self, build_config: str = None, port: int = None):

--- a/Source/JavaScriptCore/wasm/debugger/WasmQueryHandler.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmQueryHandler.cpp
@@ -87,6 +87,8 @@ void QueryHandler::handleGeneralQuery(StringView packet)
         handleWasmCallStack(packet);
     else if (packet.startsWith("qWasmLocal:"_s))
         handleWasmLocal(packet);
+    else if (packet.startsWith("qWasmGlobal:"_s))
+        handleWasmGlobal(packet);
     else if (packet.startsWith("qMemoryRegionInfo:"_s))
         m_debugServer.m_memoryHandler->handleMemoryRegionInfo(packet);
     else
@@ -433,6 +435,72 @@ void QueryHandler::handleWasmLocal(StringView packet)
     }
     default:
         RELEASE_ASSERT(false, "Unsupported TypeKind bit size: ", width, " for TypeKind: ", localType.kind);
+        break;
+    }
+    m_debugServer.sendReply(response);
+}
+
+void QueryHandler::handleWasmGlobal(StringView packet)
+{
+    // Format: qWasmGlobal:<frame-index>;<variable-index>
+    // LLDB: Get value of WebAssembly global variable for a given frame's instance
+    // Reference: https://lldb.llvm.org/resources/lldbgdbremote.html#qwasmglobal
+
+    // WebAssembly Context: Globals are per-instance; the frame index identifies which
+    // WASM instance to read from, and variable-index is the global index within that instance.
+    auto parts = splitWithDelimiters(packet, ":;"_s);
+    if (parts.size() != 3) {
+        m_debugServer.sendErrorReply(ProtocolError::InvalidPacket);
+        return;
+    }
+
+    uint32_t frameIndex = parseDecimal(parts[1]);
+    uint32_t globalIndex = parseDecimal(parts[2]);
+
+    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] qWasmGlobal frame=", frameIndex, ", global=", globalIndex);
+
+    auto* state = m_debugServer.execution().debuggeeStateSafe();
+    if (!state->atBreakpoint()) {
+        m_debugServer.sendErrorReply(ProtocolError::UnknownCommand);
+        return;
+    }
+
+    auto& stopData = *state->stopData;
+    JSWebAssemblyInstance* instance = nullptr;
+
+    if (!frameIndex)
+        instance = stopData.instance;
+    else {
+        auto frames = collectCallStack(stopData.address, stopData.callFrame, stopData.instance->vm());
+        if (frameIndex >= frames.size() || !frames[frameIndex].isWasmFrame()) {
+            m_debugServer.sendErrorReply(ProtocolError::UnknownCommand);
+            return;
+        }
+        instance = frames[frameIndex].wasmCallFrame->wasmInstance();
+    }
+
+    const auto& moduleInfo = instance->module().moduleInformation();
+    if (globalIndex >= moduleInfo.globalCount()) {
+        m_debugServer.sendErrorReply(ProtocolError::InvalidPacket);
+        return;
+    }
+
+    Type globalType = moduleInfo.global(globalIndex).type;
+    uint32_t width = typeKindToWidth(globalType.kind);
+
+    String response;
+    switch (width) {
+    case 32:
+        response = toNativeEndianHex(static_cast<uint32_t>(instance->loadI32Global(globalIndex)));
+        break;
+    case 64:
+        response = toNativeEndianHex(static_cast<uint64_t>(instance->loadI64Global(globalIndex)));
+        break;
+    case 128:
+        response = toNativeEndianHex(instance->loadV128Global(globalIndex));
+        break;
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
         break;
     }
     m_debugServer.sendReply(response);

--- a/Source/JavaScriptCore/wasm/debugger/WasmQueryHandler.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmQueryHandler.h
@@ -56,6 +56,7 @@ public:
     void handleLibrariesRead(StringView packet);
     void handleWasmCallStack(StringView packet);
     void handleWasmLocal(StringView packet);
+    void handleWasmGlobal(StringView packet);
 
 private:
     DebugServer& m_debugServer;


### PR DESCRIPTION
#### 875e3a58a1b2889a8cf92d13a650be5c652e0d0c
<pre>
[JSC][WASM][Debugger] Implement qWasmGlobal GDB remote packet handler
<a href="https://bugs.webkit.org/show_bug.cgi?id=310643">https://bugs.webkit.org/show_bug.cgi?id=310643</a>
<a href="https://rdar.apple.com/173256414">rdar://173256414</a>

Reviewed by Keith Miller and Yusuke Suzuki.

`qWasmGlobal:&lt;frame&gt;;&lt;index&gt;` is sent by LLDB when evaluating DWARF location
expressions which Swift emits for module-level variables to encode their memory-base global index.

This patch introduces `handleWasmGlobal` which resolves the WASM instance from `stopData`
for frame 0, or by walking the collected call stack for non-zero frames (needed when frames
belong to different module instances).

Tests:
JSTests/wasm/debugger/resources/swift-wasm/globals-test/Sources/globals-test/main.swift
JSTests/wasm/debugger/tests/tests.py: (SwiftWasmGlobalTestCase)

Canonical link: <a href="https://commits.webkit.org/309876@main">https://commits.webkit.org/309876@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f201822100a5d6683e04232b138d6fea814bb487

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151943 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24724 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18296 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160686 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105400 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bfacf173-3203-452c-9ba0-b0c9a1c6d3d5) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25217 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25028 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117368 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83260 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154903 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19539 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136351 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98083 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/753e61b4-5ec2-427a-b8ef-c623813e36a5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18621 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/16632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8520 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/143949 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128254 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14254 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163150 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/12744 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6298 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15846 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125390 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24523 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20616 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125570 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34085 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24524 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136050 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81106 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20594 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12825 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/183567 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24141 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88426 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46821 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23832 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23992 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23893 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->