### PR TITLE
Enhanced <select>: correct <option> outline

### DIFF
--- a/LayoutTests/fast/forms/select/base/option-focus-visible-outline-offset-expected.txt
+++ b/LayoutTests/fast/forms/select/base/option-focus-visible-outline-offset-expected.txt
@@ -1,0 +1,16 @@
+Tests that option elements in a base-select have a negative outline-offset equal to the outline width when focus-visible.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS outlineOffset == "-3px" || outlineOffset == "-2px" is true
+PASS getComputedStyle(opt1).outlineOffset is "0px"
+PASS getComputedStyle(opt1).outlineOffset is "0px"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+Option 1
+Option 2
+Option 3
+

--- a/LayoutTests/fast/forms/select/base/option-focus-visible-outline-offset.html
+++ b/LayoutTests/fast/forms/select/base/option-focus-visible-outline-offset.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/js-test.js"></script>
+<script src="../../../../resources/ui-helper.js"></script>
+<style>
+select, ::picker(select) {
+    appearance: base-select;
+}
+</style>
+</head>
+<body>
+<select id="select">
+    <option id="opt1">Option 1</option>
+    <option id="opt2">Option 2</option>
+    <option id="opt3">Option 3</option>
+</select>
+<script>
+description("Tests that option elements in a base-select have a negative outline-offset equal to the outline width when focus-visible.");
+
+jsTestIsAsync = true;
+
+(async () => {
+    const select = document.getElementById("select");
+    const opt1 = document.getElementById("opt1");
+
+    // Open the picker via keyboard (Space) to trigger focus-visible on the option.
+    select.focus();
+    await UIHelper.keyDown(" ");
+    await UIHelper.animationFrame();
+
+    window.outlineOffset = getComputedStyle(opt1).outlineOffset;
+    shouldBeTrue('outlineOffset == "-3px" || outlineOffset == "-2px"');
+
+    // Close the picker — option should not have focus-visible outline.
+    await UIHelper.keyDown("\x1B");
+    await UIHelper.animationFrame();
+
+    shouldBe('getComputedStyle(opt1).outlineOffset', '"0px"');
+
+    // Open via mouse click — option should not have focus-visible outline.
+    await UIHelper.activateElement(select);
+    await UIHelper.animationFrame();
+
+    shouldBe('getComputedStyle(opt1).outlineOffset', '"0px"');
+
+    finishJSTest();
+})();
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/select/base/option-internal-inset-outline-offset-expected.txt
+++ b/LayoutTests/fast/forms/select/base/option-internal-inset-outline-offset-expected.txt
@@ -1,0 +1,14 @@
+Tests that -internal-inset outline-offset resolves correctly with various outline widths, styles, and zoom.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS defaultOffset == "-3px" || defaultOffset == "-2px" is true
+PASS actualOffset is "-2px"
+PASS actualOffset is "-10px"
+PASS zoomedOffset == "-3px" || zoomedOffset == "-2px" is true
+PASS actualOffset is "-5px"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/select/base/option-internal-inset-outline-offset.html
+++ b/LayoutTests/fast/forms/select/base/option-internal-inset-outline-offset.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/js-test.js"></script>
+<script src="../../../../resources/ui-helper.js"></script>
+<style>
+select, ::picker(select) {
+    appearance: base-select;
+}
+</style>
+</head>
+<body>
+<select id="default"><option id="default-opt">Default</option><option>Other</option></select>
+<select id="solid"><option id="solid-opt">Solid</option><option>Other</option></select>
+<select id="wide"><option id="wide-opt">Wide</option><option>Other</option></select>
+<select id="zoomed"><option id="zoomed-opt">Zoomed</option><option>Other</option></select>
+<select id="solid-zoomed"><option id="solid-zoomed-opt">Solid zoomed</option><option>Other</option></select>
+
+<style>
+#solid-opt { outline-style: solid; outline-width: 2px; }
+#wide-opt { outline-style: solid; outline-width: 10px; }
+#zoomed-opt { zoom: 2; }
+#solid-zoomed-opt { outline-style: solid; outline-width: 5px; zoom: 2; }
+</style>
+
+<script>
+description("Tests that -internal-inset outline-offset resolves correctly with various outline widths, styles, and zoom.");
+
+jsTestIsAsync = true;
+
+async function openAndCheck(selectId, optId, expectedOffset) {
+    const select = document.getElementById(selectId);
+    const opt = document.getElementById(optId);
+
+    select.focus();
+    await UIHelper.keyDown(" ");
+    await UIHelper.animationFrame();
+
+    window.actualOffset = getComputedStyle(opt).outlineOffset;
+    window.expectedOffset = expectedOffset;
+    shouldBeEqualToString('actualOffset', expectedOffset);
+
+    await UIHelper.keyDown("\x1B");
+    await UIHelper.animationFrame();
+}
+
+(async () => {
+    // Default: outline-style: auto, platform focus ring width (3px Mac, 2px Adwaita).
+    const defaultOpt = document.getElementById("default-opt");
+    document.getElementById("default").focus();
+    await UIHelper.keyDown(" ");
+    await UIHelper.animationFrame();
+    window.defaultOffset = getComputedStyle(defaultOpt).outlineOffset;
+    shouldBeTrue('defaultOffset == "-3px" || defaultOffset == "-2px"');
+    await UIHelper.keyDown("\x1B");
+    await UIHelper.animationFrame();
+
+    // Solid 2px: offset should be -2px.
+    await openAndCheck("solid", "solid-opt", "-2px");
+
+    // Solid 10px: offset should be -10px.
+    await openAndCheck("wide", "wide-opt", "-10px");
+
+    // Auto with zoom: 2, computed value is pre-zoom.
+    const zoomedOpt = document.getElementById("zoomed-opt");
+    document.getElementById("zoomed").focus();
+    await UIHelper.keyDown(" ");
+    await UIHelper.animationFrame();
+    window.zoomedOffset = getComputedStyle(zoomedOpt).outlineOffset;
+    shouldBeTrue('zoomedOffset == "-3px" || zoomedOffset == "-2px"');
+    await UIHelper.keyDown("\x1B");
+    await UIHelper.animationFrame();
+
+    // Solid 5px with zoom: 2, computed value is pre-zoom.
+    await openAndCheck("solid-zoomed", "solid-zoomed-opt", "-5px");
+
+    finishJSTest();
+})();
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/ios/fast/forms/select/base/option-focus-visible-outline-offset-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/select/base/option-focus-visible-outline-offset-expected.txt
@@ -1,0 +1,17 @@
+Tests that option elements in a base-select have a negative outline-offset equal to the outline width when focus-visible.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+FAIL outlineOffset == "-3px" || outlineOffset == "-2px" should be true. Was false.
+PASS getComputedStyle(opt1).outlineOffset is "0px"
+PASS getComputedStyle(opt1).outlineOffset is "0px"
+PASS successfullyParsed is true
+Some tests failed.
+
+TEST COMPLETE
+
+Option 1
+Option 2
+Option 3
+

--- a/LayoutTests/platform/ios/fast/forms/select/base/option-internal-inset-outline-offset-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/select/base/option-internal-inset-outline-offset-expected.txt
@@ -1,0 +1,15 @@
+Tests that -internal-inset outline-offset resolves correctly with various outline widths, styles, and zoom.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+FAIL defaultOffset == "-3px" || defaultOffset == "-2px" should be true. Was false.
+FAIL actualOffset should be -2px. Was 0px.
+FAIL actualOffset should be -10px. Was 0px.
+FAIL zoomedOffset == "-3px" || zoomedOffset == "-2px" should be true. Was false.
+FAIL actualOffset should be -5px. Was 0px.
+PASS successfullyParsed is true
+Some tests failed.
+
+TEST COMPLETE
+

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3333,6 +3333,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/non-standard/StyleWebKitTextStrokeWidth.h
     style/values/non-standard/StyleWebKitTouchCallout.h
 
+    style/values/outline/StyleOutlineOffset.h
+
     style/values/overflow/StyleBlockEllipsis.h
     style/values/overflow/StyleMaximumLines.h
     style/values/overflow/StyleOverflowClipMargin.h

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -7037,14 +7037,20 @@
         "outline-offset": {
             "animation-type": "by computed value",
             "initial": "0px",
+            "values": [
+                {
+                	"value": "-internal-inset",
+                	"status": "internal"
+                }
+            ],
             "codegen-properties": {
-                "computed-style-initial-constexpr": true,
                 "computed-style-storage-path": ["m_nonInheritedData", "backgroundData", "outline"],
                 "computed-style-storage-container": "struct",
                 "computed-style-storage-kind": "reference",
-                "computed-style-type": "Style::Length<>",
+                "computed-style-type": "Style::OutlineOffset",
                 "skip-render-style-getter": true,
-                "parser-grammar": "<length>"
+                "style-extractor-custom": true,
+                "parser-grammar": "<length> | <<values>>"
             },
             "specification": {
                 "category": "css-ui",

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -1849,6 +1849,9 @@ allow-discrete
 // inline
 -internal-textarea-auto
 
+// outline-offset
+-internal-inset
+
 // CSS Anchor Positioning
 anchor
 anchor-size

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -1185,6 +1185,10 @@ select option:disabled {
     color: color-mix(currentColor 50%, transparent);
 }
 
+select option:focus-visible {
+    outline-offset: -internal-inset;
+}
+
 select option::checkmark {
     content: "\2713" / "";
 }

--- a/Source/WebCore/rendering/style/OutlineValue.h
+++ b/Source/WebCore/rendering/style/OutlineValue.h
@@ -28,13 +28,14 @@
 #include <WebCore/RenderStyleConstants.h>
 #include <WebCore/StyleColor.h>
 #include <WebCore/StyleLineWidth.h>
+#include <WebCore/StyleOutlineOffset.h>
 
 namespace WebCore {
 
 struct OutlineValue {
     Style::Color outlineColor { Style::Color::currentColor() };
     Style::LineWidth outlineWidth { Style::LineWidth::Length { 3.0f } };
-    Style::Length<> outlineOffset { 0 };
+    Style::OutlineOffset outlineOffset { Style::Length<> { 0.0f } };
     PREFERRED_TYPE(OutlineStyle) unsigned outlineStyle : 4 { static_cast<unsigned>(OutlineStyle::None) };
 
     bool isVisible() const;

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -402,7 +402,10 @@ Style::LineWidth RenderStyle::usedColumnRuleWidth() const
 
 Style::Length<> RenderStyle::usedOutlineOffset() const
 {
-    return m_computedStyle.outline().outlineOffset;
+    auto& outline = m_computedStyle.outline();
+    if (outline.outlineOffset.isInternalInset())
+        return Style::Length<> { -Style::evaluate<float>(usedOutlineWidth(), Style::ZoomNeeded { }) };
+    return *outline.outlineOffset.tryLength();
 }
 
 Style::LineWidth RenderStyle::usedOutlineWidth() const

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -144,6 +144,7 @@ inline OffsetDistance forwardInheritedValue(const OffsetDistance& value) { auto 
 inline OffsetPath forwardInheritedValue(const OffsetPath& value) { auto copy = value; return copy; }
 inline OffsetPosition forwardInheritedValue(const OffsetPosition& value) { auto copy = value; return copy; }
 inline OffsetRotate forwardInheritedValue(const OffsetRotate& value) { auto copy = value; return copy; }
+inline OutlineOffset forwardInheritedValue(const OutlineOffset& value) { auto copy = value; return copy; }
 inline OverflowClipMargin forwardInheritedValue(const OverflowClipMargin& value) { auto copy = value; return copy; }
 inline Position forwardInheritedValue(const Position& value) { auto copy = value; return copy; }
 inline PositionAnchor forwardInheritedValue(const PositionAnchor& value) { auto copy = value; return copy; }

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -129,6 +129,7 @@ public:
     static Ref<CSSValue> extractWebkitMaskSourceType(ExtractorState&);
     static Ref<CSSValue> extractColor(ExtractorState&);
     static Ref<CSSValue> extractCaretColor(ExtractorState&);
+    static RefPtr<CSSValue> extractOutlineOffset(ExtractorState&);
 
     // MARK: Shorthands
 
@@ -227,6 +228,7 @@ public:
     static void extractWebkitMaskSourceTypeSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractColorSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractCaretColorSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
+    static void extractOutlineOffsetSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
 
     static void extractAnimationShorthandSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractAnimationRangeShorthandSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
@@ -2412,6 +2414,16 @@ inline void ExtractorCustom::extractCaretColorSerialization(ExtractorState& stat
         return;
     }
     extractSerialization<CSSPropertyCaretColor>(state, builder, context);
+}
+
+inline RefPtr<CSSValue> ExtractorCustom::extractOutlineOffset(ExtractorState& state)
+{
+    return createCSSValue(state.pool, state.style, state.style.usedOutlineOffset());
+}
+
+inline void ExtractorCustom::extractOutlineOffsetSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context)
+{
+    serializationForCSS(builder, context, state.style, state.style.usedOutlineOffset());
 }
 
 // MARK: - Shorthands

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.h
@@ -308,6 +308,7 @@ struct OffsetPosition;
 struct OffsetRotate;
 struct Opacity;
 struct Orphans;
+struct OutlineOffset;
 struct OverflowClipMargin;
 struct PaddingEdge;
 struct PageSize;

--- a/Source/WebCore/style/values/StyleValueTypes.h
+++ b/Source/WebCore/style/values/StyleValueTypes.h
@@ -1240,6 +1240,24 @@ template<typename... StyleTypes> struct Blending<Variant<StyleTypes...>> {
     }
 };
 
+// Specialization for `ValueOrKeyword`.
+template<ValueOrKeywordDerived T> struct Blending<T> {
+    auto canBlend(const T& a, const T& b) -> bool
+    {
+        if (a.isKeyword() != b.isKeyword())
+            return false;
+        if (a.isKeyword())
+            return true;
+        return WebCore::Style::canBlend(*a.tryValue(), *b.tryValue());
+    }
+    auto blend(const T& a, const T& b, const auto& context) -> T
+    {
+        if (a.isKeyword())
+            return context.progress < 0.5 ? a : b;
+        return T { WebCore::Style::blend(*a.tryValue(), *b.tryValue(), context) };
+    }
+};
+
 // Specialization for `SpaceSeparatedVector`.
 template<typename StyleType, size_t inlineCapacity> struct Blending<SpaceSeparatedVector<StyleType, inlineCapacity>> {
     auto equals(const SpaceSeparatedVector<StyleType, inlineCapacity>& a, const SpaceSeparatedVector<StyleType, inlineCapacity>& b) -> bool

--- a/Source/WebCore/style/values/outline/StyleOutlineOffset.h
+++ b/Source/WebCore/style/values/outline/StyleOutlineOffset.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/StylePrimitiveNumeric.h>
+#include <WebCore/StyleValueTypes.h>
+
+namespace WebCore::Style {
+
+// <'outline-offset'> = <length> | -internal-inset
+struct OutlineOffset : ValueOrKeyword<Length<>, CSS::Keyword::InternalInset> {
+    using Base::Base;
+
+    OutlineOffset(CSS::ValueLiteral<CSS::LengthUnit::Px> literal) : Base(Length<> { literal }) { }
+
+    bool isInternalInset() const { return isKeyword(); }
+    std::optional<Length<>> tryLength() const { return tryValue(); }
+};
+
+} // namespace WebCore::Style
+
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::OutlineOffset)


### PR DESCRIPTION
#### 32c2254f39e0d5e781893f478bbc0761b7a1cd29
<pre>
Enhanced &lt;select&gt;: correct &lt;option&gt; outline
<a href="https://bugs.webkit.org/show_bug.cgi?id=310721">https://bugs.webkit.org/show_bug.cgi?id=310721</a>

Reviewed by Antti Koivisto.

Since ::picker(select) has overflow: auto, we need to draw the &lt;option&gt;
outline on the inside. To do this we introduce an -internal-inset value
for outline-offset which we hope to standardize down the line.

We do this by adding a struct for OutlineOffset using the
ValueOrKeyword&lt;&gt; template and add the necessary Blending support.

Not tested via web-platform-tests because this is user-agent-specific.

Canonical link: <a href="https://commits.webkit.org/310364@main">https://commits.webkit.org/310364@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77f50e3150b504be9416e6dd95a09cc550a399f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153621 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26405 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20022 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162371 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107079 "An unexpected error occured. Recent messages:Printed configuration") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cb383e9e-163a-4c83-aecb-765da0320c5f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155494 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26933 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26727 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118773 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/107079 "An unexpected error occured. Recent messages:Printed configuration") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/46c526a9-9045-466e-a28e-e60dca635036) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156580 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21024 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/137930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99484 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b4b58afc-24fe-4aea-83eb-d4c3ad5a0653) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20103 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18048 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10204 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129750 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15790 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164842 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7976 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17384 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126848 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26202 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22082 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127012 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26204 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137585 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82872 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23483 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21925 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14366 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25821 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90108 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25512 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25672 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25572 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->