### PR TITLE
[GLib] hardening IPC message decoding

### DIFF
--- a/Source/WebKit/Platform/IPC/glib/ConnectionGLib.cpp
+++ b/Source/WebKit/Platform/IPC/glib/ConnectionGLib.cpp
@@ -34,6 +34,7 @@
 #include <gio/gunixconnection.h>
 #include <gio/gunixfdmessage.h>
 #include <sys/socket.h>
+#include <wtf/CheckedArithmetic.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/UniStdExtras.h>
 #include <wtf/glib/GRefPtr.h>
@@ -141,6 +142,28 @@ std::unique_ptr<Decoder> Connection::createMessageDecoder()
     }
 
     auto attachmentCount = messageInfo.attachmentCount();
+    if (messageInfo.isBodyOutOfLine() && !attachmentCount) {
+        RELEASE_LOG_FAULT(IPC, "createMessageDecoder: out-of-line message body is missing its attachment");
+        ASSERT_NOT_REACHED();
+        return nullptr;
+    }
+
+    auto attachmentInfoBytes = checkedProduct<size_t>(attachmentCount, sizeof(AttachmentInfo));
+    if (attachmentInfoBytes.hasOverflowed() || attachmentInfoBytes.value() > messageData.size()) {
+        RELEASE_LOG_FAULT(IPC, "createMessageDecoder: attachment metadata exceeds read buffer (attachments: %zu, buffer size: %zu)", attachmentCount, messageData.size());
+        ASSERT_NOT_REACHED();
+        return nullptr;
+    }
+
+    if (!messageInfo.isBodyOutOfLine()) {
+        auto inlineBodySize = checkedSum<size_t>(attachmentInfoBytes.value(), messageInfo.bodySize());
+        if (inlineBodySize.hasOverflowed() || inlineBodySize.value() > messageData.size()) {
+            RELEASE_LOG_FAULT(IPC, "createMessageDecoder: inline body exceeds read buffer (body size: %zu, buffer size: %zu)", messageInfo.bodySize(), messageData.size());
+            ASSERT_NOT_REACHED();
+            return nullptr;
+        }
+    }
+
     if (!attachmentCount)
         return Decoder::create(messageData.first(messageInfo.bodySize()), { });
 
@@ -157,14 +180,24 @@ std::unique_ptr<Decoder> Connection::createMessageDecoder()
         case AttachmentInfo::Type::FileDescriptor:
             if (attachmentInfo.isNull())
                 attachments[attachmentIndex] = UnixFileDescriptor();
-            else
+            else {
+                if (fdIndex >= m_fileDescriptors.size()) {
+                    RELEASE_LOG_FAULT(IPC, "createMessageDecoder: missing file descriptor for attachment %zu", i);
+                    ASSERT_NOT_REACHED();
+                    return nullptr;
+                }
                 attachments[attachmentIndex] = WTF::move(m_fileDescriptors[fdIndex++]);
+            }
             break;
         case AttachmentInfo::Type::HardwareBuffer:
             if (attachmentInfo.isNull())
                 attachments[attachmentIndex] = nullptr;
             else {
-                RELEASE_ASSERT(!m_incomingHardwareBuffers.isEmpty());
+                if (m_incomingHardwareBuffers.isEmpty()) {
+                    RELEASE_LOG_FAULT(IPC, "createMessageDecoder: missing incoming hardware buffer for attachment %zu", i);
+                    ASSERT_NOT_REACHED();
+                    return nullptr;
+                }
                 attachments[attachmentIndex] = WTF::move(m_incomingHardwareBuffers.first());
                 m_incomingHardwareBuffers.removeAt(0);
             }
@@ -173,8 +206,14 @@ std::unique_ptr<Decoder> Connection::createMessageDecoder()
             RELEASE_ASSERT_NOT_REACHED();
         }
 #else
-        if (!attachmentInfo.isNull())
+        if (!attachmentInfo.isNull()) {
+            if (fdIndex >= m_fileDescriptors.size()) {
+                RELEASE_LOG_FAULT(IPC, "createMessageDecoder: missing file descriptor for attachment %zu", i);
+                ASSERT_NOT_REACHED();
+                return nullptr;
+            }
             attachments[attachmentIndex] = WTF::move(m_fileDescriptors[fdIndex++]);
+        }
 #endif
     }
 
@@ -188,6 +227,11 @@ std::unique_ptr<Decoder> Connection::createMessageDecoder()
         return nullptr;
     }
 
+    if (fdIndex >= m_fileDescriptors.size()) {
+        RELEASE_LOG_FAULT(IPC, "createMessageDecoder: missing shared-memory file descriptor for out-of-line body");
+        ASSERT_NOT_REACHED();
+        return nullptr;
+    }
     auto handle = WebCore::SharedMemory::Handle { WTF::move(m_fileDescriptors[fdIndex]), messageInfo.bodySize() };
     auto messageBody = WebCore::SharedMemory::map(WTF::move(handle), WebCore::SharedMemory::Protection::ReadOnly);
     if (!messageBody) {
@@ -246,6 +290,8 @@ void Connection::readyReadHandler()
 
         if (auto decoder = createMessageDecoder())
             processIncomingMessage(makeUniqueRefFromNonNullUniquePtr(WTF::move(decoder)));
+        else
+            connectionDidClose();
     }
 #endif
 
@@ -290,6 +336,8 @@ void Connection::readyReadHandler()
 
         if (auto decoder = createMessageDecoder())
             processIncomingMessage(makeUniqueRefFromNonNullUniquePtr(WTF::move(decoder)));
+        else
+            connectionDidClose();
     }
 }
 


### PR DESCRIPTION
#### e3541aeec1ab11e3852b4010ede84b88c0998159
<pre>
[GLib] hardening IPC message decoding
<a href="https://bugs.webkit.org/show_bug.cgi?id=310669">https://bugs.webkit.org/show_bug.cgi?id=310669</a>

Reviewed by Adrian Perez de Castro.

This adds error checking when creating an IPC message decoder. When
detecting an error, it logs and returns null on release, asserting on
debug (or when assertions are enabled).

Then, on receiving a null message decoder, the connection is deemed
unsafed and closed.

* Source/WebKit/Platform/IPC/glib/ConnectionGLib.cpp:
(IPC::Connection::createMessageDecoder):
(IPC::Connection::readyReadHandler):

Canonical link: <a href="https://commits.webkit.org/310908@main">https://commits.webkit.org/310908@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef82564cab171088a8637da8b101ef6ec5c10375

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155200 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28460 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21619 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163960 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108945 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28600 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28308 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120088 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/84834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158159 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22339 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139378 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100783 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21425 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19481 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11786 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131089 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166438 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/10592 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18824 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128192 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28004 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23516 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128329 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34846 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27928 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139008 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84637 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23192 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15804 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27621 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91725 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27199 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27429 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27272 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->