### PR TITLE
[run-benchmark] Add MotionMark 1.3.1 composition plans for testing GPU compositing

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner.py
@@ -34,6 +34,12 @@ class BenchmarkRunner(object):
         if timeout_override:
             self._plan['timeout'] = timeout_override
         self._subtests = self.validate_subtests(subtests) if subtests else None
+        if not self._subtests and self._plan.get('default_subtests'):
+            default = self._plan['default_subtests']
+            if default is True:
+                default = self._plan.get('subtests', {})
+            self._subtests = self.validate_subtests(
+                BenchmarkRunner.format_subtests(default))
         self._browser_driver = BrowserDriverFactory.create(platform, browser, browser_args)
         self._browser_path = browser_path
         self._build_dir = os.path.abspath(build_dir) if build_dir else None

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/patches/extra/MotionMark-Composition.patch
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/patches/extra/MotionMark-Composition.patch
@@ -1,0 +1,148 @@
+--- a/resources/debug-runner/tests.js	2026-03-25 10:54:32.366303243 +0100
++++ b/resources/debug-runner/tests.js	2026-03-25 10:54:49.803597112 +0100
+@@ -456,3 +456,48 @@
+         }
+     ]
+ ));
++
++Suites.push(new Suite("Composition suite",
++    [
++        {
++            url: "dom/compositing-transforms.html?particleWidth=50&particleHeight=50&filters=yes",
++            name: "Transforms with filters"
++        },
++        {
++            url: "dom/compositing-transforms.html?particleWidth=50&particleHeight=50",
++            name: "Transforms no filters"
++        },
++        {
++            url: "dom/particles.html?composited=yes",
++            name: "DOM Particles"
++        },
++        {
++            url: "bouncing-particles/bouncing-css-shapes.html?particleWidth=12&particleHeight=12&shape=circle&composited=yes",
++            name: "Bouncing circles"
++        },
++        {
++            url: "bouncing-particles/bouncing-css-shapes.html?particleWidth=40&particleHeight=40&shape=rect&clip=star&composited=yes",
++            name: "Bouncing clipped rects"
++        },
++        {
++            url: "bouncing-particles/bouncing-css-shapes.html?particleWidth=80&particleHeight=80&shape=circle&blend&composited=yes",
++            name: "Bouncing blend circles"
++        },
++        {
++            url: "bouncing-particles/bouncing-css-shapes.html?particleWidth=80&particleHeight=80&shape=circle&filter&composited=yes",
++            name: "Bouncing filter circles"
++        },
++        {
++            url: "dom/leaves.html?style=simple&composited=yes",
++            name: "Leaves translate"
++        },
++        {
++            url: "dom/leaves.html?style=scale&composited=yes",
++            name: "Leaves translate + scale"
++        },
++        {
++            url: "dom/leaves.html?style=opacity&composited=yes",
++            name: "Leaves translate + opacity"
++        }
++    ]
++));
+--- a/tests/bouncing-particles/resources/bouncing-css-shapes.js	2026-03-25 10:54:32.991549419 +0100
++++ b/tests/bouncing-particles/resources/bouncing-css-shapes.js	2026-03-25 10:55:41.472435136 +0100
+@@ -28,6 +28,7 @@
+     function(stage)
+     {
+         BouncingParticle.call(this, stage);
++        this.composited = stage.composited;
+ 
+         this.element = this._createSpan(stage);
+ 
+@@ -64,7 +65,10 @@
+ 
+     _move: function()
+     {
+-        this.element.style.transform = "translate(" + this.position.x + "px," + this.position.y + "px)" + this.rotater.rotateZ();
++        if (this.composited)
++            this.element.style.transform = "translate3d(" + this.position.x + "px," + this.position.y + "px, 0)" + this.rotater.rotateZ();
++        else
++            this.element.style.transform = "translate(" + this.position.x + "px," + this.position.y + "px)" + this.rotater.rotateZ();
+     },
+ 
+     animate: function(timeDelta)
+@@ -85,6 +89,7 @@
+     {
+         BouncingParticlesStage.prototype.initialize.call(this, benchmark, options);
+         this.parseShapeParameters(options);
++        this.composited = options["composited"] == "yes";
+     },
+ 
+     createParticle: function()
+--- a/tests/dom/resources/dom-particles.js	2026-03-25 10:54:32.552230424 +0100
++++ b/tests/dom/resources/dom-particles.js	2026-03-25 10:55:16.422573676 +0100
+@@ -29,6 +29,7 @@
+     {
+         this.element = document.createElement("div");
+         stage.element.appendChild(this.element);
++        this.composited = stage.composited;
+ 
+         Particle.call(this, stage);
+     }, {
+@@ -51,7 +52,10 @@
+ 
+     move: function()
+     {
+-        this.element.style.transform = "translate(" + this.position.x + "px, " + this.position.y + "px)" + this.rotater.rotateZ();
++        if (this.composited)
++            this.element.style.transform = "translate3d(" + this.position.x + "px, " + this.position.y + "px, 0)" + this.rotater.rotateZ();
++        else
++            this.element.style.transform = "translate(" + this.position.x + "px, " + this.position.y + "px)" + this.rotater.rotateZ();
+     }
+ });
+ 
+@@ -72,6 +76,7 @@
+             new Point(this.size.x * .75, this.size.y * .333)
+         ];
+         this.colorOffset = Stage.randomInt(0, 359);
++        this.composited = (new URLSearchParams(window.location.search)).get("composited") === "yes";
+     },
+ 
+     createParticle: function()
+--- a/tests/dom/resources/leaves.js	2026-03-25 10:54:32.757080390 +0100
++++ b/tests/dom/resources/leaves.js	2026-03-25 10:55:26.708337854 +0100
+@@ -25,6 +25,7 @@
+ (function() {
+ 
+ var SuperLeaf = window.Leaf;
++var composited = (new URLSearchParams(window.location.search)).get("composited") === "yes";
+ var SimpleLeaf = Utilities.createSubclass(SuperLeaf,
+     function(stage)
+     {
+@@ -37,7 +38,7 @@
+ 
+     move: function()
+     {
+-        this.element.style.transform = "translate(" + this._position.x + "px, " + this._position.y + "px)" + this.rotater.rotateZ();
++        this.element.style.transform = (composited ? "translate3d(" + this._position.x + "px, " + this._position.y + "px, 0)" : "translate(" + this._position.x + "px, " + this._position.y + "px)") + this.rotater.rotateZ();
+     }
+ });
+ 
+@@ -53,7 +54,7 @@
+ 
+     move: function()
+     {
+-        this.element.style.transform = "translate(" + this._position.x + "px, " + this._position.y + "px)" + this.rotater.rotateZ();
++        this.element.style.transform = (composited ? "translate3d(" + this._position.x + "px, " + this._position.y + "px, 0)" : "translate(" + this._position.x + "px, " + this._position.y + "px)") + this.rotater.rotateZ();
+     }
+ });
+ 
+@@ -69,7 +70,7 @@
+ 
+     move: function()
+     {
+-        this.element.style.transform = "translate(" + this._position.x + "px, " + this._position.y + "px)" + this.rotater.rotateZ();
++        this.element.style.transform = (composited ? "translate3d(" + this._position.x + "px, " + this._position.y + "px, 0)" : "translate(" + this._position.x + "px, " + this._position.y + "px)") + this.rotater.rotateZ();
+         this.element.style.opacity = this._opacity;
+     }
+ });

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/patches/extra/MotionMark1.3.1-30FPS.patch
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/patches/extra/MotionMark1.3.1-30FPS.patch
@@ -1,0 +1,97 @@
+diff --git a/tests/resources/main.js b/tests/resources/main.js
+--- a/tests/resources/main.js
++++ b/tests/resources/main.js
+@@ -885,6 +885,7 @@
+     function(stage, options)
+     {
+         this._animateLoop = this._animateLoop.bind(this);
++        this._animateLoopProxy = this._animateLoopProxy.bind(this);
+         this._warmupLength = options["warmup-length"];
+         this._frameCount = 0;
+         this._warmupFrameCount = options["warmup-frame-count"];
+@@ -946,6 +947,7 @@
+             this._finishPromise = new SimplePromise;
+             this._previousTimestamp = undefined;
+             this._didWarmUp = false;
++            this._callbackCount = 0;
+             this._stage.tune(this._controller.initialComplexity - this._stage.complexity());
+             this._animateLoop();
+             return this._finishPromise;
+@@ -960,6 +962,15 @@
+         return promise;
+     },
+
++    _animateLoopProxy: function(timestamp)
++    {
++        this._callbackCount++;
++        if (this._callbackCount % 2 == 0) { // Ensure 30 FPS, only dispatch every 2nd callback.
++            this._animateLoop(timestamp);
++        } else
++            requestAnimationFrame(this._animateLoopProxy);
++    },
++
+     _animateLoop: function(timestamp)
+     {
+         timestamp = (this._getTimestamp && this._getTimestamp()) || timestamp;
+@@ -986,13 +997,13 @@
+
+             this._stage.animate(0);
+             ++this._frameCount;
+-            requestAnimationFrame(this._animateLoop);
++            requestAnimationFrame(this._animateLoopProxy);
+             return;
+         }
+
+         this._controller.update(timestamp, this._stage);
+         this._stage.animate(timestamp - this._previousTimestamp);
+         this._previousTimestamp = timestamp;
+-        requestAnimationFrame(this._animateLoop);
++        requestAnimationFrame(this._animateLoopProxy);
+     }
+ });
+diff --git a/resources/runner/motionmark.js b/resources/runner/motionmark.js
+index a2ea114..14a9cba 100644
+--- a/resources/runner/motionmark.js
++++ b/resources/runner/motionmark.js
+@@ -477,8 +477,11 @@ window.benchmarkController = {
+         "warmup-length": 2000,
+         "warmup-frame-count": 30,
+         "first-frame-minimum-length": 0,
+-        "system-frame-rate": 60,
+-        "frame-rate": 60,
++        // Running with a target of 30FPS allows low-end devices (like the RPi)
++        // to get higher scores that are more useful for performance regression
++        // tracking.
++        "system-frame-rate": 30,
++        "frame-rate": 30,
+     },
+
+     initialize: async function()
+@@ -493,11 +496,12 @@ window.benchmarkController = {
+         this._startButton.disabled = true;
+         this._startButton.textContent = Strings.text.determininingFrameRate;
+
+-        let targetFrameRate;
++        let targetFrameRate = this.benchmarkDefaultParameters["frame-rate"];
++        /* Do no autodetect the frame-rate, use the one from benchmarkDefaultParameters.
+         try {
+             targetFrameRate = await benchmarkController.determineFrameRate();
+         } catch (e) {
+-        }
++        }*/
+         this.frameRateDeterminationComplete(targetFrameRate);
+     },
+
+diff --git a/resources/strings.js b/resources/strings.js
+index c82e047..45d7771 100644
+--- a/resources/strings.js
++++ b/resources/strings.js
+@@ -23,7 +23,7 @@
+  * THE POSSIBILITY OF SUCH DAMAGE.
+  */
+ var Strings = {
+-    version: "1.3.1",
++    version: "1.3.1-30fps",
+     text: {
+         testName: "Test Name",
+         score: "Score",

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark-composition-1.3.1-30fps.plan
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark-composition-1.3.1-30fps.plan
@@ -1,0 +1,23 @@
+{
+    "import_plan_file": "motionmark1.3.1.plan",
+    "output_file": "motionmark-composition-1.3.1-30fps.result",
+    "extra_patches": [
+        "data/patches/extra/MotionMark1.3.1-30FPS.patch",
+        "data/patches/extra/MotionMark-Composition.patch"
+    ],
+    "subtests": {
+        "CompositionSuite": [
+            "TransformsWithFilters",
+            "TransformsNoFilters",
+            "DOMParticles",
+            "BouncingCircles",
+            "BouncingClippedRects",
+            "BouncingBlendCircles",
+            "BouncingFilterCircles",
+            "LeavesTranslate",
+            "LeavesTranslateScale",
+            "LeavesTranslateOpacity"
+        ]
+    },
+    "default_subtests": true
+}

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark-composition-1.3.1-60fps.plan
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark-composition-1.3.1-60fps.plan
@@ -1,0 +1,23 @@
+{
+    "import_plan_file": "motionmark1.3.1.plan",
+    "output_file": "motionmark-composition-1.3.1-60fps.result",
+    "extra_patches": [
+        "data/patches/extra/MotionMark1.3.1-60FPS.patch",
+        "data/patches/extra/MotionMark-Composition.patch"
+    ],
+    "subtests": {
+        "CompositionSuite": [
+            "TransformsWithFilters",
+            "TransformsNoFilters",
+            "DOMParticles",
+            "BouncingCircles",
+            "BouncingClippedRects",
+            "BouncingBlendCircles",
+            "BouncingFilterCircles",
+            "LeavesTranslate",
+            "LeavesTranslateScale",
+            "LeavesTranslateOpacity"
+        ]
+    },
+    "default_subtests": true
+}

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark-composition-1.3.1.plan
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark-composition-1.3.1.plan
@@ -1,0 +1,22 @@
+{
+    "import_plan_file": "motionmark1.3.1.plan",
+    "output_file": "motionmark-composition-1.3.1.result",
+    "extra_patches": [
+        "data/patches/extra/MotionMark-Composition.patch"
+    ],
+    "subtests": {
+        "CompositionSuite": [
+            "TransformsWithFilters",
+            "TransformsNoFilters",
+            "DOMParticles",
+            "BouncingCircles",
+            "BouncingClippedRects",
+            "BouncingBlendCircles",
+            "BouncingFilterCircles",
+            "LeavesTranslate",
+            "LeavesTranslateScale",
+            "LeavesTranslateOpacity"
+        ]
+    },
+    "default_subtests": true
+}

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.3-60fps.plan
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.3-60fps.plan
@@ -1,5 +1,0 @@
-{
-    "import_plan_file": "motionmark1.3.plan",
-    "output_file": "motionmark1.3-60fps.result",
-    "extra_patches": ["data/patches/extra/MotionMark1.3-60FPS.patch"]
-}

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.3.1-15fps.plan
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.3.1-15fps.plan
@@ -1,5 +1,0 @@
-{
-    "import_plan_file": "motionmark1.3.1.plan",
-    "output_file": "motionmark1.3.1-15fps.result",
-    "extra_patches": ["data/patches/extra/MotionMark1.3.1-15FPS.patch"]
-}

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.3.1-30fps.plan
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.3.1-30fps.plan
@@ -1,0 +1,5 @@
+{
+    "import_plan_file": "motionmark1.3.1.plan",
+    "output_file": "motionmark1.3.1-30fps.result",
+    "extra_patches": ["data/patches/extra/MotionMark1.3.1-30FPS.patch"]
+}


### PR DESCRIPTION
#### 0d88193488f8512f5437263af919f2b41a52bddf
<pre>
[run-benchmark] Add MotionMark 1.3.1 composition plans for testing GPU compositing
<a href="https://bugs.webkit.org/show_bug.cgi?id=310704">https://bugs.webkit.org/show_bug.cgi?id=310704</a>

Reviewed by Carlos Alberto Lopez Perez.

Add new benchmark plans that run a focused set of composited tests
(translate3d) to measure GPU compositing performance. This includes
composited variants of DOM particles, bouncing CSS shapes (with blend,
filter, and clip-path), leaves, and transform tests.

Cleanup the various MotionMark plans, and alter the variants.
We left those variants untouched (not used by GTK/WPE ports):
 - motionmark1.0
 - motionmark1.1
 - motionmark1.2.1
 - motionmark1.3
 - motionmark1.3.1

We delete the following variants previously used by GTK/WPE ports:
 - motionmark1.3-60fps (only used by GTK/desktop, will be migrated)
 - motionmark1.3.1-15fps (no plans to continue 15 FPS testing)

We keep the following variants used by GTK/WPE ports:
 - motionmark1.3-15fps (continue to use for testing rpi4 on WPE)
 - motionmark1.3.1-30fps (new - that we plan to run for rpi4/WPE)
 - motionmark1.3.1-60fps (we&apos;ll switch motionm

We add the following new ones (to be used by our ports):
 - motionmark-composition-1.3.1 (only for interactive testing)
 - motionmark-composition-1.3.1-30fps (for WPE/rpi4)
 - motionmark-composition-1.3.1-60fps (for GTK/desktop)

* Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner.py:
(BenchmarkRunner.__init__):
* Tools/Scripts/webkitpy/benchmark_runner/data/patches/extra/MotionMark-Composition.patch: Added.
* Tools/Scripts/webkitpy/benchmark_runner/data/patches/extra/MotionMark1.3.1-30FPS.patch: Added.
* Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark-composition-1.3.1-30fps.plan: Added.
* Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark-composition-1.3.1-60fps.plan: Added.
* Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark-composition-1.3.1.plan: Added.
* Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.3-60fps.plan: Removed.
* Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.3.1-15fps.plan: Removed.
* Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.3.1-30fps.plan: Added.

Canonical link: <a href="https://commits.webkit.org/311061@main">https://commits.webkit.org/311061@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ad3ffd3c7082940600b9e5e72fba552317914db

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154924 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28183 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21343 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163684 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108394 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156797 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28322 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28032 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119861 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84720 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157883 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22133 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139130 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100554 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/154244 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21218 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19248 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11510 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130880 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16974 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166159 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18583 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127964 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27728 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23287 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128103 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34934 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27652 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138767 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84359 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22980 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15562 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27344 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26922 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27153 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26995 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->