### PR TITLE
https://bugs.webkit.org/show_bug.cgi?id=289445

### DIFF
--- a/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp
@@ -42,6 +42,7 @@
 #include <WebCore/ResourceResponseBase.h>
 #include <wtf/FileSystem.h>
 #include <wtf/text/CString.h>
+#include <wtf/text/MakeString.h>
 #include <wtf/text/WTFString.h>
 
 #if PLATFORM(MAC)
@@ -162,6 +163,37 @@ void DownloadProxy::decideDestinationWithSuggestedFilename(const WebCore::Resour
     else if (!m_suggestedFilename.isEmpty())
         suggestedFilename = m_suggestedFilename;
     suggestedFilename = MIMETypeRegistry::appendFileExtensionIfNecessary(suggestedFilename, response.mimeType());
+
+    // Correct the file extension if it doesn't match the Content-Type. rdar://147183354
+    auto mimeType = response.mimeType();
+    if (!suggestedFilename.isEmpty() && !mimeType.isEmpty()
+        && mimeType != defaultMIMEType() && mimeType != "text/plain"_s
+        && !response.isAttachmentWithFilename() && m_suggestedFilename.isEmpty()) {
+        auto preferredExtension = MIMETypeRegistry::preferredExtensionForMIMEType(mimeType);
+        if (!preferredExtension.isEmpty()) {
+            auto dotPosition = suggestedFilename.reverseFind('.');
+            if (dotPosition != notFound) {
+                auto currentExtension = suggestedFilename.substring(dotPosition + 1);
+                auto validExtensions = MIMETypeRegistry::extensionsForMIMEType(mimeType);
+                if (!validExtensions.contains(currentExtension))
+                    suggestedFilename = makeString(suggestedFilename.left(dotPosition), '.', preferredExtension);
+                else {
+                    auto basePart = suggestedFilename.left(dotPosition);
+                    auto secondDotPosition = basePart.reverseFind('.');
+                    if (secondDotPosition != notFound) {
+                        auto middleExtension = basePart.substring(secondDotPosition + 1);
+                        // Only strip the middle extension if it belongs to a different major MIME type to preserve compound extensions (eg. ".tar.gz").
+                        auto middleMIMEType = MIMETypeRegistry::mimeTypeForExtension(middleExtension);
+                        auto slashPosition = mimeType.find('/');
+                        auto middleSlashPosition = middleMIMEType.find('/');
+                        if (!middleMIMEType.isEmpty() && slashPosition != notFound && middleSlashPosition != notFound
+                            && mimeType.left(slashPosition) != middleMIMEType.left(middleSlashPosition))
+                            suggestedFilename = makeString(basePart.left(secondDotPosition), '.', preferredExtension);
+                    }
+                }
+            }
+        }
+    }
 
     protect(client())->decideDestinationWithSuggestedFilename(*this, response, ResourceResponseBase::sanitizeSuggestedFilename(suggestedFilename), [this, protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler)] (AllowOverwrite allowOverwrite, String destination) mutable {
         SandboxExtension::Handle sandboxExtensionHandle;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm
@@ -3417,4 +3417,49 @@ TEST(WKDownload, OriginatingFrameHostWhenDownloadComesFromClientInputNavigation)
     Util::run(&downloadDestinationDecided);
 }
 
+// rdar://147183354
+TEST(WKDownload, SuggestedFilenameCorrectedByContentType)
+{
+    using namespace TestWebKitAPI;
+
+    HTTPServer server([](Connection connection) {
+        connection.receiveHTTPRequest([connection](Vector<char>&&) {
+            connection.send(makeString(
+                "HTTP/1.1 200 OK\r\n"
+                "Content-Type: video/mp4\r\n"
+                "Content-Length: 5000\r\n"
+                "\r\n"_s, longString<5000>('a')
+            ));
+        });
+    });
+
+    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    auto downloadDelegate = adoptNS([TestDownloadDelegate new]);
+
+    __block bool downloadDestinationDecided = false;
+    __block RetainPtr<NSString> receivedSuggestedFilename;
+
+    navigationDelegate.get().decidePolicyForNavigationResponse = ^(WKNavigationResponse *, void (^completionHandler)(WKNavigationResponsePolicy)) {
+        completionHandler(WKNavigationResponsePolicyDownload);
+    };
+
+    navigationDelegate.get().navigationResponseDidBecomeDownload = ^(WKNavigationResponse *, WKDownload *download) {
+        download.delegate = downloadDelegate.get();
+    };
+
+    downloadDelegate.get().decideDestinationUsingResponse = ^(WKDownload *, NSURLResponse *, NSString *suggestedFilename, void (^completionHandler)(NSURL *)) {
+        receivedSuggestedFilename = suggestedFilename;
+        downloadDestinationDecided = true;
+        completionHandler(nil);
+    };
+
+    auto requestURL = makeString("http://127.0.0.1:"_s, server.port(), "/video.gif"_s);
+    auto webView = adoptNS([WKWebView new]);
+    [webView setNavigationDelegate:navigationDelegate.get()];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:requestURL.createNSString().get()]]];
+    Util::run(&downloadDestinationDecided);
+
+    EXPECT_WK_STREQ("video.mp4", receivedSuggestedFilename.get());
+}
+
 }


### PR DESCRIPTION
#### 44b6799af97f274a00cb1deaf96d3a3f1520ee8d
<pre>
<a href="https://bugs.webkit.org/show_bug.cgi?id=289445">https://bugs.webkit.org/show_bug.cgi?id=289445</a>
<a href="https://rdar.apple.com/173343223">rdar://173343223</a> (DownloadsManager overrides WebKit&apos;s MIME-corrected filename with stale URL-derived extension)

Reviewed by NOBODY (OOPS!).

When a download is initiated via context menu, Safari caches a URL-derived filename on the
DownloadProgressEntry before the HTTP response arrives. The cached filename&apos;s extension may
not match the actual Content-Type (e.g., .gif for a video/mp4 response). In
decideDestinationUsingResponse:suggestedFilename:completionHandler: the stale filename
unconditionally overrides WebKit&apos;s MIME-corrected suggested filename.

Fix: Only apply the entry&apos;s suggested filename when the file extensions match, preserving
WebKit&apos;s MIME-corrected extension when they differ.

Related: <a href="https://rdar.apple.com/147183354">rdar://147183354</a>

No new tests (OOPS!).

* Mac/Safari/Downloads/DownloadsManager.mm:
(-[DownloadsManager download:decideDestinationUsingResponse:suggestedFilename:completionHandler:]):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44b6799af97f274a00cb1deaf96d3a3f1520ee8d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152251 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/25033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18629 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160994 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154125 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/25560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25339 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/117624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155211 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/25560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/136694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98337 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/25560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/16845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/8828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/25560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/14568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163462 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/6606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/16162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125652 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/24831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/20883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125828 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/24832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/136364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/81431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/24832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/13141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/24449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/88734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/24140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/24300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/24201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->