### PR TITLE
[libpas] Fix adjacent-tag-exclusion for bitfit objects

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_mte.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_mte.h
@@ -66,9 +66,11 @@ PAS_IGNORE_WARNINGS_BEGIN("unsafe-buffer-usage")
 #endif
 
 #define PAS_MTE_SMALL_PAGE_NO_MASK (0x0000ffffffffffffull & ~((1ull << PAS_SMALL_PAGE_DEFAULT_SHIFT) - 1ull))
-#define PAS_MTE_MEDIUM_PAGE_NO_MASK (0x0000ffffffffffffull & ~((1ull << PAS_MEDIUM_PAGE_DEFAULT_SHIFT) - 1ull))
+#define PAS_MTE_MEDIUM_SEGREGATED_PAGE_NO_MASK (0x0000ffffffffffffull & ~((1ull << PAS_MEDIUM_PAGE_DEFAULT_SHIFT) - 1ull))
+#define PAS_MTE_MEDIUM_BITFIT_PAGE_NO_MASK (0x0000ffffffffffffull & ~((1ull << PAS_MEDIUM_BITFIT_PAGE_DEFAULT_SHIFT) - 1ull))
 #define PAS_MTE_SMALL_PAGE_NO(ptr) (((uintptr_t)ptr) & PAS_MTE_SMALL_PAGE_NO_MASK)
-#define PAS_MTE_MEDIUM_PAGE_NO(ptr) (((uintptr_t)ptr) & PAS_MTE_MEDIUM_PAGE_NO_MASK)
+#define PAS_MTE_MEDIUM_SEGREGATED_PAGE_NO(ptr) (((uintptr_t)ptr) & PAS_MTE_MEDIUM_SEGREGATED_PAGE_NO_MASK)
+#define PAS_MTE_MEDIUM_BITFIT_PAGE_NO(ptr) (((uintptr_t)ptr) & PAS_MTE_MEDIUM_BITFIT_PAGE_NO_MASK)
 
 #define PAS_MTE_GET_MTAG(ptr) do { \
         __asm__ volatile( \
@@ -133,19 +135,6 @@ PAS_IGNORE_WARNINGS_BEGIN("unsafe-buffer-usage")
             : \
         ); \
     } while (0)
-#define PAS_MTE_CREATE_RANDOM_TAG(ptr, mask) do { \
-        if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_ZERO_TAG_ALL)) { \
-            ptr &= (uintptr_t)~PAS_MTE_TAG_MASK; \
-            break; \
-        } \
-        __asm__ volatile( \
-            ".arch_extension memtag\n\t" \
-            "irg %0, %0, %1" \
-            : "+r"(ptr) \
-            : "r"((uintptr_t)(mask)) \
-            : \
-        ); \
-    } while (0)
 
 /*
  * DC GVA writes tags for a contiguous range of addresses in bulk. The size of this
@@ -202,7 +191,7 @@ typedef enum pas_mte_tag_constraint pas_mte_tag_constraint;
 
 PAS_ALWAYS_INLINE pas_mte_tag_constraint pas_mte_exclude_tag(pas_mte_tag_constraint base, uint8_t tag_value_to_exclude)
 {
-    return (pas_mte_tag_constraint)((unsigned)base & ~(1u << tag_value_to_exclude));
+    return (pas_mte_tag_constraint)((unsigned)base | (1u << tag_value_to_exclude));
 }
 
 PAS_ALWAYS_INLINE pas_mte_tag_constraint
@@ -239,9 +228,17 @@ pas_mte_compute_valid_tags_under_adjacent_tag_exclusion(
             succeeding_pageno = PAS_MTE_SMALL_PAGE_NO(succeeding_granule);
             current_pageno = PAS_MTE_SMALL_PAGE_NO(ptr);
         } else {
-            prior_pageno = PAS_MTE_MEDIUM_PAGE_NO(prior_granule);
-            succeeding_pageno = PAS_MTE_MEDIUM_PAGE_NO(succeeding_granule);
-            current_pageno = PAS_MTE_MEDIUM_PAGE_NO(ptr);
+            if (homogeneity == pas_mte_homogeneous_allocator) {
+                prior_pageno = PAS_MTE_MEDIUM_SEGREGATED_PAGE_NO(prior_granule);
+                succeeding_pageno = PAS_MTE_MEDIUM_SEGREGATED_PAGE_NO(succeeding_granule);
+                current_pageno = PAS_MTE_MEDIUM_SEGREGATED_PAGE_NO(ptr);
+            } else if (homogeneity == pas_mte_nonhomogeneous_allocator) {
+                prior_pageno = PAS_MTE_MEDIUM_BITFIT_PAGE_NO(prior_granule);
+                succeeding_pageno = PAS_MTE_MEDIUM_BITFIT_PAGE_NO(succeeding_granule);
+                current_pageno = PAS_MTE_MEDIUM_BITFIT_PAGE_NO(ptr);
+            } else {
+                PAS_ASSERT_NOT_REACHED();
+            }
         }
         // Since we cannot ldg addresses which lie on another page
         // from our own, we need some way to ensure that if the
@@ -483,19 +480,21 @@ inline __attribute__((always_inline)) void pas_mte_tag_dc_gva_switching(uint8_t*
 
 PAS_IGNORE_WARNINGS_END
 
-#define ASSERT_PRIOR_TAG_IS_DISJOINT(ptr) do { \
-        uint8_t* prev_ptr = (uint8_t*)((uintptr_t)ptr - 16); \
-        uint8_t* curr_ptr = (uint8_t*)ptr; \
-        if (PAS_MTE_SMALL_PAGE_NO(prev_ptr) == PAS_MTE_SMALL_PAGE_NO(curr_ptr)) { \
-            PAS_MTE_GET_MTAG(prev_ptr); \
-            PAS_MTE_GET_MTAG(curr_ptr); \
-            uintptr_t prev_tag = (uintptr_t)prev_ptr & PAS_MTE_TAG_MASK; \
-            uintptr_t curr_tag = (uintptr_t)curr_ptr & PAS_MTE_TAG_MASK; \
-            if (prev_tag == curr_tag && !curr_tag) \
-                printf("[MTE]\tAdjacent tag collision between %p and %p: crashing\n", prev_ptr, curr_ptr); \
-            PAS_ASSERT(prev_tag != curr_tag || !curr_tag, (uintptr_t)prev_ptr, (uintptr_t)curr_ptr); \
-        } \
-    } while (0)
+PAS_ALWAYS_INLINE void
+pas_mte_assert_prior_tag_is_disjoint(uintptr_t begin)
+{
+    uint8_t* prev_ptr = (uint8_t*)((uintptr_t)begin - 16);
+    uint8_t* curr_ptr = (uint8_t*)begin;
+    if (PAS_MTE_SMALL_PAGE_NO(prev_ptr) == PAS_MTE_SMALL_PAGE_NO(curr_ptr)) {
+        PAS_MTE_GET_MTAG(prev_ptr);
+        PAS_MTE_GET_MTAG(curr_ptr);
+        uintptr_t prev_tag = (uintptr_t)prev_ptr & PAS_MTE_TAG_MASK;
+        uintptr_t curr_tag = (uintptr_t)curr_ptr & PAS_MTE_TAG_MASK;
+        if (prev_tag == curr_tag && curr_tag)
+            printf("[MTE]\tAdjacent tag collision between %p and %p: crashing\n", prev_ptr, curr_ptr);
+        PAS_ASSERT(prev_tag != curr_tag || !curr_tag, (uintptr_t)prev_ptr, (uintptr_t)curr_ptr);
+    }
+}
 
 PAS_ALWAYS_INLINE void
 pas_mte_tag_region_from_pointer(
@@ -580,6 +579,23 @@ pas_mte_tag_region_from_pointer(
 #define PAS_MTE_IS_KNOWN_MEDIUM_PAGE(page_config) 0
 #endif
 
+PAS_ALWAYS_INLINE uintptr_t
+pas_mte_generate_random_tag(
+    uintptr_t begin,
+    pas_mte_tag_constraint constraint)
+{
+    if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_ZERO_TAG_ALL))
+        return begin & ~PAS_MTE_TAG_MASK;
+    __asm__ volatile( \
+        ".arch_extension memtag\n\t"
+        "irg %0, %0, %1"
+        : "+r"(begin)
+        : "r"((uintptr_t)(constraint))
+        :
+    );
+    return begin;
+}
+
 /*
  * Tagging is what actually applies an PAS_MTE tag to an allocation. If the
  * pas_allocation_mode passed to this macro is compact, we zero the upper
@@ -605,14 +621,14 @@ pas_mte_generate_tag_and_tag_region(
             valid_tags = pas_mte_compute_valid_tags_under_adjacent_tag_exclusion(begin, size, homogeneity, is_known_medium);
         else
             valid_tags = pas_mte_any_nonzero_tag;
-        PAS_MTE_CREATE_RANDOM_TAG(begin, valid_tags);
+        begin = pas_mte_generate_random_tag(begin, valid_tags);
     }
     if (mode != pas_always_compact_allocation_mode) {
         pas_mte_tag_region_from_pointer(begin, size, is_known_medium);
         if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_ADJACENT_TAG_EXCLUSION)
             && PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_ASSERT_ADJACENT_TAGS_ARE_DISJOINT)) {
-            ASSERT_PRIOR_TAG_IS_DISJOINT(begin);
-            ASSERT_PRIOR_TAG_IS_DISJOINT(begin + size);
+            pas_mte_assert_prior_tag_is_disjoint(begin);
+            pas_mte_assert_prior_tag_is_disjoint(begin + size);
         }
     }
     return begin;


### PR DESCRIPTION
#### ad6be0805df10039435e667cf9a94471709b7142
<pre>
[libpas] Fix adjacent-tag-exclusion for bitfit objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=310736">https://bugs.webkit.org/show_bug.cgi?id=310736</a>
<a href="https://rdar.apple.com/171744344">rdar://171744344</a>

Reviewed by Dan Hecht.

The logic was not accounting for the split of medium-bitfit and
medium-segregated page-sizes, and was thus incorrectly assuming that
allocations could not cross over a particular page boundary.
In addition, a previous patch (304033@main) aligned the polarity of the
pas_mte_tag_constraint type with that of the mask used in hardware,
but due to a rebasing mistake part of the the prior definition of
(the macro that is now) pas_mte_exclude_tag was carried over, meaning
we &amp; instead of |, and thus don&apos;t actually exclude the adjacent
allocations for bitfit objects in particular.
This patch fixes the above issues and replaces a few other macro
definitions with inline functions for better readability / debugging.

Canonical link: <a href="https://commits.webkit.org/310329@main">https://commits.webkit.org/310329@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a814b530c8bdb333cf2399d9d61e7dfc77dba543

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153501 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26285 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19885 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162250 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a776d4bd-88ab-4af5-b6c3-23e57be62ddf) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26811 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26605 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118679 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/79ace941-aa20-4bb7-8c58-dfbf87782dce) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156460 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/20923 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137807 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99390 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/74bbb367-8da1-4fb2-a134-29c7f7a3ea5e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/20012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17948 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10084 "Built successfully") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/145514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129648 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15677 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164722 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/14325 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17271 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/126744 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26082 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/21984 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126909 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34417 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26084 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137473 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82751 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21835 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14253 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/185137 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25701 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/47483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25392 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25551 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25452 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->