### PR TITLE
[EME] Check support for full content type (including codecs)

### DIFF
--- a/LayoutTests/media/encrypted-media/mock-navigator-requestMediaKeySystemAccess-expected.txt
+++ b/LayoutTests/media/encrypted-media/mock-navigator-requestMediaKeySystemAccess-expected.txt
@@ -13,6 +13,11 @@ EXPECTED (access.getConfiguration().sessionTypes[0] == 'temporary') OK
 EXPECTED (access.getConfiguration().distinctiveIdentifier == 'not-allowed') OK
 EXPECTED (access.getConfiguration().persistentState == 'not-allowed') OK
 
+SET capabilities = '[ { "initDataTypes": [ "mock" ], "videoCapabilities": [ { "contentType": "video/mock; codecs=\"unknown\"" } ] } ]'
+RUN(promise = navigator.requestMediaKeySystemAccess("org.webkit.mock", capabilities))
+Promise rejected correctly OK
+EXPECTED (exceptionCode.name == 'NotSupportedError') OK
+
 SET capabilities = '[ { "initDataTypes": [ "mock" ], "videoCapabilities": [ { "contentType": "unknown/mime; codecs=\"unknown\"" } ] } ]'
 RUN(promise = navigator.requestMediaKeySystemAccess("org.webkit.mock", capabilities))
 Promise rejected correctly OK

--- a/LayoutTests/media/encrypted-media/mock-navigator-requestMediaKeySystemAccess.html
+++ b/LayoutTests/media/encrypted-media/mock-navigator-requestMediaKeySystemAccess.html
@@ -69,6 +69,17 @@
         function() {
             failingTestWithCapabilities([{
                     initDataTypes: ['mock'],
+                    videoCapabilities: [{ contentType: 'video/mock; codecs="unknown"' }]
+                }],
+                exceptionCode => {
+                    window.exceptionCode = exceptionCode;
+                    testExpected('exceptionCode.name', 'NotSupportedError');
+                });
+        },
+
+        function() {
+            failingTestWithCapabilities([{
+                    initDataTypes: ['mock'],
                     videoCapabilities: [{ contentType: 'unknown/mime; codecs="unknown"' }] 
                 }],
                 exceptionCode => {

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3493,7 +3493,6 @@ webkit.org/b/189345 http/tests/media/clearkey/collect-webkit-media-session.html 
 
 media/encrypted-media [ Pass ]
 
-webkit.org/b/205857 media/encrypted-media/mock-navigator-requestMediaKeySystemAccess.html [ Skip ]
 webkit.org/b/205860 media/encrypted-media/mock-MediaKeySession-remove.html [ Skip ]
 
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -2782,9 +2782,6 @@ webkit.org/b/245610 http/tests/security/xss-DENIED-xsl-external-entity.xml [ Fai
 # Form validation popover does not obey minimum font size setting on iOS but Dynamic Type instead.
 fast/forms/validation-message-minimum-font-size.html [ Skip ]
 
-# New Encrypted Media API not enabled on iOS
-media/encrypted-media/mock-navigator-requestMediaKeySystemAccess.html [ Skip ]
-
 webkit.org/b/166736 fast/scrolling/page-cache-back-overflow-scroll-restore.html [ Skip ]
 
 # Requires changes to QuickLook.framework tracked by rdar://problem/28544527

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1000,7 +1000,6 @@ webkit.org/b/165530 compositing/layer-creation/fixed-position-out-of-view-scaled
 webkit.org/b/165874 streams/pipe-to.html [ Pass Failure ]
 
 # New Encrypted Media API not enabled on Mac
-media/encrypted-media/mock-navigator-requestMediaKeySystemAccess.html [ Skip ]
 media/encrypted-media/mock-MediaKeySystemAccess.html [ Skip ]
 media/encrypted-media/mock-MediaKeys-setServerCertificate.html [ Skip ]
 media/encrypted-media/mock-MediaKeys-createSession.html [ Skip ]

--- a/Source/WebCore/platform/encryptedmedia/CDMPrivate.cpp
+++ b/Source/WebCore/platform/encryptedmedia/CDMPrivate.cpp
@@ -422,7 +422,7 @@ std::optional<Vector<CDMMediaCapability>> CDMPrivate::getSupportedCapabilitiesFo
         // 3.13. If the user agent and implementation definitely support playback of encrypted media data for the
         //       combination of container, media types, robustness and local accumulated configuration in combination
         //       with restrictions:
-        MediaEngineSupportParameters parameters { .type = ContentType(contentType->mimeType()) };
+        MediaEngineSupportParameters parameters { .type = ContentType(contentType->contentType()) };
         if (MediaPlayer::supportsType(parameters) == MediaPlayer::SupportsType::IsNotSupported) {
             // Try with Media Source:
             parameters.platformType = PlatformMediaDecodingType::MediaSource;

--- a/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
@@ -98,6 +98,9 @@ MediaPlayer::SupportsType MockMediaPlayerMediaSource::supportsType(const MediaEn
     if (codecs == "mock"_s || codecs == "kcom"_s)
         return MediaPlayer::SupportsType::IsSupported;
 
+    if (codecs == "unknown"_s || codecs == "invalid"_s)
+        return MediaPlayer::SupportsType::IsNotSupported;
+
     return MediaPlayer::SupportsType::MayBeSupported;
 }
 

--- a/Source/WebCore/platform/network/ParsedContentType.h
+++ b/Source/WebCore/platform/network/ParsedContentType.h
@@ -44,6 +44,7 @@ public:
     ParsedContentType(ParsedContentType&&) = default;
 
     String mimeType() const { return m_mimeType; }
+    String contentType() const { return m_contentType; }
     String charset() const;
     void setCharset(String&&);
 


### PR DESCRIPTION
#### 3632c80665b4c970873a72bbbbc63565da970ac0
<pre>
[EME] Check support for full content type (including codecs)
<a href="https://bugs.webkit.org/show_bug.cgi?id=310709">https://bugs.webkit.org/show_bug.cgi?id=310709</a>

Reviewed by Jer Noble and Xabier Rodriguez-Calvar.

When evaluating media capabilities for requestMediaKeySystemAccess,
we use pass ParsedContentType&apos;s m_mimeType to the MediaSource,
which omits parameters of the MIME type like codecs.

The right field to use here is m_contentType, so MediaSource
can check support against the full MIME type, rather than just
its container type.

* LayoutTests/media/encrypted-media/mock-navigator-requestMediaKeySystemAccess-expected.txt:
* LayoutTests/media/encrypted-media/mock-navigator-requestMediaKeySystemAccess.html: Add test with supported type but unknown codec.
* LayoutTests/platform/glib/TestExpectations: Unflag mock-navigator-requestMediaKeySystemAccess.html.
* LayoutTests/platform/ios/TestExpectations: Ditto.
* LayoutTests/platform/mac/TestExpectations: Ditto.
* Source/WebCore/platform/encryptedmedia/CDMPrivate.cpp:
(WebCore::CDMPrivate::getSupportedCapabilitiesForAudioVideoType): Use full contentType for MediaEngineSupportParameters.
* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp:
(WebCore::MockMediaPlayerMediaSource::supportsType): Return NotSupported if codec is &apos;unknown&apos; or &apos;invalid&apos;.
* Source/WebCore/platform/network/ParsedContentType.h:
(WebCore::ParsedContentType::contentType const): Added, returns m_contentType.

Original author: Andrzej Surdej &lt;Andrzej_Surdej@comcast.com&gt;

See: <a href="https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1643">https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1643</a>
Canonical link: <a href="https://commits.webkit.org/310696@main">https://commits.webkit.org/310696@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9d619e92d100cbaa5c026c183bc7e25db922719

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152380 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25162 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18761 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161123 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105837 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154254 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25690 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25468 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117738 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83469 "3 flakes 2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155340 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19950 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136801 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98451 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19027 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16960 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8957 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128677 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14675 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163593 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6735 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16269 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125774 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24960 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20999 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125945 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34696 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24962 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136471 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/81562 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20939 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13250 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24578 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88864 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24269 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24429 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24330 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->