### PR TITLE
Cherry-pick 301765.417@safari-7623-branch (75bcb9f43cbe). rdar://169213380

### DIFF
--- a/LayoutTests/http/tests/security/resources/page-with-text.html
+++ b/LayoutTests/http/tests/security/resources/page-with-text.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body { height: 3000px; }
+        .content { margin-top: 2000px; }
+    </style>
+</head>
+<body>
+    <h1>Test Page</h1>
+    <div class="content">
+        <p>This is some text before the secret.</p>
+        <p>SecretText is located here in the middle of the page.</p>
+        <p>This is some text after the secret.</p>
+    </div>
+</body>
+<script defer>
+    function report() {
+        opener.postMessage({ scrollTop: document.documentElement.scrollTop }, "*");
+    }
+
+    window.addEventListener('message', report);
+    setTimeout(report, 10);
+</script>
+</html>

--- a/LayoutTests/http/tests/security/text-fragment/popup-cross-origin-blocked-expected.txt
+++ b/LayoutTests/http/tests/security/text-fragment/popup-cross-origin-blocked-expected.txt
@@ -1,0 +1,10 @@
+Tests that text fragment is blocked in cross-origin window.open() popup.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Text fragment correctly blocked in cross-origin popup (no scroll)
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/security/text-fragment/popup-cross-origin-blocked.html
+++ b/LayoutTests/http/tests/security/text-fragment/popup-cross-origin-blocked.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<body>
+    <script src="/js-test-resources/js-test.js"></script>
+    <script>
+        description("Tests that text fragment is blocked in cross-origin window.open() popup.");
+        jsTestIsAsync = true;
+
+        async function sleep(ms) {
+            return new Promise((resolve) => setTimeout(resolve, ms));
+        }
+
+        async function getScrollTop() {
+            return new Promise((resolve) => addEventListener('message', ({ data }) => resolve(data.scrollTop)));
+        }
+
+        async function runTest() {
+            const BaseURL = "http://localhost:8000/security/resources/page-with-text.html";
+
+            const popup = window.open("");
+            if (!popup) {
+                testFailed("Failed to open popup");
+                finishJSTest();
+                return;
+            }
+
+            // Initially navigate to cross-origin url.
+            popup.location = BaseURL;
+            let scrollTop = await getScrollTop();
+
+            if (scrollTop !== 0) {
+                testFailed("Initial scroll position must be 0 - page scrolled to: " + scrollTop);
+                popup.close();
+                finishJSTest();
+                return;
+            }
+
+            // Navigate to same-document text fragment synchronously.
+            popup.location = BaseURL + "#:~:text=SecretText";
+            popup.postMessage('ping', '*');
+
+            scrollTop = await getScrollTop();
+            if (scrollTop === 0)
+                testPassed("Text fragment correctly blocked in cross-origin popup (no scroll)");
+            else
+                testFailed("Text fragment was NOT blocked - page scrolled to: " + scrollTop);
+
+            popup.close();
+            finishJSTest();
+        }
+
+        runTest();
+    </script>
+</body>
+</html>

--- a/LayoutTests/http/tests/security/text-fragment/popup-same-origin-allowed-expected.txt
+++ b/LayoutTests/http/tests/security/text-fragment/popup-same-origin-allowed-expected.txt
@@ -1,0 +1,10 @@
+Tests that text fragment works in same-origin window.open() popup.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Text fragment correctly activated in same-origin popup (scrollTop > 0)
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/security/text-fragment/popup-same-origin-allowed.html
+++ b/LayoutTests/http/tests/security/text-fragment/popup-same-origin-allowed.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<body>
+    <script src="/js-test-resources/js-test.js"></script>
+    <script>
+        description("Tests that text fragment works in same-origin window.open() popup.");
+        jsTestIsAsync = true;
+
+        async function waitNavigationComplete() {
+            return new Promise((resolve) => addEventListener('message', ({ data }) => resolve(data)));
+        }
+
+        async function runTest() {
+            // Open popup to same-origin page with text fragment.
+            var popup = window.open("/security/resources/page-with-text.html#:~:text=SecretText");
+            if (!popup) {
+                testFailed("Failed to open popup");
+                finishJSTest();
+                return;
+            }
+
+            const { scrollTop } = await waitNavigationComplete();
+
+            // Check if text fragment was activated by checking scroll position.
+            if (scrollTop > 0)
+                testPassed("Text fragment correctly activated in same-origin popup (scrollTop > 0)");
+            else
+                testFailed("Text fragment was blocked in same-origin popup (unexpected)");
+
+            popup.close();
+            finishJSTest();
+        }
+
+        runTest();
+    </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment-security.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment-security.sub-expected.txt
@@ -3,6 +3,6 @@
 PASS Test that a text fragment directive requires a user activation (user_activation=true).
 FAIL Test that a text fragment directive requires a user activation (user_activation=false). assert_equals: Expected window.open() with no user activation to not activate text fragment directive. expected "top" but got "text"
 PASS Test that a text fragment directive is not activated when there is a window opener (noopener=true).
-FAIL Test that a text fragment directive is not activated when there is a window opener (noopener=false). assert_equals: Expected window.open() with opener to not activate text fragment directive. expected "top" but got "text"
+PASS Test that a text fragment directive is not activated when there is a window opener (noopener=false).
 PASS Test that a text fragment directive is not activated within an iframe.
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7679,7 +7679,6 @@ imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment.
 # webkit.org/b/261038 localhost alias
 imported/w3c/web-platform-tests/scroll-to-text-fragment/iframe-scroll.sub.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-to-text-fragment/iframes.sub.html [ Skip ]
-imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment-security.sub.html [ Skip ]
 
 imported/w3c/web-platform-tests/scroll-to-text-fragment/sequential-focus.html [ Failure ]
 

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -785,7 +785,6 @@ imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-mode
 # webkit.org/b/261038 localhost alias
 imported/w3c/web-platform-tests/scroll-to-text-fragment/iframe-scroll.sub.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-to-text-fragment/iframes.sub.html [ Skip ]
-imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment-security.sub.html [ Skip ]
 
 imported/w3c/web-platform-tests/scroll-to-text-fragment/sequential-focus.html [ Failure ]
 

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -3021,6 +3021,31 @@ bool LocalFrameView::scrollToFragment(const URL& url)
     return false;
 }
 
+static bool checkTextFragmentSecurity(LocalFrame& frame)
+{
+    RefPtr openerFrame = frame.opener();
+    if (!openerFrame)
+        return true;
+
+    RefPtr localOpener = dynamicDowncast<LocalFrame>(openerFrame.get());
+    if (!localOpener)
+        return false;
+
+    RefPtr openerDocument = localOpener->document();
+    RefPtr currentDocument = frame.document();
+    if (!openerDocument || !currentDocument)
+        return true;
+
+    Ref openerOrigin = openerDocument->securityOrigin();
+    Ref currentOrigin = currentDocument->securityOrigin();
+
+    // Block if cross-origin popup
+    if (!openerOrigin->isSameOriginAs(currentOrigin))
+        return false;
+
+    return true;
+}
+
 bool LocalFrameView::scrollToTextFragment(IsRetry isRetry)
 {
     static constexpr auto scrollToTextFragmentRetryInterval = 500_ms;
@@ -3033,6 +3058,10 @@ bool LocalFrameView::scrollToTextFragment(IsRetry isRetry)
         return false;
 
     if (!m_frame->isMainFrame())
+        return false;
+
+    // Block text fragments in cross-origin window.open() popups
+    if (!checkTextFragmentSecurity(m_frame.get()))
         return false;
 
     document->fragmentHighlightRegistry().clear();


### PR DESCRIPTION
#### 279154ae0524174e4801c673c624062445a3cfba
<pre>
Cherry-pick 301765.417@safari-7623-branch (75bcb9f43cbe). <a href="https://rdar.apple.com/169213380">rdar://169213380</a>

    Block text fragments in cross-origin window.open() popups.
    <a href="https://rdar.apple.com/163804356">rdar://163804356</a>

    Reviewed by Chris Dumez.

    This implements a security defense against timing side-channel attacks
    using Text Fragments in cross-origin popups.

    The exploit pattern:
    w = window.open(&quot;attacker.com&quot;);
    w.location = &quot;victim.com&quot;;
    w.location = &quot;victim.com#:~:text=secret&quot;;
    w.location = &quot;about:blank&quot;;
    // Measure timing to detect if text was found

    Defense mechanism:
    - Add checkTextFragmentSecurity() in LocalFrameView.cpp
    - Block text fragments when opener origin ≠ current document origin
    - Allow text fragments in same-origin popups (legitimate use)
    - Allow text fragments in top-level navigation (no opener)

    This aligns with Chrome&apos;s 2019 defense (commit c0d3c4cca8b16),
    which uses RelatedPages().size() check. WebKit uses a simpler
    cross-origin check that achieves the same security goal.

    The fix does not affect about:blank origin inheritance or WPT tests,
    as those don&apos;t use text fragments.

    Tests: http/tests/security/text-fragment/popup-cross-origin-blocked.html
           http/tests/security/text-fragment/popup-same-origin-allowed.html
    * LayoutTests/http/tests/security/resources/page-with-text.html: Added.
    * LayoutTests/http/tests/security/text-fragment/popup-cross-origin-blocked-expected.txt: Added.
    * LayoutTests/http/tests/security/text-fragment/popup-cross-origin-blocked.html: Added.
    * LayoutTests/http/tests/security/text-fragment/popup-same-origin-allowed-expected.txt: Added.
    * LayoutTests/http/tests/security/text-fragment/popup-same-origin-allowed.html: Added.
    * Source/WebCore/page/LocalFrameView.cpp:
    (WebCore::checkTextFragmentSecurity):
    (WebCore::LocalFrameView::scrollToTextFragment):

    Identifier: 301765.417@safari-7623-branch

Identifier: 305413.221@safari-7624-branch
Canonical link: <a href="https://commits.webkit.org/310046@main">https://commits.webkit.org/310046@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd1caf77da769bacc4f2b5dfd17a6f89edef9eee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152401 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25183 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18782 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161144 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105858 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7d1e8223-d96e-4a6d-a2ef-84add6c0e724) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154275 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25711 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25489 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117755 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83482 "3 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0aa46d05-84e2-4147-bc9f-cb82433a7ca8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155361 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19973 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136822 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98469 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0926087d-e5a4-46c0-9058-64a63388ea25) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19050 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16979 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8979 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128700 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14696 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163614 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13202 "Build is in progress. Recent messages:") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6756 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16290 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125791 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24981 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21018 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125962 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34205 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24983 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136492 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81583 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20967 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13271 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24599 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88885 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24290 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24450 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24351 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->