### PR TITLE
Create SPI to suppress form validation bubble presentation

### DIFF
--- a/Source/WebCore/platform/ValidationBubble.h
+++ b/Source/WebCore/platform/ValidationBubble.h
@@ -76,6 +76,7 @@ public:
 
 #if PLATFORM(IOS_FAMILY)
     WEBCORE_EXPORT void setAnchorRect(const IntRect& anchorRect, UIViewController* presentingViewController = nullptr);
+    WEBCORE_EXPORT void setShouldSuppressPresentation(bool);
     WEBCORE_EXPORT void show();
 #elif PLATFORM(GTK)
     WEBCORE_EXPORT virtual void showRelativeTo(const IntRect&) = 0;
@@ -103,6 +104,7 @@ protected:
     RetainPtr<WebValidationBubbleDelegate> m_popoverDelegate;
     WeakObjCPtr<UIViewController> m_presentingViewController;
     bool m_startingToPresentViewController { false };
+    bool m_shouldSuppressPresentation { false };
 #endif
 };
 

--- a/Source/WebCore/platform/ios/ValidationBubbleIOS.mm
+++ b/Source/WebCore/platform/ios/ValidationBubbleIOS.mm
@@ -185,8 +185,16 @@ ValidationBubble::~ValidationBubble()
     [m_popoverController dismissViewControllerAnimated:NO completion:nil];
 }
 
+void ValidationBubble::setShouldSuppressPresentation(bool suppress)
+{
+    m_shouldSuppressPresentation = suppress;
+}
+
 void ValidationBubble::show()
 {
+    if (m_shouldSuppressPresentation)
+        return;
+
     if ([m_popoverController parentViewController] || [m_popoverController presentingViewController] || m_startingToPresentViewController)
         return;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -6761,6 +6761,16 @@ static Vector<Ref<API::TargetedElementInfo>> elementsFromWKElements(NSArray<_WKT
 #endif
 }
 
+- (BOOL)_shouldSuppressFormValidationBubble
+{
+    return _shouldSuppressFormValidationBubble;
+}
+
+- (void)_setShouldSuppressFormValidationBubble:(BOOL)value
+{
+    _shouldSuppressFormValidationBubble = value;
+}
+
 - (void)_takeSnapshotOfNode:(_WKJSHandle *)node completionHandler:(void (^)(CocoaImage *image, NSError *))completionHandler
 {
     if (!node)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -337,6 +337,7 @@ struct PerWebProcessState {
     BOOL _usePlatformFindUI;
     BOOL _usesAutomaticContentInsetBackgroundFill;
     BOOL _shouldSuppressTopColorExtensionView;
+    BOOL _shouldSuppressFormValidationBubble;
 #if PLATFORM(MAC)
     OptionSet<WebKit::PreferSolidColorHardPocketReason> _preferSolidColorHardPocketReasons;
     BOOL _isGettingAdjustedColorForTopContentInsetColorFromDelegate;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -645,6 +645,8 @@ typedef NS_OPTIONS(NSUInteger, _WKWebViewDataType) {
 
 @property (nonatomic, setter=_setShouldSuppressTopColorExtensionView:) BOOL _shouldSuppressTopColorExtensionView WK_API_AVAILABLE(macos(26.0), ios(26.0));
 
+@property (nonatomic, setter=_setShouldSuppressFormValidationBubble:) BOOL _shouldSuppressFormValidationBubble WK_API_AVAILABLE(ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
 #if TARGET_OS_OSX
 - (NSUInteger)accessibilityRemoteChildTokenHash;
 - (NSUInteger)accessibilityUIProcessLocalTokenHash;

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -489,6 +489,8 @@ public:
     virtual Ref<WebCore::ValidationBubble> createValidationBubble(String&& message, const WebCore::ValidationBubble::Settings&) = 0;
 #endif
 
+    virtual bool shouldSuppressFormValidationBubble() const { return false; }
+
 #if PLATFORM(COCOA)
     virtual CALayer *textIndicatorInstallationLayer() = 0;
 

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -157,6 +157,7 @@ private:
 
     RefPtr<WebPopupMenuProxy> createPopupMenuProxy(WebPageProxy&) override;
     Ref<WebCore::ValidationBubble> createValidationBubble(String&& message, const WebCore::ValidationBubble::Settings&) final;
+    bool shouldSuppressFormValidationBubble() const final;
 
     RefPtr<WebColorPicker> createColorPicker(WebPageProxy&, const WebCore::Color& initialColor, const WebCore::IntRect&, ColorControlSupportsAlpha, Vector<WebCore::Color>&&, std::optional<WebCore::FrameIdentifier>) final { return nullptr; }
 

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -1140,6 +1140,11 @@ Ref<ValidationBubble> PageClientImpl::createValidationBubble(String&& message, c
     return ValidationBubble::create(protect(m_contentView.getAutoreleased()), WTF::move(message), settings);
 }
 
+bool PageClientImpl::shouldSuppressFormValidationBubble() const
+{
+    return [webView() _shouldSuppressFormValidationBubble];
+}
+
 RefPtr<WebDataListSuggestionsDropdown> PageClientImpl::createDataListSuggestionsDropdown(WebPageProxy& page)
 {
     return WebDataListSuggestionsDropdownIOS::create(page, protect(m_contentView.getAutoreleased()));

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -1187,6 +1187,8 @@ void WebPageProxy::showValidationMessage(const IntRect& anchorClientRect, String
     m_validationBubble = pageClient->createValidationBubble(WTF::move(message), { protect(m_preferences)->minimumFontSize() });
     Ref validationBubble = *m_validationBubble;
 
+    validationBubble->setShouldSuppressPresentation(pageClient->shouldSuppressFormValidationBubble());
+
     // FIXME: When in element fullscreen, UIClient::presentingViewController() may not return the
     // WKFullScreenViewController even though that is the presenting view controller of the WKWebView.
     // We should call PageClientImpl::presentingViewController() instead.

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FormValidation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FormValidation.mm
@@ -25,10 +25,12 @@
 
 #import "config.h"
 
+#import "InstanceMethodSwizzler.h"
 #import "TestUIDelegate.h"
 #import "TestWKWebView.h"
 #import "Utilities.h"
 #import <WebKit/WKContentWorldPrivate.h>
+#import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/WebKit.h>
 #import <WebKit/_WKContentWorldConfiguration.h>
 
@@ -66,5 +68,50 @@ TEST(FormValidation, FormValidationOnUnparentedWindowDoesNotCrash)
     Util::run(&ranScript);
     Util::runFor(100_ms);
 }
+
+#if PLATFORM(IOS) || PLATFORM(VISION)
+TEST(FormValidation, ShouldSuppressFormValidationBubble)
+{
+    bool bubblePresented = false;
+    auto swizzledPresentBlock = makeBlockPtr([&](id, UIViewController *, BOOL, void (^)()) {
+        bubblePresented = true;
+    });
+
+    InstanceMethodSwizzler presentSwizzler { [UIViewController class], @selector(presentViewController:animated:completion:), imp_implementationWithBlock(swizzledPresentBlock.get()) };
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 300, 300)]);
+
+    RetainPtr rootViewController = adoptNS([[UIViewController alloc] init]);
+    [[webView window] setRootViewController:rootViewController.get()];
+    [rootViewController view].frame = [webView window].bounds;
+    [[rootViewController view] addSubview:webView.get()];
+
+    RetainPtr formHTML = @"<!DOCTYPE html>"
+        "<form>"
+        "    <input required>"
+        "    <input type='submit'>"
+        "</form>"
+        "<script>document.querySelector('input[type=submit]').click()</script>";
+
+    EXPECT_FALSE([webView _shouldSuppressFormValidationBubble]);
+
+    [webView synchronouslyLoadHTMLString:formHTML];
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_TRUE(bubblePresented);
+
+    bubblePresented = false;
+    [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><body></body>"];
+    [webView waitForNextPresentationUpdate];
+
+    [webView _setShouldSuppressFormValidationBubble:YES];
+    EXPECT_TRUE([webView _shouldSuppressFormValidationBubble]);
+
+    [webView synchronouslyLoadHTMLString:formHTML];
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_FALSE(bubblePresented);
+}
+#endif
 
 }


### PR DESCRIPTION
#### 74cd1a931428159efb1200511a7b70740cfd526a
<pre>
Create SPI to suppress form validation bubble presentation
<a href="https://bugs.webkit.org/show_bug.cgi?id=310695">https://bugs.webkit.org/show_bug.cgi?id=310695</a>
<a href="https://rdar.apple.com/173305613">rdar://173305613</a>

Reviewed by Aditya Keerthi and Abrar Rahman Protyasha.

Add SPI to suppress form validation bubble presentation. The validation bubble
could appear unexpectedly when the host app&apos;s window is invisible.

Consider the context: when WebView is hosted inside a remote view service,
ValidationBubble::show() presents a popover via m_presentingViewController,
which is the service&apos;s view controller. This controller only has access to the
remote window layer, not the host app&apos;s actual UIWindow.

One approach of checking the host app&apos;s window visibility directly from
ValidationBubble::show() was considered, but is not easily feasible because the
presenting view controller lives in the service process and cannot observe the
host app&apos;s window state. Additionally, a visibility check at show() time would
be susceptible to timing issues if the window state changes.

Instead, this patch adds a WKWebView SPI property that clients can set to
unconditionally suppress validation bubble presentation. Once set, the bubble
will not show. This follows the same pattern as
_shouldSuppressTopColorExtensionView.

* Source/WebCore/platform/ValidationBubble.h:
* Source/WebCore/platform/ios/ValidationBubbleIOS.mm:
(WebCore::ValidationBubble::setShouldSuppressPresentation):
(WebCore::ValidationBubble::show):
Implement setShouldSuppressPresentation and add early return in show() when
suppression is enabled.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _shouldSuppressFormValidationBubble]):
(-[WKWebView _setShouldSuppressFormValidationBubble:]):
Implement getter and setter for _shouldSuppressFormValidationBubble

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
Declare _shouldSuppressFormValidationBubble SPI property for iOS and visionOS

* Source/WebKit/UIProcess/PageClient.h:
(WebKit::PageClient::shouldSuppressFormValidationBubble const):
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::shouldSuppressFormValidationBubble const):
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::showValidationMessage):
Query PageClient for the suppression flag and propagate it to the newly created
ValidationBubble.

Canonical link: <a href="https://commits.webkit.org/310117@main">https://commits.webkit.org/310117@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f24574c07c3a0ef51570433c99066ac0c6575347

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152685 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25466 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19065 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161429 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106141 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154558 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25994 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25772 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117984 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155644 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20208 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137071 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98697 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19283 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17227 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9265 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128934 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14945 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163901 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7039 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16539 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126044 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25264 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21266 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126202 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34256 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25266 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136741 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/81870 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21173 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13520 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24882 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89168 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24574 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24733 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24634 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->