### PR TITLE
[IndexedDB API] Add IDL and stub for IDBObjectStore::getAllRecords()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAll-options.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAll-options.any-expected.txt
@@ -1,26 +1,26 @@
 
-FAIL Single item get assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Single item get (generated key) assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL getAll on empty object store assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get all values assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get all with large values assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Test maxCount assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get bound range assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get bound range with maxCount assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get upper excluded assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get lower excluded assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get bound range (generated) with maxCount assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Non existent key assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL zero maxCount assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Max value count assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Query with empty range where  first key < upperBound assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Query with empty range where lowerBound < last key assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction: next assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction: prev assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction: nextunique assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction: prevunique assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction and query assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction, query and count assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
+FAIL Single item get Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Single item get (generated key) Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL getAll on empty object store Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get all values Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get all with large values Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Test maxCount Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get bound range Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get bound range with maxCount Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get upper excluded Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get lower excluded Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get bound range (generated) with maxCount Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Non existent key Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL zero maxCount Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Max value count Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Query with empty range where  first key < upperBound Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Query with empty range where lowerBound < last key Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction: next Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction: prev Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction: nextunique Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction: prevunique Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction and query Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction, query and count Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
 FAIL Get all values with both options and count Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
 PASS Get all values with invalid query keys
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAll-options.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAll-options.any.serviceworker-expected.txt
@@ -1,26 +1,26 @@
 
-FAIL Single item get assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Single item get (generated key) assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL getAll on empty object store assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get all values assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get all with large values assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Test maxCount assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get bound range assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get bound range with maxCount assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get upper excluded assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get lower excluded assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get bound range (generated) with maxCount assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Non existent key assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL zero maxCount assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Max value count assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Query with empty range where  first key < upperBound assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Query with empty range where lowerBound < last key assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction: next assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction: prev assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction: nextunique assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction: prevunique assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction and query assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction, query and count assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
+FAIL Single item get Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Single item get (generated key) Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL getAll on empty object store Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get all values Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get all with large values Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Test maxCount Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get bound range Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get bound range with maxCount Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get upper excluded Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get lower excluded Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get bound range (generated) with maxCount Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Non existent key Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL zero maxCount Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Max value count Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Query with empty range where  first key < upperBound Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Query with empty range where lowerBound < last key Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction: next Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction: prev Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction: nextunique Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction: prevunique Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction and query Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction, query and count Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
 FAIL Get all values with both options and count Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
 PASS Get all values with invalid query keys
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAll-options.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAll-options.any.sharedworker-expected.txt
@@ -1,26 +1,26 @@
 
-FAIL Single item get assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Single item get (generated key) assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL getAll on empty object store assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get all values assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get all with large values assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Test maxCount assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get bound range assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get bound range with maxCount assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get upper excluded assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get lower excluded assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get bound range (generated) with maxCount assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Non existent key assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL zero maxCount assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Max value count assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Query with empty range where  first key < upperBound assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Query with empty range where lowerBound < last key assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction: next assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction: prev assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction: nextunique assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction: prevunique assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction and query assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction, query and count assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
+FAIL Single item get Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Single item get (generated key) Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL getAll on empty object store Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get all values Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get all with large values Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Test maxCount Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get bound range Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get bound range with maxCount Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get upper excluded Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get lower excluded Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get bound range (generated) with maxCount Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Non existent key Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL zero maxCount Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Max value count Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Query with empty range where  first key < upperBound Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Query with empty range where lowerBound < last key Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction: next Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction: prev Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction: nextunique Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction: prevunique Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction and query Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction, query and count Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
 FAIL Get all values with both options and count Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
 PASS Get all values with invalid query keys
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAll-options.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAll-options.any.worker-expected.txt
@@ -1,26 +1,26 @@
 
-FAIL Single item get assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Single item get (generated key) assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL getAll on empty object store assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get all values assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get all with large values assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Test maxCount assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get bound range assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get bound range with maxCount assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get upper excluded assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get lower excluded assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Get bound range (generated) with maxCount assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Non existent key assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL zero maxCount assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Max value count assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Query with empty range where  first key < upperBound assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Query with empty range where lowerBound < last key assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction: next assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction: prev assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction: nextunique assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction: prevunique assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction and query assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
-FAIL Direction, query and count assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAll". expected true got false
+FAIL Single item get Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Single item get (generated key) Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL getAll on empty object store Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get all values Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get all with large values Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Test maxCount Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get bound range Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get bound range with maxCount Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get upper excluded Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get lower excluded Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get bound range (generated) with maxCount Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Non existent key Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL zero maxCount Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Max value count Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Query with empty range where  first key < upperBound Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Query with empty range where lowerBound < last key Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction: next Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction: prev Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction: nextunique Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction: prevunique Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction and query Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction, query and count Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
 FAIL Get all values with both options and count Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key.
 PASS Get all values with invalid query keys
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAllKeys-options.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAllKeys-options.any-expected.txt
@@ -1,25 +1,25 @@
 
-FAIL Single item get assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Single item get (generated key) assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
+FAIL Single item get Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Single item get (generated key) Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
 PASS getAllKeys on empty object store
 PASS Get all keys
-FAIL Test maxCount assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get bound range assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get bound range with maxCount assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get upper excluded assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get lower excluded assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get bound range (generated) with maxCount assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Non existent key assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL zero maxCount assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Max value count assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Query with empty range where  first key < upperBound assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Query with empty range where lowerBound < last key assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction: next assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction: prev assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction: nextunique assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction: prevunique assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction and query assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction, query and count assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
+FAIL Test maxCount Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get bound range Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get bound range with maxCount Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get upper excluded Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get lower excluded Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get bound range (generated) with maxCount Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Non existent key Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL zero maxCount Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Max value count Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Query with empty range where  first key < upperBound Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Query with empty range where lowerBound < last key Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction: next Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction: prev Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction: nextunique Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction: prevunique Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction and query Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction, query and count Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
 FAIL Get all keys with both options and count Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
 PASS Get all keys with invalid query keys
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAllKeys-options.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAllKeys-options.any.serviceworker-expected.txt
@@ -1,25 +1,25 @@
 
-FAIL Single item get assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Single item get (generated key) assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
+FAIL Single item get Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Single item get (generated key) Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
 PASS getAllKeys on empty object store
 PASS Get all keys
-FAIL Test maxCount assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get bound range assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get bound range with maxCount assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get upper excluded assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get lower excluded assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get bound range (generated) with maxCount assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Non existent key assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL zero maxCount assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Max value count assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Query with empty range where  first key < upperBound assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Query with empty range where lowerBound < last key assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction: next assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction: prev assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction: nextunique assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction: prevunique assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction and query assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction, query and count assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
+FAIL Test maxCount Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get bound range Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get bound range with maxCount Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get upper excluded Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get lower excluded Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get bound range (generated) with maxCount Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Non existent key Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL zero maxCount Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Max value count Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Query with empty range where  first key < upperBound Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Query with empty range where lowerBound < last key Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction: next Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction: prev Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction: nextunique Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction: prevunique Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction and query Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction, query and count Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
 FAIL Get all keys with both options and count Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
 PASS Get all keys with invalid query keys
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAllKeys-options.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAllKeys-options.any.sharedworker-expected.txt
@@ -1,25 +1,25 @@
 
-FAIL Single item get assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Single item get (generated key) assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
+FAIL Single item get Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Single item get (generated key) Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
 PASS getAllKeys on empty object store
 PASS Get all keys
-FAIL Test maxCount assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get bound range assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get bound range with maxCount assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get upper excluded assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get lower excluded assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get bound range (generated) with maxCount assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Non existent key assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL zero maxCount assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Max value count assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Query with empty range where  first key < upperBound assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Query with empty range where lowerBound < last key assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction: next assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction: prev assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction: nextunique assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction: prevunique assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction and query assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction, query and count assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
+FAIL Test maxCount Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get bound range Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get bound range with maxCount Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get upper excluded Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get lower excluded Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get bound range (generated) with maxCount Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Non existent key Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL zero maxCount Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Max value count Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Query with empty range where  first key < upperBound Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Query with empty range where lowerBound < last key Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction: next Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction: prev Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction: nextunique Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction: prevunique Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction and query Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction, query and count Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
 FAIL Get all keys with both options and count Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
 PASS Get all keys with invalid query keys
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAllKeys-options.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAllKeys-options.any.worker-expected.txt
@@ -1,25 +1,25 @@
 
-FAIL Single item get assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Single item get (generated key) assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
+FAIL Single item get Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Single item get (generated key) Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
 PASS getAllKeys on empty object store
 PASS Get all keys
-FAIL Test maxCount assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get bound range assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get bound range with maxCount assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get upper excluded assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get lower excluded assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Get bound range (generated) with maxCount assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Non existent key assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL zero maxCount assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Max value count assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Query with empty range where  first key < upperBound assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Query with empty range where lowerBound < last key assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction: next assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction: prev assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction: nextunique assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction: prevunique assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction and query assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
-FAIL Direction, query and count assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllKeys". expected true got false
+FAIL Test maxCount Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get bound range Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get bound range with maxCount Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get upper excluded Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get lower excluded Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Get bound range (generated) with maxCount Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Non existent key Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL zero maxCount Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Max value count Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Query with empty range where  first key < upperBound Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Query with empty range where lowerBound < last key Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction: next Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction: prev Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction: nextunique Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction: prevunique Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction and query Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
+FAIL Direction, query and count Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
 FAIL Get all keys with both options and count Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key.
 PASS Get all keys with invalid query keys
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAllRecords.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAllRecords.any-expected.txt
@@ -1,29 +1,29 @@
 
-FAIL Single item assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Single item with generated key assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Empty object store queryTarget[getAllFunctionName] is not a function. (In 'queryTarget[getAllFunctionName]()', 'queryTarget[getAllFunctionName]' is undefined)
-FAIL Get all records queryTarget[getAllFunctionName] is not a function. (In 'queryTarget[getAllFunctionName]()', 'queryTarget[getAllFunctionName]' is undefined)
-FAIL Get all records with empty options assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Get all records with large values queryTarget[getAllFunctionName] is not a function. (In 'queryTarget[getAllFunctionName]()', 'queryTarget[getAllFunctionName]' is undefined)
-FAIL Count assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with bound range assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with bound range and count assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with upper excluded bound range assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with lower excluded bound range assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with bound range and count for generated keys assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with nonexistent key assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Zero count assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Max value count assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with empty range where first key < upperBound assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with empty range where lowerBound < last key assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction: next assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction: prev assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction: nextunique assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction: prevunique assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction and query assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction, query and count assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Get all records with transaction.commit() store.getAllRecords is not a function. (In 'store.getAllRecords()', 'store.getAllRecords' is undefined)
+FAIL Single item getAllRecords is not yet supported
+FAIL Single item with generated key getAllRecords is not yet supported
+FAIL Empty object store getAllRecords is not yet supported
+FAIL Get all records getAllRecords is not yet supported
+FAIL Get all records with empty options getAllRecords is not yet supported
+FAIL Get all records with large values getAllRecords is not yet supported
+FAIL Count getAllRecords is not yet supported
+FAIL Query with bound range getAllRecords is not yet supported
+FAIL Query with bound range and count getAllRecords is not yet supported
+FAIL Query with upper excluded bound range getAllRecords is not yet supported
+FAIL Query with lower excluded bound range getAllRecords is not yet supported
+FAIL Query with bound range and count for generated keys getAllRecords is not yet supported
+FAIL Query with nonexistent key getAllRecords is not yet supported
+FAIL Zero count getAllRecords is not yet supported
+FAIL Max value count getAllRecords is not yet supported
+FAIL Query with empty range where first key < upperBound getAllRecords is not yet supported
+FAIL Query with empty range where lowerBound < last key getAllRecords is not yet supported
+FAIL Direction: next getAllRecords is not yet supported
+FAIL Direction: prev getAllRecords is not yet supported
+FAIL Direction: nextunique getAllRecords is not yet supported
+FAIL Direction: prevunique getAllRecords is not yet supported
+FAIL Direction and query getAllRecords is not yet supported
+FAIL Direction, query and count getAllRecords is not yet supported
+FAIL Get all records with transaction.commit() getAllRecords is not yet supported
 FAIL Get all records with invalid query keys assert_throws_dom: An invalid Date(NaN) key must throw an exception. function "() => {
         queryTarget[getAllFunctionName](argument);
-      }" threw object "TypeError: queryTarget[getAllFunctionName] is not a function. (In 'queryTarget[getAllFunctionName](argument)', 'queryTarget[getAllFunctionName]' is undefined)" that is not a DOMException DataError: property "code" is equal to undefined, expected 0
+      }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAllRecords.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAllRecords.any.serviceworker-expected.txt
@@ -1,29 +1,29 @@
 
-FAIL Single item assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Single item with generated key assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Empty object store queryTarget[getAllFunctionName] is not a function. (In 'queryTarget[getAllFunctionName]()', 'queryTarget[getAllFunctionName]' is undefined)
-FAIL Get all records queryTarget[getAllFunctionName] is not a function. (In 'queryTarget[getAllFunctionName]()', 'queryTarget[getAllFunctionName]' is undefined)
-FAIL Get all records with empty options assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Get all records with large values queryTarget[getAllFunctionName] is not a function. (In 'queryTarget[getAllFunctionName]()', 'queryTarget[getAllFunctionName]' is undefined)
-FAIL Count assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with bound range assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with bound range and count assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with upper excluded bound range assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with lower excluded bound range assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with bound range and count for generated keys assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with nonexistent key assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Zero count assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Max value count assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with empty range where first key < upperBound assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with empty range where lowerBound < last key assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction: next assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction: prev assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction: nextunique assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction: prevunique assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction and query assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction, query and count assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Get all records with transaction.commit() store.getAllRecords is not a function. (In 'store.getAllRecords()', 'store.getAllRecords' is undefined)
+FAIL Single item getAllRecords is not yet supported
+FAIL Single item with generated key getAllRecords is not yet supported
+FAIL Empty object store getAllRecords is not yet supported
+FAIL Get all records getAllRecords is not yet supported
+FAIL Get all records with empty options getAllRecords is not yet supported
+FAIL Get all records with large values getAllRecords is not yet supported
+FAIL Count getAllRecords is not yet supported
+FAIL Query with bound range getAllRecords is not yet supported
+FAIL Query with bound range and count getAllRecords is not yet supported
+FAIL Query with upper excluded bound range getAllRecords is not yet supported
+FAIL Query with lower excluded bound range getAllRecords is not yet supported
+FAIL Query with bound range and count for generated keys getAllRecords is not yet supported
+FAIL Query with nonexistent key getAllRecords is not yet supported
+FAIL Zero count getAllRecords is not yet supported
+FAIL Max value count getAllRecords is not yet supported
+FAIL Query with empty range where first key < upperBound getAllRecords is not yet supported
+FAIL Query with empty range where lowerBound < last key getAllRecords is not yet supported
+FAIL Direction: next getAllRecords is not yet supported
+FAIL Direction: prev getAllRecords is not yet supported
+FAIL Direction: nextunique getAllRecords is not yet supported
+FAIL Direction: prevunique getAllRecords is not yet supported
+FAIL Direction and query getAllRecords is not yet supported
+FAIL Direction, query and count getAllRecords is not yet supported
+FAIL Get all records with transaction.commit() getAllRecords is not yet supported
 FAIL Get all records with invalid query keys assert_throws_dom: An invalid Date(NaN) key must throw an exception. function "() => {
         queryTarget[getAllFunctionName](argument);
-      }" threw object "TypeError: queryTarget[getAllFunctionName] is not a function. (In 'queryTarget[getAllFunctionName](argument)', 'queryTarget[getAllFunctionName]' is undefined)" that is not a DOMException DataError: property "code" is equal to undefined, expected 0
+      }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAllRecords.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAllRecords.any.sharedworker-expected.txt
@@ -1,29 +1,29 @@
 
-FAIL Single item assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Single item with generated key assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Empty object store queryTarget[getAllFunctionName] is not a function. (In 'queryTarget[getAllFunctionName]()', 'queryTarget[getAllFunctionName]' is undefined)
-FAIL Get all records queryTarget[getAllFunctionName] is not a function. (In 'queryTarget[getAllFunctionName]()', 'queryTarget[getAllFunctionName]' is undefined)
-FAIL Get all records with empty options assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Get all records with large values queryTarget[getAllFunctionName] is not a function. (In 'queryTarget[getAllFunctionName]()', 'queryTarget[getAllFunctionName]' is undefined)
-FAIL Count assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with bound range assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with bound range and count assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with upper excluded bound range assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with lower excluded bound range assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with bound range and count for generated keys assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with nonexistent key assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Zero count assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Max value count assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with empty range where first key < upperBound assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with empty range where lowerBound < last key assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction: next assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction: prev assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction: nextunique assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction: prevunique assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction and query assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction, query and count assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Get all records with transaction.commit() store.getAllRecords is not a function. (In 'store.getAllRecords()', 'store.getAllRecords' is undefined)
+FAIL Single item getAllRecords is not yet supported
+FAIL Single item with generated key getAllRecords is not yet supported
+FAIL Empty object store getAllRecords is not yet supported
+FAIL Get all records getAllRecords is not yet supported
+FAIL Get all records with empty options getAllRecords is not yet supported
+FAIL Get all records with large values getAllRecords is not yet supported
+FAIL Count getAllRecords is not yet supported
+FAIL Query with bound range getAllRecords is not yet supported
+FAIL Query with bound range and count getAllRecords is not yet supported
+FAIL Query with upper excluded bound range getAllRecords is not yet supported
+FAIL Query with lower excluded bound range getAllRecords is not yet supported
+FAIL Query with bound range and count for generated keys getAllRecords is not yet supported
+FAIL Query with nonexistent key getAllRecords is not yet supported
+FAIL Zero count getAllRecords is not yet supported
+FAIL Max value count getAllRecords is not yet supported
+FAIL Query with empty range where first key < upperBound getAllRecords is not yet supported
+FAIL Query with empty range where lowerBound < last key getAllRecords is not yet supported
+FAIL Direction: next getAllRecords is not yet supported
+FAIL Direction: prev getAllRecords is not yet supported
+FAIL Direction: nextunique getAllRecords is not yet supported
+FAIL Direction: prevunique getAllRecords is not yet supported
+FAIL Direction and query getAllRecords is not yet supported
+FAIL Direction, query and count getAllRecords is not yet supported
+FAIL Get all records with transaction.commit() getAllRecords is not yet supported
 FAIL Get all records with invalid query keys assert_throws_dom: An invalid Date(NaN) key must throw an exception. function "() => {
         queryTarget[getAllFunctionName](argument);
-      }" threw object "TypeError: queryTarget[getAllFunctionName] is not a function. (In 'queryTarget[getAllFunctionName](argument)', 'queryTarget[getAllFunctionName]' is undefined)" that is not a DOMException DataError: property "code" is equal to undefined, expected 0
+      }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAllRecords.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAllRecords.any.worker-expected.txt
@@ -1,29 +1,29 @@
 
-FAIL Single item assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Single item with generated key assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Empty object store queryTarget[getAllFunctionName] is not a function. (In 'queryTarget[getAllFunctionName]()', 'queryTarget[getAllFunctionName]' is undefined)
-FAIL Get all records queryTarget[getAllFunctionName] is not a function. (In 'queryTarget[getAllFunctionName]()', 'queryTarget[getAllFunctionName]' is undefined)
-FAIL Get all records with empty options assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Get all records with large values queryTarget[getAllFunctionName] is not a function. (In 'queryTarget[getAllFunctionName]()', 'queryTarget[getAllFunctionName]' is undefined)
-FAIL Count assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with bound range assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with bound range and count assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with upper excluded bound range assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with lower excluded bound range assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with bound range and count for generated keys assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with nonexistent key assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Zero count assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Max value count assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with empty range where first key < upperBound assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Query with empty range where lowerBound < last key assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction: next assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction: prev assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction: nextunique assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction: prevunique assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction and query assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Direction, query and count assert_true: "[object IDBObjectStore]" must support "getAllRecords()" to use an "IDBGetAllOptions" dictionary with "getAllRecords". expected true got false
-FAIL Get all records with transaction.commit() store.getAllRecords is not a function. (In 'store.getAllRecords()', 'store.getAllRecords' is undefined)
+FAIL Single item getAllRecords is not yet supported
+FAIL Single item with generated key getAllRecords is not yet supported
+FAIL Empty object store getAllRecords is not yet supported
+FAIL Get all records getAllRecords is not yet supported
+FAIL Get all records with empty options getAllRecords is not yet supported
+FAIL Get all records with large values getAllRecords is not yet supported
+FAIL Count getAllRecords is not yet supported
+FAIL Query with bound range getAllRecords is not yet supported
+FAIL Query with bound range and count getAllRecords is not yet supported
+FAIL Query with upper excluded bound range getAllRecords is not yet supported
+FAIL Query with lower excluded bound range getAllRecords is not yet supported
+FAIL Query with bound range and count for generated keys getAllRecords is not yet supported
+FAIL Query with nonexistent key getAllRecords is not yet supported
+FAIL Zero count getAllRecords is not yet supported
+FAIL Max value count getAllRecords is not yet supported
+FAIL Query with empty range where first key < upperBound getAllRecords is not yet supported
+FAIL Query with empty range where lowerBound < last key getAllRecords is not yet supported
+FAIL Direction: next getAllRecords is not yet supported
+FAIL Direction: prev getAllRecords is not yet supported
+FAIL Direction: nextunique getAllRecords is not yet supported
+FAIL Direction: prevunique getAllRecords is not yet supported
+FAIL Direction and query getAllRecords is not yet supported
+FAIL Direction, query and count getAllRecords is not yet supported
+FAIL Get all records with transaction.commit() getAllRecords is not yet supported
 FAIL Get all records with invalid query keys assert_throws_dom: An invalid Date(NaN) key must throw an exception. function "() => {
         queryTarget[getAllFunctionName](argument);
-      }" threw object "TypeError: queryTarget[getAllFunctionName] is not a function. (In 'queryTarget[getAllFunctionName](argument)', 'queryTarget[getAllFunctionName]' is undefined)" that is not a DOMException DataError: property "code" is equal to undefined, expected 0
+      }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idlharness.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idlharness.any-expected.txt
@@ -99,7 +99,7 @@ PASS IDBObjectStore interface: operation get(any)
 PASS IDBObjectStore interface: operation getKey(any)
 PASS IDBObjectStore interface: operation getAll(optional any, optional unsigned long)
 PASS IDBObjectStore interface: operation getAllKeys(optional any, optional unsigned long)
-FAIL IDBObjectStore interface: operation getAllRecords(optional IDBGetAllOptions) assert_own_property: interface prototype object missing non-static operation expected property "getAllRecords" missing
+PASS IDBObjectStore interface: operation getAllRecords(optional IDBGetAllOptions)
 PASS IDBObjectStore interface: operation count(optional any)
 PASS IDBObjectStore interface: operation openCursor(optional any, optional IDBCursorDirection)
 PASS IDBObjectStore interface: operation openKeyCursor(optional any, optional IDBCursorDirection)

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idlharness.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idlharness.any.serviceworker-expected.txt
@@ -99,7 +99,7 @@ PASS IDBObjectStore interface: operation get(any)
 PASS IDBObjectStore interface: operation getKey(any)
 PASS IDBObjectStore interface: operation getAll(optional any, optional unsigned long)
 PASS IDBObjectStore interface: operation getAllKeys(optional any, optional unsigned long)
-FAIL IDBObjectStore interface: operation getAllRecords(optional IDBGetAllOptions) assert_own_property: interface prototype object missing non-static operation expected property "getAllRecords" missing
+PASS IDBObjectStore interface: operation getAllRecords(optional IDBGetAllOptions)
 PASS IDBObjectStore interface: operation count(optional any)
 PASS IDBObjectStore interface: operation openCursor(optional any, optional IDBCursorDirection)
 PASS IDBObjectStore interface: operation openKeyCursor(optional any, optional IDBCursorDirection)

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idlharness.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idlharness.any.sharedworker-expected.txt
@@ -99,7 +99,7 @@ PASS IDBObjectStore interface: operation get(any)
 PASS IDBObjectStore interface: operation getKey(any)
 PASS IDBObjectStore interface: operation getAll(optional any, optional unsigned long)
 PASS IDBObjectStore interface: operation getAllKeys(optional any, optional unsigned long)
-FAIL IDBObjectStore interface: operation getAllRecords(optional IDBGetAllOptions) assert_own_property: interface prototype object missing non-static operation expected property "getAllRecords" missing
+PASS IDBObjectStore interface: operation getAllRecords(optional IDBGetAllOptions)
 PASS IDBObjectStore interface: operation count(optional any)
 PASS IDBObjectStore interface: operation openCursor(optional any, optional IDBCursorDirection)
 PASS IDBObjectStore interface: operation openKeyCursor(optional any, optional IDBCursorDirection)

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idlharness.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idlharness.any.worker-expected.txt
@@ -99,7 +99,7 @@ PASS IDBObjectStore interface: operation get(any)
 PASS IDBObjectStore interface: operation getKey(any)
 PASS IDBObjectStore interface: operation getAll(optional any, optional unsigned long)
 PASS IDBObjectStore interface: operation getAllKeys(optional any, optional unsigned long)
-FAIL IDBObjectStore interface: operation getAllRecords(optional IDBGetAllOptions) assert_own_property: interface prototype object missing non-static operation expected property "getAllRecords" missing
+PASS IDBObjectStore interface: operation getAllRecords(optional IDBGetAllOptions)
 PASS IDBObjectStore interface: operation count(optional any)
 PASS IDBObjectStore interface: operation openCursor(optional any, optional IDBCursorDirection)
 PASS IDBObjectStore interface: operation openKeyCursor(optional any, optional IDBCursorDirection)

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any-expected.txt
@@ -20,9 +20,15 @@ PASS IDBIndex getKey() method with throwing/invalid keys
 PASS IDBIndex count() method with throwing/invalid keys
 PASS IDBIndex openCursor() method with throwing/invalid keys
 PASS IDBIndex openKeyCursor() method with throwing/invalid keys
-PASS IDBObjectStore getAll() method with throwing/invalid keys
-PASS IDBObjectStore getAllKeys() method with throwing/invalid keys
-PASS IDBObjectStore getAllRecords() method with throwing/invalid keys
+FAIL IDBObjectStore getAll() method with throwing/invalid keys assert_throws_exactly: options query key conversion with throwing getter should rethrow function "() => {
+    receiver[method]({query: key});
+  }" threw object "DataError: Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key." but we expected it to throw object "getter: throwing from getter"
+FAIL IDBObjectStore getAllKeys() method with throwing/invalid keys assert_throws_exactly: options query key conversion with throwing getter should rethrow function "() => {
+    receiver[method]({query: key});
+  }" threw object "DataError: Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key." but we expected it to throw object "getter: throwing from getter"
+FAIL IDBObjectStore getAllRecords() method with throwing/invalid keys assert_throws_dom: options query key conversion with invalid key should throw DataError function "() => {
+    receiver[method]({query: invalid_key});
+  }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0
 FAIL IDBIndex getAll() method with throwing/invalid keys assert_throws_exactly: options query key conversion with throwing getter should rethrow function "() => {
     receiver[method]({query: key});
   }" threw object "DataError: Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key." but we expected it to throw object "getter: throwing from getter"

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.serviceworker-expected.txt
@@ -20,9 +20,15 @@ PASS IDBIndex getKey() method with throwing/invalid keys
 PASS IDBIndex count() method with throwing/invalid keys
 PASS IDBIndex openCursor() method with throwing/invalid keys
 PASS IDBIndex openKeyCursor() method with throwing/invalid keys
-PASS IDBObjectStore getAll() method with throwing/invalid keys
-PASS IDBObjectStore getAllKeys() method with throwing/invalid keys
-PASS IDBObjectStore getAllRecords() method with throwing/invalid keys
+FAIL IDBObjectStore getAll() method with throwing/invalid keys assert_throws_exactly: options query key conversion with throwing getter should rethrow function "() => {
+    receiver[method]({query: key});
+  }" threw object "DataError: Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key." but we expected it to throw object "getter: throwing from getter"
+FAIL IDBObjectStore getAllKeys() method with throwing/invalid keys assert_throws_exactly: options query key conversion with throwing getter should rethrow function "() => {
+    receiver[method]({query: key});
+  }" threw object "DataError: Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key." but we expected it to throw object "getter: throwing from getter"
+FAIL IDBObjectStore getAllRecords() method with throwing/invalid keys assert_throws_dom: options query key conversion with invalid key should throw DataError function "() => {
+    receiver[method]({query: invalid_key});
+  }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0
 FAIL IDBIndex getAll() method with throwing/invalid keys assert_throws_exactly: options query key conversion with throwing getter should rethrow function "() => {
     receiver[method]({query: key});
   }" threw object "DataError: Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key." but we expected it to throw object "getter: throwing from getter"

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.sharedworker-expected.txt
@@ -20,9 +20,15 @@ PASS IDBIndex getKey() method with throwing/invalid keys
 PASS IDBIndex count() method with throwing/invalid keys
 PASS IDBIndex openCursor() method with throwing/invalid keys
 PASS IDBIndex openKeyCursor() method with throwing/invalid keys
-PASS IDBObjectStore getAll() method with throwing/invalid keys
-PASS IDBObjectStore getAllKeys() method with throwing/invalid keys
-PASS IDBObjectStore getAllRecords() method with throwing/invalid keys
+FAIL IDBObjectStore getAll() method with throwing/invalid keys assert_throws_exactly: options query key conversion with throwing getter should rethrow function "() => {
+    receiver[method]({query: key});
+  }" threw object "DataError: Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key." but we expected it to throw object "getter: throwing from getter"
+FAIL IDBObjectStore getAllKeys() method with throwing/invalid keys assert_throws_exactly: options query key conversion with throwing getter should rethrow function "() => {
+    receiver[method]({query: key});
+  }" threw object "DataError: Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key." but we expected it to throw object "getter: throwing from getter"
+FAIL IDBObjectStore getAllRecords() method with throwing/invalid keys assert_throws_dom: options query key conversion with invalid key should throw DataError function "() => {
+    receiver[method]({query: invalid_key});
+  }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0
 FAIL IDBIndex getAll() method with throwing/invalid keys assert_throws_exactly: options query key conversion with throwing getter should rethrow function "() => {
     receiver[method]({query: key});
   }" threw object "DataError: Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key." but we expected it to throw object "getter: throwing from getter"

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.worker-expected.txt
@@ -20,9 +20,15 @@ PASS IDBIndex getKey() method with throwing/invalid keys
 PASS IDBIndex count() method with throwing/invalid keys
 PASS IDBIndex openCursor() method with throwing/invalid keys
 PASS IDBIndex openKeyCursor() method with throwing/invalid keys
-PASS IDBObjectStore getAll() method with throwing/invalid keys
-PASS IDBObjectStore getAllKeys() method with throwing/invalid keys
-PASS IDBObjectStore getAllRecords() method with throwing/invalid keys
+FAIL IDBObjectStore getAll() method with throwing/invalid keys assert_throws_exactly: options query key conversion with throwing getter should rethrow function "() => {
+    receiver[method]({query: key});
+  }" threw object "DataError: Failed to execute 'getAll' on 'IDBObjectStore': The parameter is not a valid key." but we expected it to throw object "getter: throwing from getter"
+FAIL IDBObjectStore getAllKeys() method with throwing/invalid keys assert_throws_exactly: options query key conversion with throwing getter should rethrow function "() => {
+    receiver[method]({query: key});
+  }" threw object "DataError: Failed to execute 'getAllKeys' on 'IDBObjectStore': The parameter is not a valid key." but we expected it to throw object "getter: throwing from getter"
+FAIL IDBObjectStore getAllRecords() method with throwing/invalid keys assert_throws_dom: options query key conversion with invalid key should throw DataError function "() => {
+    receiver[method]({query: invalid_key});
+  }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0
 FAIL IDBIndex getAll() method with throwing/invalid keys assert_throws_exactly: options query key conversion with throwing getter should rethrow function "() => {
     receiver[method]({query: key});
   }" threw object "DataError: Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key." but we expected it to throw object "getter: throwing from getter"

--- a/Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp
@@ -33,6 +33,7 @@
 #include "IDBCursor.h"
 #include "IDBDatabase.h"
 #include "IDBError.h"
+#include "IDBGetAllOptions.h"
 #include "IDBGetRecordData.h"
 #include "IDBIndex.h"
 #include "IDBKey.h"
@@ -678,6 +679,11 @@ ExceptionOr<Ref<IDBRequest>> IDBObjectStore::getAllKeys(JSGlobalObject& execStat
 
         return ExceptionOr<RefPtr<IDBKeyRange>> { onlyResult.releaseReturnValue() };
     });
+}
+
+ExceptionOr<Ref<IDBRequest>> IDBObjectStore::getAllRecords(JSGlobalObject&, IDBGetAllOptions&&)
+{
+    return Exception { ExceptionCode::NotSupportedError, "getAllRecords is not yet supported"_s };
 }
 
 void IDBObjectStore::markAsDeleted()

--- a/Source/WebCore/Modules/indexeddb/IDBObjectStore.h
+++ b/Source/WebCore/Modules/indexeddb/IDBObjectStore.h
@@ -55,6 +55,7 @@ class SerializedScriptValue;
 class WeakPtrImplWithEventTargetData;
 class WebCoreOpaqueRoot;
 
+struct IDBGetAllOptions;
 struct IDBKeyRangeData;
 
 template<typename> class ExceptionOr;
@@ -104,6 +105,8 @@ public:
     ExceptionOr<Ref<IDBRequest>> getAll(JSC::JSGlobalObject&, JSC::JSValue key, std::optional<uint32_t> count);
     ExceptionOr<Ref<IDBRequest>> getAllKeys(RefPtr<IDBKeyRange>&&, std::optional<uint32_t> count);
     ExceptionOr<Ref<IDBRequest>> getAllKeys(JSC::JSGlobalObject&, JSC::JSValue key, std::optional<uint32_t> count);
+
+    ExceptionOr<Ref<IDBRequest>> getAllRecords(JSC::JSGlobalObject&, IDBGetAllOptions&&);
 
     ExceptionOr<Ref<IDBRequest>> putForCursorUpdate(JSC::JSGlobalObject&, JSC::JSValue, RefPtr<IDBKey>&&, RefPtr<SerializedScriptValue>&&);
 

--- a/Source/WebCore/Modules/indexeddb/IDBObjectStore.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBObjectStore.idl
@@ -54,6 +54,7 @@ typedef (DOMString or sequence<DOMString>) IDBKeyPath;
     [NewObject, CallWith=CurrentGlobalObject] IDBRequest getAll(any key, optional [EnforceRange] unsigned long count);
     [NewObject] IDBRequest getAllKeys(optional IDBKeyRange? range = null, optional [EnforceRange] unsigned long count);
     [NewObject, CallWith=CurrentGlobalObject] IDBRequest getAllKeys(any key, optional [EnforceRange] unsigned long count);
+    [NewObject, CallWith=CurrentGlobalObject, EnabledBySetting=IndexedDBGetAllRecordsEnabled] IDBRequest getAllRecords(optional IDBGetAllOptions options = {});
     [NewObject] IDBRequest count(optional IDBKeyRange? range = null);
     [NewObject, CallWith=CurrentGlobalObject] IDBRequest count(any key);
 


### PR DESCRIPTION
#### 926106daaf9a833fc5644d646c7e179ce35e4cea
<pre>
[IndexedDB API] Add IDL and stub for IDBObjectStore::getAllRecords()
<a href="https://bugs.webkit.org/show_bug.cgi?id=310703">https://bugs.webkit.org/show_bug.cgi?id=310703</a>
<a href="https://rdar.apple.com/173312729">rdar://173312729</a>

Reviewed by Brady Eidson.

This adds the IDL for IDBObjecStore::getAllRecords() and a stub that returns a
NotSupportedError. It is gated behind a new feature flag IndexedDBGetAllRecordsEnabled.

The implementation will come in future patches.

* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAll-options.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAll-options.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAll-options.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAll-options.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAllKeys-options.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAllKeys-options.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAllKeys-options.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAllKeys-options.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAllRecords.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAllRecords.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAllRecords.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAllRecords.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idlharness.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idlharness.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idlharness.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idlharness.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.worker-expected.txt:
* Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp:
(WebCore::IDBObjectStore::getAllRecords):
* Source/WebCore/Modules/indexeddb/IDBObjectStore.h:
* Source/WebCore/Modules/indexeddb/IDBObjectStore.idl:

Canonical link: <a href="https://commits.webkit.org/309950@main">https://commits.webkit.org/309950@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/772b2bcb592965984ce3d507a95ebd354708c095

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152175 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24957 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18549 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160918 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105632 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154049 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25532 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25263 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117564 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83380 "10 flakes 2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155135 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136601 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98277 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/18911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16779 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8752 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14476 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163384 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6530 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16068 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125591 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24755 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20820 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125767 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24756 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136272 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81355 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23350 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20776 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13049 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24373 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88658 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24064 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24224 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24125 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->