### PR TITLE
Fix WPT test expectations for circle()/ellipse() specified value position serialization

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-functions/circle-function-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-functions/circle-function-valid-expected.txt
@@ -1,16 +1,16 @@
 
 PASS e.style['shape-outside'] = "circle()" should set the property value
 PASS e.style['shape-outside'] = "circle(1px)" should set the property value
-FAIL e.style['shape-outside'] = "circle(20px at center)" should set the property value assert_equals: serialization should be canonical expected "circle(20px at 50% 50%)" but got "circle(20px at center center)"
+PASS e.style['shape-outside'] = "circle(20px at center)" should set the property value
 PASS e.style['shape-outside'] = "circle(at 10% 20%)" should set the property value
-FAIL e.style['shape-outside'] = "circle(4% at top right)" should set the property value assert_equals: serialization should be canonical expected "circle(4% at 100% 0%)" but got "circle(4% at right top)"
+PASS e.style['shape-outside'] = "circle(4% at top right)" should set the property value
 PASS e.style['shape-outside'] = "circle(calc(100% - 20px) at calc(100% - 20px) calc(100% / 4))" should set the property value
-FAIL e.style['shape-outside'] = "circle(closest-corner at center)" should set the property value assert_equals: serialization should be canonical expected "circle(closest-corner at 50% 50%)" but got "circle(closest-corner at center center)"
+PASS e.style['shape-outside'] = "circle(closest-corner at center)" should set the property value
 PASS e.style['shape-outside'] = "circle(closest-corner at 20px 50px)" should set the property value
-FAIL e.style['shape-outside'] = "circle(closest-side at center)" should set the property value assert_equals: serialization should be canonical expected "circle(at 50% 50%)" but got "circle(at center center)"
+PASS e.style['shape-outside'] = "circle(closest-side at center)" should set the property value
 PASS e.style['shape-outside'] = "circle(closest-side at 20px 30%)" should set the property value
-FAIL e.style['shape-outside'] = "circle(farthest-corner at center top)" should set the property value assert_equals: serialization should be canonical expected "circle(farthest-corner at 50% 0%)" but got "circle(farthest-corner at center top)"
-FAIL e.style['shape-outside'] = "circle(farthest-corner at center)" should set the property value assert_equals: serialization should be canonical expected "circle(farthest-corner at 50% 50%)" but got "circle(farthest-corner at center center)"
-FAIL e.style['shape-outside'] = "circle(farthest-side at center top)" should set the property value assert_equals: serialization should be canonical expected "circle(farthest-side at 50% 0%)" but got "circle(farthest-side at center top)"
-FAIL e.style['shape-outside'] = "circle(farthest-side at center)" should set the property value assert_equals: serialization should be canonical expected "circle(farthest-side at 50% 50%)" but got "circle(farthest-side at center center)"
+PASS e.style['shape-outside'] = "circle(farthest-corner at center top)" should set the property value
+PASS e.style['shape-outside'] = "circle(farthest-corner at center)" should set the property value
+PASS e.style['shape-outside'] = "circle(farthest-side at center top)" should set the property value
+PASS e.style['shape-outside'] = "circle(farthest-side at center)" should set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-functions/circle-function-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-functions/circle-function-valid.html
@@ -14,19 +14,19 @@
 <script>
 test_valid_value("shape-outside", "circle()");
 test_valid_value("shape-outside", "circle(1px)");
-test_valid_value("shape-outside", "circle(20px at center)", "circle(20px at 50% 50%)");
+test_valid_value("shape-outside", "circle(20px at center)", "circle(20px at center center)");
 test_valid_value("shape-outside", "circle(at 10% 20%)");
-test_valid_value("shape-outside", "circle(4% at top right)", "circle(4% at 100% 0%)");
+test_valid_value("shape-outside", "circle(4% at top right)", "circle(4% at right top)");
 test_valid_value("shape-outside", "circle(calc(100% - 20px) at calc(100% - 20px) calc(100% / 4))", "circle(calc(100% - 20px) at calc(100% - 20px) calc(25%))");
 
-test_valid_value("shape-outside", "circle(closest-corner at center)", "circle(closest-corner at 50% 50%)");
+test_valid_value("shape-outside", "circle(closest-corner at center)", "circle(closest-corner at center center)");
 test_valid_value("shape-outside", "circle(closest-corner at 20px 50px)", "circle(closest-corner at 20px 50px)");
-test_valid_value("shape-outside", "circle(closest-side at center)", "circle(at 50% 50%)");
+test_valid_value("shape-outside", "circle(closest-side at center)", "circle(at center center)");
 test_valid_value("shape-outside", "circle(closest-side at 20px 30%)", "circle(at 20px 30%)");
-test_valid_value("shape-outside", "circle(farthest-corner at center top)", "circle(farthest-corner at 50% 0%)");
-test_valid_value("shape-outside", "circle(farthest-corner at center)", "circle(farthest-corner at 50% 50%)");
-test_valid_value("shape-outside", "circle(farthest-side at center top)", "circle(farthest-side at 50% 0%)");
-test_valid_value("shape-outside", "circle(farthest-side at center)", "circle(farthest-side at 50% 50%)");
+test_valid_value("shape-outside", "circle(farthest-corner at center top)");
+test_valid_value("shape-outside", "circle(farthest-corner at center)", "circle(farthest-corner at center center)");
+test_valid_value("shape-outside", "circle(farthest-side at center top)");
+test_valid_value("shape-outside", "circle(farthest-side at center)", "circle(farthest-side at center center)");
 </script>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-functions/ellipse-function-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-functions/ellipse-function-valid-expected.txt
@@ -1,16 +1,16 @@
 
 PASS e.style['shape-outside'] = "ellipse()" should set the property value
 PASS e.style['shape-outside'] = "ellipse(1px 2px)" should set the property value
-FAIL e.style['shape-outside'] = "ellipse(20px 40px at center)" should set the property value assert_equals: serialization should be canonical expected "ellipse(20px 40px at 50% 50%)" but got "ellipse(20px 40px at center center)"
+PASS e.style['shape-outside'] = "ellipse(20px 40px at center)" should set the property value
 PASS e.style['shape-outside'] = "ellipse(closest-side 20%)" should set the property value
 PASS e.style['shape-outside'] = "ellipse(farthest-side 20%)" should set the property value
 PASS e.style['shape-outside'] = "ellipse(closest-corner 20%)" should set the property value
 PASS e.style['shape-outside'] = "ellipse(farthest-corner 20%)" should set the property value
 PASS e.style['shape-outside'] = "ellipse(at 10% 20%)" should set the property value
 PASS e.style['shape-outside'] = "ellipse(at -10px -20%)" should set the property value
-FAIL e.style['shape-outside'] = "ellipse(4% 20% at top right)" should set the property value assert_equals: serialization should be canonical expected "ellipse(4% 20% at 100% 0%)" but got "ellipse(4% 20% at right top)"
+PASS e.style['shape-outside'] = "ellipse(4% 20% at top right)" should set the property value
 PASS e.style['shape-outside'] = "ellipse(calc(100% - 20px) calc(80% - 10px) at calc(100% - 20px) calc(100% / 4))" should set the property value
-FAIL e.style['shape-outside'] = "ellipse(10px closest-side at top right)" should set the property value assert_equals: serialization should be canonical expected "ellipse(10px closest-side at 100% 0%)" but got "ellipse(10px closest-side at right top)"
-FAIL e.style['shape-outside'] = "ellipse(farthest-side 20px at center top)" should set the property value assert_equals: serialization should be canonical expected "ellipse(farthest-side 20px at 50% 0%)" but got "ellipse(farthest-side 20px at center top)"
-FAIL e.style['shape-outside'] = "ellipse(farthest-side farthest-side at top right)" should set the property value assert_equals: serialization should be canonical expected "ellipse(farthest-side farthest-side at 100% 0%)" but got "ellipse(farthest-side farthest-side at right top)"
+PASS e.style['shape-outside'] = "ellipse(10px closest-side at top right)" should set the property value
+PASS e.style['shape-outside'] = "ellipse(farthest-side 20px at center top)" should set the property value
+PASS e.style['shape-outside'] = "ellipse(farthest-side farthest-side at top right)" should set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-functions/ellipse-function-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-functions/ellipse-function-valid.html
@@ -13,19 +13,19 @@
 <script>
 test_valid_value("shape-outside", "ellipse()");
 test_valid_value("shape-outside", "ellipse(1px 2px)");
-test_valid_value("shape-outside", "ellipse(20px 40px at center)", "ellipse(20px 40px at 50% 50%)");
+test_valid_value("shape-outside", "ellipse(20px 40px at center)", "ellipse(20px 40px at center center)");
 test_valid_value("shape-outside", "ellipse(closest-side 20%)");
 test_valid_value("shape-outside", "ellipse(farthest-side 20%)");
 test_valid_value("shape-outside", "ellipse(closest-corner 20%)");
 test_valid_value("shape-outside", "ellipse(farthest-corner 20%)");
 test_valid_value("shape-outside", "ellipse(at 10% 20%)");
 test_valid_value("shape-outside", "ellipse(at -10px -20%)");
-test_valid_value("shape-outside", "ellipse(4% 20% at top right)", "ellipse(4% 20% at 100% 0%)");
+test_valid_value("shape-outside", "ellipse(4% 20% at top right)", "ellipse(4% 20% at right top)");
 test_valid_value("shape-outside", "ellipse(calc(100% - 20px) calc(80% - 10px) at calc(100% - 20px) calc(100% / 4))", "ellipse(calc(100% - 20px) calc(80% - 10px) at calc(100% - 20px) calc(25%))");
 
-test_valid_value("shape-outside", "ellipse(10px closest-side at top right)", "ellipse(10px closest-side at 100% 0%)");
-test_valid_value("shape-outside", "ellipse(farthest-side 20px at center top)", "ellipse(farthest-side 20px at 50% 0%)");
-test_valid_value("shape-outside", "ellipse(farthest-side farthest-side at top right)", "ellipse(farthest-side farthest-side at 100% 0%)");
+test_valid_value("shape-outside", "ellipse(10px closest-side at top right)", "ellipse(10px closest-side at right top)");
+test_valid_value("shape-outside", "ellipse(farthest-side 20px at center top)");
+test_valid_value("shape-outside", "ellipse(farthest-side farthest-side at top right)", "ellipse(farthest-side farthest-side at right top)");
 </script>
 </body>
 </html>


### PR DESCRIPTION
#### dade038b6069f612e1312d8da3c9de2027899b42
<pre>
Fix WPT test expectations for circle()/ellipse() specified value position serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=310663">https://bugs.webkit.org/show_bug.cgi?id=310663</a>
<a href="https://rdar.apple.com/173273168">rdar://173273168</a>

Reviewed by Sam Weinig.

Update test expectations in circle-function-valid.html and ellipse-function-valid.html
to preserve position keywords in specified value serialization instead of converting
them to percentages.

Per CSS Values Level 5 4.3 (Serializing), the canonical 2 component form
should serialize keywords as keywords, not as equivalent percentages.

These tests read from element.style (specified values), where the spec requires
preserving keywords in their canonical representation. The previous expectations
incorrectly required keyword-to-percentage conversion, which is only appropriate
for computed values.

References:
- CSS Values Level 5 4.3: <a href="https://drafts.csswg.org/css-values-5/#position-serialization">https://drafts.csswg.org/css-values-5/#position-serialization</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-functions/circle-function-valid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-functions/circle-function-valid.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-functions/ellipse-function-valid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-functions/ellipse-function-valid.html:

Canonical link: <a href="https://commits.webkit.org/310644@main">https://commits.webkit.org/310644@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/755a2c97775728172cbd64cc2b735a116b8fc30c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151997 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24779 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18417 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160740 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105454 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/449b38b7-6cea-4328-b588-a2295399f998) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25271 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25084 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117410 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83282 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/81efc24e-d0cc-4bdd-86df-756028cfa828) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154957 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19582 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136465 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98125 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/adf1058b-21c2-467e-bf02-4abe428d10cf) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18664 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16605 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8574 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128297 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14355 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163204 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15947 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125432 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24577 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20662 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125609 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34658 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24578 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136151 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81160 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20625 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12927 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24195 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23886 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24046 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23947 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->