### PR TITLE
[Tahoe Debug] editing/execCommand/apply-inline-style-to-element-with-no-renderer-crash.html is a flaky text failure.

### DIFF
--- a/LayoutTests/editing/execCommand/apply-inline-style-to-element-with-no-renderer-crash.html
+++ b/LayoutTests/editing/execCommand/apply-inline-style-to-element-with-no-renderer-crash.html
@@ -39,4 +39,6 @@ test(function() {
     document.designMode='on';
     document.execCommand('italic');
 });
+// Remove SVG to prevent flaky text output from mangled DOM.
+document.querySelector('svg').remove();
 </script>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -613,8 +613,6 @@ imported/w3c/web-platform-tests/css/css-ui/outline-negative-offset-composited-sc
 imported/w3c/web-platform-tests/css/css-transforms/transform3d-preserve3d-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/cssom-view/scroll-behavior-element.html [ Failure ]
 
-webkit.org/b/260640 [ Release arm64 ] editing/execCommand/apply-inline-style-to-element-with-no-renderer-crash.html [ Pass Failure ]
-
 ### END OF (1) Classified failures with bug reports
 ########################################
 
@@ -2413,8 +2411,6 @@ webkit.org/b/305947 compositing/visibility/frameset-visibility-hidden.html [ Ima
 webkit.org/b/305958 imported/w3c/web-platform-tests/media-source/mediasource-changetype-play.html [ Pass Failure ]
 
 webkit.org/b/305959 fast/text/FontFaceSet-status-after-style-update.html [ Pass Failure ]
-
-webkit.org/b/310683 [ Tahoe Debug ] editing/execCommand/apply-inline-style-to-element-with-no-renderer-crash.html [ Pass Failure ]
 
 webkit.org/b/306047 accessibility/mac/replaced-element-text-selection.html [ Pass Failure ]
 


### PR DESCRIPTION
#### c93f90c3bb072ff0adb52b7d1485ba8a2f4726c9
<pre>
[Tahoe Debug] editing/execCommand/apply-inline-style-to-element-with-no-renderer-crash.html is a flaky text failure.
<a href="https://rdar.apple.com/173282462">rdar://173282462</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=310683">https://bugs.webkit.org/show_bug.cgi?id=310683</a>

Reviewed by Ryosuke Niwa.

The test is flaky because the editing commands (Transpose, CreateLink, Undo) leave
the DOM in a restructured state where text content from the SVG &lt;tspan&gt; element
(%uef5f%u9776%u638a) non-deterministically appears in the text dump. Since the
test only verifies that these operations don&apos;t cause a crash, it is safe to remove
the SVG element from the DOM after the test completes to ensure deterministic output.

Fix in LayoutTests/editing/execCommand/apply-inline-style-to-element-with-no-renderer-crash.html:

Added one line after the test() function to remove the SVG element before the test
runner captures the text dump.

* LayoutTests/editing/execCommand/apply-inline-style-to-element-with-no-renderer-crash.html:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/310011@main">https://commits.webkit.org/310011@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ab836c78b7f8171f25b1778a29541c606310dca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152216 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24998 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18593 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160959 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105673 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25490 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25304 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117599 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83396 "10 flakes 2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155176 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19787 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136653 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98312 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18864 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16819 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8793 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128514 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14527 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163426 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16119 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125627 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24796 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20858 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125803 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34177 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24797 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136323 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81396 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20811 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13100 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24414 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24105 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24265 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24166 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->