### PR TITLE
Cull simple non-empty canvas text drawing outside of the clip

### DIFF
--- a/LayoutTests/fast/canvas/fillText-edge-clip-expected.html
+++ b/LayoutTests/fast/canvas/fillText-edge-clip-expected.html
@@ -1,0 +1,26 @@
+<html>
+<body>
+<canvas width="100" height="100" style="border: solid 1px gray"></canvas>
+<script>
+const clip = 20;
+const iterations = 10;
+const increment = 4;
+
+const canvas = document.getElementsByTagName('canvas')[0];
+const width = canvas.width - clip;
+const ctx = canvas.getContext('2d');
+
+ctx.font = "10px monospace";
+ctx.fillStyle = "blue";
+
+for (let i = 0; i < iterations; ++i) {
+  const x = width + (i - iterations / 2) * increment;
+  const y = i * 10;
+  ctx.fillText("Hi", x, y);
+}
+
+ctx.clearRect(width, 0, clip, canvas.height);
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/canvas/fillText-edge-clip-shadow-expected.html
+++ b/LayoutTests/fast/canvas/fillText-edge-clip-shadow-expected.html
@@ -1,0 +1,31 @@
+<html>
+<body>
+<canvas width="100" height="100" style="border: solid 1px gray"></canvas>
+<script>
+const clip = 20;
+const shadowOffsetX = -20;
+const iterations = 10;
+const increment = 4;
+
+const canvas = document.getElementsByTagName('canvas')[0];
+const width = canvas.width - clip;
+const ctx = canvas.getContext('2d');
+
+ctx.font = "10px monospace";
+
+for (let i = 0; i < iterations; ++i) {
+  const x = width + (i - iterations / 2) * increment;
+  const y = i * 10;
+  ctx.fillStyle = "black";
+  ctx.fillText("Hi", x + shadowOffsetX, y);
+  if (x < width) {
+    ctx.fillStyle = "blue";
+    ctx.fillText("Hi", x, y);
+  }
+}
+
+ctx.clearRect(width, 0, clip, canvas.height);
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/canvas/fillText-edge-clip-shadow.html
+++ b/LayoutTests/fast/canvas/fillText-edge-clip-shadow.html
@@ -1,0 +1,32 @@
+<html>
+<body>
+<canvas width="100" height="100" style="border: solid 1px gray"></canvas>
+<script>
+const clip = 20;
+const shadowOffsetX = -20;
+const iterations = 10;
+const increment = 4;
+
+const canvas = document.getElementsByTagName('canvas')[0];
+const width = canvas.width - clip;
+const ctx = canvas.getContext('2d');
+
+let region = new Path2D();
+region.rect(0, 0, width, canvas.height);
+ctx.clip(region);
+
+ctx.shadowColor = "black";
+ctx.shadowOffsetX = shadowOffsetX;
+
+ctx.font = "10px monospace";
+ctx.fillStyle = "blue";
+
+for (let i = 0; i < iterations; ++i) {
+  const x = width + (i - iterations / 2) * increment;
+  const y = i * 10;
+  ctx.fillText("Hi", x, y);
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/canvas/fillText-edge-clip.html
+++ b/LayoutTests/fast/canvas/fillText-edge-clip.html
@@ -1,0 +1,28 @@
+<html>
+<body>
+<canvas width="100" height="100" style="border: solid 1px gray"></canvas>
+<script>
+const clip = 20;
+const iterations = 10;
+const increment = 4;
+
+const canvas = document.getElementsByTagName('canvas')[0];
+const width = canvas.width - clip;
+const ctx = canvas.getContext('2d');
+
+let region = new Path2D();
+region.rect(0, 0, width, canvas.height);
+ctx.clip(region);
+
+ctx.font = "10px monospace";
+ctx.fillStyle = "blue";
+
+for (let i = 0; i < iterations; ++i) {
+  const x = width + (i - iterations / 2) * increment;
+  const y = i * 10;
+  ctx.fillText("Hi", x, y);
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/canvas/fillText-edge-expected.html
+++ b/LayoutTests/fast/canvas/fillText-edge-expected.html
@@ -1,0 +1,25 @@
+<html>
+<body>
+<canvas width="100" height="100" style="border: solid 1px gray"></canvas>
+<script>
+const iterations = 10;
+const increment = 4;
+
+const canvas = document.getElementsByTagName('canvas')[0];
+const width = canvas.width;
+const ctx = canvas.getContext('2d');
+
+ctx.font = "10px monospace";
+ctx.fillStyle = "blue";
+
+for (let i = 0; i < iterations; ++i) {
+  const x = width + (i - iterations / 2) * increment;
+  const y = i * 10;
+  if (x < width) {
+    ctx.fillText("Hi", x, y);
+  }
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/canvas/fillText-edge-shadow-expected.html
+++ b/LayoutTests/fast/canvas/fillText-edge-shadow-expected.html
@@ -1,0 +1,28 @@
+<html>
+<body>
+<canvas width="100" height="100" style="border: solid 1px gray"></canvas>
+<script>
+const shadowOffsetX = -20;
+const iterations = 10;
+const increment = 4;
+
+const canvas = document.getElementsByTagName('canvas')[0];
+const width = canvas.width;
+const ctx = canvas.getContext('2d');
+
+ctx.font = "10px monospace";
+
+for (let i = 0; i < iterations; ++i) {
+  const x = width + (i - iterations / 2) * increment;
+  const y = i * 10;
+  ctx.fillStyle = "black";
+  ctx.fillText("Hi", x + shadowOffsetX, y);
+  if (x < width) {
+    ctx.fillStyle = "blue";
+    ctx.fillText("Hi", x, y);
+  }
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/canvas/fillText-edge-shadow.html
+++ b/LayoutTests/fast/canvas/fillText-edge-shadow.html
@@ -1,0 +1,27 @@
+<html>
+<body>
+<canvas width="100" height="100" style="border: solid 1px gray"></canvas>
+<script>
+const shadowOffsetX = -20;
+const iterations = 10;
+const increment = 4;
+
+const canvas = document.getElementsByTagName('canvas')[0];
+const width = canvas.width;
+const ctx = canvas.getContext('2d');
+
+ctx.shadowColor = "black";
+ctx.shadowOffsetX = shadowOffsetX;
+
+ctx.font = "10px monospace";
+ctx.fillStyle = "blue";
+
+for (let i = 0; i < iterations; ++i) {
+  const x = width + (i - iterations / 2) * increment;
+  const y = i * 10;
+  ctx.fillText("Hi", x, y);
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/canvas/fillText-edge.html
+++ b/LayoutTests/fast/canvas/fillText-edge.html
@@ -1,0 +1,23 @@
+<html>
+<body>
+<canvas width="100" height="100" style="border: solid 1px gray"></canvas>
+<script>
+const iterations = 10;
+const increment = 4;
+
+const canvas = document.getElementsByTagName('canvas')[0];
+const width = canvas.width;
+const ctx = canvas.getContext('2d');
+
+ctx.font = "10px monospace";
+ctx.fillStyle = "blue";
+
+for (let i = 0; i < iterations; ++i) {
+  const x = width + (i - iterations / 2) * increment;
+  const y = i * 10;
+  ctx.fillText("Hi", x, y);
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/canvas/fillText-empty-clip-expected.html
+++ b/LayoutTests/fast/canvas/fillText-empty-clip-expected.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+<canvas width="100" height="100" style="border: solid 1px gray"></canvas>
+</body>
+</html>

--- a/LayoutTests/fast/canvas/fillText-empty-clip.html
+++ b/LayoutTests/fast/canvas/fillText-empty-clip.html
@@ -1,0 +1,27 @@
+<html>
+<body>
+<canvas width="100" height="100" style="border: solid 1px gray"></canvas>
+<script>
+const iterations = 10;
+const increment = 4;
+
+const canvas = document.getElementsByTagName('canvas')[0];
+const width = canvas.width;
+const ctx = canvas.getContext('2d');
+
+let region = new Path2D();
+region.rect(width - 1, 0, 0, canvas.height);
+ctx.clip(region);
+
+ctx.font = "10px monospace";
+ctx.fillStyle = "blue";
+
+for (let i = 0; i < iterations; ++i) {
+  const x = width + (i - iterations / 2) * increment;
+  const y = i * 10;
+  ctx.fillText("Hi", x, y);
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -4513,6 +4513,9 @@ fast/css/highlight-text-repaint.html [ Skip ] # Failure
 fast/css/text-underline-offset-repaint.html [ Skip ] # Failure
 fast/flexbox/missing-repaint-when-flext-item-never-had-layout.html [ Skip ] # Failure
 
+fast/canvas/fillText-edge-clip-shadow.html [ ImageOnlyFailure ]
+fast/canvas/fillText-edge-shadow.html [ ImageOnlyFailure ]
+
 webkit.org/b/286284 fast/canvas/canvas-image-shadow.html [ Failure ]
 webkit.org/b/286284 webgl/2.0.y/conformance/canvas/to-data-url-test.html [ Failure ]
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -3005,8 +3005,12 @@ void CanvasRenderingContext2DBase::drawTextUnchecked(const TextRun& textRun, dou
         clearCanvas();
         drawText(*c, location);
         repaintEntireCanvas = true;
-    } else
+    } else {
+        auto clipBounds = c->clipBounds();
+        if ((clipBounds.isEmpty() || (!textRect.isEmpty() && !clipBounds.intersects(enclosingIntRect(textRect)))) && !shouldDrawShadows())
+            return;
         drawText(*c, location);
+    }
 
     didDraw(repaintEntireCanvas, targetSwitcher ? targetSwitcher->expandedBounds() : textRect);
 }


### PR DESCRIPTION
#### 386d6232aa5bbe3ad751b37f5761ef1d681f5949
<pre>
Cull simple non-empty canvas text drawing outside of the clip
<a href="https://bugs.webkit.org/show_bug.cgi?id=306394">https://bugs.webkit.org/show_bug.cgi?id=306394</a>
<a href="https://rdar.apple.com/172308695">rdar://172308695</a>

Reviewed by Simon Fraser.

In simple cases where no-frills text would be drawn on top of a canvas,
it&apos;s easy and fast to check if the text does NOT intersect with the
current clip, in which case the whole operation can safely be skipped.

As an exception, if the textRect is computed to be empty (zero width or
height), it is assumed to be of unknown but actually-non-empty size, so
the optimization is just skipped. This may be used by some websites to
obscure privacy-sensitive texts.

* LayoutTests/fast/canvas/fillText-edge-clip-expected.html: Added.
* LayoutTests/fast/canvas/fillText-edge-clip-shadow-expected.html: Added.
* LayoutTests/fast/canvas/fillText-edge-clip-shadow.html: Added.
* LayoutTests/fast/canvas/fillText-edge-clip.html: Added.
* LayoutTests/fast/canvas/fillText-edge-expected.html: Added.
* LayoutTests/fast/canvas/fillText-edge-shadow-expected.html: Added.
* LayoutTests/fast/canvas/fillText-edge-shadow.html: Added.
* LayoutTests/fast/canvas/fillText-edge.html: Added.
* LayoutTests/fast/canvas/fillText-empty-clip-expected.html: Added.
* LayoutTests/fast/canvas/fillText-empty-clip.html: Added.
* LayoutTests/platform/win/TestExpectations:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::drawTextUnchecked):

Canonical link: <a href="https://commits.webkit.org/309944@main">https://commits.webkit.org/309944@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a37ac2d0efe1b802bfaf944454445e4959c0e741

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152065 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24847 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18429 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160808 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105522 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c98268e2-5b59-4fdc-99c8-d7cc6c1376d1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153939 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25339 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25153 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117465 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83317 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/de69841e-e3f4-4f4e-892f-ed8bb6d49d3f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155025 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19650 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136482 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98179 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dc14c097-a33c-432b-bf2e-c6807870c4d3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18728 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16675 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8642 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128371 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14370 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163274 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6420 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15962 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125492 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24645 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20724 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125668 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34134 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24646 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136166 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81228 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20679 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12943 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24263 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88548 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23954 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24114 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24015 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->