### PR TITLE
Fix some JSC API implementation functions to avoid unnecessarily copying CallFrame arguments.

### DIFF
--- a/Source/JavaScriptCore/API/APICallbackFunction.h
+++ b/Source/JavaScriptCore/API/APICallbackFunction.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2020, 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,6 +28,7 @@
 
 #include "APICast.h"
 #include "Error.h"
+#include "Integrity.h"
 #include "JSCallbackConstructor.h"
 #include "JSLock.h"
 #include <wtf/Vector.h>
@@ -48,16 +49,24 @@ EncodedJSValue APICallbackFunction::callImpl(JSGlobalObject* globalObject, CallF
     JSObjectRef functionRef = toRef(callFrame->jsCallee());
     JSObjectRef thisObjRef = toRef(jsCast<JSObject*>(callFrame->thisValue().toThis(globalObject, ECMAMode::sloppy())));
 
-    int argumentCount = static_cast<int>(callFrame->argumentCount());
-    Vector<JSValueRef, 16> arguments(argumentCount, [&](size_t i) {
+#if CPU(ADDRESS64)
+    auto argumentsSpan = Integrity::audit(callFrame->argumentsSpan());
+    JSValueRef* argumentsSpanData = std::bit_cast<JSValueRef*>(argumentsSpan.data());
+#else
+    // It is safe to use a Vector here because the values are protected by their source
+    // location in the call frame arguments on the stack.
+    Vector<JSValueRef, 16> arguments(callFrame->argumentCount(), [&](size_t i) {
         return toRef(globalObject, callFrame->uncheckedArgument(i));
     });
+    auto argumentsSpan = arguments.span();
+    auto* argumentsSpanData = argumentsSpan.data();
+#endif
 
     JSValueRef exception = nullptr;
     JSValueRef result;
     {
         JSLock::DropAllLocks dropAllLocks(globalObject);
-        result = jsCast<T*>(toJS(functionRef))->functionCallback()(execRef, functionRef, thisObjRef, argumentCount, arguments.span().data(), &exception);
+        result = jsCast<T*>(toJS(functionRef))->functionCallback()(execRef, functionRef, thisObjRef, argumentsSpan.size(), argumentsSpanData, &exception);
     }
     if (exception) {
         throwException(globalObject, scope, toJS(globalObject, exception));
@@ -91,16 +100,24 @@ EncodedJSValue APICallbackFunction::constructImpl(JSGlobalObject* globalObject, 
             RETURN_IF_EXCEPTION(scope, { });
         }
 
-        size_t argumentCount = callFrame->argumentCount();
-        Vector<JSValueRef, 16> arguments(argumentCount, [&](size_t i) {
+#if CPU(ADDRESS64)
+        auto argumentsSpan = Integrity::audit(callFrame->argumentsSpan());
+        JSValueRef* argumentsSpanData = std::bit_cast<JSValueRef*>(argumentsSpan.data());
+#else
+        // It is safe to use a Vector here because the values are protected by their source
+        // location in the call frame arguments on the stack.
+        Vector<JSValueRef, 16> arguments(callFrame->argumentCount(), [&](size_t i) {
             return toRef(globalObject, callFrame->uncheckedArgument(i));
         });
+        auto argumentsSpan = arguments.span();
+        auto* argumentsSpanData = argumentsSpan.data();
+#endif
 
         JSValueRef exception = nullptr;
         JSObjectRef result;
         {
             JSLock::DropAllLocks dropAllLocks(globalObject);
-            result = callback(ctx, constructorRef, argumentCount, arguments.span().data(), &exception);
+            result = callback(ctx, constructorRef, argumentsSpan.size(), argumentsSpanData, &exception);
         }
 
         if (exception) {

--- a/Source/JavaScriptCore/API/JSCallbackObjectFunctions.h
+++ b/Source/JavaScriptCore/API/JSCallbackObjectFunctions.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2020, 2026 Apple Inc. All rights reserved.
  * Copyright (C) 2007 Eric Seidel <eric@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,6 +29,7 @@
 #include "APICast.h"
 #include "Error.h"
 #include "ExceptionHelpers.h"
+#include "Integrity.h"
 #include "JSCallbackFunction.h"
 #include "JSClassRef.h"
 #include "JSFunction.h"
@@ -478,15 +479,23 @@ EncodedJSValue JSCallbackObject<Parent>::constructImpl(JSGlobalObject* globalObj
     
     for (JSClassRef jsClass = jsCast<JSCallbackObject<Parent>*>(constructor)->classRef(); jsClass; jsClass = jsClass->parentClass) {
         if (JSObjectCallAsConstructorCallback callAsConstructor = jsClass->callAsConstructor) {
-            size_t argumentCount = callFrame->argumentCount();
-            Vector<JSValueRef, 16> arguments(argumentCount, [&](size_t i) {
+#if CPU(ADDRESS64)
+            auto argumentsSpan = Integrity::audit(callFrame->argumentsSpan());
+            JSValueRef* argumentsSpanData = std::bit_cast<JSValueRef*>(argumentsSpan.data());
+#else
+            // It is safe to use a Vector here because the values are protected by their source
+            // location in the call frame arguments on the stack.
+            Vector<JSValueRef, 16> arguments(callFrame->argumentCount(), [&](size_t i) {
                 return toRef(globalObject, callFrame->uncheckedArgument(i));
             });
+            auto argumentsSpan = arguments.span();
+            auto* argumentsSpanData = argumentsSpan.data();
+#endif
             JSValueRef exception = nullptr;
             JSObject* result;
             {
                 JSLock::DropAllLocks dropAllLocks(globalObject);
-                result = toJS(callAsConstructor(execRef, constructorRef, argumentCount, arguments.span().data(), &exception));
+                result = toJS(callAsConstructor(execRef, constructorRef, argumentsSpan.size(), argumentsSpanData, &exception));
             }
             if (exception) {
                 throwException(globalObject, scope, toJS(globalObject, exception));
@@ -556,16 +565,24 @@ EncodedJSValue JSCallbackObject<Parent>::callImpl(JSGlobalObject* globalObject, 
     
     for (JSClassRef jsClass = jsCast<JSCallbackObject<Parent>*>(toJS(functionRef))->classRef(); jsClass; jsClass = jsClass->parentClass) {
         if (JSObjectCallAsFunctionCallback callAsFunction = jsClass->callAsFunction) {
-            size_t argumentCount = callFrame->argumentCount();
-            Vector<JSValueRef, 16> arguments(argumentCount, [&](size_t i) {
+#if CPU(ADDRESS64)
+            auto argumentsSpan = Integrity::audit(callFrame->argumentsSpan());
+            JSValueRef* argumentsSpanData = std::bit_cast<JSValueRef*>(argumentsSpan.data());
+#else
+            // It is safe to use a Vector here because the values are protected by their source
+            // location in the call frame arguments on the stack.
+            Vector<JSValueRef, 16> arguments(callFrame->argumentCount(), [&](size_t i) {
                 return toRef(globalObject, callFrame->uncheckedArgument(i));
             });
+            auto argumentsSpan = arguments.span();
+            auto* argumentsSpanData = argumentsSpan.data();
+#endif
 
             JSValueRef exception = nullptr;
             JSValue result;
             {
                 JSLock::DropAllLocks dropAllLocks(globalObject);
-                result = toJS(globalObject, callAsFunction(execRef, functionRef, thisObjRef, argumentCount, arguments.span().data(), &exception));
+                result = toJS(globalObject, callAsFunction(execRef, functionRef, thisObjRef, argumentsSpan.size(), argumentsSpanData, &exception));
             }
             if (exception) {
                 throwException(globalObject, scope, toJS(globalObject, exception));

--- a/Source/JavaScriptCore/interpreter/CallFrame.h
+++ b/Source/JavaScriptCore/interpreter/CallFrame.h
@@ -1,7 +1,7 @@
 /*
  *  Copyright (C) 1999-2001 Harri Porten (porten@kde.org)
  *  Copyright (C) 2001 Peter Kelly (pmk@post.com)
- *  Copyright (C) 2003-2025 Apple Inc. All rights reserved.
+ *  Copyright (C) 2003-2026 Apple Inc. All rights reserved.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Library General Public
@@ -283,6 +283,8 @@ using JSInstruction = BaseInstruction<JSOpcodeTraits>;
         size_t argumentCountIncludingThis() const { return this[static_cast<int>(CallFrameSlot::argumentCountIncludingThis)].payload(); }
         static constexpr int argumentOffset(int argument) { return (CallFrameSlot::firstArgument + argument); }
         static constexpr int argumentOffsetIncludingThis(int argument) { return (CallFrameSlot::thisArgument + argument); }
+
+        std::span<JSValue> argumentsSpan() { return { addressOfArgumentsStart(), argumentCount() }; }
 
         // In the following (argument() and setArgument()), the 'argument'
         // parameter is the index of the arguments of the target function of

--- a/Source/JavaScriptCore/tools/Integrity.cpp
+++ b/Source/JavaScriptCore/tools/Integrity.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -176,6 +176,16 @@ JSValue doAudit(JSValue value)
         doAudit(value.asCell());
     return value;
 }
+
+#if ENABLE(EXTRA_INTEGRITY_CHECKS) && USE(JSVALUE64)
+template<>
+std::span<JSValue> audit(std::span<JSValue> span)
+{
+    for (auto it : span)
+        JSC::Integrity::audit(it);
+    return span;
+}
+#endif
 
 bool Analyzer::analyzeVM(VM& vm, Analyzer::Action action)
 {

--- a/Source/JavaScriptCore/tools/Integrity.h
+++ b/Source/JavaScriptCore/tools/Integrity.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2022, 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <JavaScriptCore/JSExportMacros.h>
+#include <span>
 #include <wtf/AccessibleAddress.h>
 #include <wtf/Assertions.h>
 #include <wtf/Lock.h>
@@ -176,6 +177,10 @@ ALWAYS_INLINE void auditStructureID(StructureID);
 
 #if ENABLE(EXTRA_INTEGRITY_CHECKS) && USE(JSVALUE64)
 template<typename T> ALWAYS_INLINE T audit(T value) { return std::bit_cast<T>(doAudit(value)); }
+
+template<>
+std::span<JSValue> audit(std::span<JSValue>);
+
 #else
 template<typename T> ALWAYS_INLINE T audit(T value) { return value; }
 #endif


### PR DESCRIPTION
#### 3b5ee5168e4f033bd863dc2a3e89160179a62aff
<pre>
Fix some JSC API implementation functions to avoid unnecessarily copying CallFrame arguments.
<a href="https://bugs.webkit.org/show_bug.cgi?id=310647">https://bugs.webkit.org/show_bug.cgi?id=310647</a>
<a href="https://rdar.apple.com/173257607">rdar://173257607</a>

Reviewed by Marcus Plutowski.

This is a minor optimization on 64-bit platforms where JSValueRef is basically a JSValue.
The pre-existing code iterates the CallFrame arguments and copies them into a JSvalueRef
Vector before passing the vector&apos;s backing store to a target function as out-going arguments.

On 64-bit, a JSValueRef is a JSValue (see toJS() implementation in APICast.h).  So, we can
avoid this iteration and vector construction by simply having CallFrame return its arguments
in a std::span&lt;JSValue&gt; for this use case.

On 32-bit, we still need to go thru the conversion from JSValue to JSValueRef because the
2 are not equivalent.

From a GC perspective, it&apos;s safe to use a Vector here because the original source of the
JSValues (i.e. the CallFrame arguments from the caller) are still on the stack, and are
therefore protected from the GC.

No new tests because there is just an optimization.  There is no externally observable
behavior change.

* Source/JavaScriptCore/API/APICallbackFunction.h:
(JSC::APICallbackFunction::callImpl):
(JSC::APICallbackFunction::constructImpl):
* Source/JavaScriptCore/API/JSCallbackObjectFunctions.h:
(JSC::JSCallbackObject&lt;Parent&gt;::constructImpl):
(JSC::JSCallbackObject&lt;Parent&gt;::callImpl):
* Source/JavaScriptCore/interpreter/CallFrame.h:
(JSC::CallFrame::argumentsSpan):
* Source/JavaScriptCore/tools/Integrity.cpp:
(JSC::Integrity::audit):
* Source/JavaScriptCore/tools/Integrity.h:

Canonical link: <a href="https://commits.webkit.org/309885@main">https://commits.webkit.org/309885@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ffda2331e9cb71cf8d5171a29801d8835b83e7b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151999 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24781 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/18419 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160742 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/871aaeff-051f-435b-bc7c-e008769f3dde) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153873 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25273 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25086 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117417 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/17aeb897-c879-434d-abd9-e9fe7c4a5979) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154959 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19590 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/136472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98132 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18671 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/16612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8576 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144006 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128306 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/14361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163206 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/12800 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6354 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/15953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125442 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24579 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20668 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125619 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24580 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/136157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81162 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23333 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20636 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/12933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/183623 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24197 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88482 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46834 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23888 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24048 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23949 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->