### PR TITLE
utf8Buffer() in SharedBuffer.h allocates too much memory for 8-bit strings

### DIFF
--- a/Source/WebCore/platform/SharedBuffer.cpp
+++ b/Source/WebCore/platform/SharedBuffer.cpp
@@ -743,13 +743,16 @@ Ref<SharedBuffer> SharedBufferDataView::createSharedBuffer() const
 RefPtr<SharedBuffer> utf8Buffer(const String& string)
 {
     // Allocate a buffer big enough to hold all the characters.
+    // 8-bit (Latin1) characters expand to at most 2 UTF-8 bytes.
+    // 16-bit characters expand to at most 3 UTF-8 bytes.
     const size_t length = string.length();
+    const size_t maxExpansion = string.is8Bit() ? 2 : 3;
     if constexpr (String::MaxLength > std::numeric_limits<size_t>::max() / 3) {
-        if (length > std::numeric_limits<size_t>::max() / 3)
+        if (length > std::numeric_limits<size_t>::max() / maxExpansion)
             return nullptr;
     }
 
-    Vector<uint8_t> buffer(length * 3);
+    Vector<uint8_t> buffer(length * maxExpansion);
     WTF::Unicode::ConversionResult<char8_t> result;
     if (length) {
         if (string.is8Bit())


### PR DESCRIPTION
#### 65bc0fda9edd68bc4a2de32a3fc6d9a668c165d5
<pre>
utf8Buffer() in SharedBuffer.h allocates too much memory for 8-bit strings
<a href="https://bugs.webkit.org/show_bug.cgi?id=310770">https://bugs.webkit.org/show_bug.cgi?id=310770</a>

Reviewed by Anne van Kesteren.

Latin1 characters (0x80-0xFF) encode as at most 2 UTF-8 bytes; ASCII
(0x00-0x7F) as 1 byte. So length * 2 is sufficient for 8-bit strings.
The 3x multiplier is only needed for 16-bit strings (a single BMP
codepoint can be 3 UTF-8 bytes). Additionally,
`Vector&lt;uint8_t&gt; buffer(length * 3)` zero-initializes the entire
allocation, so the waste is both allocation and initialization.

* Source/WebCore/platform/SharedBuffer.cpp:
(WebCore::utf8Buffer):

Canonical link: <a href="https://commits.webkit.org/309984@main">https://commits.webkit.org/309984@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d8e2bdf52167299b79fa23c20d93ee95684fca3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152326 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25108 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18707 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161069 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105783 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5c335a3e-646b-47db-b43f-31412f4d392e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154200 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25635 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25414 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117688 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83438 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155286 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19901 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136751 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98401 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ce801c07-7c30-4b90-9652-e31bd95ca1ee) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18978 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16909 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8903 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128628 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14625 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163538 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6681 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16219 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125724 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24906 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20947 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125898 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34161 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24907 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136421 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81507 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20893 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13200 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24524 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88809 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24215 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24375 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24276 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->