### PR TITLE
Resync `the-page` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-page/body-margin-1c.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-page/body-margin-1c.html
@@ -1,5 +1,5 @@
 <!doctype html>
 <meta charset=utf-8>
-<title>Test that body's leftmargin/rightmargin attributes have the right effect in standards mode</title>
+<title>Test that body's leftmargin attribute has the right effect in standards mode</title>
 <link rel=match href="body-margin-1-ref.html">
-<iframe src="data:text/html,<!doctype html><body leftmargin='100' rightmargin='100'>100px left/right margins, default top/bottom margins</body>"></iframe>
+<iframe src="data:text/html,<!doctype html><body leftmargin='100'>100px left/right margins, default top/bottom margins</body>"></iframe>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-page/body-margin-1d.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-page/body-margin-1d.html
@@ -1,5 +1,5 @@
 <!doctype html>
 <meta charset=utf-8>
-<title>Test that body's leftmargin/rightmargin attributes have the right effect in quirks mode</title>
+<title>Test that body's leftmargin attribute has the right effect in quirks mode</title>
 <link rel=match href="body-margin-1-ref.html">
-<iframe src="data:text/html,<body leftmargin='100' rightmargin='100'>100px left/right margins, default top/bottom margins</body>"></iframe>
+<iframe src="data:text/html,<body leftmargin='100'>100px left/right margins, default top/bottom margins</body>"></iframe>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-page/body-margin-1k.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-page/body-margin-1k.html
@@ -1,5 +1,5 @@
 <!doctype html>
 <meta charset=utf-8>
-<title>Test that body's leftmargin/rightmargin attributes take precedence over iframe marginwidth in standards mode</title>
+<title>Test that body's leftmargin attribute takes precedence over iframe marginwidth in standards mode</title>
 <link rel=match href="body-margin-1-ref.html">
-<iframe marginwidth="20" src="data:text/html,<!doctype html><body leftmargin='100' rightmargin='100'>100px left/right margins, default top/bottom margins</body>"></iframe>
+<iframe marginwidth="20" src="data:text/html,<!doctype html><body leftmargin='100'>100px left/right margins, default top/bottom margins</body>"></iframe>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-page/body-margin-1l.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-page/body-margin-1l.html
@@ -1,5 +1,5 @@
 <!doctype html>
 <meta charset=utf-8>
-<title>Test that body's leftmargin/rightmargin attributes take precedence over iframe marginwidth in quirks mode</title>
+<title>Test that body's leftmargin attribute takes precedence over iframe marginwidth in quirks mode</title>
 <link rel=match href="body-margin-1-ref.html">
-<iframe marginwidth="20" src="data:text/html,<body leftmargin='100' rightmargin='100'>100px left/right margins, default top/bottom margins</body>"></iframe>
+<iframe marginwidth="20" src="data:text/html,<body leftmargin='100'>100px left/right margins, default top/bottom margins</body>"></iframe>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-page/body-margin-3a-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-page/body-margin-3a-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Test that body's rightmargin and bottommargin attributes are ignored in standards mode assert_equals: expected "8px" but got "100px"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-page/body-margin-3a.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-page/body-margin-3a.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Test that body's rightmargin and bottommargin attributes are ignored in standards mode</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body rightmargin=100 bottommargin=100>
+<script>
+test(() => {
+  const style = getComputedStyle(document.body);
+  assert_equals(style.marginTop, '8px');
+  assert_equals(style.marginRight, '8px');
+  assert_equals(style.marginBottom, '8px');
+  assert_equals(style.marginLeft, '8px');
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-page/body-margin-3b-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-page/body-margin-3b-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Test that body's rightmargin and bottommargin attributes are ignored in quirks mode assert_equals: expected "8px" but got "100px"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-page/body-margin-3b.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-page/body-margin-3b.html
@@ -1,0 +1,14 @@
+<meta charset=utf-8>
+<title>Test that body's rightmargin and bottommargin attributes are ignored in quirks mode</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body rightmargin=100 bottommargin=100>
+<script>
+test(() => {
+  const style = getComputedStyle(document.body);
+  assert_equals(style.marginTop, '8px');
+  assert_equals(style.marginRight, '8px');
+  assert_equals(style.marginBottom, '8px');
+  assert_equals(style.marginLeft, '8px');
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-page/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-page/w3c-import.log
@@ -64,6 +64,8 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-page/body-margin-2k.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-page/body-margin-2l-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-page/body-margin-2l.html
+/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-page/body-margin-3a.html
+/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-page/body-margin-3b.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-page/body_link.xhtml
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-page/body_text_00ffff-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-page/body_text_00ffff-ref.html


### PR DESCRIPTION
#### f3363e9721a95eac6e7a1dadca9965aad174a3c9
<pre>
Resync `the-page` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=310701">https://bugs.webkit.org/show_bug.cgi?id=310701</a>
<a href="https://rdar.apple.com/173312443">rdar://173312443</a>

Reviewed by Brandon Stewart and Rupin Mittal.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/f91d55e900c5946ecfb6f4ca52f6b2ca5dc2d539">https://github.com/web-platform-tests/wpt/commit/f91d55e900c5946ecfb6f4ca52f6b2ca5dc2d539</a>

* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-page/body-margin-1c.html:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-page/body-margin-1d.html:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-page/body-margin-1k.html:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-page/body-margin-1l.html:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-page/body-margin-3a-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-page/body-margin-3a.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-page/body-margin-3b-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-page/body-margin-3b.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-page/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/309917@main">https://commits.webkit.org/309917@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/174fa15992c206a07f50f221dc86577e130ee4fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152119 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24901 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18487 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160862 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105576 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25393 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25207 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117510 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155079 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19692 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136537 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98223 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18769 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/16726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8696 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14419 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163328 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16011 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125536 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24699 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20770 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125712 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34116 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24700 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136215 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81293 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20722 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12992 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24317 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24008 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24168 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24069 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->