### PR TITLE
[Swift in WebKit] Non-PAL targets should not access the internal PAL Swift bridging header (part 3)

### DIFF
--- a/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
+++ b/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
@@ -9,11 +9,13 @@
 /* Begin PBXBuildFile section */
 		070BEE2D2F0381BF00392FEA /* module.modulemap in Headers */ = {isa = PBXBuildFile; fileRef = 94C759022B990D31000CC511 /* module.modulemap */; settings = {ATTRIBUTES = (Private, ); }; };
 		071CFF4F2F0614FB00E07A47 /* pal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 071CFF4E2F0614FB00E07A47 /* pal.swift */; };
-		0721D32D2F709E930069239A /* RegexHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 0721D32A2F709E930069239A /* RegexHelper.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		0721D3322F709F9F0069239A /* RegexHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0721D3312F709F9F0069239A /* RegexHelper.swift */; };
 		0721D3202F7082570069239A /* CryptoAlgorithmAESGCMCocoa.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0721D31F2F7082570069239A /* CryptoAlgorithmAESGCMCocoa.cpp */; };
 		0721D3212F7082570069239A /* CryptoAlgorithmAESGCMCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = 0721D31E2F7082570069239A /* CryptoAlgorithmAESGCMCocoa.h */; };
+		0721D32D2F709E930069239A /* RegexHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 0721D32A2F709E930069239A /* RegexHelper.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		0721D3322F709F9F0069239A /* RegexHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0721D3312F709F9F0069239A /* RegexHelper.swift */; };
 		07611DB7243FA5BF00D80704 /* UsageTrackingSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 07611DB5243FA5BF00D80704 /* UsageTrackingSoftLink.mm */; };
+		076E34C42F725D9D006A65D9 /* CryptoKit+UnsafeOverlays.swift in Sources */ = {isa = PBXBuildFile; fileRef = 076E34C32F725D9D006A65D9 /* CryptoKit+UnsafeOverlays.swift */; };
+		076E34C92F725DD9006A65D9 /* CryptoTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 076E34C82F725DD9006A65D9 /* CryptoTypes.swift */; };
 		077121B62C1E8B4400FACBF9 /* WritingToolsSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 077121B52C1E8B4400FACBF9 /* WritingToolsSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		077121BA2C1E8BE500FACBF9 /* WritingToolsUISPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 077121B92C1E8BE500FACBF9 /* WritingToolsUISPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		07789181273B14FF00E408D1 /* ScreenCaptureKitSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0778917F273B14FF00E408D1 /* ScreenCaptureKitSoftLink.mm */; };
@@ -93,7 +95,6 @@
 		7B47F2A328587B9700E793C8 /* CoreGraphicsSoftLink.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B47F2A128587B9700E793C8 /* CoreGraphicsSoftLink.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7B47F2A428587B9700E793C8 /* CoreGraphicsSoftLink.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B47F2A228587B9700E793C8 /* CoreGraphicsSoftLink.cpp */; };
 		93B38EC025821CD800198E63 /* SpeechSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 93B38EBF25821CD700198E63 /* SpeechSoftLink.mm */; };
-		94A41E732BB1E10D00DA715C /* UnsafeOverlays.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94A41E702BB1E10D00DA715C /* UnsafeOverlays.swift */; };
 		94F4AA022B730D2C006DFFDE /* CryptoKitShim.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94F4AA012B730D2C006DFFDE /* CryptoKitShim.swift */; };
 		A1038D332AB12BF100F57BA4 /* WebAVContentKeyGrouping.h in Headers */ = {isa = PBXBuildFile; fileRef = A1038D322AB12BF100F57BA4 /* WebAVContentKeyGrouping.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A1038D4F2AB21FBB00F57BA4 /* WebAVContentKeyReportGroupExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = A1038D4D2AB21FBB00F57BA4 /* WebAVContentKeyReportGroupExtras.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -460,12 +461,14 @@
 
 /* Begin PBXFileReference section */
 		071CFF4E2F0614FB00E07A47 /* pal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = pal.swift; sourceTree = "<group>"; };
-		0721D32A2F709E930069239A /* RegexHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RegexHelper.h; sourceTree = "<group>"; };
-		0721D3312F709F9F0069239A /* RegexHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegexHelper.swift; sourceTree = "<group>"; };
 		0721D31E2F7082570069239A /* CryptoAlgorithmAESGCMCocoa.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CryptoAlgorithmAESGCMCocoa.h; sourceTree = "<group>"; };
 		0721D31F2F7082570069239A /* CryptoAlgorithmAESGCMCocoa.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CryptoAlgorithmAESGCMCocoa.cpp; sourceTree = "<group>"; };
+		0721D32A2F709E930069239A /* RegexHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RegexHelper.h; sourceTree = "<group>"; };
+		0721D3312F709F9F0069239A /* RegexHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegexHelper.swift; sourceTree = "<group>"; };
 		07611DB4243FA5BE00D80704 /* UsageTrackingSoftLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UsageTrackingSoftLink.h; sourceTree = "<group>"; };
 		07611DB5243FA5BF00D80704 /* UsageTrackingSoftLink.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = UsageTrackingSoftLink.mm; sourceTree = "<group>"; };
+		076E34C32F725D9D006A65D9 /* CryptoKit+UnsafeOverlays.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CryptoKit+UnsafeOverlays.swift"; sourceTree = "<group>"; };
+		076E34C82F725DD9006A65D9 /* CryptoTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoTypes.swift; sourceTree = "<group>"; };
 		077121B52C1E8B4400FACBF9 /* WritingToolsSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WritingToolsSPI.h; sourceTree = "<group>"; };
 		077121B92C1E8BE500FACBF9 /* WritingToolsUISPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WritingToolsUISPI.h; sourceTree = "<group>"; };
 		0778917F273B14FF00E408D1 /* ScreenCaptureKitSoftLink.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ScreenCaptureKitSoftLink.mm; sourceTree = "<group>"; };
@@ -684,7 +687,6 @@
 		93DB7D3624626BCC004BD8A3 /* NSTextInputContextSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSTextInputContextSPI.h; sourceTree = "<group>"; };
 		93DB7D3924626F86004BD8A3 /* NSUndoManagerSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSUndoManagerSPI.h; sourceTree = "<group>"; };
 		93E5909C1F93BF1E0067F8CF /* UnencodableHandling.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UnencodableHandling.h; sourceTree = "<group>"; };
-		94A41E702BB1E10D00DA715C /* UnsafeOverlays.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UnsafeOverlays.swift; path = pal/PALSwift/UnsafeOverlays.swift; sourceTree = SOURCE_ROOT; };
 		94C759022B990D31000CC511 /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		94F4AA012B730D2C006DFFDE /* CryptoKitShim.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CryptoKitShim.swift; path = pal/PALSwift/CryptoKitShim.swift; sourceTree = SOURCE_ROOT; };
 		A10265881F56747A00B4C844 /* HIToolboxSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HIToolboxSPI.h; sourceTree = "<group>"; };
@@ -812,7 +814,6 @@
 			isa = PBXGroup;
 			children = (
 				94F4AA012B730D2C006DFFDE /* CryptoKitShim.swift */,
-				94A41E702BB1E10D00DA715C /* UnsafeOverlays.swift */,
 			);
 			path = PALSwift;
 			sourceTree = "<group>";
@@ -1101,7 +1102,9 @@
 				0721D31F2F7082570069239A /* CryptoAlgorithmAESGCMCocoa.cpp */,
 				0721D31E2F7082570069239A /* CryptoAlgorithmAESGCMCocoa.h */,
 				1C09D0521E31C44100725F18 /* CryptoDigest.h */,
+				076E34C32F725D9D006A65D9 /* CryptoKit+UnsafeOverlays.swift */,
 				07C9C8DB2EDAAABD007B579A /* CryptoTypes.h */,
+				076E34C82F725DD9006A65D9 /* CryptoTypes.swift */,
 			);
 			path = crypto;
 			sourceTree = "<group>";
@@ -1817,8 +1820,10 @@
 				1C77C8C925D7972000635E0C /* CoreTextSoftLink.cpp in Sources */,
 				0721D3202F7082570069239A /* CryptoAlgorithmAESGCMCocoa.cpp in Sources */,
 				1C09D0561E31C46500725F18 /* CryptoDigestCommonCrypto.cpp in Sources */,
+				076E34C42F725D9D006A65D9 /* CryptoKit+UnsafeOverlays.swift in Sources */,
 				57F1C90A25DCF0CF00E8F6EA /* CryptoKitPrivateSoftLink.mm in Sources */,
 				94F4AA022B730D2C006DFFDE /* CryptoKitShim.swift in Sources */,
+				076E34C92F725DD9006A65D9 /* CryptoTypes.swift in Sources */,
 				F4DDD01B264DC69E00EF1B91 /* DataDetectorsCoreSoftLink.mm in Sources */,
 				F4E0875C266ACA53000F814A /* DataDetectorsSoftLink.mm in Sources */,
 				7AA1E2D029EF5947002D4455 /* DataDetectorsUISoftLink.mm in Sources */,
@@ -1881,7 +1886,6 @@
 				1C5C57E027571A25003B540D /* ThreadGlobalData.cpp in Sources */,
 				F44C007C29A06B1C00211F33 /* TranslationUIServicesSoftLink.mm in Sources */,
 				2E1342CD215AA10A007199D2 /* UIKitSoftLink.mm in Sources */,
-				94A41E732BB1E10D00DA715C /* UnsafeOverlays.swift in Sources */,
 				07611DB7243FA5BF00D80704 /* UsageTrackingSoftLink.mm in Sources */,
 				44B1A8672A7C339400DC80A6 /* UserInterfaceIdiom.mm in Sources */,
 				41E1F344248A6A000022D5DE /* VideoToolboxSoftLink.cpp in Sources */,

--- a/Source/WebCore/PAL/pal/PALSwift/CryptoKitShim.swift
+++ b/Source/WebCore/PAL/pal/PALSwift/CryptoKitShim.swift
@@ -26,6 +26,8 @@ public import Foundation
 
 public import pal.Core.crypto.CryptoTypes
 
+// FIXME: (rdar://164560176) resolve the many 'unsafe' statements here
+
 // FIXME: PALSwift should have no public symbols.
 // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
 public typealias CryptoOperationReturnValue = PAL.Crypto.CryptoOperationReturnValue

--- a/Source/WebCore/PAL/pal/crypto/CryptoKit+UnsafeOverlays.swift
+++ b/Source/WebCore/PAL/pal/crypto/CryptoKit+UnsafeOverlays.swift
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Apple Inc. All rights reserved.
+// Copyright (C) 2026 Apple Inc. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -21,51 +21,19 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-public import CryptoKit
-public import Foundation
+import CryptoKit
+import Foundation
+import pal.Core.crypto.CryptoTypes
 
-public import pal.Core.crypto.CryptoTypes
+// FIXME: (rdar://164560176) resolve the many 'unsafe' statements here
 
-enum UnsafeErrors: Error {
+private enum UnsafeErrors: Error {
     case invalidLength
     case emptySpan
 }
 
-extension CryptoKit.HashFunction {
-    mutating func update(data: SpanConstUInt8) {
-        if unsafe data.empty() {
-            self.update(data: Data())
-        } else {
-            unsafe self.update(
-                bufferPointer: UnsafeRawBufferPointer(
-                    start: data.__dataUnsafe(),
-                    count: data.size()
-                )
-            )
-        }
-    }
-}
-
-extension ContiguousBytes {
-    // FIXME: PALSwift should have no public symbols.
-    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-    public func copyToVectorUInt8() -> VectorUInt8 {
-        unsafe self.withUnsafeBytes { buf in
-            let result = VectorUInt8(buf.count)
-            unsafe buf.copyBytes(
-                to: UnsafeMutableRawBufferPointer(
-                    start: UnsafeMutableRawPointer(mutating: result.span().__dataUnsafe()),
-                    count: result.size()
-                ),
-                count: result.size()
-            )
-            return result
-        }
-    }
-}
-
 extension Data {
-    fileprivate static func temporaryDataFromSpan(spanNoCopy: SpanConstUInt8) -> Data {
+    fileprivate static func temporaryDataFromSpan(spanNoCopy: PAL.Crypto.SpanConstUInt8) -> Data {
         guard unsafe spanNoCopy.empty() else {
             return unsafe Data(
                 bytesNoCopy: UnsafeMutablePointer(mutating: spanNoCopy.__dataUnsafe()),
@@ -79,14 +47,27 @@ extension Data {
     }
 }
 
+extension CryptoKit.HashFunction {
+    mutating func update(data: PAL.Crypto.SpanConstUInt8) {
+        if unsafe data.empty() {
+            self.update(data: Data())
+        } else {
+            unsafe self.update(
+                bufferPointer: UnsafeRawBufferPointer(
+                    start: data.__dataUnsafe(),
+                    count: data.size()
+                )
+            )
+        }
+    }
+}
+
 extension AES.GCM {
-    // FIXME: PALSwift should have no public symbols.
-    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-    public static func seal(
-        _ message: SpanConstUInt8,
-        key: SpanConstUInt8,
-        iv: SpanConstUInt8,
-        ad: SpanConstUInt8
+    static func seal(
+        _ message: PAL.Crypto.SpanConstUInt8,
+        key: PAL.Crypto.SpanConstUInt8,
+        iv: PAL.Crypto.SpanConstUInt8,
+        ad: PAL.Crypto.SpanConstUInt8
     ) throws -> AES.GCM.SealedBox {
         guard unsafe ad.size() > 0 else {
             return try unsafe AES.GCM.seal(
@@ -105,18 +86,14 @@ extension AES.GCM {
 }
 
 extension AES.KeyWrap {
-    // FIXME: PALSwift should have no public symbols.
-    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-    public static func unwrap(_ wrapped: SpanConstUInt8, using: SpanConstUInt8) throws -> SymmetricKey {
+    static func unwrap(_ wrapped: PAL.Crypto.SpanConstUInt8, using: PAL.Crypto.SpanConstUInt8) throws -> SymmetricKey {
         try unsafe AES.KeyWrap.unwrap(
             Data.temporaryDataFromSpan(spanNoCopy: wrapped),
             using: SymmetricKey(data: Data.temporaryDataFromSpan(spanNoCopy: using))
         )
     }
 
-    // FIXME: PALSwift should have no public symbols.
-    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-    public static func wrap(_ keyToWrap: SpanConstUInt8, using: SpanConstUInt8) throws -> VectorUInt8 {
+    static func wrap(_ keyToWrap: PAL.Crypto.SpanConstUInt8, using: PAL.Crypto.SpanConstUInt8) throws -> PAL.Crypto.VectorUInt8 {
         try unsafe AES.KeyWrap
             .wrap(
                 SymmetricKey(data: Data.temporaryDataFromSpan(spanNoCopy: keyToWrap)),
@@ -127,7 +104,7 @@ extension AES.KeyWrap {
 }
 
 extension P256.Signing.ECDSASignature {
-    init(span: SpanConstUInt8) throws {
+    init(span: PAL.Crypto.SpanConstUInt8) throws {
         if unsafe span.empty() {
             throw UnsafeErrors.emptySpan
         }
@@ -136,7 +113,7 @@ extension P256.Signing.ECDSASignature {
 }
 
 extension P384.Signing.ECDSASignature {
-    init(span: SpanConstUInt8) throws {
+    init(span: PAL.Crypto.SpanConstUInt8) throws {
         if unsafe span.empty() {
             throw UnsafeErrors.emptySpan
         }
@@ -145,7 +122,7 @@ extension P384.Signing.ECDSASignature {
 }
 
 extension P521.Signing.ECDSASignature {
-    init(span: SpanConstUInt8) throws {
+    init(span: PAL.Crypto.SpanConstUInt8) throws {
         if unsafe span.empty() {
             throw UnsafeErrors.emptySpan
         }
@@ -154,14 +131,14 @@ extension P521.Signing.ECDSASignature {
 }
 
 extension P256.Signing.PublicKey {
-    init(span: SpanConstUInt8) throws {
+    init(span: PAL.Crypto.SpanConstUInt8) throws {
         if unsafe span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(x963Representation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
 
-    init(spanCompressed: SpanConstUInt8) throws {
+    init(spanCompressed: PAL.Crypto.SpanConstUInt8) throws {
         if unsafe spanCompressed.empty() {
             throw UnsafeErrors.emptySpan
         }
@@ -172,14 +149,14 @@ extension P256.Signing.PublicKey {
 }
 
 extension P384.Signing.PublicKey {
-    init(span: SpanConstUInt8) throws {
+    init(span: PAL.Crypto.SpanConstUInt8) throws {
         if unsafe span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(x963Representation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
 
-    init(spanCompressed: SpanConstUInt8) throws {
+    init(spanCompressed: PAL.Crypto.SpanConstUInt8) throws {
         if unsafe spanCompressed.empty() {
             throw UnsafeErrors.emptySpan
         }
@@ -190,14 +167,14 @@ extension P384.Signing.PublicKey {
 }
 
 extension P521.Signing.PublicKey {
-    init(span: SpanConstUInt8) throws {
+    init(span: PAL.Crypto.SpanConstUInt8) throws {
         if unsafe span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(x963Representation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
 
-    init(spanCompressed: SpanConstUInt8) throws {
+    init(spanCompressed: PAL.Crypto.SpanConstUInt8) throws {
         if unsafe spanCompressed.empty() {
             throw UnsafeErrors.emptySpan
         }
@@ -208,7 +185,7 @@ extension P521.Signing.PublicKey {
 }
 
 extension P256.Signing.PrivateKey {
-    init(span: SpanConstUInt8) throws {
+    init(span: PAL.Crypto.SpanConstUInt8) throws {
         if unsafe span.empty() {
             throw UnsafeErrors.emptySpan
         }
@@ -217,7 +194,7 @@ extension P256.Signing.PrivateKey {
 }
 
 extension P384.Signing.PrivateKey {
-    init(span: SpanConstUInt8) throws {
+    init(span: PAL.Crypto.SpanConstUInt8) throws {
         if unsafe span.empty() {
             throw UnsafeErrors.emptySpan
         }
@@ -226,7 +203,7 @@ extension P384.Signing.PrivateKey {
 }
 
 extension P521.Signing.PrivateKey {
-    init(span: SpanConstUInt8) throws {
+    init(span: PAL.Crypto.SpanConstUInt8) throws {
         if unsafe span.empty() {
             throw UnsafeErrors.emptySpan
         }
@@ -235,16 +212,14 @@ extension P521.Signing.PrivateKey {
 }
 
 extension Curve25519.Signing.PrivateKey {
-    init(span: SpanConstUInt8) throws {
+    init(span: PAL.Crypto.SpanConstUInt8) throws {
         if unsafe span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
 
-    // FIXME: PALSwift should have no public symbols.
-    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-    public func signature(span: SpanConstUInt8) throws -> VectorUInt8 {
+    func signature(span: PAL.Crypto.SpanConstUInt8) throws -> PAL.Crypto.VectorUInt8 {
         if unsafe span.empty() {
             return try self.signature(for: Data()).copyToVectorUInt8()
         }
@@ -254,16 +229,14 @@ extension Curve25519.Signing.PrivateKey {
 }
 
 extension Curve25519.Signing.PublicKey {
-    init(span: SpanConstUInt8) throws {
+    init(span: PAL.Crypto.SpanConstUInt8) throws {
         if unsafe span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
 
-    // FIXME: PALSwift should have no public symbols.
-    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-    public func isValidSignature(signature: SpanConstUInt8, data: SpanConstUInt8) -> Bool {
+    func isValidSignature(signature: PAL.Crypto.SpanConstUInt8, data: PAL.Crypto.SpanConstUInt8) -> Bool {
         if unsafe (signature.empty() || data.empty()) {
             return false
         }
@@ -276,16 +249,14 @@ extension Curve25519.Signing.PublicKey {
 }
 
 extension Curve25519.KeyAgreement.PrivateKey {
-    init(span: SpanConstUInt8) throws {
+    init(span: PAL.Crypto.SpanConstUInt8) throws {
         if unsafe span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
 
-    // FIXME: PALSwift should have no public symbols.
-    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-    public func sharedSecretFromKeyAgreement(pubSpan: SpanConstUInt8) throws -> VectorUInt8 {
+    func sharedSecretFromKeyAgreement(pubSpan: PAL.Crypto.SpanConstUInt8) throws -> PAL.Crypto.VectorUInt8 {
         if unsafe pubSpan.empty() {
             throw UnsafeErrors.emptySpan
         }
@@ -297,7 +268,7 @@ extension Curve25519.KeyAgreement.PrivateKey {
 }
 
 extension Curve25519.KeyAgreement.PublicKey {
-    init(span: SpanConstUInt8) throws {
+    init(span: PAL.Crypto.SpanConstUInt8) throws {
         if unsafe span.empty() {
             throw UnsafeErrors.emptySpan
         }
@@ -306,7 +277,7 @@ extension Curve25519.KeyAgreement.PublicKey {
 }
 
 extension CryptoKit.HMAC {
-    static func authenticationCode(data: SpanConstUInt8, key: SpanConstUInt8) -> VectorUInt8 {
+    static func authenticationCode(data: PAL.Crypto.SpanConstUInt8, key: PAL.Crypto.SpanConstUInt8) -> PAL.Crypto.VectorUInt8 {
         unsafe self.authenticationCode(
             for: Data.temporaryDataFromSpan(spanNoCopy: data),
             using: SymmetricKey(data: Data.temporaryDataFromSpan(spanNoCopy: key))
@@ -314,7 +285,11 @@ extension CryptoKit.HMAC {
         .copyToVectorUInt8()
     }
 
-    static func isValidAuthenticationCode(mac: SpanConstUInt8, data: SpanConstUInt8, key: SpanConstUInt8) -> Bool {
+    static func isValidAuthenticationCode(
+        mac: PAL.Crypto.SpanConstUInt8,
+        data: PAL.Crypto.SpanConstUInt8,
+        key: PAL.Crypto.SpanConstUInt8
+    ) -> Bool {
         unsafe Self.isValidAuthenticationCode(
             Data.temporaryDataFromSpan(spanNoCopy: mac),
             authenticating: Data.temporaryDataFromSpan(spanNoCopy: data),
@@ -325,11 +300,11 @@ extension CryptoKit.HMAC {
 
 extension CryptoKit.HKDF {
     static func deriveKey(
-        inputKeyMaterial: SpanConstUInt8,
-        salt: SpanConstUInt8,
-        info: SpanConstUInt8,
+        inputKeyMaterial: PAL.Crypto.SpanConstUInt8,
+        salt: PAL.Crypto.SpanConstUInt8,
+        info: PAL.Crypto.SpanConstUInt8,
         outputByteCount: Int
-    ) -> VectorUInt8 {
+    ) -> PAL.Crypto.VectorUInt8 {
         unsafe Self.deriveKey(
             inputKeyMaterial: SymmetricKey(
                 data: Data.temporaryDataFromSpan(spanNoCopy: inputKeyMaterial)

--- a/Source/WebCore/PAL/pal/crypto/CryptoTypes.swift
+++ b/Source/WebCore/PAL/pal/crypto/CryptoTypes.swift
@@ -1,0 +1,43 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+import Foundation
+import pal.Core.crypto.CryptoTypes
+
+// FIXME: (rdar://164560176) resolve the many 'unsafe' statements here
+
+extension ContiguousBytes {
+    func copyToVectorUInt8() -> PAL.Crypto.VectorUInt8 {
+        unsafe self.withUnsafeBytes { buf in
+            let result = PAL.Crypto.VectorUInt8(buf.count)
+            unsafe buf.copyBytes(
+                to: UnsafeMutableRawBufferPointer(
+                    start: UnsafeMutableRawPointer(mutating: result.span().__dataUnsafe()),
+                    count: result.size()
+                ),
+                count: result.size()
+            )
+            return result
+        }
+    }
+}


### PR DESCRIPTION
#### c48e777f452b5e3a1676874e695c5cbdb544d191
<pre>
[Swift in WebKit] Non-PAL targets should not access the internal PAL Swift bridging header (part 3)
<a href="https://bugs.webkit.org/show_bug.cgi?id=310648">https://bugs.webkit.org/show_bug.cgi?id=310648</a>
<a href="https://rdar.apple.com/173257558">rdar://173257558</a>

Reviewed by Geoffrey Garen.

Various cleanup in preparation for moving more WebCore code to PAL

- Remove some `unsafe`s that aren&apos;t needed
- Get rid of `UnsafeOverlays.swift` in favor of more sensical, crypto-specific files
- Get rid of a bunch of `public`s
- Use actual types instead of public typealiases so they can eventually be removed

* Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj:
* Source/WebCore/PAL/pal/crypto/CryptoKit+UnsafeOverlays.swift: Renamed from Source/WebCore/PAL/pal/PALSwift/UnsafeOverlays.swift.
(Data.temporaryDataFromSpan(_:)):
(CryptoKit.update(_:)):
(AES.unwrap(_:using:)):
(AES.wrap(_:using:)):
(Curve25519.signature(_:)):
(Curve25519.isValidSignature(_:data:)):
(Curve25519.sharedSecretFromKeyAgreement(_:)):
(CryptoKit.authenticationCode(_:key:)):
* Source/WebCore/PAL/pal/crypto/CryptoTypes.swift: Added.
(ContiguousBytes.copyToVectorUInt8):

Canonical link: <a href="https://commits.webkit.org/309867@main">https://commits.webkit.org/309867@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/007f07a265374b2df6fbf896caeac5324de08a3c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151949 "52 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24730 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18302 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160692 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6024d458-9f4a-474f-96f7-cc515cfa2343) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153823 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25223 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25034 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117376 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/97228dc1-21f3-41c2-97f9-0e3f4b5b5f34) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154909 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19544 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136346 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98091 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18626 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16562 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8526 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128259 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14249 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163156 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6304 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15841 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125396 "Found 1 new test failure: media/media-vp8-webm.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24529 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20621 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125576 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34078 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24530 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136045 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/81112 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20595 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12820 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24147 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88432 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23838 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23998 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23899 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->