### PR TITLE
Remove assertion in Download::publishProgress when bookmark data is invalid

### DIFF
--- a/Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
+++ b/Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
@@ -156,7 +156,6 @@ void Download::publishProgress(const URL& url, std::span<const uint8_t> bookmark
     BOOL bookmarkIsStale = NO;
     NSError* error = nil;
     m_bookmarkURL = [NSURL URLByResolvingBookmarkData:m_bookmarkData.get() options:NSURLBookmarkResolutionWithoutUI relativeToURL:nil bookmarkDataIsStale:&bookmarkIsStale error:&error];
-    ASSERT(m_bookmarkURL);
     if (!m_bookmarkURL)
         DOWNLOAD_RELEASE_LOG("publishProgress: Unable to create bookmark URL, error = %@", error);
 

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxyCocoa.mm
@@ -89,6 +89,8 @@ Vector<uint8_t> DownloadProxy::bookmarkDataForURL(const URL& url)
     RetainPtr localURL = adoptNS([[NSURL alloc] initFileURLWithPath:url.fileSystemPath().createNSString().get() relativeToURL:nil]);
     NSError *error = nil;
     RetainPtr bookmark = [localURL bookmarkDataWithOptions:NSURLBookmarkCreationMinimalBookmark includingResourceValuesForKeys:nil relativeToURL:nil error:&error];
+    if (!bookmark && error)
+        RELEASE_LOG_ERROR(Network, "DownloadProxy::bookmarkDataForURL: Failed to create bookmark data for URL, error = %" PUBLIC_LOG_STRING, error.description.c_str());
     return span(bookmark.get());
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm
@@ -2408,6 +2408,45 @@ TEST(WKDownload, PlaceholderPolicyDisable)
         DownloadCallback::DidFinish,
     });
 }
+
+TEST(WKDownload, PlaceholderPolicyDisableWithNonExistentPlaceholderURL)
+{
+    HTTPServer server({
+        { "/"_s, { 404, { }, "http body"_s } }
+    });
+    RetainPtr expectedDownloadFile = tempFileThatDoesNotExist();
+    auto delegate = adoptNS([TestDownloadDelegate new]);
+    auto webView = adoptNS([WKWebView new]);
+    [webView setNavigationDelegate:delegate.get()];
+
+    // Pass a non-existent file URL as the placeholder. This should not cause
+    // an assertion failure when creating bookmark data for the URL.
+    NSURL *nonExistentPlaceholder = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:@"NonExistentPlaceholder.txt"]];
+    [[NSFileManager defaultManager] removeItemAtURL:nonExistentPlaceholder error:nil];
+
+    __block bool didFinish = false;
+    [webView startDownloadUsingRequest:server.request() completionHandler:^(WKDownload *download) {
+        download.delegate = delegate.get();
+        delegate.get().decideDestinationUsingResponse = ^(WKDownload *, NSURLResponse *, NSString *, void (^completionHandler)(NSURL *)) {
+            completionHandler(expectedDownloadFile.get());
+        };
+        delegate.get().decidePlaceholderPolicy = ^(WKDownload *, void (^completionHandler)(WKDownloadPlaceholderPolicy, NSURL *)) {
+            completionHandler(WKDownloadPlaceholderPolicyDisable, nonExistentPlaceholder);
+        };
+        delegate.get().downloadDidFinish = ^(WKDownload *download) {
+            didFinish = true;
+        };
+    }];
+    Util::run(&didFinish);
+
+    checkFileContents(expectedDownloadFile.get(), "http body"_s);
+
+    checkCallbackRecord(delegate.get(), {
+        DownloadCallback::DecideDestination,
+        DownloadCallback::DecidePlaceholderPolicy,
+        DownloadCallback::DidFinish,
+    });
+}
 #endif
 
 TEST(WKDownload, NetworkProcessCrash)


### PR DESCRIPTION
#### 09e47e61e5b8e6a5a1dfc49e8a878d79110e4bbe
<pre>
Remove assertion in Download::publishProgress when bookmark data is invalid
<a href="https://bugs.webkit.org/show_bug.cgi?id=310658">https://bugs.webkit.org/show_bug.cgi?id=310658</a>
<a href="https://rdar.apple.com/160644491">rdar://160644491</a>

Reviewed by Per Arne Vollan.

When a non-existent file URL is passed as the placeholder URL in
decidePlaceholderPolicy, bookmarkDataWithOptions: returns nil because
there is no file to create a bookmark for. The empty bookmark data is
sent to the Network Process, where URLByResolvingBookmarkData: returns
nil, hitting ASSERT(m_bookmarkURL).

The adoptNS fix in r282517 addressed one cause of nil m_bookmarkURL but
also added this assertion, which exposed the pre-existing failure mode
of invalid bookmark data.

Fix by removing the assertion (the nil case is already handled gracefully
with a release log) and adding error logging in bookmarkDataForURL so the
root cause is visible in UI process logs.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm
* Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm:
(WebKit::Download::publishProgress):
* Source/WebKit/UIProcess/Downloads/DownloadProxyCocoa.mm:
(WebKit::DownloadProxy::bookmarkDataForURL):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm:
(TestWebKitAPI::PlaceholderPolicyDisableWithNonExistentPlaceholderURL)):

Canonical link: <a href="https://commits.webkit.org/309929@main">https://commits.webkit.org/309929@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e52d4eae281ed208dee69a04d935e1391a953a2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151991 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24773 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18348 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160734 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105448 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ecbd4f1f-d9ed-4b63-9c0f-263398eefee7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153865 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25265 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25078 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117408 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83279 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/11c545ec-172e-4502-825d-8239a0138640) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154951 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19578 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136396 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98123 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18660 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16600 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8568 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128293 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14295 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163198 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6346 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15887 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125433 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24571 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20657 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125610 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34124 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24572 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136091 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81154 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20622 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12867 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24189 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88474 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23880 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24040 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23941 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->