### PR TITLE
[css-anchor-position-1] Accommodate pseudo-elements when sorting anchor elements by tree order

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-function-chain-pseudo-elements-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-function-chain-pseudo-elements-expected.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+
+<style>
+  .containing-block {
+    border: 1px solid black;
+
+    width: 500px;
+    height: 200px;
+
+    display: flex;
+    flex-direction: row;
+    gap: 10px;
+  }
+
+  .box {
+    width: 50px;
+    height: 50px;
+  }
+
+  #box1 { background-color: #cce7cc; }
+  #box2 { background-color: #99cf99; }
+  #box3 { background-color: #66b866; }
+  #box4 { background-color: #33a033; }
+  #box5 { background-color: #008000; }
+</style>
+
+<p>You should see a row of five boxes in increasing gradient.</p>
+
+<div class="containing-block">
+  <div class="box" id="box1"></div>
+  <div class="box" id="box2"></div>
+  <div class="box" id="box3"></div>
+  <div class="box" id="box4"></div>
+  <div class="box" id="box5"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-function-chain-pseudo-elements.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-function-chain-pseudo-elements.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+
+<title>Tests that chain of pseudo-elements that anchor to each other using anchor() works</title>
+
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#anchor-pos">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#determining">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+<link rel="match" href="reference/pseudo-element-chain-ref.html">
+
+<style>
+  .containing-block {
+    border: 1px solid black;
+
+    position: relative;
+    width: 500px;
+    height: 200px;
+  }
+
+  .box-after::after, .box-before::before {
+    position: absolute;
+    left: calc(anchor(--box right) + 10px);
+    anchor-name: --box;
+
+    width: 50px;
+    height: 50px;
+    content: "";
+  }
+
+  /* Give both ::before and ::after background colors,
+     so we can switch boxes between ::before and ::after. */
+  #box1::before, #box1::after { background-color: #cce7cc; }
+  #box2::before, #box2::after { background-color: #99cf99; }
+  #box3::before, #box3::after { background-color: #66b866; }
+  #box4::before, #box4::after { background-color: #33a033; }
+  #box5::before, #box5::after { background-color: #008000; }
+</style>
+
+<p>You should see a row of five boxes in increasing gradient.</p>
+
+<div class="containing-block">
+  <div class="box-after" id="box1"></div>
+  <div class="box-before" id="box2"></div>
+  <div class="box-before" id="box3"></div>
+  <div class="box-after" id="box4"></div>
+  <div class="box-after" id="box5"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-function-chain-pseudo-elements-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-function-chain-pseudo-elements-expected.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<style>
+  .containing-block {
+    border: 1px solid black;
+
+    position: relative;
+    width: 500px;
+    height: 200px;
+  }
+
+  .box-before::before, .box-after::after {
+    position: absolute;
+    background-color: green;
+    content: "";
+  }
+
+  #box1::before, #box1::after {
+    width: 50px;
+    height: 60px;
+  }
+
+  #box2::before, #box2::after {
+    left: 60px;
+    width: 60px;
+    height: 80px;
+  }
+
+  #box3::before, #box3::after {
+    left: 130px;
+    width: 70px;
+    height: 100px;
+  }
+
+  #box4::before, #box4::after {
+    left: 210px;
+    width: 80px;
+    height: 120px;
+  }
+
+  #box5::before, #box5::after {
+    left: 300px;
+    width: 90px;
+    height: 140px;
+  }
+</style>
+
+<p>You should see a row of five rectangles growing in size.</p>
+
+<div class="containing-block">
+  <div class="box-after" id="box1"></div>
+  <div class="box-before" id="box2"></div>
+  <div class="box-before" id="box3"></div>
+  <div class="box-after" id="box4"></div>
+  <div class="box-before" id="box5"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-function-chain-pseudo-elements-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-function-chain-pseudo-elements-ref.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<style>
+  .containing-block {
+    border: 1px solid black;
+
+    position: relative;
+    width: 500px;
+    height: 200px;
+  }
+
+  .box-before::before, .box-after::after {
+    position: absolute;
+    background-color: green;
+    content: "";
+  }
+
+  #box1::before, #box1::after {
+    width: 50px;
+    height: 60px;
+  }
+
+  #box2::before, #box2::after {
+    left: 60px;
+    width: 60px;
+    height: 80px;
+  }
+
+  #box3::before, #box3::after {
+    left: 130px;
+    width: 70px;
+    height: 100px;
+  }
+
+  #box4::before, #box4::after {
+    left: 210px;
+    width: 80px;
+    height: 120px;
+  }
+
+  #box5::before, #box5::after {
+    left: 300px;
+    width: 90px;
+    height: 140px;
+  }
+</style>
+
+<p>You should see a row of five rectangles growing in size.</p>
+
+<div class="containing-block">
+  <div class="box-after" id="box1"></div>
+  <div class="box-before" id="box2"></div>
+  <div class="box-before" id="box3"></div>
+  <div class="box-after" id="box4"></div>
+  <div class="box-before" id="box5"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-function-chain-pseudo-elements.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-function-chain-pseudo-elements.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+
+<title>Tests that chain of elements that anchor to each other using anchor-size() works.</title>
+
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#anchor-size-fn">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#determining">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+<link rel="match" href="anchor-size-function-chain-pseudo-elements-ref.html">
+
+<style>
+  .containing-block {
+    border: 1px solid black;
+
+    position: relative;
+    width: 500px;
+    height: 200px;
+  }
+
+  .box-before::before, .box-after::after {
+    /* Can only use anchor-size() with position: absolute */
+    position: absolute;
+    anchor-name: --box;
+    width: calc(anchor-size(--box width) + 10px);
+    height: calc(anchor-size(--box height) + 20px);
+
+    background-color: green;
+    content: "";
+  }
+
+  #box1::before, #box1::after {
+    width: 50px;
+    height: 60px;
+  }
+
+  #box2::before, #box2::after { left: 60px; }
+  #box3::before, #box3::after { left: 130px; }
+  #box4::before, #box4::after { left: 210px; }
+  #box5::before, #box5::after { left: 300px; }
+</style>
+
+<p>You should see a row of five rectangles growing in size.</p>
+
+<div class="containing-block">
+  <!--
+    The increasing size is to check that the boxes are anchoring to each other
+    in the correct order i.e box2 chains to box1, box3 chains to box2, ...
+  -->
+  <div class="box-after" id="box1"></div>
+  <div class="box-before" id="box2"></div>
+  <div class="box-before" id="box3"></div>
+  <div class="box-after" id="box4"></div>
+  <div class="box-before" id="box5"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-chain-pseudo-elements-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-chain-pseudo-elements-expected.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+
+<style>
+  .containing-block {
+    border: 1px solid black;
+
+    width: 500px;
+    height: 200px;
+
+    display: flex;
+    flex-direction: row;
+    gap: 10px;
+  }
+
+  .box {
+    width: 50px;
+    height: 50px;
+  }
+
+  #box1 { background-color: #cce7cc; }
+  #box2 { background-color: #99cf99; }
+  #box3 { background-color: #66b866; }
+  #box4 { background-color: #33a033; }
+  #box5 { background-color: #008000; }
+</style>
+
+<p>You should see a row of five boxes in increasing gradient.</p>
+
+<div class="containing-block">
+  <div class="box" id="box1"></div>
+  <div class="box" id="box2"></div>
+  <div class="box" id="box3"></div>
+  <div class="box" id="box4"></div>
+  <div class="box" id="box5"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-chain-pseudo-elements.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-chain-pseudo-elements.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+
+<title>Tests that chain of pseudo-elements that anchor to each other using position-area works</title>
+
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#position-area">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#determining">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+<link rel="match" href="reference/pseudo-element-chain-ref.html">
+
+<style>
+  .containing-block {
+    border: 1px solid black;
+
+    position: relative;
+    width: 500px;
+    height: 200px;
+  }
+
+  .box-after::after, .box-before::before {
+    position: absolute;
+    anchor-name: --box;
+    position-area: center right;
+    position-anchor: --box;
+
+    width: 50px;
+    height: 50px;
+    content: "";
+    border-right: 10px white solid;
+  }
+
+  /* Give both ::before and ::after background colors,
+     so we can switch boxes between ::before and ::after. */
+  #box1::before, #box1::after { background-color: #cce7cc; }
+  #box2::before, #box2::after { background-color: #99cf99; }
+  #box3::before, #box3::after { background-color: #66b866; }
+  #box4::before, #box4::after { background-color: #33a033; }
+  #box5::before, #box5::after { background-color: #008000; }
+</style>
+
+<p>You should see a row of five boxes in increasing gradient.</p>
+
+<div class="containing-block">
+  <div class="box-before" id="box1"></div>
+  <div class="box-before" id="box2"></div>
+  <div class="box-after" id="box3"></div>
+  <div class="box-before" id="box4"></div>
+  <div class="box-after" id="box5"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/pseudo-element-anchor-tree-order-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/pseudo-element-anchor-tree-order-expected.txt
@@ -1,0 +1,7 @@
+
+PASS One element anchor, two pseudo-element anchors (::before, ::after)
+PASS One pseudo-element anchor in one host element, two pseudo-element anchors (::before, ::after) in another host element
+PASS Two pseudo-element anchors in the same host
+PASS Two sibling anchors, ::before and an element
+PASS Two sibling anchors, an element and ::after
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/pseudo-element-anchor-tree-order.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/pseudo-element-anchor-tree-order.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+
+<title>Tests the ordering of pseudo-element anchors by tree order</title>
+
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#target">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  main {
+    border: 1px solid black;
+
+    position: relative;
+    width: 500px;
+    height: 200px;
+  }
+
+  .box, .box-before::before, .box-after::after {
+    position: absolute;
+    width: 50px;
+    height: 50px;
+    content: "";
+  }
+
+  .box-anchor, .box-before-anchor::before, .box-after-anchor::after { anchor-name: --box; }
+  .box-red, .box-before-red::before, .box-after-red::after { background-color: red; }
+  .box-green, .box-before-green::before, .box-after-green::after { background-color: green; }
+
+  .target {
+    position: absolute;
+    position-anchor: --box;
+    top: calc(anchor(bottom) + 10px);
+    left: anchor(left);
+    width: 50px;
+    height: 50px;
+    background-color: blue;
+  }
+</style>
+
+<script>
+  function inflate(t, template_element) {
+    t.add_cleanup(() => main.replaceChildren());
+    main.append(template_element.content.cloneNode(true));
+  }
+</script>
+
+<main id="main">
+</main>
+
+<template id="one_element_two_pseudo_elements">
+  <style>
+    #anchor1 { inset: 0 }
+    #anchor23::before { top: 0; left: 60px; }
+    #anchor23::after { top: 0; left: 120px; }
+  </style>
+
+  <div class="containing-block">
+    <div class="box box-anchor box-red" id="anchor1"></div>
+    <div class="box-before box-before-anchor box-before-red box-after box-after-anchor box-after-green" id="anchor23"></div>
+    <!-- Anchor used is #anchor23::after -->
+    <div class="target" id="target"></div>
+  </div>
+</template>
+<script>
+  test((t) => {
+    inflate(t, one_element_two_pseudo_elements);
+
+    const targetComputedStyle = getComputedStyle(main.querySelector("#target"));
+    assert_equals(targetComputedStyle.top, "60px");
+    assert_equals(targetComputedStyle.left, "120px");
+  }, "One element anchor, two pseudo-element anchors (::before, ::after)");
+</script>
+
+<template id="one_pseudo_in_one_host_two_pseudos_in_another_host">
+  <style>
+    #anchor1 { inset: 0 }
+    #anchor23::before { top: 0; left: 60px; }
+    #anchor23::after { top: 0; left: 120px; }
+  </style>
+
+  <div class="containing-block">
+    <div class="box-before box-before-anchor box-before-red" id="anchor1"></div>
+    <div class="box-before box-before-anchor box-before-red box-after box-after-anchor box-after-green" id="anchor23"></div>
+    <!-- Anchor used is #anchor23::after -->
+    <div class="target" id="target" data-offset-x="120" data-offset-y="50"></div>
+  </div>
+</template>
+<script>
+  test((t) => {
+    inflate(t, one_pseudo_in_one_host_two_pseudos_in_another_host);
+
+    const targetComputedStyle = getComputedStyle(main.querySelector("#target"));
+    assert_equals(targetComputedStyle.top, "60px");
+    assert_equals(targetComputedStyle.left, "120px");
+  }, "One pseudo-element anchor in one host element, two pseudo-element anchors (::before, ::after) in another host element");
+</script>
+
+<template id="two_pseudos_in_same_host">
+  <style>
+    #anchor12::before { inset: 0; }
+    #anchor12::after { top: 0; left: 60px; }
+  </style>
+
+  <div class="containing-block">
+    <div class="box-before box-before-anchor box-before-red box-after box-after-anchor box-after-green" id="anchor12"></div>
+    <!-- Anchor used is #anchor12::after -->
+    <div class="target" id="target"></div>
+  </div>
+</template>
+<script>
+  test((t) => {
+    inflate(t, two_pseudos_in_same_host);
+
+    const targetComputedStyle = getComputedStyle(main.querySelector("#target"));
+    assert_equals(targetComputedStyle.top, "60px");
+    assert_equals(targetComputedStyle.left, "60px");
+  }, "Two pseudo-element anchors in the same host");
+</script>
+
+<template id="before_and_element_sibling">
+  <style>
+    #anchor1::before { inset: 0 }
+    #anchor2 { top: 0; left: 60px; }
+  </style>
+
+  <div class="containing-block">
+    <div class="box-before box-before-anchor box-before-green" id="anchor1">
+      <div class="box box-anchor box-red" id="anchor2"></div>
+    </div>
+    <!-- Anchor used is #anchor2 -->
+    <div class="target" id="target"></div>
+  </div>
+</template>
+<script>
+  test((t) => {
+    inflate(t, before_and_element_sibling);
+
+    const targetComputedStyle = getComputedStyle(main.querySelector("#target"));
+    assert_equals(targetComputedStyle.top, "60px");
+    assert_equals(targetComputedStyle.left, "60px");
+  }, "Two sibling anchors, ::before and an element");
+</script>
+
+<template id="element_and_after_sibling">
+  <style>
+    #anchor1 { inset: 0 }
+    #anchor2::after { top: 0; left: 60px; }
+  </style>
+
+  <div class="containing-block">
+    <div class="box-after box-after-anchor box-after-green" id="anchor2">
+      <div class="box box-anchor box-red" id="anchor1"></div>
+    </div>
+    <!-- Anchor used is #anchor2::after -->
+    <div class="target" id="target"></div>
+  </div>
+</template>
+<script>
+  test((t) => {
+    inflate(t, element_and_after_sibling);
+
+    const targetComputedStyle = getComputedStyle(main.querySelector("#target"));
+    assert_equals(targetComputedStyle.top, "60px");
+    assert_equals(targetComputedStyle.left, "60px");
+  }, "Two sibling anchors, an element and ::after");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/reference/pseudo-element-chain-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/reference/pseudo-element-chain-ref.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+
+<style>
+  .containing-block {
+    border: 1px solid black;
+
+    width: 500px;
+    height: 200px;
+
+    display: flex;
+    flex-direction: row;
+    gap: 10px;
+  }
+
+  .box {
+    width: 50px;
+    height: 50px;
+  }
+
+  #box1 { background-color: #cce7cc; }
+  #box2 { background-color: #99cf99; }
+  #box3 { background-color: #66b866; }
+  #box4 { background-color: #33a033; }
+  #box5 { background-color: #008000; }
+</style>
+
+<p>You should see a row of five boxes in increasing gradient.</p>
+
+<div class="containing-block">
+  <div class="box" id="box1"></div>
+  <div class="box" id="box2"></div>
+  <div class="box" id="box3"></div>
+  <div class="box" id="box4"></div>
+  <div class="box" id="box5"></div>
+</div>

--- a/Source/WebCore/dom/BoundaryPoint.cpp
+++ b/Source/WebCore/dom/BoundaryPoint.cpp
@@ -33,6 +33,7 @@ namespace WebCore {
 
 template std::partial_ordering treeOrder<Tree>(const BoundaryPoint&, const BoundaryPoint&);
 template std::partial_ordering treeOrder<ShadowIncludingTree>(const BoundaryPoint&, const BoundaryPoint&);
+template std::partial_ordering treeOrder<ComposedTreeIncludingPseudoElements>(const BoundaryPoint&, const BoundaryPoint&);
 
 std::optional<BoundaryPoint> makeBoundaryPointBeforeNode(Node& node)
 {
@@ -106,6 +107,8 @@ std::partial_ordering treeOrderForTesting(TreeType type, const BoundaryPoint& a,
         return treeOrder<ShadowIncludingTree>(a, b);
     case ComposedTree:
         return treeOrder<ComposedTree>(a, b);
+    case ComposedTreeIncludingPseudoElements:
+        return treeOrder<ComposedTreeIncludingPseudoElements>(a, b);
     }
     ASSERT_NOT_REACHED();
     return std::partial_ordering::unordered;

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -3002,6 +3002,11 @@ template<> ContainerNode* parent<ComposedTree>(const Node& node)
     return node.parentInComposedTree();
 }
 
+template<> ContainerNode* parent<ComposedTreeIncludingPseudoElements>(const Node& node)
+{
+    return node.parentElementInComposedTree();
+}
+
 template<TreeType treeType> size_t NODELETE depth(const Node& node)
 {
     size_t depth = 0;
@@ -3055,16 +3060,26 @@ template<TreeType treeType> Node* commonInclusiveAncestor(const Node& a, const N
 template Node* commonInclusiveAncestor<Tree>(const Node&, const Node&);
 template Node* commonInclusiveAncestor<ComposedTree>(const Node&, const Node&);
 template Node* commonInclusiveAncestor<ShadowIncludingTree>(const Node&, const Node&);
+template Node* commonInclusiveAncestor<ComposedTreeIncludingPseudoElements>(const Node&, const Node&);
 
-static bool NODELETE isSiblingSubsequent(const Node& siblingA, const Node& siblingB)
+template<TreeType treeType> bool NODELETE isSiblingSubsequent(const Node& siblingA, const Node& siblingB)
 {
-    ASSERT(siblingA.parentNode());
-    ASSERT(siblingA.parentNode() == siblingB.parentNode());
     ASSERT(&siblingA != &siblingB);
+    ASSERT(parent<treeType>(siblingA));
+    ASSERT(parent<treeType>(siblingA) == parent<treeType>(siblingB));
+
+    if (siblingA.isBeforePseudoElement() || siblingB.isAfterPseudoElement())
+        return true;
+    if (siblingA.isAfterPseudoElement() || siblingB.isBeforePseudoElement())
+        return false;
+
+    ASSERT(!siblingA.isPseudoElement() && !siblingB.isPseudoElement());
+
     for (auto sibling = &siblingA; sibling; sibling = sibling->nextSibling()) {
         if (sibling == &siblingB)
             return true;
     }
+
     return false;
 }
 
@@ -3089,12 +3104,13 @@ template<TreeType treeType> std::partial_ordering treeOrder(const Node& a, const
         ASSERT_NOT_REACHED();
         return std::partial_ordering::unordered;
     }
-    return isSiblingSubsequent(*result.distinctAncestorA, *result.distinctAncestorB) ? std::partial_ordering::less : std::partial_ordering::greater;
+    return isSiblingSubsequent<treeType>(*result.distinctAncestorA, *result.distinctAncestorB) ? std::partial_ordering::less : std::partial_ordering::greater;
 }
 
 template std::partial_ordering treeOrder<Tree>(const Node&, const Node&);
 template std::partial_ordering treeOrder<ShadowIncludingTree>(const Node&, const Node&);
 template std::partial_ordering treeOrder<ComposedTree>(const Node&, const Node&);
+template std::partial_ordering treeOrder<ComposedTreeIncludingPseudoElements>(const Node&, const Node&);
 
 std::partial_ordering treeOrderForTesting(TreeType type, const Node& a, const Node& b)
 {
@@ -3105,6 +3121,8 @@ std::partial_ordering treeOrderForTesting(TreeType type, const Node& a, const No
         return treeOrder<ShadowIncludingTree>(a, b);
     case ComposedTree:
         return treeOrder<ComposedTree>(a, b);
+    case ComposedTreeIncludingPseudoElements:
+        return treeOrder<ComposedTreeIncludingPseudoElements>(a, b);
     }
     ASSERT_NOT_REACHED();
     return std::partial_ordering::unordered;

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -827,7 +827,7 @@ private:
 
 bool NODELETE connectedInSameTreeScope(const Node*, const Node*);
 
-enum TreeType { Tree, ShadowIncludingTree, ComposedTree };
+enum TreeType { Tree, ShadowIncludingTree, ComposedTree, ComposedTreeIncludingPseudoElements };
 template<TreeType = Tree> ContainerNode* parent(const Node&);
 template<TreeType = Tree> Node* commonInclusiveAncestor(const Node&, const Node&);
 template<TreeType = Tree> std::partial_ordering treeOrder(const Node&, const Node&);

--- a/Source/WebCore/dom/SimpleRange.cpp
+++ b/Source/WebCore/dom/SimpleRange.cpp
@@ -183,6 +183,8 @@ bool contains(TreeType type, const SimpleRange& range, const BoundaryPoint& poin
         return contains<ShadowIncludingTree>(range, point);
     case ComposedTree:
         return contains<ComposedTree>(range, point);
+    case ComposedTreeIncludingPseudoElements:
+        return contains<ComposedTreeIncludingPseudoElements>(range, point);
     }
     ASSERT_NOT_REACHED();
     return false;
@@ -226,6 +228,8 @@ bool contains(TreeType type, const SimpleRange& outerRange, const SimpleRange& i
         return contains<ShadowIncludingTree>(outerRange, innerRange);
     case ComposedTree:
         return contains<ComposedTree>(outerRange, innerRange);
+    case ComposedTreeIncludingPseudoElements:
+        return contains<ComposedTreeIncludingPseudoElements>(outerRange, innerRange);
     }
     ASSERT_NOT_REACHED();
     return false;
@@ -248,6 +252,8 @@ bool intersectsForTesting(TreeType type, const SimpleRange& a, const SimpleRange
         return intersects<ShadowIncludingTree>(a, b);
     case ComposedTree:
         return intersects<ComposedTree>(a, b);
+    case ComposedTreeIncludingPseudoElements:
+        return contains<ComposedTreeIncludingPseudoElements>(a, b);
     }
     ASSERT_NOT_REACHED();
     return false;
@@ -291,6 +297,8 @@ bool contains(TreeType type, const SimpleRange& range, const Node& node)
         return contains<ShadowIncludingTree>(range, node);
     case ComposedTree:
         return contains<ComposedTree>(range, node);
+    case ComposedTreeIncludingPseudoElements:
+        return contains<ComposedTreeIncludingPseudoElements>(range, node);
     }
     ASSERT_NOT_REACHED();
     return false;
@@ -333,6 +341,8 @@ bool intersectsForTesting(TreeType type, const SimpleRange& range, const Node& n
         return intersects<ShadowIncludingTree>(range, node);
     case ComposedTree:
         return intersects<ComposedTree>(range, node);
+    case ComposedTreeIncludingPseudoElements:
+        return contains<ComposedTreeIncludingPseudoElements>(range, node);
     }
     ASSERT_NOT_REACHED();
     return false;

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -1266,10 +1266,13 @@ static AnchorsForAnchorName collectAnchorsForAnchorName(const Document& document
     // Sort them in tree order.
     for (auto& anchors : anchorsForAnchorName.values()) {
         std::ranges::sort(anchors, [](auto& a, auto& b) {
-            // FIXME: Figure out anonymous pseudo-elements.
-            if (!a->element() || !b->element())
-                return !!b->element();
-            return is_lt(treeOrder<ComposedTree>(*a->element(), *b->element()));
+            RefPtr aElement = a->element();
+            RefPtr bElement = b->element();
+
+            if (!aElement || !bElement)
+                return false;
+
+            return is_lt(treeOrder<ComposedTreeIncludingPseudoElements>(*aElement, *bElement));
         });
     }
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -7921,6 +7921,8 @@ constexpr TreeType NODELETE convertType(Internals::TreeType type)
         return ShadowIncludingTree;
     case Internals::ComposedTree:
         return ComposedTree;
+    case Internals::ComposedTreeIncludingPseudoElements:
+        return ComposedTreeIncludingPseudoElements;
     }
     ASSERT_NOT_REACHED();
     return Tree;

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1599,7 +1599,7 @@ public:
 
 #endif // ENABLE(MEDIA_SESSION)
 
-    enum TreeType : uint8_t { Tree, ShadowIncludingTree, ComposedTree };
+    enum TreeType : uint8_t { Tree, ShadowIncludingTree, ComposedTree, ComposedTreeIncludingPseudoElements };
     String treeOrder(Node&, Node&, TreeType);
     String treeOrderBoundaryPoints(Node& containerA, unsigned offsetA, Node& containerB, unsigned offsetB, TreeType);
     bool rangeContainsNode(const AbstractRange&, Node&, TreeType);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -97,7 +97,8 @@ enum ContentSizeCategory {
 enum TreeType {
     "Tree",
     "ShadowIncludingTree",
-    "ComposedTree"
+    "ComposedTree",
+    "ComposedTreeIncludingPseudoElements"
 };
 
 [Conditional=WEBGL] enum SimulatedWebGLContextEvent {


### PR DESCRIPTION
#### 8c2cc6504c168761df1878632290de83f5c85ffd
<pre>
[css-anchor-position-1] Accommodate pseudo-elements when sorting anchor elements by tree order
<a href="https://rdar.apple.com/173032203">rdar://173032203</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=310398">https://bugs.webkit.org/show_bug.cgi?id=310398</a>

Reviewed by Antti Koivisto.

When determining which element is the anchor, the last element in tree order that satistifes
the anchor query wins [1]:

&gt; If an ancestor of query el satisfies the following conditions, return the nearest such element
&gt; to query el. Otherwise, return the last element el in tree order that satisfies the conditions.

WebKit implemented this by sorting anchors with the same anchor name in reverse tree order,
using treeOrder&lt;ComposedTree&gt; to determine the order. But treeOrder doesn&apos;t work with
pseudo-elements (e.g ::before, ::after). Fix this by extending treeOrder to support pseudo-elements.

Tests: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-function-chain-pseudo-elements.html
       imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-function-chain-pseudo-elements.html
       imported/w3c/web-platform-tests/css/css-anchor-position/position-area-chain-pseudo-elements.html
       imported/w3c/web-platform-tests/css/css-anchor-position/pseudo-element-anchor-tree-order.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-function-chain-pseudo-elements-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-function-chain-pseudo-elements.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-function-chain-pseudo-elements-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-function-chain-pseudo-elements-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-function-chain-pseudo-elements.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-chain-pseudo-elements-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-chain-pseudo-elements.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/pseudo-element-anchor-tree-order-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/pseudo-element-anchor-tree-order.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/reference/pseudo-element-chain-ref.html: Added.
* Source/WebCore/dom/BoundaryPoint.cpp:
(WebCore::treeOrderForTesting):
* Source/WebCore/dom/Node.cpp:
(WebCore::parent&lt;ComposedTreeIncludingPseudoElements&gt;):
    * Add a new TreeType called ComposedTreeIncludingPseudoElements. This is similar to ComposedTree,
      but parent&lt;ComposedTreeIncludingPseudoElements&gt; will traverse from a pseudo-element to its host.

(WebCore::isSiblingSubsequent):
    * Extend isSiblingSubsequent to sort ::before and ::after. ::before comes before all other
      elements, and ::after comes after all other elements.
    * Make it generic over TreeType, so it can use parent&lt;TreeType&gt; to get the node&apos;s parent.
      parentNode() wouldn&apos;t work to get the host of pseudo-elements.

(WebCore::treeOrder):
(WebCore::treeOrderForTesting):
* Source/WebCore/dom/Node.h:
* Source/WebCore/dom/SimpleRange.cpp:
(WebCore::contains):
(WebCore::intersectsForTesting):
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::collectAnchorsForAnchorName):
    * Use treeOrder&lt;ComposedTreeIncludingPseudoElements&gt; to sort the anchors.

* Source/WebCore/testing/Internals.cpp:
(WebCore::convertType):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/310407@main">https://commits.webkit.org/310407@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60f9965022b7fd2a85f0e634f44871f4fd640e1e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153686 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26470 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20087 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162436 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107144 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/daba7c07-85a9-4436-92d7-8bbf990c82ef) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155559 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26998 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26792 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118830 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/107144 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/90a3bbf4-30e3-426b-ba70-abd4d0cba556) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156645 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21081 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137994 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99540 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/159a8943-fbe5-4366-a157-707a2c556d44) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20160 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18112 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10269 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129809 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15853 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164907 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8041 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17447 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126903 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26267 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22144 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127070 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34482 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26269 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137648 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82947 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21978 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14430 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25886 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90174 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25577 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25737 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25637 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->