### PR TITLE
Fix empty TransferString being deserialized as null string

### DIFF
--- a/LayoutTests/ipc/serialized-type-info.html
+++ b/LayoutTests/ipc/serialized-type-info.html
@@ -124,6 +124,7 @@
             "short",
             "float",
             "bool",
+            "std::monostate",
             "std::nullptr_t",
             "uint32_t",
             "int32_t",

--- a/Source/WebKit/Platform/IPC/ArgumentCoders.h
+++ b/Source/WebKit/Platform/IPC/ArgumentCoders.h
@@ -30,6 +30,7 @@
 #include "Encoder.h"
 #include "GeneratedSerializers.h"
 #include <utility>
+#include <variant>
 #include <wtf/ArgumentCoder.h>
 #include <wtf/Box.h>
 #include <wtf/CheckedArithmetic.h>
@@ -40,6 +41,7 @@
 #include <wtf/SHA1.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/Unexpected.h>
+#include <wtf/Variant.h>
 #include <wtf/WallTime.h>
 
 #if OS(ANDROID)
@@ -843,6 +845,12 @@ template<> struct ArgumentCoder<std::nullptr_t> {
     template<typename Encoder>
     static void encode(Encoder&, const std::nullptr_t&) { }
     static std::optional<std::nullptr_t> decode(Decoder&) { return nullptr; }
+};
+
+template<> struct ArgumentCoder<std::monostate> {
+    template<typename Encoder>
+    static void encode(Encoder&, const std::monostate&) { }
+    static std::optional<std::monostate> decode(Decoder&) { return std::monostate { }; }
 };
 
 template<typename T, typename Traits> struct ArgumentCoder<WTF::Markable<T, Traits>> {

--- a/Source/WebKit/Platform/IPC/TransferString.cpp
+++ b/Source/WebKit/Platform/IPC/TransferString.cpp
@@ -138,6 +138,8 @@ TransferString::IPCData TransferString::toIPCData() const LIFETIME_BOUND
         },
 #if USE(CF)
         [](const RetainPtr<CFStringRef>& string) {
+            if (!string)
+                return IPCData { std::monostate { } };
             if (auto span8 = CFStringGetLatin1CStringSpan(string.get()); !span8.empty())
                 return IPCData { span8 };
             return IPCData { CFStringGetCharactersSpan(string.get()) };

--- a/Source/WebKit/Platform/IPC/TransferString.h
+++ b/Source/WebKit/Platform/IPC/TransferString.h
@@ -145,10 +145,10 @@ inline TransferString::TransferString(IPCData&& data)
             m_storage = String { };
         },
         [&](std::span<const Latin1Character> characters) {
-            m_storage = String { characters };
+            m_storage = characters.data() ? String { characters } : emptyString();
         },
         [&](std::span<const char16_t> characters) {
-            m_storage = String { characters };
+            m_storage = characters.data() ? String { characters } : emptyString();
         },
         [&](SharedSpan8 handle) {
             m_storage = WTF::move(handle);

--- a/Source/WebKit/Platform/IPC/TransferString.serialization.in
+++ b/Source/WebKit/Platform/IPC/TransferString.serialization.in
@@ -21,17 +21,18 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 webkit_platform_header: "TransferString.h"
+webkit_platform_header: <wtf/RuntimeApplicationChecks.h>
 
-[Nested, RValue] struct IPC::TransferString::SharedSpan8 {
+[Nested, RValue, WebKitPlatform] struct IPC::TransferString::SharedSpan8 {
     WebCore::SharedMemoryHandle dataHandle;
 };
 
-[Nested, RValue] struct IPC::TransferString::SharedSpan16 {
+[Nested, RValue, WebKitPlatform] struct IPC::TransferString::SharedSpan16 {
     WebCore::SharedMemoryHandle dataHandle;
 };
 
 using IPC::TransferString::IPCData = Variant<std::monostate, std::span<const uint8_t>, std::span<const char16_t>, IPC::TransferString::SharedSpan8, IPC::TransferString::SharedSpan16>;
 
-[CustomHeader] class IPC::TransferString {
+[CustomHeader, WebKitPlatform] class IPC::TransferString {
     IPC::TransferString::IPCData toIPCData();
 };

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -266,10 +266,6 @@ header: <wtf/MemoryPressureHandler.h>
     Critical,
 }
 
-header: <wtf/Variant.h>
-[AdditionalEncoder=StreamConnectionEncoder, Nested] struct std::monostate {
-}
-
 enum class WTFLogLevel : uint8_t {
     Always,
     Error,

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2590,7 +2590,7 @@ headers: <wtf/unix/UnixFileDescriptor.h> "ArgumentCodersUnix.h"
 header: <wtf/MachSendRight.h>
 #endif
 
-[CustomHeader, RValue] class WebCore::SharedMemoryHandle {
+[CustomHeader, RValue, WebKitPlatform] class WebCore::SharedMemoryHandle {
 #if USE(UNIX_DOMAIN_SOCKETS)
     [Validator='!!m_handle && *m_handle'] UnixFileDescriptor m_handle;
 #endif

--- a/Tools/TestWebKitAPI/Tests/IPC/TransferStringObjCTests.mm
+++ b/Tools/TestWebKitAPI/Tests/IPC/TransferStringObjCTests.mm
@@ -25,6 +25,7 @@
 
 #import "config.h"
 
+#import "IPCTestUtilities.h"
 #import "Test.h"
 #import "TransferString.h"
 #import <Foundation/Foundation.h>
@@ -50,12 +51,25 @@ TEST(TransferStringTests, CreateFromNSString)
     for (bool releaseToCopy : bools) {
         for (auto& subcase : subcases) {
             String wtfString { subcase.get() };
-            SCOPED_TRACE(::testing::Message() << "releaseToCopy: " << releaseToCopy << " subcase: \"" << wtfString << "\"" << " ptr: " << static_cast<void*>(subcase.get()));
-            auto ts = IPC::TransferString::create(subcase.get());
-            EXPECT_TRUE(ts.has_value());
-            auto string = releaseToCopy ? WTF::move(*ts).releaseToCopy() : WTF::move(*ts).release();
-            ASSERT_TRUE(string.has_value());
-            EXPECT_EQ(*string, wtfString);
+            {
+                SCOPED_TRACE(::testing::Message() << "TransferString(NSString *) releaseToCopy: " << releaseToCopy << " subcase: \"" << wtfString << "\"" << " ptr: " << static_cast<void*>(subcase.get()));
+                auto ts = IPC::TransferString::create(subcase.get());
+                EXPECT_TRUE(ts.has_value());
+                auto string = releaseToCopy ? WTF::move(*ts).releaseToCopy() : WTF::move(*ts).release();
+                ASSERT_TRUE(string.has_value());
+                EXPECT_EQ(*string, wtfString);
+            }
+
+            {
+                SCOPED_TRACE(::testing::Message() << "TransferString(NSString *) IPC encode/decode, releaseToCopy: " << releaseToCopy << " subcase: \"" << wtfString << "\"" << " ptr: " << static_cast<void*>(subcase.get()));
+                auto ts = IPC::TransferString::create(subcase.get());
+                EXPECT_TRUE(ts.has_value());
+                auto tsAfterIPC = copyViaEncoder(*ts);
+                ASSERT_TRUE(tsAfterIPC.has_value());
+                auto string = releaseToCopy ? WTF::move(*tsAfterIPC).releaseToCopy() : WTF::move(*tsAfterIPC).release();
+                ASSERT_TRUE(string.has_value());
+                EXPECT_EQ(*string, wtfString);
+            }
         }
     }
 }

--- a/Tools/TestWebKitAPI/Tests/IPC/TransferStringTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/TransferStringTests.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 
+#include "IPCTestUtilities.h"
 #include "Test.h"
 #include "TransferString.h"
 
@@ -48,17 +49,38 @@ TEST(TransferStringTests, CreateFromString)
     bool bools[] = { false, true };
     for (bool releaseToCopy : bools) {
         for (auto& subcase : subcases) {
-            SCOPED_TRACE(::testing::Message() << "releaseToCopy: " << releaseToCopy << " subcase: \"" << subcase << "\"");
             {
+                SCOPED_TRACE(::testing::Message() << "TransferString(String) releaseToCopy: " << releaseToCopy << " subcase: \"" << subcase << "\"");
                 auto ts = IPC::TransferString::create(subcase);
                 EXPECT_TRUE(ts.has_value());
                 auto string = releaseToCopy ? WTF::move(*ts).releaseToCopy() : WTF::move(*ts).release();
                 EXPECT_EQ(string, subcase);
             }
             {
+                SCOPED_TRACE(::testing::Message() << "TransferString(StringView) releaseToCopy: " << releaseToCopy << " subcase: \"" << subcase << "\"");
                 auto ts = IPC::TransferString::create(StringView { subcase });
                 EXPECT_TRUE(ts.has_value());
                 auto string = releaseToCopy ? WTF::move(*ts).releaseToCopy() : WTF::move(*ts).release();
+                EXPECT_EQ(string, subcase);
+            }
+
+            {
+                SCOPED_TRACE(::testing::Message() << "TransferString(String) IPC encode/decode, releaseToCopy: " << releaseToCopy << " subcase: \"" << subcase << "\"");
+                auto ts = IPC::TransferString::create(subcase);
+                EXPECT_TRUE(ts.has_value());
+                auto tsAfterIPC = copyViaEncoder(*ts);
+                ASSERT_TRUE(tsAfterIPC.has_value());
+                auto string = releaseToCopy ? WTF::move(*tsAfterIPC).releaseToCopy() : WTF::move(*tsAfterIPC).release();
+                EXPECT_EQ(string, subcase);
+            }
+
+            {
+                SCOPED_TRACE(::testing::Message() << "TransferString(StringView) IPC encode/decode, releaseToCopy: " << releaseToCopy << " subcase: \"" << subcase << "\"");
+                auto ts = IPC::TransferString::create(StringView { subcase });
+                EXPECT_TRUE(ts.has_value());
+                auto tsAfterIPC = copyViaEncoder(*ts);
+                ASSERT_TRUE(tsAfterIPC.has_value());
+                auto string = releaseToCopy ? WTF::move(*tsAfterIPC).releaseToCopy() : WTF::move(*tsAfterIPC).release();
                 EXPECT_EQ(string, subcase);
             }
         }

--- a/Tools/TestWebKitAPI/Tests/WebKit/EvaluateJavaScript.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/EvaluateJavaScript.cpp
@@ -60,6 +60,25 @@ TEST(WebKit, EvaluateJavaScriptThatThrowsAnException)
     Util::run(&testDone);
 }
 
+static void didRunEmptyJavaScript(WKTypeRef result, WKErrorRef error, void* context)
+{
+    EXPECT_EQ(reinterpret_cast<void*>(0x1234578), context);
+    EXPECT_NULL(result);
+    EXPECT_NULL(error);
+    testDone = true;
+}
+
+TEST(WebKit, EvaluateEmptyJavaScript)
+{
+    WKRetainPtr<WKContextRef> context = adoptWK(WKContextCreateWithConfiguration(nullptr));
+    PlatformWebView webView(context.get());
+
+    WKRetainPtr<WKStringRef> javaScriptString = adoptWK(WKStringCreateWithUTF8CString(""));
+    WKPageEvaluateJavaScriptInMainFrame(webView.page(), javaScriptString.get(), reinterpret_cast<void*>(0x1234578), didRunEmptyJavaScript);
+
+    Util::run(&testDone);
+}
+
 static void didCreateBlob(WKTypeRef result, WKErrorRef error, void* context)
 {
     EXPECT_NULL(result);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm
@@ -50,6 +50,25 @@
 #import <wtf/Vector.h>
 #import <wtf/text/MakeString.h>
 
+TEST(WKWebView, EvaluateEmptyJavaScript)
+{
+    __block bool isDone = false;
+    __block RetainPtr<id> result;
+    __block RetainPtr<NSError> error;
+
+    RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    [webView synchronouslyLoadHTMLString:@"<p>Hello world!</p>"];
+    [webView evaluateJavaScript:@"" completionHandler:^(id myResult, NSError *myError) {
+        isDone = true;
+        result = myResult;
+        error = myError;
+    }];
+    TestWebKitAPI::Util::run(&isDone);
+
+    EXPECT_NULL(result);
+    EXPECT_NULL(error);
+}
+
 TEST(WKWebView, EvaluateJavaScriptBlockCrash)
 {
     @autoreleasepool {


### PR DESCRIPTION
#### 0e087dfe1af10698f029462cdb7293fad227b1d5
<pre>
Fix empty TransferString being deserialized as null string
<a href="https://bugs.webkit.org/show_bug.cgi?id=310662">https://bugs.webkit.org/show_bug.cgi?id=310662</a>
<a href="https://rdar.apple.com/173272865">rdar://173272865</a>

Reviewed by Per Arne Vollan.

Sending an empty String instance over IPC via TransferString results in a null String instance on
the receiver side. This is unexpected and can cause downstream issues. For instance, if the receiver
then puts the unexpectedly null String in to a hash map, it will crash.

The reason this happens is that TransferString serializes an empty string as an empty span. On the
receiver side, after IPC, the span is not only empty but contains a null data member. The null data
member causes the `String(span)` constructor to construct a null String rather than an empty String.

To fix this, make the `TransferString(IPCData)` constructor always construct non-null Strings when
it is initialized with a span on the receiver side. Sending and receiving null strings is already
handled via the existing monostate variant.

Added some tests to make sure empty strings actually deserialize as empty strings after IPC. This
required some changes so that the serialization logic ended up in libWebKitPlatform for the API
tests.

This is a reland of 309942@main as that broke builds on some SDKs due to a missing include of
`&lt;wtf/Variant.h&gt;`.

Tests: Tools/TestWebKitAPI/Tests/IPC/TransferStringObjCTests.mm
       Tools/TestWebKitAPI/Tests/IPC/TransferStringTests.cpp
       Tools/TestWebKitAPI/Tests/WebKit/EvaluateJavaScript.cpp
       Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm

* LayoutTests/ipc/serialized-type-info.html:
* Source/WebKit/Platform/IPC/ArgumentCoders.h:
(IPC::ArgumentCoder&lt;std::monostate&gt;::encode):
(IPC::ArgumentCoder&lt;std::monostate&gt;::decode):
* Source/WebKit/Platform/IPC/TransferString.cpp:
* Source/WebKit/Platform/IPC/TransferString.h:
(IPC::TransferString::TransferString):
* Source/WebKit/Platform/IPC/TransferString.serialization.in:
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Tools/TestWebKitAPI/Tests/IPC/TransferStringObjCTests.mm:
(TestWebKitAPI::TEST(TransferStringTests, CreateFromNSString)):
* Tools/TestWebKitAPI/Tests/IPC/TransferStringTests.cpp:
(TestWebKitAPI::TEST(TransferStringTests, CreateFromString)):
* Tools/TestWebKitAPI/Tests/WebKit/EvaluateJavaScript.cpp:
(TestWebKitAPI::didRunEmptyJavaScript):
(TestWebKitAPI::TEST(WebKit, EvaluateEmptyJavaScript)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm:
(TEST(WKWebView, EvaluateEmptyJavaScript)):

Canonical link: <a href="https://commits.webkit.org/309962@main">https://commits.webkit.org/309962@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9436e66ea8962ee62de671c71ece8e451bf5d38c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152284 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25066 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18664 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161027 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e1b42b53-86f0-4430-a853-3a7efc4eb061) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154158 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25593 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25372 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117647 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e4dcecae-8739-448e-8a85-c676cba10f94) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155244 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136712 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98360 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/34b68ca9-b3ad-4e20-97ed-4dd4dfd4d204) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/18930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16869 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8861 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14586 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163495 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6639 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16180 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125680 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24864 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20907 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125854 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34145 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24865 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136382 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81464 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20854 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13160 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24482 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88767 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24173 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24333 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24234 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->