### PR TITLE
[iOS] VideoPresentationManagerProxy fails to create a visibility propagation view for fullscreen on platforms that don't use ExtensionKit

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
@@ -230,7 +230,7 @@ private:
 
     RetainPtr<WKLayerHostView> createLayerHostViewWithID(PlaybackSessionContextIdentifier, const WebCore::HostingContext&, const WebCore::FloatSize& initialSize, float hostingScaleFactor);
 
-#if USE(EXTENSIONKIT)
+#if HAVE(VISIBILITY_PROPAGATION_VIEW)
     void setVisibilityPropagationViewForLayerHostView(UIView *, WKLayerHostView *);
 #endif
 

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -84,7 +84,7 @@
 
 @interface WKLayerHostView : CocoaView
 @property (nonatomic, assign) uint32_t contextID;
-#if USE(EXTENSIONKIT)
+#if HAVE(VISIBILITY_PROPAGATION_VIEW)
 @property (nonatomic, strong) CocoaView *visibilityPropagationView;
 #endif
 @end
@@ -93,10 +93,12 @@
 #if PLATFORM(IOS_FAMILY)
     WeakObjCPtr<UIWindow> _window;
 #endif
-#if USE(EXTENSIONKIT)
+#if HAVE(VISIBILITY_PROPAGATION_VIEW)
     RetainPtr<CocoaView> _visibilityPropagationView;
+#if USE(EXTENSIONKIT)
 @public
     RetainPtr<BELayerHierarchyHostingView> _hostingView;
+#endif
 #endif
 }
 
@@ -140,7 +142,7 @@
 }
 #endif
 
-#if USE(EXTENSIONKIT)
+#if HAVE(VISIBILITY_PROPAGATION_VIEW)
 - (CocoaView *)visibilityPropagationView
 {
     return _visibilityPropagationView.get();
@@ -152,7 +154,7 @@
     _visibilityPropagationView = visibilityPropagationView;
     [self addSubview:_visibilityPropagationView.get()];
 }
-#endif // USE(EXTENSIONKIT)
+#endif // HAVE(VISIBILITY_PROPAGATION_VIEW)
 
 @end
 
@@ -940,7 +942,7 @@ RetainPtr<WKLayerHostView> VideoPresentationManagerProxy::createLayerHostViewWit
     return view;
 }
 
-#if USE(EXTENSIONKIT)
+#if HAVE(VISIBILITY_PROPAGATION_VIEW)
 void VideoPresentationManagerProxy::setVisibilityPropagationViewForLayerHostView(UIView *visibilityPropagationView, WKLayerHostView *layerHostView)
 {
     if (RefPtr page = m_page.get()) {
@@ -1105,7 +1107,7 @@ void VideoPresentationManagerProxy::setupFullscreenWithID(PlaybackSessionContext
 #endif
 
     RetainPtr view = interface->layerHostView() ? RetainPtr { static_cast<WKLayerHostView*>(interface->layerHostView()) } : createLayerHostViewWithID(contextId, hostingContext, initialSize, hostingDeviceScaleFactor);
-#if USE(EXTENSIONKIT)
+#if HAVE(VISIBILITY_PROPAGATION_VIEW)
     RefPtr pageClient = page->pageClient();
     if (RetainPtr visibilityPropagationView = pageClient ? pageClient->createVisibilityPropagationView() : nil)
         setVisibilityPropagationViewForLayerHostView(visibilityPropagationView.get(), view.get());
@@ -1543,7 +1545,7 @@ void VideoPresentationManagerProxy::didCleanupFullscreen(PlaybackSessionContextI
 
     auto [model, interface] = ensureModelAndInterface(contextId);
 
-#if USE(EXTENSIONKIT)
+#if HAVE(VISIBILITY_PROPAGATION_VIEW)
     if (RetainPtr layerHostView = dynamic_objc_cast<WKLayerHostView>(interface->layerHostView()))
         setVisibilityPropagationViewForLayerHostView(nil, layerHostView.get());
 #endif

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -448,10 +448,8 @@ public:
 #if ENABLE(MODEL_PROCESS)
     virtual void didCreateContextInModelProcessForVisibilityPropagation(LayerHostingContextID) { }
 #endif
-#if USE(EXTENSIONKIT)
-    virtual UIView *createVisibilityPropagationView() { return nullptr; }
+    virtual RetainPtr<UIView> createVisibilityPropagationView() { return nullptr; }
     virtual void removeVisibilityPropagationView(UIView *) { }
-#endif
 #endif // HAVE(VISIBILITY_PROPAGATION_VIEW)
 
 #if ENABLE(GPU_PROCESS)

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -99,10 +99,8 @@ private:
     void didCreateContextInModelProcessForVisibilityPropagation(LayerHostingContextID) override;
     void didReceiveInteractiveModelElement(std::optional<WebCore::NodeIdentifier>) override;
 #endif // ENABLE(MODEL_PROCESS)
-#if USE(EXTENSIONKIT)
-    UIView *createVisibilityPropagationView() override;
+    RetainPtr<UIView> createVisibilityPropagationView() override;
     void removeVisibilityPropagationView(UIView *) override;
-#endif
 #endif // HAVE(VISIBILITY_PROPAGATION_VIEW)
 
 #if ENABLE(GPU_PROCESS)

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -300,8 +300,7 @@ void PageClientImpl::didReceiveInteractiveModelElement(std::optional<WebCore::No
 }
 #endif // ENABLE(MODEL_PROCESS)
 
-#if USE(EXTENSIONKIT)
-UIView *PageClientImpl::createVisibilityPropagationView()
+RetainPtr<UIView> PageClientImpl::createVisibilityPropagationView()
 {
     return [contentView() _createVisibilityPropagationView];
 }
@@ -310,7 +309,6 @@ void PageClientImpl::removeVisibilityPropagationView(UIView *view)
 {
     [contentView() _removeVisibilityPropagationView:view];
 }
-#endif
 #endif // HAVE(VISIBILITY_PROPAGATION_VIEW)
 
 #if ENABLE(GPU_PROCESS)

--- a/Source/WebKit/UIProcess/ios/WKContentView.h
+++ b/Source/WebKit/UIProcess/ios/WKContentView.h
@@ -115,10 +115,8 @@ using LayerHostingContextID = uint32_t;
 #if ENABLE(MODEL_PROCESS)
 - (void)_modelProcessDidCreateContextForVisibilityPropagation;
 #endif // ENABLE(MODEL_PROCESS)
-#if USE(EXTENSIONKIT)
-- (UIView *)_createVisibilityPropagationView;
+- (RetainPtr<UIView>)_createVisibilityPropagationView;
 - (void)_removeVisibilityPropagationView:(UIView *)view;
-#endif
 #endif // HAVE(VISIBILITY_PROPAGATION_VIEW)
 
 - (void)_setAcceleratedCompositingRootView:(UIView *)rootView;

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -227,25 +227,7 @@ typedef NS_ENUM(NSInteger, _WKPrintRenderingCallbackType) {
 #endif
 
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)
-#if USE(EXTENSIONKIT)
     RetainPtr<NSMutableSet<WKVisibilityPropagationView *>> _visibilityPropagationViews;
-#elif HAVE(NON_HOSTING_VISIBILITY_PROPAGATION_VIEW)
-    HashMap<WebCore::ProcessIdentifier, RetainPtr<_UINonHostingVisibilityPropagationView>> _visibilityPropagationViewsForWebProcesses;
-#if ENABLE(GPU_PROCESS)
-    RetainPtr<_UINonHostingVisibilityPropagationView> _visibilityPropagationViewForGPUProcess;
-#endif // ENABLE(GPU_PROCESS)
-#if ENABLE(MODEL_PROCESS)
-    RetainPtr<_UINonHostingVisibilityPropagationView> _visibilityPropagationViewForModelProcess;
-#endif // ENABLE(MODEL_PROCESS)
-#else
-    HashMap<WebCore::ProcessIdentifier, RetainPtr<_UILayerHostView>> _visibilityPropagationViewsForWebProcesses;
-#if ENABLE(GPU_PROCESS)
-    RetainPtr<_UILayerHostView> _visibilityPropagationViewForGPUProcess;
-#endif // ENABLE(GPU_PROCESS)
-#if ENABLE(MODEL_PROCESS)
-    RetainPtr<_UILayerHostView> _visibilityPropagationViewForModelProcess;
-#endif // ENABLE(MODEL_PROCESS)
-#endif // !USE(EXTENSIONKIT)
 #endif // HAVE(VISIBILITY_PROPAGATION_VIEW)
 
     __weak UIScreen *_screen;
@@ -310,7 +292,8 @@ typedef NS_ENUM(NSInteger, _WKPrintRenderingCallbackType) {
 #endif
 
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)
-    [self _installVisibilityPropagationViews];
+    [self addSubview:[self _createVisibilityPropagationView].get()];
+    [self _setupVisibilityPropagation];
 #endif
 
 #if HAVE(SPATIAL_TRACKING_LABEL)
@@ -343,65 +326,31 @@ typedef NS_ENUM(NSInteger, _WKPrintRenderingCallbackType) {
 }
 
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)
-- (void)_installVisibilityPropagationViews
-{
-#if USE(EXTENSIONKIT)
-    if (UIView *visibilityPropagationView = [self _createVisibilityPropagationView]) {
-        [self addSubview:visibilityPropagationView];
-        return;
-    }
-#endif
-
-    [self _setupVisibilityPropagation];
-}
 
 - (void)_setupVisibilityPropagationForWebProcess:(WebKit::WebProcessProxy&)process contextID:(WebKit::LayerHostingContextID)contextID
 {
-#if USE(EXTENSIONKIT)
     for (WKVisibilityPropagationView *visibilityPropagationView in _visibilityPropagationViews.get())
-        [visibilityPropagationView propagateVisibilityToProcess:process];
-#else
-    auto processID = process.processID();
-    if (!processID)
-        return;
-    auto coreIdentifier = process.coreProcessIdentifier();
-    if (_visibilityPropagationViewsForWebProcesses.contains(coreIdentifier))
-        return;
-#if HAVE(NON_HOSTING_VISIBILITY_PROPAGATION_VIEW)
-    auto environmentIdentifier = process.environmentIdentifier();
-    RetainPtr visibilityPropagationViewForWebProcess = adoptNS([[_UINonHostingVisibilityPropagationView alloc] initWithFrame:CGRectZero pid:processID environmentIdentifier:environmentIdentifier.createNSString().get()]);
-#else
-    if (!contextID)
-        return;
-    RetainPtr visibilityPropagationViewForWebProcess = adoptNS([[_UILayerHostView alloc] initWithFrame:CGRectZero pid:processID contextID:contextID]);
-#endif
-    RELEASE_LOG(Process, "Created visibility propagation view %p (contextID=%u) for WebContent process with PID=%d", visibilityPropagationViewForWebProcess.get(), contextID, processID);
-    _visibilityPropagationViewsForWebProcesses.add(coreIdentifier, visibilityPropagationViewForWebProcess);
-    [self addSubview:visibilityPropagationViewForWebProcess.get()];
-#endif
+        [visibilityPropagationView propagateVisibilityToProcess:process contextID:contextID];
 }
 
 - (void)_removeVisibilityPropagationForWebProcess:(WebKit::WebProcessProxy&)process
 {
-#if USE(EXTENSIONKIT)
     for (WKVisibilityPropagationView *visibilityPropagationView in _visibilityPropagationViews.get())
         [visibilityPropagationView stopPropagatingVisibilityToProcess:process];
-#else
-    auto coreIdentifier = process.coreProcessIdentifier();
-    ASSERT(_visibilityPropagationViewsForWebProcesses.contains(coreIdentifier));
-    if (!_visibilityPropagationViewsForWebProcesses.contains(coreIdentifier))
-        return;
-    _visibilityPropagationViewsForWebProcesses.remove(coreIdentifier);
-#endif
 }
 
 - (void)_setupVisibilityPropagationForAllWebProcesses
 {
-    if (!protect(_page)->hasRunningProcess())
+    RefPtr page = _page.get();
+    if (!page)
         return;
 
-    Ref mainFrameProcess = _page->siteIsolatedProcess();
-    [self _setupVisibilityPropagationForWebProcess:mainFrameProcess contextID:_page->contextIDForVisibilityPropagationInWebProcess()];
+    if (!page->hasRunningProcess())
+        return;
+
+    Ref mainFrameProcess = page->siteIsolatedProcess();
+    [self _setupVisibilityPropagationForWebProcess:mainFrameProcess contextID:page->contextIDForVisibilityPropagationInWebProcess()];
+
     auto remotePages = mainFrameProcess->remotePages();
     for (auto& remotePage : remotePages)
         [self _setupVisibilityPropagationForWebProcess:remotePage->process() contextID:remotePage->contextIDForVisibilityPropagationInWebProcess()];
@@ -410,117 +359,79 @@ typedef NS_ENUM(NSInteger, _WKPrintRenderingCallbackType) {
 #if ENABLE(GPU_PROCESS)
 - (void)_setupVisibilityPropagationForGPUProcess
 {
-    RefPtr gpuProcess = _page->configuration().processPool().gpuProcess();
+    RefPtr page = _page.get();
+    if (!page)
+        return;
+
+    RefPtr gpuProcess = page->configuration().processPool().gpuProcess();
     if (!gpuProcess)
         return;
 
-#if USE(EXTENSIONKIT)
     for (WKVisibilityPropagationView *visibilityPropagationView in _visibilityPropagationViews.get())
-        [visibilityPropagationView propagateVisibilityToProcess:*gpuProcess];
-#else
-    auto processID = gpuProcess->processID();
-    if (!processID)
-        return;
-
-    if (_visibilityPropagationViewForGPUProcess)
-        return;
-
-    // Propagate the view's visibility state to the GPU process so that it is marked as "Foreground Running" when necessary.
-#if HAVE(NON_HOSTING_VISIBILITY_PROPAGATION_VIEW)
-    auto environmentIdentifier = gpuProcess->environmentIdentifier();
-    _visibilityPropagationViewForGPUProcess = adoptNS([[_UINonHostingVisibilityPropagationView alloc] initWithFrame:CGRectZero pid:processID environmentIdentifier:environmentIdentifier.createNSString().get()]);
-#else
-    auto contextID = _page->contextIDForVisibilityPropagationInGPUProcess();
-    if (!contextID)
-        return;
-    _visibilityPropagationViewForGPUProcess = adoptNS([[_UILayerHostView alloc] initWithFrame:CGRectZero pid:processID contextID:contextID]);
-#endif
-    [self addSubview:_visibilityPropagationViewForGPUProcess.get()];
-    RELEASE_LOG(Process, "Created visibility propagation view %p for GPU process with PID=%d", _visibilityPropagationViewForGPUProcess.get(), processID);
-#endif
+        [visibilityPropagationView propagateVisibilityToProcess:*gpuProcess contextID:page->contextIDForVisibilityPropagationInGPUProcess()];
 }
 #endif // ENABLE(GPU_PROCESS)
 
 #if ENABLE(MODEL_PROCESS)
 - (void)_setupVisibilityPropagationForModelProcess
 {
-    RefPtr modelProcess = _page->configuration().processPool().modelProcess();
+    RefPtr page = _page.get();
+    if (!page)
+        return;
+
+    RefPtr modelProcess = page->configuration().processPool().modelProcess();
     if (!modelProcess)
         return;
-    auto processIdentifier = modelProcess->processID();
-    if (!processIdentifier)
-        return;
 
-    if (_visibilityPropagationViewForModelProcess)
-        return;
-
-    // Propagate the view's visibility state to the model process so that it is marked as "Foreground Running" when necessary.
-#if HAVE(NON_HOSTING_VISIBILITY_PROPAGATION_VIEW)
-    auto environmentIdentifier = modelProcess->environmentIdentifier();
-    _visibilityPropagationViewForModelProcess = adoptNS([[_UINonHostingVisibilityPropagationView alloc] initWithFrame:CGRectZero pid:processIdentifier environmentIdentifier:environmentIdentifier.createNSString().get()]);
-#else
-    auto contextID = _page->contextIDForVisibilityPropagationInModelProcess();
-    if (!contextID)
-        return;
-    _visibilityPropagationViewForModelProcess = adoptNS([[_UILayerHostView alloc] initWithFrame:CGRectZero pid:processIdentifier contextID:contextID]);
-#endif
-    RELEASE_LOG(Process, "Created visibility propagation view %p for model process with PID=%d", _visibilityPropagationViewForModelProcess.get(), processIdentifier);
-    [self addSubview:_visibilityPropagationViewForModelProcess.get()];
+    for (WKVisibilityPropagationView *visibilityPropagationView in _visibilityPropagationViews.get())
+        [visibilityPropagationView propagateVisibilityToProcess:*modelProcess contextID:page->contextIDForVisibilityPropagationInModelProcess()];
 }
 #endif // ENABLE(MODEL_PROCESS)
 
 - (void)_removeVisibilityPropagationViewForWebProcess
 {
-#if USE(EXTENSIONKIT)
-    if (RefPtr page = _page.get()) {
-        Ref mainFrameProcess = _page->siteIsolatedProcess();
-        for (WKVisibilityPropagationView *visibilityPropagationView in _visibilityPropagationViews.get())
-            [visibilityPropagationView stopPropagatingVisibilityToProcess:mainFrameProcess];
-        auto remotePages = mainFrameProcess->remotePages();
-        for (auto& remotePage : remotePages) {
-            for (WKVisibilityPropagationView *visibilityPropagationView in _visibilityPropagationViews.get())
-                [visibilityPropagationView stopPropagatingVisibilityToProcess:remotePage->process()];
-        }
-    }
-#else
-    for (auto& keyAndValue : _visibilityPropagationViewsForWebProcesses) {
-        RetainPtr visibilityPropagationViewForWebProcess = keyAndValue.value;
-        RELEASE_LOG(Process, "Removing visibility propagation view %p", visibilityPropagationViewForWebProcess.get());
-        [visibilityPropagationViewForWebProcess removeFromSuperview];
-    }
-    _visibilityPropagationViewsForWebProcesses.clear();
-#endif
+    RefPtr page = _page.get();
+    if (!page)
+        return;
+
+    Ref mainFrameProcess = page->siteIsolatedProcess();
+    [self _removeVisibilityPropagationForWebProcess:mainFrameProcess];
+
+    auto remotePages = mainFrameProcess->remotePages();
+    for (auto& remotePage : remotePages)
+        [self _removeVisibilityPropagationForWebProcess:remotePage->process()];
 }
 
 - (void)_removeVisibilityPropagationViewForGPUProcess
 {
-#if USE(EXTENSIONKIT)
     RefPtr page = _page.get();
-    if (RefPtr gpuProcess = page ? page->configuration().processPool().gpuProcess() : nullptr) {
-        for (WKVisibilityPropagationView *visibilityPropagationView in _visibilityPropagationViews.get())
-            [visibilityPropagationView stopPropagatingVisibilityToProcess:*gpuProcess];
-    }
-#else
-    if (!_visibilityPropagationViewForGPUProcess)
+    if (!page)
         return;
 
-    RELEASE_LOG(Process, "Removing visibility propagation view %p", _visibilityPropagationViewForGPUProcess.get());
-    [_visibilityPropagationViewForGPUProcess removeFromSuperview];
-    _visibilityPropagationViewForGPUProcess = nullptr;
-#endif
+    RefPtr gpuProcess = page->configuration().processPool().gpuProcess();
+    if (!gpuProcess)
+        return;
+
+    for (WKVisibilityPropagationView *visibilityPropagationView in _visibilityPropagationViews.get())
+        [visibilityPropagationView stopPropagatingVisibilityToProcess:*gpuProcess];
 }
 
 #if ENABLE(MODEL_PROCESS)
 - (void)_removeVisibilityPropagationViewForModelProcess
 {
-    if (!_visibilityPropagationViewForModelProcess)
+    RefPtr page = _page.get();
+    if (!page)
         return;
 
-    RELEASE_LOG(Process, "Removing visibility propagation view %p", _visibilityPropagationViewForModelProcess.get());
-    [_visibilityPropagationViewForModelProcess removeFromSuperview];
-    _visibilityPropagationViewForModelProcess = nullptr;
+    RefPtr modelProcess = page->configuration().processPool().modelProcess();
+    if (!modelProcess)
+        return;
+
+    for (WKVisibilityPropagationView *visibilityPropagationView in _visibilityPropagationViews.get())
+        [visibilityPropagationView stopPropagatingVisibilityToProcess:*modelProcess];
 }
 #endif // ENABLE(MODEL_PROCESS)
+
 #endif // HAVE(VISIBILITY_PROPAGATION_VIEW)
 
 - (instancetype)initWithFrame:(CGRect)frame processPool:(std::reference_wrapper<WebKit::WebProcessPool>)processPool configuration:(Ref<API::PageConfiguration>&&)configuration webView:(WKWebView *)webView
@@ -947,10 +858,8 @@ static void storeAccessibilityRemoteConnectionInformation(id element, pid_t pid,
 
 - (void)_resetVisibilityPropagation
 {
-#if USE(EXTENSIONKIT)
     for (WKVisibilityPropagationView *visibilityPropagationView in _visibilityPropagationViews.get())
         [visibilityPropagationView clear];
-#endif
 }
 
 - (void)_setupVisibilityPropagation
@@ -989,6 +898,7 @@ static void storeAccessibilityRemoteConnectionInformation(id element, pid_t pid,
 }
 
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)
+
 - (void)_webProcessDidCreateContextForVisibilityPropagation
 {
     [self _setupVisibilityPropagationForAllWebProcesses];
@@ -1006,8 +916,7 @@ static void storeAccessibilityRemoteConnectionInformation(id element, pid_t pid,
 }
 #endif
 
-#if USE(EXTENSIONKIT)
-- (WKVisibilityPropagationView *)_createVisibilityPropagationView
+- (RetainPtr<UIView>)_createVisibilityPropagationView
 {
     if (!_visibilityPropagationViews)
         _visibilityPropagationViews = adoptNS([[NSMutableSet alloc] init]);
@@ -1015,9 +924,7 @@ static void storeAccessibilityRemoteConnectionInformation(id element, pid_t pid,
     RetainPtr visibilityPropagationView = adoptNS([[WKVisibilityPropagationView alloc] init]);
     [_visibilityPropagationViews addObject:visibilityPropagationView.get()];
 
-    [self _setupVisibilityPropagation];
-
-    return visibilityPropagationView.autorelease();
+    return visibilityPropagationView;
 }
 
 - (void)_removeVisibilityPropagationView:(UIView *)view
@@ -1025,7 +932,7 @@ static void storeAccessibilityRemoteConnectionInformation(id element, pid_t pid,
     if (RetainPtr visibilityPropagationView = dynamic_objc_cast<WKVisibilityPropagationView>(view))
         [_visibilityPropagationViews removeObject:visibilityPropagationView.get()];
 }
-#endif // USE(EXTENSIONKIT)
+
 #endif // HAVE(VISIBILITY_PROPAGATION_VIEW)
 
 - (void)_didCommitLayerTree:(const WebKit::RemoteLayerTreeTransaction&)layerTreeTransaction mainFrameData:(const std::optional<WebKit::MainFrameData>&)mainFrameData pageData:(const WebKit::PageData&)pageData transactionID:(const WebKit::TransactionID&)transactionID

--- a/Source/WebKit/UIProcess/ios/WKVisibilityPropagationView.h
+++ b/Source/WebKit/UIProcess/ios/WKVisibilityPropagationView.h
@@ -23,19 +23,20 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#if HAVE(VISIBILITY_PROPAGATION_VIEW) && USE(EXTENSIONKIT)
+#if HAVE(VISIBILITY_PROPAGATION_VIEW)
 
 #import <UIKit/UIKit.h>
 
 namespace WebKit {
 class AuxiliaryProcessProxy;
+using LayerHostingContextID = uint32_t;
 }
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface WKVisibilityPropagationView : UIView
 
-- (void)propagateVisibilityToProcess:(WebKit::AuxiliaryProcessProxy&)process;
+- (void)propagateVisibilityToProcess:(WebKit::AuxiliaryProcessProxy&)process contextID:(WebKit::LayerHostingContextID)contextID;
 - (void)stopPropagatingVisibilityToProcess:(WebKit::AuxiliaryProcessProxy&)process;
 - (void)clear;
 
@@ -43,4 +44,4 @@ NS_ASSUME_NONNULL_BEGIN
 
 NS_ASSUME_NONNULL_END
 
-#endif // HAVE(VISIBILITY_PROPAGATION_VIEW) && USE(EXTENSIONKIT)
+#endif // HAVE(VISIBILITY_PROPAGATION_VIEW)

--- a/Source/WebKit/UIProcess/ios/WKVisibilityPropagationView.mm
+++ b/Source/WebKit/UIProcess/ios/WKVisibilityPropagationView.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 #import "config.h"
 #import "WKVisibilityPropagationView.h"
 
-#if HAVE(VISIBILITY_PROPAGATION_VIEW) && USE(EXTENSIONKIT)
+#if HAVE(VISIBILITY_PROPAGATION_VIEW)
 
 #import "AuxiliaryProcessProxy.h"
 #import "ExtensionKitSPI.h"
@@ -35,18 +35,23 @@
 #import <wtf/WeakPtr.h>
 
 namespace WebKit {
-using ProcessAndInteractionPair = std::pair<WeakPtr<AuxiliaryProcessProxy>, RetainPtr<id<UIInteraction>>>;
+#if USE(EXTENSIONKIT)
+using ProcessAndVisibilityPropagatorPair = std::pair<WeakPtr<AuxiliaryProcessProxy>, RetainPtr<id<UIInteraction>>>;
+#else
+using ProcessAndVisibilityPropagatorPair = std::pair<WeakPtr<AuxiliaryProcessProxy>, RetainPtr<UIView>>;
+#endif
 }
 
 @implementation WKVisibilityPropagationView {
-    Vector<WebKit::ProcessAndInteractionPair> _processesAndInteractions;
+    Vector<WebKit::ProcessAndVisibilityPropagatorPair> _processesAndVisibilityPropagators;
 }
 
-- (void)propagateVisibilityToProcess:(WebKit::AuxiliaryProcessProxy&)process
+- (void)propagateVisibilityToProcess:(WebKit::AuxiliaryProcessProxy&)process contextID:(WebKit::LayerHostingContextID)contextID
 {
-    if ([self _containsInteractionForProcess:process])
+    if ([self _containsVisibilityPropagatorForProcess:process])
         return;
 
+#if USE(EXTENSIONKIT)
     auto extensionProcess = process.extensionProcess();
     if (!extensionProcess)
         return;
@@ -55,40 +60,71 @@ using ProcessAndInteractionPair = std::pair<WeakPtr<AuxiliaryProcessProxy>, Reta
     if (!visibilityPropagationInteraction)
         return;
 
+    RELEASE_LOG(Process, "Created visibility propagation interaction %p for process with PID=%d", visibilityPropagationInteraction.get(), process.processID());
+
     [self addInteraction:visibilityPropagationInteraction.get()];
+    auto processAndVisibilityPropagator = std::make_pair(WeakPtr(process), WTF::move(visibilityPropagationInteraction));
+#else
+    auto processID = process.processID();
+    if (!processID)
+        return;
 
-    RELEASE_LOG(Process, "Created visibility propagation interaction %@ for process with PID=%d", visibilityPropagationInteraction.get(), process.processID());
+#if HAVE(NON_HOSTING_VISIBILITY_PROPAGATION_VIEW)
+    RetainPtr visibilityPropagationView = adoptNS([[_UINonHostingVisibilityPropagationView alloc] initWithFrame:CGRectZero pid:processID environmentIdentifier:process.environmentIdentifier().createNSString().get()]);
+#else
+    if (!contextID)
+        return;
 
-    auto processAndInteraction = std::make_pair(WeakPtr(process), visibilityPropagationInteraction);
-    _processesAndInteractions.append(WTF::move(processAndInteraction));
+    RetainPtr visibilityPropagationView = adoptNS([[_UILayerHostView alloc] initWithFrame:CGRectZero pid:processID contextID:contextID]);
+#endif
+
+    RELEASE_LOG(Process, "Created visibility propagation view %p (contextID=%u) for process with PID=%d", visibilityPropagationView.get(), contextID, processID);
+
+    [self addSubview:visibilityPropagationView.get()];
+    auto processAndVisibilityPropagator = std::make_pair(WeakPtr(process), WTF::move(visibilityPropagationView));
+#endif
+
+    _processesAndVisibilityPropagators.append(WTF::move(processAndVisibilityPropagator));
+}
+
+- (void)_removeVisibilityPropagator:(const WebKit::ProcessAndVisibilityPropagatorPair::second_type&)visibilityPropagator
+{
+#if USE(EXTENSIONKIT)
+    [self removeInteraction:visibilityPropagator.get()];
+#else
+    [visibilityPropagator removeFromSuperview];
+#endif
 }
 
 - (void)stopPropagatingVisibilityToProcess:(WebKit::AuxiliaryProcessProxy&)process
 {
-    _processesAndInteractions.removeAllMatching([&](auto& processAndInteraction) {
-        auto existingProcess = processAndInteraction.first.get();
+    _processesAndVisibilityPropagators.removeAllMatching([&](auto& processAndVisibilityPropagator) {
+        auto existingProcess = processAndVisibilityPropagator.first.get();
         if (existingProcess && existingProcess != &process)
             return false;
 
-        RELEASE_LOG(Process, "Removing visibility propagation interaction %p", processAndInteraction.second.get());
+        RELEASE_LOG(Process, "Removing visibility propagation %p", processAndVisibilityPropagator.second.get());
 
-        [self removeInteraction:processAndInteraction.second.get()];
+        [self _removeVisibilityPropagator:processAndVisibilityPropagator.second];
         return true;
     });
 }
 
-- (BOOL)_containsInteractionForProcess:(WebKit::AuxiliaryProcessProxy&)process
+- (BOOL)_containsVisibilityPropagatorForProcess:(WebKit::AuxiliaryProcessProxy&)process
 {
-    return _processesAndInteractions.containsIf([&](auto& processAndInteraction) {
-        return processAndInteraction.first.get() == &process;
+    return _processesAndVisibilityPropagators.containsIf([&](auto& processesAndVisibilityPropagator) {
+        return processesAndVisibilityPropagator.first.get() == &process;
     });
 }
 
 - (void)clear
 {
-    _processesAndInteractions.clear();
+    _processesAndVisibilityPropagators.removeAllMatching([&](auto& processAndVisibilityPropagator) {
+        [self _removeVisibilityPropagator:processAndVisibilityPropagator.second];
+        return true;
+    });
 }
 
 @end
 
-#endif // HAVE(VISIBILITY_PROPAGATION_VIEW) && USE(EXTENSIONKIT)
+#endif // HAVE(VISIBILITY_PROPAGATION_VIEW)


### PR DESCRIPTION
#### c1264c2f2254b3324f66f96af8e89be666af3eab
<pre>
[iOS] VideoPresentationManagerProxy fails to create a visibility propagation view for fullscreen on platforms that don&apos;t use ExtensionKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=310732">https://bugs.webkit.org/show_bug.cgi?id=310732</a>
<a href="https://rdar.apple.com/173354163">rdar://173354163</a>

Reviewed by Per Arne Vollan, Aditya Keerthi, and Jer Noble.

VideoPresentationManagerProxy::setupFullscreenWithID adds a WKVisibilityPropagationView as a
subview of its WKLayerHostView so that visibility is propagated to the GPU and WebContent processes
when a video is playing in fullscreen or PiP. However, prior to this change
WKVisibilityPropagationView was ony supported on platforms that use ExtensionKit, leaving
non-ExtensionKit-using iOS-family platforms without proper visibility propagation in these
fullscreen modes.

Resolved this by moving the logic for creating _UINonHostingVisibilityPropagationViews or
_UILayerHostViews from WKContentView to WKVisibilityPropagationView and making the latter available
wherever HAVE(VISIBILITY_PROPAGATION_VIEW) is true. As a result both WKContentView and
VideoPresentationManagerProxy can create WKVisibilityPropagationViews that work properly with or
without ExtensionKit.

* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::setupFullscreenWithID):
(WebKit::VideoPresentationManagerProxy::didCleanupFullscreen):
  Added and removed WKVisibilityPropagationViews whenever HAVE(VISIBILITY_PROPAGATION_VIEW) is true.

* Source/WebKit/UIProcess/PageClient.h:
(WebKit::PageClient::createVisibilityPropagationView):
(WebKit::PageClient::removeVisibilityPropagationView):
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::createVisibilityPropagationView):
(WebKit::PageClientImpl::removeVisibilityPropagationView):

* Source/WebKit/UIProcess/ios/WKContentView.h:
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView _commonInitializationWithProcessPool:configuration:]):
(-[WKContentView _setupVisibilityPropagationForWebProcess:contextID:]):
(-[WKContentView _removeVisibilityPropagationForWebProcess:]):
(-[WKContentView _setupVisibilityPropagationForAllWebProcesses]):
(-[WKContentView _setupVisibilityPropagationForGPUProcess]):
(-[WKContentView _setupVisibilityPropagationForModelProcess]):
(-[WKContentView _removeVisibilityPropagationViewForWebProcess]):
(-[WKContentView _removeVisibilityPropagationViewForGPUProcess]):
(-[WKContentView _removeVisibilityPropagationViewForModelProcess]):
(-[WKContentView _resetVisibilityPropagation]):
(-[WKContentView _createVisibilityPropagationView]):
  Moved logic for non-ExtensionKit visibility propagation to WKVisibilityPropagationView.

(-[WKContentView _installVisibilityPropagationViews]): Deleted.

* Source/WebKit/UIProcess/ios/WKVisibilityPropagationView.h:
* Source/WebKit/UIProcess/ios/WKVisibilityPropagationView.mm:
(-[WKVisibilityPropagationView propagateVisibilityToProcess:contextID:]):
(-[WKVisibilityPropagationView _removeVisibilityPropagator:]):
(-[WKVisibilityPropagationView stopPropagatingVisibilityToProcess:]):
(-[WKVisibilityPropagationView _containsVisibilityPropagatorForProcess:]):
(-[WKVisibilityPropagationView clear]):
  Moved logic for non-ExtensionKit visibility propagation from WKContentView. For
  _UINonHostingVisibilityPropagationViews and _UILayerHostViews, these views are added/removed as
  subviews of the propagation view.

(-[WKVisibilityPropagationView propagateVisibilityToProcess:]): Deleted.
(-[WKVisibilityPropagationView _containsInteractionForProcess:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/310035@main">https://commits.webkit.org/310035@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fec66f02512d74c64eeab5dc6252841f4175c67a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152452 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25234 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18833 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161195 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25762 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25540 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117805 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155412 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20012 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136868 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98519 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19088 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17029 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9031 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128738 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163665 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13254 "Build is in progress. Recent messages:") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6807 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16336 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125843 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25032 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21068 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126014 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34197 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25034 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136538 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81634 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21002 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13317 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24650 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88936 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24341 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24501 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24402 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->