### PR TITLE
MediaSource should actually cache the response

### DIFF
--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -39,6 +39,7 @@
 #include "AudioTrackPrivate.h"
 #include "ContentType.h"
 #include "ContentTypeUtilities.h"
+#include "MediaSourceTypeSupportedCache.h"
 #include "ContextDestructionObserverInlines.h"
 #include "DocumentQuirks.h"
 #include "Event.h"
@@ -1188,15 +1189,24 @@ bool MediaSource::isTypeSupported(ScriptExecutionContext& context, const String&
         parameters.allowedMediaCaptionFormatTypes = document->settings().allowedMediaCaptionFormatTypes();
     }
 
+    auto& cache = MediaSourceTypeSupportedCache::singleton();
+    if (auto cached = cache.lookup(contentType.raw()))
+        return *cached;
+
     MediaPlayer::SupportsType supported;
     callOnMainThreadAndWait([&] {
         supported = MediaPlayer::supportsType(parameters);
     });
 
+    bool isSupported;
     if (codecs.isEmpty())
-        return supported != MediaPlayer::SupportsType::IsNotSupported;
+        isSupported = supported != MediaPlayer::SupportsType::IsNotSupported;
+    else
+        isSupported = supported == MediaPlayer::SupportsType::IsSupported;
 
-    return supported == MediaPlayer::SupportsType::IsSupported;
+    cache.store(contentType.raw(), isSupported);
+
+    return isSupported;
 }
 
 bool MediaSource::isOpen() const

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2586,6 +2586,7 @@ platform/graphics/LayoutRoundedRect.cpp
 platform/graphics/LayoutSize.cpp
 platform/graphics/MIMESniffer.cpp
 platform/graphics/MIMETypeCache.cpp
+platform/graphics/MediaSourceTypeSupportedCache.cpp
 platform/graphics/MediaPlaybackTargetWirelessPlayback.cpp
 platform/graphics/MediaPlayer.cpp
 platform/graphics/MediaPlayerPrivate.cpp

--- a/Source/WebCore/platform/graphics/MediaSourceTypeSupportedCache.cpp
+++ b/Source/WebCore/platform/graphics/MediaSourceTypeSupportedCache.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "MediaSourceTypeSupportedCache.h"
+
+#if ENABLE(MEDIA_SOURCE)
+
+#include <wtf/NeverDestroyed.h>
+
+namespace WebCore {
+
+MediaSourceTypeSupportedCache& MediaSourceTypeSupportedCache::singleton()
+{
+    static NeverDestroyed<MediaSourceTypeSupportedCache> cache;
+    return cache.get();
+}
+
+std::optional<bool> MediaSourceTypeSupportedCache::lookup(const String& type) const
+{
+    Locker locker { m_lock };
+    auto it = m_cache.find(type);
+    if (it == m_cache.end())
+        return std::nullopt;
+    return it->value;
+}
+
+void MediaSourceTypeSupportedCache::store(const String& type, bool isSupported)
+{
+    CacheUpdateCallback callback;
+
+    {
+        Locker locker { m_lock };
+        auto result = m_cache.add(type, isSupported);
+        if (!result.isNewEntry)
+            return;
+        if (m_callback)
+            callback = m_callback;
+    }
+
+    if (callback)
+        callback(type, isSupported);
+}
+
+void MediaSourceTypeSupportedCache::initialize(HashMap<String, bool>&& results)
+{
+    Locker locker { m_lock };
+    ASSERT(m_cache.isEmpty());
+    m_cache = WTF::move(results);
+}
+
+void MediaSourceTypeSupportedCache::setCacheUpdateCallback(CacheUpdateCallback&& callback)
+{
+    Locker locker { m_lock };
+    m_callback = WTF::move(callback);
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(MEDIA_SOURCE)

--- a/Source/WebCore/platform/graphics/MediaSourceTypeSupportedCache.h
+++ b/Source/WebCore/platform/graphics/MediaSourceTypeSupportedCache.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(MEDIA_SOURCE)
+
+#include <functional>
+#include <wtf/Forward.h>
+#include <wtf/HashMap.h>
+#include <wtf/Lock.h>
+#include <wtf/NeverDestroyed.h>
+#include <wtf/text/StringHash.h>
+
+namespace WebCore {
+
+class WEBCORE_EXPORT MediaSourceTypeSupportedCache {
+public:
+    static MediaSourceTypeSupportedCache& singleton();
+
+    std::optional<bool> lookup(const String& type) const;
+    void store(const String& type, bool isSupported);
+
+    void initialize(HashMap<String, bool>&&);
+
+    using CacheUpdateCallback = std::function<void(const String&, bool)>;
+    void setCacheUpdateCallback(CacheUpdateCallback&&);
+
+private:
+    friend NeverDestroyed<MediaSourceTypeSupportedCache>;
+    MediaSourceTypeSupportedCache() = default;
+
+    mutable Lock m_lock;
+    HashMap<String, bool> m_cache WTF_GUARDED_BY_LOCK(m_lock);
+    CacheUpdateCallback m_callback WTF_GUARDED_BY_LOCK(m_lock);
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(MEDIA_SOURCE)

--- a/Source/WebKit/Shared/WebProcessCreationParameters.h
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.h
@@ -170,6 +170,7 @@ struct WebProcessCreationParameters {
 
 #if PLATFORM(COCOA)
     Vector<String> mediaMIMETypes;
+    HashMap<String, bool> mediaSourceTypesSupported;
 #endif
 
 #if PLATFORM(COCOA) || PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))

--- a/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
@@ -114,6 +114,7 @@
 
 #if PLATFORM(COCOA)
     Vector<String> mediaMIMETypes;
+    HashMap<String, bool> mediaSourceTypesSupported;
 #endif
 
 #if PLATFORM(COCOA) || PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -375,9 +375,15 @@ void WebProcessPool::platformResolvePathsForSandboxExtensions()
     m_resolvedPaths.uiProcessBundleResourcePath = resolvePathForSandboxExtension(String { [[NSBundle mainBundle] resourcePath] });
 }
 
+void WebProcessPool::cacheMediaSourceTypeSupported(const String& type, bool isSupported)
+{
+    m_mediaSourceTypesSupported.add(type, isSupported);
+}
+
 void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process, WebProcessCreationParameters& parameters)
 {
     parameters.mediaMIMETypes = process.mediaMIMETypes();
+    parameters.mediaSourceTypesSupported = m_mediaSourceTypesSupported;
 
 #if PLATFORM(MAC)
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
@@ -135,9 +135,14 @@ void WebProcessProxy::cacheMediaMIMETypesInternal(const Vector<String>& types)
     send(Messages::WebProcess::SetMediaMIMETypes(types), 0);
 }
 
-Vector<String> WebProcessProxy::mediaMIMETypes() const
+const Vector<String>& WebProcessProxy::mediaMIMETypes()
 {
     return mediaTypeCache();
+}
+
+void WebProcessProxy::cacheMediaSourceTypeSupported(const String& type, bool isSupported)
+{
+    processPool().cacheMediaSourceTypeSupported(type, isSupported);
 }
 
 #if ENABLE(REMOTE_INSPECTOR)

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -617,6 +617,8 @@ public:
 
 #if PLATFORM(COCOA)
     void registerAssetFonts(WebProcessProxy&);
+    const HashMap<String, bool>& mediaSourceTypesSupported() const { return m_mediaSourceTypesSupported; }
+    void cacheMediaSourceTypeSupported(const String& type, bool isSupported);
 #endif
 
 #if PLATFORM(MAC)
@@ -1035,6 +1037,7 @@ private:
     std::optional<HashMap<String, URL>> m_userInstalledFontURLs;
     std::optional<HashMap<String, Vector<String>>> m_userInstalledFontFamilyMap;
     std::optional<Vector<URL>> m_sandboxExtensionURLs;
+    HashMap<String, bool> m_mediaSourceTypesSupported;
 #endif
 
 #if ENABLE(IPC_TESTING_API)

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -397,8 +397,9 @@ public:
     bool isBackground() const { return !!m_backgroundToken; }
 
 #if PLATFORM(COCOA)
-    Vector<String> mediaMIMETypes() const;
+    static const Vector<String>& mediaMIMETypes();
     void cacheMediaMIMETypes(const Vector<String>&);
+    void cacheMediaSourceTypeSupported(const String& type, bool isSupported);
 #endif
 
 #if HAVE(DISPLAY_LINK)

--- a/Source/WebKit/UIProcess/WebProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebProcessProxy.messages.in
@@ -60,6 +60,7 @@ messages -> WebProcessProxy WantsDispatchMessage {
 
 #if PLATFORM(COCOA)
     CacheMediaMIMETypes(Vector<String> types)
+    CacheMediaSourceTypeSupported(String type, bool isSupported)
 #endif
 
 #if HAVE(DISPLAY_LINK)

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -61,6 +61,7 @@
 #import <JavaScriptCore/ConfigFile.h>
 #import <JavaScriptCore/Options.h>
 #import <WebCore/AVAssetMIMETypeCache.h>
+#import <WebCore/MediaSourceTypeSupportedCache.h>
 #import <algorithm>
 #import <pal/spi/cf/VideoToolboxSPI.h>
 #import <pal/spi/cg/ImageIOSPI.h>
@@ -556,13 +557,24 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
     pthread_set_fixedpriority_self();
 #endif
 
+    ASSERT(parentProcessConnection());
     if (!parameters.mediaMIMETypes.isEmpty())
         setMediaMIMETypes(parameters.mediaMIMETypes);
     else {
-        AVAssetMIMETypeCache::singleton().setCacheMIMETypesCallback([protectedThis = Ref { *this }](const Vector<String>& types) {
-            protect(protectedThis->parentProcessConnection())->send(Messages::WebProcessProxy::CacheMediaMIMETypes(types), 0);
+        AVAssetMIMETypeCache::singleton().setCacheMIMETypesCallback([connection = parentProcessConnection()](const Vector<String>& types) {
+            connection->send(Messages::WebProcessProxy::CacheMediaMIMETypes(types), 0);
         });
     }
+    ASSERT(parentProcessConnection());
+
+#if ENABLE(MEDIA_SOURCE)
+    if (!parameters.mediaSourceTypesSupported.isEmpty())
+        MediaSourceTypeSupportedCache::singleton().initialize(WTF::move(parameters.mediaSourceTypesSupported));
+
+    MediaSourceTypeSupportedCache::singleton().setCacheUpdateCallback([connection = parentProcessConnection()](const String& type, bool isSupported) {
+        connection->send(Messages::WebProcessProxy::CacheMediaSourceTypeSupported(type, isSupported), 0);
+    });
+#endif
 
     WebCore::setScreenProperties(parameters.screenProperties);
 

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -226,7 +226,6 @@
 		44AC8BC621D0245A00CAFB34 /* RetainPtr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC029B161486AD6400817DA9 /* RetainPtr.cpp */; };
 		44B28A0528D18AD20010172C /* RetainPtrHashing.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C0991C50143C7D68007998F2 /* RetainPtrHashing.cpp */; };
 		44B28A0728D18ADA0010172C /* VectorCF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 44B289FC28D18AAA0010172C /* VectorCF.cpp */; };
-		BE606FF491F5983FDE2D79A8 /* StringCF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0B2C1116CEC224BD5FD603A6 /* StringCF.cpp */; };
 		44CDE4D426EE6E4A009F6ACB /* TypeCastsCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 44CDE4D326EE6E41009F6ACB /* TypeCastsCocoa.mm */; };
 		44CF31FD249941E8009CB6CB /* ContextMenuAction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 44CF31FB24993F66009CB6CB /* ContextMenuAction.cpp */; };
 		44D3F8402BE1A74200BE0218 /* XMLParsing.mm in Sources */ = {isa = PBXBuildFile; fileRef = 44D3F8382BE1A6BE00BE0218 /* XMLParsing.mm */; };
@@ -1344,6 +1343,7 @@
 		BCE0DFB72D188ADC003F0349 /* CompactVariant.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCE0DFB62D188ADC003F0349 /* CompactVariant.cpp */; };
 		BCEA080E2CD00F5C000AC148 /* VariantList.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCEA080D2CD00F5C000AC148 /* VariantList.cpp */; };
 		BCED51762D3B3C1200C57E2D /* StyleGradient.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCED51752D3B3C1200C57E2D /* StyleGradient.cpp */; };
+		BE606FF491F5983FDE2D79A8 /* StringCF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0B2C1116CEC224BD5FD603A6 /* StringCF.cpp */; };
 		C0BD669F131D3CFF00E18F2A /* ResponsivenessTimerDoesntFireEarly_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C0BD669E131D3CFF00E18F2A /* ResponsivenessTimerDoesntFireEarly_Bundle.cpp */; };
 		C0C5D3C61459912900A802A6 /* GetBackingScaleFactor_Bundle.mm in Sources */ = {isa = PBXBuildFile; fileRef = C0C5D3BD14598B6F00A802A6 /* GetBackingScaleFactor_Bundle.mm */; };
 		C104BC1F2547237100C078C9 /* OverrideAppleLanguagesPreference.mm in Sources */ = {isa = PBXBuildFile; fileRef = C104BC1E2547237100C078C9 /* OverrideAppleLanguagesPreference.mm */; };
@@ -1357,6 +1357,8 @@
 		C1FF9EDB244644F000839AE4 /* WebFilter.mm in Sources */ = {isa = PBXBuildFile; fileRef = C1FF9EDA244644F000839AE4 /* WebFilter.mm */; };
 		C54237F116B8957D00E638FC /* PasteboardNotifications_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C54237ED16B8955800E638FC /* PasteboardNotifications_Bundle.cpp */; };
 		C9E6DD351EA97D0800DD78AA /* FirstResponderSuppression.mm in Sources */ = {isa = PBXBuildFile; fileRef = C9E6DD311EA972D800DD78AA /* FirstResponderSuppression.mm */; };
+		CC00010A2F71000000AA0001 /* MSEIsTypeSupportedCaching.mm in Sources */ = {isa = PBXBuildFile; fileRef = CC00010B2F71000000AA0002 /* MSEIsTypeSupportedCaching.mm */; };
+		CC00010C2F71000000AA0003 /* is-type-supported-perf.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CC00010D2F71000000AA0004 /* is-type-supported-perf.html */; };
 		CD0BD0A61F79924D001AB2CF /* ContextMenuImgWithVideo.mm in Sources */ = {isa = PBXBuildFile; fileRef = CD0BD0A51F799220001AB2CF /* ContextMenuImgWithVideo.mm */; };
 		CD21458A2F56305100DF59D1 /* MediaPlayerPrivateAVFoundationObjCTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CD2145892F56305100DF59D1 /* MediaPlayerPrivateAVFoundationObjCTests.mm */; };
 		CD27A1C123C661ED006E11DD /* WKWebViewPausePlayingAudioTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CD27A1C023C661ED006E11DD /* WKWebViewPausePlayingAudioTests.mm */; };
@@ -2154,6 +2156,7 @@
 				A17C47AB2C98E5C20023F3C7 /* InspectorExtension-basic-tab.html in Copy Resources */,
 				A17C47AC2C98E5C20023F3C7 /* InspectorExtension-TabIcon-30x30.png in Copy Resources */,
 				A17C46FF2C98E58C0023F3C7 /* invalidDeviceIDHashSalts in Copy Resources */,
+				CC00010C2F71000000AA0003 /* is-type-supported-perf.html in Copy Resources */,
 				A17C46792C98E4D20023F3C7 /* IsNavigationActionTrusted.html in Copy Resources */,
 				A17C46C42C98E54B0023F3C7 /* js-autoplay-audio.html in Copy Resources */,
 				A17C46C52C98E54B0023F3C7 /* js-play-with-controls.html in Copy Resources */,
@@ -2563,6 +2566,7 @@
 		07F7696D2CA8BAC500FF004B /* IOSMouseEventTestHarness.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = IOSMouseEventTestHarness.mm; sourceTree = "<group>"; };
 		07FAA74C2CE95E3200128360 /* WebPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPageTests.swift; sourceTree = "<group>"; };
 		07FE67422F5BC233001DA439 /* DictationStreamingOpacity.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DictationStreamingOpacity.mm; sourceTree = "<group>"; };
+		0B2C1116CEC224BD5FD603A6 /* StringCF.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StringCF.cpp; sourceTree = "<group>"; };
 		0BCD833414857CE400EA2003 /* HashMap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HashMap.cpp; sourceTree = "<group>"; };
 		0BCD85691485C98B00EA2003 /* SetForScope.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SetForScope.cpp; sourceTree = "<group>"; };
 		0DE559E52A6B0AAF009AA320 /* WKWebViewResize.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebViewResize.mm; sourceTree = "<group>"; };
@@ -2963,7 +2967,6 @@
 		44A622C114A0E2B60048515B /* WTFTestUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WTFTestUtilities.h; sourceTree = "<group>"; };
 		44ABED4A2DA6E46600F472EF /* WKFragmentDirectiveGeneration.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKFragmentDirectiveGeneration.mm; sourceTree = "<group>"; };
 		44B289FC28D18AAA0010172C /* VectorCF.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VectorCF.cpp; sourceTree = "<group>"; };
-		0B2C1116CEC224BD5FD603A6 /* StringCF.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StringCF.cpp; sourceTree = "<group>"; };
 		44C2FBE125E7592C00ABC72F /* WKAppHighlights.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKAppHighlights.mm; sourceTree = "<group>"; };
 		44CDE4D326EE6E41009F6ACB /* TypeCastsCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = TypeCastsCocoa.mm; sourceTree = "<group>"; };
 		44CF31FB24993F66009CB6CB /* ContextMenuAction.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ContextMenuAction.cpp; sourceTree = "<group>"; };
@@ -4073,6 +4076,8 @@
 		CAB0FF50223323F6006CA5B0 /* IndexedDBFileName-2.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "IndexedDBFileName-2.html"; sourceTree = "<group>"; };
 		CAB0FF51223323F6006CA5B0 /* IndexedDBFileName-1.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "IndexedDBFileName-1.html"; sourceTree = "<group>"; };
 		CAB0FF5422332C3A006CA5B0 /* IndexedDBFileName.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = IndexedDBFileName.mm; sourceTree = "<group>"; };
+		CC00010B2F71000000AA0002 /* MSEIsTypeSupportedCaching.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MSEIsTypeSupportedCaching.mm; sourceTree = "<group>"; };
+		CC00010D2F71000000AA0004 /* is-type-supported-perf.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "is-type-supported-perf.html"; sourceTree = "<group>"; };
 		CD0370E224A44B7A00BA3CAE /* MediaLoading.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MediaLoading.mm; sourceTree = "<group>"; };
 		CD0BD0A51F799220001AB2CF /* ContextMenuImgWithVideo.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ContextMenuImgWithVideo.mm; sourceTree = "<group>"; };
 		CD0BD0A71F7997C2001AB2CF /* ContextMenuImgWithVideo.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = ContextMenuImgWithVideo.html; sourceTree = "<group>"; };
@@ -5087,6 +5092,7 @@
 				5261EAF92DE9768900A721AE /* ModelProcess.mm */,
 				331987702CEF456200BC283C /* MouseSupportUIDelegate.h */,
 				331987782CEF457300BC283C /* MouseSupportUIDelegate.mm */,
+				CC00010B2F71000000AA0002 /* MSEIsTypeSupportedCaching.mm */,
 				1ABC3DED1899BE6D004F0626 /* Navigation.mm */,
 				6351992722275C6A00890AD3 /* NavigationAction.mm */,
 				7BFD3B202F6939EA003DAADD /* NavigationAPI.mm */,
@@ -6732,6 +6738,7 @@
 				BCBD372E125ABBE600D2C2AF /* icon.svg */,
 				1CC80CE92474F1F7004DC489 /* idempotent-mode-autosizing-only-honors-percentages.html */,
 				CE3524F51B142BBB0028A7C5 /* input-focus-blur.html */,
+				CC00010D2F71000000AA0004 /* is-type-supported-perf.html */,
 				C9B4AD2B1ECA6F7600F5FEA0 /* js-autoplay-audio.html */,
 				C99B675B1E3971FC00FC6C80 /* js-play-with-controls.html */,
 				55226A2E1EB969B600C36AD0 /* large-red-square-image.html */,
@@ -8138,6 +8145,7 @@
 				E38EDC372B1D673A00963F9B /* MonospaceFontTests.cpp in Sources */,
 				F4E5CCC92A6C79770051934C /* MouseEventTests.mm in Sources */,
 				7CCE7F011A411AE600447C4C /* MouseMoveAfterCrash.cpp in Sources */,
+				CC00010A2F71000000AA0001 /* MSEIsTypeSupportedCaching.mm in Sources */,
 				A17C57EC2C9A5392009DD0B5 /* NavigationClientDefaultCrypto.cpp in Sources */,
 				9B19CDA01F06DFE3000548DD /* NetworkProcessCrashWithPendingConnection.mm in Sources */,
 				7CCE7F021A411AE600447C4C /* NewFirstVisuallyNonEmptyLayout.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebKit/is-type-supported-perf.html
+++ b/Tools/TestWebKitAPI/Tests/WebKit/is-type-supported-perf.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+const codecStrings = [
+    // H.264 Baseline / Main / High at various levels
+    'video/mp4; codecs="avc1.42E01E"',  // Baseline 3.0
+    'video/mp4; codecs="avc1.4D401E"',  // Main 3.0
+    'video/mp4; codecs="avc1.64001E"',  // High 3.0
+    'video/mp4; codecs="avc1.640029"',  // High 4.1
+    'video/mp4; codecs="avc1.64002A"',  // High 4.2
+    'video/mp4; codecs="avc1.640033"',  // High 5.1
+    'video/mp4; codecs="avc1.42E00A"',  // Baseline 1.0
+    // HEVC Main / Main 10
+    'video/mp4; codecs="hvc1.1.6.L93.B0"',
+    'video/mp4; codecs="hvc1.1.6.L120.B0"',
+    'video/mp4; codecs="hvc1.2.4.L93.B0"',   // Main 10
+    'video/mp4; codecs="hev1.1.6.L93.B0"',
+    // AAC audio
+    'audio/mp4; codecs="mp4a.40.2"',   // AAC-LC
+    'audio/mp4; codecs="mp4a.40.5"',   // HE-AAC
+    'audio/mp4; codecs="mp4a.40.29"',  // HE-AAC v2
+    // Video + audio combined
+    'video/mp4; codecs="avc1.42E01E,mp4a.40.2"',
+    'video/mp4; codecs="avc1.640029,mp4a.40.5"',
+    // VP9 Profile 0 (8-bit 4:2:0) at various levels
+    'video/webm; codecs="vp09.00.10.08"',
+    'video/webm; codecs="vp09.00.20.08"',
+    'video/webm; codecs="vp09.00.30.08"',
+    'video/webm; codecs="vp09.00.40.08"',
+    'video/webm; codecs="vp09.00.41.08"',
+    'video/webm; codecs="vp09.00.50.08"',
+    'video/webm; codecs="vp09.00.51.08"',
+    // VP9 Profile 1 (8-bit 4:2:2/4:4:4)
+    'video/webm; codecs="vp09.01.41.08"',
+    // VP9 Profile 2 (10-bit 4:2:0)
+    'video/webm; codecs="vp09.02.10.10"',
+    'video/webm; codecs="vp09.02.41.10"',
+    'video/webm; codecs="vp09.02.51.10.01.09.16.09.01"',
+    // VP9 Profile 3 (10-bit 4:2:2/4:4:4)
+    'video/webm; codecs="vp09.03.41.10"',
+    // VP9 full codec string with all optional parameters
+    'video/webm; codecs="vp09.02.10.10.01.09.16.09.01"',
+    'video/webm; codecs="vp09.02.10.10.01.09.16.09.00"',
+    'video/webm; codecs="vp09.00.51.08.01.01.01.01.00"',
+    // VP9 short-form codec identifiers
+    'video/webm; codecs="vp9"',
+    'video/webm; codecs="vp9,opus"',
+    'video/webm; codecs="vp09.00.41.10"',
+    // Invalid codec strings
+    'video/mp4; codecs="avc1.ZZZZZZ"',
+    'video/mp4; codecs="notacodec"',
+    'audio/mp4; codecs="mp4a.99.99"',
+    'video/webm; codecs="vp09.00.70.08"',  // invalid level 70
+    'video/webm; codecs="vp09.04.41.08"',  // invalid profile 4
+];
+
+function runIsTypeSupportedBatch(iterations) {
+    const start = performance.now();
+    for (let i = 0; i < iterations; i++) {
+        for (const codec of codecStrings) {
+            ManagedMediaSource.isTypeSupported(codec);
+        }
+    }
+    return performance.now() - start;
+}
+
+function measurePerformance() {
+    if (typeof ManagedMediaSource === 'undefined')
+        return JSON.stringify({ error: "ManagedMediaSource not available" });
+
+    const iterations = 100;
+    const totalCalls = iterations * codecStrings.length;
+
+    // First pass: measures cold cache (first-ever calls in this process).
+    // This is where cross-process caching of container types matters.
+    const coldElapsed = runIsTypeSupportedBatch(1);
+    const coldCalls = codecStrings.length;
+
+    // Subsequent passes: measures warm cache (m_cachedResults hit).
+    const warmElapsed = runIsTypeSupportedBatch(iterations);
+
+    return JSON.stringify({
+        coldCalls: coldCalls,
+        coldElapsedMs: coldElapsed,
+        warmTotalCalls: totalCalls,
+        warmElapsedMs: warmElapsed,
+        avgPerCallUs: (warmElapsed * 1000) / totalCalls,
+    });
+}
+</script>
+</head>
+<body>
+</body>
+</html>

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/MSEIsTypeSupportedCaching.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/MSEIsTypeSupportedCaching.mm
@@ -1,0 +1,235 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#import "PlatformUtilities.h"
+#import "Test.h"
+#import "TestWKWebView.h"
+#import <WebCore/Logging.h>
+#import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/WKProcessPoolPrivate.h>
+#import <WebKit/WKWebViewPrivate.h>
+#import <WebKit/WKWebsiteDataStore.h>
+#import <WebKit/_WKProcessPoolConfiguration.h>
+#import <wtf/RetainPtr.h>
+#import <wtf/Vector.h>
+
+using namespace WebCore;
+
+namespace TestWebKitAPI {
+
+// All web views share a single process pool so that m_mediaSourceTypesSupported
+// accumulates across processes. Each web view gets its own non-persistent data
+// store, which prevents process reuse (processForSite matches on both site and
+// data store), guaranteeing each web view lands in a fresh web process.
+static WKProcessPool *sharedProcessPool()
+{
+    static NeverDestroyed<RetainPtr<WKProcessPool>> pool;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        auto processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+        pool.get() = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    });
+    return pool.get().get();
+}
+
+static RetainPtr<TestWKWebView> createWebViewWithSeparateProcess()
+{
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration setProcessPool:sharedProcessPool()];
+    [configuration setWebsiteDataStore:[WKWebsiteDataStore nonPersistentDataStore]];
+    [[configuration preferences] _setManagedMediaSourceEnabled:YES];
+    [[configuration preferences] _setMediaSourceEnabled:YES];
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    [webView synchronouslyLoadTestPageNamed:@"is-type-supported-perf"];
+    return webView;
+}
+
+static std::optional<std::pair<double, double>> runMeasurement(TestWKWebView *webView)
+{
+    // Bail out if ManagedMediaSource is not available.
+    if (![[webView objectByEvaluatingJavaScript:@"typeof ManagedMediaSource !== 'undefined'"] boolValue])
+        return std::nullopt;
+
+    NSString *resultJSON = [webView objectByEvaluatingJavaScript:@"measurePerformance()"];
+    NSData *data = [resultJSON dataUsingEncoding:NSUTF8StringEncoding];
+    NSDictionary *result = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+
+    if (result[@"error"])
+        return std::nullopt;
+
+    return std::make_pair([result[@"coldElapsedMs"] doubleValue], [result[@"warmElapsedMs"] doubleValue]);
+}
+
+// This test measures the performance of ManagedMediaSource.isTypeSupported with MP4 codecs
+// across multiple web content processes. The isTypeSupported result cache is delivered via
+// WebProcessCreationParameters.mediaSourceTypesSupported (populated from the UIProcess
+// WebProcessPool::m_mediaSourceTypesSupported), so only processes created *after* the
+// UIProcess cache has been populated benefit. Processes that were already running when
+// the first CacheMediaSourceTypeSupported IPC arrived will not receive the cache.
+TEST(MediaSource, IsTypeSupportedCachingAcrossProcesses)
+{
+    constexpr size_t preCacheCount = 3;
+    constexpr size_t postCacheCount = 3;
+
+    // --- Create pre-cache web views upfront, all before any isTypeSupported call ---
+    // All processes are launched before the UIProcess cache is populated,
+    // so none of them receive mediaSourceTypesSupported via WebProcessCreationParameters.
+    Vector<RetainPtr<TestWKWebView>> preCacheViews;
+    for (size_t i = 0; i < preCacheCount; i++)
+        preCacheViews.append(createWebViewWithSeparateProcess());
+
+    for (size_t i = 0; i < preCacheCount; i++)
+        EXPECT_NE([preCacheViews[i] _webProcessIdentifier], 0);
+
+    // Measure all pre-cache views.
+    Vector<std::pair<double, double>> preCacheResults;
+    for (size_t i = 0; i < preCacheCount; i++) {
+        auto result = runMeasurement(preCacheViews[i].get());
+        if (!result) {
+            LOG(Media, "Skipping IsTypeSupportedCachingAcrossProcesses: ManagedMediaSource not available");
+            return;
+        }
+        LOG(Media, "Pre-cache process %zu (PID %d): cold=%.2f ms, warm=%.2f ms", i + 1, [preCacheViews[i] _webProcessIdentifier], result->first, result->second);
+        preCacheResults.append(*result);
+    }
+
+    // Allow time for the CacheMediaSourceTypeSupported IPC messages to propagate back
+    // to the UIProcess and populate WebProcessPool::m_mediaSourceTypesSupported.
+    Util::runFor(0.5_s);
+
+    // --- Create post-cache web views AFTER the UIProcess cache is populated ---
+    // These processes receive mediaSourceTypesSupported via WebProcessCreationParameters,
+    // so their MediaSourceTypeSupportedCache is pre-populated and avoids querying AVFoundation.
+    Vector<std::pair<double, double>> postCacheResults;
+    for (size_t i = 0; i < postCacheCount; i++) {
+        auto webView = createWebViewWithSeparateProcess();
+        auto result = runMeasurement(webView.get());
+        ASSERT_TRUE(result.has_value());
+        LOG(Media, "Post-cache process %zu (PID %d): cold=%.2f ms, warm=%.2f ms", i + 1, [webView _webProcessIdentifier], result->first, result->second);
+        postCacheResults.append(*result);
+    }
+
+    // Compute averages.
+    double preColdAvg = 0, postColdAvg = 0;
+    for (auto& r : preCacheResults)
+        preColdAvg += r.first;
+    preColdAvg /= preCacheCount;
+
+    for (auto& r : postCacheResults)
+        postColdAvg += r.first;
+    postColdAvg /= postCacheCount;
+
+    LOG(Media, "=== IsTypeSupported MP4 Performance Summary ===");
+    LOG(Media, "  Pre-cache avg cold:  %.2f ms (%zu processes)", preColdAvg, preCacheCount);
+    LOG(Media, "  Post-cache avg cold: %.2f ms (%zu processes)", postColdAvg, postCacheCount);
+    if (preColdAvg > 0 && postColdAvg > 0)
+        LOG(Media, "  Cold call speedup (post-cache vs pre-cache): %.1fx", preColdAvg / postColdAvg);
+}
+
+// This test verifies that isTypeSupported returns consistent results across
+// multiple web content processes for a variety of MP4 codec strings, both
+// for processes created before and after the UIProcess cache is populated.
+TEST(MediaSource, IsTypeSupportedConsistencyAcrossProcesses)
+{
+    // Wrap each JS expression with String() to ensure we always get a string back
+    // from objectByEvaluatingJavaScript: (booleans would return NSNumber otherwise).
+    Vector<RetainPtr<NSString>> codecStrings = {
+        // MP4 / H.264
+        @"String(ManagedMediaSource.isTypeSupported('video/mp4; codecs=\"avc1.42E01E\"'))",
+        @"String(ManagedMediaSource.isTypeSupported('video/mp4; codecs=\"avc1.4D401E\"'))",
+        @"String(ManagedMediaSource.isTypeSupported('video/mp4; codecs=\"avc1.64001E\"'))",
+        @"String(ManagedMediaSource.isTypeSupported('video/mp4; codecs=\"avc1.640029\"'))",
+        // HEVC
+        @"String(ManagedMediaSource.isTypeSupported('video/mp4; codecs=\"hvc1.1.6.L93.B0\"'))",
+        @"String(ManagedMediaSource.isTypeSupported('video/mp4; codecs=\"hev1.1.6.L93.B0\"'))",
+        // AAC
+        @"String(ManagedMediaSource.isTypeSupported('audio/mp4; codecs=\"mp4a.40.2\"'))",
+        // Combined
+        @"String(ManagedMediaSource.isTypeSupported('video/mp4; codecs=\"avc1.42E01E,mp4a.40.2\"'))",
+        // VP9
+        @"String(ManagedMediaSource.isTypeSupported('video/webm; codecs=\"vp09.00.41.08\"'))",
+        @"String(ManagedMediaSource.isTypeSupported('video/webm; codecs=\"vp09.02.10.10\"'))",
+        @"String(ManagedMediaSource.isTypeSupported('video/webm; codecs=\"vp09.02.10.10.01.09.16.09.01\"'))",
+        @"String(ManagedMediaSource.isTypeSupported('video/webm; codecs=\"vp9\"'))",
+        @"String(ManagedMediaSource.isTypeSupported('video/webm; codecs=\"vp9,opus\"'))",
+        @"String(ManagedMediaSource.isTypeSupported('video/webm; codecs=\"vp09.01.41.08\"'))",
+        @"String(ManagedMediaSource.isTypeSupported('video/webm; codecs=\"vp09.03.41.10\"'))",
+        // Invalid codec strings
+        @"String(ManagedMediaSource.isTypeSupported('video/mp4; codecs=\"avc1.ZZZZZZ\"'))",
+        @"String(ManagedMediaSource.isTypeSupported('video/mp4; codecs=\"notacodec\"'))",
+        @"String(ManagedMediaSource.isTypeSupported('video/webm; codecs=\"vp09.04.41.08\"'))",
+        @"String(ManagedMediaSource.isTypeSupported('video/webm; codecs=\"vp09.00.70.08\"'))",
+    };
+
+    // Create two web views upfront (both before UIProcess cache is populated).
+    auto webView1 = createWebViewWithSeparateProcess();
+    auto webView2 = createWebViewWithSeparateProcess();
+
+    if (![[webView1 objectByEvaluatingJavaScript:@"typeof ManagedMediaSource !== 'undefined'"] boolValue]) {
+        LOG(Media, "Skipping IsTypeSupportedConsistencyAcrossProcesses: ManagedMediaSource not available");
+        return;
+    }
+
+    EXPECT_NE([webView1 _webProcessIdentifier], [webView2 _webProcessIdentifier]);
+
+    // Collect results from both pre-cache processes.
+    Vector<RetainPtr<NSString>> results1;
+    for (auto& js : codecStrings)
+        results1.append([webView1 objectByEvaluatingJavaScript:js.get()]);
+
+    Vector<RetainPtr<NSString>> results2;
+    for (auto& js : codecStrings)
+        results2.append([webView2 objectByEvaluatingJavaScript:js.get()]);
+
+    // Verify pre-cache processes are consistent with each other.
+    for (size_t i = 0; i < codecStrings.size(); i++) {
+        EXPECT_WK_STREQ(results1[i].get(), results2[i].get());
+        if (![results1[i] isEqualToString:results2[i].get()])
+            LOG(Media, "MISMATCH (pre-cache) for %s: process1=%s, process2=%s", [codecStrings[i] UTF8String], [results1[i] UTF8String], [results2[i] UTF8String]);
+    }
+
+    // Allow cache propagation to UIProcess.
+    Util::runFor(0.5_s);
+
+    // Create a third web view after cache is populated.
+    auto webView3 = createWebViewWithSeparateProcess();
+    EXPECT_NE([webView1 _webProcessIdentifier], [webView3 _webProcessIdentifier]);
+
+    Vector<RetainPtr<NSString>> results3;
+    for (auto& js : codecStrings)
+        results3.append([webView3 objectByEvaluatingJavaScript:js.get()]);
+
+    // Verify post-cache process is consistent with pre-cache results.
+    for (size_t i = 0; i < codecStrings.size(); i++) {
+        EXPECT_WK_STREQ(results1[i].get(), results3[i].get());
+        if (![results1[i] isEqualToString:results3[i].get()])
+            LOG(Media, "MISMATCH (post-cache) for %s: process1=%s, process3=%s", [codecStrings[i] UTF8String], [results1[i] UTF8String], [results3[i] UTF8String]);
+    }
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### 877c1eacc4bb0fcb250707f9912a3db08e5ce639
<pre>
MediaSource should actually cache the response
<a href="https://bugs.webkit.org/show_bug.cgi?id=310616">https://bugs.webkit.org/show_bug.cgi?id=310616</a>
<a href="https://rdar.apple.com/173224564">rdar://173224564</a>

Reviewed by Youenn Fablet.

Add thread-safe MediaSourceTypeSupportedCache for MediaSource.isTypeSupported

MediaSource.isTypeSupported() requires a synchronous dispatch to the main
thread when invoked from Worker threads via callOnMainThreadAndWait. This
patch introduces a thread-safe cache that eliminates redundant type-support
queries across threads and processes. On a cache hit, the result is returned
immediately without dispatching to the main thread.

Cache contents are mirrored to the UI process following the existing
setCacheMIMETypesCallback/setMediaMIMETypes pattern: when a WebContent
process discovers a new result, it notifies the UI process via
CacheMediaSourceTypeSupported IPC. The cache is only distributed to
new content process.
New WebContent processes receive the full cache through
WebProcessCreationParameters::mediaSourceTypesSupported.

Add API Tests:
Tools/TestWebKitAPI/Tests/WebKit/is-type-supported-perf.html
Tools/TestWebKitAPI/Tests/WebKitCocoa/MSEIsTypeSupportedCaching.mm
Following this change:
Pre-cache process 1 (PID 19401): cold=22.00 ms, warm=3.00 ms
Pre-cache process 2 (PID 19428): cold=17.00 ms, warm=0.00 ms
Pre-cache process 3 (PID 19435): cold=17.00 ms, warm=2.00 ms
Post-cache process 1 (PID 19438): cold=0.00 ms, warm=1.00 ms
Post-cache process 2 (PID 19440): cold=0.00 ms, warm=1.00 ms
Post-cache process 3 (PID 19445): cold=0.00 ms, warm=1.00 ms
=== IsTypeSupported MP4 Performance Summary ===
  Pre-cache avg cold:  18.67 ms (3 processes)
  Post-cache avg cold: 0.00 ms (3 processes)

* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::isTypeSupported):
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/MediaSourceTypeSupportedCache.cpp: Added.
(WebCore::MediaSourceTypeSupportedCache::singleton):
(WebCore::MediaSourceTypeSupportedCache::lookup const):
(WebCore::MediaSourceTypeSupportedCache::store):
(WebCore::MediaSourceTypeSupportedCache::initialize):
(WebCore::MediaSourceTypeSupportedCache::setCacheUpdateCallback):
* Source/WebCore/platform/graphics/MediaSourceTypeSupportedCache.h: Added.
* Source/WebKit/Shared/WebProcessCreationParameters.h:
* Source/WebKit/Shared/WebProcessCreationParameters.serialization.in:
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::cacheMediaSourceTypeSupported):
(WebKit::WebProcessPool::platformInitializeWebProcess):
* Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm:
(WebKit::WebProcessProxy::mediaMIMETypes):
(WebKit::WebProcessProxy::cacheMediaSourceTypeSupported):
(WebKit::WebProcessProxy::mediaMIMETypes const): Deleted.
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/WebProcessProxy.messages.in:
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::accessibilityFocusedUIElement):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit/is-type-supported-perf.html: Added.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/MSEIsTypeSupportedCaching.mm: Added.
(TestWebKitAPI::createWebViewWithSeparateProcess):
(TestWebKitAPI::runMeasurement):
(TestWebKitAPI::TEST(MediaSource, IsTypeSupportedCachingAcrossProcesses)):
(TestWebKitAPI::TEST(MediaSource, IsTypeSupportedConsistencyAcrossProcesses)):

Canonical link: <a href="https://commits.webkit.org/309981@main">https://commits.webkit.org/309981@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48f6e719a08ee2f2a5ce9d1eac917d73cb0d79bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152386 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25168 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18767 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161129 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/67bd4b99-744b-4faf-935a-be767bc40f90) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154260 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25696 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25474 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117743 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cbeed935-68a2-49e2-b0f8-a81d3b09c981) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155346 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136809 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98456 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2e5f380b-4f1d-4153-bd52-fa350e80c41b) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/19029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/16966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8963 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14683 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163599 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/6741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/16277 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125780 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24966 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/21005 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125951 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34159 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24968 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136479 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/81568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20946 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13258 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24584 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/88870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24275 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24435 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24336 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->