### PR TITLE
Initial implementation of Borrow and CanBorrow

### DIFF
--- a/LayoutTests/fast/webgpu/regression/repro_173266457-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_173266457-expected.txt
@@ -1,0 +1,4 @@
+CONSOLE MESSAGE: Index buffer contents after submission:
+
+PASS Out-of-order command buffer submission: index buffer contains OOB values after B submitted before A
+

--- a/LayoutTests/fast/webgpu/regression/repro_173266457.html
+++ b/LayoutTests/fast/webgpu/regression/repro_173266457.html
@@ -1,0 +1,154 @@
+<!-- webkit-test-runner [ enableMetalShaderValidation=true ] -->
+<html>
+<head>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<canvas id="canvas" width="400" height="300"></canvas>
+<script>
+promise_test(async t => {
+    assert_true(!!navigator.gpu, "WebGPU is not supported");
+
+const adapter = await navigator.gpu.requestAdapter();
+assert_true(adapter !== null, "Failed to get GPU adapter");
+
+const device = await adapter.requestDevice();
+t.add_cleanup(() => device.destroy());
+
+const canvas = document.getElementById("canvas");
+const context = canvas.getContext("webgpu");
+const format = navigator.gpu.getPreferredCanvasFormat();
+context.configure({ device, format, alphaMode: "premultiplied" });
+
+// Vertex buffer — 4 vertices (x, y in clip space).
+// Valid indices are 0–3; 30000 is guaranteed out-of-bounds.
+const vertexData = new Float32Array([
+    -0.5, -0.5,
+     0.5, -0.5,
+     0.5,  0.5,
+    -0.5,  0.5,
+]);
+const vertexBuffer = device.createBuffer({
+    size:  vertexData.byteLength,
+    usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
+});
+device.queue.writeBuffer(vertexBuffer, 0, vertexData);
+
+// Index buffer — 6 valid indices for two triangles.
+// Needs COPY_SRC so we can read it back, and COPY_DST so command buffer B
+// can overwrite it.
+const INDEX_COUNT   = 6;
+const OOB_VALUE     = 30000;
+const initialIndices = new Uint32Array([0, 1, 2, 0, 2, 3]);
+const indexBuffer = device.createBuffer({
+    size:  initialIndices.byteLength,
+    usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
+});
+device.queue.writeBuffer(indexBuffer, 0, initialIndices);
+
+// Staging buffer used to upload the out-of-bounds values inside encoder B.
+const oobData = new Uint32Array(INDEX_COUNT).fill(OOB_VALUE);
+const uploadBuffer = device.createBuffer({
+    size:  oobData.byteLength,
+    usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
+});
+device.queue.writeBuffer(uploadBuffer, 0, oobData);
+
+// Readback staging buffer.
+const readbackBuffer = device.createBuffer({
+    size:  initialIndices.byteLength,
+    usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+
+// Render pipeline.
+const shaderModule = device.createShaderModule({
+    code: `
+        @vertex
+        fn vs_main(@location(0) pos: vec2f) -> @builtin(position) vec4f {
+            return vec4f(pos, 0.0, 1.0);
+        }
+
+        @fragment
+        fn fs_main() -> @location(0) vec4f {
+            return vec4f(0.2, 0.6, 1.0, 1.0);
+        }
+    `,
+});
+
+const pipeline = device.createRenderPipeline({
+    layout: "auto",
+    vertex: {
+        module:     shaderModule,
+        entryPoint: "vs_main",
+        buffers: [{
+            arrayStride: 8,
+            attributes: [{ shaderLocation: 0, offset: 0, format: "float32x2" }],
+        }],
+    },
+    fragment: {
+        module:     shaderModule,
+        entryPoint: "fs_main",
+        targets: [{ format }],
+    },
+    primitive: { topology: "triangle-list" },
+});
+
+for (let iteration = 0; iteration < 2; iteration++) {
+    // Command buffer A — render pass with drawIndexed.
+    const encoderA = device.createCommandEncoder();
+    {
+        const pass = encoderA.beginRenderPass({
+            colorAttachments: [{
+                view:       context.getCurrentTexture().createView(),
+                clearValue: { r: 0.0, g: 0.0, b: 0.0, a: 1.0 },
+                loadOp:     "clear",
+                storeOp:    "store",
+            }],
+        });
+        pass.setPipeline(pipeline);
+        pass.setVertexBuffer(0, vertexBuffer);
+        pass.setIndexBuffer(indexBuffer, "uint32");
+        pass.drawIndexed(INDEX_COUNT);
+        pass.end();
+    }
+    const cmdBufA = encoderA.finish();
+
+    if (iteration == 1) {
+        // Command buffer B — overwrites every index in the index buffer with 30000.
+        const encoderB = device.createCommandEncoder();
+        encoderB.copyBufferToBuffer(uploadBuffer, 0, indexBuffer, 0, oobData.byteLength);
+        const cmdBufB = encoderB.finish();
+
+        // Submit B first, then A — intentional out-of-order submission.
+        device.queue.submit([cmdBufB]);
+        await device.queue.onSubmittedWorkDone();
+    }
+    device.queue.submit([cmdBufA]);
+
+    // Command buffer C — copy index buffer to readback staging buffer.
+    // Submitted after A so it is ordered after both B and A on the queue.
+    const encoderC = device.createCommandEncoder();
+    encoderC.copyBufferToBuffer(indexBuffer, 0, readbackBuffer, 0, initialIndices.byteLength);
+    device.queue.submit([encoderC.finish()]);
+
+    await device.queue.onSubmittedWorkDone();
+
+    if (iteration == 1) {
+        await readbackBuffer.mapAsync(GPUMapMode.READ);
+        const result = new Uint32Array(readbackBuffer.getMappedRange().slice(0));
+        readbackBuffer.unmap();
+
+        // Every index must be 30000 — the out-of-bounds value written by B.
+        for (let i = 0; i < INDEX_COUNT; i++)
+            assert_equals(result[i], OOB_VALUE, `index[${i}] should be ${OOB_VALUE}`);
+
+        console.log("Index buffer contents after submission:", Array.from(result).join(", "));
+    }
+}
+
+}, "Out-of-order command buffer submission: index buffer contains OOB values after B submitted before A");
+</script>
+
+</body>
+</html>

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -556,6 +556,8 @@
 		DD3DC97227A4BF8E007E5B61 /* InlineASM.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472BC151A825A004123FF /* InlineASM.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC97327A4BF8E007E5B61 /* ExportMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4729F151A825A004123FF /* ExportMacros.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC97427A4BF8E007E5B61 /* BloomFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47265151A825A004123FF /* BloomFilter.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		F50D171852941FCC9DB3F894 /* Borrow.h in Headers */ = {isa = PBXBuildFile; fileRef = DED4D271AFDD9025027F5497 /* Borrow.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		7310722B5EF464F16AAE91D7 /* CanBorrow.h in Headers */ = {isa = PBXBuildFile; fileRef = 41036C754D844912316DC00E /* CanBorrow.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC97527A4BF8E007E5B61 /* Locker.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472C3151A825A004123FF /* Locker.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC97627A4BF8E007E5B61 /* SingleRootGraph.h in Headers */ = {isa = PBXBuildFile; fileRef = 795212021F42588800BD6421 /* SingleRootGraph.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC97727A4BF8E007E5B61 /* MemoryPressureHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = AD89B6B61E6415080090707F /* MemoryPressureHandler.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1546,6 +1548,8 @@
 		A8A47260151A825A004123FF /* BitVector.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BitVector.cpp; sourceTree = "<group>"; };
 		A8A47261151A825A004123FF /* BitVector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BitVector.h; sourceTree = "<group>"; };
 		A8A47265151A825A004123FF /* BloomFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BloomFilter.h; sourceTree = "<group>"; };
+		DED4D271AFDD9025027F5497 /* Borrow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Borrow.h; sourceTree = "<group>"; };
+		41036C754D844912316DC00E /* CanBorrow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CanBorrow.h; sourceTree = "<group>"; };
 		A8A47267151A825A004123FF /* BumpPointerAllocator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BumpPointerAllocator.h; sourceTree = "<group>"; };
 		A8A4726A151A825A004123FF /* CheckedArithmetic.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CheckedArithmetic.h; sourceTree = "<group>"; };
 		A8A47270151A825A004123FF /* Compiler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Compiler.h; sourceTree = "<group>"; };
@@ -2342,6 +2346,7 @@
 				0F0C03E6299828E50064230A /* BloomFilter.cpp */,
 				A8A47265151A825A004123FF /* BloomFilter.h */,
 				0FB399B820AF5A580017E213 /* BooleanLattice.h */,
+				DED4D271AFDD9025027F5497 /* Borrow.h */,
 				0F93274A1C17F4B700CF6564 /* Box.h */,
 				0F93274A1C17F4B700CF6566 /* BoxPtr.h */,
 				7C3F72391D78811900674E26 /* Brigand.h */,
@@ -2352,6 +2357,7 @@
 				0FEC3C4F1F323C6800F59B6C /* CagedPtr.h */,
 				0F5F3D681F3FEBA600B115A2 /* CagedUniquePtr.h */,
 				413FE8F51F8D2EAB00F6D7D7 /* CallbackAggregator.h */,
+				41036C754D844912316DC00E /* CanBorrow.h */,
 				46209A27266D543A007F8F4A /* CancellableTask.h */,
 				1470EAF62BD6FB3F00E26254 /* CanMakeWeakPtr.h */,
 				A8A4726A151A825A004123FF /* CheckedArithmetic.h */,
@@ -3480,6 +3486,7 @@
 				DD3DC97427A4BF8E007E5B61 /* BloomFilter.h in Headers */,
 				468378C62EC2D84200A9257A /* BOMSPI.h in Headers */,
 				DD3DC90E27A4BF8E007E5B61 /* BooleanLattice.h in Headers */,
+				F50D171852941FCC9DB3F894 /* Borrow.h in Headers */,
 				DD3DC91B27A4BF8E007E5B61 /* Box.h in Headers */,
 				DD3DC92927A4BF8E007E5B61 /* BoxPtr.h in Headers */,
 				DD3DC91C27A4BF8E007E5B61 /* Brigand.h in Headers */,
@@ -3492,6 +3499,7 @@
 				DD3DC95427A4BF8E007E5B61 /* CagedPtr.h in Headers */,
 				DD3DC95527A4BF8E007E5B61 /* CagedUniquePtr.h in Headers */,
 				DD3DC8E927A4BF8E007E5B61 /* CallbackAggregator.h in Headers */,
+				7310722B5EF464F16AAE91D7 /* CanBorrow.h in Headers */,
 				DD3DC99B27A4BF8E007E5B61 /* CancellableTask.h in Headers */,
 				1470EAF72BD6FB3F00E26254 /* CanMakeWeakPtr.h in Headers */,
 				DDF306DA27C08654006A526F /* CFBundleSPI.h in Headers */,

--- a/Source/WTF/wtf/Borrow.h
+++ b/Source/WTF/wtf/Borrow.h
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/CanBorrow.h>
+#include <wtf/Compiler.h>
+#include <wtf/ForbidHeapAllocation.h>
+#include <wtf/Noncopyable.h>
+
+#if OS(DARWIN)
+#include <pthread.h>
+#endif
+
+namespace WTF {
+
+/**
+ * @brief Borrow is a scoped token that ensures a view into an object remains
+ * valid even if the object performs internal destruction.
+ *
+ * Some objects may invalidate internal state as a side effect of mutation. For
+ * example, a Vector may reallocate its backing store during append(), which
+ * would invalidate any outstanding span(). A Borrow<T> prevents such
+ * invalidation for as long as it is alive: if the borrowed object attempts a
+ * destructive operation while a Borrow is outstanding, the program will crash
+ * (via RELEASE_ASSERT) instead of silently corrupting memory.
+ *
+ * Borrow is noncopyable and intended for stack use.
+ * @code
+ * Borrow vector = object->vector();
+ * auto span = vector->span(); // span is guaranteed valid for the lifetime of vector
+ * use(span);
+ * @endcode
+ *
+ * @code
+ * use(borrow(object->vector())->span()); // argument is guaranteed valid for the duration of the call
+ * @endcode
+ *
+ * T must implement the CanBorrow protocol — either by inheriting from
+ * CanBorrow, or by providing setIsBorrowed() / crashIfBorrowed() by hand.
+ *
+ * Borrow is a new concept and we are still working through the static analysis
+ * that will enforce it.
+ */
+template<typename T>
+class Borrow {
+    WTF_MAKE_NONCOPYABLE(Borrow);
+    WTF_FORBID_HEAP_ALLOCATION;
+public:
+    explicit Borrow(T& ref)
+        : m_ref(ref)
+        , m_previous(m_ref.setIsBorrowed(true))
+    {
+        assertIsOnStack();
+    }
+
+    explicit Borrow(T* ptr)
+        : m_ref(*ptr)
+        , m_previous(m_ref.setIsBorrowed(true))
+    {
+        assertIsOnStack();
+    }
+
+    ~Borrow()
+    {
+        m_ref.setIsBorrowed(m_previous);
+    }
+
+    T& get() const LIFETIME_BOUND
+    {
+        return m_ref;
+    }
+
+    T* operator->() const LIFETIME_BOUND
+    {
+        return &m_ref;
+    }
+
+private:
+    void assertIsOnStack()
+    {
+#if OS(DARWIN) && ASSERT_ENABLED
+        auto self = pthread_self();
+        void* origin = pthread_get_stackaddr_np(self);
+        rlim_t size = pthread_get_stacksize_np(self);
+
+        ASSERT(origin, this < origin);
+        ASSERT(size, reinterpret_cast<uintptr_t>(origin) - reinterpret_cast<uintptr_t>(this) < size);
+#endif
+    }
+
+    T& m_ref;
+    bool m_previous { false };
+};
+
+template<typename T>
+inline Borrow<T> borrow(T& ref)
+{
+    return Borrow<T>(ref);
+}
+
+template<typename T>
+inline Borrow<T> borrow(T* ptr)
+{
+    return Borrow<T>(ptr);
+}
+
+} // namespace WTF
+
+using WTF::Borrow;
+using WTF::borrow;

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -29,6 +29,7 @@ set(WTF_PUBLIC_HEADERS
     BlockPtr.h
     BloomFilter.h
     BooleanLattice.h
+    Borrow.h
     Box.h
     BoxPtr.h
     Brigand.h
@@ -37,10 +38,11 @@ set(WTF_PUBLIC_HEADERS
     ButterflyArray.h
     ByteOrder.h
     CPUTime.h
-    CanMakeWeakPtr.h
     CagedPtr.h
     CagedUniquePtr.h
     CallbackAggregator.h
+    CanBorrow.h
+    CanMakeWeakPtr.h
     CancellableTask.h
     CheckedArithmetic.h
     CheckedPtr.h

--- a/Source/WTF/wtf/CanBorrow.h
+++ b/Source/WTF/wtf/CanBorrow.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <utility>
+#include <wtf/Assertions.h>
+
+namespace WTF {
+
+template<typename T> class Borrow;
+
+/**
+ * @brief CanBorrow is a base class that provides support for Borrow<T>.
+ *
+ * Inheriting from CanBorrow gives a class the bookkeeping needed by Borrow:
+ * a boolean flag that tracks whether the object is currently borrowed, and a
+ * destructor that crashes if the object is destroyed while borrowed.
+ *
+ * Classes that want tighter control over memory layout may implement the
+ * CanBorrow protocol by hand (providing setIsBorrowed() and
+ * crashIfBorrowed()) instead of inheriting from this class.
+ *
+ * @code
+ * class MyContainer : public CanBorrow {
+ *     void mutate() {
+ *         crashIfBorrowed(); // Ensure no outstanding Borrow before mutating.
+ *         // ... destructive operation ...
+ *     }
+ * };
+ * @endcode
+ *
+ * @see Borrow
+ */
+class CanBorrow {
+public:
+    ~CanBorrow()
+    {
+        RELEASE_ASSERT(!m_isBorrowed);
+    }
+
+    void crashIfBorrowed()
+    {
+        RELEASE_ASSERT(!m_isBorrowed);
+    }
+
+private:
+    template<typename T> friend class Borrow;
+
+    bool setIsBorrowed(bool isBorrowed)
+    {
+        return std::exchange(m_isBorrowed, isBorrowed);
+    }
+
+    bool m_isBorrowed { false };
+};
+
+} // namespace WTF
+
+using WTF::CanBorrow;

--- a/Source/WebGPU/WebGPU/Buffer.h
+++ b/Source/WebGPU/WebGPU/Buffer.h
@@ -33,6 +33,7 @@
 #import <WebGPU/WebGPU.h>
 #import <WebGPU/WebGPUExt.h>
 #import <utility>
+#import <wtf/CanBorrow.h>
 #import <wtf/Compiler.h>
 #import <wtf/CompletionHandler.h>
 #import <wtf/FastMalloc.h>
@@ -55,7 +56,7 @@ class CommandEncoder;
 class Device;
 
 // https://gpuweb.github.io/gpuweb/#gpubuffer
-class Buffer : public WGPUBufferImpl, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Buffer>, public TrackedResource {
+class Buffer : public WGPUBufferImpl, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Buffer>, public CanBorrow, public TrackedResource {
     WTF_MAKE_TZONE_ALLOCATED(Buffer);
 public:
     enum class State : uint8_t;

--- a/Source/WebGPU/WebGPU/Buffer.mm
+++ b/Source/WebGPU/WebGPU/Buffer.mm
@@ -30,6 +30,7 @@
 #import "CommandBuffer.h"
 #import "Device.h"
 
+#import <wtf/Borrow.h>
 #import <wtf/CheckedArithmetic.h>
 #import <wtf/StdLibExtras.h>
 #import <wtf/TZoneMallocInlines.h>
@@ -242,6 +243,8 @@ void Buffer::setCommandEncoder(CommandEncoder& commandEncoder, bool mayModifyBuf
 
 void Buffer::destroy()
 {
+    crashIfBorrowed();
+
     // https://gpuweb.github.io/gpuweb/#dom-gpubuffer-destroy
 
     if (m_state != State::Unmapped && m_state != State::Destroyed) {
@@ -289,7 +292,7 @@ static size_t NODELETE computeRangeSize(uint64_t size, size_t offset)
         return 0;
     return result.value();
 }
-  
+
 std::span<uint8_t> Buffer::getMappedRange(size_t offset, size_t size)
 {
 #if ENABLE(WEBGPU_SWIFT)
@@ -519,17 +522,17 @@ void Buffer::takeSlowIndexValidationPath(CommandBuffer& commandBuffer, uint32_t 
         verified = verifyIndexBufferData<uint32_t>(m_buffer, firstIndex, indexCount, vertexCount, primitiveOffset);
 
     if (!verified) {
-        auto priorData = getBufferContents();
+        SUPPRESS_UNCOUNTED_ARG Vector<uint8_t> priorData = borrow(this)->getBufferContents();
+
         queue->clearBuffer(m_buffer);
         queue->finalizeBlitCommandEncoder();
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)
         if (m_buffer.storageMode == MTLStorageModeManaged)
             [m_buffer didModifyRange:NSMakeRange(0, m_buffer.length)];
 #endif
-        commandBuffer.addPostCommitHandler([queue, priorData, protectedThis = Ref { *this }](id<MTLCommandBuffer> mtlCommandBuffer) {
+        commandBuffer.addPostCommitHandler([queue, priorData = WTF::move(priorData), protectedThis = Ref { *this }](id<MTLCommandBuffer> mtlCommandBuffer) mutable {
             [mtlCommandBuffer waitUntilCompleted];
-
-            queue->writeBuffer(*protectedThis.ptr(), 0, priorData);
+            queue->writeBuffer(*protectedThis.ptr(), 0, priorData.mutableSpan());
         });
     }
 }
@@ -555,17 +558,18 @@ void Buffer::takeSlowIndirectIndexValidationPath(CommandBuffer& commandBuffer, B
         verified = verifyIndexBufferData<uint32_t>(apiIndexBuffer.buffer(), args.indexStart, args.indexCount, minVertexCount > static_cast<int64_t>(args.baseVertex) ? minVertexCount - args.baseVertex : 0, primitiveOffset);
 
     if (!verified) {
-        auto priorData = getBufferContents();
+        SUPPRESS_UNCOUNTED_ARG Vector<uint8_t> priorData = borrow(this)->getBufferContents();
+
         queue->clearBuffer(m_buffer, indirectOffset, sizeof(MTLDrawPrimitivesIndirectArguments));
         queue->finalizeBlitCommandEncoder();
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)
         if (m_buffer.storageMode == MTLStorageModeManaged)
             [m_buffer didModifyRange:NSMakeRange(0, m_buffer.length)];
 #endif
-        commandBuffer.addPostCommitHandler([queue, priorData, protectedThis = Ref { *this }](id<MTLCommandBuffer> mtlCommandBuffer) {
+        commandBuffer.addPostCommitHandler([queue, priorData = WTF::move(priorData), protectedThis = Ref { *this }](id<MTLCommandBuffer> mtlCommandBuffer) mutable {
             [mtlCommandBuffer waitUntilCompleted];
 
-            queue->writeBuffer(*protectedThis.ptr(), 0, priorData);
+            queue->writeBuffer(*protectedThis.ptr(), 0, priorData.mutableSpan());
         });
     }
 }
@@ -591,7 +595,8 @@ void Buffer::takeSlowIndirectValidationPath(CommandBuffer& commandBuffer, uint64
     bool verified = verifyIndirectBufferData(args, minVertexCount, minInstanceCount);
 
     if (!verified) {
-        auto priorData = getBufferContents();
+        SUPPRESS_UNCOUNTED_ARG Vector<uint8_t> priorData = borrow(this)->getBufferContents();
+
         MTLDrawPrimitivesIndirectArguments data = {
             .vertexCount = std::min(args.vertexCount, minVertexCount),
             .instanceCount = std::min(args.instanceCount, minInstanceCount),
@@ -605,10 +610,10 @@ void Buffer::takeSlowIndirectValidationPath(CommandBuffer& commandBuffer, uint64
         if (m_buffer.storageMode == MTLStorageModeManaged)
             [m_buffer didModifyRange:NSMakeRange(0, m_buffer.length)];
 #endif
-        commandBuffer.addPostCommitHandler([queue, priorData, protectedThis = Ref { *this }](id<MTLCommandBuffer> mtlCommandBuffer) {
+        commandBuffer.addPostCommitHandler([queue, priorData = WTF::move(priorData), protectedThis = Ref { *this }](id<MTLCommandBuffer> mtlCommandBuffer) mutable {
             [mtlCommandBuffer waitUntilCompleted];
 
-            queue->writeBuffer(*protectedThis.ptr(), 0, priorData);
+            queue->writeBuffer(*protectedThis.ptr(), 0, priorData.mutableSpan());
         });
     }
 }

--- a/Source/WebGPU/WebGPU/Queue.mm
+++ b/Source/WebGPU/WebGPU/Queue.mm
@@ -35,16 +35,18 @@
 #import "MetalSPI.h"
 #import "Texture.h"
 #import "TextureView.h"
+#import <simd/simd.h>
+#import <wtf/Borrow.h>
+#import <wtf/CheckedArithmetic.h>
+#import <wtf/StdLibExtras.h>
+#import <wtf/TZoneMallocInlines.h>
+
 #if ENABLE(WEBGPU_SWIFT)
 #import "CxxBridging.h"
 #import <WebGPU/CxxBridgingPublic.h>
 #import <WebGPU/WGPUTextureImpl.h>
 #import "WebGPUSwift-Generated.h"
 #endif
-#import <simd/simd.h>
-#import <wtf/CheckedArithmetic.h>
-#import <wtf/StdLibExtras.h>
-#import <wtf/TZoneMallocInlines.h>
 
 namespace WebGPU {
 
@@ -561,11 +563,11 @@ void Queue::writeBuffer(Buffer& buffer, uint64_t bufferOffset, std::span<uint8_t
     if (isIdle()) {
         switch (buffer.buffer().storageMode) {
         case MTLStorageModeShared:
-            memcpySpan(buffer.getBufferContents().subspan(bufferOffset, data.size()), data);
+            SUPPRESS_UNCOUNTED_ARG memcpySpan(borrow(buffer)->getBufferContents().subspan(bufferOffset, data.size()), data);
             return;
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)
         case MTLStorageModeManaged:
-            memcpySpan(buffer.getBufferContents().subspan(bufferOffset, data.size()), data);
+            SUPPRESS_UNCOUNTED_ARG memcpySpan(borrow(buffer)->getBufferContents().subspan(bufferOffset, data.size()), data);
             [buffer.buffer() didModifyRange:NSMakeRange(bufferOffset, data.size())];
             return;
 #endif


### PR DESCRIPTION
#### da573f8d6dcaa5b04b588465b1b9f4b009e0bdf2
<pre>
Initial implementation of Borrow and CanBorrow
<a href="https://bugs.webkit.org/show_bug.cgi?id=310655">https://bugs.webkit.org/show_bug.cgi?id=310655</a>
<a href="https://rdar.apple.com/173266457">rdar://173266457</a>

Reviewed by Mike Wyrzykowski and Ryosuke Niwa.

Adopted in WebGPU::Buffer to inform our experiment with Swift in WebGPU.

This test adoption already found an invalid borrow bug, where the author
captured a span in a lambda when they meant to capture a copy instead.

The consequence of the bug is minor (since the lambda also captures the owning
buffer), but it is a welcome validation of the approach.

I&apos;m suppressing the SaferCPP failures around borrow(x)-&gt; for now, while we
decide how SaferCPP should model borrow() / Borrow&lt;T&gt;.

* LayoutTests/fast/webgpu/regression/repro_173266457-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/repro_173266457.html: Added. Regression
test for the observable side effect of the minor bug I described above.
After submitting an invalid set of GPU commands, the program should see
its buffer unchanged, rather than zeroed.

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/Borrow.h: Added.
(WTF::Borrow::Borrow):
(WTF::Borrow::~Borrow):
(WTF::Borrow::assertIsOnStack):
(WTF::borrow):
* Source/WTF/wtf/CMakeLists.txt: List new headers.

* Source/WTF/wtf/CanBorrow.h: Added.
(WTF::CanBorrow::~CanBorrow):
(WTF::CanBorrow::crashIfBorrowed):
(WTF::CanBorrow::setIsBorrowed): New types to describe runtime borrowing.

* Source/WebGPU/WebGPU/Buffer.h:
* Source/WebGPU/WebGPU/Buffer.mm:
(WebGPU::Buffer::destroy):
(WebGPU::Buffer::takeSlowIndexValidationPath):
(WebGPU::Buffer::takeSlowIndirectIndexValidationPath):
(WebGPU::Buffer::takeSlowIndirectValidationPath): Make sure to borrow. Copying
a Borrow is not allowed, and that revealed a pre-existing bug: The code copied a
span across an async lambda callback. The code&apos;s intention was to make a deep
copy, so I&apos;ve switched to a Vector. We don&apos;t care that this is slow because it&apos;s
already in the invalid slow path.

* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::writeBuffer): Make sure to borrow.

Canonical link: <a href="https://commits.webkit.org/310068@main">https://commits.webkit.org/310068@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d68fb6da036f731a1a1c590627fe27657dca607c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152497 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25279 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18878 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161242 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105954 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ea4a4104-aacd-4d27-a23e-4304d34dc0d5) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25807 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25585 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117841 "Found 1 new test failure: media/media-vp8-webm.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83518 "3 flakes 2 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5899494e-ef39-4f5c-8e50-0693d2f03d5a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155457 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20053 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136913 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98555 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f8f9085a-6105-4be5-a5eb-8460ada0b51b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19129 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17067 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9076 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144509 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128779 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14787 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163711 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13300 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6852 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16381 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125885 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25077 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21106 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126051 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25079 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136583 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81681 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23386 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21042 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13362 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184129 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24695 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88981 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46952 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24386 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24546 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24447 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->