### PR TITLE
Unable to change message font to Helvetica in Mail

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -686,21 +686,31 @@ static void registerFontIfNeeded(const String& family) WTF_REQUIRES_LOCK(userIns
     }
 }
 
-std::unique_ptr<FontPlatformData> FontCache::createFontPlatformData(const FontDescription& fontDescription, const AtomString& family, const FontCreationContext& fontCreationContext, OptionSet<FontLookupOptions> options)
+static void registerFontsInFamilyIfNeeded(const String& family)
 {
-    {
-        Locker locker(userInstalledFontMapLock());
-        if (!userInstalledFontMap().isEmpty()) {
-            auto fontFamily = family.string().convertToASCIILowercase();
-            registerFontIfNeeded(fontFamily);
-            auto fontNames = userInstalledFontFamilyMap().find(fontFamily);
-            if (fontNames != userInstalledFontFamilyMap().end()) {
-                for (auto& fontName : fontNames->value)
-                    registerFontIfNeeded(fontName);
-                userInstalledFontFamilyMap().remove(fontNames);
-            }
+    Locker locker(userInstalledFontMapLock());
+    if (!userInstalledFontMap().isEmpty()) {
+        auto fontFamily = family.convertToASCIILowercase();
+
+        if (fontFamily == "helvetica"_s) {
+            // Helvetica is a system font with several variants, so we choose not to register additional fonts in this family.
+            // This is because it can affect font matching. See rdar://172261885.
+            return;
+        }
+
+        registerFontIfNeeded(fontFamily);
+        auto fontNames = userInstalledFontFamilyMap().find(fontFamily);
+        if (fontNames != userInstalledFontFamilyMap().end()) {
+            for (auto& fontName : fontNames->value)
+                registerFontIfNeeded(fontName);
+            userInstalledFontFamilyMap().remove(fontNames);
         }
     }
+}
+
+std::unique_ptr<FontPlatformData> FontCache::createFontPlatformData(const FontDescription& fontDescription, const AtomString& family, const FontCreationContext& fontCreationContext, OptionSet<FontLookupOptions> options)
+{
+    registerFontsInFamilyIfNeeded(family);
 
     auto size = fontDescription.adjustedSizeForFontFace(fontCreationContext.sizeAdjust());
     auto& fontDatabase = database(fontDescription.shouldAllowUserInstalledFonts());


### PR DESCRIPTION
#### 517f3888ca361e77463953f13bb27dd8834956d1
<pre>
Unable to change message font to Helvetica in Mail
<a href="https://bugs.webkit.org/show_bug.cgi?id=310675">https://bugs.webkit.org/show_bug.cgi?id=310675</a>
<a href="https://rdar.apple.com/172261885">rdar://172261885</a>

Reviewed by Sihui Liu.

Helvetica is a system font with several variants, so we choose not to register additional fonts in this family.
This is because it can affect font matching, since manually registered fonts take precedence. We intend to
follow up with a more generic fix.

* Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
(WebCore::registerFontsInFamilyIfNeeded):
(WebCore::FontCache::createFontPlatformData):

Canonical link: <a href="https://commits.webkit.org/309931@main">https://commits.webkit.org/309931@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/099b8a0d984840faae2cf1f4c51054350eb0ae64

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152028 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24810 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18386 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160771 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105485 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e5d08da4-acb4-457e-b753-cf44e4349de1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153902 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25302 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25116 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117430 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83294 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154988 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19610 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136430 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98145 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3299f3f2-7a77-4f22-8302-6f44168d3b0e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18691 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16636 "Found 1 new API test failure: TestWebKitAPI.TextManipulation.StartTextManipulationDoesNotFindContentInNewMainFrame (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8605 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144036 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128328 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14324 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163235 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6383 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15916 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125458 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24608 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20689 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125634 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24609 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136120 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81191 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23342 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20645 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12896 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24226 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88511 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23917 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24077 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23978 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->