### PR TITLE
Replace HAVE_DC_ISSUER_IDENTIFIER_SUPPORT with relevant canImport condition instead

### DIFF
--- a/Source/WebKit/WebKitSwift/IdentityDocumentServices/ISO18013MobileDocumentRequest+Extras.swift
+++ b/Source/WebKit/WebKitSwift/IdentityDocumentServices/ISO18013MobileDocumentRequest+Extras.swift
@@ -34,7 +34,7 @@ extension ISO18013MobileDocumentRequest.ElementInfo {
 
 extension ISO18013MobileDocumentRequest.DocumentRequest {
     init(_ source: WKIdentityDocumentPresentmentMobileDocumentIndividualDocumentRequest) {
-        #if HAVE_DC_ISSUER_IDENTIFIER_SUPPORT
+        #if canImport(IdentityDocumentServices, _version: 9.22.2)
         self = .init(
             documentType: source.documentType,
             namespaces: source.namespaces.mapValues {

--- a/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentMobileDocumentRequest+Extras.swift
+++ b/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentMobileDocumentRequest+Extras.swift
@@ -34,7 +34,7 @@ extension WKIdentityDocumentPresentmentMobileDocumentElementInfo {
 
 extension WKIdentityDocumentPresentmentMobileDocumentIndividualDocumentRequest {
     convenience init(_ source: ISO18013MobileDocumentRequest.DocumentRequest) {
-        #if HAVE_DC_ISSUER_IDENTIFIER_SUPPORT
+        #if canImport(IdentityDocumentServices, _version: 9.22.2)
         self.init(
             documentType: source.documentType,
             namespaces: source.namespaces.mapValues {


### PR DESCRIPTION
#### 5c47ee43ba73f3b00046dcc6bdd6212ad06e6296
<pre>
Replace HAVE_DC_ISSUER_IDENTIFIER_SUPPORT with relevant canImport condition instead
<a href="https://bugs.webkit.org/show_bug.cgi?id=310716">https://bugs.webkit.org/show_bug.cgi?id=310716</a>
<a href="https://rdar.apple.com/173331794">rdar://173331794</a>

Reviewed by Abrar Rahman Protyasha.

Rather than having a new compile time flag introduced, we should just leverage canImport with a version instead.

* Source/WebKit/WebKitSwift/IdentityDocumentServices/ISO18013MobileDocumentRequest+Extras.swift:
* Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentMobileDocumentRequest+Extras.swift:

Canonical link: <a href="https://commits.webkit.org/310264@main">https://commits.webkit.org/310264@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0375dced7f9b596472ecaecc8e762a32ebd5b4c2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153252 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26034 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19632 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161997 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106710 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/da96cb07-fb0f-400a-9951-27b06cfa3e41) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26561 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26339 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118477 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3604d103-62b8-4886-98db-35924404a7c7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156211 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20713 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137594 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99190 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c5e54f7b-083f-4af1-a9ca-294f43b24205) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19789 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9832 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129439 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164471 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7606 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17057 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126536 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25831 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21773 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/semantics/structured-clone/shared.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126694 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34375 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25833 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137259 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/82502 "The change is no longer eligible for processing.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21641 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14038 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25451 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89736 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25142 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25301 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25201 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->