### PR TITLE
[Site Isolation] Fix null dereference crash when focus navigates into cross-origin iframe containing

### DIFF
--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -812,6 +812,8 @@ FocusableElementSearchResult FocusController::findFocusableElementAcrossFocusSco
     }
 
     auto candidateInCurrentScope = findFocusableElementWithinScope(direction, scope, currentNode, focusEventData, shouldFocusElement);
+    if (candidateInCurrentScope.continuedSearchInRemoteFrame == ContinuedSearchInRemoteFrame::Yes)
+        return candidateInCurrentScope;
     if (candidateInCurrentScope.element) {
         if (direction == FocusDirection::Backward) {
             // Skip through invokers if they have popovers with focusable contents, and navigate through those contents instead.
@@ -860,15 +862,19 @@ FocusableElementSearchResult FocusController::findFocusableElementAcrossFocusSco
             },
             [&](const RefPtr<Frame>& frame) -> FocusableElementSearchResult {
                 switch (frame->frameType()) {
-                case Frame::FrameType::Remote:
-
+                case Frame::FrameType::Remote: {
+                    if (!currentNode)
+                        return { };
+                    RefPtr currentFrame = currentNode->document().frame();
+                    if (!currentFrame)
+                        return { };
                     if (shouldFocusElement == ShouldFocusElement::Yes) {
-                        RefPtr currentFrame = currentNode->document().frame();
                         clearSelectionIfNeeded(currentFrame.get(), nullptr, nullptr);
                         currentNode->document().setFocusedElement(nullptr);
                     }
-                    downcast<RemoteFrame>(*frame).client().findFocusableElementContinuingFromFrame(direction, currentNode->document().frame()->frameID(), focusEventData, shouldFocusElement);
+                    downcast<RemoteFrame>(*frame).client().findFocusableElementContinuingFromFrame(direction, currentFrame->frameID(), focusEventData, shouldFocusElement);
                     return { nullptr, ContinuedSearchInRemoteFrame::Yes };
+                }
                 case Frame::FrameType::Local:
                     if (RefPtr ownerElement = frame->ownerElement())
                         return handleElementOwner(*ownerElement);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FocusWebView.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FocusWebView.mm
@@ -233,6 +233,63 @@ TEST(FocusWebView, MultipleFrames)
     EXPECT_WK_STREQ([uiDelegate waitForAlert], "https://apple.com focused");
 }
 
+static void runFocusNavigationIntoFrameWithNestedRemoteFrameTest(bool siteIsolationEnabled)
+{
+    auto mainHTML = "<body>"
+        "<input id='mainInput'>"
+        "<iframe id='outerFrame' src='https://webkit.org/outerframe'></iframe>"
+        "</body>"_s;
+
+    auto outerFrameHTML = "<body>"
+        "<iframe src='https://apple.com/innerframe'></iframe>"
+        "<input id='outerInput'>"
+        "<script>document.getElementById('outerInput').addEventListener('focusin', () => alert('outerInput focused'));</script>"
+        "</body>"_s;
+
+    auto innerFrameHTML = "<body>"
+        "<input id='innerInput'>"
+        "<script>document.getElementById('innerInput').addEventListener('focusin', () => alert('innerInput focused'));</script>"
+        "</body>"_s;
+
+    HTTPServer server({
+        { "/main"_s, { mainHTML } },
+        { "/outerframe"_s, { outerFrameHTML } },
+        { "/innerframe"_s, { innerFrameHTML } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    if (siteIsolationEnabled)
+        [[configuration preferences] _setSiteIsolationEnabled:YES];
+
+    auto [webView, navigationDelegate, uiDelegate] = makeWebViewAndDelegates(WTF::move(configuration));
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/main"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    [webView evaluateJavaScript:@""
+        "document.getElementById('mainInput').addEventListener('focusin', () => alert('mainInput focused'));"
+        "document.getElementById('mainInput').focus();" completionHandler:nil];
+    EXPECT_WK_STREQ([uiDelegate waitForAlert], "mainInput focused");
+
+    [webView typeCharacter:'\t'];
+    EXPECT_WK_STREQ([uiDelegate waitForAlert], "innerInput focused");
+
+    if (!siteIsolationEnabled) {
+        [webView typeCharacter:'\t'];
+        EXPECT_WK_STREQ([uiDelegate waitForAlert], "outerInput focused");
+    }
+}
+
+TEST(FocusWebView, FocusNavigationIntoFrameWithNestedRemoteFrame)
+{
+    runFocusNavigationIntoFrameWithNestedRemoteFrameTest(false);
+}
+
+TEST(FocusWebView, FocusNavigationIntoFrameWithNestedRemoteFrameSiteIsolation)
+{
+    runFocusNavigationIntoFrameWithNestedRemoteFrameTest(true);
+}
+
 TEST(FocusWebView, DoNotFocusWebViewWhenUnparented)
 {
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];


### PR DESCRIPTION
#### 6a158c26f43225035d5999c7f758c164534308e8
<pre>
[Site Isolation] Fix null dereference crash when focus navigates into cross-origin iframe containing
a nested remote frame <a href="https://rdar.apple.com/172564611">rdar://172564611</a> <a href="https://bugs.webkit.org/show_bug.cgi?id=310307">https://bugs.webkit.org/show_bug.cgi?id=310307</a>

Reviewed by Megan Gardner.

When findFocusableElementAcrossFocusScope found a candidate with ContinuedSearchInRemoteFrame::Yes,
it did not return early, allowing execution to continue into the Remote frame owner case with a null
currentNode, causing a crash. Also adds null checks for currentNode and currentFrame in the Remote
frame handling path.

* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::findFocusableElementAcrossFocusScope): Scope the Remote case with case
Frame::FrameType::Remote: { } to satisfy C++ jump-past-initialization rules.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/FocusWebView.mm:
(FocusWebView.FocusNavigationIntoFrameWithNestedRemoteFrame): Regression test with site isolation
disabled. Tab key navigation descends into the nested frame tree, focusing innerInput then
outerInput.
(FocusWebView.FocusNavigationIntoFrameWithNestedRemoteFrameSiteIsolation): Same test with site
isolation enabled. With site isolation, innerFrame (apple.com) is a RemoteFrame from webkit.org&apos;s
perspective. isFocusScopeOwner returns false for remote-frame iframes, so focus traversal skips it
and lands directly on the first locally-reachable element (outerInput) in webkit.org&apos;s process.
Only one Tab is needed: mainInput → outerInput.

Canonical link: <a href="https://commits.webkit.org/310547@main">https://commits.webkit.org/310547@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbf6ed2bf326a7854a83392ab9ba223704c8f283

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154109 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27366 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20524 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162861 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107577 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155982 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27498 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27217 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119186 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84263 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157068 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21425 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138384 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99886 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20521 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18519 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10694 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130183 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16235 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165334 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8544 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17836 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127278 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26912 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22563 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127429 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34585 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26835 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138029 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/83422 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22296 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14817 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26527 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90630 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26107 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26337 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26179 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->