### PR TITLE
Fix SharedBuffer:isSpanWithinBounds()

### DIFF
--- a/Source/WebCore/platform/SharedBuffer.h
+++ b/Source/WebCore/platform/SharedBuffer.h
@@ -453,10 +453,11 @@ inline bool SharedBuffer::isSpanWithinBounds(std::span<T> otherSpan) const
 {
     auto thisSpan = this->span();
     auto otherByteSpan = asByteSpan(otherSpan);
-    if (std::to_address(otherByteSpan.end()) < std::to_address(thisSpan.begin()))
-        return false;
-    size_t offset = std::to_address(otherByteSpan.end()) - std::to_address(thisSpan.begin());
-    return offset <= size(); // "<=" because end is included as valid.
+    auto* thisBegin = std::to_address(thisSpan.begin());
+    auto* thisEnd = std::to_address(thisSpan.end());
+    auto* otherBegin = std::to_address(otherByteSpan.begin());
+    auto* otherEnd = std::to_address(otherByteSpan.end());
+    return otherBegin >= thisBegin && otherEnd <= thisEnd;
 }
 
 } // namespace WebCore

--- a/Tools/TestWebKitAPI/Tests/WebCore/SharedBuffer.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/SharedBuffer.cpp
@@ -404,6 +404,58 @@ TEST_F(FragmentedSharedBufferTest, extractData)
     EXPECT_GT(original->begin()->segment->size(), 0u);
 }
 
+TEST_F(FragmentedSharedBufferTest, isSpanWithinBounds)
+{
+    // Use a Provider-backed SharedBuffer so the underlying data lives in our
+    // controlled allocation, allowing safe pointer arithmetic to construct
+    // out-of-bounds spans for testing.
+    Vector<uint8_t> backing(200, 'x');
+    auto* base = backing.span().data();
+    constexpr size_t bufferOffset = 50;
+    constexpr size_t bufferSize = 100;
+    auto bufferDataSpan = std::span<const uint8_t>(base + bufferOffset, bufferSize);
+    auto buffer = SharedBuffer::create(DataSegment::Provider {
+        [bufferDataSpan]() { return bufferDataSpan; }
+    });
+    auto bufferSpan = buffer->span();
+    ASSERT_EQ(bufferSpan.data(), base + bufferOffset);
+    ASSERT_EQ(bufferSpan.size(), bufferSize);
+
+    // Fully within bounds.
+    EXPECT_TRUE(buffer->isSpanWithinBounds(bufferSpan));
+    EXPECT_TRUE(buffer->isSpanWithinBounds(bufferSpan.subspan(0, 50)));
+    EXPECT_TRUE(buffer->isSpanWithinBounds(bufferSpan.subspan(50)));
+    EXPECT_TRUE(buffer->isSpanWithinBounds(bufferSpan.subspan(10, 80)));
+
+    // Empty spans at boundaries.
+    EXPECT_TRUE(buffer->isSpanWithinBounds(bufferSpan.subspan(0, 0)));
+    EXPECT_TRUE(buffer->isSpanWithinBounds(bufferSpan.subspan(bufferSize, 0)));
+
+    // Span starts before buffer but ends within it.
+    std::span<const uint8_t> startsBeforeEndsWithin(base + bufferOffset - 10, 50);
+    EXPECT_FALSE(buffer->isSpanWithinBounds(startsBeforeEndsWithin));
+
+    // Span starts within buffer but extends past the end.
+    std::span<const uint8_t> startsWithinEndsPast(base + bufferOffset + 80, 30);
+    EXPECT_FALSE(buffer->isSpanWithinBounds(startsWithinEndsPast));
+
+    // Span entirely before buffer.
+    std::span<const uint8_t> entirelyBefore(base, 20);
+    EXPECT_FALSE(buffer->isSpanWithinBounds(entirelyBefore));
+
+    // Span entirely after buffer.
+    std::span<const uint8_t> entirelyAfter(base + bufferOffset + bufferSize + 10, 20);
+    EXPECT_FALSE(buffer->isSpanWithinBounds(entirelyAfter));
+
+    // Empty span before buffer.
+    std::span<const uint8_t> emptyBefore(base, 0);
+    EXPECT_FALSE(buffer->isSpanWithinBounds(emptyBefore));
+
+    // Empty span after buffer.
+    std::span<const uint8_t> emptyAfter(base + bufferOffset + bufferSize + 10, 0);
+    EXPECT_FALSE(buffer->isSpanWithinBounds(emptyAfter));
+}
+
 TEST_F(FragmentedSharedBufferTest, copyIsContiguous)
 {
     EXPECT_TRUE(SharedBuffer::create()->copy()->isContiguous());


### PR DESCRIPTION
#### 5d2a8a719f04ed26b8ca5a77bda4054891bffd48
<pre>
Fix SharedBuffer:isSpanWithinBounds()
<a href="https://bugs.webkit.org/show_bug.cgi?id=310769">https://bugs.webkit.org/show_bug.cgi?id=310769</a>

Reviewed by Kimmo Kinnunen.

The function only checked that otherSpan.end() falls within
`[thisSpan.begin(), thisSpan.end()]``. It never checks that
`otherSpan.begin() &gt;= thisSpan.begin()`. A span that starts before the
buffer but ends within it would incorrectly return true.

Test: Tools/TestWebKitAPI/Tests/WebCore/SharedBuffer.cpp

* Source/WebCore/platform/SharedBuffer.h:
(WebCore::SharedBuffer::isSpanWithinBounds const):
* Tools/TestWebKitAPI/Tests/WebCore/SharedBuffer.cpp:
(TestWebKitAPI::TEST_F(FragmentedSharedBufferTest, isSpanWithinBounds)):

Canonical link: <a href="https://commits.webkit.org/309975@main">https://commits.webkit.org/309975@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2648f22bdb60472390f0870a93a115d010b20c8a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152325 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25107 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18706 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161068 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/02915496-3229-4a90-aec3-f11c20f066b6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154199 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25634 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25413 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117690 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bd27e13b-e968-4ad3-9d91-30ff6ef05e29) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155285 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136750 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98403 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/18974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16908 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8902 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14624 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163537 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6680 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16218 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125723 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24905 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20946 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125897 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34154 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24906 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136420 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81506 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20892 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13199 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24523 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88808 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24214 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24374 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24275 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->