### PR TITLE
HTMLPreloadScanner should not preload stylesheets with the disabled attribute

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1010,7 +1010,6 @@ imported/w3c/web-platform-tests/html/syntax/speculative-charset/speculative-scri
 imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/base-href-script-src.tentative.html [ Failure Pass ]
 imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/img-src-loading-lazy.tentative.html [ Failure Pass ]
 imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/link-rel-alternate-stylesheet.tentative.html [ Failure Pass ]
-imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/link-rel-stylesheet-disabled.tentative.html [ Failure Pass ]
 imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/link-rel-stylesheet-nomatch-media.tentative.html [ Failure Pass ]
 imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/math-font-script-src.tentative.html [ Failure Pass ]
 imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/math-script-src.tentative.html [ Failure Pass ]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/link-rel-stylesheet-disabled.tentative.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/link-rel-stylesheet-disabled.tentative.sub-expected.txt
@@ -1,7 +1,3 @@
 
-    <!-- speculative case in document.write -->
-    <link rel="stylesheet" href="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid=efab125c-1514-41db-9dbf-837ebc4c084b&amp;encodingcheck=&Gbreve;" disabled>
-
-
-FAIL Speculative parsing, document.write(): link-rel-stylesheet-disabled Unhandled rejection: assert_equals: speculative case incorrectly fetched expected "" but got "param-encodingcheck: %C4%9E\r\n"
+PASS Speculative parsing, document.write(): link-rel-stylesheet-disabled
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/link-rel-stylesheet-disabled.tentative.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/link-rel-stylesheet-disabled.tentative.sub.html
@@ -17,7 +17,7 @@
   document.write(`
     <script src="/common/slow.py?delay=1500"><\/script>
     <script>
-     document.write('<plaintext>');
+     document.write('<!--');
     <\/script>
     <\!-- speculative case in document.write -->
     <link rel="stylesheet" href="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid=${uuid}&amp;encodingcheck=&Gbreve;" disabled>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/link-rel-stylesheet-disabled.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/link-rel-stylesheet-disabled.tentative-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Speculative parsing, page load: link-rel-stylesheet-disabled Unhandled rejection: assert_equals: speculative case incorrectly fetched expected "" but got "param-encodingcheck: %C4%9E\r\nAccept: text/css,*/*;q=0.1\r\nReferer: http://localhost:8800/html/syntax/speculative-parsing/generated/page-load/resources/link-rel-stylesheet-disabled-framed.sub.html?uuid=bb1aa5ea-1de1-406b-a7f2-97b61fe1d564"
+PASS Speculative parsing, page load: link-rel-stylesheet-disabled
 

--- a/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
+++ b/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
@@ -322,6 +322,8 @@ private:
                 m_referrerPolicy = parseReferrerPolicy(attributeValue, ReferrerPolicySource::ReferrerPolicyAttribute).value_or(ReferrerPolicy::EmptyString);
             else if (match(attributeName, fetchpriorityAttr))
                 m_fetchPriority = parseEnumerationFromString<RequestPriority>(attributeValue.toString()).value_or(RequestPriority::Auto);
+            else if (match(attributeName, disabledAttr))
+                m_linkIsDisabled = true;
             break;
         case TagId::Input:
             if (match(attributeName, srcAttr))
@@ -417,6 +419,9 @@ private:
         if (m_tagId == TagId::Link && !m_linkIsStyleSheet && !m_linkIsPreload)
             return false;
 
+        if (m_tagId == TagId::Link && m_linkIsDisabled)
+            return false;
+
         if (m_tagId == TagId::Input && !m_inputIsImage)
             return false;
 
@@ -434,6 +439,7 @@ private:
     String m_crossOriginMode;
     bool m_linkIsStyleSheet;
     bool m_linkIsPreload;
+    bool m_linkIsDisabled { false };
     String m_mediaAttribute;
     String m_nonceAttribute;
     String m_metaContent;


### PR DESCRIPTION
#### f92d19110cc338ec402b1335935f59acaf2f005d
<pre>
HTMLPreloadScanner should not preload stylesheets with the disabled attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=310767">https://bugs.webkit.org/show_bug.cgi?id=310767</a>
<a href="https://rdar.apple.com/173378582">rdar://173378582</a>

Reviewed by Chris Dumez.

This patch aligns WebKit with Gecko / Firefox.

The speculative preload scanner was issuing preload requests for
&lt;link rel=&quot;stylesheet&quot; disabled&gt; elements. Per the speculative HTML
parsing spec [1], user agents &quot;must not speculatively fetch resources
that would not be fetched with the normal HTML parser.&quot; Since a link
element with the disabled attribute does not trigger a resource fetch
when processed normally, the speculative parser should skip it as well.

Teach the preload scanner to recognize the disabled attribute on link
elements and skip preloading when it is present.

[1] <a href="https://html.spec.whatwg.org/multipage/parsing.html#speculative-html-parsing">https://html.spec.whatwg.org/multipage/parsing.html#speculative-html-parsing</a>

* LayoutTests/TestExpectations: Unskip test
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/link-rel-stylesheet-disabled.tentative.sub-expected.txt: Progression
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/link-rel-stylesheet-disabled.tentative.sub.html: Updated to not dump &lt;plaintext&gt;
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/link-rel-stylesheet-disabled.tentative-expected.txt: Ditto
* Source/WebCore/html/parser/HTMLPreloadScanner.cpp:
(WebCore::TokenPreloadScanner::StartTagScanner::processAttribute):
(WebCore::TokenPreloadScanner::StartTagScanner::shouldPreload):

Canonical link: <a href="https://commits.webkit.org/311776@main">https://commits.webkit.org/311776@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8344fea678ff2f65fc1fa44e36f8a498daae7d51

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157942 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31279 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24472 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166770 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112025 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159813 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31415 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31281 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122315 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85872 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160900 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24604 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141847 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102982 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/23660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/21958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14543 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133342 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19647 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169260 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/14333 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21270 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130489 "Found 1 new test failure: media/media-vp8-webm.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31025 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26023 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130603 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35379 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30963 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141441 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88842 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25339 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18247 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30515 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/95771 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30036 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30266 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30163 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->