### PR TITLE
FontCascadeDescription: Rename isSpecifiedFont to hasAuthorSpecifiedNonGenericPrimaryFont

### DIFF
--- a/Source/WebCore/platform/graphics/FontCascadeDescription.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeDescription.cpp
@@ -67,7 +67,7 @@ FontCascadeDescription::FontCascadeDescription()
     , m_kerning(std::to_underlying(Kerning::Auto))
     , m_keywordSize(0)
     , m_fontSmoothing(std::to_underlying(FontSmoothingMode::Auto))
-    , m_isSpecifiedFont(false)
+    , m_hasAuthorSpecifiedNonGenericPrimaryFont(false)
 {
 }
 
@@ -180,7 +180,7 @@ TextStream& operator<<(TextStream& ts, const FontCascadeDescription& fontCascade
         ts << ", font smoothing "_s << fontCascadeDescription.fontSmoothing();
 
     ts << ", keyword size "_s << fontCascadeDescription.keywordSize();
-    ts << ", is specified font "_s << fontCascadeDescription.isSpecifiedFont();
+    ts << ", has author specified non-generic primary font "_s << fontCascadeDescription.hasAuthorSpecifiedNonGenericPrimaryFont();
 
     return ts;
 }

--- a/Source/WebCore/platform/graphics/FontCascadeDescription.h
+++ b/Source/WebCore/platform/graphics/FontCascadeDescription.h
@@ -89,7 +89,13 @@ public:
     }
     FontSmoothingMode fontSmoothing() const { return static_cast<FontSmoothingMode>(m_fontSmoothing); }
     FontSmoothingMode NODELETE usedFontSmoothing() const;
-    bool isSpecifiedFont() const { return m_isSpecifiedFont; }
+    // Used by RenderText::computeUseBackslashAsYenSymbol. In Japanese encodings
+    // (EUC-JP, Shift_JIS, etc.), the backslash byte (0x5C) maps to the yen sign.
+    // When the CSS author (or canvas font string) explicitly chose a non-generic
+    // primary font, WebKit respects that font's backslash glyph rather than
+    // substituting yen. Only the primary font matters because it represents the
+    // author's primary typographic choice.
+    bool hasAuthorSpecifiedNonGenericPrimaryFont() const { return m_hasAuthorSpecifiedNonGenericPrimaryFont; }
 
     void setOneFamily(const AtomString& family) { ASSERT(m_families->size() == 1); m_families.get()[0] = family; }
     void setFamilies(const Vector<AtomString>& families) { m_families = RefCountedFixedVector<AtomString>::createFromVector(families); }
@@ -111,7 +117,7 @@ public:
         setKeywordSize(identifier ? identifier - CSSValueXxSmall + 1 : 0);
     }
     void setFontSmoothing(FontSmoothingMode smoothing) { m_fontSmoothing = static_cast<unsigned>(smoothing); }
-    void setIsSpecifiedFont(bool isSpecifiedFont) { m_isSpecifiedFont = isSpecifiedFont; }
+    void setHasAuthorSpecifiedNonGenericPrimaryFont(bool value) { m_hasAuthorSpecifiedNonGenericPrimaryFont = value; }
 
 #if ENABLE(TEXT_AUTOSIZING)
     bool NODELETE familiesEqualForTextAutoSizing(const FontCascadeDescription& other) const;
@@ -141,7 +147,7 @@ private:
     unsigned m_keywordSize : 4;
     unsigned m_fontSmoothing : 2; // FontSmoothingMode
     // True if a web page specifies a non-generic font family as the first font family.
-    unsigned m_isSpecifiedFont : 1;
+    unsigned m_hasAuthorSpecifiedNonGenericPrimaryFont : 1;
 };
 
 inline bool FontCascadeDescription::operator==(const FontCascadeDescription& other) const
@@ -153,7 +159,7 @@ inline bool FontCascadeDescription::operator==(const FontCascadeDescription& oth
         && m_kerning == other.m_kerning
         && m_keywordSize == other.m_keywordSize
         && m_fontSmoothing == other.m_fontSmoothing
-        && m_isSpecifiedFont == other.m_isSpecifiedFont;
+        && m_hasAuthorSpecifiedNonGenericPrimaryFont == other.m_hasAuthorSpecifiedNonGenericPrimaryFont;
 }
 
 WTF::TextStream& operator<<(WTF::TextStream&, const FontCascadeDescription&);

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -385,7 +385,7 @@ bool RenderText::computeUseBackslashAsYenSymbol() const
     const auto& fontDescription = style.fontDescription();
     if (style.fontCascade().useBackslashAsYenSymbol())
         return true;
-    if (fontDescription.isSpecifiedFont())
+    if (fontDescription.hasAuthorSpecifiedNonGenericPrimaryFont())
         return false;
     const PAL::TextEncoding* encoding = document().decoder() ? &document().decoder()->encoding() : 0;
     if (encoding && encoding->backslashAsCurrencySymbol() != '\\')

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -567,7 +567,7 @@ inline void BuilderCustom::applyInitialFontFamily(BuilderState& builderState)
     }
 
     if (!initialDesc.firstFamily().isEmpty())
-        builderState.setFontDescriptionFamilies(FontFamilies { initialDesc.families(), fontDescription.isSpecifiedFont() });
+        builderState.setFontDescriptionFamilies(FontFamilies { initialDesc.families(), fontDescription.hasAuthorSpecifiedNonGenericPrimaryFont() });
 }
 
 inline void BuilderCustom::applyInheritFontFamily(BuilderState& builderState)

--- a/Source/WebCore/style/StyleBuilderStateInlines.h
+++ b/Source/WebCore/style/StyleBuilderStateInlines.h
@@ -78,13 +78,13 @@ inline void BuilderState::setFontDescriptionFontSize(float fontSize)
 
 inline void BuilderState::setFontDescriptionFamilies(FontFamilies&& families)
 {
-    if (m_style.fontDescription().families() == families.toPlatform() && m_style.fontDescription().isSpecifiedFont() == families.isSpecifiedFont())
+    if (m_style.fontDescription().families() == families.toPlatform() && m_style.fontDescription().hasAuthorSpecifiedNonGenericPrimaryFont() == families.hasAuthorSpecifiedNonGenericPrimaryFont())
         return;
 
     m_fontDirty = true;
     auto& fontCascade = m_style.mutableFontCascadeWithoutUpdate();
     fontCascade.mutableFontDescription().setFamilies(families.takePlatform());
-    fontCascade.mutableFontDescription().setIsSpecifiedFont(families.isSpecifiedFont());
+    fontCascade.mutableFontDescription().setHasAuthorSpecifiedNonGenericPrimaryFont(families.hasAuthorSpecifiedNonGenericPrimaryFont());
     fontCascade.updateUseBackslashAsYenSymbol();
 }
 

--- a/Source/WebCore/style/StyleResolveForFont.cpp
+++ b/Source/WebCore/style/StyleResolveForFont.cpp
@@ -309,13 +309,13 @@ static FontVariantCaps NODELETE fontVariantCapsFromUnresolvedFontVariantCaps(con
 
 struct ResolvedFontFamily {
     Vector<AtomString> family;
-    bool isSpecifiedFont;
+    bool hasAuthorSpecifiedNonGenericPrimaryFont;
 };
 
 static ResolvedFontFamily fontFamilyFromUnresolvedFontFamily(const CSSPropertyParserHelpers::UnresolvedFontFamily& unresolvedFamily, Ref<ScriptExecutionContext> context)
 {
     bool isFirstFont = true;
-    bool isSpecifiedFont = false;
+    bool hasAuthorSpecifiedNonGenericPrimaryFont = false;
 
     auto family = WTF::compactMap(unresolvedFamily, [&](auto& item) -> std::optional<AtomString> {
         auto [family, isGenericFamily] = switchOn(item,
@@ -337,7 +337,7 @@ static ResolvedFontFamily fontFamilyFromUnresolvedFontFamily(const CSSPropertyPa
             return std::nullopt;
 
         if (isFirstFont) {
-            isSpecifiedFont = !isGenericFamily;
+            hasAuthorSpecifiedNonGenericPrimaryFont = !isGenericFamily;
             isFirstFont = false;
         }
         return family;
@@ -345,7 +345,7 @@ static ResolvedFontFamily fontFamilyFromUnresolvedFontFamily(const CSSPropertyPa
 
     return {
         .family = WTF::move(family),
-        .isSpecifiedFont = isSpecifiedFont
+        .hasAuthorSpecifiedNonGenericPrimaryFont = hasAuthorSpecifiedNonGenericPrimaryFont
     };
 }
 
@@ -373,7 +373,7 @@ std::optional<FontCascade> resolveForUnresolvedFont(const CSSPropertyParserHelpe
     if (resolvedFamily.family.isEmpty())
         return std::nullopt;
     fontDescription.setFamilies(resolvedFamily.family);
-    fontDescription.setIsSpecifiedFont(resolvedFamily.isSpecifiedFont);
+    fontDescription.setHasAuthorSpecifiedNonGenericPrimaryFont(resolvedFamily.hasAuthorSpecifiedNonGenericPrimaryFont);
 
     if (useFixedDefaultSize(fontDescription) != oldFamilyUsedFixedDefaultSize) {
         if (auto sizeIdentifier = fontDescription.keywordSizeAsIdentifier()) {

--- a/Source/WebCore/style/computed/StyleComputedStyleProperties+GettersCustomInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleProperties+GettersCustomInlines.h
@@ -138,7 +138,7 @@ float ComputedStyleProperties::specifiedFontSize() const
 
 inline FontFamilies ComputedStyleProperties::fontFamily() const
 {
-    return { fontDescription().families(), fontDescription().isSpecifiedFont() };
+    return { fontDescription().families(), fontDescription().hasAuthorSpecifiedNonGenericPrimaryFont() };
 }
 
 inline FontPalette ComputedStyleProperties::fontPalette() const

--- a/Source/WebCore/style/values/fonts/StyleFontFamily.h
+++ b/Source/WebCore/style/values/fonts/StyleFontFamily.h
@@ -79,8 +79,8 @@ struct FontFamilies {
     {
     }
 
-    FontFamilies(Ref<RefCountedFixedVector<AtomString>>&& families, bool isSpecifiedFont)
-        : FontFamilies { WTF::move(families), isSpecifiedFont ? FontFamilyKind::Specified : FontFamilyKind::Generic }
+    FontFamilies(Ref<RefCountedFixedVector<AtomString>>&& families, bool hasAuthorSpecifiedNonGenericPrimaryFont)
+        : FontFamilies { WTF::move(families), hasAuthorSpecifiedNonGenericPrimaryFont ? FontFamilyKind::Specified : FontFamilyKind::Generic }
     {
     }
 
@@ -124,7 +124,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     Ref<RefCountedFixedVector<AtomString>> takePlatform() { return WTF::move(m_families); }
 
     FontFamilyKind firstFontKind() const { return m_firstFontKind; }
-    bool isSpecifiedFont() const { return m_firstFontKind == FontFamilyKind::Specified; }
+    bool hasAuthorSpecifiedNonGenericPrimaryFont() const { return m_firstFontKind == FontFamilyKind::Specified; }
 
     bool operator==(const FontFamilies& other) const
     {


### PR DESCRIPTION
#### 5f7ab494f00fa5a696fcd9fddbe70cc01c926734
<pre>
FontCascadeDescription: Rename isSpecifiedFont to hasAuthorSpecifiedNonGenericPrimaryFont
<a href="https://bugs.webkit.org/show_bug.cgi?id=310759">https://bugs.webkit.org/show_bug.cgi?id=310759</a>
<a href="https://rdar.apple.com/173363991">rdar://173363991</a>

Reviewed by Elika Etemad.

In Japanese encodings (EUC-JP, Shift_JIS, etc.), the backslash byte (0x5C)
maps to the yen sign. When the CSS author explicitly chose a non-generic
primary font, WebKit respects that font&apos;s backslash glyph rather than
substituting yen. This flag tracks that provenance, so rename it to make
its purpose clear.

* Source/WebCore/platform/graphics/FontCascadeDescription.cpp:
(WebCore::FontCascadeDescription::FontCascadeDescription):
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/FontCascadeDescription.h:
(WebCore::FontCascadeDescription::hasAuthorSpecifiedNonGenericPrimaryFont const):
(WebCore::FontCascadeDescription::setHasAuthorSpecifiedNonGenericPrimaryFont):
(WebCore::FontCascadeDescription::operator== const):
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::RenderText::computeUseBackslashAsYenSymbol const):
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyInitialFontFamily):
* Source/WebCore/style/StyleBuilderStateInlines.h:
(WebCore::Style::BuilderState::setFontDescriptionFamilies):
* Source/WebCore/style/StyleResolveForFont.cpp:
(WebCore::Style::fontFamilyFromUnresolvedFontFamily):
(WebCore::Style::resolveForUnresolvedFont):
* Source/WebCore/style/computed/StyleComputedStyleProperties+GettersCustomInlines.h:
(WebCore::Style::ComputedStyleProperties::fontFamily const):
* Source/WebCore/style/values/fonts/StyleFontFamily.h:

Canonical link: <a href="https://commits.webkit.org/309956@main">https://commits.webkit.org/309956@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb322983c842fb488d058864ebf7a0f1478c300d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152296 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25078 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18677 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161039 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/02cd40dd-cfce-42a2-9a26-62f1abad2afe) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154170 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25605 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25384 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117661 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8bfa00be-f3e1-40e7-8e9f-a7aa957e5e72) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155256 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/136723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98374 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3399c7ad-4e79-4b77-a84a-ee8dbba1a815) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/18946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/16882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8873 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14597 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163507 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6651 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16191 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125694 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24876 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20920 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125868 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34140 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24877 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136393 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/81476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20867 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/13172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24494 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88779 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24185 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24345 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24246 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->