### PR TITLE
[Site Isolation] Fix WKNavigation.LeakCheck

### DIFF
--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -914,12 +914,14 @@ void WebProcessProxy::removeWebPage(WebPageProxy& webPage, EndsUsingDataStore en
     WEBPROCESSPROXY_RELEASE_LOG(Process, "removeWebPage: webPage=%p, pageProxyID=%" PRIu64 ", webPageID=%" PRIu64, &webPage, webPage.identifier().toUInt64(), webPage.webPageIDInMainFrameProcess().toUInt64());
     RefPtr removedPage = m_pageMap.take(webPage.identifier()).get();
     ASSERT_UNUSED(removedPage, removedPage == &webPage);
+
+    // reportProcessDisassociatedWithPageIfNecessary gets page from globalPageMap() for operation,
+    // so it must be invoked before removal.
+    reportProcessDisassociatedWithPageIfNecessary(webPage.identifier());
     removedPage = globalPageMap().take(webPage.identifier()).get();
     ASSERT_UNUSED(removedPage, removedPage == &webPage);
 
     logger().setEnabled(this, isAlwaysOnLoggingAllowed());
-
-    reportProcessDisassociatedWithPageIfNecessary(webPage.identifier());
 
     if (endsUsingDataStore == EndsUsingDataStore::Yes)
         protect(processPool())->pageEndUsingWebsiteDataStore(webPage, protect(webPage.websiteDataStore()));

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm
@@ -50,6 +50,7 @@
 #import <WebKit/WKWebsiteDataStorePrivate.h>
 #import <WebKit/_WKFeature.h>
 #import <WebKit/_WKPageLoadTiming.h>
+#import <WebKit/_WKProcessPoolConfiguration.h>
 #import <WebKit/_WKWebsiteDataStoreConfiguration.h>
 #import <WebKit/_WKWebsiteDataStoreDelegate.h>
 #import <wtf/RetainPtr.h>
@@ -4351,7 +4352,8 @@ TEST(WKNavigation, PreferredHTTPSPolicyNoFallbackOnCertificateError)
     EXPECT_WK_STREQ(@"", [webView URL].absoluteString);
 }
 
-TEST(WKNavigation, LeakCheck)
+enum class ShouldEnablePageCache : bool { No, Yes };
+static void runNavigationLeakCheck(ShouldEnablePageCache shouldEnablePageCache)
 {
     using namespace TestWebKitAPI;
     HTTPServer server({
@@ -4359,16 +4361,18 @@ TEST(WKNavigation, LeakCheck)
         { "/webkit"_s, { "hi"_s } }
     }, HTTPServer::Protocol::HttpsProxy);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
-    [storeConfiguration setHTTPSProxy:[NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", server.port()]]];
-    [storeConfiguration setAllowsHSTSWithUntrustedRootCertificate:YES];
-    auto viewConfiguration = adoptNS([WKWebViewConfiguration new]);
-    [viewConfiguration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]).get()];
+    RetainPtr viewConfiguration = server.httpsProxyConfiguration();
+    if (shouldEnablePageCache == ShouldEnablePageCache::No) {
+        RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+        processPoolConfiguration.get().pageCacheEnabled = NO;
+        RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+        [viewConfiguration setProcessPool:processPool.get()];
+    }
 
     __block __weak WKNavigation *gLastNavigation = nil;
 
     __block bool done = false;
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [delegate allowAnyTLSCertificate];
     delegate.get().didStartProvisionalNavigation = ^(WKWebView *, WKNavigation *navigation) {
         gLastNavigation = navigation;
@@ -4377,7 +4381,7 @@ TEST(WKNavigation, LeakCheck)
         EXPECT_EQ(gLastNavigation, navigation);
         done = true;
     };
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:viewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:viewConfiguration.get()]);
     [webView setNavigationDelegate:delegate.get()];
 
     __weak WKNavigation *navigationToExample;
@@ -4400,6 +4404,16 @@ TEST(WKNavigation, LeakCheck)
 
     while (navigationToExample)
         Util::spinRunLoop();
+}
+
+TEST(WKNavigation, LeakCheck)
+{
+    runNavigationLeakCheck(ShouldEnablePageCache::Yes);
+}
+
+TEST(WKNavigation, LeakCheckNoPageCache)
+{
+    runNavigationLeakCheck(ShouldEnablePageCache::No);
 }
 
 TEST(WKNavigation, Multiple303Redirects)


### PR DESCRIPTION
#### 44d356832079f46fbbdd3b7d305ad675701c0b04
<pre>
[Site Isolation] Fix WKNavigation.LeakCheck
<a href="https://bugs.webkit.org/show_bug.cgi?id=310670">https://bugs.webkit.org/show_bug.cgi?id=310670</a>
<a href="https://rdar.apple.com/173275669">rdar://173275669</a>

Reviewed by Per Arne Vollan.

The test WKNavigation.LeakCheck tries to verify `WKNavigation` or `API::Navigation` will be destroyed when it is not in
use, and here is the flow:
1. Create a WKWebView and loads &quot;example.com&quot; in it =&gt; This navigation creates first `WKNavigation` object.
2. Load &quot;webkit.org&quot; in the view =&gt; This navigation creates a second `WKNavigation` object.
3. Clear backforward cache.
4. Wait until the first `WKNavigation` object is destroyed.

The test is currently timed out under Site Isolation because the `WKNavigation` object is never destroyed. The idea
behind the test is (see 264449@main): if a page (`WebPageProxy`, including its `SuspendededPageProxy` and
`ProvisionalPageProxy`) stops using a web process (`WebProcessProxy`), it should clear all navigation objects related to
that process (`WebProcessProxy::reportProcessDisassociatedWithPageIfNecessary`). Under Site Isolation, backforward cache
is currently disabled, so the page should be stop using the web process for &quot;example.com&quot; after navigation, and the
navigation object should be destroyed; i.e. the test is still expected to pass.

It turns out to be a bug in `WebProcessProxy::removeWebPage`. So `reportProcessDisassociatedWithPageIfNecessary` is
responsible for notifying `WebPageProxy` about process is no longer in use, and `WebPageProxy` will go ahead to update
navigation state (`WebNavigationState`), which leads to destruction of `WKNavigation` object. In `removeWebPage`,
`reportProcessDisassociatedWithPageIfNecessary` is invoked after page is removed from `globalPageMap()`, so it cannot
find the corresponding page for notificaiton, and the update on navigation state never happens (navigation object is
not destroyed). To fix this, moving invocation of `reportProcessDisassociatedWithPageIfNecessary` to before the removal
on `globalPageMap()`. This patch also adds a new dedicated test for this bug.

Test: WKNavigation.LeakCheckNoPageCache

* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::removeWebPage):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm:
(runNavigationLeakCheck):
(TEST(WKNavigation, LeakCheck)):
(TEST(WKNavigation, LeakCheckNoPageCache)):

Canonical link: <a href="https://commits.webkit.org/310037@main">https://commits.webkit.org/310037@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6d9b6fb665627c31ac07ed00f16ce03e0fbc7d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152051 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24833 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18411 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160794 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105508 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f18f5640-892f-42bb-95e0-70bafef2c39a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153925 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25325 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25139 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117451 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83307 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c0731f1a-e79f-4a99-b40a-589687609597) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155011 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19632 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136460 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98165 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18712 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16660 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8628 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128350 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14351 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163259 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6406 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15943 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125477 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24631 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20710 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125653 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34199 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24632 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136147 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81214 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20664 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12923 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24249 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88534 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23940 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24100 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24001 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->