### PR TITLE
Find in page match is updated incorrectly

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -224,16 +224,29 @@ void FindController::updateMatchIndex(unsigned matchCount, OptionSet<FindOptions
 {
     if (!options.contains(FindOptions::DetermineMatchIndex))
         return;
+    if (options.contains(FindOptions::NoIndexChange))
+        return;
 
     if (matchCount == static_cast<unsigned>(kWKMoreThanMaximumMatchCount)) {
         m_foundStringMatchIndex = std::nullopt;
         return;
     }
 
-    if (!m_foundStringMatchIndex)
-        m_foundStringMatchIndex = matchCount;
-    else if (*m_foundStringMatchIndex >= matchCount)
-        *m_foundStringMatchIndex -= matchCount;
+    if (!m_foundStringMatchIndex) {
+        m_foundStringMatchIndex = 0;
+        return;
+    }
+
+    if (options.contains(FindOptions::Backwards)) {
+        if (!*m_foundStringMatchIndex)
+            m_foundStringMatchIndex = matchCount - 1;
+        else
+            (*m_foundStringMatchIndex)--;
+    } else {
+        (*m_foundStringMatchIndex)++;
+        if (*m_foundStringMatchIndex >= matchCount)
+            *m_foundStringMatchIndex %= matchCount;
+    }
 }
 
 void FindController::updateFindUIAfterFindingAllMatches(bool found, const String& string, OptionSet<FindOptions> options, unsigned maxMatchCount)
@@ -327,7 +340,6 @@ void FindController::findString(const String& string, OptionSet<FindOptions> opt
 
     protect(protect(m_webPage.get())->corePage())->removeAllActiveTextMatches();
 
-    bool foundStringStartsAfterSelection = false;
     RefPtr webPage { m_webPage.get() };
 #if ENABLE(PDF_PLUGIN)
     if (!pluginView)
@@ -337,7 +349,7 @@ void FindController::findString(const String& string, OptionSet<FindOptions> opt
             if (protect(selectedFrame->selection())->selectionBounds().isEmpty()) {
                 auto result = protect(webPage->corePage())->findTextMatches(string, coreOptions, maxMatchCount);
                 m_foundStringMatchIndex = result.indexForSelection;
-                foundStringStartsAfterSelection = true;
+                options.add(FindOptions::NoIndexChange);
             }
         }
     }
@@ -365,16 +377,6 @@ void FindController::findString(const String& string, OptionSet<FindOptions> opt
         if (selectedFrame) {
             if (std::optional<SimpleRange> range = selectedFrame->selection().selection().range())
                 addMarker(*range, DocumentMarkerType::ActiveTextMatch);
-        }
-
-        if (!foundStringStartsAfterSelection && options.contains(FindOptions::DetermineMatchIndex)) {
-            if (m_foundStringMatchIndex) {
-                if (options.contains(FindOptions::Backwards))
-                    (*m_foundStringMatchIndex)--;
-                else if (!options.contains(FindOptions::NoIndexChange))
-                    (*m_foundStringMatchIndex)++;
-            } else
-                m_foundStringMatchIndex = 0;
         }
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewFindString.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewFindString.mm
@@ -175,4 +175,93 @@ TEST(WKWebViewFindString, MatchIndexIsCorrectWhenNavigatingForwardAndBackward)
     EXPECT_EQ(1, [findDelegate matchIndex]);
 }
 
+TEST(WKWebViewFindString, MatchIndexDoesNotUpdateWithoutDetermineMatchIndexOption)
+{
+    auto findDelegate = adoptNS([[WKWebViewFindStringFindDelegate alloc] init]);
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 300, 200) configuration:configuration.get() addToWindow:YES]);
+    [webView synchronouslyLoadHTMLString:@"<p>hello</p><p>hello</p><p>hello</p>"];
+    [webView _setFindDelegate:findDelegate.get()];
+
+    [webView _findString:@"hello" options:_WKFindOptionsDetermineMatchIndex maxCount:maxCount];
+    Util::run(&isDone);
+    EXPECT_EQ(0, [findDelegate matchIndex]);
+
+    isDone = false;
+    [webView _findString:@"hello" options:_WKFindOptionsDetermineMatchIndex maxCount:maxCount];
+    Util::run(&isDone);
+    EXPECT_EQ(1, [findDelegate matchIndex]);
+
+    isDone = false;
+    [webView _findString:@"hello" options:_WKFindOptionsDetermineMatchIndex maxCount:maxCount];
+    Util::run(&isDone);
+    EXPECT_EQ(2, [findDelegate matchIndex]);
+
+    isDone = false;
+    [webView _findString:@"hello" options:_WKFindOptionsBackwards | _WKFindOptionsDetermineMatchIndex  maxCount:maxCount];
+    Util::run(&isDone);
+    EXPECT_EQ(1, [findDelegate matchIndex]);
+}
+
+TEST(WKWebViewFindString, MatchIndexIsCorrectNavigatingWrapAround)
+{
+    auto findDelegate = adoptNS([[WKWebViewFindStringFindDelegate alloc] init]);
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 300, 200) configuration:configuration.get() addToWindow:YES]);
+    [webView synchronouslyLoadHTMLString:@"<p>hello</p><p>hello</p><p>hello</p>"];
+    [webView _setFindDelegate:findDelegate.get()];
+
+    auto findOptions = _WKFindOptionsWrapAround | _WKFindOptionsDetermineMatchIndex;
+
+    [webView _findString:@"hello" options:findOptions maxCount:maxCount];
+    Util::run(&isDone);
+    EXPECT_EQ(0, [findDelegate matchIndex]);
+
+    isDone = false;
+    [webView _findString:@"hello" options:findOptions maxCount:maxCount];
+    Util::run(&isDone);
+    EXPECT_EQ(1, [findDelegate matchIndex]);
+
+    isDone = false;
+    [webView _findString:@"hello" options:findOptions maxCount:maxCount];
+    Util::run(&isDone);
+    EXPECT_EQ(2, [findDelegate matchIndex]);
+
+    isDone = false;
+    [webView _findString:@"hello" options:findOptions maxCount:maxCount];
+    Util::run(&isDone);
+    EXPECT_EQ(0, [findDelegate matchIndex]);
+}
+
+TEST(WKWebViewFindString, MatchIndexIsCorrectNavigatingWrapAroundBackwards)
+{
+    auto findDelegate = adoptNS([[WKWebViewFindStringFindDelegate alloc] init]);
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 300, 200) configuration:configuration.get() addToWindow:YES]);
+    [webView synchronouslyLoadHTMLString:@"<p>hello</p><p>hello</p><p>hello</p>"];
+    [webView _setFindDelegate:findDelegate.get()];
+
+    auto findOptions = _WKFindOptionsWrapAround | _WKFindOptionsDetermineMatchIndex;
+    auto findOptionsBackwards =  findOptions | _WKFindOptionsBackwards;
+
+    [webView _findString:@"hello" options:findOptions maxCount:maxCount];
+    Util::run(&isDone);
+    EXPECT_EQ(0, [findDelegate matchIndex]);
+
+    isDone = false;
+    [webView _findString:@"hello" options:findOptionsBackwards maxCount:maxCount];
+    Util::run(&isDone);
+    EXPECT_EQ(2, [findDelegate matchIndex]);
+
+    isDone = false;
+    [webView _findString:@"hello" options:findOptionsBackwards maxCount:maxCount];
+    Util::run(&isDone);
+    EXPECT_EQ(1, [findDelegate matchIndex]);
+
+    isDone = false;
+    [webView _findString:@"hello" options:findOptionsBackwards maxCount:maxCount];
+    Util::run(&isDone);
+    EXPECT_EQ(0, [findDelegate matchIndex]);
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### fcded16b06bb20e17608486228e58ed918633a9b
<pre>
Find in page match is updated incorrectly
<a href="https://bugs.webkit.org/show_bug.cgi?id=310679">https://bugs.webkit.org/show_bug.cgi?id=310679</a>
<a href="https://rdar.apple.com/173280425">rdar://173280425</a>

Reviewed by Megan Gardner.

The match index was being updated incorrectly after changing the type
from an int to an optional unsigned. I fix the logic and consolidated
it to one function.

* Source/WebKit/WebProcess/WebPage/FindController.cpp:
(WebKit::FindController::updateMatchIndex):
(WebKit::FindController::findString):

Added some tests to exercise this change.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewFindString.mm:
(TestWebKitAPI::TEST(WKWebViewFindString, MatchIndexDoesNotUpdateWithoutDetermineMatchIndexOption)):
(TestWebKitAPI::TEST(WKWebViewFindString, MatchIndexIsCorrectNavigatingWrapAround)):
(TestWebKitAPI::TEST(WKWebViewFindString, MatchIndexIsCorrectNavigatingWrapAroundBackwards)):

Canonical link: <a href="https://commits.webkit.org/310022@main">https://commits.webkit.org/310022@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff15d4e3459ebc84e9264e85cc4a249c9be77a57

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152204 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24986 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18580 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160947 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105661 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154078 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25548 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25292 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117588 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83462 "8 flakes 2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155164 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19826 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136635 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98301 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18903 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16809 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8781 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128554 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14509 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163413 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6559 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16134 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125615 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24784 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20848 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125791 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34184 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24785 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136305 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81384 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20805 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13082 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24402 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88687 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24093 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24253 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24154 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->