### PR TITLE
[Swift in WebKit] Non-PAL targets should not access the internal PAL Swift bridging header (part 5)

### DIFF
--- a/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
+++ b/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
@@ -26,6 +26,8 @@
 		077121BA2C1E8BE500FACBF9 /* WritingToolsUISPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 077121B92C1E8BE500FACBF9 /* WritingToolsUISPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		07789181273B14FF00E408D1 /* ScreenCaptureKitSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0778917F273B14FF00E408D1 /* ScreenCaptureKitSoftLink.mm */; };
 		077E87B1226A460200A2AFF0 /* AVFoundationSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 077E87AF226A460200A2AFF0 /* AVFoundationSoftLink.mm */; };
+		078D1F3D2F74D8D000B6BFA9 /* PlatformECKey.h in Headers */ = {isa = PBXBuildFile; fileRef = 078D1F3C2F74D8D000B6BFA9 /* PlatformECKey.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		078D1F422F74FB5D00B6BFA9 /* PlatformECKey.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 078D1F412F74FB5D00B6BFA9 /* PlatformECKey.cpp */; };
 		079D1D9826950DD700883577 /* SystemStatusSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 079D1D9626950DD700883577 /* SystemStatusSoftLink.mm */; };
 		07C9C8DC2EDAAABD007B579A /* CryptoTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 07C9C8DB2EDAAABD007B579A /* CryptoTypes.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0CF99CA41F736375007EE793 /* MediaTimeAVFoundation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0C00CFD11F68CE4600AAC26D /* MediaTimeAVFoundation.cpp */; };
@@ -487,6 +489,8 @@
 		07789180273B14FF00E408D1 /* ScreenCaptureKitSoftLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScreenCaptureKitSoftLink.h; sourceTree = "<group>"; };
 		077E87AF226A460200A2AFF0 /* AVFoundationSoftLink.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AVFoundationSoftLink.mm; sourceTree = "<group>"; };
 		077E87B0226A460200A2AFF0 /* AVFoundationSoftLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AVFoundationSoftLink.h; sourceTree = "<group>"; };
+		078D1F3C2F74D8D000B6BFA9 /* PlatformECKey.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PlatformECKey.h; sourceTree = "<group>"; };
+		078D1F412F74FB5D00B6BFA9 /* PlatformECKey.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PlatformECKey.cpp; sourceTree = "<group>"; };
 		079D1D9526950DD700883577 /* SystemStatusSoftLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SystemStatusSoftLink.h; sourceTree = "<group>"; };
 		079D1D9626950DD700883577 /* SystemStatusSoftLink.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = SystemStatusSoftLink.mm; sourceTree = "<group>"; };
 		07C9C8DB2EDAAABD007B579A /* CryptoTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CryptoTypes.h; sourceTree = "<group>"; };
@@ -1123,6 +1127,8 @@
 				076E34C32F725D9D006A65D9 /* CryptoKit+UnsafeOverlays.swift */,
 				07C9C8DB2EDAAABD007B579A /* CryptoTypes.h */,
 				076E34C82F725DD9006A65D9 /* CryptoTypes.swift */,
+				078D1F412F74FB5D00B6BFA9 /* PlatformECKey.cpp */,
+				078D1F3C2F74D8D000B6BFA9 /* PlatformECKey.h */,
 			);
 			path = crypto;
 			sourceTree = "<group>";
@@ -1592,6 +1598,7 @@
 				DD20DD2227BC90D60093D175 /* PassKitSoftLink.h in Headers */,
 				DD20DE0327BC90D80093D175 /* PassKitSPI.h in Headers */,
 				DD20DE3E27BC90D80093D175 /* PIPSPI.h in Headers */,
+				078D1F3D2F74D8D000B6BFA9 /* PlatformECKey.h in Headers */,
 				DD20DE4527BC90D80093D175 /* PopupMenu.h in Headers */,
 				E34F26F62846D0D90076E549 /* PowerLogSPI.h in Headers */,
 				DD20DE0427BC90D80093D175 /* pthreadSPI.h in Headers */,
@@ -1874,6 +1881,7 @@
 				071CFF4F2F0614FB00E07A47 /* pal.swift in Sources */,
 				FE62AC3D2CFE2E0300740A18 /* PALTZoneImpls.cpp in Sources */,
 				A1F63CA021A4DBF7006FB43B /* PassKitSoftLink.mm in Sources */,
+				078D1F422F74FB5D00B6BFA9 /* PlatformECKey.cpp in Sources */,
 				A1175B4F1F6B337300C4B9F0 /* PopupMenu.mm in Sources */,
 				D065131629B69F11008C65C4 /* QuartzCoreSoftLink.mm in Sources */,
 				4450FC9F21F5F602004DFA56 /* QuickLookSoftLink.mm in Sources */,

--- a/Source/WebCore/PAL/pal/PALSwift/CryptoKitShim.swift
+++ b/Source/WebCore/PAL/pal/PALSwift/CryptoKitShim.swift
@@ -219,14 +219,6 @@ public class Digest {
     }
 }
 
-// FIXME: PALSwift should have no public symbols.
-// swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-public enum ECCurve {
-    case p256
-    case p384
-    case p521
-}
-
 enum ECPrivateKey {
     case p256(P256.Signing.PrivateKey)
     case p384(P384.Signing.PrivateKey)
@@ -246,34 +238,21 @@ enum ECKeyInternal {
 
 // FIXME: PALSwift should have no public symbols.
 // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-public enum ECImportReturnCode {
-    case defaultValue
-    case success
-    case importFailed
-}
-
-// FIXME: PALSwift should have no public symbols.
-// swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-public struct ECImportReturnValue {
-    public var errorCode: ECImportReturnCode = .defaultValue
-    public var key: ECKey? = nil
-}
-
-// FIXME: PALSwift should have no public symbols.
-// swift-format-ignore: AllPublicDeclarationsHaveDocumentation
 public struct ECKey {
     let key: ECKeyInternal
 
     // FIXME: PALSwift should have no public symbols.
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-    public init(curve: ECCurve) {
+    public init(curve: PAL.Crypto.ECNamedCurve) {
         switch curve {
-        case .p256:
+        case .P256:
             key = .privateKey(.p256(P256.Signing.PrivateKey(compactRepresentable: true)))
-        case .p384:
+        case .P384:
             key = .privateKey(.p384(P384.Signing.PrivateKey(compactRepresentable: true)))
-        case .p521:
+        case .P521:
             key = .privateKey(.p521(P521.Signing.PrivateKey(compactRepresentable: true)))
+        @unknown default:
+            fatalError()
         }
     }
 
@@ -309,22 +288,21 @@ public struct ECKey {
 
     // FIXME: PALSwift should have no public symbols.
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-    public static func importX963Pub(data: SpanConstUInt8, curve: ECCurve) -> ECImportReturnValue {
-        var returnValue = ECImportReturnValue()
+    public static func importX963Pub(data: SpanConstUInt8, curve: PAL.Crypto.ECNamedCurve) -> ECKey? {
         do {
-            switch curve {
-            case .p256:
-                returnValue.key = unsafe ECKey(internalKey: .publicKey(.p256(try P256.Signing.PublicKey(span: data))))
-            case .p384:
-                returnValue.key = unsafe ECKey(internalKey: .publicKey(.p384(try P384.Signing.PublicKey(span: data))))
-            case .p521:
-                returnValue.key = unsafe ECKey(internalKey: .publicKey(.p521(try P521.Signing.PublicKey(span: data))))
+            return switch curve {
+            case .P256:
+                unsafe ECKey(internalKey: .publicKey(.p256(try P256.Signing.PublicKey(span: data))))
+            case .P384:
+                unsafe ECKey(internalKey: .publicKey(.p384(try P384.Signing.PublicKey(span: data))))
+            case .P521:
+                unsafe ECKey(internalKey: .publicKey(.p521(try P521.Signing.PublicKey(span: data))))
+            @unknown default:
+                fatalError()
             }
-            returnValue.errorCode = .success
         } catch {
-            returnValue.errorCode = .importFailed
+            return nil
         }
-        return returnValue
     }
 
     // FIXME: PALSwift should have no public symbols.
@@ -349,42 +327,40 @@ public struct ECKey {
 
     // FIXME: PALSwift should have no public symbols.
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-    public static func importCompressedPub(data: SpanConstUInt8, curve: ECCurve) -> ECImportReturnValue {
-        var returnValue = ECImportReturnValue()
+    public static func importCompressedPub(data: SpanConstUInt8, curve: PAL.Crypto.ECNamedCurve) -> ECKey? {
         do {
-            switch curve {
-            case .p256:
-                returnValue.key = unsafe ECKey(publicKey: .p256(try P256.Signing.PublicKey(spanCompressed: data)))
-            case .p384:
-                returnValue.key = unsafe ECKey(publicKey: .p384(try P384.Signing.PublicKey(spanCompressed: data)))
-            case .p521:
-                returnValue.key = unsafe ECKey(publicKey: .p521(try P521.Signing.PublicKey(spanCompressed: data)))
+            return switch curve {
+            case .P256:
+                unsafe ECKey(publicKey: .p256(try P256.Signing.PublicKey(spanCompressed: data)))
+            case .P384:
+                unsafe ECKey(publicKey: .p384(try P384.Signing.PublicKey(spanCompressed: data)))
+            case .P521:
+                unsafe ECKey(publicKey: .p521(try P521.Signing.PublicKey(spanCompressed: data)))
+            @unknown default:
+                fatalError()
             }
-            returnValue.errorCode = .success
         } catch {
-            returnValue.errorCode = .importFailed
+            return nil
         }
-        return returnValue
     }
 
     // FIXME: PALSwift should have no public symbols.
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-    public static func importX963Private(data: SpanConstUInt8, curve: ECCurve) -> ECImportReturnValue {
-        var returnValue = ECImportReturnValue()
+    public static func importX963Private(data: SpanConstUInt8, curve: PAL.Crypto.ECNamedCurve) -> ECKey? {
         do {
-            switch curve {
-            case .p256:
-                returnValue.key = unsafe ECKey(privateKey: .p256(try P256.Signing.PrivateKey(span: data)))
-            case .p384:
-                returnValue.key = unsafe ECKey(privateKey: .p384(try P384.Signing.PrivateKey(span: data)))
-            case .p521:
-                returnValue.key = unsafe ECKey(privateKey: .p521(try P521.Signing.PrivateKey(span: data)))
+            return switch curve {
+            case .P256:
+                unsafe ECKey(privateKey: .p256(try P256.Signing.PrivateKey(span: data)))
+            case .P384:
+                unsafe ECKey(privateKey: .p384(try P384.Signing.PrivateKey(span: data)))
+            case .P521:
+                unsafe ECKey(privateKey: .p521(try P521.Signing.PrivateKey(span: data)))
+            @unknown default:
+                fatalError()
             }
-            returnValue.errorCode = .success
         } catch {
-            returnValue.errorCode = .importFailed
+            return nil
         }
-        return returnValue
     }
 
     // FIXME: PALSwift should have no public symbols.

--- a/Source/WebCore/PAL/pal/crypto/CryptoAlgorithmAESGCMCocoa.cpp
+++ b/Source/WebCore/PAL/pal/crypto/CryptoAlgorithmAESGCMCocoa.cpp
@@ -27,11 +27,7 @@
 #include "CryptoAlgorithmAESGCMCocoa.h"
 
 #include "CommonCryptoSPI.h"
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
 #include "PALSwift-Generated.h"
-#pragma clang diagnostic pop
-
 #include <wtf/CryptographicUtilities.h>
 
 namespace PAL::Crypto {

--- a/Source/WebCore/PAL/pal/crypto/CryptoAlgorithmAESKWCocoaBridging.cpp
+++ b/Source/WebCore/PAL/pal/crypto/CryptoAlgorithmAESKWCocoaBridging.cpp
@@ -27,11 +27,7 @@
 #include "CryptoAlgorithmAESKWCocoaBridging.h"
 
 #include "CommonCryptoSPI.h"
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
 #include "PALSwift-Generated.h"
-#pragma clang diagnostic pop
-
 #include <wtf/CryptographicUtilities.h>
 
 namespace PAL::Crypto {

--- a/Source/WebCore/PAL/pal/crypto/CryptoAlgorithmEd25519CocoaBridging.cpp
+++ b/Source/WebCore/PAL/pal/crypto/CryptoAlgorithmEd25519CocoaBridging.cpp
@@ -27,11 +27,7 @@
 #include "CryptoAlgorithmEd25519CocoaBridging.h"
 
 #include "CommonCryptoSPI.h"
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
 #include "PALSwift-Generated.h"
-#pragma clang diagnostic pop
-
 #include <wtf/CryptographicUtilities.h>
 
 namespace PAL::Crypto {

--- a/Source/WebCore/PAL/pal/crypto/CryptoAlgorithmX25519CocoaBridging.cpp
+++ b/Source/WebCore/PAL/pal/crypto/CryptoAlgorithmX25519CocoaBridging.cpp
@@ -27,11 +27,7 @@
 #include "CryptoAlgorithmX25519CocoaBridging.h"
 
 #include "CommonCryptoSPI.h"
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
 #include "PALSwift-Generated.h"
-#pragma clang diagnostic pop
-
 #include <wtf/CryptographicUtilities.h>
 
 namespace PAL::Crypto {

--- a/Source/WebCore/PAL/pal/crypto/PlatformECKey.cpp
+++ b/Source/WebCore/PAL/pal/crypto/PlatformECKey.cpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "PlatformECKey.h"
+
+#include "PALSwift-Generated.h"
+
+namespace PAL::Crypto {
+
+PlatformECKey::PlatformECKey(NamedCurve curve)
+    : PlatformECKey(pal::ECKey::init(curve))
+{
+}
+
+PlatformECKey::PlatformECKey(const pal::ECKey& key)
+    : m_key(makeUniqueRefWithoutFastMallocCheck<pal::ECKey>(key))
+{
+}
+
+PlatformECKey::PlatformECKey(PlatformECKey&&) = default;
+
+PlatformECKey& PlatformECKey::operator=(PlatformECKey&&) = default;
+
+PlatformECKey::~PlatformECKey() = default;
+
+CryptoOperationReturnValue PlatformECKey::deriveBits(const PlatformECKey& publicKey) const
+{
+    return m_key->deriveBits(publicKey.m_key.get());
+}
+
+CryptoOperationReturnValue PlatformECKey::sign(SpanConstUInt8 message, CryptoDigestHashFunction hashFunction) const
+{
+    return m_key->sign(message, hashFunction);
+}
+
+CryptoOperationReturnValue PlatformECKey::doVerify(SpanConstUInt8 message, SpanConstUInt8 signature, CryptoDigestHashFunction hashFunction) const
+{
+    return m_key->verify(message, signature, hashFunction);
+}
+
+PlatformECKey PlatformECKey::toPub() const
+{
+    return { m_key->toPub() };
+}
+
+CryptoOperationReturnValue PlatformECKey::exportX963Pub() const
+{
+    return m_key->exportX963Pub();
+}
+
+CryptoOperationReturnValue PlatformECKey::exportX963Private() const
+{
+    return m_key->exportX963Private();
+}
+
+std::optional<PlatformECKey> PlatformECKey::importX963Pub(SpanConstUInt8 data, NamedCurve curve)
+{
+    auto result = pal::ECKey::importX963Pub(data, curve);
+    if (result)
+        return { { result.get() } };
+
+    return std::nullopt;
+}
+
+std::optional<PlatformECKey> PlatformECKey::importX963Private(SpanConstUInt8 data, NamedCurve curve)
+{
+    auto result = pal::ECKey::importX963Private(data, curve);
+    if (result)
+        return { { result.get() } };
+
+    return std::nullopt;
+}
+
+std::optional<PlatformECKey> PlatformECKey::importCompressedPub(SpanConstUInt8 data, NamedCurve curve)
+{
+    auto result = pal::ECKey::importCompressedPub(data, curve);
+    if (result)
+        return { { result.get() } };
+
+    return std::nullopt;
+}
+
+}

--- a/Source/WebCore/PAL/pal/crypto/PlatformECKey.h
+++ b/Source/WebCore/PAL/pal/crypto/PlatformECKey.h
@@ -25,56 +25,51 @@
 
 #pragma once
 
-#include <cstdint>
-#include <span>
-#include <wtf/Vector.h>
+#include <pal/crypto/CryptoTypes.h>
+#include <wtf/UniqueRef.h>
+
+namespace pal {
+class ECKey;
+};
 
 namespace PAL::Crypto {
 
-using VectorUInt8 = WTF::Vector<uint8_t>;
+class PlatformECKey {
+    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(PlatformECKey);
+    WTF_MAKE_NONCOPYABLE(PlatformECKey);
+public:
+    using NamedCurve = ECNamedCurve;
 
-using SpanConstUInt8 = std::span<const uint8_t>;
+    PlatformECKey(NamedCurve);
 
-enum class CryptoDigestHashFunction: int {
-    SHA_1,
-    DEPRECATED_SHA_224,
-    SHA_256,
-    SHA_384,
-    SHA_512,
+    PlatformECKey(PlatformECKey&&);
+
+    PlatformECKey& operator=(PlatformECKey&&);
+
+    ~PlatformECKey();
+
+    CryptoOperationReturnValue deriveBits(const PlatformECKey& publicKey) const;
+
+    CryptoOperationReturnValue sign(SpanConstUInt8 message, CryptoDigestHashFunction) const;
+
+    CryptoOperationReturnValue doVerify(SpanConstUInt8 message, SpanConstUInt8 signature, CryptoDigestHashFunction) const;
+
+    PlatformECKey toPub() const;
+
+    CryptoOperationReturnValue exportX963Pub() const;
+
+    CryptoOperationReturnValue exportX963Private() const;
+
+    static std::optional<PlatformECKey> importX963Pub(SpanConstUInt8, NamedCurve);
+
+    static std::optional<PlatformECKey> importX963Private(SpanConstUInt8, NamedCurve);
+
+    static std::optional<PlatformECKey> importCompressedPub(SpanConstUInt8, NamedCurve);
+
+private:
+    PlatformECKey(const pal::ECKey&);
+
+    UniqueRef<pal::ECKey> m_key;
 };
-
-enum class Error: int {
-    Success = 0,
-    WrongTagSize,
-    EncryptionFailed,
-    EncryptionResultNil,
-    InvalidArgument,
-    TooBigArguments,
-    DecryptionFailed,
-    HashingFailed,
-    PublicKeyProvidedToSign,
-    FailedToSign,
-    FailedToVerify,
-    PrivateKeyProvidedForVerification,
-    FailedToImport,
-    FailedToDerive,
-    FailedToExport,
-    DefaultValue,
-    UnsupportedAlgorithm,
-};
-
-struct CryptoOperationReturnValue {
-    Error errorCode = Error::DefaultValue;
-    VectorUInt8 result;
-};
-
-enum class ECNamedCurve : uint8_t {
-    P256,
-    P384,
-    P521,
-};
-
-constexpr auto ed25519KeySize = 32;
-constexpr auto ed25519SignatureSize = ed25519KeySize * 2;
 
 } // namespace PAL::Crypto

--- a/Source/WebCore/PAL/pal/crypto/commoncrypto/CryptoDigestCommonCrypto.cpp
+++ b/Source/WebCore/PAL/pal/crypto/commoncrypto/CryptoDigestCommonCrypto.cpp
@@ -26,16 +26,12 @@
 #include "config.h"
 #include "CryptoDigest.h"
 
+#include "PALSwift-Generated.h"
 #include <CommonCrypto/CommonCrypto.h>
 #include <optional>
 #include <pal/crypto/CryptoTypes.h>
 #include <span>
 #include <wtf/TZoneMallocInlines.h>
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
-#include "PALSwift-Generated.h"
-#pragma clang diagnostic pop
 
 namespace PAL::Crypto {
 

--- a/Source/WebCore/PAL/pal/module.modulemap
+++ b/Source/WebCore/PAL/pal/module.modulemap
@@ -29,4 +29,4 @@ module pal [system] {
     export *
 }
 
-// (v2) This comment ensures an incremental build causes this module to rebuild (rdar://170129992)
+// (v3) This comment ensures an incremental build causes this module to rebuild (rdar://170129992)

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmECDHCocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmECDHCocoa.cpp
@@ -29,17 +29,13 @@
 #include "CommonCryptoUtilities.h"
 #include "CryptoKeyEC.h"
 #include <pal/crypto/CryptoTypes.h>
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
-#include "PALSwift-Generated.h"
-#pragma clang diagnostic pop
+#include <pal/crypto/PlatformECKey.h>
 
 namespace WebCore {
 
 static std::optional<Vector<uint8_t>> platformDeriveBitsCryptoKit(const CryptoKeyEC& baseKey, const CryptoKeyEC& publicKey)
 {
-    auto rv = baseKey.platformKey()->deriveBits(publicKey.platformKey());
+    auto rv = baseKey.platformKey().deriveBits(publicKey.platformKey());
     if (rv.errorCode != PAL::Crypto::Error::Success)
         return std::nullopt;
     return std::make_optional(WTF::move(rv.result));

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSACocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSACocoa.cpp
@@ -32,10 +32,6 @@
 #include "CryptoKeyEC.h"
 #include "CryptoTypesBridging.h"
 #include "ExceptionOr.h"
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
-#include "PALSwift-Generated.h"
-#pragma clang diagnostic pop
 #include <pal/crypto/CryptoTypes.h>
 #include <wtf/StdLibExtras.h>
 
@@ -45,7 +41,7 @@ static ExceptionOr<Vector<uint8_t>> signECDSACryptoKit(CryptoAlgorithmIdentifier
 {
     if (!isValidHashParameter(hash))
         return Exception { ExceptionCode::OperationError };
-    auto rv = key->sign(data.span(), toCKHashFunction(hash));
+    auto rv = key.sign(data.span(), toCKHashFunction(hash));
     if (rv.errorCode != PAL::Crypto::Error::Success)
         return Exception { ExceptionCode::OperationError };
     return WTF::move(rv.result);
@@ -55,7 +51,7 @@ static ExceptionOr<bool> verifyECDSACryptoKit(CryptoAlgorithmIdentifier hash, co
 {
     if (!isValidHashParameter(hash))
         return Exception { ExceptionCode::OperationError };
-    return key->verify(data.span(), signature.span(), toCKHashFunction(hash)).errorCode == PAL::Crypto::Error::Success;
+    return key.doVerify(data.span(), signature.span(), toCKHashFunction(hash)).errorCode == PAL::Crypto::Error::Success;
 }
 
 ExceptionOr<Vector<uint8_t>> CryptoAlgorithmECDSA::platformSign(const CryptoAlgorithmEcdsaParams& parameters, const CryptoKeyEC& key, const Vector<uint8_t>& data)

--- a/Source/WebCore/crypto/cocoa/CryptoKeyECCocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoKeyECCocoa.cpp
@@ -28,10 +28,6 @@
 
 #include "CommonCryptoDERUtilities.h"
 #include "JsonWebKey.h"
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
-#include "PALSwift-Generated.h"
-#pragma clang diagnostic pop
 #include <pal/crypto/CryptoTypes.h>
 #include <wtf/text/Base64.h>
 
@@ -101,29 +97,10 @@ bool CryptoKeyEC::platformSupportedCurve(NamedCurve curve)
     return curve == NamedCurve::P256 || curve == NamedCurve::P384 || curve == NamedCurve::P521;
 }
 
-static pal::ECCurve namedCurveToCryptoKitCurve(CryptoKeyEC::NamedCurve curve)
-{
-    switch (curve) {
-    case CryptoKeyEC::NamedCurve::P256:
-        return pal::ECCurve::p256();
-    case CryptoKeyEC::NamedCurve::P384:
-        return pal::ECCurve::p384();
-    case CryptoKeyEC::NamedCurve::P521:
-        return pal::ECCurve::p521();
-    }
-
-    ASSERT_NOT_REACHED();
-    return pal::ECCurve::p256();
-}
-static PlatformECKeyContainer toPlatformKey(pal::ECKey key)
-{
-    return makeUniqueRefWithoutFastMallocCheck<pal::ECKey>(key);
-}
-
 std::optional<CryptoKeyPair> CryptoKeyEC::platformGeneratePair(CryptoAlgorithmIdentifier identifier, NamedCurve curve, bool extractable, CryptoKeyUsageBitmap usages)
 {
-    auto privateKey = CryptoKeyEC::create(identifier, curve, CryptoKeyType::Private, toPlatformKey(pal::ECKey::init(namedCurveToCryptoKitCurve(curve))), extractable, usages);
-    auto publicKey = CryptoKeyEC::create(identifier, curve, CryptoKeyType::Public, toPlatformKey(privateKey->platformKey()->toPub()), true, usages);
+    Ref privateKey = CryptoKeyEC::create(identifier, curve, CryptoKeyType::Private, PAL::Crypto::PlatformECKey(curve), extractable, usages);
+    Ref publicKey = CryptoKeyEC::create(identifier, curve, CryptoKeyType::Public, privateKey->platformKey().toPub(), true, usages);
     return CryptoKeyPair { WTF::move(publicKey), WTF::move(privateKey) };
 }
 
@@ -132,16 +109,16 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportRaw(CryptoAlgorithmIdentifier ide
     if (!doesUncompressedPointMatchNamedCurve(curve, keyData.size()))
         return nullptr;
 
-    auto rv = pal::ECKey::importX963Pub(keyData.span(), namedCurveToCryptoKitCurve(curve));
-    if (!rv.getErrorCode().isSuccess() || !rv.getKey())
+    auto rv = PAL::Crypto::PlatformECKey::importX963Pub(keyData.span(), curve);
+    if (!rv)
         return nullptr;
-    return create(identifier, curve, CryptoKeyType::Public, toPlatformKey(rv.getKey().get()), extractable, usages);
+    return create(identifier, curve, CryptoKeyType::Public, WTF::move(*rv), extractable, usages);
 }
 
 Vector<uint8_t> CryptoKeyEC::platformExportRaw() const
 {
     size_t expectedSize = 2 * keySizeInBytes() + 1; // Per Section 2.3.4 of http://www.secg.org/sec1-v2.pdf
-    auto rv = platformKey()->exportX963Pub();
+    auto rv = platformKey().exportX963Pub();
     if (rv.errorCode != PAL::Crypto::Error::Success)
         return { };
     if (rv.result.size() != expectedSize)
@@ -172,10 +149,10 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportJWKPrivate(CryptoAlgorithmIdentif
     binaryInput.appendVector(y);
     binaryInput.appendVector(d);
 
-    auto rv = pal::ECKey::importX963Private(binaryInput.span(), namedCurveToCryptoKitCurve(curve));
-    if (!rv.getErrorCode().isSuccess() || !rv.getKey())
+    auto rv = PAL::Crypto::PlatformECKey::importX963Private(binaryInput.span(), curve);
+    if (!rv)
         return nullptr;
-    return create(identifier, curve, CryptoKeyType::Private, toPlatformKey(rv.getKey().get()), extractable, usages);
+    return create(identifier, curve, CryptoKeyType::Private, WTF::move(*rv), extractable, usages);
 }
 
 bool CryptoKeyEC::platformAddFieldElements(JsonWebKey& jwk) const
@@ -187,14 +164,14 @@ bool CryptoKeyEC::platformAddFieldElements(JsonWebKey& jwk) const
     Vector<uint8_t> result(privateKeySize);
     switch (type()) {
     case CryptoKeyType::Public: {
-        auto rv = platformKey()->exportX963Pub();
+        auto rv = platformKey().exportX963Pub();
         if (rv.errorCode != PAL::Crypto::Error::Success)
             return false;
         result = WTF::move(rv.result);
         break;
     }
     case CryptoKeyType::Private: {
-        auto rv = platformKey()->exportX963Private();
+        auto rv = platformKey().exportX963Private();
         if (rv.errorCode != PAL::Crypto::Error::Success)
             return false;
         result = WTF::move(rv.result);
@@ -263,10 +240,10 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportSpki(CryptoAlgorithmIdentifier id
         return platformImportRaw(identifier, curve, Vector<uint8_t>(keyData.subspan(index, keyData.size() - index)), extractable, usages);
 
     // CryptoKit can read pure compressed so no need for index++ here.
-    auto rv = pal::ECKey::importCompressedPub(keyData.subspan(index, keyData.size() - index), namedCurveToCryptoKitCurve(curve));
-    if (!rv.getErrorCode().isSuccess() || !rv.getKey())
+    auto rv = PAL::Crypto::PlatformECKey::importCompressedPub(keyData.subspan(index, keyData.size() - index), curve);
+    if (!rv)
         return nullptr;
-    return create(identifier, curve, CryptoKeyType::Public, toPlatformKey(rv.getKey().get()), extractable, usages);
+    return create(identifier, curve, CryptoKeyType::Public, WTF::move(*rv), extractable, usages);
 }
 
 Vector<uint8_t> CryptoKeyEC::platformExportSpki() const
@@ -275,7 +252,7 @@ Vector<uint8_t> CryptoKeyEC::platformExportSpki() const
     Vector<uint8_t> keyBytes(expectedKeySize);
     size_t keySize = keyBytes.size();
 
-    auto rv = platformKey()->exportX963Pub();
+    auto rv = platformKey().exportX963Pub();
     if (rv.errorCode != PAL::Crypto::Error::Success)
         return { };
     if (rv.result.size() != expectedKeySize)
@@ -363,10 +340,10 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportPkcs8(CryptoAlgorithmIdentifier i
         return nullptr;
     keyBinary.append(keyData.subspan(privateKeyPos, privateKeySize));
 
-    auto rv = pal::ECKey::importX963Private(keyBinary.span(), namedCurveToCryptoKitCurve(curve));
-    if (!rv.getErrorCode().isSuccess() || !rv.getKey())
+    auto rv = PAL::Crypto::PlatformECKey::importX963Private(keyBinary.span(), curve);
+    if (!rv)
         return nullptr;
-    return create(identifier, curve, CryptoKeyType::Private, toPlatformKey(rv.getKey().get()), extractable, usages);
+    return create(identifier, curve, CryptoKeyType::Private, WTF::move(*rv), extractable, usages);
 }
 
 Vector<uint8_t> CryptoKeyEC::platformExportPkcs8() const
@@ -375,7 +352,7 @@ Vector<uint8_t> CryptoKeyEC::platformExportPkcs8() const
     size_t expectedKeySize = keySizeInBytes * 3 + 1; // 04 + X + Y + D
     Vector<uint8_t> keyBytes(expectedKeySize);
 
-    auto rv = platformKey()->exportX963Private();
+    auto rv = platformKey().exportX963Private();
     if (rv.errorCode != PAL::Crypto::Error::Success)
         return { };
     if (rv.result.size() != expectedKeySize)

--- a/Source/WebCore/crypto/cocoa/CryptoKeyOKPCocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoKeyOKPCocoa.cpp
@@ -30,6 +30,10 @@
 #include "ExceptionOr.h"
 #include "JsonWebKey.h"
 #include "Logging.h"
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
+#include "PALSwift-Generated.h"
+#pragma clang diagnostic pop
 #include <pal/crypto/CryptoTypes.h>
 #include <pal/spi/cocoa/CoreCryptoSPI.h>
 #include <wtf/StdLibExtras.h>

--- a/Source/WebCore/crypto/keys/CryptoKeyEC.cpp
+++ b/Source/WebCore/crypto/keys/CryptoKeyEC.cpp
@@ -33,10 +33,7 @@
 
 #if OS(DARWIN) && !PLATFORM(GTK)
 #include <pal/crypto/CryptoTypes.h>
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
-#include "PALSwift-Generated.h"
-#pragma clang diagnostic pop
+#include <pal/crypto/PlatformECKey.h>
 #endif
 
 namespace WebCore {

--- a/Source/WebCore/crypto/keys/CryptoKeyEC.h
+++ b/Source/WebCore/crypto/keys/CryptoKeyEC.h
@@ -31,12 +31,12 @@
 #include <wtf/Platform.h>
 #if OS(DARWIN) && !PLATFORM(GTK)
 #include <WebCore/CommonCryptoUtilities.h>
-namespace pal {
-class ECKey;
-}
+
+#include <pal/crypto/CryptoTypes.h>
+#include <pal/crypto/PlatformECKey.h>
 
 namespace WebCore {
-using PlatformECKeyContainer = UniqueRef<pal::ECKey>;
+using PlatformECKeyContainer = PAL::Crypto::PlatformECKey;
 }
 #endif
 
@@ -61,11 +61,7 @@ template<typename> class ExceptionOr;
 
 class CryptoKeyEC final : public CryptoKey {
 public:
-    enum class NamedCurve : uint8_t {
-        P256,
-        P384,
-        P521,
-    };
+    using NamedCurve = PAL::Crypto::ECNamedCurve;
 
     static Ref<CryptoKeyEC> create(CryptoAlgorithmIdentifier identifier, NamedCurve curve, CryptoKeyType type, PlatformECKeyContainer&& platformKey, bool extractable, CryptoKeyUsageBitmap usages)
     {


### PR DESCRIPTION
#### 2b31bb8e06289efd1c5474fa30423980e708038a
<pre>
[Swift in WebKit] Non-PAL targets should not access the internal PAL Swift bridging header (part 5)
<a href="https://bugs.webkit.org/show_bug.cgi?id=310776">https://bugs.webkit.org/show_bug.cgi?id=310776</a>
<a href="https://rdar.apple.com/173383749">rdar://173383749</a>

Reviewed by Abrar Rahman Protyasha.

Sink the ECKey implementation details into PAL from WebCore.

* Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj:
* Source/WebCore/PAL/pal/PALSwift/CryptoKitShim.swift:
(ECKey.importX963Pub(_:curve:)):
(ECKey.importCompressedPub(_:curve:)):
(ECKey.importX963Private(_:curve:)):
(ECImportReturnValue.errorCode): Deleted.
(ECImportReturnValue.key): Deleted.

- Remove the concept of a &quot;ECImportReturnValue&quot; since it is not needed; a simple optional suffices and is much simpler.
- Remove the custom Swift ECCurve type in favor of the agnostic PAL ECCurve type

* Source/WebCore/PAL/pal/crypto/CryptoAlgorithmAESGCMCocoa.cpp:
* Source/WebCore/PAL/pal/crypto/CryptoAlgorithmAESKWCocoaBridging.cpp:
* Source/WebCore/PAL/pal/crypto/CryptoAlgorithmEd25519CocoaBridging.cpp:
* Source/WebCore/PAL/pal/crypto/CryptoAlgorithmX25519CocoaBridging.cpp:
* Source/WebCore/PAL/pal/crypto/CryptoTypes.h:

- Add a `ECNamedCurve` type and use it from both PAL and WebCore

* Source/WebCore/PAL/pal/crypto/PlatformECKey.cpp: Added.
(PAL::Crypto::PlatformECKey::PlatformECKey):
(PAL::Crypto::PlatformECKey::deriveBits const):
(PAL::Crypto::PlatformECKey::sign const):
(PAL::Crypto::PlatformECKey::doVerify const):
(PAL::Crypto::PlatformECKey::toPub const):
(PAL::Crypto::PlatformECKey::exportX963Pub const):
(PAL::Crypto::PlatformECKey::exportX963Private const):
(PAL::Crypto::PlatformECKey::importX963Pub):
(PAL::Crypto::PlatformECKey::importX963Private):
(PAL::Crypto::PlatformECKey::importCompressedPub):
* Source/WebCore/PAL/pal/crypto/PlatformECKey.h: Copied from Source/WebCore/PAL/pal/crypto/CryptoTypes.h.

Introduce a `PlatformECKey` C++ type to be used by WebCore, which hides the Swift implementation details using the Pimpl idiom
and fixes the layering violation.

* Source/WebCore/PAL/pal/crypto/commoncrypto/CryptoDigestCommonCrypto.cpp:

- Remove some pragma diagnostic ignores now that it doesn&apos;t result in an error to do so.

* Source/WebCore/PAL/pal/module.modulemap:

- Silly workaround for incremental build issues

* Source/WebCore/crypto/cocoa/CryptoAlgorithmECDHCocoa.cpp:
* Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSACocoa.cpp:
(WebCore::verifyECDSACryptoKit):
* Source/WebCore/crypto/cocoa/CryptoKeyECCocoa.cpp:
(WebCore::toPlatformKey):
(WebCore::CryptoKeyEC::platformGeneratePair):
(WebCore::CryptoKeyEC::platformImportRaw):
(WebCore::CryptoKeyEC::platformImportJWKPrivate):
(WebCore::CryptoKeyEC::platformImportSpki):
(WebCore::CryptoKeyEC::platformImportPkcs8):
(WebCore::namedCurveToCryptoKitCurve):
* Source/WebCore/crypto/cocoa/CryptoKeyOKPCocoa.cpp:
* Source/WebCore/crypto/keys/CryptoKeyEC.cpp:
* Source/WebCore/crypto/keys/CryptoKeyEC.h:

- Remove includes of the generated header
- Use the new PlatformECKey type instead

Canonical link: <a href="https://commits.webkit.org/310102@main">https://commits.webkit.org/310102@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6cccb15ace985fa0f0d9360332656f61a40c8a8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152717 "9 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25498 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19097 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161461 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154590 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26026 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25804 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/118010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f0adf2d6-978b-4092-9de1-5b11b9c55137) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155676 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/20247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/137104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98723 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/28708caf-e50c-452d-a007-a3192c26e0fe) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/19322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9297 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14978 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163933 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7071 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16572 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/126068 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/25296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21293 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126226 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34245 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25298 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136774 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/81902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/21196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/13553 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24914 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89200 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/24606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/24765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/24666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->