### PR TITLE
[Build Speed] Remove expensive transitive bmalloc.h include from IPC headers

### DIFF
--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -29,14 +29,14 @@
 #pragma once
 
 #include "ConnectionHandle.h"
+#include "Decoder.h"
+#include "MessageNames.h"
 #include "MessageReceiveQueueMap.h"
 #include "MessageReceiver.h"
 #include "ReceiverMatcher.h"
 #include "SyncRequestID.h"
 #include "Timeout.h"
 #include <atomic>
-#include <bmalloc/TZoneHeap.h>
-#include <bmalloc/bmalloc.h>
 #include <new>
 #include <tuple>
 #include <wtf/Assertions.h>
@@ -52,6 +52,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/Lock.h>
 #include <wtf/MainThread.h>
+#include <wtf/Markable.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/NativePromise.h>
 #include <wtf/Noncopyable.h>

--- a/Source/WebKit/Platform/IPC/Decoder.h
+++ b/Source/WebKit/Platform/IPC/Decoder.h
@@ -29,8 +29,6 @@
 #include "MessageNames.h"
 #include "ReceiverMatcher.h"
 #include "SyncRequestID.h"
-#include <bmalloc/TZoneHeap.h>
-#include <bmalloc/bmalloc.h>
 #include <memory>
 #include <span>
 #include <wtf/ArgumentCoder.h>

--- a/Source/WebKit/Platform/IPC/MessageReceiveQueueMap.cpp
+++ b/Source/WebKit/Platform/IPC/MessageReceiveQueueMap.cpp
@@ -25,6 +25,8 @@
 
 #include "config.h"
 #include "MessageReceiveQueueMap.h"
+
+#include "Decoder.h"
 #include <wtf/text/TextStream.h>
 
 namespace IPC {

--- a/Source/WebKit/Platform/IPC/MessageReceiveQueueMap.h
+++ b/Source/WebKit/Platform/IPC/MessageReceiveQueueMap.h
@@ -25,13 +25,14 @@
 
 #pragma once
 
-#include "Decoder.h"
 #include "MessageReceiveQueue.h"
+#include "ReceiverMatcher.h"
 #include <wtf/HashMap.h>
 #include <wtf/Variant.h>
 
 namespace IPC {
 
+class Decoder;
 enum class ReceiverName : uint8_t;
 
 class MessageReceiveQueueMap {


### PR DESCRIPTION
#### 986ed55af67c0cff200e8f9b90457a6ceefe6553
<pre>
[Build Speed] Remove expensive transitive bmalloc.h include from IPC headers
<a href="https://rdar.apple.com/173275649">rdar://173275649</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=310672">https://bugs.webkit.org/show_bug.cgi?id=310672</a>

Reviewed by Timothy Hatcher.

Remove unnecessary #include &lt;bmalloc/bmalloc.h&gt; and &lt;bmalloc/TZoneHeap.h&gt; from
Decoder.h and Connection.h. Decoder.h already includes &lt;wtf/TZoneMalloc.h&gt;
which provides WTF_MAKE_TZONE_ALLOCATED, and Connection.h doesn&apos;t use bmalloc
at all.

Also forward-declare Decoder in MessageReceiveQueueMap.h instead of including
the full definition, since it&apos;s only used as a const reference parameter. Add
explicit includes of Decoder.h, MessageNames.h, and Markable.h to Connection.h
where they were previously obtained transitively.

Reduces Decoder.h per-include cost from ~2441ms to ~238ms and Connection.h from
~2109ms to ~354ms, removing Decoder.h (884s total), bmalloc.h (806s total), and
Connection.h (690s total) from the top 10 most expensive headers.

* Source/WebKit/Platform/IPC/Connection.h:
* Source/WebKit/Platform/IPC/Decoder.h:
* Source/WebKit/Platform/IPC/MessageReceiveQueueMap.cpp:
* Source/WebKit/Platform/IPC/MessageReceiveQueueMap.h:

Canonical link: <a href="https://commits.webkit.org/309894@main">https://commits.webkit.org/309894@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9202d20a7f9fe164d3c179baa6293f8ed9bf0963

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152021 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24803 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18378 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160764 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105478 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8c7fc262-afdd-41b3-82e1-baf2c1aeaa0e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25295 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25108 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117426 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83289 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154981 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19602 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136415 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98141 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dafaeb66-4496-4aae-a9ba-be8c275cf06f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18683 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16627 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8598 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128319 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163228 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6376 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15903 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125454 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24601 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20681 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125630 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34097 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24602 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136107 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81184 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20642 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12883 "Found 7 new test failures: http/tests/misc/object-image-error-with-onload.html http/tests/navigation/process-swap-on-client-side-redirect-private.html http/tests/security/cannot-read-cssrules.html http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py http/tests/storageAccess/deny-storage-access-under-opener-if-auto-dismiss-ephemeral.html http/tests/websocket/tests/hybi/contentextensions/block-cookies.py http/tests/xmlhttprequest/web-apps/014.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24219 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88504 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23910 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24070 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23971 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->