### PR TITLE
ViewTransition snapshots are incorrectly stored in sRGB.

### DIFF
--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -465,7 +465,9 @@ static RefPtr<ImageBuffer> snapshotElementVisualOverflowClippedToViewport(LocalF
         return nullptr;
     auto hostWindow = frameView->root() ? protect(frameView->root())->hostWindow() : nullptr;
 
-    auto buffer = ImageBuffer::create(paintRect.size(), RenderingMode::Accelerated, RenderingPurpose::Snapshot, scaleFactor, DestinationColorSpace::SRGB(), PixelFormat::BGRA8, hostWindow);
+    auto buffer = hostWindow
+        ? ImageBuffer::createCompatible(*hostWindow, paintRect.size(), RenderingMode::Accelerated, RenderingPurpose::Snapshot, scaleFactor, ImageBufferFormat { PixelFormat::BGRA8 })
+        : ImageBuffer::create(paintRect.size(), RenderingMode::Accelerated, RenderingPurpose::Snapshot, scaleFactor, DestinationColorSpace::SRGB(), ImageBufferFormat { PixelFormat::BGRA8 });
     if (!buffer)
         return nullptr;
 

--- a/Source/WebCore/page/Chrome.cpp
+++ b/Source/WebCore/page/Chrome.cpp
@@ -522,6 +522,11 @@ RefPtr<ImageBuffer> Chrome::createImageBuffer(const FloatSize& size, RenderingMo
     return m_client->createImageBuffer(size, renderingMode, purpose, resolutionScale, colorSpace, pixelFormat);
 }
 
+RefPtr<ImageBuffer> Chrome::createCompatibleImageBuffer(const FloatSize& size, RenderingMode renderingMode, RenderingPurpose purpose, float resolutionScale, ImageBufferFormat pixelFormat) const
+{
+    return m_client->createCompatibleImageBuffer(size, renderingMode, purpose, resolutionScale, pixelFormat);
+}
+
 RefPtr<ImageBuffer> Chrome::sinkIntoImageBuffer(std::unique_ptr<SerializedImageBuffer> imageBuffer)
 {
     return m_client->sinkIntoImageBuffer(WTF::move(imageBuffer));

--- a/Source/WebCore/page/Chrome.h
+++ b/Source/WebCore/page/Chrome.h
@@ -131,6 +131,7 @@ public:
     void setCursorHiddenUntilMouseMoves(bool) override;
 
     RefPtr<ImageBuffer> createImageBuffer(const FloatSize&, RenderingMode, RenderingPurpose, float resolutionScale, const DestinationColorSpace&, ImageBufferFormat) const override;
+    RefPtr<ImageBuffer> createCompatibleImageBuffer(const FloatSize&, RenderingMode, RenderingPurpose, float resolutionScale, ImageBufferFormat) const override;
     RefPtr<WebCore::ImageBuffer> sinkIntoImageBuffer(std::unique_ptr<WebCore::SerializedImageBuffer>) override;
 
 #if ENABLE(WEBGL)

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -465,6 +465,7 @@ public:
     virtual DisplayRefreshMonitorFactory* displayRefreshMonitorFactory() const { return nullptr; }
 
     virtual RefPtr<ImageBuffer> createImageBuffer(const FloatSize&, RenderingMode, RenderingPurpose, float, const DestinationColorSpace&, ImageBufferFormat) const { return nullptr; }
+    virtual RefPtr<ImageBuffer> createCompatibleImageBuffer(const FloatSize&, RenderingMode, RenderingPurpose, float, ImageBufferFormat) const { return nullptr; }
     WEBCORE_EXPORT virtual RefPtr<WebCore::ImageBuffer> sinkIntoImageBuffer(std::unique_ptr<WebCore::SerializedImageBuffer>);
 
 #if ENABLE(WEBGL)

--- a/Source/WebCore/platform/GraphicsClient.h
+++ b/Source/WebCore/platform/GraphicsClient.h
@@ -64,6 +64,8 @@ public:
 private:
     // Called by passing GraphicsClient into ImageBuffer functions.
     virtual RefPtr<ImageBuffer> createImageBuffer(const FloatSize&, RenderingMode, RenderingPurpose, float resolutionScale, const DestinationColorSpace&, ImageBufferFormat) const = 0;
+    // Like createImageBuffer, but uses the display colorspace instead of a caller-specified one.
+    virtual RefPtr<ImageBuffer> createCompatibleImageBuffer(const FloatSize&, RenderingMode, RenderingPurpose, float resolutionScale, ImageBufferFormat) const = 0;
 
     // Called by passing GraphicsClient into SerializedImageBuffer functions.
     virtual RefPtr<WebCore::ImageBuffer> sinkIntoImageBuffer(std::unique_ptr<WebCore::SerializedImageBuffer>) = 0;

--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -74,11 +74,8 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(SerializedImageBuffer);
 
 static const float MaxClampedLength = 4096;
 static const float MaxClampedArea = MaxClampedLength * MaxClampedLength;
-
 RefPtr<ImageBuffer> ImageBuffer::create(const FloatSize& size, RenderingMode renderingMode, RenderingPurpose purpose, float resolutionScale, const DestinationColorSpace& colorSpace, ImageBufferFormat pixelFormat, GraphicsClient* graphicsClient)
 {
-    RefPtr<ImageBuffer> imageBuffer;
-
     if (graphicsClient) {
         if (auto imageBuffer = graphicsClient->createImageBuffer(size, renderingMode, purpose, resolutionScale, colorSpace, pixelFormat))
             return imageBuffer;
@@ -116,6 +113,14 @@ RefPtr<ImageBuffer> ImageBuffer::create(const FloatSize& size, RenderingMode ren
 
     ASSERT_NOT_REACHED();
     return nullptr;
+}
+
+RefPtr<ImageBuffer> ImageBuffer::createCompatible(GraphicsClient& graphicsClient, const FloatSize& size, RenderingMode renderingMode, RenderingPurpose purpose, float resolutionScale, ImageBufferFormat pixelFormat)
+{
+    if (auto imageBuffer = graphicsClient.createCompatibleImageBuffer(size, renderingMode, purpose, resolutionScale, pixelFormat))
+        return imageBuffer;
+
+    return create(size, renderingMode, purpose, resolutionScale, DestinationColorSpace::SRGB(), pixelFormat, &graphicsClient);
 }
 
 ImageBuffer::ImageBuffer(Parameters parameters, const ImageBufferBackend::Info& backendInfo, const WebCore::ImageBufferCreationContext&, std::unique_ptr<ImageBufferBackend>&& backend, RenderingResourceIdentifier renderingResourceIdentifier)

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -99,6 +99,7 @@ public:
     }
 
     WEBCORE_EXPORT static RefPtr<ImageBuffer> create(const FloatSize&, RenderingMode, RenderingPurpose, float resolutionScale, const DestinationColorSpace&, ImageBufferFormat, GraphicsClient* = nullptr);
+    WEBCORE_EXPORT static RefPtr<ImageBuffer> createCompatible(GraphicsClient&, const FloatSize&, RenderingMode, RenderingPurpose, float resolutionScale, ImageBufferFormat);
 
     template<typename BackendType, typename ImageBufferType = ImageBuffer, typename... Arguments>
     static RefPtr<ImageBufferType> create(const FloatSize& size, float resolutionScale, const DestinationColorSpace& colorSpace, ImageBufferFormat bufferFormat, RenderingPurpose purpose, const ImageBufferCreationContext& creationContext, Arguments&&... arguments)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -293,6 +293,12 @@ RefPtr<RemoteImageBufferProxy> RemoteRenderingBackendProxy::createImageBuffer(co
     return imageBuffer;
 }
 
+RefPtr<RemoteImageBufferProxy> RemoteRenderingBackendProxy::createCompatibleImageBuffer(const FloatSize& size, RenderingMode renderingMode, RenderingPurpose purpose, float resolutionScale, ImageBufferFormat bufferFormat)
+{
+    auto resolvedColorSpace = m_displayColorSpace.value_or(DestinationColorSpace::SRGB());
+    return createImageBuffer(size, renderingMode, purpose, resolutionScale, resolvedColorSpace, bufferFormat);
+}
+
 void RemoteRenderingBackendProxy::releaseImageBuffer(RemoteImageBufferProxy& imageBuffer)
 {
     auto identifier = imageBuffer.renderingResourceIdentifier();

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -110,9 +110,15 @@ public:
     std::unique_ptr<RemoteSerializedImageBufferProxy> moveToSerializedBuffer(RemoteImageBufferProxy&);
     Ref<RemoteImageBufferProxy> moveToImageBuffer(RemoteSerializedImageBufferProxy&);
 
+    void setColorSpace(std::optional<WebCore::DestinationColorSpace> colorSpace)
+    {
+        m_displayColorSpace = colorSpace;
+    }
+
     bool isCached(const WebCore::ImageBuffer&) const;
 
     RefPtr<RemoteImageBufferProxy> createImageBuffer(const WebCore::FloatSize&, WebCore::RenderingMode, WebCore::RenderingPurpose, float resolutionScale, const WebCore::DestinationColorSpace&, WebCore::ImageBufferFormat);
+    RefPtr<RemoteImageBufferProxy> createCompatibleImageBuffer(const WebCore::FloatSize&, WebCore::RenderingMode, WebCore::RenderingPurpose, float resolutionScale, WebCore::ImageBufferFormat);
     void releaseImageBuffer(RemoteImageBufferProxy&);
     bool getPixelBufferForImageBuffer(WebCore::RenderingResourceIdentifier, const WebCore::PixelBufferFormat& destinationFormat, const WebCore::IntRect& srcRect, std::span<uint8_t> result);
     // Returns backing store bitmap for the RemoteNativeImageProxy.
@@ -250,6 +256,8 @@ private:
 #if PLATFORM(COCOA)
     Vector<LayerPrepareBuffersData> m_bufferSetsToPrepare;
 #endif
+
+    std::optional<WebCore::DestinationColorSpace> m_displayColorSpace;
 
     RenderingUpdateID m_renderingUpdateID;
     RenderingUpdateID m_didRenderingUpdateID;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1138,6 +1138,18 @@ RefPtr<ImageBuffer> WebChromeClient::createImageBuffer(const FloatSize& size, Re
     return nullptr;
 }
 
+RefPtr<ImageBuffer> WebChromeClient::createCompatibleImageBuffer(const FloatSize& size, RenderingMode renderingMode, RenderingPurpose purpose, float resolutionScale, ImageBufferFormat pixelFormat) const
+{
+    if (WebProcess::singleton().shouldUseRemoteRenderingFor(purpose)) {
+        RefPtr page = m_page.get();
+        if (!page)
+            return nullptr;
+        return protect(page->ensureRemoteRenderingBackendProxy())->createCompatibleImageBuffer(size, renderingMode, purpose, resolutionScale, pixelFormat);
+    }
+
+    return nullptr;
+}
+
 RefPtr<ImageBuffer> WebChromeClient::sinkIntoImageBuffer(std::unique_ptr<SerializedImageBuffer> imageBuffer)
 {
     if (!is<RemoteSerializedImageBufferProxy>(imageBuffer))

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -271,6 +271,7 @@ private:
 
 #if ENABLE(GPU_PROCESS)
     RefPtr<WebCore::ImageBuffer> createImageBuffer(const WebCore::FloatSize&, WebCore::RenderingMode, WebCore::RenderingPurpose, float resolutionScale, const WebCore::DestinationColorSpace&, WebCore::ImageBufferFormat) const final;
+    RefPtr<WebCore::ImageBuffer> createCompatibleImageBuffer(const WebCore::FloatSize&, WebCore::RenderingMode, WebCore::RenderingPurpose, float resolutionScale, WebCore::ImageBufferFormat) const final;
     RefPtr<WebCore::ImageBuffer> sinkIntoImageBuffer(std::unique_ptr<WebCore::SerializedImageBuffer>) final;
 #endif
     std::unique_ptr<WebCore::WorkerClient> createWorkerClient(SerialFunctionDispatcher&) final;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp
@@ -56,6 +56,7 @@ public:
     UniqueRef<WorkerClient> createNestedWorkerClient(SerialFunctionDispatcher&) final;
     RefPtr<WebCore::ImageBuffer> sinkIntoImageBuffer(std::unique_ptr<WebCore::SerializedImageBuffer>) final;
     RefPtr<WebCore::ImageBuffer> createImageBuffer(const WebCore::FloatSize&, WebCore::RenderingMode, WebCore::RenderingPurpose, float resolutionScale, const WebCore::DestinationColorSpace&, WebCore::ImageBufferFormat) const final;
+    RefPtr<WebCore::ImageBuffer> createCompatibleImageBuffer(const WebCore::FloatSize&, WebCore::RenderingMode, WebCore::RenderingPurpose, float resolutionScale, WebCore::ImageBufferFormat) const final;
 #if ENABLE(WEBGL)
     RefPtr<WebCore::GraphicsContextGL> createGraphicsContextGL(const WebCore::GraphicsContextGLAttributes&) const final;
 #endif
@@ -103,6 +104,15 @@ RefPtr<ImageBuffer> GPUProcessWebWorkerClient::createImageBuffer(const FloatSize
         assertIsCurrent(*dispatcher);
     if (WebProcess::singleton().shouldUseRemoteRenderingFor(purpose))
         return protect(ensureRenderingBackend())->createImageBuffer(size, renderingMode, purpose, resolutionScale, colorSpace, pixelFormat);
+    return nullptr;
+}
+
+RefPtr<ImageBuffer> GPUProcessWebWorkerClient::createCompatibleImageBuffer(const FloatSize& size, RenderingMode renderingMode, RenderingPurpose purpose, float resolutionScale, ImageBufferFormat pixelFormat) const
+{
+    if (RefPtr dispatcher = this->dispatcher())
+        assertIsCurrent(*dispatcher);
+    if (WebProcess::singleton().shouldUseRemoteRenderingFor(purpose))
+        return protect(ensureRenderingBackend())->createCompatibleImageBuffer(size, renderingMode, purpose, resolutionScale, pixelFormat);
     return nullptr;
 }
 
@@ -173,6 +183,12 @@ RefPtr<ImageBuffer> WebWorkerClient::sinkIntoImageBuffer(std::unique_ptr<Seriali
 }
 
 RefPtr<ImageBuffer> WebWorkerClient::createImageBuffer(const FloatSize& size, RenderingMode renderingMode, RenderingPurpose purpose, float resolutionScale, const DestinationColorSpace& colorSpace, ImageBufferFormat pixelFormat) const
+{
+    assertIsCurrent(*dispatcher().get());
+    return nullptr;
+}
+
+RefPtr<ImageBuffer> WebWorkerClient::createCompatibleImageBuffer(const FloatSize& size, RenderingMode renderingMode, RenderingPurpose purpose, float resolutionScale, ImageBufferFormat pixelFormat) const
 {
     assertIsCurrent(*dispatcher().get());
     return nullptr;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.h
@@ -60,6 +60,7 @@ public:
 
     RefPtr<WebCore::ImageBuffer> sinkIntoImageBuffer(std::unique_ptr<WebCore::SerializedImageBuffer>) override;
     RefPtr<WebCore::ImageBuffer> createImageBuffer(const WebCore::FloatSize&, WebCore::RenderingMode, WebCore::RenderingPurpose, float resolutionScale, const WebCore::DestinationColorSpace&, WebCore::ImageBufferFormat) const override;
+    RefPtr<WebCore::ImageBuffer> createCompatibleImageBuffer(const WebCore::FloatSize&, WebCore::RenderingMode, WebCore::RenderingPurpose, float resolutionScale, WebCore::ImageBufferFormat) const override;
 #if ENABLE(WEBGL)
     RefPtr<WebCore::GraphicsContextGL> createGraphicsContextGL(const WebCore::GraphicsContextGLAttributes&) const override;
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -9388,11 +9388,21 @@ void WebPage::notifyPageOfAppBoundBehavior()
 }
 #endif
 
+void WebPage::colorspaceChanged()
+{
+#if ENABLE(GPU_PROCESS)
+    if (m_remoteRenderingBackendProxy)
+        m_remoteRenderingBackendProxy->setColorSpace(m_drawingArea->displayColorSpace());
+#endif
+}
+
 #if ENABLE(GPU_PROCESS)
 RemoteRenderingBackendProxy& WebPage::ensureRemoteRenderingBackendProxy()
 {
-    if (!m_remoteRenderingBackendProxy)
+    if (!m_remoteRenderingBackendProxy) {
         m_remoteRenderingBackendProxy = RemoteRenderingBackendProxy::create(*this);
+        m_remoteRenderingBackendProxy->setColorSpace(m_drawingArea->displayColorSpace());
+    }
     return *m_remoteRenderingBackendProxy;
 }
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -708,6 +708,8 @@ public:
     RemoteWebInspectorUI* remoteInspectorUI();
     bool isInspectorPage() { return !!m_inspectorUI || !!m_remoteInspectorUI; }
 
+    void colorspaceChanged();
+
     void inspectorFrontendCountChanged(unsigned);
 
 #if PLATFORM(IOS_FAMILY) || (PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE))


### PR DESCRIPTION
#### df818e9231ffeaecd0156bd769c58c147ff66b54
<pre>
ViewTransition snapshots are incorrectly stored in sRGB.
<a href="https://bugs.webkit.org/show_bug.cgi?id=304981">https://bugs.webkit.org/show_bug.cgi?id=304981</a>
&lt;<a href="https://rdar.apple.com/problem/167634138">rdar://problem/167634138</a>&gt;

Reviewed by NOBODY (OOPS!).

ViewTransition snapshot were using sRGB, which can represent colors differently to how the live content displays them (in device-specific colorspace).

Adds a new option to ImageBuffer::create to get a snapshot buffer using the device colorspace.

* Source/WebCore/dom/ViewTransition.cpp:
* Source/WebCore/page/Chrome.cpp:
(WebCore::Chrome::createCompatibleImageBuffer const):
* Source/WebCore/page/Chrome.h:
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::createCompatibleImageBuffer const):
* Source/WebCore/platform/GraphicsClient.h:
* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::create):
(WebCore::ImageBuffer::createCompatible):
* Source/WebCore/platform/graphics/ImageBuffer.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::createCompatibleImageBuffer):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:
(WebKit::RemoteRenderingBackendProxy::setColorSpace):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::createCompatibleImageBuffer const):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp:
(WebKit::GPUProcessWebWorkerClient::createCompatibleImageBuffer const):
(WebKit::WebWorkerClient::createCompatibleImageBuffer const):
* Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::colorspaceChanged):
(WebKit::WebPage::ensureRemoteRenderingBackendProxy):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df818e9231ffeaecd0156bd769c58c147ff66b54

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152060 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24842 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18497 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160803 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105517 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153934 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25334 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25148 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117460 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83313 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155020 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19643 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136554 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98174 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/982da4ef-8a61-4970-8226-37ec1b87db52) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18721 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16670 "Found 10 new API test failures: TestWebKitAPI.WKWebExtensionAPIExtension.GetViewsExcludesServiceWorkerBackground, TestWebKitAPI.WKWebExtensionAPIExtension.GetBackgroundPageFromTab, TestWebKitAPI.LockdownMode.NotSupportedFontLoadingAPI, TestWebKitAPI.LockdownMode.NotAllowedFont, TestWebKitAPI.JSHandle.WebpagePreferences, TestWebKitAPI.WKWebExtension.LoadFromDirectoryWithoutTrailingSlash, TestWebKitAPI.KeyboardEventTests.SmoothKeyboardScrolling, TestWebKitAPI.ImmediateActionTests.ImmediateActionOverText, TestWebKitAPI.EditorStateTests.TypingAttributesTextAlignmentStartEnd, TestWebKitAPI.WEBKIT.NavigationActionHasOpener14 (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8637 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128363 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14433 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163269 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6415 "Found 6 new failures in WebProcess/WebPage/WebPage.cpp") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16025 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125487 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24640 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20719 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125663 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24641 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136229 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81223 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20673 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13006 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24258 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88543 "Found 6 new failures in WebProcess/WebPage/WebPage.cpp") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23949 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24109 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24010 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->