### PR TITLE
Avoid fp->integer UB throughout WebKit repository

### DIFF
--- a/Source/WTF/wtf/CurrentTime.cpp
+++ b/Source/WTF/wtf/CurrentTime.cpp
@@ -35,6 +35,7 @@
 #include <wtf/ApproximateTime.h>
 #include <wtf/ContinuousApproximateTime.h>
 #include <wtf/ContinuousTime.h>
+#include <wtf/MathExtras.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/WallTime.h>
@@ -257,7 +258,7 @@ MonotonicTime MonotonicTime::fromMachAbsoluteTime(uint64_t machAbsoluteTime)
 uint64_t MonotonicTime::toMachAbsoluteTime() const
 {
     auto& info = machTimebaseInfo();
-    return static_cast<uint64_t>((m_value * 1.0e9 * info.denom) / info.numer);
+    return truncateDoubleToUint64((m_value * 1.0e9 * info.denom) / info.numer);
 }
 
 ApproximateTime ApproximateTime::fromMachApproximateTime(uint64_t machApproximateTime)
@@ -269,7 +270,7 @@ ApproximateTime ApproximateTime::fromMachApproximateTime(uint64_t machApproximat
 uint64_t ApproximateTime::toMachApproximateTime() const
 {
     auto& info = machTimebaseInfo();
-    return static_cast<uint64_t>((m_value * 1.0e9 * info.denom) / info.numer);
+    return truncateDoubleToUint64((m_value * 1.0e9 * info.denom) / info.numer);
 }
 
 ContinuousTime ContinuousTime::fromMachContinuousTime(uint64_t machContinuousTime)
@@ -281,7 +282,7 @@ ContinuousTime ContinuousTime::fromMachContinuousTime(uint64_t machContinuousTim
 uint64_t ContinuousTime::toMachContinuousTime() const
 {
     auto& info = machTimebaseInfo();
-    return static_cast<uint64_t>((m_value * 1.0e9 * info.denom) / info.numer);
+    return truncateDoubleToUint64((m_value * 1.0e9 * info.denom) / info.numer);
 }
 
 ContinuousApproximateTime ContinuousApproximateTime::fromMachContinuousApproximateTime(uint64_t machContinuousApproximateTime)
@@ -293,7 +294,7 @@ ContinuousApproximateTime ContinuousApproximateTime::fromMachContinuousApproxima
 uint64_t ContinuousApproximateTime::toMachContinuousApproximateTime() const
 {
     auto& info = machTimebaseInfo();
-    return static_cast<uint64_t>((m_value * 1.0e9 * info.denom) / info.numer);
+    return truncateDoubleToUint64((m_value * 1.0e9 * info.denom) / info.numer);
 }
 #endif
 

--- a/Source/WTF/wtf/JSONValues.cpp
+++ b/Source/WTF/wtf/JSONValues.cpp
@@ -36,6 +36,7 @@
 #include <functional>
 #include <wtf/ASCIICType.h>
 #include <wtf/CommaPrinter.h>
+#include <wtf/MathExtras.h>
 #include <wtf/ZippedRange.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/ParsingUtilities.h>
@@ -593,7 +594,7 @@ std::optional<int> Value::asInteger() const
     if (auto* number = std::get_if<int>(&m_value))
         return *number;
     if (auto* number = std::get_if<double>(&m_value))
-        return static_cast<int>(*number);
+        return truncateDoubleToInt32(*number);
     return std::nullopt;
 }
 

--- a/Source/WTF/wtf/MathExtras.h
+++ b/Source/WTF/wtf/MathExtras.h
@@ -868,7 +868,7 @@ constexpr T roundDownToMultipleOf(T x)
 
 #define WTF_PROVEN_TRUE(x) (__builtin_constant_p(x) && (x))
 
-ALWAYS_INLINE int32_t truncateDoubleToInt32(double number)
+SUPPRESS_NODELETE ALWAYS_INLINE int32_t NODELETE truncateDoubleToInt32(double number)
 {
 #if CPU(X86_64)
     return _mm_cvttsd_si32(_mm_set_sd(number));
@@ -895,7 +895,7 @@ ALWAYS_INLINE int32_t truncateDoubleToInt32(double number)
 #endif
 }
 
-ALWAYS_INLINE int64_t truncateDoubleToInt64(double number)
+SUPPRESS_NODELETE ALWAYS_INLINE int64_t NODELETE truncateDoubleToInt64(double number)
 {
 #if CPU(X86_64)
     return _mm_cvttsd_si64(_mm_set_sd(number));
@@ -917,7 +917,7 @@ ALWAYS_INLINE int64_t truncateDoubleToInt64(double number)
 #endif
 }
 
-ALWAYS_INLINE uint32_t truncateDoubleToUint32(double number)
+SUPPRESS_NODELETE ALWAYS_INLINE uint32_t NODELETE truncateDoubleToUint32(double number)
 {
 #if CPU(X86_64)
     return static_cast<uint32_t>(_mm_cvttsd_si64(_mm_set_sd(number)));
@@ -939,7 +939,7 @@ ALWAYS_INLINE uint32_t truncateDoubleToUint32(double number)
 #endif
 }
 
-ALWAYS_INLINE uint64_t truncateDoubleToUint64(double number)
+SUPPRESS_NODELETE ALWAYS_INLINE uint64_t NODELETE truncateDoubleToUint64(double number)
 {
 #if CPU(X86_64)
     // Branchless conversion matching compiler codegen for static_cast<uint64_t>(double).
@@ -975,7 +975,7 @@ ALWAYS_INLINE uint64_t truncateDoubleToUint64(double number)
 
 // Float-to-integer truncation helpers.
 
-ALWAYS_INLINE int32_t truncateFloatToInt32(float number)
+SUPPRESS_NODELETE ALWAYS_INLINE int32_t NODELETE truncateFloatToInt32(float number)
 {
 #if CPU(X86_64)
     return _mm_cvttss_si32(_mm_set_ss(number));
@@ -997,7 +997,7 @@ ALWAYS_INLINE int32_t truncateFloatToInt32(float number)
 #endif
 }
 
-ALWAYS_INLINE int64_t truncateFloatToInt64(float number)
+SUPPRESS_NODELETE ALWAYS_INLINE int64_t NODELETE truncateFloatToInt64(float number)
 {
 #if CPU(X86_64)
     return _mm_cvttss_si64(_mm_set_ss(number));
@@ -1024,7 +1024,7 @@ ALWAYS_INLINE int64_t truncateFloatToInt64(float number)
 #endif
 }
 
-ALWAYS_INLINE uint32_t truncateFloatToUint32(float number)
+SUPPRESS_NODELETE ALWAYS_INLINE uint32_t NODELETE truncateFloatToUint32(float number)
 {
 #if CPU(X86_64)
     return static_cast<uint32_t>(_mm_cvttss_si64(_mm_set_ss(number)));
@@ -1040,7 +1040,7 @@ ALWAYS_INLINE uint32_t truncateFloatToUint32(float number)
 #endif
 }
 
-ALWAYS_INLINE uint64_t truncateFloatToUint64(float number)
+SUPPRESS_NODELETE ALWAYS_INLINE uint64_t NODELETE truncateFloatToUint64(float number)
 {
 #if CPU(X86_64)
     // Branchless conversion matching compiler codegen for static_cast<uint64_t>(float).
@@ -1078,7 +1078,7 @@ ALWAYS_INLINE uint64_t truncateFloatToUint64(float number)
 // tryConvertToStrictInt32: Attempts to convert a double to int32_t, returning
 // std::nullopt if the value is not exactly representable as int32 (including
 // -0.0, NaN, Infinity, non-integer values, and out-of-range values).
-ALWAYS_INLINE std::optional<int32_t> tryConvertToStrictInt32(double value)
+SUPPRESS_NODELETE ALWAYS_INLINE std::optional<int32_t> NODELETE tryConvertToStrictInt32(double value)
 {
 #if HAVE(FJCVTZS_INSTRUCTION)
     int32_t result;

--- a/Source/WTF/wtf/MemoryPressureHandler.cpp
+++ b/Source/WTF/wtf/MemoryPressureHandler.cpp
@@ -31,6 +31,7 @@
 #include <functional>
 #include <ranges>
 #include <wtf/Logging.h>
+#include <wtf/MathExtras.h>
 #include <wtf/MemoryFootprint.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RAMSize.h>
@@ -112,7 +113,7 @@ static size_t thresholdForMemoryKillOfActiveProcess(unsigned tabCount)
     return baseThreshold + tabCount * GB;
 #else
     UNUSED_PARAM(tabCount);
-    return std::min(3 * GB, static_cast<size_t>(ramSize() * 0.9));
+    return std::min(3 * GB, static_cast<size_t>(truncateDoubleToUint64(ramSize() * 0.9)));
 #endif
 }
 
@@ -123,7 +124,7 @@ static size_t thresholdForMemoryKillOfInactiveProcess(unsigned tabCount)
 #else
     size_t baseThreshold = tabCount > 1 ? 3 * GB : 2 * GB;
 #endif
-    return std::min(baseThreshold, static_cast<size_t>(ramSize() * 0.9));
+    return std::min(baseThreshold, static_cast<size_t>(truncateDoubleToUint64(ramSize() * 0.9)));
 }
 
 void MemoryPressureHandler::setPageCount(unsigned pageCount)

--- a/Source/WTF/wtf/StatisticsManager.cpp
+++ b/Source/WTF/wtf/StatisticsManager.cpp
@@ -27,6 +27,7 @@
 #include <wtf/StatisticsManager.h>
 
 #include <wtf/DataLog.h>
+#include <wtf/MathExtras.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringHash.h>
@@ -62,7 +63,7 @@ static void dumpHistogram(const AbstractLocker&, const Vector<double>& values, d
     double binSize = (max - min) / binCount;
 
     for (double value : values) {
-        size_t index = std::min(binCount - 1, static_cast<size_t>((value - min) / binSize));
+        size_t index = std::min(binCount - 1, static_cast<size_t>(truncateDoubleToUint64((value - min) / binSize)));
         ++bins[index];
     }
 

--- a/Source/WTF/wtf/text/TextStream.cpp
+++ b/Source/WTF/wtf/text/TextStream.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include <wtf/text/TextStream.h>
 
+#include <wtf/MathExtras.h>
 #include <wtf/MediaTime.h>
 #include <wtf/ObjectIdentifier.h>
 #include <wtf/Seconds.h>
@@ -41,7 +42,7 @@ static constexpr size_t printBufferSize = 100; // large enough for any integer o
 static inline bool NODELETE hasFractions(double val)
 {
     static constexpr double s_epsilon = 0.0001;
-    int ival = static_cast<int>(val);
+    int ival = truncateDoubleToInt32(val);
     double dval = static_cast<double>(ival);
     return std::abs(val - dval) > s_epsilon;
 }

--- a/Source/WebCore/html/ImageDocument.cpp
+++ b/Source/WebCore/html/ImageDocument.cpp
@@ -54,6 +54,7 @@
 #include "RenderElement.h"
 #include "Settings.h"
 #include "UserScriptTypes.h"
+#include <wtf/MathExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
@@ -441,8 +442,8 @@ void ImageDocument::imageClicked(int x, int y)
         float scale = this->scale();
 
         auto viewportSize = view->visibleSize();
-        int scrollX = static_cast<int>(x / scale - viewportSize.width() / 2.0f);
-        int scrollY = static_cast<int>(y / scale - viewportSize.height() / 2.0f);
+        int scrollX = truncateFloatToInt32(x / scale - viewportSize.width() / 2.0f);
+        int scrollY = truncateFloatToInt32(y / scale - viewportSize.height() / 2.0f);
 
         view->setScrollPosition(IntPoint(scrollX, scrollY));
     }

--- a/Source/WebCore/platform/animation/AnimationUtilities.h
+++ b/Source/WebCore/platform/animation/AnimationUtilities.h
@@ -29,6 +29,7 @@
 #include <WebCore/IntPoint.h>
 #include <WebCore/IterationCompositeOperation.h>
 #include <WebCore/LayoutPoint.h>
+#include <wtf/MathExtras.h>
 
 namespace WebCore {
 
@@ -68,27 +69,27 @@ struct BlendingContext {
 inline int blend(int from, int to, const BlendingContext& context)
 {  
     if (context.iterationCompositeOperation == IterationCompositeOperation::Accumulate && context.currentIteration) {
-        auto iterationIncrement = static_cast<int>(context.currentIteration * static_cast<double>(to));
+        auto iterationIncrement = truncateDoubleToInt32(context.currentIteration * static_cast<double>(to));
         from += iterationIncrement;
         to += iterationIncrement;
     }
 
     if (context.compositeOperation == CompositeOperation::Replace)
-        return static_cast<int>(roundTowardsPositiveInfinity(from + (static_cast<double>(to) - from) * context.progress));
-    return static_cast<int>(roundTowardsPositiveInfinity(static_cast<double>(from) + static_cast<double>(from) + static_cast<double>(to - from) * context.progress));
+        return truncateDoubleToInt32(roundTowardsPositiveInfinity(from + (static_cast<double>(to) - from) * context.progress));
+    return truncateDoubleToInt32(roundTowardsPositiveInfinity(static_cast<double>(from) + static_cast<double>(from) + static_cast<double>(to - from) * context.progress));
 }
 
 inline unsigned blend(unsigned from, unsigned to, const BlendingContext& context)
 {
     if (context.iterationCompositeOperation == IterationCompositeOperation::Accumulate && context.currentIteration) {
-        auto iterationIncrement = static_cast<unsigned>(context.currentIteration * static_cast<double>(to));
+        auto iterationIncrement = truncateDoubleToUint32(context.currentIteration * static_cast<double>(to));
         from += iterationIncrement;
         to += iterationIncrement;
     }
 
     if (context.compositeOperation == CompositeOperation::Replace)
-        return static_cast<unsigned>(lround(from + (static_cast<double>(to) - from) * context.progress));
-    return static_cast<unsigned>(lround(from + from + (static_cast<double>(to) - from) * context.progress));
+        return truncateDoubleToUint32(lround(from + (static_cast<double>(to) - from) * context.progress));
+    return truncateDoubleToUint32(lround(from + from + (static_cast<double>(to) - from) * context.progress));
 }
 
 inline double blend(double from, double to, const BlendingContext& context)

--- a/Source/WebCore/platform/audio/AudioResamplerKernel.cpp
+++ b/Source/WebCore/platform/audio/AudioResamplerKernel.cpp
@@ -32,6 +32,7 @@
 #include "AudioUtilities.h"
 #include <algorithm>
 #include <wtf/CheckedArithmetic.h>
+#include <wtf/MathExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -55,7 +56,7 @@ std::span<float> AudioResamplerKernel::getSourceSpan(size_t framesToProcess, siz
     double nextFractionalIndex = m_virtualReadIndex + framesToProcess * rate();
 
     // Because we're linearly interpolating between the previous and next sample we need to round up so we include the next sample.
-    int endIndex = static_cast<int>(nextFractionalIndex + 1.0); // round up to next integer index
+    int endIndex = truncateDoubleToInt32(nextFractionalIndex + 1.0); // round up to next integer index
 
     // Determine how many input frames we'll need.
     // We need to fill the buffer up to and including endIndex (so add 1) but we've already buffered m_fillIndex frames from last time.

--- a/Source/WebCore/platform/graphics/FormatConverter.cpp
+++ b/Source/WebCore/platform/graphics/FormatConverter.cpp
@@ -30,6 +30,7 @@
 #if ENABLE(WEBGL)
 
 #include "FormatConverter.h"
+#include <wtf/MathExtras.h>
 #include <wtf/text/ParsingUtilities.h>
 
 #if HAVE(ARM_NEON_INTRINSICS)
@@ -1123,9 +1124,9 @@ void pack<GraphicsContextGL::DataFormat::RGBA32, GraphicsContextGL::AlphaOp::DoP
 {
     for (unsigned i = 0; i < pixels_per_row; ++i) {
         double scaleFactor = static_cast<double>(source[3]) / MaxUInt32Value;
-        destination[0] = static_cast<uint32_t>(static_cast<double>(source[0]) * scaleFactor);
-        destination[1] = static_cast<uint32_t>(static_cast<double>(source[1]) * scaleFactor);
-        destination[2] = static_cast<uint32_t>(static_cast<double>(source[2]) * scaleFactor);
+        destination[0] = truncateDoubleToUint32(static_cast<double>(source[0]) * scaleFactor);
+        destination[1] = truncateDoubleToUint32(static_cast<double>(source[1]) * scaleFactor);
+        destination[2] = truncateDoubleToUint32(static_cast<double>(source[2]) * scaleFactor);
         destination[3] = source[3];
         skip(source, 4);
         skip(destination, 4);
@@ -1138,9 +1139,9 @@ void pack<GraphicsContextGL::DataFormat::RGBA32_S, GraphicsContextGL::AlphaOp::D
     for (unsigned i = 0; i < pixels_per_row; ++i) {
         destination[3] = clampMin(source[3]);
         double scaleFactor = static_cast<double>(destination[3]) / MaxInt32Value;
-        destination[0] = static_cast<int32_t>(static_cast<double>(clampMin(source[0])) * scaleFactor);
-        destination[1] = static_cast<int32_t>(static_cast<double>(clampMin(source[1])) * scaleFactor);
-        destination[2] = static_cast<int32_t>(static_cast<double>(clampMin(source[2])) * scaleFactor);
+        destination[0] = truncateDoubleToInt32(static_cast<double>(clampMin(source[0])) * scaleFactor);
+        destination[1] = truncateDoubleToInt32(static_cast<double>(clampMin(source[1])) * scaleFactor);
+        destination[2] = truncateDoubleToInt32(static_cast<double>(clampMin(source[2])) * scaleFactor);
         skip(source, 4);
         skip(destination, 4);
     }
@@ -1150,10 +1151,10 @@ template<> ALWAYS_INLINE
 void pack<GraphicsContextGL::DataFormat::RGBA2_10_10_10, GraphicsContextGL::AlphaOp::DoNothing, float, uint32_t>(std::span<const float> source, std::span<uint32_t> destination, unsigned pixels_per_row)
 {
     for (unsigned i = 0; i < pixels_per_row; ++i) {
-        uint32_t r = static_cast<uint32_t>(source[0] * 1023.0f);
-        uint32_t g = static_cast<uint32_t>(source[1] * 1023.0f);
-        uint32_t b = static_cast<uint32_t>(source[2] * 1023.0f);
-        uint32_t a = static_cast<uint32_t>(source[3] * 3.0f);
+        uint32_t r = truncateFloatToUint32(source[0] * 1023.0f);
+        uint32_t g = truncateFloatToUint32(source[1] * 1023.0f);
+        uint32_t b = truncateFloatToUint32(source[2] * 1023.0f);
+        uint32_t a = truncateFloatToUint32(source[3] * 3.0f);
         destination[0] = (a << 30) | (b << 20) | (g << 10) | r;
         skip(source, 4);
         skip(destination, 1);
@@ -1164,10 +1165,10 @@ template<> ALWAYS_INLINE
 void pack<GraphicsContextGL::DataFormat::RGBA2_10_10_10, GraphicsContextGL::AlphaOp::DoPremultiply, float, uint32_t>(std::span<const float> source, std::span<uint32_t> destination, unsigned pixels_per_row)
 {
     for (unsigned i = 0; i < pixels_per_row; ++i) {
-        uint32_t r = static_cast<uint32_t>(source[0] * source[3] * 1023.0f);
-        uint32_t g = static_cast<uint32_t>(source[1] * source[3] * 1023.0f);
-        uint32_t b = static_cast<uint32_t>(source[2] * source[3] * 1023.0f);
-        uint32_t a = static_cast<uint32_t>(source[3] * 3.0f);
+        uint32_t r = truncateFloatToUint32(source[0] * source[3] * 1023.0f);
+        uint32_t g = truncateFloatToUint32(source[1] * source[3] * 1023.0f);
+        uint32_t b = truncateFloatToUint32(source[2] * source[3] * 1023.0f);
+        uint32_t a = truncateFloatToUint32(source[3] * 3.0f);
         destination[0] = (a << 30) | (b << 20) | (g << 10) | r;
         skip(source, 4);
         skip(destination, 1);
@@ -1179,10 +1180,10 @@ void pack<GraphicsContextGL::DataFormat::RGBA2_10_10_10, GraphicsContextGL::Alph
 {
     for (unsigned i = 0; i < pixels_per_row; ++i) {
         float scaleFactor = source[3] ? 1023.0f / source[3] : 1023.0f;
-        uint32_t r = static_cast<uint32_t>(source[0] * scaleFactor);
-        uint32_t g = static_cast<uint32_t>(source[1] * scaleFactor);
-        uint32_t b = static_cast<uint32_t>(source[2] * scaleFactor);
-        uint32_t a = static_cast<uint32_t>(source[3] * 3.0f);
+        uint32_t r = truncateFloatToUint32(source[0] * scaleFactor);
+        uint32_t g = truncateFloatToUint32(source[1] * scaleFactor);
+        uint32_t b = truncateFloatToUint32(source[2] * scaleFactor);
+        uint32_t a = truncateFloatToUint32(source[3] * 3.0f);
         destination[0] = (a << 30) | (b << 20) | (g << 10) | r;
         skip(source, 4);
         skip(destination, 1);

--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -39,6 +39,7 @@
 #include "SystemImage.h"
 #include "TextRunIterator.h"
 #include "VideoFrame.h"
+#include <wtf/MathExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
@@ -709,11 +710,11 @@ auto GraphicsContext::computeRectsAndStrokeColorForLinesForText(const FloatPoint
             auto left = lineSegment.begin;
             auto width = lineSegment.length();
             auto doubleWidth = 2 * dashWidth;
-            auto quotient = static_cast<int>(left / doubleWidth);
+            auto quotient = truncateDoubleToInt32(left / doubleWidth);
             auto startOffset = left - quotient * doubleWidth;
             auto effectiveLeft = left + startOffset;
-            auto startParticle = static_cast<int>(std::floor(effectiveLeft / doubleWidth));
-            auto endParticle = static_cast<int>(std::ceil((left + width) / doubleWidth));
+            auto startParticle = truncateDoubleToInt32(std::floor(effectiveLeft / doubleWidth));
+            auto endParticle = truncateDoubleToInt32(std::ceil((left + width) / doubleWidth));
 
             for (auto j = startParticle; j < endParticle; ++j) {
                 auto actualDashWidth = dashWidth;

--- a/Source/WebCore/platform/graphics/IntRect.cpp
+++ b/Source/WebCore/platform/graphics/IntRect.cpp
@@ -30,6 +30,7 @@
 #include "LayoutRect.h"
 #include <algorithm>
 #include <wtf/CheckedArithmetic.h>
+#include <wtf/MathExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
@@ -128,10 +129,10 @@ void IntRect::uniteIfNonZero(const IntRect& other)
 
 void IntRect::scale(float s)
 {
-    m_location.setX((int)(x() * s));
-    m_location.setY((int)(y() * s));
-    m_size.setWidth((int)(width() * s));
-    m_size.setHeight((int)(height() * s));
+    m_location.setX(truncateFloatToInt32(x() * s));
+    m_location.setY(truncateFloatToInt32(y() * s));
+    m_size.setWidth(truncateFloatToInt32(width() * s));
+    m_size.setHeight(truncateFloatToInt32(height() * s));
 }
 
 static inline int NODELETE distanceToInterval(int pos, int start, int end)

--- a/Source/WebCore/platform/graphics/IntSize.h
+++ b/Source/WebCore/platform/graphics/IntSize.h
@@ -31,6 +31,7 @@
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/JSONValues.h>
 #include <wtf/Forward.h>
+#include <wtf/MathExtras.h>
 #include <wtf/Platform.h>
 
 #if USE(CG)
@@ -93,8 +94,8 @@ public:
 
     void scale(float widthScale, float heightScale)
     {
-        m_width = static_cast<int>(static_cast<float>(m_width) * widthScale);
-        m_height = static_cast<int>(static_cast<float>(m_height) * heightScale);
+        m_width = truncateFloatToInt32(static_cast<float>(m_width) * widthScale);
+        m_height = truncateFloatToInt32(static_cast<float>(m_height) * heightScale);
     }
 
     void scale(float scale)

--- a/Source/WebCore/platform/graphics/ShadowBlur.cpp
+++ b/Source/WebCore/platform/graphics/ShadowBlur.cpp
@@ -248,7 +248,7 @@ static void calculateLobes(std::array<std::array<int, 2>, 3>& lobes, float blurR
 {
     int diameter;
     if (shadowsIgnoreTransforms)
-        diameter = std::max(2, static_cast<int>(floorf((2 / 3.f) * blurRadius))); // Canvas shadow. FIXME: we should adjust the blur radius higher up.
+        diameter = std::max(2, truncateFloatToInt32(floorf((2 / 3.f) * blurRadius))); // Canvas shadow. FIXME: we should adjust the blur radius higher up.
     else {
         // http://dev.w3.org/csswg/css3-background/#box-shadow
         // Approximate a Gaussian blur with a standard deviation equal to half the blur radius,
@@ -258,7 +258,7 @@ static void calculateLobes(std::array<std::array<int, 2>, 3>& lobes, float blurR
         float stdDev = blurRadius / 2;
         const float gaussianKernelFactor = 3 / 4.f * sqrtf(2 * std::numbers::pi_v<float>);
         const float fudgeFactor = 0.88f;
-        diameter = std::max(2, static_cast<int>(floorf(stdDev * gaussianKernelFactor * fudgeFactor + 0.5f)));
+        diameter = std::max(2, truncateFloatToInt32(floorf(stdDev * gaussianKernelFactor * fudgeFactor + 0.5f)));
     }
 
     if (diameter & 1) {


### PR DESCRIPTION
#### aa5eadc0c2eb2e1c3b9a1fcb40ab54dacfa620c5
<pre>
Avoid fp-&gt;integer UB throughout WebKit repository
<a href="https://bugs.webkit.org/show_bug.cgi?id=310697">https://bugs.webkit.org/show_bug.cgi?id=310697</a>
<a href="https://rdar.apple.com/173311131">rdar://173311131</a>

Reviewed by Chris Dumez and Dan Hecht.

Apply 309786@main change throughout the WebKit repository. When
converting fp to integers, if it is not fitting in a range of integer&apos;s
representable range, it is UB. And the recent clang is leverageing this
UB a bit too aggressively and causing breakage of semantics in the code
when it is used in an UB manner.

* Source/WTF/wtf/CurrentTime.cpp:
* Source/WTF/wtf/JSONValues.cpp:
(WTF::JSONImpl::Value::asInteger const):
* Source/WTF/wtf/MathExtras.h:
(WTF::truncateDoubleToInt32):
(WTF::truncateDoubleToInt64):
(WTF::truncateDoubleToUint32):
(WTF::truncateDoubleToUint64):
(WTF::truncateFloatToInt32):
(WTF::truncateFloatToInt64):
(WTF::truncateFloatToUint32):
(WTF::truncateFloatToUint64):
(WTF::tryConvertToStrictInt32):
* Source/WTF/wtf/MemoryPressureHandler.cpp:
(WTF::thresholdForMemoryKillOfActiveProcess):
(WTF::thresholdForMemoryKillOfInactiveProcess):
* Source/WTF/wtf/StatisticsManager.cpp:
(WTF::dumpHistogram):
* Source/WTF/wtf/text/TextStream.cpp:
(WTF::hasFractions):
* Source/WebCore/html/ImageDocument.cpp:
(WebCore::ImageDocument::imageClicked):
* Source/WebCore/platform/animation/AnimationUtilities.h:
(WebCore::blend):
* Source/WebCore/platform/audio/AudioResamplerKernel.cpp:
(WebCore::AudioResamplerKernel::getSourceSpan):
* Source/WebCore/platform/graphics/FormatConverter.cpp:
(WebCore::uint32_t&gt;):
(WebCore::int32_t&gt;):
* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::computeRectsAndStrokeColorForLinesForText):
* Source/WebCore/platform/graphics/IntRect.cpp:
(WebCore::IntRect::scale):
* Source/WebCore/platform/graphics/IntSize.h:
(WebCore::IntSize::scale):
* Source/WebCore/platform/graphics/ShadowBlur.cpp:
(WebCore::calculateLobes):

Canonical link: <a href="https://commits.webkit.org/309964@main">https://commits.webkit.org/309964@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c2b575ff1de22f0b9fb2e02e6dfc278fe7c1554

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152271 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25053 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18650 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161014 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154145 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25580 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25359 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117651 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155231 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136711 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98364 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/18939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16867 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8848 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144283 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14585 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163482 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13072 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6626 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16179 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125681 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24851 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20905 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125855 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24852 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136381 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81451 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23355 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20856 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13159 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/183895 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24469 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88754 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46884 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24160 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24320 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24221 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->