### PR TITLE
animation-fill-mode does not correctly apply viewport-based units

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/responsive/fill-forwards-viewport-units-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/responsive/fill-forwards-viewport-units-expected.txt
@@ -1,0 +1,3 @@
+
+PASS fill: forwards with viewport units updates on viewport resize
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/responsive/fill-forwards-viewport-units.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/responsive/fill-forwards-viewport-units.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Animations: fill-forwards with viewport units responds to viewport resize</title>
+<link rel="help" href="https://drafts.csswg.org/css-animations-1/#animation-fill-mode">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../support/testcommon.js"></script>
+<style>
+  iframe {
+    width: 200px;
+    height: 200px;
+    border: none;
+  }
+</style>
+<body>
+<div id="log"></div>
+<script>
+'use strict';
+
+function createIframe(test) {
+  const iframe = document.createElement('iframe');
+  iframe.srcdoc = `
+    <style>
+      @keyframes grow {
+        from { width: 10vw; }
+        to { width: 50vw; }
+      }
+      #target {
+        width: 0px;
+        height: 100px;
+        background: green;
+        animation: grow 100s forwards linear;
+      }
+    </style>
+    <div id="target"></div>
+  `;
+  document.body.appendChild(iframe);
+  test.add_cleanup(() => iframe.remove());
+  return new Promise(resolve => iframe.addEventListener('load', () => resolve(iframe)));
+}
+
+promise_test(async t => {
+  const iframe = await createIframe(t);
+  const doc = iframe.contentDocument;
+  const win = iframe.contentWindow;
+  const target = doc.getElementById('target');
+  const anim = target.getAnimations()[0];
+
+  // Jump to end so fill-mode: forwards takes effect.
+  anim.currentTime = 100 * 1000;
+  await anim.finished;
+  await waitForAnimationFrames(2);
+
+  // iframe is 200px wide, so 50vw = 100px.
+  assert_approx_equals(
+    parseFloat(win.getComputedStyle(target).width), 100, 1,
+    'Filled width should be 50vw of 200px viewport'
+  );
+
+  // Resize iframe to 400px wide.
+  iframe.style.width = '400px';
+  target.offsetHeight;
+  await waitForAnimationFrames(3);
+
+  // 50vw of 400px = 200px.
+  assert_approx_equals(
+    parseFloat(win.getComputedStyle(target).width), 200, 1,
+    'Filled width should update to 50vw of 400px viewport after resize'
+  );
+
+  // Resize iframe to 600px wide.
+  iframe.style.width = '600px';
+  target.offsetHeight;
+  await waitForAnimationFrames(3);
+
+  // 50vw of 600px = 300px.
+  assert_approx_equals(
+    parseFloat(win.getComputedStyle(target).width), 300, 1,
+    'Filled width should update to 50vw of 600px viewport after second resize'
+  );
+}, 'fill: forwards with viewport units updates on viewport resize');
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/fill-forwards-viewport-units-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/fill-forwards-viewport-units-expected.txt
@@ -1,0 +1,3 @@
+
+PASS fill: forwards with viewport units updates on viewport resize
+

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/fill-forwards-viewport-units.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/fill-forwards-viewport-units.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Fill-forwards animation with viewport units responds to viewport resize</title>
+<link rel="help" href="https://drafts.csswg.org/web-animations-1/#fill-behavior">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../testcommon.js"></script>
+<style>
+  iframe {
+    width: 200px;
+    height: 200px;
+    border: none;
+  }
+</style>
+<body>
+<div id="log"></div>
+<script>
+'use strict';
+
+function createIframe(test) {
+  const iframe = document.createElement('iframe');
+  iframe.srcdoc = `
+    <style>
+      #target {
+        width: 0px;
+        height: 100px;
+        background: green;
+      }
+    </style>
+    <div id="target"></div>
+  `;
+  document.body.appendChild(iframe);
+  test.add_cleanup(() => iframe.remove());
+  return new Promise(resolve => iframe.addEventListener('load', () => resolve(iframe)));
+}
+
+promise_test(async t => {
+  const iframe = await createIframe(t);
+  const doc = iframe.contentDocument;
+  const win = iframe.contentWindow;
+  const target = doc.getElementById('target');
+
+  const anim = target.animate(
+    [{ width: '10vw' }, { width: '50vw' }],
+    { duration: 1000, fill: 'forwards', easing: 'linear' }
+  );
+
+  anim.currentTime = 1000;
+  await anim.finished;
+  await waitForAnimationFrames(2);
+
+  // iframe is 200px wide, so 50vw = 100px.
+  assert_approx_equals(
+    parseFloat(win.getComputedStyle(target).width), 100, 1,
+    'Filled width should be 50vw of 200px viewport'
+  );
+
+  // Resize iframe to 400px wide.
+  iframe.style.width = '400px';
+  target.offsetHeight;
+  await waitForAnimationFrames(3);
+
+  // 50vw of 400px = 200px.
+  assert_approx_equals(
+    parseFloat(win.getComputedStyle(target).width), 200, 1,
+    'Filled width should update to 50vw of 400px viewport after resize'
+  );
+
+  // Resize iframe to 600px wide.
+  iframe.style.width = '600px';
+  target.offsetHeight;
+  await waitForAnimationFrames(3);
+
+  // 50vw of 600px = 300px.
+  assert_approx_equals(
+    parseFloat(win.getComputedStyle(target).width), 300, 1,
+    'Filled width should update to 50vw of 600px viewport after second resize'
+  );
+}, 'fill: forwards with viewport units updates on viewport resize');
+</script>
+</body>

--- a/Source/WebCore/animation/BlendingKeyframes.cpp
+++ b/Source/WebCore/animation/BlendingKeyframes.cpp
@@ -281,6 +281,15 @@ bool BlendingKeyframes::usesContainerUnits() const
     return false;
 }
 
+bool BlendingKeyframes::usesViewportUnits() const
+{
+    for (auto& keyframe : m_keyframes) {
+        if (keyframe.style()->usesViewportUnits())
+            return true;
+    }
+    return false;
+}
+
 void BlendingKeyframes::addProperty(const AnimatableCSSProperty& property)
 {
     ASSERT(!std::holds_alternative<CSSPropertyID>(property) || std::get<CSSPropertyID>(property) != CSSPropertyCustom);

--- a/Source/WebCore/animation/BlendingKeyframes.h
+++ b/Source/WebCore/animation/BlendingKeyframes.h
@@ -149,6 +149,7 @@ public:
     auto end() const LIFETIME_BOUND { return m_keyframes.end(); }
 
     bool NODELETE usesContainerUnits() const;
+    bool usesViewportUnits() const;
     bool usesRelativeFontWeight() const { return m_usesRelativeFontWeight; }
     bool hasSubstitutionFunctions() const { return m_containsSubstitutionFunctions; }
     bool hasColorSetToCurrentColor() const;

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -440,6 +440,9 @@ std::unique_ptr<RenderStyle> Resolver::styleForKeyframe(Element& element, const 
     builder.state().setIsBuildingKeyframeStyle();
     builder.applyAllProperties();
 
+    if (state.style()->usesViewportUnits())
+        element.document().setHasStyleWithViewportUnits();
+
     Adjuster adjuster(document(), *state.parentStyle(), nullptr, !pseudoElementIdentifier ? &element : nullptr);
     adjuster.adjust(*state.style());
 

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -58,6 +58,7 @@
 #include "SVGStyleElement.h"
 #include "Settings.h"
 #include "ShadowRoot.h"
+#include "StyleableInlines.h"
 #include "StyleBuilder.h"
 #include "StyleCustomPropertyRegistry.h"
 #include "StyleInvalidator.h"
@@ -908,8 +909,9 @@ void Scope::didChangeViewportSize()
 
     // FIXME: Ideally, we should save the list of elements that have viewport units and only iterate over those.
     for (RefPtr element = ElementTraversal::firstWithin(rootNode); element; element = ElementTraversal::nextIncludingPseudo(*element)) {
+        bool styleableHasViewportUnitAnimation = Styleable::fromElement(*element).viewportSizeDidChange();
         auto* renderer = element->renderer();
-        if (renderer && renderer->style().usesViewportUnits())
+        if (styleableHasViewportUnitAnimation || (renderer && renderer->style().usesViewportUnits()))
             element->invalidateStyle();
     }
 }

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -905,7 +905,6 @@ ElementUpdate TreeResolver::createAnimatedElementUpdate(ResolvedStyle&& resolved
         return { WTF::move(animatedStyle), animationImpact };
     };
 
-    // FIXME: Something like this is also needed for viewport units.
     if (currentStyle && parent().needsUpdateQueryContainerDependentStyle)
         styleable.queryContainerDidChange();
 

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -956,6 +956,25 @@ void Styleable::queryContainerDidChange() const
     }
 }
 
+bool Styleable::viewportSizeDidChange() const
+{
+    auto* animations = this->animations();
+    if (!animations)
+        return false;
+    bool changed = false;
+    for (auto& animation : *animations) {
+        RefPtr keyframeEffect = animation->keyframeEffect();
+        if (keyframeEffect && keyframeEffect->blendingKeyframes().usesViewportUnits()) {
+            if (RefPtr cssAnimation = dynamicDowncast<CSSAnimation>(animation))
+                cssAnimation->keyframesRuleDidChange();
+            else
+                keyframeEffect->recomputeKeyframesAtNextOpportunity();
+            changed = true;
+        }
+    }
+    return changed;
+}
+
 bool Styleable::capturedInViewTransition() const
 {
     return !element.viewTransitionCapturedName(pseudoElementIdentifier).isNull();

--- a/Source/WebCore/style/Styleable.h
+++ b/Source/WebCore/style/Styleable.h
@@ -174,6 +174,7 @@ struct Styleable {
     }
 
     void queryContainerDidChange() const;
+    bool viewportSizeDidChange() const;
 
     bool animationListContainsNewlyValidAnimation(const Style::Animations&) const;
 


### PR DESCRIPTION
#### 243e5fe708ed5bbba9f6e7ae34bff9a678907614
<pre>
animation-fill-mode does not correctly apply viewport-based units
<a href="https://bugs.webkit.org/show_bug.cgi?id=227615">https://bugs.webkit.org/show_bug.cgi?id=227615</a>
<a href="https://rdar.apple.com/80075191">rdar://80075191</a>

Reviewed by Antoine Quint.

When an animation with animation-fill-mode: forwards uses viewport units
(vw, vh) in keyframes, the filled values become stale on viewport resize.
The cached BlendingKeyframes are never recomputed because there is no
viewport-unit-aware invalidation for animations.

This mirrors the existing container unit pattern  (usesContainerUnits /
queryContainerDidChange):

- Add BlendingKeyframes::usesViewportUnits() to detect viewport units in
keyframe styles.
- Add Styleable::viewportSizeDidChange() which clears and recomputes
blending keyframes for animations using viewport units.
- Call viewportSizeDidChange() from StyleScope::didChangeViewportSize()
and ensure full style invalidation when animations use viewport units.
- Set the document&apos;s hasStyleWithViewportUnits flag when keyframe styles
use viewport units, so didChangeViewportSize() does not early-return.
- Remove the FIXME in StyleTreeResolver.cpp that noted this gap.

* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/responsive/fill-forwards-viewport-units-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/responsive/fill-forwards-viewport-units.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/fill-forwards-viewport-units-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/fill-forwards-viewport-units.html: Added.
* Source/WebCore/animation/BlendingKeyframes.cpp:
(WebCore::BlendingKeyframes::usesContainerUnits const):
(WebCore::BlendingKeyframes::usesViewportUnits const):
* Source/WebCore/animation/BlendingKeyframes.h:
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::styleForKeyframe const):
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::didChangeViewportSize):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::createAnimatedElementUpdate):
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::viewportSizeDidChange const):
* Source/WebCore/style/Styleable.h:

Canonical link: <a href="https://commits.webkit.org/310007@main">https://commits.webkit.org/310007@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96d1f57bd3cd510d1fce17db5ca6ac33f7c170fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152435 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25217 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18816 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161178 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3bb788fe-dcef-4557-af83-ef14a628b6be) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154309 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25745 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25523 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117790 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1a210a3d-b41d-4dc9-a0e3-94db8ce40277) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155395 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/20004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136852 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98504 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c8ab13eb-8a24-4f05-a11e-ef2b14598467) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/19080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9013 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14726 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163648 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/6790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16320 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125827 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25015 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21053 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125998 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34176 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25017 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136522 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81617 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20994 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13301 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24633 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/88919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24324 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24484 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24385 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->