### PR TITLE
FontCascadeDescription: Store FontFamily instead of AtomString

### DIFF
--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
@@ -784,7 +784,7 @@ AccessibilityObjectAtspi::TextAttributes AccessibilityObjectAtspi::textAttribute
             addAttributeIfNeeded("fg-color"_s, makeString(r, ',', g, ',', b));
         }
 
-        addAttributeIfNeeded("family-name"_s, style.fontCascade().firstFamily());
+        addAttributeIfNeeded("family-name"_s, style.fontCascade().firstFamily().name);
         addAttributeIfNeeded("size"_s, makeString(std::round(style.computedFontSize() * 72 / WebCore::fontDPI()), "pt"_s));
         addAttributeIfNeeded("weight"_s, makeString(static_cast<float>(style.fontCascade().weight())));
         addAttributeIfNeeded("style"_s, style.fontCascade().fontStyleSlope() ? "italic"_s : "normal"_s);

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -400,7 +400,7 @@ String CanvasRenderingContext2DBase::State::fontString() const
     serializedFont.append(font.computedSize(), "px"_s);
 
     for (unsigned i = 0; i < font.familyCount(); ++i) {
-        StringView family = font.familyAt(i);
+        StringView family = font.familyAt(i).name;
         if (family.startsWith("-webkit-"_s))
             family = family.substring(8);
 

--- a/Source/WebCore/inspector/InspectorOverlayLabel.cpp
+++ b/Source/WebCore/inspector/InspectorOverlayLabel.cpp
@@ -63,7 +63,7 @@ InspectorOverlayLabel::InspectorOverlayLabel(const String& text, FloatPoint loca
 static FontCascade systemFont()
 {
     FontCascadeDescription fontDescription;
-    fontDescription.setFamilies({ "system-ui"_s });
+    fontDescription.setFamilies({ { "system-ui"_s, FontFamilyKind::Generic } });
     fontDescription.setWeight(FontSelectionValue(500));
     fontDescription.setComputedSize(12);
 

--- a/Source/WebCore/page/PrintContext.cpp
+++ b/Source/WebCore/page/PrintContext.cpp
@@ -418,7 +418,7 @@ String PrintContext::pageProperty(LocalFrame* frame, const String& propertyName,
     if (propertyName == "font-size"_s)
         return makeString(style->fontDescription().computedSize());
     if (propertyName == "font-family"_s)
-        return style->fontDescription().firstFamily();
+        return style->fontDescription().firstFamily().name;
     if (propertyName == "size"_s) {
         return WTF::switchOn(style->pageSize(),
             [&](const CSS::Keyword::Auto&) -> String {

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -500,7 +500,7 @@ bool FontCascade::hasValidAverageCharWidth() const
 {
     ASSERT(isMainThread());
 
-    const AtomString& family = firstFamily();
+    const auto& family = firstFamily().name;
     if (family.isEmpty())
         return false;
 
@@ -1345,7 +1345,7 @@ bool FontCascade::isLoadingCustomFonts() const
 
 bool FontCascade::computeUseBackslashAsYenSymbol() const
 {
-    return protect(FontCache::forCurrentThread())->useBackslashAsYenSignForFamily(m_fontDescription.firstFamily());
+    return protect(FontCache::forCurrentThread())->useBackslashAsYenSignForFamily(m_fontDescription.firstFamily().name);
 }
 
 enum class GlyphUnderlineType : uint8_t {

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -146,9 +146,9 @@ public:
     bool enableKerning() const { return m_enableKerning; }
     bool requiresShaping() const { return m_requiresShaping; }
 
-    const AtomString& firstFamily() const LIFETIME_BOUND { return m_fontDescription.firstFamily(); }
+    const FontFamily& firstFamily() const LIFETIME_BOUND { return m_fontDescription.firstFamily(); }
     unsigned familyCount() const { return m_fontDescription.familyCount(); }
-    const AtomString& familyAt(unsigned i) const LIFETIME_BOUND { return m_fontDescription.familyAt(i); }
+    const FontFamily& familyAt(unsigned i) const LIFETIME_BOUND { return m_fontDescription.familyAt(i); }
 
     // A std::nullopt return value indicates "font-style: normal".
     std::optional<FontSelectionValue> fontStyleSlope() const { return m_fontDescription.fontStyleSlope(); }

--- a/Source/WebCore/platform/graphics/FontCascadeCache.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeCache.cpp
@@ -106,7 +106,7 @@ static FontCascadeCacheKey makeFontCascadeCacheKey(const FontCascadeDescription&
     auto hasComplexFontSelector = fontSelector && !fontSelector->isSimpleFontSelectorForDescription();
     return FontCascadeCacheKey {
         FontDescriptionKey(description),
-        Vector<FontFamilyName, 3>(familyCount, [&](size_t i) { return description.familyAt(i); }),
+        Vector<FontFamilyName, 3>(familyCount, [&](size_t familyIndex) { return description.familyAt(familyIndex).name; }),
         hasComplexFontSelector ? fontSelector->uniqueId() : 0,
         hasComplexFontSelector ? fontSelector->version() : 0,
         hasComplexFontSelector

--- a/Source/WebCore/platform/graphics/FontCascadeDescription.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeDescription.cpp
@@ -62,7 +62,7 @@ struct SameSizeAsFontCascadeDescription {
 static_assert(sizeof(FontCascadeDescription) == sizeof(SameSizeAsFontCascadeDescription), "FontCascadeDescription should stay small");
 
 FontCascadeDescription::FontCascadeDescription()
-    : m_families(RefCountedFixedVector<AtomString>::create(1))
+    : m_families(RefCountedFixedVector<FontFamily>::create(1))
     , m_isAbsoluteSize(false)
     , m_kerning(std::to_underlying(Kerning::Auto))
     , m_keywordSize(0)
@@ -104,7 +104,7 @@ bool FontCascadeDescription::familiesEqualForTextAutoSizing(const FontCascadeDes
         return false;
 
     for (unsigned i = 0; i < thisFamilyCount; ++i) {
-        if (!familyNamesAreEqual(familyAt(i), other.familyAt(i)))
+        if (!familyNamesAreEqual(familyAt(i).name, other.familyAt(i).name))
             return false;
     }
 
@@ -166,7 +166,7 @@ TextStream& operator<<(TextStream& ts, const FontCascadeDescription& fontCascade
     for (auto& family : fontCascadeDescription.families()) {
         if (!first)
             ts << ", "_s;
-        ts << family;
+        ts << family.name;
         first = false;
     }
 

--- a/Source/WebCore/platform/graphics/FontCascadeDescription.h
+++ b/Source/WebCore/platform/graphics/FontCascadeDescription.h
@@ -41,6 +41,16 @@ class TextStream;
 
 namespace WebCore {
 
+enum class FontFamilyKind : bool { Specified, Generic };
+
+struct FontFamily {
+    AtomString name;
+    FontFamilyKind kind { FontFamilyKind::Generic };
+
+    bool isGeneric() const { return kind == FontFamilyKind::Generic; }
+    bool operator==(const FontFamily&) const = default;
+};
+
 #if PLATFORM(COCOA)
 typedef FontFamilySpecificationCoreText FontFamilyPlatformSpecification;
 #else
@@ -58,9 +68,9 @@ public:
     bool operator==(const FontCascadeDescription&) const;
 
     unsigned familyCount() const { return m_families->size(); }
-    const AtomString& firstFamily() const { return familyAt(0); }
-    const AtomString& familyAt(unsigned i) const { return m_families.get()[i]; }
-    RefCountedFixedVector<AtomString>& families() const { return m_families.get(); }
+    const FontFamily& firstFamily() const { return familyAt(0); }
+    const FontFamily& familyAt(unsigned i) const { return m_families.get()[i]; }
+    RefCountedFixedVector<FontFamily>& families() const { return m_families.get(); }
 
     static bool NODELETE familyNamesAreEqual(const AtomString&, const AtomString&);
     static unsigned familyNameHash(const AtomString&);
@@ -77,7 +87,7 @@ public:
     static FontSelectionValue bolderWeight(FontSelectionValue);
 
     // only use fixed default size when there is only one font family, and that family is "monospace"
-    bool useFixedDefaultSize() const { return familyCount() == 1 && firstFamily() == monospaceFamily; }
+    bool useFixedDefaultSize() const { return familyCount() == 1 && firstFamily().name == monospaceFamily; }
 
     Kerning kerning() const { return static_cast<Kerning>(m_kerning); }
     unsigned keywordSize() const { return m_keywordSize; }
@@ -97,10 +107,11 @@ public:
     // author's primary typographic choice.
     bool hasAuthorSpecifiedNonGenericPrimaryFont() const { return m_hasAuthorSpecifiedNonGenericPrimaryFont; }
 
-    void setOneFamily(const AtomString& family) { ASSERT(m_families->size() == 1); m_families.get()[0] = family; }
-    void setFamilies(const Vector<AtomString>& families) { m_families = RefCountedFixedVector<AtomString>::createFromVector(families); }
-    void setFamilies(RefCountedFixedVector<AtomString>& families) { m_families = families; }
-    void setFamilies(Ref<RefCountedFixedVector<AtomString>>&& families) { m_families = WTF::move(families); }
+    void setOneFamily(const FontFamily& family) { ASSERT(m_families->size() == 1); m_families.get()[0] = family; }
+    void setOneFamily(const AtomString& familyName) { setOneFamily(FontFamily { familyName, FontFamilyKind::Specified }); }
+    void setFamilies(const Vector<FontFamily>& families) { m_families = RefCountedFixedVector<FontFamily>::createFromVector(families); }
+    void setFamilies(RefCountedFixedVector<FontFamily>& families) { m_families = families; }
+    void setFamilies(Ref<RefCountedFixedVector<FontFamily>>&& families) { m_families = WTF::move(families); }
     void setSpecifiedSize(float s) { m_specifiedSize = clampToFloat(s); }
     void setIsAbsoluteSize(bool s) { m_isAbsoluteSize = s; }
     void setKerning(Kerning kerning) { m_kerning = static_cast<unsigned>(kerning); }
@@ -134,7 +145,7 @@ public:
     WEBCORE_EXPORT void NODELETE resolveFontSizeAdjustFromFontIfNeeded(const Font&);
 
 private:
-    Ref<RefCountedFixedVector<AtomString>> m_families;
+    Ref<RefCountedFixedVector<FontFamily>> m_families;
 
     // Specified CSS value. Independent of rendering issues such as integer rounding, minimum font sizes, and zooming.
     float m_specifiedSize { 0 };

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
@@ -187,7 +187,7 @@ static FontRanges realizeNextFallback(const FontCascadeDescription& description,
     // For example on macOS, we know to map any families containing the words Arabic, Pashto, or Urdu to the
     // Geeza Pro font.
     for (auto& family : description.families()) {
-        if (auto font = fontCache->similarFont(description, family))
+        if (auto font = fontCache->similarFont(description, family.name))
             return FontRanges(WTF::move(font));
     }
     return { };
@@ -416,7 +416,7 @@ static void opportunisticallyStartFontDataURLLoading(const FontCascadeDescriptio
     if (!fontSelector)
         return;
     for (unsigned i = 0; i < description.familyCount(); ++i)
-        fontSelector->opportunisticallyStartFontDataURLLoading(description, description.familyAt(i));
+        fontSelector->opportunisticallyStartFontDataURLLoading(description, description.familyAt(i).name);
 }
 
 GlyphData FontCascadeFonts::glyphDataForVariant(char32_t character, const FontCascadeDescription& description, FontSelector* fontSelector, FontVariant variant, ResolvedEmojiPolicy resolvedEmojiPolicy, unsigned fallbackIndex)

--- a/Source/WebCore/platform/graphics/cocoa/FontDescriptionCocoa.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontDescriptionCocoa.cpp
@@ -40,7 +40,7 @@ unsigned FontCascadeDescription::effectiveFamilyCount() const
     // FIXME: Move all the other system font keywords from fontDescriptorWithFamilySpecialCase() to here.
     unsigned result = 0;
     for (unsigned i = 0; i < familyCount(); ++i) {
-        const auto& cssFamily = familyAt(i);
+        const auto& cssFamily = familyAt(i).name;
         if (auto use = SystemFontDatabaseCoreText::forCurrentThread().matchSystemFontUse(cssFamily))
             result += systemFontCascadeList(*this, cssFamily, *use, shouldAllowUserInstalledFonts()).size();
         else
@@ -58,7 +58,7 @@ FontFamilySpecification FontCascadeDescription::effectiveFamilyAt(unsigned index
     // means that "src:local(system-ui)" can't follow the Core Text cascade list (the way it does for regular lookups).
     // These two behaviors should be unified, which would hopefully allow us to delete this duplicate code.
     for (unsigned i = 0; i < familyCount(); ++i) {
-        const auto& cssFamily = familyAt(i);
+        const auto& cssFamily = familyAt(i).name;
         if (auto use = SystemFontDatabaseCoreText::forCurrentThread().matchSystemFontUse(cssFamily)) {
             auto cascadeList = systemFontCascadeList(*this, cssFamily, *use, shouldAllowUserInstalledFonts());
             if (index < cascadeList.size())

--- a/Source/WebCore/platform/graphics/harfbuzz/FontDescriptionHarfBuzz.cpp
+++ b/Source/WebCore/platform/graphics/harfbuzz/FontDescriptionHarfBuzz.cpp
@@ -35,7 +35,7 @@ unsigned FontCascadeDescription::effectiveFamilyCount() const
 
 FontFamilySpecification FontCascadeDescription::effectiveFamilyAt(unsigned index) const
 {
-    return familyAt(index);
+    return familyAt(index).name;
 }
 
 }

--- a/Source/WebCore/platform/graphics/skia/FontDescriptionSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontDescriptionSkia.cpp
@@ -35,7 +35,7 @@ unsigned FontCascadeDescription::effectiveFamilyCount() const
 
 FontFamilySpecification FontCascadeDescription::effectiveFamilyAt(unsigned index) const
 {
-    return familyAt(index);
+    return familyAt(index).name;
 }
 
 }

--- a/Source/WebCore/platform/graphics/win/FontDescriptionWin.cpp
+++ b/Source/WebCore/platform/graphics/win/FontDescriptionWin.cpp
@@ -35,7 +35,7 @@ unsigned FontCascadeDescription::effectiveFamilyCount() const
 
 FontFamilySpecification FontCascadeDescription::effectiveFamilyAt(unsigned index) const
 {
-    return familyAt(index);
+    return familyAt(index).name;
 }
 
 }

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -181,7 +181,7 @@ struct TextRunWithUnderlyingString {
 static FontCascade disclosureMarkerFontCascade(const RenderStyle& style, Document& document)
 {
     auto fontDescription = FontCascadeDescription { style.fontDescription() };
-    fontDescription.setFamilies(Vector<AtomString> { "system-ui"_s });
+    fontDescription.setFamilies({ { "system-ui"_s, FontFamilyKind::Generic } });
     auto fontCascade = FontCascade(WTF::move(fontDescription));
     fontCascade.update(&document.fontSelector());
     return fontCascade;

--- a/Source/WebCore/rendering/RenderTextControlMultiLine.cpp
+++ b/Source/WebCore/rendering/RenderTextControlMultiLine.cpp
@@ -72,7 +72,7 @@ float RenderTextControlMultiLine::getAverageCharWidth()
     // Since Lucida Grande is the default font, we want this to match the width
     // of Courier New, the default font for textareas in IE, Firefox and Safari Win.
     // 1229 is the avgCharWidth value in the OS/2 table for Courier New.
-    if (style().fontCascade().firstFamily() == "Lucida Grande"_s)
+    if (style().fontCascade().firstFamily().name == "Lucida Grande"_s)
         return scaleEmToUnits(1229);
 #endif
 

--- a/Source/WebCore/rendering/RenderTextControlSingleLine.cpp
+++ b/Source/WebCore/rendering/RenderTextControlSingleLine.cpp
@@ -375,7 +375,7 @@ float RenderTextControlSingleLine::getAverageCharWidth()
     // of MS Shell Dlg, the default font for textareas in Firefox, Safari Win and
     // IE for some encodings (in IE, the default font is encoding specific).
     // 901 is the avgCharWidth value in the OS/2 table for MS Shell Dlg.
-    if (style().fontCascade().firstFamily() == "Lucida Grande"_s)
+    if (style().fontCascade().firstFamily().name == "Lucida Grande"_s)
         return scaleEmToUnits(901);
 #endif
 
@@ -394,7 +394,7 @@ LayoutUnit RenderTextControlSingleLine::preferredContentLogicalWidth(float charW
     float maxCharWidth = 0.f;
 
 #if !PLATFORM(IOS_FAMILY)
-    const AtomString& family = style().fontCascade().firstFamily();
+    const auto& family = style().fontCascade().firstFamily().name;
     // Since Lucida Grande is the default font, we want this to match the width
     // of MS Shell Dlg, the default font for textareas in Firefox, Safari Win and
     // IE for some encodings (in IE, the default font is encoding specific).

--- a/Source/WebCore/rendering/TextAutoSizing.cpp
+++ b/Source/WebCore/rendering/TextAutoSizing.cpp
@@ -107,7 +107,7 @@ static unsigned computeFontHash(const FontCascade& font)
 {
     // FIXME: Would be better to hash the family name rather than hashing a hash of the family name. Also, should this use FontCascadeDescription::familyNameHash?
     return computeHash(
-        ASCIICaseInsensitiveHash::hash(font.fontDescription().firstFamily()),
+        ASCIICaseInsensitiveHash::hash(font.fontDescription().firstFamily().name),
         font.fontDescription().specifiedSize()
     );
 }

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -566,7 +566,7 @@ inline void BuilderCustom::applyInitialFontFamily(BuilderState& builderState)
             builderState.setFontDescriptionFontSize(Style::fontSizeForKeyword(sizeIdentifier, false, builderState.document()));
     }
 
-    if (!initialDesc.firstFamily().isEmpty())
+    if (!initialDesc.firstFamily().name.isEmpty())
         builderState.setFontDescriptionFamilies(FontFamilies { initialDesc.families(), fontDescription.hasAuthorSpecifiedNonGenericPrimaryFont() });
 }
 

--- a/Source/WebCore/style/StyleBuilderStateInlines.h
+++ b/Source/WebCore/style/StyleBuilderStateInlines.h
@@ -78,13 +78,15 @@ inline void BuilderState::setFontDescriptionFontSize(float fontSize)
 
 inline void BuilderState::setFontDescriptionFamilies(FontFamilies&& families)
 {
-    if (m_style.fontDescription().families() == families.toPlatform() && m_style.fontDescription().hasAuthorSpecifiedNonGenericPrimaryFont() == families.hasAuthorSpecifiedNonGenericPrimaryFont())
+    bool hasAuthorSpecifiedNonGenericPrimaryFont = families.hasAuthorSpecifiedNonGenericPrimaryFont();
+    if (m_style.fontDescription().families() == families.toPlatform()
+        && m_style.fontDescription().hasAuthorSpecifiedNonGenericPrimaryFont() == hasAuthorSpecifiedNonGenericPrimaryFont)
         return;
 
     m_fontDirty = true;
     auto& fontCascade = m_style.mutableFontCascadeWithoutUpdate();
     fontCascade.mutableFontDescription().setFamilies(families.takePlatform());
-    fontCascade.mutableFontDescription().setHasAuthorSpecifiedNonGenericPrimaryFont(families.hasAuthorSpecifiedNonGenericPrimaryFont());
+    fontCascade.mutableFontDescription().setHasAuthorSpecifiedNonGenericPrimaryFont(hasAuthorSpecifiedNonGenericPrimaryFont);
     fontCascade.updateUseBackslashAsYenSymbol();
 }
 

--- a/Source/WebCore/style/StyleResolveForFont.cpp
+++ b/Source/WebCore/style/StyleResolveForFont.cpp
@@ -49,6 +49,7 @@
 #include "ScriptExecutionContext.h"
 #include "Settings.h"
 #include "StyleBuilderChecking.h"
+#include "StyleFontFamily.h"
 #include "StyleFontSizeFunctions.h"
 #include "StyleLengthResolution.h"
 #include "StylePrimitiveNumericTypes+Conversions.h"
@@ -308,7 +309,7 @@ static FontVariantCaps NODELETE fontVariantCapsFromUnresolvedFontVariantCaps(con
 // MARK: - 'font-family'
 
 struct ResolvedFontFamily {
-    Vector<AtomString> family;
+    Vector<WebCore::FontFamily> families;
     bool hasAuthorSpecifiedNonGenericPrimaryFont;
 };
 
@@ -317,8 +318,8 @@ static ResolvedFontFamily fontFamilyFromUnresolvedFontFamily(const CSSPropertyPa
     bool isFirstFont = true;
     bool hasAuthorSpecifiedNonGenericPrimaryFont = false;
 
-    auto family = WTF::compactMap(unresolvedFamily, [&](auto& item) -> std::optional<AtomString> {
-        auto [family, isGenericFamily] = switchOn(item,
+    auto families = WTF::compactMap(unresolvedFamily, [&](auto& item) -> std::optional<WebCore::FontFamily> {
+        auto [familyName, isGenericFamily] = switchOn(item,
             [&](CSSValueID ident) -> std::pair<AtomString, bool> {
                 if (ident != CSSValueWebkitBody) {
                     // FIXME: Treat system-ui like other generic font families
@@ -333,18 +334,18 @@ static ResolvedFontFamily fontFamilyFromUnresolvedFontFamily(const CSSPropertyPa
             }
         );
 
-        if (family.isEmpty())
+        if (familyName.isEmpty())
             return std::nullopt;
 
         if (isFirstFont) {
             hasAuthorSpecifiedNonGenericPrimaryFont = !isGenericFamily;
             isFirstFont = false;
         }
-        return family;
+        return WebCore::FontFamily { WTF::move(familyName), isGenericFamily ? FontFamilyKind::Generic : FontFamilyKind::Specified };
     });
 
     return {
-        .family = WTF::move(family),
+        .families = WTF::move(families),
         .hasAuthorSpecifiedNonGenericPrimaryFont = hasAuthorSpecifiedNonGenericPrimaryFont
     };
 }
@@ -362,7 +363,7 @@ std::optional<FontCascade> resolveForUnresolvedFont(const CSSPropertyParserHelpe
 
     auto useFixedDefaultSize = [](const FontCascadeDescription& fontDescription) {
         return fontDescription.familyCount() == 1
-            && fontDescription.firstFamily() == *familyNamesData->at(FamilyNamesIndex::MonospaceFamily);
+            && fontDescription.firstFamily().name == *familyNamesData->at(FamilyNamesIndex::MonospaceFamily);
     };
 
     // Font family applied in the same way as StyleBuilderCustom::applyValueFontFamily
@@ -370,9 +371,9 @@ std::optional<FontCascade> resolveForUnresolvedFont(const CSSPropertyParserHelpe
     bool oldFamilyUsedFixedDefaultSize = useFixedDefaultSize(fontDescription);
 
     auto resolvedFamily = fontFamilyFromUnresolvedFontFamily(unresolvedFont.family, protectedContext);
-    if (resolvedFamily.family.isEmpty())
+    if (resolvedFamily.families.isEmpty())
         return std::nullopt;
-    fontDescription.setFamilies(resolvedFamily.family);
+    fontDescription.setFamilies(resolvedFamily.families);
     fontDescription.setHasAuthorSpecifiedNonGenericPrimaryFont(resolvedFamily.hasAuthorSpecifiedNonGenericPrimaryFont);
 
     if (useFixedDefaultSize(fontDescription) != oldFamilyUsedFixedDefaultSize) {

--- a/Source/WebCore/style/values/fonts/StyleFontFamily.cpp
+++ b/Source/WebCore/style/values/fonts/StyleFontFamily.cpp
@@ -83,7 +83,7 @@ auto CSSValueConversion<FontFamilies>::operator()(BuilderState& state, const CSS
         return { nullAtom(), FontFamilyKind::Generic };
 
     std::optional<FontFamilyKind> firstFontKind;
-    auto families = WTF::compactMap(*valueList, [&](auto& contentValue) -> std::optional<AtomString> {
+    auto families = WTF::compactMap(*valueList, [&](auto& contentValue) -> std::optional<WebCore::FontFamily> {
         auto [family, kind] = [&] -> std::pair<AtomString, FontFamilyKind> {
             if (contentValue.isFontFamily())
                 return { AtomString { contentValue.stringValue() }, FontFamilyKind::Specified };
@@ -101,7 +101,7 @@ auto CSSValueConversion<FontFamilies>::operator()(BuilderState& state, const CSS
         if (!firstFontKind)
             firstFontKind = kind;
 
-        return family;
+        return WebCore::FontFamily { WTF::move(family), kind };
     });
 
     if (families.isEmpty()) {
@@ -110,7 +110,7 @@ auto CSSValueConversion<FontFamilies>::operator()(BuilderState& state, const CSS
     }
 
     return {
-        RefCountedFixedVector<AtomString>::createFromVector(WTF::move(families)),
+        RefCountedFixedVector<WebCore::FontFamily>::createFromVector(WTF::move(families)),
         *firstFontKind
     };
 }

--- a/Source/WebCore/style/values/fonts/StyleFontFamily.h
+++ b/Source/WebCore/style/values/fonts/StyleFontFamily.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/FontCascadeDescription.h>
 #include <WebCore/StyleFontFamilyName.h>
 #include <WebCore/StyleValueTypes.h>
 #include <WebCore/WebKitFontFamilyNames.h>
@@ -33,12 +34,10 @@
 namespace WebCore {
 namespace Style {
 
-enum class FontFamilyKind : bool { Specified, Generic };
-
 // <single-font-family> = [ <family-name> | <generic-family> ]
 // https://drafts.csswg.org/css-fonts-4/#propdef-font-family
-struct SingleFontFamily {
-    AtomString value;
+struct FontFamily {
+    WebCore::FontFamily value;
 
     template<typename... F> decltype(auto) switchOn(F&&... f) const
     {
@@ -46,59 +45,61 @@ struct SingleFontFamily {
 
         auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
 
-        // <generic-family>
-        if (value == cursiveFamily)
-            return visitor(CSS::Keyword::Cursive { });
-        if (value == fantasyFamily)
-            return visitor(CSS::Keyword::Fantasy { });
-        if (value == monospaceFamily)
-            return visitor(CSS::Keyword::Monospace { });
-        if (value == mathFamily)
-            return visitor(CSS::Keyword::Math { });
-        if (value == pictographFamily)
-            return visitor(CSS::Keyword::WebkitPictograph { });
-        if (value == sansSerifFamily)
-            return visitor(CSS::Keyword::SansSerif { });
-        if (value == serifFamily)
-            return visitor(CSS::Keyword::Serif { });
-        if (value == systemUiFamily)
-            return visitor(CSS::Keyword::SystemUi { });
+        if (value.isGeneric()) {
+            // <generic-family>
+            if (value.name == sansSerifFamily)
+                return visitor(CSS::Keyword::SansSerif { });
+            if (value.name == monospaceFamily)
+                return visitor(CSS::Keyword::Monospace { });
+            if (value.name == serifFamily)
+                return visitor(CSS::Keyword::Serif { });
+            if (value.name == systemUiFamily)
+                return visitor(CSS::Keyword::SystemUi { });
+            if (value.name == cursiveFamily)
+                return visitor(CSS::Keyword::Cursive { });
+            if (value.name == fantasyFamily)
+                return visitor(CSS::Keyword::Fantasy { });
+            if (value.name == mathFamily)
+                return visitor(CSS::Keyword::Math { });
+            if (value.name == pictographFamily)
+                return visitor(CSS::Keyword::WebkitPictograph { });
+        }
         // <family-name>
-        return visitor(FontFamilyName { value });
+        return visitor(FontFamilyName { value.name });
     }
 
-    bool operator==(const SingleFontFamily&) const = default;
+    bool operator==(const FontFamily&) const = default;
 };
 
 // <'font-family'> = [ <family-name> | <generic-family> ]#
 // https://drafts.csswg.org/css-fonts-4/#propdef-font-family
 struct FontFamilies {
-    FontFamilies(Ref<RefCountedFixedVector<AtomString>>&& families, FontFamilyKind firstFontKind)
+    FontFamilies(Ref<RefCountedFixedVector<WebCore::FontFamily>>&& families, FontFamilyKind firstFontKind)
         : m_families { WTF::move(families) }
         , m_firstFontKind { firstFontKind }
     {
     }
 
-    FontFamilies(Ref<RefCountedFixedVector<AtomString>>&& families, bool hasAuthorSpecifiedNonGenericPrimaryFont)
+    FontFamilies(Ref<RefCountedFixedVector<WebCore::FontFamily>>&& families, bool hasAuthorSpecifiedNonGenericPrimaryFont)
         : FontFamilies { WTF::move(families), hasAuthorSpecifiedNonGenericPrimaryFont ? FontFamilyKind::Specified : FontFamilyKind::Generic }
     {
     }
 
     FontFamilies(AtomString family, FontFamilyKind firstFontKind)
-        : FontFamilies { RefCountedFixedVector<AtomString>::create({ WTF::move(family) }), firstFontKind }
+        : FontFamilies { RefCountedFixedVector<WebCore::FontFamily>::create({ WebCore::FontFamily { WTF::move(family), firstFontKind } }), firstFontKind }
     {
     }
 
     class const_iterator {
     public:
-        using inner_iterator = RefCountedFixedVector<AtomString>::const_iterator;
+        using inner_iterator = RefCountedFixedVector<WebCore::FontFamily>::const_iterator;
         using iterator_category = std::forward_iterator_tag;
-        using value_type = SingleFontFamily;
+        using value_type = FontFamily;
         using difference_type = std::ptrdiff_t;
 
         const_iterator(inner_iterator it) : m_it { it } { }
 
-        value_type operator*() const { return SingleFontFamily { *m_it }; }
+        value_type operator*() const { return FontFamily { *m_it }; }
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         const_iterator& operator++() { ++m_it; return *this; }
@@ -116,12 +117,12 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     unsigned size() const { return m_families->size(); }
 
-    SingleFontFamily first() const { return SingleFontFamily { m_families.get()[0] }; }
-    SingleFontFamily last() const { return SingleFontFamily { m_families.get()[size() - 1] }; }
+    FontFamily first() const { return FontFamily { m_families.get()[0] }; }
+    FontFamily last() const { return FontFamily { m_families.get()[size() - 1] }; }
 
-    RefCountedFixedVector<AtomString>& toPlatform() LIFETIME_BOUND { return m_families.get(); }
-    const RefCountedFixedVector<AtomString>& toPlatform() const LIFETIME_BOUND { return m_families.get(); }
-    Ref<RefCountedFixedVector<AtomString>> takePlatform() { return WTF::move(m_families); }
+    RefCountedFixedVector<WebCore::FontFamily>& toPlatform() LIFETIME_BOUND { return m_families.get(); }
+    const RefCountedFixedVector<WebCore::FontFamily>& toPlatform() const LIFETIME_BOUND { return m_families.get(); }
+    Ref<RefCountedFixedVector<WebCore::FontFamily>> takePlatform() { return WTF::move(m_families); }
 
     FontFamilyKind firstFontKind() const { return m_firstFontKind; }
     bool hasAuthorSpecifiedNonGenericPrimaryFont() const { return m_firstFontKind == FontFamilyKind::Specified; }
@@ -133,7 +134,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
 
 private:
-    Ref<RefCountedFixedVector<AtomString>> m_families;
+    Ref<RefCountedFixedVector<WebCore::FontFamily>> m_families;
     FontFamilyKind m_firstFontKind { FontFamilyKind::Generic };
 };
 
@@ -145,4 +146,4 @@ template<> struct CSSValueConversion<FontFamilies> { auto operator()(BuilderStat
 } // namespace WebCore
 
 DEFINE_COMMA_SEPARATED_RANGE_LIKE_CONFORMANCE(WebCore::Style::FontFamilies)
-DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::SingleFontFamily)
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::FontFamily)


### PR DESCRIPTION
#### f6a37815e1754b841a3badaf7307d2906a68b018
<pre>
FontCascadeDescription: Store FontFamily instead of AtomString
<a href="https://bugs.webkit.org/show_bug.cgi?id=310722">https://bugs.webkit.org/show_bug.cgi?id=310722</a>
<a href="https://rdar.apple.com/173340379">rdar://173340379</a>

Reviewed by Elika Etemad and Simon Fraser.

FontCascadeDescription stored font families as plain AtomString, losing the
distinction between generic CSS keywords (serif, monospace) and custom family
names (&quot;serif&quot;). This forced Style::FontFamily::switchOn to do string
comparisons against every known generic name even for custom families.

Store FontFamily (name + FontFamilyKind) instead, so the generic/specified
distinction is carried through from CSS parsing. Move FontFamilyKind and
FontFamily from the style layer to platform/graphics to not incur in a layering
violation.

Platform consumers only read .name, so the mechanical change is adding .name
at each access site. Style::FontFamily wraps WebCore::FontFamily and uses
FontFamilyKind to short-circuit the generic keyword visitor. So no changes
on behavior are expected.

We are also renaming Style::SingleFontFamily to Style::FontFamily.

* Source/WebCore/platform/graphics/FontCascadeDescription.h:
(WebCore::FontFamily::isGeneric const):
(WebCore::FontCascadeDescription::firstFamily const):
(WebCore::FontCascadeDescription::familyAt const):
(WebCore::FontCascadeDescription::families const):
(WebCore::FontCascadeDescription::useFixedDefaultSize const):
(WebCore::FontCascadeDescription::setOneFamily):
(WebCore::FontCascadeDescription::setFamilies):
(WebCore::FontCascadeDescription::operator== const):
* Source/WebCore/platform/graphics/FontCascadeDescription.cpp:
(WebCore::FontCascadeDescription::FontCascadeDescription):
(WebCore::FontCascadeDescription::familiesEqualForTextAutoSizing const):
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::hasValidAverageCharWidth const):
(WebCore::FontCascade::computeUseBackslashAsYenSymbol const):
* Source/WebCore/platform/graphics/FontCascade.h:
(WebCore::FontCascade::firstFamily const):
(WebCore::FontCascade::familyAt const):
* Source/WebCore/platform/graphics/FontCascadeCache.cpp:
(WebCore::makeFontCascadeCacheKey):
* Source/WebCore/platform/graphics/FontCascadeFonts.cpp:
(WebCore::realizeNextFallback):
(WebCore::opportunisticallyStartFontDataURLLoading):
* Source/WebCore/platform/graphics/cocoa/FontDescriptionCocoa.cpp:
(WebCore::FontCascadeDescription::effectiveFamilyCount const):
(WebCore::FontCascadeDescription::effectiveFamilyAt const):
* Source/WebCore/platform/graphics/harfbuzz/FontDescriptionHarfBuzz.cpp:
(WebCore::FontCascadeDescription::effectiveFamilyAt const):
* Source/WebCore/platform/graphics/skia/FontDescriptionSkia.cpp:
(WebCore::FontCascadeDescription::effectiveFamilyAt const):
* Source/WebCore/platform/graphics/win/FontDescriptionWin.cpp:
(WebCore::FontCascadeDescription::effectiveFamilyAt const):
* Source/WebCore/style/values/fonts/StyleFontFamily.h:
(WebCore::Style::FontFamily::switchOn const):
(WebCore::Style::FontFamilies::FontFamilies):
(WebCore::Style::FontFamilies::first const):
(WebCore::Style::FontFamilies::last const):
* Source/WebCore/style/values/fonts/StyleFontFamily.cpp:
(WebCore::Style::CSSValueConversion&lt;FontFamilies&gt;::operator()):
* Source/WebCore/style/StyleResolveForFont.cpp:
(WebCore::Style::fontFamilyFromUnresolvedFontFamily):
(WebCore::Style::resolveForUnresolvedFont):
* Source/WebCore/style/StyleBuilderStateInlines.h:
(WebCore::Style::BuilderState::setFontDescriptionFamilies):
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyInitialFontFamily):
* Source/WebCore/style/computed/StyleComputedStyleProperties+GettersCustomInlines.h:
(WebCore::Style::ComputedStyleProperties::fontFamily const):
* Source/WebCore/rendering/RenderListMarker.cpp:
(WebCore::disclosureMarkerFontCascade):
* Source/WebCore/rendering/RenderTextControlSingleLine.cpp:
(WebCore::RenderTextControlSingleLine::getAverageCharWidth):
(WebCore::RenderTextControlSingleLine::preferredContentLogicalWidth):
* Source/WebCore/rendering/RenderTextControlMultiLine.cpp:
(WebCore::RenderTextControlMultiLine::getAverageCharWidth):
* Source/WebCore/rendering/TextAutoSizing.cpp:
(WebCore::computeFontHash):
* Source/WebCore/page/PrintContext.cpp:
(WebCore::PrintContext::pageProperty):
* Source/WebCore/inspector/InspectorOverlayLabel.cpp:
(WebCore::systemFont):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::State::fontString const):
* Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::textAttributes const):

Canonical link: <a href="https://commits.webkit.org/310118@main">https://commits.webkit.org/310118@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7b20ced490ab9df2caeb58d19e1fb18f624a282

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152718 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25499 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19098 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161462 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154591 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26027 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25805 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118016 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ff7e9627-7990-46ec-b597-fc32d51251bf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155677 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20246 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137108 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98729 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19321 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17258 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9298 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128973 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14982 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163934 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7072 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16576 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126077 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25297 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21297 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126235 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34258 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25299 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136778 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81903 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21195 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13557 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24915 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89201 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24607 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24766 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24667 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->