### PR TITLE
Use CompactVariant in Style::Color

### DIFF
--- a/Source/WTF/wtf/CompactVariantOperations.h
+++ b/Source/WTF/wtf/CompactVariantOperations.h
@@ -49,7 +49,7 @@ template<typename T> struct CompactVariantTraits {
    */
 };
 
-template<typename T> concept CompactVariantAlternativeSmallEnough = sizeof(T) <= 4;
+template<typename T> concept CompactVariantAlternativeSmallEnough = sizeof(T) <= 6;
 template<typename T> concept CompactVariantAlternativePointer =
        std::is_pointer_v<T>
    ||  IsSmartPtr<T>::value;

--- a/Source/WebCore/platform/graphics/Color.cpp
+++ b/Source/WebCore/platform/graphics/Color.cpp
@@ -36,6 +36,7 @@
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(Color);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(OutOfLineColor);
 
 static constexpr auto lightenedBlack = SRGBA<uint8_t> { 84, 84, 84 };
 static constexpr auto darkenedWhite = SRGBA<uint8_t> { 171, 171, 171 };

--- a/Source/WebCore/platform/graphics/Color.cpp
+++ b/Source/WebCore/platform/graphics/Color.cpp
@@ -36,7 +36,6 @@
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(Color);
-WTF_MAKE_TZONE_ALLOCATED_IMPL(OutOfLineColor);
 
 static constexpr auto lightenedBlack = SRGBA<uint8_t> { 84, 84, 84 };
 static constexpr auto darkenedWhite = SRGBA<uint8_t> { 171, 171, 171 };

--- a/Source/WebCore/platform/graphics/Color.h
+++ b/Source/WebCore/platform/graphics/Color.h
@@ -216,7 +216,6 @@ public:
 
 private:
     friend class InlineColor;
-    friend class OutOfLineColor;
     friend void add(Hasher&, const Color&);
 
     class OutOfLineComponents : public ThreadSafeRefCounted<OutOfLineComponents> {
@@ -296,12 +295,13 @@ private:
     uint64_t m_colorAndFlags { invalidColorAndFlags };
 };
 
-// InlineColor and OutOfLineColor can be used to save space with
-// CompactVariant<InlineColor, UniqueRef<OutOfLineColor>>
-class InlineColor {
+// InlineColor can be put inside CompactVariant<> directly
+class __attribute__((packed)) InlineColor {
 public:
     explicit InlineColor(const Color& color)
-        : m_colorAndFlags(color.m_colorAndFlags)
+        : m_rgba(color.m_colorAndFlags & Color::colorValueMask)
+        , m_flags((color.m_colorAndFlags >> Color::flagsShift) & 0xFF)
+        , m_colorSpace((color.m_colorAndFlags >> Color::colorSpaceShift) & 0xFF)
     {
         ASSERT(!color.isOutOfLine());
     }
@@ -309,75 +309,18 @@ public:
     operator Color() const
     {
         Color result;
-        result.m_colorAndFlags = m_colorAndFlags;
+        result.m_colorAndFlags = (static_cast<uint64_t>(m_colorSpace) << Color::colorSpaceShift) | (static_cast<uint64_t>(m_flags) << Color::flagsShift) | m_rgba;
         return result;
     }
 
     Color toColor() const { return static_cast<Color>(*this); }
-
     bool operator==(const InlineColor&) const = default;
 
-    // For CompactVariantTraits packing into 48 bits.
-    // Inline colors have: bits 0-31 = RGBA, bits 48-55 = flags, bits 56-63 = colorspace.
-    // Bits 32-47 are always zero for inline colors.
-    static_assert(Color::flagsSize + Color::colorSpaceSize + 32 <= 48);
-    uint64_t encodedForCompactVariant() const
-    {
-        uint64_t rgba = m_colorAndFlags & 0xFFFFFFFFULL;
-        uint64_t flags = (m_colorAndFlags >> Color::flagsShift) & 0xFF;
-        uint64_t colorSpace = (m_colorAndFlags >> Color::colorSpaceShift) & 0xFF;
-        return rgba | (flags << 32) | (colorSpace << 40);
-    }
-
-    static InlineColor decodedFromCompactVariant(uint64_t encoded)
-    {
-        uint64_t rgba = encoded & 0xFFFFFFFFULL;
-        uint64_t flags = (encoded >> 32) & 0xFF;
-        uint64_t colorSpace = (encoded >> 40) & 0xFF;
-        uint64_t raw = rgba | (flags << Color::flagsShift) | (colorSpace << Color::colorSpaceShift);
-        return InlineColor(raw);
-    }
-
 private:
-    explicit InlineColor(uint64_t raw)
-        : m_colorAndFlags(raw)
-    {
-    }
-
-    uint64_t m_colorAndFlags;
+    uint32_t m_rgba;
+    uint8_t m_flags;
+    uint8_t m_colorSpace;
 };
-
-class OutOfLineColor {
-    WTF_MAKE_TZONE_ALLOCATED(OutOfLineColor);
-public:
-    explicit OutOfLineColor(const Color& color)
-        : m_colorSpace(color.colorSpace())
-        , m_components(color.asOutOfLine().unresolvedComponents())
-    {
-        ASSERT(color.isOutOfLine());
-        if (color.isSemantic())
-            m_flags.add(Color::Flags::Semantic);
-        if (color.usesColorFunctionSerialization())
-            m_flags.add(Color::Flags::UseColorFunctionSerialization);
-    }
-
-    Color toColor() const
-    {
-        return Color(Color::OutOfLineComponents::create(ColorComponents<float, 4> { m_components }), m_colorSpace, m_flags);
-    }
-
-    bool operator==(const OutOfLineColor&) const = default;
-
-private:
-    ColorSpace m_colorSpace;
-    OptionSet<Color::Flags> m_flags;
-    ColorComponents<float, 4> m_components;
-};
-
-inline bool operator==(const UniqueRef<OutOfLineColor>& a, const UniqueRef<OutOfLineColor>& b)
-{
-    return a.get() == b.get();
-}
 
 inline void add(Hasher& hasher, const Color& color)
 {
@@ -719,20 +662,6 @@ inline void Color::setOutOfLineComponents(Ref<OutOfLineComponents>&& color, Colo
 } // namespace WebCore
 
 namespace WTF {
-
-template<> struct CompactVariantTraits<WebCore::InlineColor> {
-    static constexpr bool hasAlternativeRepresentation = true;
-
-    static uint64_t encode(const WebCore::InlineColor& value)
-    {
-        return value.encodedForCompactVariant();
-    }
-
-    static WebCore::InlineColor decode(uint64_t encoded)
-    {
-        return WebCore::InlineColor::decodedFromCompactVariant(encoded);
-    }
-};
 
 template<> struct HashTraits<WebCore::Color>;
 }

--- a/Source/WebCore/platform/graphics/Color.h
+++ b/Source/WebCore/platform/graphics/Color.h
@@ -33,6 +33,7 @@
 #include <functional>
 #include <utility>
 #include <wtf/Assertions.h>
+#include <wtf/CompactVariantOperations.h>
 #include <wtf/Compiler.h>
 #include <wtf/Forward.h>
 #include <wtf/GetPtr.h>
@@ -44,6 +45,7 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/UniqueRef.h>
 #include <wtf/Variant.h>
 
 #if USE(CG)
@@ -213,6 +215,8 @@ public:
     WEBCORE_EXPORT String debugDescription() const;
 
 private:
+    friend class InlineColor;
+    friend class OutOfLineColor;
     friend void add(Hasher&, const Color&);
 
     class OutOfLineComponents : public ThreadSafeRefCounted<OutOfLineComponents> {
@@ -291,6 +295,89 @@ private:
     static constexpr uint64_t invalidColorAndFlags = 0;
     uint64_t m_colorAndFlags { invalidColorAndFlags };
 };
+
+// InlineColor and OutOfLineColor can be used to save space with
+// CompactVariant<InlineColor, UniqueRef<OutOfLineColor>>
+class InlineColor {
+public:
+    explicit InlineColor(const Color& color)
+        : m_colorAndFlags(color.m_colorAndFlags)
+    {
+        ASSERT(!color.isOutOfLine());
+    }
+
+    operator Color() const
+    {
+        Color result;
+        result.m_colorAndFlags = m_colorAndFlags;
+        return result;
+    }
+
+    Color toColor() const { return static_cast<Color>(*this); }
+
+    bool operator==(const InlineColor&) const = default;
+
+    // For CompactVariantTraits packing into 48 bits.
+    // Inline colors have: bits 0-31 = RGBA, bits 48-55 = flags, bits 56-63 = colorspace.
+    // Bits 32-47 are always zero for inline colors.
+    static_assert(Color::flagsSize + Color::colorSpaceSize + 32 <= 48);
+    uint64_t encodedForCompactVariant() const
+    {
+        uint64_t rgba = m_colorAndFlags & 0xFFFFFFFFULL;
+        uint64_t flags = (m_colorAndFlags >> Color::flagsShift) & 0xFF;
+        uint64_t colorSpace = (m_colorAndFlags >> Color::colorSpaceShift) & 0xFF;
+        return rgba | (flags << 32) | (colorSpace << 40);
+    }
+
+    static InlineColor decodedFromCompactVariant(uint64_t encoded)
+    {
+        uint64_t rgba = encoded & 0xFFFFFFFFULL;
+        uint64_t flags = (encoded >> 32) & 0xFF;
+        uint64_t colorSpace = (encoded >> 40) & 0xFF;
+        uint64_t raw = rgba | (flags << Color::flagsShift) | (colorSpace << Color::colorSpaceShift);
+        return InlineColor(raw);
+    }
+
+private:
+    explicit InlineColor(uint64_t raw)
+        : m_colorAndFlags(raw)
+    {
+    }
+
+    uint64_t m_colorAndFlags;
+};
+
+class OutOfLineColor {
+    WTF_MAKE_TZONE_ALLOCATED(OutOfLineColor);
+public:
+    explicit OutOfLineColor(const Color& color)
+        : m_colorSpace(color.colorSpace())
+        , m_components(color.asOutOfLine().unresolvedComponents())
+    {
+        ASSERT(color.isOutOfLine());
+        if (color.isSemantic())
+            m_flags.add(Color::Flags::Semantic);
+        if (color.usesColorFunctionSerialization())
+            m_flags.add(Color::Flags::UseColorFunctionSerialization);
+    }
+
+    Color toColor() const
+    {
+        return Color(Color::OutOfLineComponents::create(ColorComponents<float, 4> { m_components }), m_colorSpace, m_flags);
+    }
+
+    bool operator==(const OutOfLineColor&) const = default;
+
+private:
+    ColorSpace m_colorSpace;
+    OptionSet<Color::Flags> m_flags;
+    ColorComponents<float, 4> m_components;
+};
+
+inline bool operator==(const UniqueRef<OutOfLineColor>& a, const UniqueRef<OutOfLineColor>& b)
+{
+    return a.get() == b.get();
+}
 
 inline void add(Hasher& hasher, const Color& color)
 {
@@ -632,5 +719,20 @@ inline void Color::setOutOfLineComponents(Ref<OutOfLineComponents>&& color, Colo
 } // namespace WebCore
 
 namespace WTF {
+
+template<> struct CompactVariantTraits<WebCore::InlineColor> {
+    static constexpr bool hasAlternativeRepresentation = true;
+
+    static uint64_t encode(const WebCore::InlineColor& value)
+    {
+        return value.encodedForCompactVariant();
+    }
+
+    static WebCore::InlineColor decode(uint64_t encoded)
+    {
+        return WebCore::InlineColor::decodedFromCompactVariant(encoded);
+    }
+};
+
 template<> struct HashTraits<WebCore::Color>;
 }

--- a/Source/WebCore/style/values/color/StyleColor.cpp
+++ b/Source/WebCore/style/values/color/StyleColor.cpp
@@ -74,7 +74,7 @@ Color::Color(CSS::Keyword::Currentcolor)
 Color::Color(WebCore::Color color)
     : value { color.tryGetAsPackedInline()
         ? ColorKind { InlineResolvedColor { color } }
-        : ColorKind { makeUniqueRef<OutOfLineResolvedColor>(OutOfLineResolvedColor { color }) } }
+        : ColorKind { makeUniqueRef<ResolvedColor>(color) } }
 {
 }
 
@@ -101,7 +101,7 @@ Color::Color(CSS::Keyword::White)
 Color::Color(ResolvedColor&& color)
     : value { color.color.tryGetAsPackedInline()
         ? ColorKind { InlineResolvedColor { color.color } }
-        : ColorKind { makeUniqueRef<OutOfLineResolvedColor>(OutOfLineResolvedColor { color.color }) } }
+        : ColorKind { makeUniqueRef<ResolvedColor>(color.color) } }
 {
 }
 
@@ -295,24 +295,28 @@ bool Color::isRelativeColor() const
 
 bool Color::isResolvedColor() const
 {
-    return value.holdsAlternative<InlineResolvedColor>() || value.holdsAlternative<UniqueRef<OutOfLineResolvedColor>>();
+    return value.holdsAlternative<InlineResolvedColor>() || value.holdsAlternative<UniqueRef<ResolvedColor>>();
 }
 
 WebCore::Color Color::resolvedColor() const
 {
     ASSERT(isResolvedColor());
-    WebCore::Color result;
-    value.switchOn(
-        [&](const InlineResolvedColor& inlined) { result = inlined.toColor(); },
-        [&](const UniqueRef<OutOfLineResolvedColor>& outOfLine) { result = outOfLine.get().toColor(); },
-        [](const auto&) { RELEASE_ASSERT_NOT_REACHED(); }
+    return value.switchOn(
+        [&](const InlineResolvedColor& inlined) { return inlined.toColor(); },
+        [&](const UniqueRef<ResolvedColor>& color) { return color.get().color; },
+        [](const auto&) {
+            RELEASE_ASSERT_NOT_REACHED();
+            return WebCore::Color { };
+        }
     );
-    return result;
 }
 
 bool Color::isKnownTransparent() const
 {
-    return isResolvedColor() && resolvedColor().isValid() && !resolvedColor().isVisible();
+    if (!isResolvedColor())
+        return false;
+    auto color = resolvedColor();
+    return color.isValid() && !color.isVisible();
 }
 
 template<typename T> Color::ColorKind Color::makeIndirectColor(T&& colorType)

--- a/Source/WebCore/style/values/color/StyleColor.cpp
+++ b/Source/WebCore/style/values/color/StyleColor.cpp
@@ -56,11 +56,6 @@
 namespace WebCore {
 namespace Style {
 
-Color::Color(Color::ColorKind&& color)
-    : value { WTF::move(color) }
-{
-}
-
 Color::Color(EmptyToken token)
     : value { token }
 {
@@ -77,32 +72,36 @@ Color::Color(CSS::Keyword::Currentcolor)
 }
 
 Color::Color(WebCore::Color color)
-    : value { ResolvedColor { WTF::move(color) } }
+    : value { color.tryGetAsPackedInline()
+        ? ColorKind { InlineResolvedColor { color } }
+        : ColorKind { makeUniqueRef<OutOfLineResolvedColor>(OutOfLineResolvedColor { color }) } }
 {
 }
 
 Color::Color(SRGBA<uint8_t> color)
-    : value { ResolvedColor { WebCore::Color { color } } }
+    : value { InlineResolvedColor { WebCore::Color { color } } }
 {
 }
 
 Color::Color(CSS::Keyword::Transparent)
-    : value { ResolvedColor { WebCore::Color::transparentBlack } }
+    : value { InlineResolvedColor { WebCore::Color::transparentBlack } }
 {
 }
 
 Color::Color(CSS::Keyword::Black)
-    : value { ResolvedColor { WebCore::Color::black } }
+    : value { InlineResolvedColor { WebCore::Color::black } }
 {
 }
 
 Color::Color(CSS::Keyword::White)
-    : value { ResolvedColor { WebCore::Color::white } }
+    : value { InlineResolvedColor { WebCore::Color::white } }
 {
 }
 
 Color::Color(ResolvedColor&& color)
-    : value { WTF::move(color) }
+    : value { color.color.tryGetAsPackedInline()
+        ? ColorKind { InlineResolvedColor { color.color } }
+        : ColorKind { makeUniqueRef<OutOfLineResolvedColor>(OutOfLineResolvedColor { color.color }) } }
 {
 }
 
@@ -261,48 +260,54 @@ bool Color::containsCurrentColor() const
 
 bool Color::isCurrentColor() const
 {
-    return std::holds_alternative<CurrentColor>(value);
+    return value.holdsAlternative<CurrentColor>();
 }
 
 bool Color::isColorMix() const
 {
-    return std::holds_alternative<UniqueRef<ColorMix>>(value);
+    return value.holdsAlternative<UniqueRef<ColorMix>>();
 }
 
 bool Color::isContrastColor() const
 {
-    return std::holds_alternative<UniqueRef<ContrastColor>>(value);
+    return value.holdsAlternative<UniqueRef<ContrastColor>>();
 }
 
 bool Color::isRelativeColor() const
 {
-    return std::holds_alternative<UniqueRef<RelativeColor<RGBFunctionModernRelative>>>(value)
-        || std::holds_alternative<UniqueRef<RelativeColor<HSLFunctionModern>>>(value)
-        || std::holds_alternative<UniqueRef<RelativeColor<HWBFunction>>>(value)
-        || std::holds_alternative<UniqueRef<RelativeColor<LabFunction>>>(value)
-        || std::holds_alternative<UniqueRef<RelativeColor<LCHFunction>>>(value)
-        || std::holds_alternative<UniqueRef<RelativeColor<OKLabFunction>>>(value)
-        || std::holds_alternative<UniqueRef<RelativeColor<OKLCHFunction>>>(value)
-        || std::holds_alternative<UniqueRef<RelativeColor<ColorRGBFunction<ExtendedA98RGB<float>>>>>(value)
-        || std::holds_alternative<UniqueRef<RelativeColor<ColorRGBFunction<ExtendedDisplayP3<float>>>>>(value)
-        || std::holds_alternative<UniqueRef<RelativeColor<ColorRGBFunction<ExtendedLinearDisplayP3<float>>>>>(value)
-        || std::holds_alternative<UniqueRef<RelativeColor<ColorRGBFunction<ExtendedProPhotoRGB<float>>>>>(value)
-        || std::holds_alternative<UniqueRef<RelativeColor<ColorRGBFunction<ExtendedRec2020<float>>>>>(value)
-        || std::holds_alternative<UniqueRef<RelativeColor<ColorRGBFunction<ExtendedSRGBA<float>>>>>(value)
-        || std::holds_alternative<UniqueRef<RelativeColor<ColorRGBFunction<ExtendedLinearSRGBA<float>>>>>(value)
-        || std::holds_alternative<UniqueRef<RelativeColor<ColorXYZFunction<XYZA<float, WhitePoint::D50>>>>>(value)
-        || std::holds_alternative<UniqueRef<RelativeColor<ColorXYZFunction<XYZA<float, WhitePoint::D65>>>>>(value);
+    return value.holdsAlternative<UniqueRef<RelativeColor<RGBFunctionModernRelative>>>()
+        || value.holdsAlternative<UniqueRef<RelativeColor<HSLFunctionModern>>>()
+        || value.holdsAlternative<UniqueRef<RelativeColor<HWBFunction>>>()
+        || value.holdsAlternative<UniqueRef<RelativeColor<LabFunction>>>()
+        || value.holdsAlternative<UniqueRef<RelativeColor<LCHFunction>>>()
+        || value.holdsAlternative<UniqueRef<RelativeColor<OKLabFunction>>>()
+        || value.holdsAlternative<UniqueRef<RelativeColor<OKLCHFunction>>>()
+        || value.holdsAlternative<UniqueRef<RelativeColor<ColorRGBFunction<ExtendedA98RGB<float>>>>>()
+        || value.holdsAlternative<UniqueRef<RelativeColor<ColorRGBFunction<ExtendedDisplayP3<float>>>>>()
+        || value.holdsAlternative<UniqueRef<RelativeColor<ColorRGBFunction<ExtendedLinearDisplayP3<float>>>>>()
+        || value.holdsAlternative<UniqueRef<RelativeColor<ColorRGBFunction<ExtendedProPhotoRGB<float>>>>>()
+        || value.holdsAlternative<UniqueRef<RelativeColor<ColorRGBFunction<ExtendedRec2020<float>>>>>()
+        || value.holdsAlternative<UniqueRef<RelativeColor<ColorRGBFunction<ExtendedSRGBA<float>>>>>()
+        || value.holdsAlternative<UniqueRef<RelativeColor<ColorRGBFunction<ExtendedLinearSRGBA<float>>>>>()
+        || value.holdsAlternative<UniqueRef<RelativeColor<ColorXYZFunction<XYZA<float, WhitePoint::D50>>>>>()
+        || value.holdsAlternative<UniqueRef<RelativeColor<ColorXYZFunction<XYZA<float, WhitePoint::D65>>>>>();
 }
 
 bool Color::isResolvedColor() const
 {
-    return std::holds_alternative<ResolvedColor>(value);
+    return value.holdsAlternative<InlineResolvedColor>() || value.holdsAlternative<UniqueRef<OutOfLineResolvedColor>>();
 }
 
-const WebCore::Color& Color::resolvedColor() const
+WebCore::Color Color::resolvedColor() const
 {
     ASSERT(isResolvedColor());
-    return std::get<ResolvedColor>(value).color;
+    WebCore::Color result;
+    value.switchOn(
+        [&](const InlineResolvedColor& inlined) { result = inlined.toColor(); },
+        [&](const UniqueRef<OutOfLineResolvedColor>& outOfLine) { result = outOfLine.get().toColor(); },
+        [](const auto&) { RELEASE_ASSERT_NOT_REACHED(); }
+    );
+    return result;
 }
 
 bool Color::isKnownTransparent() const

--- a/Source/WebCore/style/values/color/StyleColor.h
+++ b/Source/WebCore/style/values/color/StyleColor.h
@@ -39,6 +39,7 @@
 #include <WebCore/StyleColorOptions.h>
 #include <WebCore/StyleCurrentColor.h>
 #include <WebCore/StyleResolvedColor.h>
+#include <wtf/CompactVariant.h>
 #include <wtf/Markable.h>
 #include <wtf/OptionSet.h>
 #include <wtf/UniqueRef.h>
@@ -68,11 +69,11 @@ private:
     friend struct MarkableTraits<Color>;
     struct EmptyToken { constexpr bool operator==(const EmptyToken&) const = default; };
 
-    // FIXME: Replace Variant with a generic CompactPointerVariant type.
-    using ColorKind = Variant<
+    using ColorKind = CompactVariant<
         EmptyToken,
-        ResolvedColor,
         CurrentColor,
+        InlineResolvedColor,
+        UniqueRef<OutOfLineResolvedColor>,
         UniqueRef<ColorLayers>,
         UniqueRef<ColorMix>,
         UniqueRef<ContrastColor>,
@@ -95,7 +96,6 @@ private:
     >;
 
     Color(EmptyToken);
-    Color(ColorKind&&);
 
 public:
     // The default constructor initializes to Style::CurrentColor to preserve old behavior,
@@ -151,7 +151,7 @@ public:
     bool NODELETE isRelativeColor() const;
 
     bool NODELETE isResolvedColor() const;
-    const WebCore::Color& resolvedColor() const;
+    WebCore::Color resolvedColor() const;
 
     WEBCORE_EXPORT WebCore::Color resolveColor(const WebCore::Color& currentColor) const;
 
@@ -219,17 +219,22 @@ template<> struct Blending<Color> {
 template<typename... F> decltype(auto) Color::switchOn(F&&... f) const
 {
     auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
-    using ResultType = decltype(visitor(std::declval<ResolvedColor>()));
+    using ResultType = decltype(visitor(std::declval<CurrentColor>()));
 
-    return WTF::switchOn(value,
+    return value.switchOn(
         [&](const EmptyToken&) -> ResultType {
             RELEASE_ASSERT_NOT_REACHED();
         },
-        [&](const ResolvedColor& resolvedColor) -> ResultType {
-            return visitor(resolvedColor);
-        },
         [&](const CurrentColor& currentColor) -> ResultType {
             return visitor(currentColor);
+        },
+        [&](const InlineResolvedColor& inlined) -> ResultType {
+            ResolvedColor resolved { inlined.toColor() };
+            return visitor(resolved);
+        },
+        [&](const UniqueRef<OutOfLineResolvedColor>& outOfLine) -> ResultType {
+            ResolvedColor resolved { outOfLine.get().toColor() };
+            return visitor(resolved);
         },
         [&]<typename T>(const UniqueRef<T>& color) -> ResultType {
             return visitor(color.get());
@@ -244,10 +249,8 @@ namespace WTF {
 
 template<>
 struct MarkableTraits<WebCore::Style::Color> {
-    static bool isEmptyValue(const WebCore::Style::Color& color) { return std::holds_alternative<WebCore::Style::Color::EmptyToken>(color.value); }
+    static bool isEmptyValue(const WebCore::Style::Color& color) { return color.value.holdsAlternative<WebCore::Style::Color::EmptyToken>(); }
     static WebCore::Style::Color emptyValue() { return WebCore::Style::Color(WebCore::Style::Color::EmptyToken()); }
 };
 
 }
-
-DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::Color)

--- a/Source/WebCore/style/values/color/StyleColor.h
+++ b/Source/WebCore/style/values/color/StyleColor.h
@@ -69,11 +69,14 @@ private:
     friend struct MarkableTraits<Color>;
     struct EmptyToken { constexpr bool operator==(const EmptyToken&) const = default; };
 
+    // InlineResolvedColor and UniqueRef<ResolvedColor> are separate special
+    // representations for ResolvedColor. The former is a special case to
+    // provide inline access.
     using ColorKind = CompactVariant<
         EmptyToken,
         CurrentColor,
         InlineResolvedColor,
-        UniqueRef<OutOfLineResolvedColor>,
+        UniqueRef<ResolvedColor>,
         UniqueRef<ColorLayers>,
         UniqueRef<ColorMix>,
         UniqueRef<ContrastColor>,
@@ -157,8 +160,8 @@ public:
 
     bool isKnownTransparent() const;
 
-    // This helper allows us to treat all the alternatives in ColorKind
-    // as const references, pretending the UniqueRefs don't exist.
+    // This helper bypasses UniqueRefs, allowing the visitor to use the
+    // underlying type directly.
     template<typename... F> decltype(auto) switchOn(F&&...) const;
 
     String debugDescription() const;
@@ -230,10 +233,6 @@ template<typename... F> decltype(auto) Color::switchOn(F&&... f) const
         },
         [&](const InlineResolvedColor& inlined) -> ResultType {
             ResolvedColor resolved { inlined.toColor() };
-            return visitor(resolved);
-        },
-        [&](const UniqueRef<OutOfLineResolvedColor>& outOfLine) -> ResultType {
-            ResolvedColor resolved { outOfLine.get().toColor() };
             return visitor(resolved);
         },
         [&]<typename T>(const UniqueRef<T>& color) -> ResultType {

--- a/Source/WebCore/style/values/color/StyleResolvedColor.h
+++ b/Source/WebCore/style/values/color/StyleResolvedColor.h
@@ -50,7 +50,6 @@ inline bool operator==(const UniqueRef<ResolvedColor>& a, const UniqueRef<Resolv
 }
 
 using InlineResolvedColor = WebCore::InlineColor;
-using OutOfLineResolvedColor = WebCore::OutOfLineColor;
 
 Color toStyleColor(const CSS::ResolvedColor&, ColorResolutionState&);
 

--- a/Source/WebCore/style/values/color/StyleResolvedColor.h
+++ b/Source/WebCore/style/values/color/StyleResolvedColor.h
@@ -44,6 +44,14 @@ struct ResolvedColor {
     bool operator==(const ResolvedColor&) const = default;
 };
 
+inline bool operator==(const UniqueRef<ResolvedColor>& a, const UniqueRef<ResolvedColor>& b)
+{
+    return a.get() == b.get();
+}
+
+using InlineResolvedColor = WebCore::InlineColor;
+using OutOfLineResolvedColor = WebCore::OutOfLineColor;
+
 Color toStyleColor(const CSS::ResolvedColor&, ColorResolutionState&);
 
 inline WebCore::Color resolveColor(const ResolvedColor& absoluteColor, const WebCore::Color&)


### PR DESCRIPTION
#### 8b09f753b67c39518cfdc4f7327578d7b76e3fa0
<pre>
Use CompactVariant in Style::Color
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Reduces the size of Style::Color from 16 bytes to 8 bytes, by
replacing Variant by CompactVariant. This causes significant savings in
Style::InheritedRareData, which contains several instances of
Style::Color.

This was not possible previously because of a single type:
ResolvedColor, a 64-bit object which either uses 48 bits (4 bytes of
rgba + 1 byte of flags + 1 byte of colorspace), or the full 64 bits
(48-bit pointer + 1 byte of flags + 1 byte for colorspace) and extra
16 bytes in the heap - 4 floats for RGBA.

To make the conversion possible, ResolvedColor is now be accessible
through an indirection involving UniqueRef. However, to avoid
indirection in most cases, ResolvedColor instances which only use 48
bits are stored as the InlineResolvedColor type, which is only 48 bits
long, fitting inside CompactVariant.

No new tests (OOPS!).
</pre>
----------------------------------------------------------------------
#### 1ebc912da580e744ed998bb63cf1576735c870f6
<pre>
Working: use CompactVariant for Style::Color
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b09f753b67c39518cfdc4f7327578d7b76e3fa0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152554 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25336 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18935 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161299 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106011 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154428 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25864 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25642 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117882 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83545 "3 flakes 2 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9f4521b4-311f-4de6-8418-558c8b1cc0f9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155514 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20101 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136961 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98691 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19176 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17119 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9133 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144566 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128826 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14835 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163770 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13489 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6909 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16429 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125939 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25134 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21158 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126101 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25136 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136631 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81738 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21082 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13410 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184186 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24752 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89038 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46969 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24444 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24603 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24504 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->