### PR TITLE
[CSS JIT] Compile :first-of-type pseudo-class

### DIFF
--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -551,6 +551,7 @@ private:
     void generateElementIsActive(Assembler::JumpList& failureCases, const SelectorFragment&);
     void generateElementIsEmpty(Assembler::JumpList& failureCases);
     void generateElementIsFirstChild(Assembler::JumpList& failureCases);
+    void generateElementIsFirstOfType(Assembler::JumpList& failureCases, const SelectorFragment&);
     void generateElementIsHovered(Assembler::JumpList& failureCases, const SelectorFragment&);
     void generateElementMatchesDir(Assembler::JumpList& failureCases, const SelectorFragment&);
     void generateElementIsInLanguage(Assembler::JumpList& failureCases, const SelectorFragment&);
@@ -1292,8 +1293,13 @@ static inline FunctionType addPseudoClassType(const CSSSelector& selector, Selec
     case CSSSelector::PseudoClass::CornerPresent:
         return FunctionType::CannotMatchAnything;
 
-    // FIXME: Compile these pseudoclasses, too!
     case CSSSelector::PseudoClass::FirstOfType:
+        fragment.pseudoClasses.add(type);
+        if (selectorContext == SelectorContext::QuerySelector)
+            return FunctionType::SimpleSelectorChecker;
+        return FunctionType::SelectorCheckerWithCheckingContext;
+
+    // FIXME: Compile these pseudoclasses, too!
     case CSSSelector::PseudoClass::LastOfType:
     case CSSSelector::PseudoClass::OnlyOfType:
     case CSSSelector::PseudoClass::NthOfType:
@@ -1723,6 +1729,8 @@ static const unsigned minimumRequiredRegisterCountForAttributeFilter = 6;
 // On other architectures, we need 6 registers for style resolution:
 //     Element + elementCounter + previousSibling + checkingContext + lastRelation + nextSiblingElement.
 static const unsigned minimumRequiredRegisterCountForNthChildFilter = 6;
+// Element + currentLocalName + currentNamespace + isFirstOfTypeRegister + previousSibling + siblingImpl + siblingLocalName.
+static const unsigned minimumRequiredRegisterCountForOfTypeFilter = 7;
 
 static unsigned minimumRegisterRequirements(const SelectorFragment& selectorFragment)
 {
@@ -1747,6 +1755,9 @@ static unsigned minimumRegisterRequirements(const SelectorFragment& selectorFrag
 
     if (!selectorFragment.nthChildFilters.isEmpty() || !selectorFragment.nthChildOfFilters.isEmpty() || !selectorFragment.nthLastChildFilters.isEmpty() || !selectorFragment.nthLastChildOfFilters.isEmpty())
         minimum = std::max(minimum, minimumRequiredRegisterCountForNthChildFilter);
+
+    if (selectorFragment.pseudoClasses.contains(CSSSelector::PseudoClass::FirstOfType))
+        minimum = std::max(minimum, minimumRequiredRegisterCountForOfTypeFilter);
 
     // :any pseudo class filters cause some register pressure.
     for (const auto& subFragments : selectorFragment.anyFilters) {
@@ -3218,6 +3229,8 @@ void SelectorCodeGenerator::generateElementMatching(Assembler::JumpList& matchin
         generateElementHasPlaceholderShown(matchingPostTagNameFailureCases);
     if (fragment.pseudoClasses.contains(CSSSelector::PseudoClass::FirstChild))
         generateElementIsFirstChild(matchingPostTagNameFailureCases);
+    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClass::FirstOfType))
+        generateElementIsFirstOfType(matchingPostTagNameFailureCases, fragment);
     if (fragment.pseudoClasses.contains(CSSSelector::PseudoClass::LastChild))
         generateElementIsLastChild(matchingPostTagNameFailureCases);
     if (!fragment.nthChildFilters.isEmpty())
@@ -3859,6 +3872,61 @@ void SelectorCodeGenerator::generateElementIsFirstChild(Assembler::JumpList& fai
     failureCases.append(m_assembler.branchTest32(Assembler::NonZero, isFirstChildRegister));
 
     successCase.link(&m_assembler);
+}
+
+void SelectorCodeGenerator::generateElementIsFirstOfType(Assembler::JumpList& failureCases, const SelectorFragment& fragment)
+{
+    LocalRegister qualifiedNameImpl(m_registerAllocator);
+    m_assembler.loadPtr(Assembler::Address(elementAddressRegister, Element::tagQNameMemoryOffset() + QualifiedName::implMemoryOffset()), qualifiedNameImpl);
+
+    LocalRegister currentLocalName(m_registerAllocator);
+    m_assembler.loadPtr(Assembler::Address(qualifiedNameImpl, QualifiedName::QualifiedNameImpl::localNameMemoryOffset()), currentLocalName);
+
+    m_assembler.load8(Assembler::Address(qualifiedNameImpl, QualifiedName::QualifiedNameImpl::namespaceMemoryOffset()), qualifiedNameImpl);
+    auto& currentNamespace = qualifiedNameImpl;
+
+    LocalRegister isFirstOfTypeRegister(m_registerAllocator);
+    m_assembler.move(Assembler::TrustedImm32(0), isFirstOfTypeRegister);
+
+    {
+        LocalRegister previousSibling(m_registerAllocator);
+        m_assembler.move(elementAddressRegister, previousSibling);
+
+        Assembler::Label loopStart = m_assembler.label();
+        m_assembler.loadPtr(Assembler::Address(previousSibling, Node::previousSiblingMemoryOffset()), previousSibling);
+        Assembler::Jump noMoreSiblings = m_assembler.branchTestPtr(Assembler::Zero, previousSibling);
+
+        DOMJIT::branchTestIsElementFlagOnNode(m_assembler, Assembler::Zero, previousSibling).linkTo(loopStart, &m_assembler);
+
+        {
+            LocalRegister siblingImpl(m_registerAllocator);
+            m_assembler.loadPtr(Assembler::Address(previousSibling, Element::tagQNameMemoryOffset() + QualifiedName::implMemoryOffset()), siblingImpl);
+
+            LocalRegister siblingLocalName(m_registerAllocator);
+            m_assembler.loadPtr(Assembler::Address(siblingImpl, QualifiedName::QualifiedNameImpl::localNameMemoryOffset()), siblingLocalName);
+            m_assembler.branchPtr(Assembler::NotEqual, siblingLocalName, currentLocalName).linkTo(loopStart, &m_assembler);
+
+            m_assembler.load8(Assembler::Address(siblingImpl, QualifiedName::QualifiedNameImpl::namespaceMemoryOffset()), siblingLocalName);
+            m_assembler.branch32(Assembler::NotEqual, siblingLocalName, currentNamespace).linkTo(loopStart, &m_assembler);
+        }
+
+        m_assembler.move(Assembler::TrustedImm32(1), isFirstOfTypeRegister);
+
+        noMoreSiblings.link(&m_assembler);
+    }
+
+    Assembler::JumpList notElementCases;
+    LocalRegister parentElement(m_registerAllocator);
+    generateWalkToParentElement(notElementCases, parentElement);
+
+    auto relation = fragmentMatchesRightmostOrAdjacentElement(fragment)
+        ? Style::Relation::ChildrenAffectedByForwardPositionalRules
+        : Style::Relation::DescendantsAffectedByForwardPositionalRules;
+    generateAddStyleRelationIfResolvingStyle(parentElement, relation);
+
+    notElementCases.link(&m_assembler);
+
+    failureCases.append(m_assembler.branchTest32(Assembler::NonZero, isFirstOfTypeRegister));
 }
 
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationElementIsHovered, bool, (const Element* element))


### PR DESCRIPTION
#### 6602ea3b4a05
<pre>
[CSS JIT] Compile :first-of-type pseudo-class
<a href="https://bugs.webkit.org/show_bug.cgi?id=310712">https://bugs.webkit.org/show_bug.cgi?id=310712</a>
<a href="https://rdar.apple.com/problem/173326949">rdar://problem/173326949</a>

Reviewed by NOBODY (OOPS!).

Add JIT compilation support for :first-of-type. Previously, any
selector containing :first-of-type fell back to the interpreter.

The justification for why :first-of-type compilation requires more
registers is that it must load and hold both the localName and
namespace from the current element&apos;s QualifiedNameImpl. It must
then compare each sibling&apos;s type identity. Type identity,
in this context, is the pair (localName, namespaceURI)

In practice, we can compare QualifiedNameImpl*, which uses fewer
registers. However, these pointers differ when elements have
different prefixes (e.g., &lt;p&gt; vs &lt;html:p&gt;), even though they
represent the same type.

* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::addPseudoClassType):
(WebCore::SelectorCompiler::minimumRegisterRequirements):
(WebCore::SelectorCompiler::SelectorCodeGenerator::generateElementMatching):
(WebCore::SelectorCompiler::SelectorCodeGenerator::generateElementIsFirstOfType):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6602ea3b4a0582011aa1e3656713bf0ed7adb96b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152650 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25432 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19031 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161395 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106107 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1e5e2ae4-a29e-40cd-92a6-3866ed4a9cd1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154524 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25960 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25738 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117957 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83580 "2 flakes 2 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/34efd657-2daa-4233-8dd2-8f19656d302c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155610 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20178 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137034 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98669 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7673fc12-2c04-4098-b53d-775bdfc63d6a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19253 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17195 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9229 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128903 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14908 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163866 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7005 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16502 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126012 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25230 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21234 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126173 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25232 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136704 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81835 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21138 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13483 "Too many flaky failures: fast/text/zero-height-first-line-assert.html, http/tests/cookies/same-site/popup-cross-site-from-cross-origin-iframe.html, http/tests/media/clearkey/clear-key-hls-aes128.html, http/tests/misc/mask-image-accept.html, http/tests/navigation/page-cache-requestAnimationFrame.html, http/tests/resourceLoadStatistics/do-not-capture-statistics-for-simple-top-navigations.html, http/tests/security/cached-cross-origin-preloaded-css-stylesheet.html, http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py, http/tests/security/contentSecurityPolicy/meta-tag-ignored-if-not-in-head2.html, http/tests/security/mixedContent/insecure-image-in-iframe-UpgradeMixedContent.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24848 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89134 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24540 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24699 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24600 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->