### PR TITLE
[iOS release] imported/w3c/web-platform-tests/css/css-writing-modes/text-orientation-mixed-srl-016.xht is a flaky image diff

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/text-orientation-mixed-srl-016-expected.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/text-orientation-mixed-srl-016-expected.xht
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" class="reftest-wait">
 
  <head>
 
@@ -35,6 +35,16 @@
   <div>月火水Abc<br />def木金土</div>
 
   <div>月火水Abc<br />def木金土</div>
+
+  <script type="text/javascript"><![CDATA[
+  document.fonts.ready.then(function() {
+    requestAnimationFrame(function() {
+      requestAnimationFrame(function() {
+        document.documentElement.classList.remove("reftest-wait");
+      });
+    });
+  });
+  ]]></script>
 
  </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/text-orientation-mixed-srl-016-ref.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/text-orientation-mixed-srl-016-ref.xht
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" class="reftest-wait">
 
  <head>
 
@@ -35,6 +35,16 @@
   <div>月火水Abc<br />def木金土</div>
 
   <div>月火水Abc<br />def木金土</div>
+
+  <script type="text/javascript"><![CDATA[
+  document.fonts.ready.then(function() {
+    requestAnimationFrame(function() {
+      requestAnimationFrame(function() {
+        document.documentElement.classList.remove("reftest-wait");
+      });
+    });
+  });
+  ]]></script>
 
  </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/text-orientation-mixed-srl-016.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/text-orientation-mixed-srl-016.xht
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" class="reftest-wait">
 
  <head>
 
@@ -50,5 +50,16 @@
 
   <div id="ref-vrl-sideways">月火水Abc<br />def木金土</div>
 
+  <script type="text/javascript"><![CDATA[
+  document.fonts.ready.then(function() {
+    requestAnimationFrame(function() {
+      requestAnimationFrame(function() {
+        document.documentElement.classList.remove("reftest-wait");
+      });
+    });
+  });
+  ]]></script>
+
  </body>
 </html>
+

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8184,8 +8184,6 @@ editing/selection/ios/select-text-using-tap-and-half.html [ Skip ]
 
 webkit.org/b/296338 http/tests/site-isolation/fullscreen.html [ Pass Failure ]
 
-webkit.org/b/310677 [ Release ] imported/w3c/web-platform-tests/css/css-writing-modes/text-orientation-mixed-srl-016.xht [ Pass ImageOnlyFailure ]
-
 webkit.org/b/310677 [ Release ] compositing/iframes/overlapped-nested-iframes.html [ Pass Failure ]
 
 # webkit.org/b/296017 7x imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/shape-image (layout-tests) are flakey image failures


### PR DESCRIPTION
#### b06fedead73aaac17b4bec31517d9fe74cc2e710
<pre>
[iOS release] imported/w3c/web-platform-tests/css/css-writing-modes/text-orientation-mixed-srl-016.xht is a flaky image diff
<a href="https://rdar.apple.com/173281695">rdar://173281695</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=310680">https://bugs.webkit.org/show_bug.cgi?id=310680</a>

Reviewed by Tim Nguyen.

The test is flaky due to small pixel inconsistencies when rendering:
Without reftest-wait, screenshots can be taken as soon as the load event fires.
The font may be &quot;loaded&quot; but may not have completed rendering with it in a fully
settled state. The double requestAnimationFrame after fonts.ready
guarantees both pages have completed at least one full rendering cycle with the final
font before the screenshot, making the comparison deterministic.

All three files (test, ref, expected) received the same two changes:

1. class=&quot;reftest-wait&quot; on &lt;html&gt;
2. Synchronization script at end of &lt;body&gt;

* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/text-orientation-mixed-srl-016-expected.xht:
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/text-orientation-mixed-srl-016-ref.xht:
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/text-orientation-mixed-srl-016.xht:
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/310535@main">https://commits.webkit.org/310535@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/932189aa086e932fd2085a9f307de270b1cef86b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152052 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24834 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18412 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160795 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105509 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25326 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25140 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117453 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83308 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155012 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19636 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136462 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98167 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18715 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16661 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8629 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128354 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14353 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163260 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15945 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125478 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24632 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20711 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125654 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34576 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24633 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136149 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81215 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20665 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12925 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24250 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23941 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24101 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24002 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | | 
<!--EWS-Status-Bubble-End-->