### PR TITLE
[grid-lanes] Improve responsiveness of CSS Grid Lanes demos on mobile

### DIFF
--- a/Websites/webkit.org/demos/grid3/home/toc.css
+++ b/Websites/webkit.org/demos/grid3/home/toc.css
@@ -26,7 +26,7 @@
   }
   @media (max-width: 700px) {
     ul {
-      grid-template-columns: minmax(250px, 400px);
+      grid-template-columns: minmax(200px, 400px);
     }
   }
   li {
@@ -44,5 +44,19 @@
   }
   footer p {
     margin-block: 0;
+  }
+}
+@media (max-width: 500px) {
+  .toc {
+    margin: 1.5rem;
+    h1 {
+      font-size: 1.5rem;
+    }
+    ul {
+      grid-template-columns: repeat(2, 1fr);
+    }
+    p {
+      font-size: 0.9rem;
+    }
   }
 }

--- a/Websites/webkit.org/demos/grid3/megamenu/styles.css
+++ b/Websites/webkit.org/demos/grid3/megamenu/styles.css
@@ -46,6 +46,11 @@ nav section {
 main {
     padding-inline: calc(10vw + 1rem);
 }
+@media (max-width: 500px) {
+    main {
+        padding-inline: calc(2vw + 0.5rem);
+    }
+}
 
 /* --------------------------------------------
    Variations on the layout
@@ -61,6 +66,11 @@ body:has(option[value="one"]:checked) main nav {
         margin-trim: block;
     }
 }
+@media (max-width: 500px) {
+    body:has(option[value="one"]:checked) main nav {
+        columns: 2;
+    }
+}
 
 /* ---- CSS Grid level 1 (without Masonry) ---- */
 body:has(option[value="two"]:checked) main nav {
@@ -68,7 +78,12 @@ body:has(option[value="two"]:checked) main nav {
     grid-template-columns: repeat(auto-fill, minmax(24ch, 1fr));
     grid-template-rows: none; /* default value */
     column-gap: 1rem;
-    justify-content: center; 
+    justify-content: center;
+}
+@media (max-width: 500px) {
+    body:has(option[value="two"]:checked) main nav {
+        grid-template-columns: repeat(2, 1fr);
+    }
 }
 
 /* ---- Classic Masonry layout ---- */
@@ -76,7 +91,12 @@ body:has(option[value="three"]:checked) main nav {
     display: grid-lanes;
     grid-template-columns: repeat(auto-fill, minmax(24ch, 1fr));
     column-gap: 2lh;
-    justify-content: center; 
+    justify-content: center;
+}
+@media (max-width: 500px) {
+    body:has(option[value="three"]:checked) main nav {
+        grid-template-columns: repeat(2, 1fr);
+    }
 }
 
 /* ---- Max-content sized columns ---- */
@@ -84,7 +104,13 @@ body:has(option[value="four"]:checked) main nav {
     display: grid-lanes;
     grid-template-columns: repeat(auto-fill, minmax(max-content, 24ch));
     column-gap: 4lh;
-    justify-content: center; 
+    justify-content: center;
+}
+@media (max-width: 500px) {
+    body:has(option[value="four"]:checked) main nav {
+        grid-template-columns: repeat(2, 1fr);
+        column-gap: 2lh;
+    }
 }
 
 /* --------------------------------------------

--- a/Websites/webkit.org/demos/grid3/museum/styles.css
+++ b/Websites/webkit.org/demos/grid3/museum/styles.css
@@ -131,15 +131,16 @@ body:has(option[value="two"]:checked) main { /* before applying masonry */
 body:has(option[value="twoandahalf"]:checked) main { /* before applying masonry */
   display: grid-lanes;
   grid-template-columns: repeat(auto-fill, minmax(24ch, 1fr));
-}
-
-/* ---- With item placement ---- */
-
-body:has(option[value="twoandahalf"]:checked) main { /* before applying masonry */
-  display: grid-lanes;
-  grid-template-columns: repeat(auto-fill, minmax(24ch, 1fr));
   header {
     grid-column: -2 / -1; /* one columns wide */
+  }
+}
+@media (max-width: 500px) {
+  body:has(option[value="twoandahalf"]:checked) main {
+    grid-template-columns: repeat(2, 1fr);
+    header {
+      grid-column: 1 / -1;
+    }
   }
 }
 @media (width > 1200px) {

--- a/Websites/webkit.org/demos/grid3/newspaper/styles.css
+++ b/Websites/webkit.org/demos/grid3/newspaper/styles.css
@@ -57,6 +57,14 @@ main {
 .interface {
   padding-inline: calc(4vw + 1rem);
 }
+@media (max-width: 500px) {
+  main {
+    padding-inline: calc(2vw + 0.5rem);
+  }
+  .interface {
+    padding-inline: calc(2vw + 0.5rem);
+  }
+}
 
 /* --------------------------------------------
    Variations on the layout
@@ -134,16 +142,31 @@ body:has(option[value="four"]:checked) main {
     }
   }
   @media (500px < width < 1002px) {
-    article:nth-child(1) { 
-      grid-column: span 2; 
-      h3 { 
-        font-size: 2.1rem; 
+    article:nth-child(1) {
+      grid-column: span 2;
+      h3 {
+        font-size: 2.1rem;
         line-height: 1.2;
-      } 
-      p { 
+      }
+      p {
         display: block;
       }
-    }  
+    }
+  }
+  @media (max-width: 500px) {
+    article {
+      grid-column: span 1;
+    }
+    article:nth-child(1) {
+      grid-column: span 1;
+      h3 {
+        font-size: 1.6rem;
+        line-height: 1.2;
+      }
+      p {
+        display: block;
+      }
+    }
   }
   @media (1001px < width < 1253px) {
     article:nth-child(1) { 

--- a/Websites/webkit.org/demos/grid3/photos/styles.css
+++ b/Websites/webkit.org/demos/grid3/photos/styles.css
@@ -34,12 +34,22 @@ body:has(option[value="two"]:checked) main { /* before applying masonry */
     grid-template-rows: auto;
     gap: 1rem;
 }
+@media (max-width: 500px) {
+    body:has(option[value="two"]:checked) main {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
 
 /* ---- Classic Masonry layout ---- */
 body:has(option[value="three"]:checked) main {
     display: grid-lanes;
     grid-template-columns: repeat(auto-fill, minmax(14rem, 1fr));
     gap: 1rem;
+}
+@media (max-width: 500px) {
+    body:has(option[value="three"]:checked) main {
+        grid-template-columns: repeat(2, 1fr);
+    }
 }
 
 /* ---- First & last columns fixed size ---- */
@@ -48,6 +58,11 @@ body:has(option[value="four"]:checked) main {
     grid-template-columns: 14ch repeat(auto-fill, minmax(28ch, 1fr)) 14ch;
     gap: 1rem;
 }
+@media (max-width: 500px) {
+    body:has(option[value="four"]:checked) main {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
 
 /* ---- Alternating narrow & wide column ---- */
 body:has(option[value="five"]:checked) main {
@@ -55,12 +70,22 @@ body:has(option[value="five"]:checked) main {
     grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr) minmax(14rem, 2fr)) minmax(8rem, 1fr);
     gap: 1rem;
 }
+@media (max-width: 500px) {
+    body:has(option[value="five"]:checked) main {
+        grid-template-columns: 1fr 2fr;
+    }
+}
 
 /* ---- Fibonacci sequence ---- */
 body:has(option[value="ten"]:checked) main {
     display: grid-lanes;
     grid-template-columns: 1fr 1fr 2fr 3fr 5fr 8fr;
     gap: 1rem;
+}
+@media (max-width: 500px) {
+    body:has(option[value="ten"]:checked) main {
+        grid-template-columns: 1fr 1fr 2fr;
+    }
 }
 
 /* ---- Every 5th item is wider ---- */
@@ -70,6 +95,11 @@ body:has(option[value="six"]:checked) main {
     gap: 1rem;
     .card:nth-child(5n) {
         grid-column: span 2;
+    }
+}
+@media (max-width: 500px) {
+    body:has(option[value="six"]:checked) main {
+        grid-template-columns: repeat(2, 1fr);
     }
 }
 
@@ -86,6 +116,11 @@ body:has(option[value="seven"]:checked) main {
     }
     img {
         border-radius: 0;
+    }
+}
+@media (max-width: 500px) {
+    body:has(option[value="seven"]:checked) main {
+        grid-template-columns: repeat(2, 1fr);
     }
 }
 
@@ -113,7 +148,7 @@ body:has(option[value="eight"]:checked) {
             overflow: hidden;
         }
         @media (prefers-reduced-motion) {
-            /* There should be mitigation here. 
+            /* There should be mitigation here.
             Make the animation 0 seconds
             Once we figure out where to define the animation */
         }
@@ -122,6 +157,14 @@ body:has(option[value="eight"]:checked) {
         }
         img {
             border-radius: 0;
+        }
+    }
+}
+@media (max-width: 500px) {
+    body:has(option[value="eight"]:checked) main {
+        grid-template-columns: repeat(2, 1fr);
+        .expanded {
+            grid-column: 1 / -1;
         }
     }
 }
@@ -137,6 +180,16 @@ body:has(option[value="nine"]:checked) {
     img {
         width: auto;
         height: 150px;
+    }
+}
+@media (max-width: 500px) {
+    body:has(option[value="nine"]:checked) {
+        main {
+            grid-template-rows: repeat(5, 100px);
+        }
+        img {
+            height: 100px;
+        }
     }
 }
 

--- a/Websites/webkit.org/demos/grid3/universal.css
+++ b/Websites/webkit.org/demos/grid3/universal.css
@@ -118,6 +118,37 @@ button.hide-controls {
   grid-area: 4 / 1;
   place-self: start;
 }
+@media (max-width: 600px) {
+  aside.interface {
+    grid-template-columns: 1fr;
+    gap: 0.75lh;
+  }
+  nav {
+    grid-area: auto;
+    line-height: 1.8;
+  }
+  section.layout-switcher {
+    grid-area: auto;
+    select {
+      max-width: 100%;
+    }
+  }
+  section.number-toggle {
+    grid-area: auto;
+  }
+  section.show-code {
+    grid-area: auto;
+    grid-row: span 1;
+    padding: 0.5rem 1rem;
+    pre {
+      width: auto;
+      font-size: 90%;
+    }
+  }
+  button.hide-controls {
+    grid-area: auto;
+  }
+}
 label {
   display: inline-block;
 }


### PR DESCRIPTION
#### 7fce753c54592224c90f1faddfbb402b2b022fa9
<pre>
[grid-lanes] Improve responsiveness of CSS Grid Lanes demos on mobile
<a href="https://bugs.webkit.org/show_bug.cgi?id=310668">https://bugs.webkit.org/show_bug.cgi?id=310668</a>
<a href="https://rdar.apple.com/173274959">rdar://173274959</a>

Reviewed by Sammy Gill.

The grid3 demos had several issues on narrow viewports (iPhone portrait):
the control bar overflowed horizontally due to its two-column grid layout,
and many demo layouts produced a single squished column or overflowed
the page because their minmax() minimums exceeded the available width.

* Websites/webkit.org/demos/grid3/universal.css:
  Add mobile breakpoint that collapses the aside.interface to a
  single-column flow layout, preventing the nav and code panel overflow.
* Websites/webkit.org/demos/grid3/home/toc.css:
  Reduce margin and use a 2-column grid on small screens.
* Websites/webkit.org/demos/grid3/photos/styles.css:
  Add mobile breakpoints for all layout variations to ensure at least
  2 columns, keeping span 2 items full-width where applicable.
* Websites/webkit.org/demos/grid3/megamenu/styles.css:
  Reduce padding and force 2-column layout on mobile for all variations.
* Websites/webkit.org/demos/grid3/newspaper/styles.css:
  Reduce padding and add mobile breakpoint for the &quot;various sizes&quot; layout.
* Websites/webkit.org/demos/grid3/museum/styles.css:
  Add mobile breakpoint with header spanning full width; remove duplicate
  twoandahalf rule block.

Canonical link: <a href="https://commits.webkit.org/310000@main">https://commits.webkit.org/310000@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb11bf00a305c20f03f3351ef671082e04c22660

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152010 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24792 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18410 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160753 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105467 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c22b1512-0a40-49ba-a3fe-c3c42c353e19) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25284 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25097 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117418 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83285 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/67c125e4-a359-434e-95fb-49ccdb360477) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154970 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19592 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136458 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98133 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f9af291e-ec25-4b4a-8d1d-a02dbedba678) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18673 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16618 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8587 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128308 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163217 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15941 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125441 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24590 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20673 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125618 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24591 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136145 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81173 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23365 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20632 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12921 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24208 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23899 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24059 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23960 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->