### PR TITLE
[WIP] GreedyRegAlloc: optimize coalescable edge accumulation and pruning

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
@@ -528,6 +528,114 @@ private:
     AllocatedIntervalSet m_allocationsHigh64; // Tracks clobbers to vector registers that preserve lower 64-bits
 };
 
+// Per-Tmp list of coalescable partners and their move costs.
+// Progresses through three phases: Accumulating (add entries), Pruning (remove
+// conflicting entries), and Finalized (binary searchable for membership).
+class Coalescables {
+public:
+    void add(Tmp tmp, float moveCost)
+    {
+        ASSERT(m_phase == Phase::Accumulating);
+        ASSERT(m_entries.isEmpty() || m_entries.last().tmp.bank() == tmp.bank());
+        m_entries.append({ tmp, moveCost });
+    }
+
+    void prepareForPruning()
+    {
+        ASSERT(m_phase == Phase::Accumulating);
+        if (m_entries.size() > 1) {
+            std::ranges::sort(m_entries, [](const auto& a, const auto& b) {
+                return a.tmp.internalValue() < b.tmp.internalValue();
+            });
+            size_t write = 0;
+            for (size_t read = 1; read < m_entries.size(); read++) {
+                if (m_entries[read].tmp == m_entries[write].tmp)
+                    m_entries[write].moveCost += m_entries[read].moveCost;
+                else
+                    m_entries[++write] = m_entries[read];
+            }
+            m_entries.shrink(write + 1);
+        }
+#if ASSERT_ENABLED
+        m_phase = Phase::Pruning;
+#endif
+    }
+
+    void remove(Tmp target)
+    {
+        ASSERT(m_phase == Phase::Pruning);
+        removeMatching([target](Tmp tmp) { return tmp == target; });
+    }
+
+    void removeMatching(NOESCAPE const Invocable<bool(Tmp)> auto& predicate)
+    {
+        ASSERT(m_phase == Phase::Pruning);
+        for (size_t i = 0; i < m_entries.size(); ) {
+            if (predicate(m_entries[i].tmp)) {
+                m_entries[i] = m_entries.last();
+                m_entries.shrink(m_entries.size() - 1);
+            } else
+                i++;
+        }
+    }
+
+    template<Bank bank>
+    void finalize()
+    {
+        ASSERT(m_phase == Phase::Pruning);
+        std::ranges::sort(m_entries, [](const auto& a, const auto& b) {
+            return a.tmp.tmpIndex(bank) < b.tmp.tmpIndex(bank);
+        });
+#if ASSERT_ENABLED
+        m_phase = Phase::Finalized;
+#endif
+    }
+
+    template<Bank bank>
+    bool contains(Tmp target) const
+    {
+        ASSERT(m_phase == Phase::Finalized);
+        auto it = std::lower_bound(m_entries.begin(), m_entries.end(), target,
+            [](const auto& entry, Tmp t) {
+                return entry.tmp.tmpIndex(bank) < t.tmpIndex(bank);
+            });
+        return it != m_entries.end() && it->tmp == target;
+    }
+
+    // Phase-independent operations.
+    size_t size() const { return m_entries.size(); }
+    bool isEmpty() const { return m_entries.isEmpty(); }
+    auto begin() const { return m_entries.begin(); }
+    auto end() const { return m_entries.end(); }
+
+    void dump(PrintStream& out) const
+    {
+        out.print(listDump(m_entries));
+    }
+
+private:
+    struct Entry {
+        Tmp tmp;
+        float moveCost;
+
+        void dump(PrintStream& out) const
+        {
+            out.print("(", tmp, ", ", moveCost, ")");
+        }
+    };
+
+    Vector<Entry> m_entries;
+#if ASSERT_ENABLED
+    enum class Phase : uint8_t {
+        Accumulating,
+        Pruning,
+        Finalized,
+    };
+
+    Phase m_phase { Phase::Accumulating };
+#endif
+};
+
 // Auxiliary register allocator data per Tmp.
 struct TmpData {
     // When an unspillable or fastTmp is coalesced with another tmp, we don't want the spillCost of the
@@ -538,20 +646,10 @@ struct TmpData {
         Unspillable,
     };
 
-    struct CoalescableWith {
-        void dump(PrintStream& out) const
-        {
-            out.print("(", tmp, ", ", moveCost, ")");
-        }
-
-        Tmp tmp;
-        float moveCost; // The frequency-adjusted number of moves between TmpData's tmp and CoalescableWith.tmp
-    };
-
     void dump(PrintStream& out) const
     {
         out.print("{stage = ", stage, " liveRange = ", liveRange, ", preferredReg = ", preferredReg,
-            ", coalescables = ", listDump(coalescables), ", useDefCost = ", useDefCost, ", spillability = ", spillability,
+            ", coalescables = ", coalescables, ", useDefCost = ", useDefCost, ", spillability = ", spillability,
             ", assigned = ", assigned, ", spillSlot = ", pointerDump(spillSlot), ", splitMetadataIndex = ", splitMetadataIndex, "}");
     }
 
@@ -587,7 +685,7 @@ struct TmpData {
     }
 
     LiveRange liveRange;
-    Vector<CoalescableWith> coalescables;
+    Coalescables coalescables;
     StackSlot* spillSlot { nullptr };
     float useDefCost { 0.0f };
     uint32_t splitMetadataIndex : 31 { 0 };
@@ -969,8 +1067,8 @@ private:
                         if (m_code.isPinned(aReg)) {
                             // It's okay if both Tmps were coalesced to the same pinned register.
                             TmpData& regData = m_map[Tmp(aReg)];
-                            if (regData.coalescables.containsIf([a](auto& with) { return with.tmp == a; })
-                                && regData.coalescables.containsIf([b](auto& with) { return with.tmp == b; }))
+                            if (regData.coalescables.template contains<bank>(a)
+                                && regData.coalescables.template contains<bank>(b))
                                 continue;
                         }
                         fail(block, a, b);
@@ -1014,7 +1112,7 @@ private:
         }
 
         // addMaybeCoalescable is used during the first pass to collect all potentially
-        // coalescables pairs. i.e. pairs of Tmps 'a' and 'b' such that there exists a
+        // coalescable pairs. i.e. pairs of Tmps 'a' and 'b' such that there exists a
         // 'Move a, b' instruction. These pairs will be pruned after liveness analysis
         // based on conflicting defs. We do this rather than simply requiring that the
         // LiveRanges of coalescable tmps do not overlap so that we can handle Tmp copies, e.g.:
@@ -1028,15 +1126,9 @@ private:
         auto addMaybeCoalescable = [&](Tmp a, Tmp b, BasicBlock* block) {
             if (a == b)
                 return;
-            TmpData& tmpData = m_map[a];
             float freq = adjustedBlockFrequency(block);
-            for (auto& with : tmpData.coalescables) {
-                if (with.tmp == b) {
-                    with.moveCost += freq;
-                    return;
-                }
-            }
-            tmpData.coalescables.append({ b, freq });
+            m_map[a].coalescables.add(b, freq);
+            m_map[b].coalescables.add(a, freq);
         };
 
         auto coalescableMoveSrc = [&](Inst& inst) {
@@ -1065,17 +1157,15 @@ private:
         // that these pairs are not coalescable.
         auto pruneCoalescable = [&](Inst& inst, Tmp def, Point point) {
             TmpData& defData = m_map[def];
-            if (!defData.coalescables.size())
+            if (defData.coalescables.isEmpty())
                 return;
             Tmp movSrc = coalescableMoveSrc(inst);
             dataLogLnIf(verbose(), "Checking affinity ", inst, " def=", def, " movSrc=", movSrc);
-            defData.coalescables.removeAllMatching([&](TmpData::CoalescableWith& with) {
-                ASSERT(with.tmp != def);
-                if (with.tmp != movSrc && isLiveAt(with.tmp, point)) {
-                    dataLogLnIf(verbose(), "Pruning affinity ", def, " ", with.tmp);
-                    m_map[with.tmp].coalescables.removeAllMatching([def](TmpData::CoalescableWith& with) {
-                        return with.tmp == def;
-                    });
+            defData.coalescables.removeMatching([&](Tmp tmp) {
+                ASSERT(tmp != def);
+                if (tmp != movSrc && isLiveAt(tmp, point)) {
+                    dataLogLnIf(verbose(), "Pruning affinity ", def, " ", tmp);
+                    m_map[tmp].coalescables.remove(def);
                     return true;
                 }
                 return false;
@@ -1120,10 +1210,13 @@ private:
                     }
                     ASSERT(inst.args[0].isTmp() && inst.args[1].isTmp());
                     addMaybeCoalescable(inst.args[0].tmp(), inst.args[1].tmp(), block);
-                    addMaybeCoalescable(inst.args[1].tmp(), inst.args[0].tmp(), block);
                 }
             }
         }
+
+        m_code.forEachTmp([&](Tmp tmp) {
+            m_map[tmp].coalescables.prepareForPruning();
+        });
 
         Point funcEndPoint = m_tailPoints[m_code.size() - 1];
         m_code.pinnedRegisters().forEachReg([&](Reg reg) {
@@ -1270,17 +1363,6 @@ private:
                 m_stats[tmp.bank()].numCoalescedPinned++;
             }
         });
-    }
-
-    // Binary search a sorted coalescables vector to check if 'target' is coalescable.
-    template<Bank bank>
-    static bool isInCoalescables(Tmp tmp, const Vector<TmpData::CoalescableWith>& coalescables)
-    {
-        auto it = std::lower_bound(coalescables.begin(), coalescables.end(), tmp,
-            [](const auto& edge, Tmp t) {
-                return edge.tmp.tmpIndex(bank) < t.tmpIndex(bank);
-            });
-        return it != coalescables.end() && it->tmp == tmp;
     }
 
     // Maps intervals to lists of Tmps live during that interval.
@@ -1583,7 +1665,7 @@ private:
     template<Bank bank>
     void coalesceSingletons(Tmp tmp0, Tmp tmp1, Vector<AffinityGroup<bank>>& groups, TmpGroupMap<bank>& tmpToGroup)
     {
-        ASSERT(isInCoalescables<bank>(tmp1, m_map.get<bank>(tmp0).coalescables) && isInCoalescables<bank>(tmp0, m_map.get<bank>(tmp1).coalescables));
+        ASSERT(m_map.get<bank>(tmp0).coalescables.template contains<bank>(tmp1) && m_map.get<bank>(tmp1).coalescables.template contains<bank>(tmp0));
         auto newIndex = groups.size();
         groups.constructAndAppend(tmp0, m_map.get<bank>(tmp0).liveRange, tmp1, m_map.get<bank>(tmp1).liveRange);
         tmpToGroup[tmp0] = newIndex;
@@ -1604,7 +1686,7 @@ private:
                 return IterationStatus::Done;
             }
             for (Tmp member : tmpList) {
-                if (!isInCoalescables<bank>(member, singletonData.coalescables)) {
+                if (!singletonData.coalescables.template contains<bank>(member)) {
                     conflict = true;
                     return IterationStatus::Done;
                 }
@@ -1629,13 +1711,13 @@ private:
         bool conflict = false;
         AffinityGroup<bank>::forEachPairwiseOverlap(group0, group1, [&](const auto& tmpListA, const auto& tmpListB) {
             for (Tmp tmpA : tmpListA) {
-                const auto& coalescables = m_map.get<bank>(tmpA).coalescables;
-                if (tmpListB.size() > coalescables.size()) {
+                const auto& aCoalescables = m_map.get<bank>(tmpA).coalescables;
+                if (tmpListB.size() > aCoalescables.size()) {
                     conflict = true; // Pigeonhole principle
                     return IterationStatus::Done;
                 }
                 for (Tmp tmpB : tmpListB) {
-                    if (!isInCoalescables<bank>(tmpB, coalescables)) {
+                    if (!aCoalescables.template contains<bank>(tmpB)) {
                         conflict = true;
                         return IterationStatus::Done;
                     }
@@ -1681,7 +1763,7 @@ private:
         };
         Vector<Move> moves;
 
-        // Sort coalescables by Tmp index for binary search in isInCoalescables.
+        // Finalize coalescables for binary search in Coalescables::contains.
         m_code.forEachTmp<bank>([&](Tmp tmp) {
             ASSERT(!tmp.isReg());
             TmpData& data = m_map.get<bank>(tmp);
@@ -1689,9 +1771,7 @@ private:
                 ASSERT(assignedReg(tmp) && m_code.isPinned(assignedReg(tmp)));
                 return; // Already coalesced with a pinned register
             }
-            std::ranges::sort(data.coalescables, [](const auto& a, const auto& b) {
-                return a.tmp.tmpIndex(bank) < b.tmp.tmpIndex(bank);
-            });
+            data.coalescables.template finalize<bank>();
             for (auto& with : data.coalescables) {
                 if (tmp.tmpIndex(bank) < with.tmp.tmpIndex(bank))
                     moves.append({ tmp, with.tmp, with.moveCost });
@@ -1982,7 +2062,7 @@ private:
                 rangeSizeOrStart = interval.begin();
             }
         }
-        m_queue.enqueue({ tmp, stage, rangeSizeOrStart, tmpData.preferredReg || tmpData.coalescables.size(), !isLocal });
+        m_queue.enqueue({ tmp, stage, rangeSizeOrStart, tmpData.preferredReg || !tmpData.coalescables.isEmpty(), !isLocal });
         dataLogLnIf(verbose(), "Enqueued (", stage, ") ", tmp);
     }
 


### PR DESCRIPTION
#### 2ccfb720adc69959d0463baf4468769e20aa5c75
<pre>
[WIP] GreedyRegAlloc: optimize coalescable edge accumulation and pruning
<a href="https://bugs.webkit.org/show_bug.cgi?id=310645">https://bugs.webkit.org/show_bug.cgi?id=310645</a>
<a href="https://rdar.apple.com/173256845">rdar://173256845</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

No new tests (OOPS!).
* Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp:
(JSC::B3::Air::Greedy::Coalescables::add):
(JSC::B3::Air::Greedy::Coalescables::prepareForPruning):
(JSC::B3::Air::Greedy::Coalescables::remove):
(JSC::B3::Air::Greedy::Coalescables::removeMatching):
(JSC::B3::Air::Greedy::Coalescables::finalize):
(JSC::B3::Air::Greedy::Coalescables::contains const):
(JSC::B3::Air::Greedy::Coalescables::size const):
(JSC::B3::Air::Greedy::Coalescables::isEmpty const):
(JSC::B3::Air::Greedy::Coalescables::begin const):
(JSC::B3::Air::Greedy::Coalescables::end const):
(JSC::B3::Air::Greedy::Coalescables::dump const):
(JSC::B3::Air::Greedy::Coalescables::Entry::dump const):
(JSC::B3::Air::Greedy::TmpData::dump const):
(JSC::B3::Air::Greedy::GreedyAllocator::validateAssignments):
(JSC::B3::Air::Greedy::GreedyAllocator::buildLiveRanges):
(JSC::B3::Air::Greedy::GreedyAllocator::coalesceSingletons):
(JSC::B3::Air::Greedy::GreedyAllocator::tryCoalesceSingletonWithGroup):
(JSC::B3::Air::Greedy::GreedyAllocator::tryCoalesceGroups):
(JSC::B3::Air::Greedy::GreedyAllocator::buildCoalescingGroups):
(JSC::B3::Air::Greedy::GreedyAllocator::setStageAndEnqueue):
(JSC::B3::Air::Greedy::TmpData::CoalescableWith::dump const): Deleted.
(JSC::B3::Air::Greedy::GreedyAllocator::isInCoalescables): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ccfb720adc69959d0463baf4468769e20aa5c75

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151944 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24725 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18297 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160687 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105401 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0e390330-02e8-4e23-9af2-dd1bf5e3b433) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25218 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25029 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117372 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83262 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f270bdb2-c701-4031-b15b-eda70297d48f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154904 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19540 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136355 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98087 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4781f7ee-bd88-42f8-ab91-1e9088dddc69) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18622 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16558 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8521 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/143950 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128255 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14258 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163151 "Built successfully") | | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/12745 "Found 2 new JSC binary failures: testair, testb3, Found 1 new JSC stress test failure: Too many failures: 2763 jsc tests failed (failure)") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6299 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15850 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125392 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24524 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20617 "Found 31 new test failures: fast/canvas/webgl/webgl2-large-getbuffersubdata.html http/tests/webgpu/webgpu/api/operation/compute/basic.html http/tests/webgpu/webgpu/api/validation/image_copy/buffer_related.html http/tests/webgpu/webgpu/shader/execution/expression/call/builtin/fma.html http/tests/webgpu/webgpu/shader/execution/expression/call/builtin/pow.html http/tests/webgpu/webgpu/shader/execution/expression/call/builtin/smoothstep.html http/tests/webgpu/webgpu/shader/execution/expression/call/builtin/subgroupMinMax.html http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/textureDimensions.html http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/textureGather.html http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/textureStore.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125572 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24525 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136054 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81107 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20596 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12829 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/183568 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24142 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88427 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46822 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23833 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23993 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23894 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->