### PR TITLE
Get rid of roundUpToAlignment() in IPC::Encoder

### DIFF
--- a/Source/WebKit/Platform/IPC/Encoder.cpp
+++ b/Source/WebKit/Platform/IPC/Encoder.cpp
@@ -29,6 +29,7 @@
 #include "ArgumentCoders.h"
 #include "MessageFlags.h"
 #include <algorithm>
+#include <wtf/MathExtras.h>
 #include <wtf/OptionSet.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -99,18 +100,13 @@ void Encoder::wrapForTesting(UniqueRef<Encoder>&& original)
     m_attachments.appendVector(original->releaseAttachments());
 }
 
-static inline size_t NODELETE roundUpToAlignment(size_t value, size_t alignment)
-{
-    return ((value + alignment - 1) / alignment) * alignment;
-}
-
 void Encoder::reserve(size_t size)
 {
     auto oldCapacityBufferSize = capacityBuffer().size();
     if (size <= oldCapacityBufferSize)
         return;
 
-    size_t newCapacity = roundUpToAlignment(oldCapacityBufferSize * 2, 4096);
+    size_t newCapacity = roundUpToMultipleOf<4096>(oldCapacityBufferSize * 2);
     while (newCapacity < size)
         newCapacity *= 2;
 
@@ -142,7 +138,7 @@ const OptionSet<MessageFlags>& Encoder::messageFlags() const
 
 std::span<uint8_t> Encoder::grow(size_t alignment, size_t size)
 {
-    size_t alignedSize = roundUpToAlignment(m_bufferSize, alignment);
+    size_t alignedSize = roundUpToMultipleOf(alignment, m_bufferSize);
     reserve(alignedSize + size);
 
     auto capacityBuffer = this->capacityBuffer();


### PR DESCRIPTION
#### 35d025f688997e25d837c0db296e114763c225dd
<pre>
Get rid of roundUpToAlignment() in IPC::Encoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=310689">https://bugs.webkit.org/show_bug.cgi?id=310689</a>

Reviewed by Kimmo Kinnunen.

Get rid of roundUpToAlignment() in IPC::Encoder and reuse WTF::roundUpToMultipleOf()
instead.

* Source/WebKit/Platform/IPC/Encoder.cpp:
(IPC::Encoder::reserve):
(IPC::Encoder::grow):
(IPC::roundUpToAlignment): Deleted.

Canonical link: <a href="https://commits.webkit.org/309899@main">https://commits.webkit.org/309899@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/134d4488a1e28100506a16088c66f377d8ac0585

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152063 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24845 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18426 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160806 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105520 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25337 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25151 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117463 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155023 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19646 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136478 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98177 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18724 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/16673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8640 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163272 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6418 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15958 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125489 "Found 1 new test failure: media/media-sources-selection.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24643 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20722 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125665 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34103 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24644 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136162 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81226 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20676 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12939 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24261 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88546 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23952 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24112 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24013 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->