### PR TITLE
REGRESSION(309877@main): [macOS] TestWebKitAPI.UnifiedPDF.PasswordFormShouldDismissAfterNavigation is a constant failure

### DIFF
--- a/Source/WebCore/bindings/js/JSValueInWrappedObject.h
+++ b/Source/WebCore/bindings/js/JSValueInWrappedObject.h
@@ -41,6 +41,7 @@ class JSValueInWrappedObject {
 public:
     JSValueInWrappedObject() = default;
     JSValueInWrappedObject(JSC::JSGlobalObject&, JSC::JSValue);
+    JSValueInWrappedObject(RefPtr<DOMWrapperWorld>&&, JSC::JSValue);
 
     explicit operator bool() const;
     template<typename Visitor> void visitInGCThread(Visitor&) const;
@@ -50,16 +51,20 @@ public:
     // The owner parameter is typically the wrapper of the DOM node this class is embedded into but can be any GCed object that
     // will visit this JSValueInWrappedObject via visitAdditionalChildrenInGCThread/isReachableFromOpaqueRoots.
     void set(JSC::JSGlobalObject&, const JSC::JSCell* owner, JSC::JSValue);
+    void set(RefPtr<DOMWrapperWorld>&&, JSC::VM&, const JSC::JSCell* owner, JSC::JSValue);
     // Only use this if you actually expect this value to be weakly held. If you call visitInGCThread on this value *DONT* set using setWeakly
     // use set instead. The GC might or might not keep your value around in that case.
     void setWeakly(JSC::JSGlobalObject&, JSC::JSValue);
+    void setWeakly(RefPtr<DOMWrapperWorld>&&, JSC::JSValue);
     JSC::JSValue getValue(JSC::JSValue nullValue = JSC::jsUndefined()) const;
 
+    RefPtr<DOMWrapperWorld> world() const;
     bool isWorldCompatible(JSC::JSGlobalObject& lexicalGlobalObject) const;
 
 private:
     void setValueInternal(JSC::JSValue);
     void setWorld(JSC::JSGlobalObject&);
+    void setWorld(RefPtr<DOMWrapperWorld>&&);
 
     // Keep in mind that all of these fields are accessed concurrently without lock from concurrent GC thread.
     JSC::JSValue m_nonCell { };
@@ -72,6 +77,11 @@ JSC::JSValue cachedPropertyValue(JSC::ThrowScope&, JSC::JSGlobalObject&, const J
 inline JSValueInWrappedObject::JSValueInWrappedObject(JSC::JSGlobalObject& globalObject, JSC::JSValue value)
 {
     setWeakly(globalObject, value);
+}
+
+inline JSValueInWrappedObject::JSValueInWrappedObject(RefPtr<DOMWrapperWorld>&& world, JSC::JSValue value)
+{
+    setWeakly(WTF::move(world), value);
 }
 
 inline JSC::JSValue JSValueInWrappedObject::getValue(JSC::JSValue nullValue) const
@@ -114,10 +124,21 @@ inline void JSValueInWrappedObject::setWorld(JSC::JSGlobalObject& globalObject)
     m_world = &currentWorld(globalObject);
 }
 
+inline void JSValueInWrappedObject::setWorld(RefPtr<DOMWrapperWorld>&& world)
+{
+    m_world = WTF::move(world);
+}
+
 inline void JSValueInWrappedObject::setWeakly(JSC::JSGlobalObject& globalObject, JSC::JSValue value)
 {
     setValueInternal(value);
     setWorld(globalObject);
+}
+
+inline void JSValueInWrappedObject::setWeakly(RefPtr<DOMWrapperWorld>&& world, JSC::JSValue value)
+{
+    setValueInternal(value);
+    setWorld(WTF::move(world));
 }
 
 inline void JSValueInWrappedObject::set(JSC::JSGlobalObject& globalObject, const JSC::JSCell* owner, JSC::JSValue value)
@@ -125,6 +146,18 @@ inline void JSValueInWrappedObject::set(JSC::JSGlobalObject& globalObject, const
     setValueInternal(value);
     globalObject.vm().writeBarrier(owner, value);
     setWorld(globalObject);
+}
+
+inline void JSValueInWrappedObject::set(RefPtr<DOMWrapperWorld>&& world, JSC::VM& vm, const JSC::JSCell* owner, JSC::JSValue value)
+{
+    setValueInternal(value);
+    vm.writeBarrier(owner, value);
+    setWorld(WTF::move(world));
+}
+
+inline RefPtr<DOMWrapperWorld> JSValueInWrappedObject::world() const
+{
+    return m_world.get();
 }
 
 inline void JSValueInWrappedObject::clear()

--- a/Source/WebCore/page/NavigateEvent.cpp
+++ b/Source/WebCore/page/NavigateEvent.cpp
@@ -63,9 +63,27 @@ NavigateEvent::NavigateEvent(JSC::JSGlobalObject& globalObject, const AtomString
     m_info.setWeakly(globalObject, init.info);
 }
 
-Ref<NavigateEvent> NavigateEvent::create(JSC::JSGlobalObject& globalObject, const AtomString& type, Init&& init, AbortController* abortController)
+NavigateEvent::NavigateEvent(RefPtr<DOMWrapperWorld>&& world, const AtomString& type, Init&& init, EventIsTrusted isTrusted, AbortController* abortController)
+    : Event(EventInterfaceType::NavigateEvent, type, WTF::move(init), isTrusted)
+    , m_navigationType(init.navigationType)
+    , m_destination(WTF::move(init.destination))
+    , m_signal(WTF::move(init.signal))
+    , m_formData(WTF::move(init.formData))
+    , m_downloadRequest(WTF::move(init.downloadRequest))
+    , m_sourceElement(WTF::move(init.sourceElement))
+    , m_canIntercept(init.canIntercept)
+    , m_userInitiated(init.userInitiated)
+    , m_hashChange(init.hashChange)
+    , m_hasUAVisualTransition(init.hasUAVisualTransition)
+    , m_abortController(abortController)
 {
-    return adoptRef(*new NavigateEvent(globalObject, type, WTF::move(init), EventIsTrusted::Yes, abortController));
+    Locker<JSC::JSLock> locker(commonVM().apiLock());
+    m_info.setWeakly(WTF::move(world), init.info);
+}
+
+Ref<NavigateEvent> NavigateEvent::create(RefPtr<DOMWrapperWorld>&& world, const AtomString& type, Init&& init, AbortController* abortController)
+{
+    return adoptRef(*new NavigateEvent(WTF::move(world), type, WTF::move(init), EventIsTrusted::Yes, abortController));
 }
 
 Ref<NavigateEvent> NavigateEvent::create(JSC::JSGlobalObject& globalObject, const AtomString& type, Init&& init)

--- a/Source/WebCore/page/NavigateEvent.h
+++ b/Source/WebCore/page/NavigateEvent.h
@@ -90,7 +90,7 @@ public:
     };
 
     static Ref<NavigateEvent> create(JSC::JSGlobalObject&, const AtomString& type, Init&&);
-    static Ref<NavigateEvent> create(JSC::JSGlobalObject&, const AtomString& type, Init&&, AbortController*);
+    static Ref<NavigateEvent> create(RefPtr<DOMWrapperWorld>&&, const AtomString& type, Init&&, AbortController*);
 
     NavigationNavigationType navigationType() const { return m_navigationType; }
     bool canIntercept() const { return m_canIntercept; }
@@ -117,6 +117,7 @@ public:
 
 private:
     NavigateEvent(JSC::JSGlobalObject&, const AtomString& type, Init&&, EventIsTrusted, AbortController*);
+    NavigateEvent(RefPtr<DOMWrapperWorld>&&, const AtomString& type, Init&&, EventIsTrusted, AbortController*);
 
     ExceptionOr<void> sharedChecks(Document&);
     void potentiallyProcessScrollBehavior(Document&);

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -1079,6 +1079,7 @@ Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavi
     bool canBeCanceled = !isTraversal || (document->isTopDocument() && isSameDocument); // FIXME: and user involvement is not browser-ui or navigation's relevant global object has transient activation.
     bool hashChange = !classicHistoryAPIState && equalIgnoringFragmentIdentifier(document->url(), destination->url()) && !equalRespectingNullity(document->url().fragmentIdentifier(),  destination->url().fragmentIdentifier());
     auto info = apiMethodTracker ? apiMethodTracker->info.getValue() : JSC::jsUndefined();
+    auto world = apiMethodTracker ? apiMethodTracker->info.world() : nullptr;
 
     RefPtr scriptExecutionContext = this->scriptExecutionContext();
     RefPtr<DOMFormData> formData = nullptr;
@@ -1118,7 +1119,7 @@ Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavi
     if (apiMethodTracker)
         apiMethodTracker->info.clear();
 
-    Ref event = NavigateEvent::create(*scriptExecutionContext->globalObject(), eventNames().navigateEvent, WTF::move(init), abortController.get());
+    Ref event = NavigateEvent::create(WTF::move(world), eventNames().navigateEvent, WTF::move(init), abortController.get());
     m_ongoingNavigateEvent = event.ptr();
     m_focusChangedDuringOngoingNavigation = FocusDidChange::No;
     m_suppressNormalScrollRestorationDuringOngoingNavigation = false;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm
@@ -737,8 +737,7 @@ UNIFIED_PDF_TEST(StablePresentationUpdateCallback)
 
 #endif
 
-// FIXME when webkit.org/b/310719 is resolved.
-UNIFIED_PDF_TEST(DISABLED_PasswordFormShouldDismissAfterNavigation)
+UNIFIED_PDF_TEST(PasswordFormShouldDismissAfterNavigation)
 {
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 600, 600) configuration:configurationForWebViewTestingUnifiedPDF().get() addToWindow:YES]);
 


### PR DESCRIPTION
#### d5e71ae3fde8c39860f29ac0ab6201d6352354a1
<pre>
REGRESSION(309877@main): [macOS] TestWebKitAPI.UnifiedPDF.PasswordFormShouldDismissAfterNavigation is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=310719">https://bugs.webkit.org/show_bug.cgi?id=310719</a>
<a href="https://rdar.apple.com/173336526">rdar://173336526</a>

Reviewed by Marcus Plutowski.

Let&apos;s not calling scriptExecution()-&gt;globalObject() in Navigation event
timing as it can happen from non-API navigation, and `internals` setup
is having a timing issue when global object gets instantiated. We should
propagate DOMWrapperWorld stored in apiMethodTracker.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm

* Source/WebCore/bindings/js/JSValueInWrappedObject.h:
(WebCore::JSValueInWrappedObject::JSValueInWrappedObject):
(WebCore::JSValueInWrappedObject::setWorld):
(WebCore::JSValueInWrappedObject::setWeakly):
(WebCore::JSValueInWrappedObject::set):
(WebCore::JSValueInWrappedObject::world const):
* Source/WebCore/page/NavigateEvent.cpp:
(WebCore::NavigateEvent::NavigateEvent):
(WebCore::NavigateEvent::create):
* Source/WebCore/page/NavigateEvent.h:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::innerDispatchNavigateEvent):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm:
(TestWebKitAPI::UNIFIED_PDF_TEST):

Canonical link: <a href="https://commits.webkit.org/309963@main">https://commits.webkit.org/309963@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd051beadfee22294db0fc98ec09f1b52d03f5ff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152247 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25029 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18625 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160990 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105704 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154121 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25556 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25335 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117621 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83408 "3 flakes 2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155207 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19839 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136679 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98334 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18916 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16847 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8824 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128567 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14553 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163458 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6602 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16147 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125655 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24827 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20885 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125831 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24828 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136349 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81427 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23354 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20830 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13126 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24445 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88730 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24136 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24296 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24197 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->