### PR TITLE
Remove temporary SPI usage of AVLegibleMediaOptionsMenuController from WebKit

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/AVKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/AVKitSPI.h
@@ -618,27 +618,3 @@ typedef NS_ENUM(NSInteger, AVPlayerControllerTimeControlStatus) {
 NS_ASSUME_NONNULL_END
 
 #endif // PLATFORM(APPLETV)
-
-// CLEANUP(rdar://164667890)
-#if HAVE(AVLEGIBLEMEDIAOPTIONSMENUCONTROLLER) && USE(APPLE_INTERNAL_SDK) && !__has_feature(modules)
-#if __has_include(<AVKit/AVLegibleMediaOptionsMenuController_Private.h>)
-#import <AVKit/AVLegibleMediaOptionsMenuController_Private.h>
-#else
-// SDK does not have -menuWithContents:. Redeclare:
-#import <AVKit/AVLegibleMediaOptionsMenuController.h>
-typedef NS_OPTIONS(NSInteger, AVLegibleMediaOptionsMenuContents) {
-    AVLegibleMediaOptionsMenuContentsLegible = 1 << 0,
-    AVLegibleMediaOptionsMenuContentsCaptionAppearance = 1 << 1,
-    AVLegibleMediaOptionsMenuContentsAll = (AVLegibleMediaOptionsMenuContentsLegible | AVLegibleMediaOptionsMenuContentsCaptionAppearance)
-} API_AVAILABLE(ios(26.4), macos(26.4), visionos(26.4)) API_UNAVAILABLE(tvos, watchos);
-
-@interface AVLegibleMediaOptionsMenuController (MenuWithContents)
-#if TARGET_OS_OSX && !TARGET_OS_MACCATALYST
-- (nullable NSMenu *)menuWithContents:(AVLegibleMediaOptionsMenuContents)contents;
-#else
-- (nullable UIMenu *)menuWithContents:(AVLegibleMediaOptionsMenuContents)contents;
-#endif
-@end
-
-#endif // __has_include(<AVKit/AVLegibleMediaOptionsMenuController_Private.h>)
-#endif // HAVE(AVLEGIBLEMEDIAOPTIONSMENUCONTROLLER) && USE(APPLE_INTERNAL_SDK)

--- a/Source/WebKit/Configurations/AllowedSPI.toml
+++ b/Source/WebKit/Configurations/AllowedSPI.toml
@@ -255,14 +255,6 @@ selectors = [
 requires = ["HAVE_UIKIT_SCROLLBAR_COLOR_SPI"]
 
 [[temporary-usage]]
-request = "rdar://164431329"
-cleanup = "rdar://164667890"
-selectors = [
-    { name = "buildMenuOfType:", class = "AVLegibleMediaOptionsMenuController" },
-]
-requires = ["HAVE_AVLEGIBLEMEDIAOPTIONSMENUCONTROLLER"]
-
-[[temporary-usage]]
 request = "rdar://165789536"
 cleanup = "rdar://165842824"
 selectors = [

--- a/Source/WebKit/UIProcess/ios/_WKCaptionStyleMenuControllerAVKit.mm
+++ b/Source/WebKit/UIProcess/ios/_WKCaptionStyleMenuControllerAVKit.mm
@@ -30,9 +30,7 @@
 
 #import "_WKCaptionStyleMenuControllerInternal.h"
 
-#if __has_include(<AVKit/AVLegibleMediaOptionsMenuController.h>)
 #import <AVKit/AVLegibleMediaOptionsMenuController.h>
-#endif
 
 #import <UIKit/UIKit.h>
 #import <WebCore/CaptionUserPreferencesMediaAF.h>
@@ -50,12 +48,6 @@ SOFT_LINK_CLASS_OPTIONAL(AVKit, AVLegibleMediaOptionsMenuController)
 
 using namespace WebCore;
 using namespace WTF;
-
-// CLEANUP(rdar://164667890)
-@interface AVLegibleMediaOptionsMenuController (WebKitSPI)
-- (nullable UIMenu *)buildMenuOfType:(NSInteger)type;
-- (nullable UIMenu *)menuWithContents:(NSInteger)contents;
-@end
 
 @interface _WKCaptionStyleMenuControllerAVKit () <AVLegibleMediaOptionsMenuControllerDelegate> {
     RetainPtr<AVLegibleMediaOptionsMenuController> _menuController;
@@ -81,12 +73,7 @@ using namespace WTF;
 
 - (void)rebuildMenu
 {
-    if ([_menuController respondsToSelector:@selector(menuWithContents:)])
-        self.menu = [_menuController menuWithContents:AVLegibleMediaOptionsMenuContentsCaptionAppearance];
-    else
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        self.menu = [_menuController buildMenuOfType:AVLegibleMediaOptionsMenuTypeCaptionAppearance];
-ALLOW_DEPRECATED_DECLARATIONS_END
+    self.menu = [_menuController menuWithContents:AVLegibleMediaOptionsMenuContentsCaptionAppearance];
 }
 
 #pragma mark - AVLegibleMediaOptionsMenuControllerDelegate

--- a/Source/WebKit/UIProcess/mac/_WKCaptionStyleMenuControllerAVKitMac.mm
+++ b/Source/WebKit/UIProcess/mac/_WKCaptionStyleMenuControllerAVKitMac.mm
@@ -30,9 +30,7 @@
 
 #import "_WKCaptionStyleMenuControllerInternal.h"
 
-#if __has_include(<AVKit/AVLegibleMediaOptionsMenuController.h>)
 #import <AVKit/AVLegibleMediaOptionsMenuController.h>
-#endif
 
 #import <AppKit/AppKit.h>
 #import <WebCore/CaptionUserPreferencesMediaAF.h>
@@ -47,12 +45,6 @@
 
 SOFTLINK_AVKIT_FRAMEWORK()
 SOFT_LINK_CLASS_OPTIONAL(AVKit, AVLegibleMediaOptionsMenuController)
-
-// CLEANUP(rdar://164667890)
-@interface AVLegibleMediaOptionsMenuController (WebKitSPI)
-- (nullable NSMenu *)buildMenuOfType:(NSInteger)type;
-- (nullable NSMenu *)menuWithContents:(NSInteger)contents;
-@end
 
 using namespace WebCore;
 using namespace WTF;
@@ -81,12 +73,7 @@ using namespace WTF;
 
 - (void)rebuildMenu
 {
-    if ([_menuController respondsToSelector:@selector(menuWithContents:)])
-        self.menu = [_menuController menuWithContents:AVLegibleMediaOptionsMenuContentsCaptionAppearance];
-    else
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        self.menu = [_menuController buildMenuOfType:AVLegibleMediaOptionsMenuTypeCaptionAppearance];
-ALLOW_DEPRECATED_DECLARATIONS_END
+    self.menu = [_menuController menuWithContents:AVLegibleMediaOptionsMenuContentsCaptionAppearance];
 }
 
 - (NSMenu *)captionStyleMenu


### PR DESCRIPTION
#### 1b2711ed3412323ea22275360a7404db46fb65da
<pre>
Remove temporary SPI usage of AVLegibleMediaOptionsMenuController from WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=310660">https://bugs.webkit.org/show_bug.cgi?id=310660</a>
<a href="https://rdar.apple.com/173268786">rdar://173268786</a>

Reviewed by Jer Noble.

AVLegibleMediaOptionsMenuController has been promoted to public API - remove the temporary SPI
declarations and workarounds that were added while waiting for API availability.

* Source/WebCore/PAL/pal/spi/cocoa/AVKitSPI.h:
* Source/WebKit/Configurations/AllowedSPI.toml:
* Source/WebKit/UIProcess/ios/_WKCaptionStyleMenuControllerAVKit.mm:
(-[_WKCaptionStyleMenuControllerAVKit rebuildMenu]):
* Source/WebKit/UIProcess/mac/_WKCaptionStyleMenuControllerAVKitMac.mm:
(-[_WKCaptionStyleMenuControllerAVKitMac rebuildMenu]):

Canonical link: <a href="https://commits.webkit.org/309935@main">https://commits.webkit.org/309935@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c592d58260d8770a9251c63d36134ace4836ea66

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152019 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24801 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18376 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160762 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105476 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/98f87e78-9db2-4743-a6fc-408b009b1bf3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153893 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25293 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25106 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117421 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83288 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154979 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19600 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136410 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98136 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/da77eeca-86f3-4305-a09d-56c97cb9625e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18681 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16623 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8596 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128317 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14307 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163226 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6374 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15899 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125447 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24599 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20678 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125623 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34127 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24600 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136103 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81182 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20641 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12879 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24217 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88502 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23908 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24068 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23969 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->