### PR TITLE
a Style checker should not suggest using swift format to fix 'unsafe' warnings

### DIFF
--- a/Tools/Scripts/webkitpy/style/checker.py
+++ b/Tools/Scripts/webkitpy/style/checker.py
@@ -1260,9 +1260,8 @@ class StyleProcessor(ProcessorBase):
 
         _log.debug("Using class: " + checker.__class__.__name__)
 
-        current_error_count = self.error_count
-        output = checker.check(lines)
-        if isinstance(checker, SwiftChecker) and self.error_count > current_error_count:
+        checker.check(lines)
+        if isinstance(checker, SwiftChecker) and checker.has_swift_format_errors:
             _log.info("These errors can be fixed using swift format --in-place \"%s\"" % file_path)
 
     def do_association_check(self, files, cwd, host=Host()):

--- a/Tools/Scripts/webkitpy/style/checkers/swift.py
+++ b/Tools/Scripts/webkitpy/style/checkers/swift.py
@@ -30,6 +30,7 @@ class SwiftChecker(object):
     def __init__(self, file_path, handle_style_error):
         self.file_path = file_path
         self.handle_style_error = handle_style_error
+        self.has_swift_format_errors = False
 
     def _swift_format(self, file_path, lines, error):
         lint_result = subprocess.run(['/usr/bin/swift', 'format', 'lint', '--strict', file_path], capture_output=True, text=True)
@@ -53,6 +54,7 @@ class SwiftChecker(object):
             category = match.group("category")
             message = match.group("message")
 
+            self.has_swift_format_errors = True
             self.handle_style_error(int(line_number), category, 5, message)
 
     def _check_unsafe(self, lines):


### PR DESCRIPTION
#### 2b6ae06a31694463e8c1cf4b94de6cf394b0c387
<pre>
a Style checker should not suggest using swift format to fix &apos;unsafe&apos; warnings
<a href="https://bugs.webkit.org/show_bug.cgi?id=310654">https://bugs.webkit.org/show_bug.cgi?id=310654</a>
<a href="https://rdar.apple.com/173264986">rdar://173264986</a>

Reviewed by Richard Robinson.

Remember whether the style issue came from swift-format.

Only suggest using swift-format to fix the issue if swift-format
generated the issue.

* Tools/Scripts/webkitpy/style/checker.py:
(StyleProcessor.process):
* Tools/Scripts/webkitpy/style/checkers/swift.py:
(SwiftChecker.__init__):
(SwiftChecker._swift_format):

Canonical link: <a href="https://commits.webkit.org/309864@main">https://commits.webkit.org/309864@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e806f6d9f8e829fa8601412fc94fb2b76a00a426

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151966 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/24747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/18321 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/160709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3edec1f6-02f0-4bd0-8121-2f8ec26dd37e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153840 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25240 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25052 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/160709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ec2abf52-f64e-4a0b-b765-e0f490bd8bd1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154926 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/136372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/160709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6e278677-55ce-4775-b408-e328a7e4829c) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/151288 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/18645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/16578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/8543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/14274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163173 "Failed to checkout and rebase branch from PR 61264") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/15866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/163173 "Failed to checkout and rebase branch from PR 61264") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/24546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/20637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/163173 "Failed to checkout and rebase branch from PR 61264") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/24547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/136070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/81129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23326 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/24547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/12845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24164 "Failed to checkout and rebase branch from PR 61264") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/23855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/24015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/23916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->