### PR TITLE
[css-anchor-position-1] Element with display: contents doesn't establish an anchor scope when using anchor-scope

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scope-display-contents.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scope-display-contents.tentative-expected.txt
@@ -3,12 +3,12 @@ PASS Can anchor to a name both defined and scoped by the same element
 PASS Sibling can not anchor into anchor-scope, even when anchor-name present
 PASS anchor-scope:all on common ancestor
 PASS anchor-scope:--a on common ancestor
-FAIL anchor-scope:all on sibling assert_equals: expected "20px" but got "40px"
-FAIL anchor-scope:all scopes multiple names assert_equals: expected "20px" but got "40px"
-FAIL anchor-scope:--a,--b scopes --a and --b assert_equals: expected "20px" but got "40px"
-FAIL anchor-scope:--a scopes only --a assert_equals: expected "20px" but got "50px"
-FAIL anchor-scope:--b scopes only --b assert_equals: expected "10px" but got "40px"
-FAIL anchor-scope:--a scopes only --a (out-of-flow anchors) assert_equals: expected "20px" but got "40px"
-FAIL anchor-scope:--a scopes only --a (both out-of-flow and in-flow anchors) assert_equals: expected "20px" but got "55px"
-FAIL anchor-scope:--a scopes only --a (both out-of-flow and in-flow anchors, reverse) assert_equals: expected "55px" but got "30px"
+PASS anchor-scope:all on sibling
+PASS anchor-scope:all scopes multiple names
+PASS anchor-scope:--a,--b scopes --a and --b
+PASS anchor-scope:--a scopes only --a
+PASS anchor-scope:--b scopes only --b
+PASS anchor-scope:--a scopes only --a (out-of-flow anchors)
+PASS anchor-scope:--a scopes only --a (both out-of-flow and in-flow anchors)
+PASS anchor-scope:--a scopes only --a (both out-of-flow and in-flow anchors, reverse)
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2825,7 +2825,7 @@ bool Element::hasDisplayNone() const
 
 void Element::storeDisplayContentsOrNoneStyle(std::unique_ptr<RenderStyle> style)
 {
-    // This is used by RenderTreeBuilder to store the style for Elements with display:{contents|none}.
+    // This is used by RenderTreeUpdater to store the style for Elements with display:{contents|none}.
     // Normally style is held in renderers but display:contents doesn't generate one.
     // This is kept distinct from ElementRareData::computedStyle() which can update outside style resolution.
     // This way renderOrDisplayContentsStyle() always returns consistent styles matching the rendering state.

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -1065,7 +1065,7 @@ static CheckedPtr<const Element> anchorScopeForAnchorName(const RenderBoxModelOb
     CheckedPtr<const Element> anchorElement = renderer.element();
     ASSERT(anchorElement);
     for (CheckedPtr<const Element> currentAncestor = anchorElement; currentAncestor; currentAncestor = currentAncestor->parentElementInComposedTree()) {
-        CheckedPtr currentAncestorStyle = currentAncestor->renderStyle();
+        CheckedPtr currentAncestorStyle = currentAncestor->renderOrDisplayContentsStyle();
         if (!currentAncestorStyle)
             continue;
         const auto& currentAncestorAnchorScope = currentAncestorStyle->anchorScope();


### PR DESCRIPTION
#### 89983a32335b1264bd3140d30f880d147a442912
<pre>
[css-anchor-position-1] Element with display: contents doesn&apos;t establish an anchor scope when using anchor-scope
<a href="https://rdar.apple.com/172355302">rdar://172355302</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=309239">https://bugs.webkit.org/show_bug.cgi?id=309239</a>

Reviewed by Antti Koivisto.

anchorScopeForAnchorName figures out which ancestor establishes an anchor scope
covering the element. It reads the value of &apos;anchor-scope&apos; property from the style
returned by Element::renderStyle(). But renderStyle() is nullptr if the element
is display: contents. Change it to use renderOrDisplayContentsStyle() instead.

Test: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scope-display-contents.tentative.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scope-display-contents.tentative-expected.txt:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::storeDisplayContentsOrNoneStyle):
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::anchorScopeForAnchorName):

Canonical link: <a href="https://commits.webkit.org/309946@main">https://commits.webkit.org/309946@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f438c699e038d002e4761c8fe4503002227527a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152032 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24814 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18390 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160775 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105489 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/089447e7-3ee1-4283-92fc-74cb9cb4abba) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153906 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25306 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25120 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117439 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83299 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2376c0c4-b52f-4097-9ffa-58b6a359839b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154992 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19625 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136434 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98154 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e47e08a2-e8fe-41f7-87b0-e519f90520cc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18694 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16641 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8609 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128331 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14328 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163239 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6387 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15920 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125462 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24612 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20693 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125638 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34137 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24613 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136124 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81195 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20651 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12900 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24230 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88515 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23921 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24081 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23982 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->