### PR TITLE
Reduce more unnecessary protected local variables in no-delete context in WebCore

### DIFF
--- a/Source/WebCore/Modules/mediasession/MediaSession.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaSession.cpp
@@ -658,7 +658,7 @@ MediaTime MediaSession::mediaSessionDuration() const
 
 std::optional<MediaSessionGroupIdentifier> MediaSession::mediaSessionGroupIdentifier() const
 {
-    RefPtr document = this->document();
+    auto* document = this->document();
     return document && document->page() ? document->page()->mediaSessionGroupIdentifier() : std::nullopt;
 }
 

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
@@ -180,7 +180,7 @@ PeerConnectionBackend::PeerConnectionBackend(RTCPeerConnection& peerConnection)
 {
 #if USE(LIBWEBRTC)
     RefPtr document = peerConnection.document();
-    if (RefPtr page = document ? document->page() : nullptr)
+    if (auto* page = document ? document->page() : nullptr)
         m_shouldFilterICECandidates = page->webRTCProvider().isSupportingMDNS();
 #endif
 

--- a/Source/WebCore/Modules/webaudio/AudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioContext.cpp
@@ -541,7 +541,7 @@ void AudioContext::didReceiveRemoteControlCommand(PlatformMediaSession::RemoteCo
 
 std::optional<MediaSessionGroupIdentifier> AudioContext::mediaSessionGroupIdentifier() const
 {
-    RefPtr document = this->document();
+    auto* document = this->document();
     return document && document->page() ? document->page()->mediaSessionGroupIdentifier() : std::nullopt;
 }
 

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -6152,7 +6152,7 @@ void AXObjectCache::updateRelationsForTree(ContainerNode& rootNode)
 
         if (RefPtr shadowRoot = element->shadowRoot(); shadowRoot && shadowRoot->mode() != ShadowRootMode::UserAgent)
             updateRelationsForTree(*shadowRoot);
-        if (RefPtr frameOwnerElement = dynamicDowncast<HTMLFrameOwnerElement>(element.get())) {
+        if (auto* frameOwnerElement = dynamicDowncast<HTMLFrameOwnerElement>(element.get())) {
             if (RefPtr document = frameOwnerElement->contentDocument())
                 updateRelationsForTree(*document);
         }

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -2585,7 +2585,7 @@ static CheckedPtr<RenderObject> nearestRendererFromNode(Node& node)
 
 static int zIndexFromRenderer(RenderObject* renderer)
 {
-    for (CheckedPtr layer = renderer->enclosingLayer(); layer; layer = layer->parent()) {
+    for (auto* layer = renderer->enclosingLayer(); layer; layer = layer->parent()) {
         if (int zIndex = layer->zIndex())
             return zIndex;
     }

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3391,7 +3391,7 @@ bool Document::isInStyleInterleavedLayoutForSelfOrAncestor() const
 {
     if (isInStyleInterleavedLayout())
         return true;
-    if (RefPtr owner = ownerElement())
+    if (auto* owner = ownerElement())
         return owner->document().isInStyleInterleavedLayoutForSelfOrAncestor();
     return false;
 }
@@ -3841,7 +3841,7 @@ AXObjectCache* Document::axObjectCache() const
 void Document::setVisuallyOrdered()
 {
     m_visuallyOrdered = true;
-    if (CheckedPtr renderView = this->renderView())
+    if (auto* renderView = this->renderView())
         renderView->mutableStyle().setRTLOrdering(Order::Visual);
 }
 

--- a/Source/WebCore/html/HTMLObjectElement.cpp
+++ b/Source/WebCore/html/HTMLObjectElement.cpp
@@ -172,7 +172,7 @@ void HTMLObjectElement::parametersForPlugin(Vector<AtomString>& paramNames, Vect
 
 bool HTMLObjectElement::hasFallbackContent() const
 {
-    for (RefPtr<Node> child = firstChild(); child; child = child->nextSibling()) {
+    for (auto* child = firstChild(); child; child = child->nextSibling()) {
         // Ignore whitespace-only text, and <param> tags, any other content is fallback content.
         if (auto* textChild = dynamicDowncast<Text>(*child)) {
             if (!textChild->containsOnlyASCIIWhitespace())

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
@@ -137,8 +137,8 @@ static inline void adjustBorderForTableAndFieldset(const RenderBoxModelObject& r
     if (renderer.isFieldset()) {
         auto adjustment = downcast<RenderBlock>(renderer).intrinsicBorderForFieldset();
         // Note that this adjustment is coming from _inside_ the fieldset so its own flow direction is what is relevant here.
-        CheckedRef style = renderer.style();
-        switch (style->writingMode().blockDirection()) {
+        auto& style = renderer.style();
+        switch (style.writingMode().blockDirection()) {
         case FlowDirection::TopToBottom:
             borderWidths.top() += adjustment;
             break;

--- a/Source/WebCore/page/DebugPageOverlays.cpp
+++ b/Source/WebCore/page/DebugPageOverlays.cpp
@@ -564,7 +564,7 @@ void InteractionRegionOverlay::drawRect(PageOverlay&, GraphicsContext& context, 
                 AffineTransform transform;
 
                 transform.translate(rectInLayerCoordinates.location());
-                if (RefPtr page = m_page)
+                if (auto* page = m_page.get())
                     transform.scale(page->pageScaleFactor());
 
                 existingClip.transform(transform);

--- a/Source/WebCore/page/WorkerNavigator.cpp
+++ b/Source/WebCore/page/WorkerNavigator.cpp
@@ -89,7 +89,7 @@ GPU* WorkerNavigator::gpu()
 void WorkerNavigator::setAppBadge(std::optional<unsigned long long> badge, Ref<DeferredPromise>&& promise)
 {
 #if ENABLE(DECLARATIVE_WEB_PUSH)
-    if (RefPtr context = dynamicDowncast<ServiceWorkerGlobalScope>(scriptExecutionContext())) {
+    if (auto* context = dynamicDowncast<ServiceWorkerGlobalScope>(scriptExecutionContext())) {
         if (auto* declarativePushEvent = context->declarativePushEvent()) {
             declarativePushEvent->setUpdatedAppBadge(WTF::move(badge));
             return;

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
@@ -143,7 +143,7 @@ AudioVideoRendererAVFObjC::~AudioVideoRendererAVFObjC()
 void AudioVideoRendererAVFObjC::setPreferences(VideoRendererPreferences preferences)
 {
     m_preferences = preferences;
-    if (RefPtr videoRenderer = m_videoRenderer)
+    if (auto* videoRenderer = m_videoRenderer.get())
         videoRenderer->setPreferences(preferences);
 }
 

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -1281,7 +1281,7 @@ bool RenderBlock::establishesIndependentFormattingContext() const
         if (!style.gridTemplateColumns().subgrid && !style.gridTemplateRows().subgrid)
             return true;
         // Masonry makes grid items not subgrids.
-        if (CheckedPtr parentGridBox = dynamicDowncast<RenderGrid>(parent()))
+        if (auto* parentGridBox = dynamicDowncast<RenderGrid>(parent()))
             return parentGridBox->isMasonry();
     }
 

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -4045,7 +4045,7 @@ static void setFullRepaintOnParentInlineBoxLayerIfNeeded(const RenderText& rende
     // Here we mark the parent inline box's layer dirty to trigger repaint at (#2).
     if (!renderer.needsLayout())
         return;
-    CheckedPtr parent = renderer.parent();
+    auto* parent = renderer.parent();
     if (!parent) {
         ASSERT_NOT_REACHED();
         return;

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -1307,7 +1307,7 @@ bool RenderTheme::isSpinUpButtonPartHovered(const RenderElement& renderer) const
 
 bool RenderTheme::isPresenting(const RenderElement& renderer) const
 {
-    RefPtr input = dynamicDowncast<HTMLInputElement>(renderer.element());
+    auto* input = dynamicDowncast<HTMLInputElement>(renderer.element());
     return input && input->isPresentingAttachedView();
 }
 

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -723,7 +723,7 @@ void Adjuster::adjust(RenderStyle& style) const
 #endif
             || style.blendMode() != BlendMode::Normal
             || !style.viewTransitionName().isNone();
-        if (RefPtr element = m_element) {
+        if (auto* element = m_element.get()) {
             auto styleable = Styleable::fromElement(*element);
             forceToFlat |= styleable.capturedInViewTransition();
         }

--- a/Source/WebCore/svg/SVGSVGElement.cpp
+++ b/Source/WebCore/svg/SVGSVGElement.cpp
@@ -647,7 +647,7 @@ FloatSize SVGSVGElement::currentViewportSizeExcludingZoom() const
             viewportSize = svgViewportContainer->viewport().size();
         else if (CheckedPtr svgRoot = dynamicDowncast<RenderSVGRoot>(renderer()))
             viewportSize = svgRoot->contentBoxRect().size() / svgRoot->style().usedZoom();
-        else if (CheckedPtr svgViewportContainer = dynamicDowncast<RenderSVGViewportContainer>(renderer()))
+        else if (auto* svgViewportContainer = dynamicDowncast<RenderSVGViewportContainer>(renderer()))
             viewportSize = svgViewportContainer->viewport().size();
         else {
             ASSERT_NOT_REACHED();


### PR DESCRIPTION
#### 6c7b7fba9f9eac05f7c0a40ccc4bd6f34b91f382
<pre>
Reduce more unnecessary protected local variables in no-delete context in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=310684">https://bugs.webkit.org/show_bug.cgi?id=310684</a>
<a href="https://rdar.apple.com/173282391">rdar://173282391</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/Modules/mediasession/MediaSession.cpp:
(WebCore::MediaSession::mediaSessionGroupIdentifier const):
* Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp:
(WebCore::PeerConnectionBackend::PeerConnectionBackend):
* Source/WebCore/Modules/webaudio/AudioContext.cpp:
(WebCore::AudioContext::mediaSessionGroupIdentifier const):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::updateRelationsForTree):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::zIndexFromRenderer):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::startOfContinuations):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::isInStyleInterleavedLayoutForSelfOrAncestor const):
(WebCore::Document::setVisuallyOrdered):
* Source/WebCore/html/HTMLObjectElement.cpp:
(WebCore::HTMLObjectElement::hasFallbackContent const):
* Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp:
(WebCore::LayoutIntegration::adjustBorderForTableAndFieldset):
* Source/WebCore/page/DebugPageOverlays.cpp:
(WebCore::InteractionRegionOverlay::drawRect):
* Source/WebCore/page/WorkerNavigator.cpp:
(WebCore::WorkerNavigator::setAppBadge):
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::setPreferences):
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::establishesIndependentFormattingContext const):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::setFullRepaintOnParentInlineBoxLayerIfNeeded):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::isPresenting const):
* Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp:
(WebCore::nextContinuation):
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const):
* Source/WebCore/svg/SVGSVGElement.cpp:
(WebCore::SVGSVGElement::currentViewportSizeExcludingZoom const):

Canonical link: <a href="https://commits.webkit.org/309997@main">https://commits.webkit.org/309997@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a44a892c411d635b084c881050174c9c3caa161

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152274 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25056 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18653 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161017 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105731 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154148 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25583 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25362 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117638 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83450 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155234 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19848 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136691 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98351 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18924 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16862 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8851 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128575 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14565 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163485 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6629 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16159 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125669 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24854 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20900 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125845 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34171 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24855 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136361 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81454 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20845 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13138 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24472 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88757 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24163 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24323 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24224 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->