### PR TITLE
Module verification fails for WTF with public Xcode 26.4

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		07AC4F0E2EF5A68600468BCB /* module.modulemap in Headers */ = {isa = PBXBuildFile; fileRef = 07AC4F0D2EF5A62500468BCB /* module.modulemap */; settings = {ATTRIBUTES = (Private, ); }; };
+		07B588172F74609A00E8AF32 /* module.modulemap in Headers */ = {isa = PBXBuildFile; fileRef = 07B588162F74607A00E8AF32 /* module.modulemap */; settings = {ATTRIBUTES = (Private, ); }; };
 		07F5EA6F2EE8A7630085B185 /* generate-tapi-filelist.py in Headers */ = {isa = PBXBuildFile; fileRef = DD28DF2329D368BD00BBB459 /* generate-tapi-filelist.py */; settings = {ATTRIBUTES = (Private, ); }; };
 		07F5EA702EE8A7660085B185 /* GenerateModuleVerifierInputsTask.py in Headers */ = {isa = PBXBuildFile; fileRef = 076382182EE550F300DB47BC /* GenerateModuleVerifierInputsTask.py */; settings = {ATTRIBUTES = (Private, ); }; };
 		07F5EA712EE8A76A0085B185 /* library-modules-verifier.py in Headers */ = {isa = PBXBuildFile; fileRef = 077FEABB2EE007FF0071F92D /* library-modules-verifier.py */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1103,6 +1104,7 @@
 		077CD86B1FD9CFD300828587 /* LoggerHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LoggerHelper.h; sourceTree = "<group>"; };
 		077FEABB2EE007FF0071F92D /* library-modules-verifier.py */ = {isa = PBXFileReference; lastKnownFileType = text.script.python; path = "library-modules-verifier.py"; sourceTree = "<group>"; };
 		07AC4F0D2EF5A62500468BCB /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
+		07B588162F74607A00E8AF32 /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		0F0C03CF29981BEB0064230A /* EmbeddedFixedVector.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EmbeddedFixedVector.cpp; sourceTree = "<group>"; };
 		0F0C03D7299820EB0064230A /* WeakPtr.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WeakPtr.cpp; sourceTree = "<group>"; };
 		0F0C03E6299828E50064230A /* BloomFilter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BloomFilter.cpp; sourceTree = "<group>"; };
@@ -3023,6 +3025,7 @@
 			isa = PBXGroup;
 			children = (
 				DDD8BAC127B347C400C109E0 /* unicode */,
+				07B588162F74607A00E8AF32 /* module.modulemap */,
 			);
 			path = icu;
 			sourceTree = "<group>";
@@ -4078,6 +4081,7 @@
 				DDF3089B27C44F08006A526F /* measunit.h in Headers */,
 				DDF308D627C44F08006A526F /* measure.h in Headers */,
 				DDF3084527C44F08006A526F /* messagepattern.h in Headers */,
+				07B588172F74609A00E8AF32 /* module.modulemap in Headers */,
 				DDF3085C27C44F08006A526F /* msgfmt.h in Headers */,
 				DDF3086627C44F08006A526F /* normalizer2.h in Headers */,
 				DDF3085427C44F08006A526F /* normlzr.h in Headers */,

--- a/Source/WTF/icu/module.modulemap
+++ b/Source/WTF/icu/module.modulemap
@@ -1,0 +1,7 @@
+module unicode [system] {
+    umbrella "."
+
+    explicit module * {
+        export *
+    }
+}

--- a/Source/WTF/icu/unicode/ucol.h
+++ b/Source/WTF/icu/unicode/ucol.h
@@ -10,7 +10,9 @@
 #ifndef UCOL_H
 #define UCOL_H
 
-DECLARE_SYSTEM_HEADER
+#if defined(__clang__)
+_Pragma("clang system_header")
+#endif
 
 #include "unicode/utypes.h"
 

--- a/Source/WTF/icu/unicode/uidna.h
+++ b/Source/WTF/icu/unicode/uidna.h
@@ -19,7 +19,9 @@
 #ifndef __UIDNA_H__
 #define __UIDNA_H__
 
-DECLARE_SYSTEM_HEADER
+#if defined(__clang__)
+_Pragma("clang system_header")
+#endif
 
 #include "unicode/utypes.h"
 

--- a/Source/WTF/icu/unicode/unorm2.h
+++ b/Source/WTF/icu/unicode/unorm2.h
@@ -19,7 +19,9 @@
 #ifndef __UNORM2_H__
 #define __UNORM2_H__
 
-DECLARE_SYSTEM_HEADER
+#if defined(__clang__)
+_Pragma("clang system_header")
+#endif
 
 /**
  * \file

--- a/Source/WTF/icu/unicode/ustring.h
+++ b/Source/WTF/icu/unicode/ustring.h
@@ -18,7 +18,9 @@
 #ifndef USTRING_H
 #define USTRING_H
 
-DECLARE_SYSTEM_HEADER
+#if defined(__clang__)
+_Pragma("clang system_header")
+#endif
 
 #include "unicode/utypes.h"
 #include "unicode/putil.h"

--- a/Source/WTF/wtf/spi/darwin/SandboxSPI.h
+++ b/Source/WTF/wtf/spi/darwin/SandboxSPI.h
@@ -34,7 +34,6 @@ DECLARE_SYSTEM_HEADER
 #if OS(DARWIN)
 
 #import <mach/message.h>
-#import <sandbox.h>
 #import <unistd.h>
 
 #if USE(APPLE_INTERNAL_SDK)

--- a/Source/WTF/wtf/spi/darwin/dyldSPI.h
+++ b/Source/WTF/wtf/spi/darwin/dyldSPI.h
@@ -30,6 +30,7 @@
 DECLARE_SYSTEM_HEADER
 
 #include <stdint.h>
+#include <uuid/uuid.h>
 #include <wtf/Platform.h>
 
 #if USE(APPLE_INTERNAL_SDK)


### PR DESCRIPTION
#### e72e7e0d970b27384225db7a8b1259f78c38bcda
<pre>
Module verification fails for WTF with public Xcode 26.4
<a href="https://bugs.webkit.org/show_bug.cgi?id=310730">https://bugs.webkit.org/show_bug.cgi?id=310730</a>
<a href="https://rdar.apple.com/173304040">rdar://173304040</a>

Reviewed by Elliott Williams and Abrar Rahman Protyasha.

Fix module issues when building for OS 26.4 in the public SDK.

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/icu/module.modulemap: Added.

Add a modulemap for `unicode`, since the public SDK does not uses the system `unicode` library.

* Source/WTF/icu/unicode/ucol.h:
* Source/WTF/icu/unicode/uidna.h:
* Source/WTF/icu/unicode/unorm2.h:
* Source/WTF/icu/unicode/ustring.h:

Use the expanded form of `DECLARE_SYSTEM_HEADER`, since that macro is defined in WTF, which is above ICU in the project layering.

* Source/WTF/wtf/spi/darwin/SandboxSPI.h:

Remove an unused include of a non-modular header.

* Source/WTF/wtf/spi/darwin/dyldSPI.h:

Add a missing include.

Canonical link: <a href="https://commits.webkit.org/310002@main">https://commits.webkit.org/310002@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec01cc6367535280d2686109a559d2f1eaac25a1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152309 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25091 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18690 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161052 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105766 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25618 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25397 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117671 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83430 "4 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/de7a4a1d-da37-4ed3-9e57-304c95c115b6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155269 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19882 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136737 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98384 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6c199b7a-8434-4068-a152-86a13d4a1ec8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18959 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16894 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8886 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144321 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128609 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14611 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163521 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13110 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6664 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16205 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125705 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24889 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20932 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125879 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34174 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24890 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136407 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81489 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20880 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13186 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/183933 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24507 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88792 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46891 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24198 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24358 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24259 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->