### PR TITLE
[css-values-5 attr()] Add transitive cycle detection for attr() type() substitution

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-cycle-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-cycle-expected.txt
@@ -2,29 +2,31 @@
 PASS CSS Values and Units Test: attr
 PASS CSS Values and Units Test: attr 1
 PASS CSS Values and Units Test: attr 2
-FAIL CSS Values and Units Test: attr 3 assert_equals: Setting property '--y' to the value 'attr(data-foo type(*))', where 'data-foo=attr(data-bar type(*))' should not change it's value. expected "" but got "\"\""
+PASS CSS Values and Units Test: attr 3
 PASS CSS Values and Units Test: attr 4
 PASS CSS Values and Units Test: attr 5
 PASS CSS Values and Units Test: attr 6
 PASS CSS Values and Units Test: attr 7
-FAIL CSS Values and Units Test: attr 8 assert_equals: Setting property '--x' to the value 'attr(data-foo type(<length>))', where 'data-foo=attr(data-foo type(<length>), 11px)' should not change it's value. expected "" but got "11px"
+PASS CSS Values and Units Test: attr 8
 PASS CSS Values and Units Test: attr 9
 PASS CSS Values and Units Test: attr 10
 PASS CSS Values and Units Test: attr 11
-FAIL CSS Values and Units Test: attr 12 assert_equals: Value 'attr(data-foo type(<length>), 11px)', where 'data-foo=attr(data-foo type(<length>), 3px)' should be valid for the property '--x'. expected "11px" but got "3px"
+PASS CSS Values and Units Test: attr 12
 PASS CSS Values and Units Test: attr 13
 PASS CSS Values and Units Test: attr 14
 PASS CSS Values and Units Test: attr 15
 PASS CSS Values and Units Test: attr 16
-FAIL CSS Values and Units Test: attr 17 assert_equals: Value 'attr(data-foo type(*), 1px)', where 'data-foo=attr(data-bar type(*), 2px)' should be valid for the property '--y'. expected "1px" but got "4px"
+PASS CSS Values and Units Test: attr 17
 PASS CSS Values and Units Test: attr 18
 PASS CSS Values and Units Test: attr 19
-FAIL CSS Values and Units Test: attr 20 assert_equals: Value 'attr(data-foo type(*), var(--y))', where 'data-foo=3' should be valid for the property '--y'. expected "3" but got ""
+PASS CSS Values and Units Test: attr 20
 PASS CSS Values and Units Test: attr 21
-FAIL CSS Values and Units Test: attr 22 assert_equals: Value 'attr(data-foo type(*), var(--x))', where 'data-foo=3' should be valid for the property '--y'. expected "3" but got ""
+PASS CSS Values and Units Test: attr 22
 PASS CSS Values and Units Test: attr 23
 PASS CSS Values and Units Test: attr 24
 PASS CSS Values and Units Test: attr 25
 PASS CSS Values and Units Test: attr 26
-FAIL CSS Values and Units Test: attr 27 assert_equals: Value 'attr(data-foo type(*), abc)', where 'data-foo=attr(data-foo' should be valid for the property '--x'. expected "abc" but got "\"\""
+PASS CSS Values and Units Test: attr 27
+PASS CSS Values and Units Test: attr 28
+PASS CSS Values and Units Test: attr 29
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-cycle.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-cycle.html
@@ -139,4 +139,16 @@
 
   /* No cycle, wrong attr syntax in attribute */
   test_attr_no_cycle('--x', 'attr(data-foo type(*), abc)', 'attr(data-foo', 'abc');
+
+  /* Multiple attributes cycling simultaneously in bare attr() form */
+  attrElem.setAttribute('data-bar', 'attr(data-foo) attr(data-bar)');
+  test_attr_no_cycle('--x', 'attr(data-foo type(*), abc)', 'attr(data-bar type(*), fallback)', 'abc');
+  attrElem.removeAttribute('data-bar');
+
+  /* Transitive cycle through var() */
+  attrElem.setAttribute('data-bar', 'attr(data-foo, 10px)');
+  attrElem.style.setProperty('--x', 'attr(data-bar type(<length>))');
+  test_attr_cycle('width', 'attr(data-foo type(<length>))', 'var(--x)');
+  attrElem.style.setProperty('--x', null);
+  attrElem.removeAttribute('data-bar');
 </script>

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -253,6 +253,7 @@ private:
     HashSet<AtomString> m_inProgressCustomProperties;
     HashSet<AtomString> m_inCycleCustomProperties;
     HashSet<AtomString> m_inProgressAttrAttributes;
+    HashSet<AtomString> m_inCycleAttrAttributes;
     WTF::BitSet<cssPropertyIDEnumValueCount> m_inProgressProperties;
     WTF::BitSet<cssPropertyIDEnumValueCount> m_invalidAtComputedValueTimeProperties;
 

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -233,15 +233,12 @@ bool SubstitutionResolver::substituteAttrFunction(CSSParserTokenRange range, Vec
             return false;
     }
 
-    // Fallback has to be resolved even when not used to detect cycles and invalid syntax.
-    std::optional<Vector<CSSParserToken>> fallbackTokens;
-    bool hasFallback = false;
-    if (!range.atEnd()) {
-        if (CSSPropertyParserHelpers::consumeCommaIncludingWhitespace(range)) {
-            hasFallback = true;
-            fallbackTokens = substituteTokenRange(range, context);
-        }
-    }
+    auto consumeFallbackRange = [&]() -> std::optional<CSSParserTokenRange> {
+        if (range.atEnd() || !CSSPropertyParserHelpers::consumeCommaIncludingWhitespace(range))
+            return std::nullopt;
+        return range;
+    };
+    auto fallbackRange = consumeFallbackRange();
 
     m_styleBuilder.state().registerContentAttribute(attributeName);
     protect(m_styleBuilder.state().style())->setHasAttrContent();
@@ -252,44 +249,62 @@ bool SubstitutionResolver::substituteAttrFunction(CSSParserTokenRange range, Vec
 
     auto& attributeValue = element->getAttribute(QualifiedName { nullAtom(), attributeName, nullAtom() });
 
-    // https://drafts.csswg.org/css-values-5/#attr-substitution
-    // Cycle detection: type(<syntax>) allows substitution of arbitrary substitution functions
-    // in the attribute value, which could create attr() cycles.
+    // Check if this attribute is already being substituted (cycle detection).
     auto isNewEntry = m_styleBuilder.state().m_inProgressAttrAttributes.add(attributeName).isNewEntry;
     auto removeOnExit = makeScopeExit([&] {
         if (isNewEntry)
             m_styleBuilder.state().m_inProgressAttrAttributes.remove(attributeName);
     });
 
-    // https://drafts.csswg.org/css-values-5/#attr-substitution
-    // FAILURE step: "If second arg is null, and syntax was omitted, return an empty CSS <string>."
-    // "If second arg is null, return the guaranteed-invalid value."
-    // "Substitute arbitrary substitution functions in second arg, and return the result."
+    // Resolve fallback lazily to avoid var() cycle detection side effects during primary resolution.
+    auto resolveFallback = [&]() -> std::optional<Vector<CSSParserToken>> {
+        if (!fallbackRange)
+            return std::nullopt;
+        return substituteTokenRange(*fallbackRange, context);
+    };
+
+    // https://drafts.csswg.org/css-values-5/#replace-an-attr-function
     auto substituteFailure = [&]() -> bool {
-        if (!hasFallback && !parsedAttrType) {
+        // "If second arg is null, and syntax was omitted, return an empty CSS <string>."
+        if (!fallbackRange && !parsedAttrType) {
             tokens.append(CSSParserToken(StringToken, emptyAtom()));
             return true;
         }
+        auto fallbackTokens = resolveFallback();
+        // "If second arg is null, return the guaranteed-invalid value."
         if (!fallbackTokens)
             return false;
-
+        // "Substitute arbitrary substitution functions in second arg, and return the result."
         tokens.appendVector(*fallbackTokens);
         return true;
     };
 
-    if (attributeValue.isNull() || !isNewEntry)
+    // Cycle detected.
+    if (!isNewEntry) {
+        // Mark as in-cycle within attr() type() context for transitive detection.
+        if (m_isInAttrTypeSyntax)
+            m_styleBuilder.state().m_inCycleAttrAttributes.add(attributeName);
+        if (parsedAttrType)
+            return false;
+        return substituteFailure();
+    }
+
+    if (attributeValue.isNull())
         return substituteFailure();
 
     // "If syntax is null or the keyword raw-string, return a CSS <string> whose value is attr value."
     auto attrType = parsedAttrType ? parsedAttrType->type : AttrType::RawString;
 
     switch (attrType) {
+    // "If given as the raw-string keyword, or omitted entirely, it causes the attribute’s literal
+    //  value to be treated as the value of a CSS string, with no CSS parsing performed at all."
     case AttrType::RawString:
         tokens.append(CSSParserToken(StringToken, attributeValue));
         return true;
 
-    // "If syntax is the keyword number, [...] the attribute's literal value, after stripping leading
-    //  and trailing whitespace, [is] parsed as a <number-token>. Values that fail to parse trigger fallback."
+    // "If given as the number keyword, it causes the attribute's literal value, after stripping
+    //  leading and trailing whitespace, to be parsed as a <number-token>. Values that fail to
+    //  parse trigger fallback."
     case AttrType::Number: {
         CSSTokenizer tokenizer(attributeValue.string().trim(isUnicodeCompatibleASCIIWhitespace<UChar>));
         auto tokenRange = tokenizer.tokenRange();
@@ -330,17 +345,19 @@ bool SubstitutionResolver::substituteAttrFunction(CSSParserTokenRange range, Vec
     //  trigger fallback."
     case AttrType::Syntax: {
         CSSTokenizer tokenizer(attributeValue.string());
-        // Keep tokenizer's escaped strings alive until substitute() copies them into CSSVariableData.
         m_intermediateTokenStrings.appendVector(tokenizer.escapedStringsForAdoption());
 
-        // Substitute any var()/attr()/env() in the attribute value.
+        SetForScope isInAttrTypeSyntax(m_isInAttrTypeSyntax, true);
+
         auto substitutedTokens = substituteTokenRange(tokenizer.tokenRange(), context);
         if (!substitutedTokens)
             return substituteFailure();
 
-        // "This is different from specifying a syntax of type(*), which still triggers CSS parsing
-        //  (but with no requirements placed on it beyond that it parse validly), and which substitutes
-        //  the result of that parsing directly as tokens, rather than as a <string> value."
+        // If this attribute was found to be in a cycle during substitution,
+        // the attr value transitively references itself.
+        if (m_styleBuilder.state().m_inCycleAttrAttributes.contains(attributeName))
+            return substituteFailure();
+
         if (!parsedAttrType->syntax.isUniversal()) {
             CSSParserTokenRange substitutedRange(*substitutedTokens);
             if (!CSSPropertyParser::isValidCustomPropertyValueForSyntax(parsedAttrType->syntax, substitutedRange, context))

--- a/Source/WebCore/style/StyleSubstitutionResolver.h
+++ b/Source/WebCore/style/StyleSubstitutionResolver.h
@@ -53,6 +53,7 @@ public:
 
 private:
     std::optional<Vector<CSSParserToken>> substituteTokenRange(CSSParserTokenRange, const CSSParserContext&);
+
     bool substituteVariableFunction(CSSParserTokenRange, CSSValueID, Vector<CSSParserToken>&, const CSSParserContext&);
     bool substituteDashedFunction(StringView functionName, CSSParserTokenRange, Vector<CSSParserToken>&);
     bool substituteAttrFunction(CSSParserTokenRange, Vector<CSSParserToken>&, const CSSParserContext&);
@@ -67,6 +68,8 @@ private:
 
     Builder& m_styleBuilder;
     Vector<String> m_intermediateTokenStrings;
+
+    bool m_isInAttrTypeSyntax { false };
 };
 
 } // namespace Style


### PR DESCRIPTION
#### 205b80c8b56b513568a5d2ee736bd16d19e2f928
<pre>
[css-values-5 attr()] Add transitive cycle detection for attr() type() substitution
<a href="https://bugs.webkit.org/show_bug.cgi?id=310641">https://bugs.webkit.org/show_bug.cgi?id=310641</a>
<a href="https://rdar.apple.com/173255515">rdar://173255515</a>

Reviewed by Alan Baradlay (OOPS\!).

attr() cycles through fallbacks or var() boundaries go undetected.

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-cycle-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-cycle.html:

Add some more subtests.

* Source/WebCore/style/StyleBuilderState.h:
* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::SubstitutionResolver::substituteAttrFunction):

Track in-cycle attributes so substitution fails at all levels.

* Source/WebCore/style/StyleSubstitutionResolver.h:

Canonical link: <a href="https://commits.webkit.org/309913@main">https://commits.webkit.org/309913@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4ea426b0d69de75abb40be11b787ce7c719a594

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152140 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24922 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18510 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160883 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154014 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25414 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25228 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117531 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155100 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/136567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98244 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/18798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/16750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8717 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14445 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163349 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6495 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16037 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125557 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24720 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20792 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125733 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34114 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24721 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/136241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81314 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20748 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/13018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24338 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88623 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24029 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24189 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24090 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->