### PR TITLE
Resync `image-map-processing-model` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/image-maps/image-map-processing-model/hash-name-reference-dynamic.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/image-maps/image-map-processing-model/hash-name-reference-dynamic.html
@@ -4,6 +4,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
 <style>
  body { margin: 0 }
@@ -20,6 +21,18 @@
 const img = document.getElementById("img");
 const map = document.querySelector("map");
 
+// test_driver.click(element) checks that the element itself receives the click.
+// In an image map, the <area> element receives the click, causing WebDriver
+// to throw an "element click intercepted" error. Using the Actions API
+// bypasses this check.
+async function clickImageMap(element) {
+    await new test_driver.Actions()
+        .pointerMove(0, 0, {origin: element})
+        .pointerDown()
+        .pointerUp()
+        .send();
+}
+
 async function clickTargetsArea() {
     let target = null;
     function handler(e) {
@@ -27,7 +40,7 @@ async function clickTargetsArea() {
         target = e.target;
     }
     document.addEventListener("click", handler, { once: true, capture: true });
-    await test_driver.click(img);
+    await clickImageMap(img);
     return target && target.tagName === "AREA";
 }
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/image-maps/image-map-processing-model/hash-name-reference-id-update-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/image-maps/image-map-processing-model/hash-name-reference-id-update-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Changing a map element's id properly updates getElementById null is not an object (evaluating 'document.body.appendChild')
+PASS Changing a map element's id properly updates getElementById
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/image-maps/image-map-processing-model/hash-name-reference-id-update.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/image-maps/image-map-processing-model/hash-name-reference-id-update.html
@@ -4,6 +4,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 
+<body>
 <script>
 test(() => {
     const map = document.createElement("map");

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/image-maps/image-map-processing-model/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/image-maps/image-map-processing-model/w3c-import.log
@@ -14,5 +14,7 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/image-maps/image-map-processing-model/hash-name-reference-dynamic.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/image-maps/image-map-processing-model/hash-name-reference-id-update.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/image-maps/image-map-processing-model/hash-name-reference-test-data.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/image-maps/image-map-processing-model/hash-name-reference.html

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/embedded-content/image-maps/image-map-processing-model/hash-name-reference-dynamic-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/embedded-content/image-maps/image-map-processing-model/hash-name-reference-dynamic-expected.txt
@@ -1,0 +1,11 @@
+
+
+FAIL Initial match by id attribute assert_true: expected true got null
+FAIL Changing id away breaks the match assert_false: expected false got null
+FAIL Setting name to match usemap restores the match assert_true: expected true got null
+FAIL Removing name and restoring id matches by id assert_true: expected true got null
+FAIL Both name and id matching usemap works assert_true: expected true got null
+FAIL Changing id away while name still matches keeps the match assert_true: expected true got null
+FAIL Changing name away too breaks the match assert_false: expected false got null
+FAIL Restoring id matches again assert_true: expected true got null
+


### PR DESCRIPTION
#### e6f88ccdfe5386700298c65898559d31661a526b
<pre>
Resync `image-map-processing-model` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=310734">https://bugs.webkit.org/show_bug.cgi?id=310734</a>
<a href="https://rdar.apple.com/173355963">rdar://173355963</a>

Reviewed by Vitor Roriz and Brandon Stewart.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/f91d55e900c5946ecfb6f4ca52f6b2ca5dc2d539">https://github.com/web-platform-tests/wpt/commit/f91d55e900c5946ecfb6f4ca52f6b2ca5dc2d539</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/image-maps/image-map-processing-model/hash-name-reference-dynamic.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/image-maps/image-map-processing-model/hash-name-reference-id-update-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/image-maps/image-map-processing-model/hash-name-reference-id-update.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/image-maps/image-map-processing-model/w3c-import.log:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/embedded-content/image-maps/image-map-processing-model/hash-name-reference-dynamic-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/309988@main">https://commits.webkit.org/309988@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c09a89d9797f5d5562df2291f8b8a83526c4386

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152332 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25114 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18713 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161075 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105789 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ff1d07f9-7901-4986-a310-0f1dd6fa5135) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25641 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25420 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117693 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9e60b6f7-77d2-4b60-bc5e-23e1370f405d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155292 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19904 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136754 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98406 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e9c9badf-25f3-4c70-b340-b5f49cf245a1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18981 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16913 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8909 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128631 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14628 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163544 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16222 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125725 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24912 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20952 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125899 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34166 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24913 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136424 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81514 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20895 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13203 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24530 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24221 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24381 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24282 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->