### PR TITLE
REGRESSION(309603@main): Context menu event over existing PDF selection presents ill-formed context menu

### DIFF
--- a/Source/WebCore/dom/Event.h
+++ b/Source/WebCore/dom/Event.h
@@ -223,7 +223,7 @@ inline void Event::setCancelBubble(bool cancel)
         m_propagationStopped = true;
 }
 
-WTF::TextStream& operator<<(WTF::TextStream&, const Event&);
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const Event&);
 
 } // namespace WebCore
 

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -30,6 +30,7 @@
 
 #include "DocumentEditingContext.h"
 #include "FrameInfoData.h"
+#include "Logging.h"
 #include "PDFPlugin.h"
 #include "UnifiedPDFPlugin.h"
 #include "WebFrame.h"
@@ -49,6 +50,7 @@
 #include <WebCore/DocumentLoader.h>
 #include <WebCore/DocumentPage.h>
 #include <WebCore/DocumentView.h>
+#include <WebCore/Event.h>
 #include <WebCore/EventHandler.h>
 #include <WebCore/EventNames.h>
 #include <WebCore/FocusController.h>
@@ -700,16 +702,21 @@ std::pair<String, String> PluginView::stringsBeforeAndAfterSelection(int charact
     return m_plugin->stringsBeforeAndAfterSelection(characterCount);
 }
 
+// Automation mouse events funnel through as synthetic clicks, except
+// for context menu events, which do not have a clear synthetic analogue.
+static bool shouldForwardToPlugin(const Event& event)
+{
+    RefPtr mouseEvent = dynamicDowncast<WebCore::MouseEvent>(event);
+    return !mouseEvent || mouseEvent->inputSource() != WebCore::MouseEventInputSource::Automation || event.type() == eventNames().contextmenuEvent;
+}
+
 void PluginView::handleEvent(Event& event)
 {
     if (!m_isInitialized)
         return;
 
-    {
-        RefPtr mouseEvent = dynamicDowncast<WebCore::MouseEvent>(event);
-        if (mouseEvent && mouseEvent->inputSource() == WebCore::MouseEventInputSource::Automation)
-            return;
-    }
+    if (!shouldForwardToPlugin(event))
+        return;
 
     const CheckedPtr currentEvent = WebPage::currentEvent();
     if (!currentEvent)
@@ -742,6 +749,8 @@ void PluginView::handleEvent(Event& event)
 
     if (didHandleEvent)
         event.setDefaultHandled();
+
+    LOG_WITH_STREAM(Plugins, stream << "PluginView::handleEvent() for event: " << event << ", was handled: " << didHandleEvent);
 }
 
 bool PluginView::handleEditingCommand(const String& commandName, const String& argument)


### PR DESCRIPTION
#### e66c9d03b983c64b492ba08a6583762fae0c14e0
<pre>
REGRESSION(309603@main): Context menu event over existing PDF selection presents ill-formed context menu
<a href="https://bugs.webkit.org/show_bug.cgi?id=310699">https://bugs.webkit.org/show_bug.cgi?id=310699</a>
<a href="https://rdar.apple.com/173311130">rdar://173311130</a>

Reviewed by Richard Robinson and Lily Spiniolas.

After 309603@main, we do not give the PDF plugin an opportunity to deal
with automation-derived context menu events. While the original patch is
still mostly correct, we need to special case for context menu events
since there is no synthetic analogue here.

* Source/WebCore/dom/Event.h:
  Drive-by: Export the textstream dumper to facilitate logging.
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::shouldNotForwardToPlugin):
(WebKit::PluginView::handleEvent):
  Drive-by: Add logging to understand how the plugin handles events.

Canonical link: <a href="https://commits.webkit.org/309954@main">https://commits.webkit.org/309954@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0cecd9bc332c510178315a70d12da0aab0150c5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152293 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25075 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18673 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161036 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154167 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25602 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25381 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117656 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Skipped layout-tests; 5 flakes 8 failures; Uploaded test results; 2 flakes 2 failures; Compiled WebKit; 2 failures; Passed layout tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9e766750-391f-45a9-be32-dbd6b7236d94) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155253 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/136719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98369 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7d1b2185-b6a8-469c-98de-ca2437be35ec) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/18941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/16877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8870 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14593 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163504 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/6648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16187 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125688 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24873 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/20915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125862 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34139 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24874 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136389 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/81473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20864 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/13168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24491 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88776 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24182 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24342 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/24243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->