### PR TITLE
Introduce enum formats where applicable for <model> serialization

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift
@@ -36,14 +36,14 @@ import WebKit
 @objc
 @implementation
 extension WKBridgeVertexAttributeFormat {
-    let semantic: Int
-    let format: UInt
+    let semantic: WKBridgeVertexSemantic
+    let format: MTLVertexFormat
     let layoutIndex: Int
     let offset: Int
 
     init(
-        semantic: Int,
-        format: UInt,
+        semantic: WKBridgeVertexSemantic,
+        format: MTLVertexFormat,
         layoutIndex: Int,
         offset: Int
     ) {
@@ -558,22 +558,22 @@ private func toDataArray<T>(_ input: [[T]]) -> [Data] {
     input.map { toData($0) }
 }
 
-private func convertSemantic(_ semantic: LowLevelMesh.VertexSemantic) -> Int {
+private func convertSemantic(_ semantic: LowLevelMesh.VertexSemantic) -> WKBridgeVertexSemantic {
     switch semantic {
-    case .position: 0
-    case .color: 1
-    case .normal: 2
-    case .tangent: 3
-    case .bitangent: 4
-    case .uv0: 5
-    case .uv1: 6
-    case .uv2: 7
-    case .uv3: 8
-    case .uv4: 9
-    case .uv5: 10
-    case .uv6: 11
-    case .uv7: 12
-    default: 13
+    case .position: .position
+    case .color: .color
+    case .normal: .normal
+    case .tangent: .tangent
+    case .bitangent: .bitangent
+    case .uv0: .UV0
+    case .uv1: .UV1
+    case .uv2: .UV2
+    case .uv3: .UV3
+    case .uv4: .UV4
+    case .uv5: .UV5
+    case .uv6: .UV6
+    case .uv7: .UV7
+    default: .unspecified
     }
 }
 
@@ -581,7 +581,7 @@ private func webAttributesFromAttributes(_ attributes: [LowLevelMesh.Attribute])
     attributes.map({ a in
         WKBridgeVertexAttributeFormat(
             semantic: convertSemantic(a.semantic),
-            format: a.format.rawValue,
+            format: a.format,
             layoutIndex: a.layoutIndex,
             offset: a.offset
         )

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h
@@ -27,6 +27,11 @@
 #include <wtf/Platform.h>
 
 #ifdef __cplusplus
+#include <WebCore/WebGPUPrimitiveTopology.h>
+#include <WebCore/WebGPUTextureFormat.h>
+#include <WebCore/WebGPUTextureUsage.h>
+#include <WebCore/WebGPUTextureViewDimension.h>
+#include <WebCore/WebGPUVertexFormat.h>
 #include <WebKit/Float3.h>
 #include <WebKit/Float4x4.h>
 #include <wtf/ExportMacros.h>
@@ -51,16 +56,33 @@ typedef NS_ENUM(uint8_t, WKBridgeDataUpdateType) {
     WKBridgeDataUpdateTypeDelta
 };
 
+typedef NS_ENUM(uint8_t, WKBridgeVertexSemantic) {
+    WKBridgeVertexSemanticPosition,
+    WKBridgeVertexSemanticColor,
+    WKBridgeVertexSemanticNormal,
+    WKBridgeVertexSemanticTangent,
+    WKBridgeVertexSemanticBitangent,
+    WKBridgeVertexSemanticUV0,
+    WKBridgeVertexSemanticUV1,
+    WKBridgeVertexSemanticUV2,
+    WKBridgeVertexSemanticUV3,
+    WKBridgeVertexSemanticUV4,
+    WKBridgeVertexSemanticUV5,
+    WKBridgeVertexSemanticUV6,
+    WKBridgeVertexSemanticUV7,
+    WKBridgeVertexSemanticUnspecified,
+};
+
 @interface WKBridgeVertexAttributeFormat : NSObject
 
-@property (nonatomic, readonly) long semantic;
-@property (nonatomic, readonly) unsigned long format;
+@property (nonatomic, readonly) WKBridgeVertexSemantic semantic;
+@property (nonatomic, readonly) MTLVertexFormat format;
 @property (nonatomic, readonly) long layoutIndex;
 @property (nonatomic, readonly) long offset;
 
 - (instancetype)init NS_UNAVAILABLE;
 
-- (instancetype)initWithSemantic:(long)semantic format:(unsigned long)format layoutIndex:(long)layoutIndex offset:(long)offset NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithSemantic:(WKBridgeVertexSemantic)semantic format:(MTLVertexFormat)format layoutIndex:(long)layoutIndex offset:(long)offset NS_DESIGNATED_INITIALIZER;
 
 @end
 
@@ -474,11 +496,11 @@ struct ImageAsset {
     long height { 0 };
     long depth { 0 };
     long bytesPerPixel { 0 };
-    uint64_t textureType { 0 };
-    uint64_t pixelFormat { 0 };
+    WebCore::WebGPU::TextureViewDimension textureType { WebCore::WebGPU::TextureViewDimension::_2d };
+    WebCore::WebGPU::TextureFormat pixelFormat { WebCore::WebGPU::TextureFormat::R8unorm };
     long mipmapLevelCount { 0 };
     long arrayLength { 0 };
-    uint64_t textureUsage { 0 };
+    WebCore::WebGPU::TextureUsageFlags textureUsage { };
     ImageAssetSwizzle swizzle { };
 };
 
@@ -491,17 +513,39 @@ struct VertexLayout {
 struct MeshPart {
     uint32_t indexOffset;
     uint32_t indexCount;
-    uint32_t topology;
+    WebCore::WebGPU::PrimitiveTopology topology;
     uint32_t materialIndex;
     Float3 boundsMin;
     Float3 boundsMax;
 };
 
+enum class VertexSemantic : uint8_t {
+    Position,
+    Color,
+    Normal,
+    Tangent,
+    Bitangent,
+    UV0, // NOLINT
+    UV1, // NOLINT
+    UV2, // NOLINT
+    UV3, // NOLINT
+    UV4, // NOLINT
+    UV5, // NOLINT
+    UV6, // NOLINT
+    UV7, // NOLINT
+    Unspecified,
+};
+
 struct VertexAttributeFormat {
-    long semantic;
-    unsigned long format;
+    VertexSemantic semantic;
+    WebCore::WebGPU::VertexFormat format;
     long layoutIndex;
     long offset;
+};
+
+enum class IndexType : uint8_t {
+    UInt16,
+    UInt32,
 };
 
 struct MeshDescriptor {
@@ -510,7 +554,7 @@ struct MeshDescriptor {
     Vector<VertexAttributeFormat> vertexAttributes;
     Vector<VertexLayout> vertexLayouts;
     long indexCapacity;
-    long indexType;
+    IndexType indexType;
 };
 
 struct Edge {

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelUtils.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelUtils.swift
@@ -157,23 +157,23 @@ extension _Proto_LowLevelTextureResource_v1.Descriptor {
     }
 }
 
-private func mapSemantic(_ semantic: Int) -> _Proto_LowLevelMeshResource_v1.VertexSemantic {
+private func mapSemantic(_ semantic: WKBridgeVertexSemantic) -> _Proto_LowLevelMeshResource_v1.VertexSemantic {
     switch semantic {
-    case 0: .position
-    case 1: .color
-    case 2: .normal
-    case 3: .tangent
-    case 4: .bitangent
-    case 5: .uv0
-    case 6: .uv1
-    case 7: .uv2
-    case 8: .uv3
-    case 9: .uv4
-    case 10: .uv5
-    case 11: .uv6
-    case 12: .uv7
-    case 13: .unspecified
-    default: .unspecified
+    case .position: .position
+    case .color: .color
+    case .normal: .normal
+    case .tangent: .tangent
+    case .bitangent: .bitangent
+    case .UV0: .uv0
+    case .UV1: .uv1
+    case .UV2: .uv2
+    case .UV3: .uv3
+    case .UV4: .uv4
+    case .UV5: .uv5
+    case .UV6: .uv6
+    case .UV7: .uv7
+    case .unspecified: .unspecified
+    @unknown default: .unspecified
     }
 }
 
@@ -184,7 +184,7 @@ extension _Proto_LowLevelMeshResource_v1.Descriptor {
         descriptor.vertexAttributes = llmDescriptor.vertexAttributes.map { attribute in
             .init(
                 semantic: mapSemantic(attribute.semantic),
-                format: MTLVertexFormat(rawValue: UInt(attribute.format)) ?? .invalid,
+                format: attribute.format,
                 layoutIndex: attribute.layoutIndex,
                 offset: attribute.offset
             )

--- a/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm
+++ b/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm
@@ -42,6 +42,397 @@ namespace WebModel {
 
 #if ENABLE(GPU_PROCESS_MODEL)
 
+// Helper conversion functions from WebGPU types to Metal types
+static WKBridgeVertexSemantic toMetal(VertexSemantic semantic)
+{
+    switch (semantic) {
+    case VertexSemantic::Position:
+        return WKBridgeVertexSemanticPosition;
+    case VertexSemantic::Color:
+        return WKBridgeVertexSemanticColor;
+    case VertexSemantic::Normal:
+        return WKBridgeVertexSemanticNormal;
+    case VertexSemantic::Tangent:
+        return WKBridgeVertexSemanticTangent;
+    case VertexSemantic::Bitangent:
+        return WKBridgeVertexSemanticBitangent;
+    case VertexSemantic::UV0:
+        return WKBridgeVertexSemanticUV0;
+    case VertexSemantic::UV1:
+        return WKBridgeVertexSemanticUV1;
+    case VertexSemantic::UV2:
+        return WKBridgeVertexSemanticUV2;
+    case VertexSemantic::UV3:
+        return WKBridgeVertexSemanticUV3;
+    case VertexSemantic::UV4:
+        return WKBridgeVertexSemanticUV4;
+    case VertexSemantic::UV5:
+        return WKBridgeVertexSemanticUV5;
+    case VertexSemantic::UV6:
+        return WKBridgeVertexSemanticUV6;
+    case VertexSemantic::UV7:
+        return WKBridgeVertexSemanticUV7;
+    case VertexSemantic::Unspecified:
+        return WKBridgeVertexSemanticUnspecified;
+    }
+}
+
+static MTLVertexFormat toMetal(WebCore::WebGPU::VertexFormat format)
+{
+    switch (format) {
+    case WebCore::WebGPU::VertexFormat::Uint8:
+        return MTLVertexFormatUChar;
+    case WebCore::WebGPU::VertexFormat::Uint8x2:
+        return MTLVertexFormatUChar2;
+    case WebCore::WebGPU::VertexFormat::Uint8x4:
+        return MTLVertexFormatUChar4;
+    case WebCore::WebGPU::VertexFormat::Sint8:
+        return MTLVertexFormatChar;
+    case WebCore::WebGPU::VertexFormat::Sint8x2:
+        return MTLVertexFormatChar2;
+    case WebCore::WebGPU::VertexFormat::Sint8x4:
+        return MTLVertexFormatChar4;
+    case WebCore::WebGPU::VertexFormat::Unorm8:
+        return MTLVertexFormatUCharNormalized;
+    case WebCore::WebGPU::VertexFormat::Unorm8x2:
+        return MTLVertexFormatUChar2Normalized;
+    case WebCore::WebGPU::VertexFormat::Unorm8x4:
+        return MTLVertexFormatUChar4Normalized;
+    case WebCore::WebGPU::VertexFormat::Snorm8:
+        return MTLVertexFormatCharNormalized;
+    case WebCore::WebGPU::VertexFormat::Snorm8x2:
+        return MTLVertexFormatChar2Normalized;
+    case WebCore::WebGPU::VertexFormat::Snorm8x4:
+        return MTLVertexFormatChar4Normalized;
+    case WebCore::WebGPU::VertexFormat::Uint16:
+        return MTLVertexFormatUShort;
+    case WebCore::WebGPU::VertexFormat::Uint16x2:
+        return MTLVertexFormatUShort2;
+    case WebCore::WebGPU::VertexFormat::Uint16x4:
+        return MTLVertexFormatUShort4;
+    case WebCore::WebGPU::VertexFormat::Sint16:
+        return MTLVertexFormatShort;
+    case WebCore::WebGPU::VertexFormat::Sint16x2:
+        return MTLVertexFormatShort2;
+    case WebCore::WebGPU::VertexFormat::Sint16x4:
+        return MTLVertexFormatShort4;
+    case WebCore::WebGPU::VertexFormat::Unorm16:
+        return MTLVertexFormatUShortNormalized;
+    case WebCore::WebGPU::VertexFormat::Unorm16x2:
+        return MTLVertexFormatUShort2Normalized;
+    case WebCore::WebGPU::VertexFormat::Unorm16x4:
+        return MTLVertexFormatUShort4Normalized;
+    case WebCore::WebGPU::VertexFormat::Snorm16:
+        return MTLVertexFormatShortNormalized;
+    case WebCore::WebGPU::VertexFormat::Snorm16x2:
+        return MTLVertexFormatShort2Normalized;
+    case WebCore::WebGPU::VertexFormat::Snorm16x4:
+        return MTLVertexFormatShort4Normalized;
+    case WebCore::WebGPU::VertexFormat::Float16:
+        return MTLVertexFormatHalf;
+    case WebCore::WebGPU::VertexFormat::Float16x2:
+        return MTLVertexFormatHalf2;
+    case WebCore::WebGPU::VertexFormat::Float16x4:
+        return MTLVertexFormatHalf4;
+    case WebCore::WebGPU::VertexFormat::Float32:
+        return MTLVertexFormatFloat;
+    case WebCore::WebGPU::VertexFormat::Float32x2:
+        return MTLVertexFormatFloat2;
+    case WebCore::WebGPU::VertexFormat::Float32x3:
+        return MTLVertexFormatFloat3;
+    case WebCore::WebGPU::VertexFormat::Float32x4:
+        return MTLVertexFormatFloat4;
+    case WebCore::WebGPU::VertexFormat::Uint32:
+        return MTLVertexFormatUInt;
+    case WebCore::WebGPU::VertexFormat::Uint32x2:
+        return MTLVertexFormatUInt2;
+    case WebCore::WebGPU::VertexFormat::Uint32x3:
+        return MTLVertexFormatUInt3;
+    case WebCore::WebGPU::VertexFormat::Uint32x4:
+        return MTLVertexFormatUInt4;
+    case WebCore::WebGPU::VertexFormat::Sint32:
+        return MTLVertexFormatInt;
+    case WebCore::WebGPU::VertexFormat::Sint32x2:
+        return MTLVertexFormatInt2;
+    case WebCore::WebGPU::VertexFormat::Sint32x3:
+        return MTLVertexFormatInt3;
+    case WebCore::WebGPU::VertexFormat::Sint32x4:
+        return MTLVertexFormatInt4;
+    case WebCore::WebGPU::VertexFormat::Unorm1010102:
+        return MTLVertexFormatUInt1010102Normalized;
+    case WebCore::WebGPU::VertexFormat::Unorm8x4Bgra:
+        return MTLVertexFormatUChar4Normalized_BGRA;
+    }
+}
+
+static MTLTextureType toMetal(WebCore::WebGPU::TextureViewDimension dimension)
+{
+    switch (dimension) {
+    case WebCore::WebGPU::TextureViewDimension::_1d:
+        return MTLTextureType1D;
+    case WebCore::WebGPU::TextureViewDimension::_2d:
+        return MTLTextureType2D;
+    case WebCore::WebGPU::TextureViewDimension::_2dArray:
+        return MTLTextureType2DArray;
+    case WebCore::WebGPU::TextureViewDimension::Cube:
+        return MTLTextureTypeCube;
+    case WebCore::WebGPU::TextureViewDimension::CubeArray:
+        return MTLTextureTypeCubeArray;
+    case WebCore::WebGPU::TextureViewDimension::_3d:
+        return MTLTextureType3D;
+    }
+}
+
+static MTLTextureUsage toMetal(WebCore::WebGPU::TextureUsageFlags flags)
+{
+    MTLTextureUsage usage = 0;
+
+    if (flags.contains(WebCore::WebGPU::TextureUsage::TextureBinding))
+        usage |= MTLTextureUsageShaderRead;
+    if (flags.contains(WebCore::WebGPU::TextureUsage::StorageBinding))
+        usage |= MTLTextureUsageShaderWrite;
+    if (flags.contains(WebCore::WebGPU::TextureUsage::RenderAttachment))
+        usage |= MTLTextureUsageRenderTarget;
+    if (flags.contains(WebCore::WebGPU::TextureUsage::CopySource) || flags.contains(WebCore::WebGPU::TextureUsage::CopyDestination))
+        usage |= MTLTextureUsagePixelFormatView;
+
+    return usage;
+}
+
+static MTLPrimitiveType toMetal(WebCore::WebGPU::PrimitiveTopology topology)
+{
+    switch (topology) {
+    case WebCore::WebGPU::PrimitiveTopology::PointList:
+        return MTLPrimitiveTypePoint;
+    case WebCore::WebGPU::PrimitiveTopology::LineList:
+        return MTLPrimitiveTypeLine;
+    case WebCore::WebGPU::PrimitiveTopology::LineStrip:
+        return MTLPrimitiveTypeLineStrip;
+    case WebCore::WebGPU::PrimitiveTopology::TriangleList:
+        return MTLPrimitiveTypeTriangle;
+    case WebCore::WebGPU::PrimitiveTopology::TriangleStrip:
+        return MTLPrimitiveTypeTriangleStrip;
+    }
+}
+
+static MTLIndexType toMetal(WebModel::IndexType indexType)
+{
+    switch (indexType) {
+    case WebModel::IndexType::UInt16:
+        return MTLIndexTypeUInt16;
+    case WebModel::IndexType::UInt32:
+        return MTLIndexTypeUInt32;
+    }
+}
+
+static MTLPixelFormat toMetal(WebCore::WebGPU::TextureFormat textureFormat)
+{
+    switch (textureFormat) {
+    case WebCore::WebGPU::TextureFormat::R8unorm:
+        return MTLPixelFormatR8Unorm;
+    case WebCore::WebGPU::TextureFormat::R8snorm:
+        return MTLPixelFormatR8Snorm;
+    case WebCore::WebGPU::TextureFormat::R8uint:
+        return MTLPixelFormatR8Uint;
+    case WebCore::WebGPU::TextureFormat::R8sint:
+        return MTLPixelFormatR8Sint;
+    case WebCore::WebGPU::TextureFormat::R16unorm:
+        return MTLPixelFormatR16Unorm;
+    case WebCore::WebGPU::TextureFormat::R16snorm:
+        return MTLPixelFormatR16Snorm;
+    case WebCore::WebGPU::TextureFormat::R16uint:
+        return MTLPixelFormatR16Uint;
+    case WebCore::WebGPU::TextureFormat::R16sint:
+        return MTLPixelFormatR16Sint;
+    case WebCore::WebGPU::TextureFormat::R16float:
+        return MTLPixelFormatR16Float;
+    case WebCore::WebGPU::TextureFormat::Rg8unorm:
+        return MTLPixelFormatRG8Unorm;
+    case WebCore::WebGPU::TextureFormat::Rg8snorm:
+        return MTLPixelFormatRG8Snorm;
+    case WebCore::WebGPU::TextureFormat::Rg8uint:
+        return MTLPixelFormatRG8Uint;
+    case WebCore::WebGPU::TextureFormat::Rg8sint:
+        return MTLPixelFormatRG8Sint;
+    case WebCore::WebGPU::TextureFormat::R32float:
+        return MTLPixelFormatR32Float;
+    case WebCore::WebGPU::TextureFormat::R32uint:
+        return MTLPixelFormatR32Uint;
+    case WebCore::WebGPU::TextureFormat::R32sint:
+        return MTLPixelFormatR32Sint;
+    case WebCore::WebGPU::TextureFormat::Rg16unorm:
+        return MTLPixelFormatRG16Unorm;
+    case WebCore::WebGPU::TextureFormat::Rg16snorm:
+        return MTLPixelFormatRG16Snorm;
+    case WebCore::WebGPU::TextureFormat::Rg16uint:
+        return MTLPixelFormatRG16Uint;
+    case WebCore::WebGPU::TextureFormat::Rg16sint:
+        return MTLPixelFormatRG16Sint;
+    case WebCore::WebGPU::TextureFormat::Rg16float:
+        return MTLPixelFormatRG16Float;
+    case WebCore::WebGPU::TextureFormat::Rgba8unorm:
+        return MTLPixelFormatRGBA8Unorm;
+    case WebCore::WebGPU::TextureFormat::Rgba8unormSRGB:
+        return MTLPixelFormatRGBA8Unorm_sRGB;
+    case WebCore::WebGPU::TextureFormat::Rgba8snorm:
+        return MTLPixelFormatRGBA8Snorm;
+    case WebCore::WebGPU::TextureFormat::Rgba8uint:
+        return MTLPixelFormatRGBA8Uint;
+    case WebCore::WebGPU::TextureFormat::Rgba8sint:
+        return MTLPixelFormatRGBA8Sint;
+    case WebCore::WebGPU::TextureFormat::Bgra8unorm:
+        return MTLPixelFormatBGRA8Unorm;
+    case WebCore::WebGPU::TextureFormat::Bgra8unormSRGB:
+        return MTLPixelFormatBGRA8Unorm_sRGB;
+    case WebCore::WebGPU::TextureFormat::Rgb10a2unorm:
+        return MTLPixelFormatRGB10A2Unorm;
+    case WebCore::WebGPU::TextureFormat::Rg11b10ufloat:
+        return MTLPixelFormatRG11B10Float;
+    case WebCore::WebGPU::TextureFormat::Rgb9e5ufloat:
+        return MTLPixelFormatRGB9E5Float;
+    case WebCore::WebGPU::TextureFormat::Rgb10a2uint:
+        return MTLPixelFormatRGB10A2Uint;
+    case WebCore::WebGPU::TextureFormat::Rg32float:
+        return MTLPixelFormatRG32Float;
+    case WebCore::WebGPU::TextureFormat::Rg32uint:
+        return MTLPixelFormatRG32Uint;
+    case WebCore::WebGPU::TextureFormat::Rg32sint:
+        return MTLPixelFormatRG32Sint;
+    case WebCore::WebGPU::TextureFormat::Rgba16unorm:
+        return MTLPixelFormatRGBA16Unorm;
+    case WebCore::WebGPU::TextureFormat::Rgba16snorm:
+        return MTLPixelFormatRGBA16Snorm;
+    case WebCore::WebGPU::TextureFormat::Rgba16uint:
+        return MTLPixelFormatRGBA16Uint;
+    case WebCore::WebGPU::TextureFormat::Rgba16sint:
+        return MTLPixelFormatRGBA16Sint;
+    case WebCore::WebGPU::TextureFormat::Rgba16float:
+        return MTLPixelFormatRGBA16Float;
+    case WebCore::WebGPU::TextureFormat::Rgba32float:
+        return MTLPixelFormatRGBA32Float;
+    case WebCore::WebGPU::TextureFormat::Rgba32uint:
+        return MTLPixelFormatRGBA32Uint;
+    case WebCore::WebGPU::TextureFormat::Rgba32sint:
+        return MTLPixelFormatRGBA32Sint;
+    case WebCore::WebGPU::TextureFormat::Stencil8:
+        return MTLPixelFormatStencil8;
+    case WebCore::WebGPU::TextureFormat::Depth16unorm:
+        return MTLPixelFormatDepth16Unorm;
+    case WebCore::WebGPU::TextureFormat::Depth24plus:
+        return MTLPixelFormatDepth32Float;
+    case WebCore::WebGPU::TextureFormat::Depth24plusStencil8:
+        return MTLPixelFormatDepth32Float_Stencil8;
+    case WebCore::WebGPU::TextureFormat::Depth32float:
+        return MTLPixelFormatDepth32Float;
+    case WebCore::WebGPU::TextureFormat::Depth32floatStencil8:
+        return MTLPixelFormatDepth32Float_Stencil8;
+    case WebCore::WebGPU::TextureFormat::Bc1RgbaUnorm:
+        return MTLPixelFormatBC1_RGBA;
+    case WebCore::WebGPU::TextureFormat::Bc1RgbaUnormSRGB:
+        return MTLPixelFormatBC1_RGBA_sRGB;
+    case WebCore::WebGPU::TextureFormat::Bc2RgbaUnorm:
+        return MTLPixelFormatBC2_RGBA;
+    case WebCore::WebGPU::TextureFormat::Bc2RgbaUnormSRGB:
+        return MTLPixelFormatBC2_RGBA_sRGB;
+    case WebCore::WebGPU::TextureFormat::Bc3RgbaUnorm:
+        return MTLPixelFormatBC3_RGBA;
+    case WebCore::WebGPU::TextureFormat::Bc3RgbaUnormSRGB:
+        return MTLPixelFormatBC3_RGBA_sRGB;
+    case WebCore::WebGPU::TextureFormat::Bc4RUnorm:
+        return MTLPixelFormatBC4_RUnorm;
+    case WebCore::WebGPU::TextureFormat::Bc4RSnorm:
+        return MTLPixelFormatBC4_RSnorm;
+    case WebCore::WebGPU::TextureFormat::Bc5RgUnorm:
+        return MTLPixelFormatBC5_RGUnorm;
+    case WebCore::WebGPU::TextureFormat::Bc5RgSnorm:
+        return MTLPixelFormatBC5_RGSnorm;
+    case WebCore::WebGPU::TextureFormat::Bc6hRgbUfloat:
+        return MTLPixelFormatBC6H_RGBUfloat;
+    case WebCore::WebGPU::TextureFormat::Bc6hRgbFloat:
+        return MTLPixelFormatBC6H_RGBFloat;
+    case WebCore::WebGPU::TextureFormat::Bc7RgbaUnorm:
+        return MTLPixelFormatBC7_RGBAUnorm;
+    case WebCore::WebGPU::TextureFormat::Bc7RgbaUnormSRGB:
+        return MTLPixelFormatBC7_RGBAUnorm_sRGB;
+    case WebCore::WebGPU::TextureFormat::Etc2Rgb8unorm:
+        return MTLPixelFormatETC2_RGB8;
+    case WebCore::WebGPU::TextureFormat::Etc2Rgb8unormSRGB:
+        return MTLPixelFormatETC2_RGB8_sRGB;
+    case WebCore::WebGPU::TextureFormat::Etc2Rgb8a1unorm:
+        return MTLPixelFormatETC2_RGB8A1;
+    case WebCore::WebGPU::TextureFormat::Etc2Rgb8a1unormSRGB:
+        return MTLPixelFormatETC2_RGB8A1_sRGB;
+    case WebCore::WebGPU::TextureFormat::Etc2Rgba8unorm:
+        return MTLPixelFormatEAC_RGBA8;
+    case WebCore::WebGPU::TextureFormat::Etc2Rgba8unormSRGB:
+        return MTLPixelFormatEAC_RGBA8_sRGB;
+    case WebCore::WebGPU::TextureFormat::EacR11unorm:
+        return MTLPixelFormatEAC_R11Unorm;
+    case WebCore::WebGPU::TextureFormat::EacR11snorm:
+        return MTLPixelFormatEAC_R11Snorm;
+    case WebCore::WebGPU::TextureFormat::EacRg11unorm:
+        return MTLPixelFormatEAC_RG11Unorm;
+    case WebCore::WebGPU::TextureFormat::EacRg11snorm:
+        return MTLPixelFormatEAC_RG11Snorm;
+    case WebCore::WebGPU::TextureFormat::Astc4x4Unorm:
+        return MTLPixelFormatASTC_4x4_LDR;
+    case WebCore::WebGPU::TextureFormat::Astc4x4UnormSRGB:
+        return MTLPixelFormatASTC_4x4_sRGB;
+    case WebCore::WebGPU::TextureFormat::Astc5x4Unorm:
+        return MTLPixelFormatASTC_5x4_LDR;
+    case WebCore::WebGPU::TextureFormat::Astc5x4UnormSRGB:
+        return MTLPixelFormatASTC_5x4_sRGB;
+    case WebCore::WebGPU::TextureFormat::Astc5x5Unorm:
+        return MTLPixelFormatASTC_5x5_LDR;
+    case WebCore::WebGPU::TextureFormat::Astc5x5UnormSRGB:
+        return MTLPixelFormatASTC_5x5_sRGB;
+    case WebCore::WebGPU::TextureFormat::Astc6x5Unorm:
+        return MTLPixelFormatASTC_6x5_LDR;
+    case WebCore::WebGPU::TextureFormat::Astc6x5UnormSRGB:
+        return MTLPixelFormatASTC_6x5_sRGB;
+    case WebCore::WebGPU::TextureFormat::Astc6x6Unorm:
+        return MTLPixelFormatASTC_6x6_LDR;
+    case WebCore::WebGPU::TextureFormat::Astc6x6UnormSRGB:
+        return MTLPixelFormatASTC_6x6_sRGB;
+    case WebCore::WebGPU::TextureFormat::Astc8x5Unorm:
+        return MTLPixelFormatASTC_8x5_LDR;
+    case WebCore::WebGPU::TextureFormat::Astc8x5UnormSRGB:
+        return MTLPixelFormatASTC_8x5_sRGB;
+    case WebCore::WebGPU::TextureFormat::Astc8x6Unorm:
+        return MTLPixelFormatASTC_8x6_LDR;
+    case WebCore::WebGPU::TextureFormat::Astc8x6UnormSRGB:
+        return MTLPixelFormatASTC_8x6_sRGB;
+    case WebCore::WebGPU::TextureFormat::Astc8x8Unorm:
+        return MTLPixelFormatASTC_8x8_LDR;
+    case WebCore::WebGPU::TextureFormat::Astc8x8UnormSRGB:
+        return MTLPixelFormatASTC_8x8_sRGB;
+    case WebCore::WebGPU::TextureFormat::Astc10x5Unorm:
+        return MTLPixelFormatASTC_10x5_LDR;
+    case WebCore::WebGPU::TextureFormat::Astc10x5UnormSRGB:
+        return MTLPixelFormatASTC_10x5_sRGB;
+    case WebCore::WebGPU::TextureFormat::Astc10x6Unorm:
+        return MTLPixelFormatASTC_10x6_LDR;
+    case WebCore::WebGPU::TextureFormat::Astc10x6UnormSRGB:
+        return MTLPixelFormatASTC_10x6_sRGB;
+    case WebCore::WebGPU::TextureFormat::Astc10x8Unorm:
+        return MTLPixelFormatASTC_10x8_LDR;
+    case WebCore::WebGPU::TextureFormat::Astc10x8UnormSRGB:
+        return MTLPixelFormatASTC_10x8_sRGB;
+    case WebCore::WebGPU::TextureFormat::Astc10x10Unorm:
+        return MTLPixelFormatASTC_10x10_LDR;
+    case WebCore::WebGPU::TextureFormat::Astc10x10UnormSRGB:
+        return MTLPixelFormatASTC_10x10_sRGB;
+    case WebCore::WebGPU::TextureFormat::Astc12x10Unorm:
+        return MTLPixelFormatASTC_12x10_LDR;
+    case WebCore::WebGPU::TextureFormat::Astc12x10UnormSRGB:
+        return MTLPixelFormatASTC_12x10_sRGB;
+    case WebCore::WebGPU::TextureFormat::Astc12x12Unorm:
+        return MTLPixelFormatASTC_12x12_LDR;
+    case WebCore::WebGPU::TextureFormat::Astc12x12UnormSRGB:
+        return MTLPixelFormatASTC_12x12_sRGB;
+    }
+}
+
 static WKBridgeConstant convert(const Constant constant)
 {
     switch (constant) {
@@ -129,7 +520,7 @@ static WKBridgeConstant convert(const Constant constant)
 
 static WKBridgeMeshPart *convert(const MeshPart& part)
 {
-    return [WebKit::allocWKBridgeMeshPartInstance() initWithIndexOffset:part.indexOffset indexCount:part.indexCount topology:static_cast<MTLPrimitiveType>(part.topology) materialIndex:part.materialIndex boundsMin:part.boundsMin boundsMax:part.boundsMax];
+    return [WebKit::allocWKBridgeMeshPartInstance() initWithIndexOffset:part.indexOffset indexCount:part.indexCount topology:toMetal(part.topology) materialIndex:part.materialIndex boundsMin:part.boundsMin boundsMax:part.boundsMax];
 }
 
 static NSArray<WKBridgeMeshPart *> *convert(const Vector<MeshPart>& parts)
@@ -175,7 +566,7 @@ static NSArray<WKBridgeVertexAttributeFormat *> *convert(const Vector<VertexAttr
 
     NSMutableArray<WKBridgeVertexAttributeFormat *> *result = [NSMutableArray array];
     for (const auto& format : formats)
-        [result addObject:[WebKit::allocWKBridgeVertexAttributeFormatInstance() initWithSemantic:format.semantic format:format.format layoutIndex:format.layoutIndex offset:format.offset]];
+        [result addObject:[WebKit::allocWKBridgeVertexAttributeFormatInstance() initWithSemantic:toMetal(format.semantic) format:toMetal(format.format) layoutIndex:format.layoutIndex offset:format.offset]];
 
     return result;
 }
@@ -202,7 +593,7 @@ static WKBridgeMeshDescriptor *convert(const MeshDescriptor& descriptor)
         vertexAttributes:convert(descriptor.vertexAttributes)
         vertexLayouts:convert(descriptor.vertexLayouts)
         indexCapacity:descriptor.indexCapacity
-        indexType:static_cast<MTLIndexType>(descriptor.indexType)];
+        indexType:toMetal(descriptor.indexType)];
 }
 
 static NSArray<NSString *> *convert(const Vector<String>& v)
@@ -389,9 +780,8 @@ static uint32_t texelBlockSize(MTLPixelFormat format)
 
 static WKBridgeImageAsset* convert(const ImageAsset& imageAsset)
 {
-    MTLPixelFormat mtlPixelFormat = static_cast<MTLPixelFormat>(imageAsset.pixelFormat);
-
-    return [WebKit::allocWKBridgeImageAssetInstance() initWithData:convert(imageAsset.data) width:imageAsset.width height:imageAsset.height depth:imageAsset.depth bytesPerPixel:imageAsset.bytesPerPixel ?: texelBlockSize(mtlPixelFormat) textureType:static_cast<MTLTextureType>(imageAsset.textureType) pixelFormat:mtlPixelFormat mipmapLevelCount:imageAsset.mipmapLevelCount arrayLength:imageAsset.arrayLength textureUsage:static_cast<MTLTextureUsage>(imageAsset.textureUsage) swizzle:convert(imageAsset.swizzle)];
+    auto mtlPixelFormat = WebModel::toMetal(imageAsset.pixelFormat);
+    return [WebKit::allocWKBridgeImageAssetInstance() initWithData:convert(imageAsset.data) width:imageAsset.width height:imageAsset.height depth:imageAsset.depth bytesPerPixel:imageAsset.bytesPerPixel ?: texelBlockSize(mtlPixelFormat) textureType:toMetal(imageAsset.textureType) pixelFormat:mtlPixelFormat mipmapLevelCount:imageAsset.mipmapLevelCount arrayLength:imageAsset.arrayLength textureUsage:toMetal(imageAsset.textureUsage) swizzle:convert(imageAsset.swizzle)];
 }
 
 static WKBridgeDataType convert(DataType type)

--- a/Source/WebKit/Shared/Model.serialization.in
+++ b/Source/WebKit/Shared/Model.serialization.in
@@ -80,13 +80,19 @@ header: <WebKit/ModelTypes.h>
 };
 
 header: <WebKit/ModelTypes.h>
+[CustomHeader] enum class WebModel::IndexType : uint8_t {
+    UInt16,
+    UInt32,
+};
+
+header: <WebKit/ModelTypes.h>
 [AdditionalEncoder=StreamConnectionEncoder, CustomHeader] struct WebModel::MeshDescriptor {
     long vertexBufferCount;
     long vertexCapacity;
     Vector<WebModel::VertexAttributeFormat> vertexAttributes;
     Vector<WebModel::VertexLayout> vertexLayouts;
     long indexCapacity;
-    long indexType;
+    WebModel::IndexType indexType;
 };
 
 header: <WebKit/ModelTypes.h>
@@ -135,9 +141,27 @@ header: <WebKit/ModelTypes.h>
 };
 
 header: <WebKit/ModelTypes.h>
+[CustomHeader] enum class WebModel::VertexSemantic : uint8_t {
+    Position,
+    Color,
+    Normal,
+    Tangent,
+    Bitangent,
+    UV0,
+    UV1,
+    UV2,
+    UV3,
+    UV4,
+    UV5,
+    UV6,
+    UV7,
+    Unspecified,
+};
+
+header: <WebKit/ModelTypes.h>
 [AdditionalEncoder=StreamConnectionEncoder, CustomHeader] struct WebModel::VertexAttributeFormat {
-    long semantic;
-    unsigned long format;
+    WebModel::VertexSemantic semantic;
+    WebCore::WebGPU::VertexFormat format;
     long layoutIndex;
     long offset;
 };
@@ -164,11 +188,11 @@ header: <WebKit/ModelTypes.h>
     long height;
     long depth;
     long bytesPerPixel;
-    uint64_t textureType;
-    uint64_t pixelFormat;
+    WebCore::WebGPU::TextureViewDimension textureType;
+    WebCore::WebGPU::TextureFormat pixelFormat;
     long mipmapLevelCount;
     long arrayLength;
-    uint64_t textureUsage;
+    WebCore::WebGPU::TextureUsageFlags textureUsage;
     WebModel::ImageAssetSwizzle swizzle;
 };
 
@@ -176,7 +200,7 @@ header: <WebKit/ModelTypes.h>
 [AdditionalEncoder=StreamConnectionEncoder, CustomHeader] struct WebModel::MeshPart {
     uint32_t indexOffset;
     uint32_t indexCount;
-    uint32_t topology;
+    WebCore::WebGPU::PrimitiveTopology topology;
     uint32_t materialIndex;
     WebModel::Float3 boundsMin;
     WebModel::Float3 boundsMax;

--- a/Source/WebKit/WebProcess/Model/ModelInlineConverters.h
+++ b/Source/WebKit/WebProcess/Model/ModelInlineConverters.h
@@ -29,16 +29,405 @@
 
 #include "ModelTypes.h"
 #include <ImageIO/CGImageSource.h>
+#include <Metal/Metal.h>
 #include <wtf/cf/VectorCF.h>
 #include <wtf/cocoa/VectorCocoa.h>
 
 namespace WebKit {
 
+// Helper conversion functions from Metal types to WebGPU types
+static WebModel::VertexSemantic toVertexSemantic(WKBridgeVertexSemantic semantic)
+{
+    switch (semantic) {
+    case WKBridgeVertexSemanticPosition:
+        return WebModel::VertexSemantic::Position;
+    case WKBridgeVertexSemanticColor:
+        return WebModel::VertexSemantic::Color;
+    case WKBridgeVertexSemanticNormal:
+        return WebModel::VertexSemantic::Normal;
+    case WKBridgeVertexSemanticTangent:
+        return WebModel::VertexSemantic::Tangent;
+    case WKBridgeVertexSemanticBitangent:
+        return WebModel::VertexSemantic::Bitangent;
+    case WKBridgeVertexSemanticUV0:
+        return WebModel::VertexSemantic::UV0;
+    case WKBridgeVertexSemanticUV1:
+        return WebModel::VertexSemantic::UV1;
+    case WKBridgeVertexSemanticUV2:
+        return WebModel::VertexSemantic::UV2;
+    case WKBridgeVertexSemanticUV3:
+        return WebModel::VertexSemantic::UV3;
+    case WKBridgeVertexSemanticUV4:
+        return WebModel::VertexSemantic::UV4;
+    case WKBridgeVertexSemanticUV5:
+        return WebModel::VertexSemantic::UV5;
+    case WKBridgeVertexSemanticUV6:
+        return WebModel::VertexSemantic::UV6;
+    case WKBridgeVertexSemanticUV7:
+        return WebModel::VertexSemantic::UV7;
+    case WKBridgeVertexSemanticUnspecified:
+        return WebModel::VertexSemantic::Unspecified;
+    }
+}
+
+static WebCore::WebGPU::VertexFormat toVertexFormat(MTLVertexFormat format)
+{
+    switch (format) {
+    case MTLVertexFormatUChar:
+        return WebCore::WebGPU::VertexFormat::Uint8;
+    case MTLVertexFormatUChar2:
+        return WebCore::WebGPU::VertexFormat::Uint8x2;
+    case MTLVertexFormatUChar4:
+        return WebCore::WebGPU::VertexFormat::Uint8x4;
+    case MTLVertexFormatChar:
+        return WebCore::WebGPU::VertexFormat::Sint8;
+    case MTLVertexFormatChar2:
+        return WebCore::WebGPU::VertexFormat::Sint8x2;
+    case MTLVertexFormatChar4:
+        return WebCore::WebGPU::VertexFormat::Sint8x4;
+    case MTLVertexFormatUCharNormalized:
+        return WebCore::WebGPU::VertexFormat::Unorm8;
+    case MTLVertexFormatUChar2Normalized:
+        return WebCore::WebGPU::VertexFormat::Unorm8x2;
+    case MTLVertexFormatUChar4Normalized:
+        return WebCore::WebGPU::VertexFormat::Unorm8x4;
+    case MTLVertexFormatCharNormalized:
+        return WebCore::WebGPU::VertexFormat::Snorm8;
+    case MTLVertexFormatChar2Normalized:
+        return WebCore::WebGPU::VertexFormat::Snorm8x2;
+    case MTLVertexFormatChar4Normalized:
+        return WebCore::WebGPU::VertexFormat::Snorm8x4;
+    case MTLVertexFormatUShort:
+        return WebCore::WebGPU::VertexFormat::Uint16;
+    case MTLVertexFormatUShort2:
+        return WebCore::WebGPU::VertexFormat::Uint16x2;
+    case MTLVertexFormatUShort4:
+        return WebCore::WebGPU::VertexFormat::Uint16x4;
+    case MTLVertexFormatShort:
+        return WebCore::WebGPU::VertexFormat::Sint16;
+    case MTLVertexFormatShort2:
+        return WebCore::WebGPU::VertexFormat::Sint16x2;
+    case MTLVertexFormatShort4:
+        return WebCore::WebGPU::VertexFormat::Sint16x4;
+    case MTLVertexFormatUShortNormalized:
+        return WebCore::WebGPU::VertexFormat::Unorm16;
+    case MTLVertexFormatUShort2Normalized:
+        return WebCore::WebGPU::VertexFormat::Unorm16x2;
+    case MTLVertexFormatUShort4Normalized:
+        return WebCore::WebGPU::VertexFormat::Unorm16x4;
+    case MTLVertexFormatShortNormalized:
+        return WebCore::WebGPU::VertexFormat::Snorm16;
+    case MTLVertexFormatShort2Normalized:
+        return WebCore::WebGPU::VertexFormat::Snorm16x2;
+    case MTLVertexFormatShort4Normalized:
+        return WebCore::WebGPU::VertexFormat::Snorm16x4;
+    case MTLVertexFormatHalf:
+        return WebCore::WebGPU::VertexFormat::Float16;
+    case MTLVertexFormatHalf2:
+        return WebCore::WebGPU::VertexFormat::Float16x2;
+    case MTLVertexFormatHalf4:
+        return WebCore::WebGPU::VertexFormat::Float16x4;
+    case MTLVertexFormatFloat:
+        return WebCore::WebGPU::VertexFormat::Float32;
+    case MTLVertexFormatFloat2:
+        return WebCore::WebGPU::VertexFormat::Float32x2;
+    case MTLVertexFormatFloat3:
+        return WebCore::WebGPU::VertexFormat::Float32x3;
+    case MTLVertexFormatFloat4:
+        return WebCore::WebGPU::VertexFormat::Float32x4;
+    case MTLVertexFormatUInt:
+        return WebCore::WebGPU::VertexFormat::Uint32;
+    case MTLVertexFormatUInt2:
+        return WebCore::WebGPU::VertexFormat::Uint32x2;
+    case MTLVertexFormatUInt3:
+        return WebCore::WebGPU::VertexFormat::Uint32x3;
+    case MTLVertexFormatUInt4:
+        return WebCore::WebGPU::VertexFormat::Uint32x4;
+    case MTLVertexFormatInt:
+        return WebCore::WebGPU::VertexFormat::Sint32;
+    case MTLVertexFormatInt2:
+        return WebCore::WebGPU::VertexFormat::Sint32x2;
+    case MTLVertexFormatInt3:
+        return WebCore::WebGPU::VertexFormat::Sint32x3;
+    case MTLVertexFormatInt4:
+        return WebCore::WebGPU::VertexFormat::Sint32x4;
+    case MTLVertexFormatUInt1010102Normalized:
+        return WebCore::WebGPU::VertexFormat::Unorm1010102;
+    case MTLVertexFormatUChar4Normalized_BGRA:
+        return WebCore::WebGPU::VertexFormat::Unorm8x4Bgra;
+    default:
+        return WebCore::WebGPU::VertexFormat::Float32;
+    }
+}
+
+static WebCore::WebGPU::PrimitiveTopology toPrimitiveTopology(MTLPrimitiveType topology)
+{
+    switch (topology) {
+    case MTLPrimitiveTypePoint:
+        return WebCore::WebGPU::PrimitiveTopology::PointList;
+    case MTLPrimitiveTypeLine:
+        return WebCore::WebGPU::PrimitiveTopology::LineList;
+    case MTLPrimitiveTypeLineStrip:
+        return WebCore::WebGPU::PrimitiveTopology::LineStrip;
+    case MTLPrimitiveTypeTriangle:
+        return WebCore::WebGPU::PrimitiveTopology::TriangleList;
+    case MTLPrimitiveTypeTriangleStrip:
+        return WebCore::WebGPU::PrimitiveTopology::TriangleStrip;
+    default:
+        return WebCore::WebGPU::PrimitiveTopology::TriangleList;
+    }
+}
+
+static WebModel::IndexType toIndexType(MTLIndexType indexType)
+{
+    switch (indexType) {
+    case MTLIndexTypeUInt16:
+        return WebModel::IndexType::UInt16;
+    case MTLIndexTypeUInt32:
+        return WebModel::IndexType::UInt32;
+    default:
+        return WebModel::IndexType::UInt16;
+    }
+}
+
+static WebCore::WebGPU::TextureViewDimension toTextureViewDimension(MTLTextureType textureType)
+{
+    switch (textureType) {
+    case MTLTextureType1D:
+        return WebCore::WebGPU::TextureViewDimension::_1d;
+    case MTLTextureType2D:
+        return WebCore::WebGPU::TextureViewDimension::_2d;
+    case MTLTextureType2DArray:
+        return WebCore::WebGPU::TextureViewDimension::_2dArray;
+    case MTLTextureTypeCube:
+        return WebCore::WebGPU::TextureViewDimension::Cube;
+    case MTLTextureTypeCubeArray:
+        return WebCore::WebGPU::TextureViewDimension::CubeArray;
+    case MTLTextureType3D:
+        return WebCore::WebGPU::TextureViewDimension::_3d;
+    default:
+        return WebCore::WebGPU::TextureViewDimension::_2d;
+    }
+}
+
+static WebCore::WebGPU::TextureFormat toTextureFormat(MTLPixelFormat pixelFormat)
+{
+    switch (pixelFormat) {
+    case MTLPixelFormatR8Unorm:
+        return WebCore::WebGPU::TextureFormat::R8unorm;
+    case MTLPixelFormatR8Snorm:
+        return WebCore::WebGPU::TextureFormat::R8snorm;
+    case MTLPixelFormatR8Uint:
+        return WebCore::WebGPU::TextureFormat::R8uint;
+    case MTLPixelFormatR8Sint:
+        return WebCore::WebGPU::TextureFormat::R8sint;
+    case MTLPixelFormatR16Uint:
+        return WebCore::WebGPU::TextureFormat::R16uint;
+    case MTLPixelFormatR16Sint:
+        return WebCore::WebGPU::TextureFormat::R16sint;
+    case MTLPixelFormatR16Float:
+        return WebCore::WebGPU::TextureFormat::R16float;
+    case MTLPixelFormatRG8Unorm:
+        return WebCore::WebGPU::TextureFormat::Rg8unorm;
+    case MTLPixelFormatRG8Snorm:
+        return WebCore::WebGPU::TextureFormat::Rg8snorm;
+    case MTLPixelFormatRG8Uint:
+        return WebCore::WebGPU::TextureFormat::Rg8uint;
+    case MTLPixelFormatRG8Sint:
+        return WebCore::WebGPU::TextureFormat::Rg8sint;
+    case MTLPixelFormatR32Float:
+        return WebCore::WebGPU::TextureFormat::R32float;
+    case MTLPixelFormatR32Uint:
+        return WebCore::WebGPU::TextureFormat::R32uint;
+    case MTLPixelFormatR32Sint:
+        return WebCore::WebGPU::TextureFormat::R32sint;
+    case MTLPixelFormatRG16Uint:
+        return WebCore::WebGPU::TextureFormat::Rg16uint;
+    case MTLPixelFormatRG16Sint:
+        return WebCore::WebGPU::TextureFormat::Rg16sint;
+    case MTLPixelFormatRG16Float:
+        return WebCore::WebGPU::TextureFormat::Rg16float;
+    case MTLPixelFormatRGBA8Unorm:
+        return WebCore::WebGPU::TextureFormat::Rgba8unorm;
+    case MTLPixelFormatRGBA8Unorm_sRGB:
+        return WebCore::WebGPU::TextureFormat::Rgba8unormSRGB;
+    case MTLPixelFormatRGBA8Snorm:
+        return WebCore::WebGPU::TextureFormat::Rgba8snorm;
+    case MTLPixelFormatRGBA8Uint:
+        return WebCore::WebGPU::TextureFormat::Rgba8uint;
+    case MTLPixelFormatRGBA8Sint:
+        return WebCore::WebGPU::TextureFormat::Rgba8sint;
+    case MTLPixelFormatBGRA8Unorm:
+        return WebCore::WebGPU::TextureFormat::Bgra8unorm;
+    case MTLPixelFormatBGRA8Unorm_sRGB:
+        return WebCore::WebGPU::TextureFormat::Bgra8unormSRGB;
+    case MTLPixelFormatRGB10A2Unorm:
+        return WebCore::WebGPU::TextureFormat::Rgb10a2unorm;
+    case MTLPixelFormatRG11B10Float:
+        return WebCore::WebGPU::TextureFormat::Rg11b10ufloat;
+    case MTLPixelFormatRGB9E5Float:
+        return WebCore::WebGPU::TextureFormat::Rgb9e5ufloat;
+    case MTLPixelFormatRGB10A2Uint:
+        return WebCore::WebGPU::TextureFormat::Rgb10a2uint;
+    case MTLPixelFormatRG32Float:
+        return WebCore::WebGPU::TextureFormat::Rg32float;
+    case MTLPixelFormatRG32Uint:
+        return WebCore::WebGPU::TextureFormat::Rg32uint;
+    case MTLPixelFormatRG32Sint:
+        return WebCore::WebGPU::TextureFormat::Rg32sint;
+    case MTLPixelFormatRGBA16Uint:
+        return WebCore::WebGPU::TextureFormat::Rgba16uint;
+    case MTLPixelFormatRGBA16Sint:
+        return WebCore::WebGPU::TextureFormat::Rgba16sint;
+    case MTLPixelFormatRGBA16Float:
+        return WebCore::WebGPU::TextureFormat::Rgba16float;
+    case MTLPixelFormatRGBA32Float:
+        return WebCore::WebGPU::TextureFormat::Rgba32float;
+    case MTLPixelFormatRGBA32Uint:
+        return WebCore::WebGPU::TextureFormat::Rgba32uint;
+    case MTLPixelFormatRGBA32Sint:
+        return WebCore::WebGPU::TextureFormat::Rgba32sint;
+    case MTLPixelFormatStencil8:
+        return WebCore::WebGPU::TextureFormat::Stencil8;
+    case MTLPixelFormatDepth16Unorm:
+        return WebCore::WebGPU::TextureFormat::Depth16unorm;
+    case MTLPixelFormatDepth32Float:
+        return WebCore::WebGPU::TextureFormat::Depth24plus;
+    case MTLPixelFormatDepth32Float_Stencil8:
+        return WebCore::WebGPU::TextureFormat::Depth24plusStencil8;
+    case MTLPixelFormatETC2_RGB8:
+        return WebCore::WebGPU::TextureFormat::Etc2Rgb8unorm;
+    case MTLPixelFormatETC2_RGB8_sRGB:
+        return WebCore::WebGPU::TextureFormat::Etc2Rgb8unormSRGB;
+    case MTLPixelFormatETC2_RGB8A1:
+        return WebCore::WebGPU::TextureFormat::Etc2Rgb8a1unorm;
+    case MTLPixelFormatETC2_RGB8A1_sRGB:
+        return WebCore::WebGPU::TextureFormat::Etc2Rgb8a1unormSRGB;
+    case MTLPixelFormatEAC_RGBA8:
+        return WebCore::WebGPU::TextureFormat::Etc2Rgba8unorm;
+    case MTLPixelFormatEAC_RGBA8_sRGB:
+        return WebCore::WebGPU::TextureFormat::Etc2Rgba8unormSRGB;
+    case MTLPixelFormatEAC_R11Unorm:
+        return WebCore::WebGPU::TextureFormat::EacR11unorm;
+    case MTLPixelFormatEAC_R11Snorm:
+        return WebCore::WebGPU::TextureFormat::EacR11snorm;
+    case MTLPixelFormatEAC_RG11Unorm:
+        return WebCore::WebGPU::TextureFormat::EacRg11unorm;
+    case MTLPixelFormatEAC_RG11Snorm:
+        return WebCore::WebGPU::TextureFormat::EacRg11snorm;
+    case MTLPixelFormatASTC_4x4_LDR:
+        return WebCore::WebGPU::TextureFormat::Astc4x4Unorm;
+    case MTLPixelFormatASTC_4x4_sRGB:
+        return WebCore::WebGPU::TextureFormat::Astc4x4UnormSRGB;
+    case MTLPixelFormatASTC_5x4_LDR:
+        return WebCore::WebGPU::TextureFormat::Astc5x4Unorm;
+    case MTLPixelFormatASTC_5x4_sRGB:
+        return WebCore::WebGPU::TextureFormat::Astc5x4UnormSRGB;
+    case MTLPixelFormatASTC_5x5_LDR:
+        return WebCore::WebGPU::TextureFormat::Astc5x5Unorm;
+    case MTLPixelFormatASTC_5x5_sRGB:
+        return WebCore::WebGPU::TextureFormat::Astc5x5UnormSRGB;
+    case MTLPixelFormatASTC_6x5_LDR:
+        return WebCore::WebGPU::TextureFormat::Astc6x5Unorm;
+    case MTLPixelFormatASTC_6x5_sRGB:
+        return WebCore::WebGPU::TextureFormat::Astc6x5UnormSRGB;
+    case MTLPixelFormatASTC_6x6_LDR:
+        return WebCore::WebGPU::TextureFormat::Astc6x6Unorm;
+    case MTLPixelFormatASTC_6x6_sRGB:
+        return WebCore::WebGPU::TextureFormat::Astc6x6UnormSRGB;
+    case MTLPixelFormatASTC_8x5_LDR:
+        return WebCore::WebGPU::TextureFormat::Astc8x5Unorm;
+    case MTLPixelFormatASTC_8x5_sRGB:
+        return WebCore::WebGPU::TextureFormat::Astc8x5UnormSRGB;
+    case MTLPixelFormatASTC_8x6_LDR:
+        return WebCore::WebGPU::TextureFormat::Astc8x6Unorm;
+    case MTLPixelFormatASTC_8x6_sRGB:
+        return WebCore::WebGPU::TextureFormat::Astc8x6UnormSRGB;
+    case MTLPixelFormatASTC_8x8_LDR:
+        return WebCore::WebGPU::TextureFormat::Astc8x8Unorm;
+    case MTLPixelFormatASTC_8x8_sRGB:
+        return WebCore::WebGPU::TextureFormat::Astc8x8UnormSRGB;
+    case MTLPixelFormatASTC_10x5_LDR:
+        return WebCore::WebGPU::TextureFormat::Astc10x5Unorm;
+    case MTLPixelFormatASTC_10x5_sRGB:
+        return WebCore::WebGPU::TextureFormat::Astc10x5UnormSRGB;
+    case MTLPixelFormatASTC_10x6_LDR:
+        return WebCore::WebGPU::TextureFormat::Astc10x6Unorm;
+    case MTLPixelFormatASTC_10x6_sRGB:
+        return WebCore::WebGPU::TextureFormat::Astc10x6UnormSRGB;
+    case MTLPixelFormatASTC_10x8_LDR:
+        return WebCore::WebGPU::TextureFormat::Astc10x8Unorm;
+    case MTLPixelFormatASTC_10x8_sRGB:
+        return WebCore::WebGPU::TextureFormat::Astc10x8UnormSRGB;
+    case MTLPixelFormatASTC_10x10_LDR:
+        return WebCore::WebGPU::TextureFormat::Astc10x10Unorm;
+    case MTLPixelFormatASTC_10x10_sRGB:
+        return WebCore::WebGPU::TextureFormat::Astc10x10UnormSRGB;
+    case MTLPixelFormatASTC_12x10_LDR:
+        return WebCore::WebGPU::TextureFormat::Astc12x10Unorm;
+    case MTLPixelFormatASTC_12x10_sRGB:
+        return WebCore::WebGPU::TextureFormat::Astc12x10UnormSRGB;
+    case MTLPixelFormatASTC_12x12_LDR:
+        return WebCore::WebGPU::TextureFormat::Astc12x12Unorm;
+    case MTLPixelFormatASTC_12x12_sRGB:
+        return WebCore::WebGPU::TextureFormat::Astc12x12UnormSRGB;
+#if !PLATFORM(WATCHOS)
+    case MTLPixelFormatBC1_RGBA:
+        return WebCore::WebGPU::TextureFormat::Bc1RgbaUnorm;
+    case MTLPixelFormatBC1_RGBA_sRGB:
+        return WebCore::WebGPU::TextureFormat::Bc1RgbaUnormSRGB;
+    case MTLPixelFormatBC2_RGBA:
+        return WebCore::WebGPU::TextureFormat::Bc2RgbaUnorm;
+    case MTLPixelFormatBC2_RGBA_sRGB:
+        return WebCore::WebGPU::TextureFormat::Bc2RgbaUnormSRGB;
+    case MTLPixelFormatBC3_RGBA:
+        return WebCore::WebGPU::TextureFormat::Bc3RgbaUnorm;
+    case MTLPixelFormatBC3_RGBA_sRGB:
+        return WebCore::WebGPU::TextureFormat::Bc3RgbaUnormSRGB;
+    case MTLPixelFormatBC4_RUnorm:
+        return WebCore::WebGPU::TextureFormat::Bc4RUnorm;
+    case MTLPixelFormatBC4_RSnorm:
+        return WebCore::WebGPU::TextureFormat::Bc4RSnorm;
+    case MTLPixelFormatBC5_RGUnorm:
+        return WebCore::WebGPU::TextureFormat::Bc5RgUnorm;
+    case MTLPixelFormatBC5_RGSnorm:
+        return WebCore::WebGPU::TextureFormat::Bc5RgSnorm;
+    case MTLPixelFormatBC6H_RGBUfloat:
+        return WebCore::WebGPU::TextureFormat::Bc6hRgbUfloat;
+    case MTLPixelFormatBC6H_RGBFloat:
+        return WebCore::WebGPU::TextureFormat::Bc6hRgbFloat;
+    case MTLPixelFormatBC7_RGBAUnorm:
+        return WebCore::WebGPU::TextureFormat::Bc7RgbaUnorm;
+    case MTLPixelFormatBC7_RGBAUnorm_sRGB:
+        return WebCore::WebGPU::TextureFormat::Bc7RgbaUnormSRGB;
+#endif
+    case MTLPixelFormatInvalid:
+    default:
+        return WebCore::WebGPU::TextureFormat::R8unorm;
+    }
+}
+
+static WebCore::WebGPU::TextureUsageFlags toTextureUsageFlags(MTLTextureUsage textureUsage)
+{
+    WebCore::WebGPU::TextureUsageFlags flags;
+
+    if (textureUsage & MTLTextureUsageShaderRead)
+        flags.add(WebCore::WebGPU::TextureUsage::TextureBinding);
+    if (textureUsage & MTLTextureUsageShaderWrite)
+        flags.add(WebCore::WebGPU::TextureUsage::StorageBinding);
+    if (textureUsage & MTLTextureUsageRenderTarget)
+        flags.add(WebCore::WebGPU::TextureUsage::RenderAttachment);
+    if (textureUsage & MTLTextureUsagePixelFormatView)
+        flags.add(WebCore::WebGPU::TextureUsage::TextureBinding);
+
+    return flags;
+}
+
 static WebModel::VertexAttributeFormat toCpp(WKBridgeVertexAttributeFormat *format)
 {
     return WebModel::VertexAttributeFormat {
-        .semantic = format.semantic,
-        .format = format.format,
+        .semantic = toVertexSemantic(format.semantic),
+        .format = toVertexFormat(format.format),
         .layoutIndex = format.layoutIndex,
         .offset = format.offset
     };
@@ -73,7 +462,7 @@ static WebModel::MeshPart toCpp(WKBridgeMeshPart *part)
     return WebModel::MeshPart {
         static_cast<uint32_t>(part.indexOffset),
         static_cast<uint32_t>(part.indexCount),
-        static_cast<uint32_t>(part.topology),
+        toPrimitiveTopology(part.topology),
         static_cast<uint32_t>(part.materialIndex),
         part.boundsMin,
         part.boundsMax
@@ -96,7 +485,7 @@ static WebModel::MeshDescriptor toCpp(WKBridgeMeshDescriptor *descriptor)
         .vertexAttributes = toCpp(descriptor.vertexAttributes),
         .vertexLayouts = toCpp(descriptor.vertexLayouts),
         .indexCapacity = descriptor.indexCapacity,
-        .indexType = static_cast<long>(descriptor.indexType)
+        .indexType = toIndexType(descriptor.indexType)
     };
 }
 
@@ -479,11 +868,11 @@ static WebModel::ImageAsset convert(WKBridgeImageAsset *imageAsset)
         .height = imageAsset.height,
         .depth = 1,
         .bytesPerPixel = imageAsset.bytesPerPixel,
-        .textureType = imageAsset.textureType,
-        .pixelFormat = imageAsset.pixelFormat,
+        .textureType = toTextureViewDimension(imageAsset.textureType),
+        .pixelFormat = toTextureFormat(imageAsset.pixelFormat),
         .mipmapLevelCount = imageAsset.mipmapLevelCount,
         .arrayLength = imageAsset.arrayLength,
-        .textureUsage = imageAsset.textureUsage,
+        .textureUsage = toTextureUsageFlags(imageAsset.textureUsage),
         .swizzle = convert(imageAsset.swizzle)
     };
 }

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
@@ -228,11 +228,11 @@ static std::optional<WebModel::ImageAsset> loadIBL(Ref<WebCore::SharedBuffer>&& 
         .height = static_cast<long>(height),
         .depth = 1,
         .bytesPerPixel = static_cast<long>(bytesPerPixel),
-        .textureType = MTLTextureType2D,
-        .pixelFormat = pixelFormat,
+        .textureType = WebCore::WebGPU::TextureViewDimension::_2d,
+        .pixelFormat = toTextureFormat(pixelFormat),
         .mipmapLevelCount = 1,
         .arrayLength = 1,
-        .textureUsage = MTLTextureUsageShaderRead,
+        .textureUsage = WebCore::WebGPU::TextureUsage::TextureBinding,
         .swizzle = WebModel::ImageAssetSwizzle {
             .red = MTLTextureSwizzleRed,
             .green = MTLTextureSwizzleGreen,
@@ -270,11 +270,11 @@ void WebModelPlayer::load(WebCore::Model& modelSource, WebCore::LayoutSize size)
         .height = 64,
         .depth = 1,
         .bytesPerPixel = 2,
-        .textureType = MTLTextureTypeCube,
-        .pixelFormat = MTLPixelFormatR16Float,
+        .textureType = WebCore::WebGPU::TextureViewDimension::Cube,
+        .pixelFormat = WebCore::WebGPU::TextureFormat::R16float,
         .mipmapLevelCount = 0,
         .arrayLength = 6,
-        .textureUsage = MTLTextureUsageShaderRead,
+        .textureUsage = WebCore::WebGPU::TextureUsage::TextureBinding,
         .swizzle = { }
     };
     WebModel::ImageAsset specularTexture {
@@ -283,11 +283,11 @@ void WebModelPlayer::load(WebCore::Model& modelSource, WebCore::LayoutSize size)
         .height = 256,
         .depth = 1,
         .bytesPerPixel = 2,
-        .textureType = MTLTextureTypeCube,
-        .pixelFormat = MTLPixelFormatR16Float,
+        .textureType = WebCore::WebGPU::TextureViewDimension::Cube,
+        .pixelFormat = WebCore::WebGPU::TextureFormat::R16float,
         .mipmapLevelCount = 0,
         .arrayLength = 6,
-        .textureUsage = MTLTextureUsageShaderRead,
+        .textureUsage = WebCore::WebGPU::TextureUsage::TextureBinding,
         .swizzle = { }
     };
 


### PR DESCRIPTION
#### 2d17cdb284521e3795809d3dd64ca23bb6ecc8fb
<pre>
Introduce enum formats where applicable for &lt;model&gt; serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=310552">https://bugs.webkit.org/show_bug.cgi?id=310552</a>
<a href="https://rdar.apple.com/173164633">rdar://173164633</a>

Reviewed by Etienne Segonzac.

Use enums where applicable instead of passing integers across IPC.

Credit Gavin Phillips for the suggestion and initial patch.

* Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift:
(convertSemantic(_:)):
(webAttributesFromAttributes(_:)):
* Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h:
* Source/WebKit/GPUProcess/graphics/Model/ModelUtils.swift:
(mapSemantic(_:)):
(_Proto_LowLevelMeshResource_v1.fromLlmDescriptor(_:)):
* Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm:
(WebModel::toMetal):
(WebModel::convert):
* Source/WebKit/Shared/Model.serialization.in:
* Source/WebKit/WebProcess/Model/ModelInlineConverters.h:
(WebKit::toVertexSemantic):
(WebKit::toVertexFormat):
(WebKit::toPrimitiveTopology):
(WebKit::toIndexType):
(WebKit::toTextureViewDimension):
(WebKit::toTextureFormat):
(WebKit::toTextureUsageFlags):
(WebKit::toCpp):
(WebKit::convert):
* Source/WebKit/WebProcess/Model/WebModelPlayer.mm:
(WebKit::toWebGPU):
(WebKit::loadIBL):
(WebKit::WebModelPlayer::load):

Canonical link: <a href="https://commits.webkit.org/309994@main">https://commits.webkit.org/309994@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31550cdf4b4f60ac9e5c3845695b23818e17477c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152411 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25193 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18792 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161154 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d9214fd1-66e4-4e11-bf31-fb5a1dd6282d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25721 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25499 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117766 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1542f328-6cfe-4c35-9da0-daa2911d6d5d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155371 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136823 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98480 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/19053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/16989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8989 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163624 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/6766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16291 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/125804 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24991 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21028 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125975 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34168 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24993 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136493 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81593 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20974 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13272 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24609 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/88895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24300 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24460 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24361 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->