### PR TITLE
[IndexedDB API] Support IDBGetAllOptions in IDBIndex::getAllKeys()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllKeys-options.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllKeys-options.any-expected.txt
@@ -1,27 +1,27 @@
 
-FAIL Single item get Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Empty object store Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get all keys Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get all generated keys Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL maxCount=10 Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get bound range Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get bound range with maxCount Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get upper excluded Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get lower excluded Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get bound range (generated) with maxCount Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Non existent key Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL maxCount=0 Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Max value count Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Query with empty range where  first key < upperBound Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Query with empty range where lowerBound < last key Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Retrieve multiEntry key Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Retrieve one key multiple values Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction: next Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction: prev Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction: nextunique Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction: prevunique Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction and query Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction, query and count Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get all keys with both options and count Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+PASS Single item get
+PASS Empty object store
+PASS Get all keys
+PASS Get all generated keys
+PASS maxCount=10
+PASS Get bound range
+PASS Get bound range with maxCount
+PASS Get upper excluded
+PASS Get lower excluded
+PASS Get bound range (generated) with maxCount
+PASS Non existent key
+PASS maxCount=0
+PASS Max value count
+PASS Query with empty range where  first key < upperBound
+PASS Query with empty range where lowerBound < last key
+PASS Retrieve multiEntry key
+PASS Retrieve one key multiple values
+PASS Direction: next
+PASS Direction: prev
+PASS Direction: nextunique
+PASS Direction: prevunique
+PASS Direction and query
+PASS Direction, query and count
+PASS Get all keys with both options and count
 PASS Get all keys with invalid query keys
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllKeys-options.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllKeys-options.any.serviceworker-expected.txt
@@ -1,27 +1,27 @@
 
-FAIL Single item get Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Empty object store Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get all keys Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get all generated keys Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL maxCount=10 Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get bound range Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get bound range with maxCount Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get upper excluded Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get lower excluded Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get bound range (generated) with maxCount Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Non existent key Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL maxCount=0 Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Max value count Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Query with empty range where  first key < upperBound Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Query with empty range where lowerBound < last key Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Retrieve multiEntry key Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Retrieve one key multiple values Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction: next Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction: prev Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction: nextunique Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction: prevunique Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction and query Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction, query and count Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get all keys with both options and count Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+PASS Single item get
+PASS Empty object store
+PASS Get all keys
+PASS Get all generated keys
+PASS maxCount=10
+PASS Get bound range
+PASS Get bound range with maxCount
+PASS Get upper excluded
+PASS Get lower excluded
+PASS Get bound range (generated) with maxCount
+PASS Non existent key
+PASS maxCount=0
+PASS Max value count
+PASS Query with empty range where  first key < upperBound
+PASS Query with empty range where lowerBound < last key
+PASS Retrieve multiEntry key
+PASS Retrieve one key multiple values
+PASS Direction: next
+PASS Direction: prev
+PASS Direction: nextunique
+PASS Direction: prevunique
+PASS Direction and query
+PASS Direction, query and count
+PASS Get all keys with both options and count
 PASS Get all keys with invalid query keys
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllKeys-options.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllKeys-options.any.sharedworker-expected.txt
@@ -1,27 +1,27 @@
 
-FAIL Single item get Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Empty object store Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get all keys Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get all generated keys Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL maxCount=10 Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get bound range Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get bound range with maxCount Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get upper excluded Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get lower excluded Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get bound range (generated) with maxCount Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Non existent key Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL maxCount=0 Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Max value count Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Query with empty range where  first key < upperBound Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Query with empty range where lowerBound < last key Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Retrieve multiEntry key Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Retrieve one key multiple values Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction: next Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction: prev Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction: nextunique Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction: prevunique Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction and query Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction, query and count Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get all keys with both options and count Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+PASS Single item get
+PASS Empty object store
+PASS Get all keys
+PASS Get all generated keys
+PASS maxCount=10
+PASS Get bound range
+PASS Get bound range with maxCount
+PASS Get upper excluded
+PASS Get lower excluded
+PASS Get bound range (generated) with maxCount
+PASS Non existent key
+PASS maxCount=0
+PASS Max value count
+PASS Query with empty range where  first key < upperBound
+PASS Query with empty range where lowerBound < last key
+PASS Retrieve multiEntry key
+PASS Retrieve one key multiple values
+PASS Direction: next
+PASS Direction: prev
+PASS Direction: nextunique
+PASS Direction: prevunique
+PASS Direction and query
+PASS Direction, query and count
+PASS Get all keys with both options and count
 PASS Get all keys with invalid query keys
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllKeys-options.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllKeys-options.any.worker-expected.txt
@@ -1,27 +1,27 @@
 
-FAIL Single item get Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Empty object store Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get all keys Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get all generated keys Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL maxCount=10 Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get bound range Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get bound range with maxCount Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get upper excluded Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get lower excluded Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get bound range (generated) with maxCount Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Non existent key Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL maxCount=0 Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Max value count Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Query with empty range where  first key < upperBound Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Query with empty range where lowerBound < last key Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Retrieve multiEntry key Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Retrieve one key multiple values Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction: next Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction: prev Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction: nextunique Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction: prevunique Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction and query Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction, query and count Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get all keys with both options and count Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key.
+PASS Single item get
+PASS Empty object store
+PASS Get all keys
+PASS Get all generated keys
+PASS maxCount=10
+PASS Get bound range
+PASS Get bound range with maxCount
+PASS Get upper excluded
+PASS Get lower excluded
+PASS Get bound range (generated) with maxCount
+PASS Non existent key
+PASS maxCount=0
+PASS Max value count
+PASS Query with empty range where  first key < upperBound
+PASS Query with empty range where lowerBound < last key
+PASS Retrieve multiEntry key
+PASS Retrieve one key multiple values
+PASS Direction: next
+PASS Direction: prev
+PASS Direction: nextunique
+PASS Direction: prevunique
+PASS Direction and query
+PASS Direction, query and count
+PASS Get all keys with both options and count
 PASS Get all keys with invalid query keys
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any-expected.txt
@@ -32,9 +32,7 @@ FAIL IDBObjectStore getAllRecords() method with throwing/invalid keys assert_thr
 FAIL IDBIndex getAll() method with throwing/invalid keys assert_throws_exactly: options query key conversion with throwing getter should rethrow function "() => {
     receiver[method]({query: key});
   }" threw object "DataError: Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key." but we expected it to throw object "getter: throwing from getter"
-FAIL IDBIndex getAllKeys() method with throwing/invalid keys assert_throws_exactly: options query key conversion with throwing getter should rethrow function "() => {
-    receiver[method]({query: key});
-  }" threw object "DataError: Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key." but we expected it to throw object "getter: throwing from getter"
+PASS IDBIndex getAllKeys() method with throwing/invalid keys
 FAIL IDBIndex getAllRecords() method with throwing/invalid keys assert_throws_dom: options query key conversion with invalid key should throw DataError function "() => {
     receiver[method]({query: invalid_key});
   }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.serviceworker-expected.txt
@@ -32,9 +32,7 @@ FAIL IDBObjectStore getAllRecords() method with throwing/invalid keys assert_thr
 FAIL IDBIndex getAll() method with throwing/invalid keys assert_throws_exactly: options query key conversion with throwing getter should rethrow function "() => {
     receiver[method]({query: key});
   }" threw object "DataError: Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key." but we expected it to throw object "getter: throwing from getter"
-FAIL IDBIndex getAllKeys() method with throwing/invalid keys assert_throws_exactly: options query key conversion with throwing getter should rethrow function "() => {
-    receiver[method]({query: key});
-  }" threw object "DataError: Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key." but we expected it to throw object "getter: throwing from getter"
+PASS IDBIndex getAllKeys() method with throwing/invalid keys
 FAIL IDBIndex getAllRecords() method with throwing/invalid keys assert_throws_dom: options query key conversion with invalid key should throw DataError function "() => {
     receiver[method]({query: invalid_key});
   }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.sharedworker-expected.txt
@@ -32,9 +32,7 @@ FAIL IDBObjectStore getAllRecords() method with throwing/invalid keys assert_thr
 FAIL IDBIndex getAll() method with throwing/invalid keys assert_throws_exactly: options query key conversion with throwing getter should rethrow function "() => {
     receiver[method]({query: key});
   }" threw object "DataError: Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key." but we expected it to throw object "getter: throwing from getter"
-FAIL IDBIndex getAllKeys() method with throwing/invalid keys assert_throws_exactly: options query key conversion with throwing getter should rethrow function "() => {
-    receiver[method]({query: key});
-  }" threw object "DataError: Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key." but we expected it to throw object "getter: throwing from getter"
+PASS IDBIndex getAllKeys() method with throwing/invalid keys
 FAIL IDBIndex getAllRecords() method with throwing/invalid keys assert_throws_dom: options query key conversion with invalid key should throw DataError function "() => {
     receiver[method]({query: invalid_key});
   }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.worker-expected.txt
@@ -32,9 +32,7 @@ FAIL IDBObjectStore getAllRecords() method with throwing/invalid keys assert_thr
 FAIL IDBIndex getAll() method with throwing/invalid keys assert_throws_exactly: options query key conversion with throwing getter should rethrow function "() => {
     receiver[method]({query: key});
   }" threw object "DataError: Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key." but we expected it to throw object "getter: throwing from getter"
-FAIL IDBIndex getAllKeys() method with throwing/invalid keys assert_throws_exactly: options query key conversion with throwing getter should rethrow function "() => {
-    receiver[method]({query: key});
-  }" threw object "DataError: Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key." but we expected it to throw object "getter: throwing from getter"
+PASS IDBIndex getAllKeys() method with throwing/invalid keys
 FAIL IDBIndex getAllRecords() method with throwing/invalid keys assert_throws_dom: options query key conversion with invalid key should throw DataError function "() => {
     receiver[method]({query: invalid_key});
   }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0

--- a/Source/WebCore/Modules/indexeddb/IDBIndex.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBIndex.cpp
@@ -30,13 +30,17 @@
 #include "ExceptionOr.h"
 #include "IDBBindingUtilities.h"
 #include "IDBCursor.h"
+#include "IDBCursorDirection.h"
 #include "IDBDatabase.h"
 #include "IDBGetAllOptions.h"
 #include "IDBKeyRangeData.h"
 #include "IDBObjectStore.h"
 #include "IDBRequest.h"
 #include "IDBTransaction.h"
+#include "JSIDBGetAllOptions.h"
+#include "JSIDBKeyRange.h"
 #include "Logging.h"
+#include "Settings.h"
 #include "WebCoreOpaqueRoot.h"
 #include <JavaScriptCore/HeapInlines.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -362,7 +366,7 @@ ExceptionOr<Ref<IDBRequest>> IDBIndex::doGetAll(std::optional<uint32_t> count, F
         return keyRange.releaseException();
 
     RefPtr keyRangePointer = keyRange.returnValue().get();
-    return transaction->requestGetAllIndexRecords(*this, keyRangePointer.get(), IndexedDB::GetAllType::Values, count);
+    return transaction->requestGetAllIndexRecords(*this, keyRangePointer.get(), IndexedDB::GetAllType::Values, count, IDBCursorDirection::Next);
 }
 
 ExceptionOr<Ref<IDBRequest>> IDBIndex::getAll(RefPtr<IDBKeyRange>&& range, std::optional<uint32_t> count)
@@ -383,7 +387,7 @@ ExceptionOr<Ref<IDBRequest>> IDBIndex::getAll(JSGlobalObject& execState, JSValue
     });
 }
 
-ExceptionOr<Ref<IDBRequest>> IDBIndex::doGetAllKeys(std::optional<uint32_t> count, Function<ExceptionOr<RefPtr<IDBKeyRange>>()>&& function)
+ExceptionOr<Ref<IDBRequest>> IDBIndex::doGetAllKeys(std::optional<uint32_t> count, Function<ExceptionOr<ParsedGetAllQueryOrOptions>()>&& function)
 {
     LOG(IndexedDB, "IDBIndex::getAllKeys");
     Ref transaction = m_objectStore->transaction();
@@ -395,29 +399,54 @@ ExceptionOr<Ref<IDBRequest>> IDBIndex::doGetAllKeys(std::optional<uint32_t> coun
     if (!transaction->isActive())
         return Exception { ExceptionCode::TransactionInactiveError, "Failed to execute 'getAllKeys' on 'IDBIndex': The transaction is inactive or finished."_s };
 
-    auto keyRange = function();
-    if (keyRange.hasException())
-        return keyRange.releaseException();
+    auto exceptionOrParsedGetAllQueryOrOptions = function();
+    if (exceptionOrParsedGetAllQueryOrOptions.hasException())
+        return exceptionOrParsedGetAllQueryOrOptions.releaseException();
 
-    RefPtr keyRangePointer = keyRange.returnValue().get();
-    return transaction->requestGetAllIndexRecords(*this, keyRangePointer.get(), IndexedDB::GetAllType::Keys, count);
+    auto parsedGetAllQueryOrOptions = exceptionOrParsedGetAllQueryOrOptions.releaseReturnValue();
+    if (parsedGetAllQueryOrOptions.count)
+        count = parsedGetAllQueryOrOptions.count;
+
+    return transaction->requestGetAllIndexRecords(*this, parsedGetAllQueryOrOptions.keyRange.get(), IndexedDB::GetAllType::Keys, count, parsedGetAllQueryOrOptions.cursorDirection);
 }
 
 ExceptionOr<Ref<IDBRequest>> IDBIndex::getAllKeys(RefPtr<IDBKeyRange>&& range, std::optional<uint32_t> count)
 {
     return doGetAllKeys(count, [range = WTF::move(range)]() {
-        return range;
+        return ParsedGetAllQueryOrOptions { range };
     });
 }
 
-ExceptionOr<Ref<IDBRequest>> IDBIndex::getAllKeys(JSGlobalObject& execState, JSValue key, std::optional<uint32_t> count)
+// https://w3c.github.io/IndexedDB/#create-a-request-to-retrieve-multiple-items
+ExceptionOr<Ref<IDBRequest>> IDBIndex::getAllKeys(JSGlobalObject& execState, JSValue keyOrOptions, std::optional<uint32_t> count)
 {
-    return doGetAllKeys(count, [state = &execState, key]() {
-        auto onlyResult = IDBKeyRange::only(*state, key);
-        if (onlyResult.hasException())
-            return ExceptionOr<RefPtr<IDBKeyRange>> { Exception(ExceptionCode::DataError, "Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key."_s) };
+    return doGetAllKeys(count, [context = RefPtr { scriptExecutionContext() }, execState = &execState, keyOrOptions]() -> ExceptionOr<ParsedGetAllQueryOrOptions> {
+        auto onlyResult = IDBKeyRange::only(*execState, keyOrOptions);
+        if (!onlyResult.hasException())
+            return ParsedGetAllQueryOrOptions { onlyResult.releaseReturnValue() };
 
-        return ExceptionOr<RefPtr<IDBKeyRange>> { onlyResult.releaseReturnValue() };
+        if (!context || !context->settingsValues().indexedDBGetAllRecordsEnabled)
+            return Exception(ExceptionCode::DataError, "Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key."_s);
+
+        auto throwScope = DECLARE_THROW_SCOPE(execState->vm());
+        auto optionsResult = convertDictionary<IDBGetAllOptions>(*execState, keyOrOptions);
+        if (throwScope.exception())
+            return Exception { ExceptionCode::DataError, "Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid options object."_s };
+
+        auto options = optionsResult.releaseReturnValue();
+        auto query = options.query;
+
+        if (query.isUndefinedOrNull())
+            return ParsedGetAllQueryOrOptions { nullptr, options.count, options.direction };
+
+        if (RefPtr keyRange = JSIDBKeyRange::toWrapped(execState->vm(), query))
+            return ParsedGetAllQueryOrOptions { WTF::move(keyRange), options.count, options.direction };
+
+        auto onlyResultFromQuery = IDBKeyRange::only(*execState, query);
+        if (onlyResultFromQuery.hasException())
+            return Exception(ExceptionCode::DataError, "Failed to execute 'getAllKeys' on 'IDBIndex': The query specified in options is not a valid key."_s);
+
+        return ParsedGetAllQueryOrOptions { onlyResultFromQuery.releaseReturnValue(), options.count, options.direction };
     });
 }
 

--- a/Source/WebCore/Modules/indexeddb/IDBIndex.h
+++ b/Source/WebCore/Modules/indexeddb/IDBIndex.h
@@ -43,6 +43,12 @@ class WebCoreOpaqueRoot;
 struct IDBGetAllOptions;
 struct IDBKeyRangeData;
 
+struct ParsedGetAllQueryOrOptions {
+    RefPtr<IDBKeyRange> keyRange;
+    std::optional<uint32_t> count { std::nullopt };
+    IDBCursorDirection cursorDirection { IDBCursorDirection::Next };
+};
+
 class IDBIndex final : public ActiveDOMObject {
     WTF_MAKE_TZONE_ALLOCATED(IDBIndex);
 public:
@@ -75,8 +81,7 @@ public:
     ExceptionOr<Ref<IDBRequest>> getAll(RefPtr<IDBKeyRange>&&, std::optional<uint32_t> count);
     ExceptionOr<Ref<IDBRequest>> getAll(JSC::JSGlobalObject&, JSC::JSValue key, std::optional<uint32_t> count);
     ExceptionOr<Ref<IDBRequest>> getAllKeys(RefPtr<IDBKeyRange>&&, std::optional<uint32_t> count);
-    ExceptionOr<Ref<IDBRequest>> getAllKeys(JSC::JSGlobalObject&, JSC::JSValue key, std::optional<uint32_t> count);
-
+    ExceptionOr<Ref<IDBRequest>> getAllKeys(JSC::JSGlobalObject&, JSC::JSValue keyOrOptions, std::optional<uint32_t> count);
     ExceptionOr<Ref<IDBRequest>> getAllRecords(JSC::JSGlobalObject&, IDBGetAllOptions&&);
 
     const IDBIndexInfo& info() const LIFETIME_BOUND { return m_info; }
@@ -99,7 +104,7 @@ private:
     ExceptionOr<Ref<IDBRequest>> doOpenCursor(IDBCursorDirection, Function<ExceptionOr<RefPtr<IDBKeyRange>>()> &&);
     ExceptionOr<Ref<IDBRequest>> doOpenKeyCursor(IDBCursorDirection, Function<ExceptionOr<RefPtr<IDBKeyRange>>()> &&);
     ExceptionOr<Ref<IDBRequest>> doGetAll(std::optional<uint32_t> count, Function<ExceptionOr<RefPtr<IDBKeyRange>>()> &&);
-    ExceptionOr<Ref<IDBRequest>> doGetAllKeys(std::optional<uint32_t> count, Function<ExceptionOr<RefPtr<IDBKeyRange>>()> &&);
+    ExceptionOr<Ref<IDBRequest>> doGetAllKeys(std::optional<uint32_t> count, Function<ExceptionOr<ParsedGetAllQueryOrOptions>()> &&);
 
     // ActiveDOMObject.
     bool virtualHasPendingActivity() const final;

--- a/Source/WebCore/Modules/indexeddb/IDBIndex.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBIndex.idl
@@ -43,18 +43,24 @@ typedef (DOMString or sequence<DOMString>) IDBKeyPath;
 
     [NewObject] IDBRequest get(IDBKeyRange? key);
     [NewObject, CallWith=CurrentGlobalObject] IDBRequest get(any key);
+
     [NewObject] IDBRequest getKey(IDBKeyRange? key);
     [NewObject, CallWith=CurrentGlobalObject] IDBRequest getKey(any key);
+
     [NewObject] IDBRequest getAll(optional IDBKeyRange? range = null, optional [EnforceRange] unsigned long count);
     [NewObject, CallWith=CurrentGlobalObject] IDBRequest getAll(any key, optional [EnforceRange] unsigned long count);
+
     [NewObject] IDBRequest getAllKeys(optional IDBKeyRange? range = null, optional [EnforceRange] unsigned long count);
-    [NewObject, CallWith=CurrentGlobalObject] IDBRequest getAllKeys(any key, optional [EnforceRange] unsigned long count);
+    [NewObject, CallWith=CurrentGlobalObject] IDBRequest getAllKeys(any keyOrOptions, optional [EnforceRange] unsigned long count);
+
     [NewObject, CallWith=CurrentGlobalObject, EnabledBySetting=IndexedDBGetAllRecordsEnabled] IDBRequest getAllRecords(optional IDBGetAllOptions options = {});
+
     [NewObject] IDBRequest count(optional IDBKeyRange? range = null);
     [NewObject, CallWith=CurrentGlobalObject] IDBRequest count(any key);
 
     [NewObject] IDBRequest openCursor(optional IDBKeyRange? range = null, optional IDBCursorDirection direction = "next");
     [NewObject, CallWith=CurrentGlobalObject] IDBRequest openCursor(any key, optional IDBCursorDirection direction = "next");
+
     [NewObject] IDBRequest openKeyCursor(optional IDBKeyRange? range = null, optional IDBCursorDirection direction = "next");
     [NewObject, CallWith=CurrentGlobalObject] IDBRequest openKeyCursor(any key, optional IDBCursorDirection direction = "next");
 };

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
@@ -936,7 +936,7 @@ Ref<IDBRequest> IDBTransaction::requestGetAllObjectStoreRecords(IDBObjectStore& 
     auto request = IDBRequest::create(*protect(scriptExecutionContext()), objectStore, *this);
     addRequest(request.get());
 
-    IDBGetAllRecordsData getAllRecordsData { keyRangeData, getAllType, count, objectStore.info().identifier() };
+    IDBGetAllRecordsData getAllRecordsData { keyRangeData, getAllType, count, IndexedDB::CursorDirection::Next, objectStore.info().identifier() };
 
     LOG(IndexedDBOperations, "IDB get all object store records operation: %s", getAllRecordsData.loggingString().utf8().data());
     scheduleOperation(IDBClient::TransactionOperationImpl::create(*this, request.get(), [protectedThis = Ref { *this }, request] (const auto& result) {
@@ -948,7 +948,7 @@ Ref<IDBRequest> IDBTransaction::requestGetAllObjectStoreRecords(IDBObjectStore& 
     return request;
 }
 
-Ref<IDBRequest> IDBTransaction::requestGetAllIndexRecords(IDBIndex& index, const IDBKeyRangeData& keyRangeData, IndexedDB::GetAllType getAllType, std::optional<uint32_t> count)
+Ref<IDBRequest> IDBTransaction::requestGetAllIndexRecords(IDBIndex& index, const IDBKeyRangeData& keyRangeData, IndexedDB::GetAllType getAllType, std::optional<uint32_t> count, IndexedDB::CursorDirection cursorDirection)
 {
     LOG(IndexedDB, "IDBTransaction::requestGetAllIndexRecords");
     ASSERT(isActive());
@@ -958,7 +958,7 @@ Ref<IDBRequest> IDBTransaction::requestGetAllIndexRecords(IDBIndex& index, const
     auto request = IDBRequest::create(*protect(scriptExecutionContext()), index, *this);
     addRequest(request.get());
 
-    IDBGetAllRecordsData getAllRecordsData { keyRangeData, getAllType, count, index.objectStore().info().identifier(), index.info().identifier() };
+    IDBGetAllRecordsData getAllRecordsData { keyRangeData, getAllType, count, cursorDirection, index.objectStore().info().identifier(), index.info().identifier() };
 
     LOG(IndexedDBOperations, "IDB get all index records operation: %s", getAllRecordsData.loggingString().utf8().data());
     scheduleOperation(IDBClient::TransactionOperationImpl::create(*this, request.get(), [protectedThis = Ref { *this }, request] (const auto& result) {

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.h
@@ -117,7 +117,7 @@ public:
     Ref<IDBRequest> requestPutOrAdd(IDBObjectStore&, RefPtr<IDBKey>&&, SerializedScriptValue&, IndexedDB::ObjectStoreOverwriteMode);
     Ref<IDBRequest> requestGetRecord(IDBObjectStore&, const IDBGetRecordData&);
     Ref<IDBRequest> requestGetAllObjectStoreRecords(IDBObjectStore&, const IDBKeyRangeData&, IndexedDB::GetAllType, std::optional<uint32_t> count);
-    Ref<IDBRequest> requestGetAllIndexRecords(IDBIndex&, const IDBKeyRangeData&, IndexedDB::GetAllType, std::optional<uint32_t> count);
+    Ref<IDBRequest> requestGetAllIndexRecords(IDBIndex&, const IDBKeyRangeData&, IndexedDB::GetAllType, std::optional<uint32_t> count, IndexedDB::CursorDirection);
     Ref<IDBRequest> requestDeleteRecord(IDBObjectStore&, const IDBKeyRangeData&);
     Ref<IDBRequest> requestClearObjectStore(IDBObjectStore&);
     Ref<IDBRequest> requestCount(IDBObjectStore&, const IDBKeyRangeData&);

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
@@ -2285,7 +2285,7 @@ IDBError SQLiteIDBBackingStore::getAllIndexRecords(const IDBResourceIdentifier& 
     if (!transaction || !transaction->inProgressOrReadOnly())
         return IDBError { ExceptionCode::UnknownError, "Attempt to get all index records from database without an in-progress transaction"_s };
 
-    auto cursor = transaction->maybeOpenBackingStoreCursor(getAllRecordsData.objectStoreIdentifier, getAllRecordsData.indexIdentifier, getAllRecordsData.keyRangeData);
+    auto cursor = transaction->maybeOpenBackingStoreCursor(getAllRecordsData.objectStoreIdentifier, getAllRecordsData.indexIdentifier, getAllRecordsData.keyRangeData, getAllRecordsData.cursorDirection);
     if (!cursor) {
         LOG_ERROR("Cannot open cursor to perform index gets in database");
         return IDBError { ExceptionCode::UnknownError, "Cannot open cursor to perform index gets in database"_s };

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.cpp
@@ -58,9 +58,9 @@ std::unique_ptr<SQLiteIDBCursor> SQLiteIDBCursor::maybeCreate(SQLiteIDBTransacti
     return cursor.moveToUniquePtr();
 }
 
-std::unique_ptr<SQLiteIDBCursor> SQLiteIDBCursor::maybeCreateBackingStoreCursor(SQLiteIDBTransaction& transaction, IDBObjectStoreIdentifier objectStoreID, std::optional<IDBIndexIdentifier> indexID, const IDBKeyRangeData& range)
+std::unique_ptr<SQLiteIDBCursor> SQLiteIDBCursor::maybeCreateBackingStoreCursor(SQLiteIDBTransaction& transaction, IDBObjectStoreIdentifier objectStoreID, std::optional<IDBIndexIdentifier> indexID, const IDBKeyRangeData& range, IndexedDB::CursorDirection cursorDirection)
 {
-    auto cursor = makeUniqueRef<SQLiteIDBCursor>(transaction, objectStoreID, indexID, range);
+    auto cursor = makeUniqueRef<SQLiteIDBCursor>(transaction, objectStoreID, indexID, range, cursorDirection);
 
     if (!cursor->establishStatement())
         return nullptr;
@@ -83,12 +83,12 @@ SQLiteIDBCursor::SQLiteIDBCursor(SQLiteIDBTransaction& transaction, const IDBCur
 {
 }
 
-SQLiteIDBCursor::SQLiteIDBCursor(SQLiteIDBTransaction& transaction, IDBObjectStoreIdentifier objectStoreID, std::optional<IDBIndexIdentifier> indexID, const IDBKeyRangeData& range)
+SQLiteIDBCursor::SQLiteIDBCursor(SQLiteIDBTransaction& transaction, IDBObjectStoreIdentifier objectStoreID, std::optional<IDBIndexIdentifier> indexID, const IDBKeyRangeData& range, IndexedDB::CursorDirection cursorDirection)
     : m_transaction(&transaction)
     , m_cursorIdentifier(transaction.transactionIdentifier())
     , m_objectStoreID(objectStoreID)
     , m_indexID(indexID)
-    , m_cursorDirection(IndexedDB::CursorDirection::Next)
+    , m_cursorDirection(cursorDirection)
     , m_cursorType(IndexedDB::CursorType::KeyAndValue)
     , m_keyRange(range)
     , m_boundID(m_objectStoreID)

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.h
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.h
@@ -33,6 +33,7 @@
 #include "IDBObjectStoreIdentifier.h"
 #include "IDBResourceIdentifier.h"
 #include "IDBValue.h"
+#include "IndexedDB.h"
 #include "SQLiteStatement.h"
 #include <wtf/CheckedPtr.h>
 #include <wtf/Deque.h>
@@ -55,7 +56,7 @@ class SQLiteIDBCursor final : public CanMakeThreadSafeCheckedPtr<SQLiteIDBCursor
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SQLiteIDBCursor);
 public:
     static std::unique_ptr<SQLiteIDBCursor> maybeCreate(SQLiteIDBTransaction&, const IDBCursorInfo&);
-    static std::unique_ptr<SQLiteIDBCursor> maybeCreateBackingStoreCursor(SQLiteIDBTransaction&, IDBObjectStoreIdentifier, std::optional<IDBIndexIdentifier>, const IDBKeyRangeData&);
+    static std::unique_ptr<SQLiteIDBCursor> maybeCreateBackingStoreCursor(SQLiteIDBTransaction&, IDBObjectStoreIdentifier, std::optional<IDBIndexIdentifier>, const IDBKeyRangeData&, IndexedDB::CursorDirection = IndexedDB::CursorDirection::Next);
 
     ~SQLiteIDBCursor();
 
@@ -84,7 +85,7 @@ public:
 
 private:
     SQLiteIDBCursor(SQLiteIDBTransaction&, const IDBCursorInfo&);
-    SQLiteIDBCursor(SQLiteIDBTransaction&, IDBObjectStoreIdentifier, std::optional<IDBIndexIdentifier>, const IDBKeyRangeData&);
+    SQLiteIDBCursor(SQLiteIDBTransaction&, IDBObjectStoreIdentifier, std::optional<IDBIndexIdentifier>, const IDBKeyRangeData&, IndexedDB::CursorDirection = IndexedDB::CursorDirection::Next);
 
     template<typename T, class... Args> friend WTF::UniqueRef<T> WTF::makeUniqueRefWithoutFastMallocCheck(Args&&...);
 

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBTransaction.cpp
@@ -158,11 +158,11 @@ void SQLiteIDBTransaction::reset()
     ASSERT(m_blobTemporaryAndStoredFilenames.isEmpty());
 }
 
-std::unique_ptr<SQLiteIDBCursor> SQLiteIDBTransaction::maybeOpenBackingStoreCursor(IDBObjectStoreIdentifier objectStoreID, std::optional<IDBIndexIdentifier> indexID, const IDBKeyRangeData& range)
+std::unique_ptr<SQLiteIDBCursor> SQLiteIDBTransaction::maybeOpenBackingStoreCursor(IDBObjectStoreIdentifier objectStoreID, std::optional<IDBIndexIdentifier> indexID, const IDBKeyRangeData& range, IndexedDB::CursorDirection cursorDirection)
 {
     ASSERT(inProgressOrReadOnly());
 
-    auto cursor = SQLiteIDBCursor::maybeCreateBackingStoreCursor(*this, objectStoreID, indexID, range);
+    auto cursor = SQLiteIDBCursor::maybeCreateBackingStoreCursor(*this, objectStoreID, indexID, range, cursorDirection);
 
     if (cursor)
         m_backingStoreCursors.add(cursor.get());

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBTransaction.h
@@ -63,7 +63,7 @@ public:
     IDBError commit();
     IDBError abort();
 
-    std::unique_ptr<SQLiteIDBCursor> maybeOpenBackingStoreCursor(IDBObjectStoreIdentifier, std::optional<IDBIndexIdentifier>, const IDBKeyRangeData&);
+    std::unique_ptr<SQLiteIDBCursor> maybeOpenBackingStoreCursor(IDBObjectStoreIdentifier, std::optional<IDBIndexIdentifier>, const IDBKeyRangeData&, IndexedDB::CursorDirection = IndexedDB::CursorDirection::Next);
     SQLiteIDBCursor* maybeOpenCursor(const IDBCursorInfo&);
 
     void closeCursor(SQLiteIDBCursor&);

--- a/Source/WebCore/Modules/indexeddb/shared/IDBGetAllRecordsData.cpp
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBGetAllRecordsData.cpp
@@ -33,16 +33,30 @@ namespace WebCore {
 
 IDBGetAllRecordsData IDBGetAllRecordsData::isolatedCopy() const
 {
-    return { keyRangeData.isolatedCopy(), getAllType, count, objectStoreIdentifier, indexIdentifier };
+    return { keyRangeData.isolatedCopy(), getAllType, count, cursorDirection, objectStoreIdentifier, indexIdentifier };
 }
 
 #if !LOG_DISABLED
 
 String IDBGetAllRecordsData::loggingString() const
 {
+    auto directionString = [&] {
+        switch (cursorDirection) {
+        case IndexedDB::CursorDirection::Next:
+            return "next"_s;
+        case IndexedDB::CursorDirection::Nextunique:
+            return "nextunique"_s;
+        case IndexedDB::CursorDirection::Prev:
+            return "prev"_s;
+        case IndexedDB::CursorDirection::Prevunique:
+            return "prevunique"_s;
+        }
+        RELEASE_ASSERT_NOT_REACHED();
+    }();
+
     if (indexIdentifier)
-        return makeString("<GetAllRecords: Idx "_s, *indexIdentifier, ", OS "_s, objectStoreIdentifier, ", "_s, getAllType == IndexedDB::GetAllType::Keys ? "Keys"_s : "Values"_s, ", range "_s, keyRangeData.loggingString(), '>');
-    return makeString("<GetAllRecords: OS "_s, objectStoreIdentifier, ", "_s, getAllType == IndexedDB::GetAllType::Keys ? "Keys"_s : "Values"_s, ", range "_s, keyRangeData.loggingString(), '>');
+        return makeString("<GetAllRecords: Idx "_s, *indexIdentifier, ", OS "_s, objectStoreIdentifier, ", "_s, getAllType == IndexedDB::GetAllType::Keys ? "Keys"_s : "Values"_s, ", cursorDirection "_s, directionString, ", range "_s, keyRangeData.loggingString(), '>');
+    return makeString("<GetAllRecords: OS "_s, objectStoreIdentifier, ", "_s, getAllType == IndexedDB::GetAllType::Keys ? "Keys"_s : "Values"_s, ", cursorDirection "_s, directionString, ", range "_s, keyRangeData.loggingString(), '>');
 }
 
 #endif

--- a/Source/WebCore/Modules/indexeddb/shared/IDBGetAllRecordsData.h
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBGetAllRecordsData.h
@@ -39,6 +39,7 @@ struct IDBGetAllRecordsData {
     IDBKeyRangeData keyRangeData;
     IndexedDB::GetAllType getAllType;
     std::optional<uint32_t> count;
+    IndexedDB::CursorDirection cursorDirection;
     IDBObjectStoreIdentifier objectStoreIdentifier;
     std::optional<IDBIndexIdentifier> indexIdentifier { };
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -473,6 +473,7 @@ struct WebCore::IDBGetAllRecordsData {
     WebCore::IDBKeyRangeData keyRangeData;
     WebCore::IndexedDB::GetAllType getAllType;
     std::optional<uint32_t> count;
+    WebCore::IndexedDB::CursorDirection cursorDirection;
     WebCore::IDBObjectStoreIdentifier objectStoreIdentifier;
     std::optional<WebCore::IDBIndexIdentifier> indexIdentifier;
 }


### PR DESCRIPTION
#### b682bbefb0ce663d093ff24a5d3447a36855309d
<pre>
[IndexedDB API] Support IDBGetAllOptions in IDBIndex::getAllKeys()
<a href="https://bugs.webkit.org/show_bug.cgi?id=310700">https://bugs.webkit.org/show_bug.cgi?id=310700</a>
<a href="https://rdar.apple.com/173311682">rdar://173311682</a>

Reviewed by Sihui Liu.

The Indexed API Spec has modified IDBIndex&apos;s getAllKeys() function to be able to
take in IDBGetAllOptions (<a href="https://w3c.github.io/IndexedDB/#dom-idbindex-getallkeys).">https://w3c.github.io/IndexedDB/#dom-idbindex-getallkeys).</a>

This means that getAllKeys() now supports specifiying an IDBCursorDirection.

This patch adds support for this.

The first step is to enable getAllKeys() to take in IDBGetAllOptions. We follow:
<a href="https://w3c.github.io/IndexedDB/#create-a-request-to-retrieve-multiple-items.">https://w3c.github.io/IndexedDB/#create-a-request-to-retrieve-multiple-items.</a>

Currently the overload of IDBIndex::getAllKeys which handles non IDBKeyRange
inputs only handles inputs that are a valid IDBKey. IDBGetAllOptions is not.
So follow the spec&apos;s steps and update the logic to be:
1. If the input &quot;is a potentially valid key range&quot;, convert it to a keyRange
   (The current algorithm ends here)
2. If we support IDBGetAllOptions, convert it to an IDBGetAllOptions
3. If that&apos;s successful, use the query, count, direction from it
   (Need to discern if query is empty, IDBKeyRange, or a regular key)

Since this input parsing must occur after other checks (implemented in
doGetAllKeys) and the input can now contain a count and direction in addition to
a KeyRange, we change doGetAllKeys to take in a new ParsedGetAllQueryOrOptions
object that contains all of these items. In the case where we do have an
IDBGetAllOptions object with a count specified, this count will be used.

The second step is to ensure that the functions later on which actaully return
the records (SQLiteIDBBackingStore::getAllIndexRecords()) receive and use this
direction.

IDBIndex::getAllKeys() will pass this direction to IDBIndex::doGetAllKeys() which
passes it to IDBTransaction::requestGetAllIndexRecords(). This will capture the
direction in an IDBGetAllRecordsData object. Via this object, the direction is
plumbed all the way down to SQLiteIDBBackingStore::getAllIndexRecords().

This function uses the SQLiteIDBCursor returned by maybeOpenBackingStoreCursor()
to iterate the records. Currently it&apos;s hardcoded to use &quot;next&quot;. So we update it
to use the direction from the IDBGetAllRecordsData object. This cursor already
knows how to deal with the direction from there.

* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllKeys-options.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllKeys-options.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllKeys-options.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllKeys-options.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.worker-expected.txt:
* Source/WebCore/Modules/indexeddb/IDBIndex.cpp:
(WebCore::IDBIndex::doGetAll):

Now that IDBTransaction::requestGetAllIndexRecords() takes in a direction,
continue hardcoding &quot;next&quot; for now so behavior is unchanged here.

(WebCore::IDBIndex::doGetAllKeys):
(WebCore::IDBIndex::getAllKeys):

Modify logic to support IDBGetAllOptions based on these steps:
<a href="https://w3c.github.io/IndexedDB/#create-a-request-to-retrieve-multiple-items">https://w3c.github.io/IndexedDB/#create-a-request-to-retrieve-multiple-items</a>

* Source/WebCore/Modules/indexeddb/IDBIndex.h:
* Source/WebCore/Modules/indexeddb/IDBIndex.idl:
* Source/WebCore/Modules/indexeddb/IDBTransaction.cpp:
(WebCore::IDBTransaction::requestGetAllObjectStoreRecords):
(WebCore::IDBTransaction::requestGetAllIndexRecords):
* Source/WebCore/Modules/indexeddb/IDBTransaction.h:
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp:
(WebCore::IDBServer::SQLiteIDBBackingStore::getAllIndexRecords):
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.cpp:
(WebCore::IDBServer::SQLiteIDBCursor::maybeCreateBackingStoreCursor):

Take a in a cursor direction and give it to SQLiteIDBCursor.

(WebCore::IDBServer::SQLiteIDBCursor::SQLiteIDBCursor):

Use the passed in cursor direction instead of always using &quot;next&quot;.

* Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.h:
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBTransaction.cpp:
(WebCore::IDBServer::SQLiteIDBTransaction::maybeOpenBackingStoreCursor):

Take in a cursor direction and give it to SQLiteIDBCursor::maybeCreateBackingStoreCursor.

* Source/WebCore/Modules/indexeddb/server/SQLiteIDBTransaction.h:
* Source/WebCore/Modules/indexeddb/shared/IDBGetAllRecordsData.cpp:
(WebCore::IDBGetAllRecordsData::isolatedCopy const):
(WebCore::IDBGetAllRecordsData::loggingString const):
* Source/WebCore/Modules/indexeddb/shared/IDBGetAllRecordsData.h:

Store a cursor direction.

* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/310051@main">https://commits.webkit.org/310051@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73402cdf52142fc94ea0c13387bc2b0783c9fcea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152520 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25302 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18901 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161265 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105977 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9884a616-92b4-41f1-b266-7cb0380be92f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154394 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25830 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25608 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117860 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1ad5e86b-fd42-4d70-9839-1b2577aba5b1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155480 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20068 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136929 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98574 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19144 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17088 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9099 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144532 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128794 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14803 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163734 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6875 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16397 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/api/crashtests/huge-fetch.any.sharedworker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125908 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25100 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21127 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126071 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25102 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136599 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81704 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23379 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21057 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13378 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24718 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89004 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24409 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24569 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24470 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->