### PR TITLE
[css-values-5 attr()] Invalidate on attribute change

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-invalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-invalidation-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL CSS Values and Units Test: attr() invalidation Error: assert_not_equals: got disallowed value "10px"
+PASS CSS Values and Units Test: attr() invalidation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-null-namespace-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-null-namespace-expected.txt
@@ -3,6 +3,6 @@ Test
 PASS Sanity check
 PASS Attribute in null-namespace is substituted
 PASS Fallback is taken when attribute does not exist in null-namespace
-FAIL Attribute in null-namespace is substituted (JS) assert_equals: expected "value8" but got "fallback"
+PASS Attribute in null-namespace is substituted (JS)
 PASS Fallback is taken when attribute does not does exist in null-namespace (JS)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-pseudo-elem-invalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-pseudo-elem-invalidation-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL CSS Values and Units Test: attr() invalidation of pseudo elements assert_not_equals: Change of attribute value should lead to invalidation of ::after element style. got disallowed value "24px"
-FAIL CSS Values and Units Test: attr() invalidation of pseudo elements 1 assert_not_equals: Change of attribute value should lead to invalidation of ::backdrop element style. got disallowed value "24px"
-FAIL CSS Values and Units Test: attr() invalidation of pseudo elements 2 assert_not_equals: Change of attribute value should lead to invalidation of ::before element style. got disallowed value "24px"
-FAIL CSS Values and Units Test: attr() invalidation of pseudo elements 3 assert_not_equals: Change of attribute value should lead to invalidation of ::first-letter element style. got disallowed value "24px"
-FAIL CSS Values and Units Test: attr() invalidation of pseudo elements 4 assert_not_equals: Change of attribute value should lead to invalidation of ::first-line element style. got disallowed value "24px"
-FAIL CSS Values and Units Test: attr() invalidation of pseudo elements 5 assert_not_equals: Change of attribute value should lead to invalidation of ::selection element style. got disallowed value "24px"
+PASS CSS Values and Units Test: attr() invalidation of pseudo elements
+PASS CSS Values and Units Test: attr() invalidation of pseudo elements 1
+PASS CSS Values and Units Test: attr() invalidation of pseudo elements 2
+PASS CSS Values and Units Test: attr() invalidation of pseudo elements 3
+PASS CSS Values and Units Test: attr() invalidation of pseudo elements 4
+PASS CSS Values and Units Test: attr() invalidation of pseudo elements 5
 

--- a/Source/WebCore/style/AttributeChangeInvalidation.cpp
+++ b/Source/WebCore/style/AttributeChangeInvalidation.cpp
@@ -58,7 +58,7 @@ void AttributeChangeInvalidation::invalidateStyle(const QualifiedName& attribute
             mayAffectStyleInShadowTree = true;
         if (features.attributesAffectingHost.contains(attributeNameForLookups))
             shouldInvalidateCurrent = true;
-        else if (features.contentAttributeNamesInRules.contains(attributeNameForLookups))
+        else if (features.substitutionAttributeNamesInRules.contains(attributeNameForLookups))
             shouldInvalidateCurrent = true;
     });
 

--- a/Source/WebCore/style/RuleFeature.cpp
+++ b/Source/WebCore/style/RuleFeature.cpp
@@ -588,7 +588,7 @@ void RuleFeatureSet::add(const RuleFeatureSet& other)
     idsMatchingAncestorsInRules.addAll(other.idsMatchingAncestorsInRules);
     attributeLowercaseLocalNamesInRules.addAll(other.attributeLowercaseLocalNamesInRules);
     attributeLocalNamesInRules.addAll(other.attributeLocalNamesInRules);
-    contentAttributeNamesInRules.addAll(other.contentAttributeNamesInRules);
+    substitutionAttributeNamesInRules.addAll(other.substitutionAttributeNamesInRules);
 
     auto addMap = [&](auto& map, auto& otherMap) {
         for (auto& keyValuePair : otherMap) {
@@ -621,9 +621,9 @@ void RuleFeatureSet::add(const RuleFeatureSet& other)
     hasStartingStyleRules = hasStartingStyleRules || other.hasStartingStyleRules;
 }
 
-void RuleFeatureSet::registerContentAttribute(const AtomString& attributeName)
+void RuleFeatureSet::registerSubstitutionAttribute(const AtomString& attributeName)
 {
-    contentAttributeNamesInRules.add(attributeName.convertToASCIILowercase());
+    substitutionAttributeNamesInRules.add(attributeName.convertToASCIILowercase());
     attributeLowercaseLocalNamesInRules.add(attributeName);
     attributeLocalNamesInRules.add(attributeName);
 }
@@ -634,7 +634,7 @@ void RuleFeatureSet::clear()
     idsMatchingAncestorsInRules.clear();
     attributeLowercaseLocalNamesInRules.clear();
     attributeLocalNamesInRules.clear();
-    contentAttributeNamesInRules.clear();
+    substitutionAttributeNamesInRules.clear();
     idRules.clear();
     classRules.clear();
     hasPseudoClassRules.clear();

--- a/Source/WebCore/style/RuleFeature.h
+++ b/Source/WebCore/style/RuleFeature.h
@@ -125,7 +125,7 @@ struct RuleFeatureSet {
         HashSet<GenericHashKey<SelectorDeduplicationKey>> selectorDeduplicationSet;
     };
     void collectFeatures(CollectionContext&, const RuleData&, const Vector<Ref<const StyleRuleScope>>& scopeRules = { });
-    void registerContentAttribute(const AtomString&);
+    void registerSubstitutionAttribute(const AtomString&);
 
     bool usesHasPseudoClass() const;
     bool usesMatchElement(MatchElement matchElement) const { return usedMatchElements[std::to_underlying(matchElement)]; }
@@ -135,7 +135,7 @@ struct RuleFeatureSet {
     HashSet<AtomString> idsMatchingAncestorsInRules;
     HashSet<AtomString> attributeLowercaseLocalNamesInRules;
     HashSet<AtomString> attributeLocalNamesInRules;
-    HashSet<AtomString> contentAttributeNamesInRules;
+    HashSet<AtomString> substitutionAttributeNamesInRules;
 
     HashMap<AtomString, std::unique_ptr<RuleFeatureVector>> idRules;
     HashMap<AtomString, std::unique_ptr<RuleFeatureVector>> classRules;

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -141,10 +141,9 @@ RefPtr<Image> BuilderState::createStyleImage(const CSSValue& value) const
     return nullptr;
 }
 
-void BuilderState::registerContentAttribute(const AtomString& attributeLocalName)
+void BuilderState::registerSubstitutionAttribute(const AtomString& attributeLocalName)
 {
-    if (style().pseudoElementType() == PseudoElementType::Before || style().pseudoElementType() == PseudoElementType::After)
-        m_registeredContentAttributes.append(attributeLocalName);
+    m_registeredSubstitutionAttributes.append(attributeLocalName);
 }
 
 void BuilderState::adjustStyleForInterCharacterRuby()

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -145,8 +145,8 @@ public:
 
     RefPtr<Image> createStyleImage(const CSSValue&) const;
 
-    const Vector<AtomString>& registeredContentAttributes() const LIFETIME_BOUND { return m_registeredContentAttributes; }
-    void registerContentAttribute(const AtomString& attributeLocalName);
+    const Vector<AtomString>& registeredSubstitutionAttributes() const LIFETIME_BOUND { return m_registeredSubstitutionAttributes; }
+    void registerSubstitutionAttribute(const AtomString& attributeLocalName);
 
     const CSSToLengthConversionData& cssToLengthConversionData() const LIFETIME_BOUND { return m_cssToLengthConversionData; }
 
@@ -262,7 +262,7 @@ private:
     const PropertyCascade* m_currentRollbackCascade { nullptr };
 
     bool m_fontDirty { false };
-    Vector<AtomString> m_registeredContentAttributes;
+    Vector<AtomString> m_registeredSubstitutionAttributes;
 
     bool m_isBuildingKeyframeStyle { false };
     bool m_hasRevertRuleOrLayerInKeyframeStyle { false };

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -772,8 +772,8 @@ void Resolver::applyMatchedProperties(State& state, const MatchResult& matchResu
 void Resolver::setGlobalStateAfterApplyingProperties(const BuilderState& builderState)
 {
     // FIXME: This stuff should be somewhere else.
-    for (auto& contentAttribute : builderState.registeredContentAttributes())
-        ruleSets().mutableFeatures().registerContentAttribute(contentAttribute);
+    for (auto& attribute : builderState.registeredSubstitutionAttributes())
+        ruleSets().mutableFeatures().registerSubstitutionAttribute(attribute);
     if (builderState.style().usesViewportUnits())
         document().setHasStyleWithViewportUnits();
 }

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -240,7 +240,7 @@ bool SubstitutionResolver::substituteAttrFunction(CSSParserTokenRange range, Vec
     };
     auto fallbackRange = consumeFallbackRange();
 
-    m_styleBuilder.state().registerContentAttribute(attributeName);
+    m_styleBuilder.state().registerSubstitutionAttribute(attributeName);
     protect(m_styleBuilder.state().style())->setHasAttrContent();
 
     CheckedPtr element = m_styleBuilder.state().element();

--- a/Source/WebCore/style/values/content/StyleContent.cpp
+++ b/Source/WebCore/style/values/content/StyleContent.cpp
@@ -79,7 +79,7 @@ auto CSSValueConversion<Content>::operator()(BuilderState& state, const CSSValue
         const AtomString& attributeValue = element ? element->getAttribute(attr) : nullAtom();
 
         // Register the fact that the attribute value affects the style.
-        state.registerContentAttribute(attr.localName());
+        state.registerSubstitutionAttribute(attr.localName());
 
         if (attributeValue.isNull()) {
             RefPtr fallback = dynamicDowncast<CSSPrimitiveValue>(value.fallback());


### PR DESCRIPTION
#### 94d12232a351d3e181fd8fa0f467d16213bea40f
<pre>
[css-values-5 attr()] Invalidate on attribute change
<a href="https://bugs.webkit.org/show_bug.cgi?id=310710">https://bugs.webkit.org/show_bug.cgi?id=310710</a>
<a href="https://rdar.apple.com/173322919">rdar://173322919</a>

Reviewed by Sam Weinig.

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-invalidation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-null-namespace-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-pseudo-elem-invalidation-expected.txt:
* Source/WebCore/style/AttributeChangeInvalidation.cpp:
(WebCore::Style::AttributeChangeInvalidation::invalidateStyle):
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::RuleFeatureSet::add):
(WebCore::Style::RuleFeatureSet::registerSubstitutionAttribute):
(WebCore::Style::RuleFeatureSet::clear):
(WebCore::Style::RuleFeatureSet::registerContentAttribute): Deleted.

Change the names to not be just about `content` property anymore.

* Source/WebCore/style/RuleFeature.h:
* Source/WebCore/style/StyleBuilderState.cpp:
(WebCore::Style::BuilderState::registerSubstitutionAttribute):

Register unconditionally, not just for ::before/::after.

(WebCore::Style::BuilderState::registerContentAttribute): Deleted.
* Source/WebCore/style/StyleBuilderState.h:
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::setGlobalStateAfterApplyingProperties):
* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::SubstitutionResolver::substituteAttrFunction):
* Source/WebCore/style/values/content/StyleContent.cpp:
(WebCore::Style::CSSValueConversion&lt;Content&gt;::operator):

Canonical link: <a href="https://commits.webkit.org/309934@main">https://commits.webkit.org/309934@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d4c887c178409721ec215cad2175cdbc2f35ad6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152154 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24936 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18527 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160897 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105611 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154028 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25428 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25242 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117547 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83368 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155114 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19732 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136582 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98260 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18809 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16764 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8731 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14459 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163363 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6509 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16051 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/api/crashtests/huge-fetch.any.sharedworker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125574 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24734 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20806 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125750 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34126 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24735 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136255 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81329 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20760 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13032 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24352 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88637 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24043 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24203 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24104 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->