### PR TITLE
[GPU Process] Tighten security around caching Filter

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -479,11 +479,10 @@ void RemoteRenderingBackend::releaseGradient(RemoteGradientIdentifier identifier
 
 void RemoteRenderingBackend::cacheFilter(Ref<Filter>&& filter)
 {
-    ASSERT(!RunLoop::isMain());
-    if (filter->hasValidRenderingResourceIdentifier())
-        m_remoteResourceCache.cacheFilter(WTF::move(filter));
-    else
-        LOG_WITH_STREAM(DisplayLists, stream << "Received a Filter without a valid resource identifier");
+    assertIsCurrent(workQueue());
+    MESSAGE_CHECK(filter->hasValidRenderingResourceIdentifier(), "Received a Filter without a valid resource identifier.");
+    bool success = m_remoteResourceCache.cacheFilter(WTF::move(filter));
+    MESSAGE_CHECK(success, "Filter already cached.");
 }
 
 void RemoteRenderingBackend::releaseFilter(RenderingResourceIdentifier identifier)

--- a/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp
@@ -87,10 +87,10 @@ RefPtr<Gradient> RemoteResourceCache::cachedGradient(RemoteGradientIdentifier id
     return m_gradients.get(identifier);
 }
 
-void RemoteResourceCache::cacheFilter(Ref<Filter>&& filter)
+bool RemoteResourceCache::cacheFilter(Ref<Filter>&& filter)
 {
     auto identifier = filter->renderingResourceIdentifier();
-    m_filters.add(identifier, WTF::move(filter));
+    return m_filters.add(identifier, WTF::move(filter)).isNewEntry;
 }
 
 bool RemoteResourceCache::releaseFilter(RenderingResourceIdentifier identifier)

--- a/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h
@@ -65,7 +65,7 @@ public:
     bool releaseGradient(RemoteGradientIdentifier);
     RefPtr<WebCore::Gradient> cachedGradient(RemoteGradientIdentifier) const;
 
-    void cacheFilter(Ref<WebCore::Filter>&&);
+    bool cacheFilter(Ref<WebCore::Filter>&&);
     bool releaseFilter(WebCore::RenderingResourceIdentifier);
     RefPtr<WebCore::Filter> cachedFilter(WebCore::RenderingResourceIdentifier) const;
 


### PR DESCRIPTION
#### 81c69d345a459fe227080e95a91d04b038d68b2a
<pre>
[GPU Process] Tighten security around caching Filter
<a href="https://bugs.webkit.org/show_bug.cgi?id=310727">https://bugs.webkit.org/show_bug.cgi?id=310727</a>
<a href="https://rdar.apple.com/172395108">rdar://172395108</a>

Reviewed by Kimmo Kinnunen.

To cache a Filter in GPU Process, the Filter has to have a valid identifier and
it should not be cached previously. If any of these cases happens, GPU Process
should be terminated immediately.

* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::cacheFilter):
* Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp:
(WebKit::RemoteResourceCache::cacheFilter):
* Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h:

Canonical link: <a href="https://commits.webkit.org/309995@main">https://commits.webkit.org/309995@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ee7e21df93d20238fe35e2d50145faab0243395

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152219 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25001 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18596 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160962 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105676 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25493 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25307 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117602 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83399 "9 flakes 2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155179 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19789 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136651 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98315 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18866 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16822 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8796 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128516 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163429 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6574 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16117 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125630 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24799 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20861 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125806 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34169 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24800 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136321 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81399 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20815 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13098 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24417 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88702 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24108 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24268 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24169 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->