### PR TITLE
[run-benchmark] Add a "manual" browser to test with browsers not controlled by the tool.

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner.py
@@ -23,7 +23,7 @@ class BenchmarkRunner(object):
     def __init__(self, plan_file, local_copy, count_override, timeout_override, build_dir, output_file, platform,
                  browser, browser_path, subtests=None, scale_unit=True, show_iteration_values=False, device_id=None,
                  diagnose_dir=None, generate_pgo_profiles=False, profile_output_dir=None, trace_type=None,
-                 profiling_interval=None, browser_args=None):
+                 profiling_interval=None, browser_args=None, http_server_type=None, http_server_port=0):
         self._plan_name, self._plan = BenchmarkRunner._load_plan_data(plan_file)
         if 'options' not in self._plan:
             self._plan['options'] = {}

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/browser_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/browser_driver.py
@@ -80,3 +80,6 @@ class BrowserDriver:
 
     def collect_pgo_profile(self, destination):
         raise NotImplementedError()
+
+    def _save_screenshot_to_path(self, output_directory, filename):
+        pass

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/browser_driver_factory.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/browser_driver_factory.py
@@ -23,5 +23,8 @@ class BrowserDriverFactory(object):
     @classmethod
     def create(cls, platform, browser_name, browser_args):
         if browser_name not in cls.browser_drivers[platform]:
-            raise ValueError("Browser \"%s\" is not available on platform \"%s\"" % (browser_name, platform))
+            if 'all' in cls.browser_drivers and browser_name in cls.browser_drivers['all']:
+                platform = 'all'
+            else:
+                raise ValueError("Browser \"%s\" is not available on platform \"%s\"" % (browser_name, platform))
         return cls.browser_drivers[platform][browser_name](browser_args)

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/browser_driver_manual.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/browser_driver_manual.py
@@ -1,0 +1,65 @@
+# Copyright (C) 2026 Igalia S.L. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import logging
+import socket
+
+from webkitpy.benchmark_runner.browser_driver.browser_driver import BrowserDriver
+_log = logging.getLogger(__name__)
+
+
+def get_ip_default_route():
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            s.connect(("1.1.1.1", 80))
+            return s.getsockname()[0]
+    except OSError:
+        return "127.0.0.1"
+
+
+# This is a manual browser that instead of executing the browser directly it prints the URL
+# and waits for the user to connect the browser manually. This is useful, for example, when
+# testing a browser from another device (like an embedded board) than where the server runs.
+class ManualBrowserDriver(BrowserDriver):
+    browser_name = 'manual'
+    process_search_list = []
+    platform = 'all'
+
+    def __init__(self, browser_args):
+        self._ip_default_route = get_ip_default_route()
+
+    def _print_action_msg(self, msg):
+        print(f'\n    [Manual Browser Testing]: {msg}\n')
+
+    def close_browsers(self):
+        self._print_action_msg('Close browser')
+
+    def launch_url(self, url, options, browser_build_path, browser_path):
+        url = url.replace('0.0.0.0', self._ip_default_route)
+        self._print_action_msg(f'Open URL {url}')
+
+    def launch_driver(self, *args, **kwargs):
+        raise ValueError(f"Browser {self.browser_name} can't use webdriver. Please use --driver webserver")

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_browser_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_browser_driver.py
@@ -172,5 +172,3 @@ class LinuxBrowserDriver(BrowserDriver):
             monitor = display.get_primary_monitor()
             return monitor.get_geometry()
 
-    def _save_screenshot_to_path(self, output_directory, filename):
-        pass

--- a/Tools/Scripts/webkitpy/benchmark_runner/http_server_driver/simple_http_server_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/http_server_driver/simple_http_server_driver.py
@@ -67,10 +67,11 @@ class SimpleHTTPServerDriver(HTTPServerDriver):
 
     platforms = ['osx', 'linux']
 
-    def __init__(self, **kwargs):
+    def __init__(self, server_ip, server_port, **kwargs):
         self._server_process = None
         self._server_port = 0
-        self._ip = '127.0.0.1'
+        self._server_port_requested = server_port
+        self._ip = server_ip
         self._http_log_path = None
         self._server_type = kwargs.get('server_type', 'twisted')
         self.set_device_id(kwargs.get('device_id'))
@@ -86,8 +87,12 @@ class SimpleHTTPServerDriver(HTTPServerDriver):
         if self._http_log_path:
             extra_args.extend(['--log-path', self._http_log_path])
             _log.info('HTTP requests will be logged to {}'.format(self._http_log_path))
+        if self._server_port_requested:
+            extra_args.extend(['--port', f'{self._server_port_requested}'])
         self._server_port = 0
-        self._server_process = subprocess.Popen([sys.executable, http_server_path, web_root] + extra_args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        server_cmd = [sys.executable, http_server_path, web_root] + extra_args
+        _log.info(f'Starting HTTP server: {" ".join(server_cmd)}')
+        self._server_process = subprocess.Popen(server_cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         max_attempt = 7
         retry_sequence = map(lambda attempt: attempt != max_attempt - 1, range(max_attempt))
         interval = 0.5
@@ -136,15 +141,16 @@ class SimpleHTTPServerDriver(HTTPServerDriver):
         # Wait for server to be up completely before exiting
         for attempt in range(max_attempt):
             try:
-                subprocess.check_call(["curl", "--silent", "--head", "--fail", "--output", "/dev/null", self.base_url()])
+                subprocess.check_call(["curl", "--silent", "--head", "--fail", "--output", "/dev/null", self.base_url(loopback_only=True)])
                 return
             except Exception as error:
                 _log.info('Server not running yet: %s' % error)
                 time.sleep(1)
-        raise Exception('Server not running, max tries exceeded: %s' % error)
+        raise Exception('Server not running, max tries exceeded')
 
-    def base_url(self):
-        return "http://%s:%d" % (self._ip, self._server_port)
+    def base_url(self, loopback_only=False):
+        ip = "127.0.0.1" if loopback_only else self._ip
+        return "http://%s:%d" % (ip, self._server_port)
 
     def fetch_result(self):
         (stdout, stderr) = self._server_process.communicate()

--- a/Tools/Scripts/webkitpy/benchmark_runner/run_benchmark.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/run_benchmark.py
@@ -47,7 +47,7 @@ def config_argument_parser():
     parser.add_argument('--count', type=int, help='Number of times to run the benchmark (e.g. 5).')
     parser.add_argument('--timeout', type=int, help='Number of seconds to wait for the benchmark to finish (e.g. 600).')
     parser.add_argument('--driver', default=WebServerBenchmarkRunner.name, choices=list(benchmark_runner_subclasses.keys()), help='Use the specified benchmark driver. Defaults to %s.' % WebServerBenchmarkRunner.name)
-    parser.add_argument('--browser', default=default_browser(), choices=BrowserDriverFactory.available_browsers(), help='Browser to run the nechmark in. Defaults to %s.' % default_browser())
+    parser.add_argument('--browser', default=default_browser(), choices=BrowserDriverFactory.available_browsers(), help='Browser to run the benchmark in, or "manual" to open URLs yourself (tip: set --http-server-port with manual). Defaults to %s.' % default_browser())
     parser.add_argument('--platform', default=default_platform(), choices=BrowserDriverFactory.available_platforms(), help='Platform that this script is running on. Defaults to %s.' % default_platform())
     parser.add_argument('--local-copy', help='Path to a local copy of the benchmark (e.g. PerformanceTests/SunSpider/).')
     parser.add_argument('--device-id', default=None, help='Undocumented option for mobile device testing.')
@@ -67,6 +67,7 @@ def config_argument_parser():
 
     parser.add_argument('browser_args', nargs='*', help='Additional arguments to pass to the browser process. These are positional arguments and must follow all other arguments. If the pass through arguments begin with a dash, use `--` before the argument list begins.')
 
+    parser.add_argument('--http-server-port', type=int, help='Specify the http server tcp port to use for the webserver benchmark runner. By default, a random port will be used.', default=0)
     parser.add_argument('--http-server-type', default="builtin", choices=["twisted", "builtin"], help="Specify the http server to use for the webserver benchmark runner. Default is `builtin`.")
 
     return parser
@@ -95,12 +96,14 @@ def run_benchmark_plan(args, plan):
     benchmark_runner_class = benchmark_runner_subclasses[args.driver]
     runner = benchmark_runner_class(plan,
                                     args.local_copy, args.count, args.timeout, args.build_dir, args.output_file,
-                                    args.platform, args.browser, args.browser_path, args.subtests, args.scale_unit,
-                                    args.show_iteration_values, args.device_id, args.diagnose_dir,
-                                    args.generate_pgo_profiles,
-                                    args.diagnose_dir if args.trace_type else None,
-                                    args.trace_type, args.profiling_interval,
-                                    args.browser_args, args.http_server_type)
+                                    args.platform, args.browser, args.browser_path, subtests=args.subtests, scale_unit=args.scale_unit,
+                                    show_iteration_values=args.show_iteration_values, device_id=args.device_id, diagnose_dir=args.diagnose_dir,
+                                    generate_pgo_profiles=args.generate_pgo_profiles,
+                                    profile_output_dir=args.diagnose_dir if args.trace_type else None,
+                                    trace_type=args.trace_type, profiling_interval=args.profiling_interval,
+                                    browser_args=args.browser_args, http_server_type=args.http_server_type,
+                                    http_server_port=max(0, int(args.http_server_port)))
+
     runner.execute()
 
 

--- a/Tools/Scripts/webkitpy/benchmark_runner/webserver_benchmark_runner.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/webserver_benchmark_runner.py
@@ -16,9 +16,11 @@ _log = logging.getLogger(__name__)
 class WebServerBenchmarkRunner(BenchmarkRunner):
     name = 'webserver'
 
-    def __init__(self, plan_file, local_copy, count_override, timeout_override, build_dir, output_file, platform, browser, browser_path, subtests=None, scale_unit=True, show_iteration_values=False, device_id=None, diagnose_dir=None, pgo_profile_output_dir=None, profile_output_dir=None, trace_type=None, profiling_interval=None, browser_args=None, http_server_type='twisted'):
-        self._http_server_driver = HTTPServerDriverFactory.create(platform, server_type=http_server_type, device_id=device_id)
-        super(WebServerBenchmarkRunner, self).__init__(plan_file, local_copy, count_override, timeout_override, build_dir, output_file, platform, browser, browser_path, subtests, scale_unit, show_iteration_values, device_id, diagnose_dir, pgo_profile_output_dir, profile_output_dir, trace_type, profiling_interval, browser_args)
+    def __init__(self, plan_file, local_copy, count_override, timeout_override, build_dir, output_file, platform, browser, browser_path, subtests=None, scale_unit=True, show_iteration_values=False, device_id=None, diagnose_dir=None, generate_pgo_profiles=False, profile_output_dir=None, trace_type=None, profiling_interval=None, browser_args=None, http_server_type='twisted', http_server_port=0):
+        # Listen on all interfaces with browser "manual" to make easier test from another devices on the network.
+        server_ip = '0.0.0.0' if browser == 'manual' else '127.0.0.1'
+        self._http_server_driver = HTTPServerDriverFactory.create(platform, server_type=http_server_type, device_id=device_id, server_ip=server_ip, server_port=http_server_port)
+        super().__init__(plan_file, local_copy, count_override, timeout_override, build_dir, output_file, platform, browser, browser_path, subtests=subtests, scale_unit=scale_unit, show_iteration_values=show_iteration_values, device_id=device_id, diagnose_dir=diagnose_dir, generate_pgo_profiles=generate_pgo_profiles, profile_output_dir=profile_output_dir, trace_type=trace_type, profiling_interval=profiling_interval, browser_args=browser_args, http_server_type=http_server_type, http_server_port=http_server_port)
         if self._diagnose_dir:
             self._http_server_driver.set_http_log(os.path.join(self._diagnose_dir, 'run-benchmark-http.log'))
 


### PR DESCRIPTION
#### a5fe38795e92dbd7662a7bae4870a23cde7b02ba
<pre>
[run-benchmark] Add a &quot;manual&quot; browser to test with browsers not controlled by the tool.
<a href="https://bugs.webkit.org/show_bug.cgi?id=310685">https://bugs.webkit.org/show_bug.cgi?id=310685</a>

Reviewed by Adrian Perez de Castro.

Having a &quot;manual&quot; browser mode that instead of launching the browser on
the URL it just prints the URL and waits for the user to connect it can
be useful for the following use cases:

- Testing with a browser running on another device (e.g. an embedded
  board): the developer machine hosts the benchmark server and the user
  manually loads the URL on the remote browser.
- Testing with a browser from an arbitrary path (or inside a container),
  or with a browser type that currently lacks a dedicated driver class.

When the browser is set to &quot;manual&quot;, the HTTP server binds to 0.0.0.0
and the tool prints the full LAN-reachable URL (resolved via the default
route interface) instead of launching a browser process. A new
--http-server-port option allows pinning the port, which is convenient
when firewall rules or the remote device require a fixed port.

* Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner.py:
(BenchmarkRunner.__init__):
* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/browser_driver.py:
(BrowserDriver.collect_pgo_profile):
(BrowserDriver):
(BrowserDriver._save_screenshot_to_path):
* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/browser_driver_factory.py:
(BrowserDriverFactory.create):
* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/browser_driver_manual.py: Added.
(get_ip_default_route):
(ManualBrowserDriver):
(ManualBrowserDriver.__init__):
(ManualBrowserDriver._print_action_msg):
(ManualBrowserDriver.close_browsers):
(ManualBrowserDriver.launch_url):
(ManualBrowserDriver.launch_driver):
* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_browser_driver.py:
(LinuxBrowserDriver._screen_size):
(LinuxBrowserDriver._save_screenshot_to_path): Deleted.
* Tools/Scripts/webkitpy/benchmark_runner/http_server_driver/simple_http_server_driver.py:
(SimpleHTTPServerDriver.__init__):
(SimpleHTTPServerDriver.serve):
(SimpleHTTPServerDriver._wait_for_http_server):
(SimpleHTTPServerDriver.base_url):
* Tools/Scripts/webkitpy/benchmark_runner/run_benchmark.py:
(config_argument_parser):
(run_benchmark_plan):
* Tools/Scripts/webkitpy/benchmark_runner/webserver_benchmark_runner.py:
(WebServerBenchmarkRunner.__init__):

Canonical link: <a href="https://commits.webkit.org/310512@main">https://commits.webkit.org/310512@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85d2b95cb1e5ebdc9e450612f38d98d7025e22b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152054 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24836 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18414 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160797 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105511 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153928 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25328 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25142 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117452 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83309 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155014 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19634 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136461 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98166 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/151376 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18713 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16663 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8631 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128351 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14352 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163262 "Built successfully") | 
| | | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15944 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/api/crashtests/huge-fetch.any.sharedworker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125479 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24634 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20712 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125655 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24635 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136148 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81217 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23533 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20666 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12924 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24252 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23943 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24103 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24004 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->