### PR TITLE
"Save as" uses the file extension name instead of the URL Content-Type

### DIFF
--- a/LayoutTests/platform/ios/http/wpt/service-workers/fetch-service-worker-preload-download-through-direct-preload.https-expected.txt
+++ b/LayoutTests/platform/ios/http/wpt/service-workers/fetch-service-worker-preload-download-through-direct-preload.https-expected.txt
@@ -1,5 +1,5 @@
 Download started.
-Downloading URL with suggested filename "fetch-service-worker-preload-script.py"
+Downloading URL with suggested filename "fetch-service-worker-preload-script.vcf"
 Download size: 11.
 Download expected size: 11.
 Download completed.

--- a/LayoutTests/platform/ios/http/wpt/service-workers/fetch-service-worker-preload-download.https-expected.txt
+++ b/LayoutTests/platform/ios/http/wpt/service-workers/fetch-service-worker-preload-download.https-expected.txt
@@ -1,5 +1,5 @@
 Download started.
-Downloading URL with suggested filename "fetch-service-worker-preload-script.py"
+Downloading URL with suggested filename "fetch-service-worker-preload-script.vcf"
 Download size: 11.
 Download completed.
 

--- a/LayoutTests/platform/ios/http/wpt/service-workers/fetch-service-worker-preload-use-download-and-clone.https-expected.txt
+++ b/LayoutTests/platform/ios/http/wpt/service-workers/fetch-service-worker-preload-use-download-and-clone.https-expected.txt
@@ -1,5 +1,5 @@
 Download started.
-Downloading URL with suggested filename "fetch-service-worker-preload-script.py"
+Downloading URL with suggested filename "fetch-service-worker-preload-script.vcf"
 Download size: 11.
 Download completed.
 

--- a/LayoutTests/platform/ios/http/wpt/service-workers/fetch-service-worker-preload-use-download.https-expected.txt
+++ b/LayoutTests/platform/ios/http/wpt/service-workers/fetch-service-worker-preload-use-download.https-expected.txt
@@ -1,5 +1,5 @@
 Download started.
-Downloading URL with suggested filename "fetch-service-worker-preload-script.py"
+Downloading URL with suggested filename "fetch-service-worker-preload-script.vcf"
 Download size: 11.
 Download completed.
 

--- a/Source/WebCore/platform/MIMETypeRegistry.cpp
+++ b/Source/WebCore/platform/MIMETypeRegistry.cpp
@@ -767,6 +767,42 @@ String MIMETypeRegistry::appendFileExtensionIfNecessary(const String& filename, 
     return makeString(filename, '.', preferredExtension);
 }
 
+String MIMETypeRegistry::correctExtensionForMIMEType(const String& suggestedFilename, const String& mimeType)
+{
+    if (suggestedFilename.isEmpty() || mimeType.isEmpty()
+        || mimeType == defaultMIMEType() || mimeType == "text/plain"_s)
+        return suggestedFilename;
+
+    auto preferredExtension = preferredExtensionForMIMEType(mimeType);
+    if (preferredExtension.isEmpty())
+        return suggestedFilename;
+
+    auto dotPosition = suggestedFilename.reverseFind('.');
+    if (dotPosition == notFound)
+        return makeString(suggestedFilename, '.', preferredExtension);
+
+    auto currentExtension = suggestedFilename.substring(dotPosition + 1);
+    if (!equalIgnoringASCIICase(mimeTypeForExtension(currentExtension), mimeType))
+        return makeString(suggestedFilename.left(dotPosition), '.', preferredExtension);
+
+    // Only strip the middle extension if it belongs to a different major MIME type to preserve compound extensions (e.g. ".tar.gz").
+    auto basePart = suggestedFilename.left(dotPosition);
+    auto secondDotPosition = basePart.reverseFind('.');
+    if (secondDotPosition == notFound)
+        return suggestedFilename;
+
+    auto middleMIMEType = mimeTypeForExtension(basePart.substring(secondDotPosition + 1));
+    if (!middleMIMEType.isEmpty()) {
+        auto slashPosition = mimeType.find('/');
+        auto middleSlashPosition = middleMIMEType.find('/');
+        if (slashPosition != notFound && middleSlashPosition != notFound
+            && mimeType.left(slashPosition) != middleMIMEType.left(middleSlashPosition))
+            return makeString(basePart.left(secondDotPosition), '.', preferredExtension);
+    }
+
+    return suggestedFilename;
+}
+
 static inline String trimmedExtension(const String& extension)
 {
     return extension.startsWith('.') ? extension.right(extension.length() - 1) : extension;

--- a/Source/WebCore/platform/MIMETypeRegistry.h
+++ b/Source/WebCore/platform/MIMETypeRegistry.h
@@ -140,6 +140,7 @@ public:
     WEBCORE_EXPORT static FixedVector<ASCIILiteral> gltfMIMETypes();
 
     WEBCORE_EXPORT static String appendFileExtensionIfNecessary(const String& filename, const String& mimeType);
+    WEBCORE_EXPORT static String correctExtensionForMIMEType(const String& filename, const String& mimeType);
 
     WEBCORE_EXPORT static String preferredImageMIMETypeForEncoding(const Vector<String>& mimeTypes, const Vector<String>& extensions);
     WEBCORE_EXPORT static bool containsImageMIMETypeForEncoding(const Vector<String>& mimeTypes, const Vector<String>& extensions);

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp
@@ -151,17 +151,36 @@ void DownloadProxy::didReceiveData(uint64_t bytesWritten, uint64_t totalBytesWri
     protect(client())->didReceiveData(*this, bytesWritten, totalBytesWritten, totalBytesExpectedToWrite);
 }
 
+// https://html.spec.whatwg.org/#getting-the-suggested-filename
+enum class FilenameSource : uint8_t {
+    ContentDisposition, // Content-Disposition header with filename
+    DownloadAttribute, // <a download="name.ext">
+    URLDerived, // Derived from the response URL
+    UserAgent, // UA fallback
+};
+
 void DownloadProxy::decideDestinationWithSuggestedFilename(const WebCore::ResourceResponse& response, String&& suggestedFilename, DecideDestinationCallback&& completionHandler)
 {
     RELEASE_LOG_INFO_IF(!response.expectedContentLength(), Network, "DownloadProxy::decideDestinationWithSuggestedFilename expectedContentLength is null");
 
-    // As per https://html.spec.whatwg.org/#as-a-download (step 2), the filename from the Content-Disposition header
-    // should override the suggested filename from the download attribute.
-    if (response.isAttachmentWithFilename() || (suggestedFilename.isEmpty() && m_suggestedFilename.isEmpty()))
+    // As per https://html.spec.whatwg.org/#getting-the-suggested-filename, the filename from the
+    // Content-Disposition header should override the suggested filename from the download attribute.
+    auto filenameSource = FilenameSource::URLDerived;
+    if (response.isAttachmentWithFilename()) {
         suggestedFilename = response.suggestedFilename();
-    else if (!m_suggestedFilename.isEmpty())
+        filenameSource = FilenameSource::ContentDisposition;
+    } else if (!m_suggestedFilename.isEmpty()) {
         suggestedFilename = m_suggestedFilename;
-    suggestedFilename = MIMETypeRegistry::appendFileExtensionIfNecessary(suggestedFilename, response.mimeType());
+        filenameSource = FilenameSource::DownloadAttribute;
+    } else if (suggestedFilename.isEmpty())
+        suggestedFilename = response.suggestedFilename();
+
+    // Correct the file extension to match the Content-Type for URL-derived filenames (rdar://147183354),
+    // or append an extension if the filename doesn't have one.
+    if (filenameSource == FilenameSource::URLDerived)
+        suggestedFilename = MIMETypeRegistry::correctExtensionForMIMEType(suggestedFilename, response.mimeType());
+    else
+        suggestedFilename = MIMETypeRegistry::appendFileExtensionIfNecessary(suggestedFilename, response.mimeType());
 
     protect(client())->decideDestinationWithSuggestedFilename(*this, response, ResourceResponseBase::sanitizeSuggestedFilename(suggestedFilename), [this, protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler)] (AllowOverwrite allowOverwrite, String destination) mutable {
         SandboxExtension::Handle sandboxExtensionHandle;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm
@@ -3456,4 +3456,49 @@ TEST(WKDownload, OriginatingFrameHostWhenDownloadComesFromClientInputNavigation)
     Util::run(&downloadDestinationDecided);
 }
 
+// rdar://147183354
+TEST(WKDownload, SuggestedFilenameCorrectedByContentType)
+{
+    using namespace TestWebKitAPI;
+
+    HTTPServer server([](Connection connection) {
+        connection.receiveHTTPRequest([connection](Vector<char>&&) {
+            connection.send(makeString(
+                "HTTP/1.1 200 OK\r\n"
+                "Content-Type: video/mp4\r\n"
+                "Content-Length: 5000\r\n"
+                "\r\n"_s, longString<5000>('a')
+            ));
+        });
+    });
+
+    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    auto downloadDelegate = adoptNS([TestDownloadDelegate new]);
+
+    __block bool downloadDestinationDecided = false;
+    __block RetainPtr<NSString> receivedSuggestedFilename;
+
+    navigationDelegate.get().decidePolicyForNavigationResponse = ^(WKNavigationResponse *, void (^completionHandler)(WKNavigationResponsePolicy)) {
+        completionHandler(WKNavigationResponsePolicyDownload);
+    };
+
+    navigationDelegate.get().navigationResponseDidBecomeDownload = ^(WKNavigationResponse *, WKDownload *download) {
+        download.delegate = downloadDelegate.get();
+    };
+
+    downloadDelegate.get().decideDestinationUsingResponse = ^(WKDownload *, NSURLResponse *, NSString *suggestedFilename, void (^completionHandler)(NSURL *)) {
+        receivedSuggestedFilename = suggestedFilename;
+        downloadDestinationDecided = true;
+        completionHandler(nil);
+    };
+
+    auto requestURL = makeString("http://127.0.0.1:"_s, server.port(), "/video.gif"_s);
+    auto webView = adoptNS([WKWebView new]);
+    [webView setNavigationDelegate:navigationDelegate.get()];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:requestURL.createNSString().get()]]];
+    Util::run(&downloadDestinationDecided);
+
+    EXPECT_WK_STREQ("video.mp4", receivedSuggestedFilename.get());
+}
+
 }


### PR DESCRIPTION
#### d496d47f982c0e0c8229b1e66faab7a218ecd2a9
<pre>
&quot;Save as&quot; uses the file extension name instead of the URL Content-Type
<a href="https://bugs.webkit.org/show_bug.cgi?id=289445">https://bugs.webkit.org/show_bug.cgi?id=289445</a>
<a href="https://rdar.apple.com/147183354">rdar://147183354</a>

Reviewed by Brent Fulgham.

NSURLResponse.suggestedFilename derives the file extension from the URL path which
does not match the actual content type sometimes (e.g., a URL ending in .gif serving video/mp4 produces
a double extension like .gif.mp4). Correct the extension in
DownloadProxy::decideDestinationWithSuggestedFilename by replacing mismatched extensions
with the correct extension for the response MIME type.

The fix:
- Does not modify filesnames from Content-Disposition headers or download attributes.
- Skips generic MIME types (e.g., text/plain) because they often are sent from servers
as fallback when type is unknown.
- Preserves compound extensions like .tar.gz by comparing major MIME types.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm

* LayoutTests/platform/ios/http/wpt/service-workers/fetch-service-worker-preload-download-through-direct-preload.https-expected.txt:
* LayoutTests/platform/ios/http/wpt/service-workers/fetch-service-worker-preload-download.https-expected.txt:
* LayoutTests/platform/ios/http/wpt/service-workers/fetch-service-worker-preload-use-download-and-clone.https-expected.txt:
* LayoutTests/platform/ios/http/wpt/service-workers/fetch-service-worker-preload-use-download.https-expected.txt:
* Source/WebCore/platform/MIMETypeRegistry.cpp:
(WebCore::MIMETypeRegistry::correctExtensionForMIMEType):
* Source/WebCore/platform/MIMETypeRegistry.h:
* Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp:
(WebKit::DownloadProxy::decideDestinationWithSuggestedFilename):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm:
(TestWebKitAPI::SuggestedFilenameCorrectedByContentType)):

Canonical link: <a href="https://commits.webkit.org/310122@main">https://commits.webkit.org/310122@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8af7d8c59933ee72369fd24a2802fabce014550d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152782 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25563 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19162 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161526 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154655 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26091 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25869 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/118066 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155741 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/20291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/137154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98779 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/19366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9362 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/129018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15028 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163998 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/7136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16622 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/126129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/25361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/21350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126287 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34261 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25363 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136824 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/81967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21239 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13603 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24979 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89266 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/24671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/24830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/24731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->