### PR TITLE
Implement VTB VP9 decoder in WebCore

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -736,6 +736,7 @@ platform/video-codecs/cocoa/VideoDecoderVTB.mm @nonARC
 platform/video-codecs/cocoa/WebRTCVideoDecoder.mm @nonARC
 platform/video-codecs/cocoa/WebRTCVideoDecoderVTB.mm @nonARC
 platform/video-codecs/cocoa/WebRTCVideoDecoderVTBAV1.mm @nonARC
+platform/video-codecs/cocoa/WebRTCVideoDecoderVTBVP9.mm @nonARC
 platform/xr/cocoa/PlatformXRPose.cpp
 rendering/AttachmentLayout.mm @nonARC
 rendering/TextAutoSizing.cpp

--- a/Source/WebCore/platform/graphics/VP9Utilities.cpp
+++ b/Source/WebCore/platform/graphics/VP9Utilities.cpp
@@ -593,6 +593,13 @@ std::optional<VPCodecConfigurationRecord> vPCodecConfigurationRecordFromVPXByteS
 
     setConfigurationColorSpaceFromVP9ColorSpace(record, colorSpace);
 
+    auto width = br.read(16);
+    auto height = br.read(16);
+    if (width && height) {
+        record.frameWidth = *width + 1;
+        record.frameHeight = *height + 1;
+    }
+
     return record;
 }
 

--- a/Source/WebCore/platform/graphics/VP9Utilities.h
+++ b/Source/WebCore/platform/graphics/VP9Utilities.h
@@ -124,6 +124,10 @@ struct VPCodecConfigurationRecord {
     uint8_t colorPrimaries { VPConfigurationColorPrimaries::BT_709_6 };
     uint8_t transferCharacteristics { VPConfigurationTransferCharacteristics::BT_709_6 };
     uint8_t matrixCoefficients { VPConfigurationMatrixCoefficients::BT_709_6 };
+
+    // Additional information parsed from bitstream
+    uint16_t frameWidth { 0 };
+    uint16_t frameHeight { 0 };
 };
 
 WEBCORE_EXPORT std::optional<VPCodecConfigurationRecord> parseVPCodecParameters(StringView codecString);

--- a/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.h
@@ -30,6 +30,8 @@
 
 #include <WebCore/VP9Utilities.h>
 
+typedef const struct opaqueCMFormatDescription* CMVideoFormatDescriptionRef;
+
 namespace WebCore {
 
 struct PlatformMediaCapabilitiesInfo;
@@ -49,6 +51,7 @@ bool isVPCodecConfigurationRecordSupported(const VPCodecConfigurationRecord&);
 std::optional<PlatformMediaCapabilitiesInfo> validateVPParameters(const VPCodecConfigurationRecord&, const PlatformMediaCapabilitiesVideoConfiguration&);
 std::optional<PlatformMediaCapabilitiesInfo> computeVPParameters(const PlatformMediaCapabilitiesVideoConfiguration&, bool vp9HardwareDecoderAvailable);
 bool NODELETE isVPSoftwareDecoderSmooth(const PlatformMediaCapabilitiesVideoConfiguration&);
+RetainPtr<CMVideoFormatDescriptionRef> createVP9FormatDescriptionFromRecord(const VPCodecConfigurationRecord&);
 
 struct VP8FrameHeader {
     bool keyframe { false };

--- a/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm
@@ -41,6 +41,7 @@
 #import "VideoDecoder.h"
 #import <JavaScriptCore/DataView.h>
 #import <webm/common/vp9_header_parser.h>
+#import <wtf/cf/VectorCF.h>
 #import <wtf/text/StringToIntegerConversion.h>
 
 #import <pal/cocoa/AVFoundationSoftLink.h>
@@ -675,6 +676,24 @@ Ref<VideoInfo> createVideoInfoFromVP8Header(const VP8FrameHeader& header, const 
     }
 
     return createVideoInfoFromVPCodecConfigurationRecord(record, { static_cast<float>(header.width), static_cast<float>(header.height) }, { static_cast<float>(video.display_width.is_present() ? video.display_width.value() : header.width), static_cast<float>(video.display_height.is_present() ? video.display_height.value() : header.height) });
+}
+
+RetainPtr<CMVideoFormatDescriptionRef> createVP9FormatDescriptionFromRecord(const VPCodecConfigurationRecord& record)
+{
+    ASSERT(record.frameWidth);
+    ASSERT(record.frameHeight);
+
+    auto vpcc = vpcCFromVPCodecConfigurationRecord(record);
+    RetainPtr cfData = toCFData(vpcc.span());
+
+    auto configurationDict = @{ @"vpcC": (__bridge NSData *)cfData.get() };
+    auto extensions = @{ (__bridge NSString *)PAL::kCMFormatDescriptionExtension_SampleDescriptionExtensionAtoms: configurationDict };
+
+    CMVideoFormatDescriptionRef formatDescription = nullptr;
+    if (PAL::CMVideoFormatDescriptionCreate(kCFAllocatorDefault, kCMVideoCodecType_VP9, record.frameWidth, record.frameHeight, (__bridge CFDictionaryRef)extensions, &formatDescription) != noErr)
+        return { };
+
+    return adoptCF(formatDescription);
 }
 
 }

--- a/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoder.mm
+++ b/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoder.mm
@@ -30,6 +30,7 @@
 #if USE(LIBWEBRTC)
 
 #import "WebRTCVideoDecoderVTBAV1.h"
+#import "WebRTCVideoDecoderVTBVP9.h"
 #import <WebCore/CMUtilities.h>
 #import <WebCore/LibWebRTCMacros.h>
 
@@ -71,7 +72,7 @@ std::unique_ptr<WebRTCVideoDecoder> WebRTCVideoDecoder::create(VideoCodecType de
     case VideoCodecType::H265:
         return makeUnique<WebRTCLocalVideoDecoder>(webrtc::createLocalH265Decoder(callback));
     case VideoCodecType::VP9:
-        return makeUnique<WebRTCLocalVideoDecoder>(webrtc::createLocalVP9Decoder(callback));
+        return makeUnique<WebRTCVideoDecoderVTBVP9>(callback);
     case VideoCodecType::AV1:
         return makeUnique<WebRTCVideoDecoderVTBAV1>(callback);
     }

--- a/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTBVP9.h
+++ b/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTBVP9.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(LIBWEBRTC)
+
+#include "WebRTCVideoDecoderVTB.h"
+
+namespace WebCore {
+
+class WebRTCVideoDecoderVTBVP9 final : public WebRTCVideoDecoderVTB {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(WebRTCVideoDecoderVTBVP9);
+public:
+    explicit WebRTCVideoDecoderVTBVP9(WebRTCVideoDecoderCallback);
+    ~WebRTCVideoDecoderVTBVP9() = default;
+
+private:
+    int32_t decodeFrame(int64_t, std::span<const uint8_t>) final;
+};
+
+}
+
+#endif // USE(LIBWEBRTC)

--- a/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTBVP9.mm
+++ b/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTBVP9.mm
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#import "config.h"
+#import "WebRTCVideoDecoderVTBVP9.h"
+
+#if USE(LIBWEBRTC)
+
+#import "CMUtilities.h"
+#import "VP9UtilitiesCocoa.h"
+#import <wtf/BlockPtr.h>
+
+namespace WebCore {
+
+static RetainPtr<CMVideoFormatDescriptionRef> createVP9FormatDescriptionFromData(std::span<const uint8_t> data, int32_t width, int32_t height)
+{
+    auto parsedRecord = vPCodecConfigurationRecordFromVPXByteStream(VPXCodec::Vp9, data);
+    if (!parsedRecord)
+        return { };
+
+    if (width)
+        parsedRecord->frameWidth = width;
+    if (height)
+        parsedRecord->frameHeight = height;
+
+    return createVP9FormatDescriptionFromRecord(*parsedRecord);
+}
+
+static void overrideVP9ColorSpaceAttachments(CVPixelBufferRef pixelBuffer)
+{
+    CVBufferSetAttachment(pixelBuffer, kCVImageBufferColorPrimariesKey, kCVImageBufferColorPrimaries_ITU_R_709_2, kCVAttachmentMode_ShouldPropagate);
+    CVBufferSetAttachment(pixelBuffer, kCVImageBufferTransferFunctionKey, kCVImageBufferTransferFunction_ITU_R_709_2, kCVAttachmentMode_ShouldPropagate);
+    CVBufferSetAttachment(pixelBuffer, kCVImageBufferYCbCrMatrixKey, kCVImageBufferYCbCrMatrix_ITU_R_709_2, kCVAttachmentMode_ShouldPropagate);
+    CVBufferSetAttachment(pixelBuffer, (CFStringRef)@"ColorInfoGuessedBy", (CFStringRef)@"WebRTCDecoderVTBVP9", kCVAttachmentMode_ShouldPropagate);
+}
+
+static BlockPtr<void(OSStatus, VTDecodeInfoFlags, CVImageBufferRef pixelBuffer, CMTaggedBufferGroupRef, CMTime presentationTime, CMTime)> createVP9Callback(WebRTCVideoDecoderCallback callback)
+{
+    return makeBlockPtr([callback = makeBlockPtr(callback)](OSStatus, VTDecodeInfoFlags, CVImageBufferRef pixelBuffer, CMTaggedBufferGroupRef, CMTime presentationTime, CMTime) mutable {
+        if (!pixelBuffer) {
+            callback(nil, 0, 0, false);
+            return;
+        }
+
+        // FIXME: We should remove this override once the encoder is properly setting color space info.
+        overrideVP9ColorSpaceAttachments(pixelBuffer);
+
+        callback((CVPixelBufferRef)pixelBuffer, presentationTime.value, 0, false);
+    });
+}
+
+WebRTCVideoDecoderVTBVP9::WebRTCVideoDecoderVTBVP9(WebRTCVideoDecoderCallback callback)
+    : WebRTCVideoDecoderVTB(createVP9Callback(WTF::move(callback)))
+{
+}
+
+int32_t WebRTCVideoDecoderVTBVP9::decodeFrame(int64_t timeStamp, std::span<const uint8_t> data)
+{
+    if (auto videoFormat = createVP9FormatDescriptionFromData(data, width(), height()))
+        setVideoFormat(WTF::move(videoFormat));
+
+    return decodeFrameInternal(timeStamp, data);
+}
+
+}
+#endif // USE(LIBWEBRTC)


### PR DESCRIPTION
#### 3b2bbde465418623652ecbb3c8a438ebb891b6dd
<pre>
Implement VTB VP9 decoder in WebCore
<a href="https://rdar.apple.com/170321335">rdar://170321335</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=307802">https://bugs.webkit.org/show_bug.cgi?id=307802</a>

Reviewed by Jean-Yves Avenard.

By migrating the VP9 VTB decoder to WebCore, we can reuse existing VP9 routines, for instance to parse/generate VP configuration.
It makes it also easier to enforce span usage and so on.
We reuse WebRTCVideoDecoderVTB like done for AV1 to reuse as much code as possible.

Covered by existing VP9 webrtc and webcodecs tests.

Canonical link: <a href="https://commits.webkit.org/309911@main">https://commits.webkit.org/309911@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08ff4b1951dd1e4757239f4ee4b6c32eb9cfb1f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152089 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24871 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18456 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160832 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105546 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153963 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25363 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25177 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117489 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155049 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19671 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136509 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98202 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18748 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/16702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8666 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14394 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163298 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6444 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15986 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125515 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24669 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20748 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125691 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34113 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24670 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136190 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81263 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20702 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12967 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24287 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88572 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23978 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24138 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24039 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->