### PR TITLE
AX: Ensure FrameGeometry is initialized on page load to a non-zero value

### DIFF
--- a/LayoutTests/accessibility/ios-simulator/frame-geometry-initialized-on-load-expected.txt
+++ b/LayoutTests/accessibility/ios-simulator/frame-geometry-initialized-on-load-expected.txt
@@ -1,0 +1,11 @@
+This test verifies that frame geometry is initialized after page load.
+
+PASS: accessibilityController.rootElement.isFrameGeometryInitialized === true
+PASS: accessibilityController.accessibleElementById('target').y > 0 === true
+PASS: accessibilityController.accessibleElementById('target').width > 0 === true
+PASS: accessibilityController.accessibleElementById('target').height > 0 === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Target

--- a/LayoutTests/accessibility/ios-simulator/frame-geometry-initialized-on-load.html
+++ b/LayoutTests/accessibility/ios-simulator/frame-geometry-initialized-on-load.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<style>
+body {
+    margin: 0;
+}
+#target {
+    position: absolute;
+    top: 200px;
+    left: 10px;
+    width: 100px;
+    height: 50px;
+}
+</style>
+</head>
+<body>
+
+<button id="target">Target</button>
+
+<script>
+var output = "This test verifies that frame geometry is initialized after page load.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    setTimeout(async function() {
+        await waitForFrameGeometryReady();
+        output += expect("accessibilityController.rootElement.isFrameGeometryInitialized", "true");
+
+        output += await expectAsync("accessibilityController.accessibleElementById('target').y > 0", "true");
+        output += await expectAsync("accessibilityController.accessibleElementById('target').width > 0", "true");
+        output += await expectAsync("accessibilityController.accessibleElementById('target').height > 0", "true");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -467,6 +467,10 @@ struct PerWebProcessState {
 
 #if PLATFORM(IOS_FAMILY)
     RefPtr<RunLoop::DispatchTimer> _pendingInteractiveObscuredInsetsChangeTimer;
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    RefPtr<RunLoop::DispatchTimer> _pendingAccessibilityFrameGeometryUpdateTimer;
+    MonotonicTime _lastAccessibilityFrameGeometryUpdate;
+#endif
 #endif
 
     // This value tracks the current adjustment added to the bottom inset due to the keyboard sliding out from the bottom

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -140,6 +140,9 @@
 static const Seconds delayBeforeNoVisibleContentsRectsLogging = 1_s;
 static const Seconds delayBeforeNoCommitsLogging = 5_s;
 static constexpr Seconds delayBeforeUpdatingVisibleContentRectsWhenChangingObscuredInsetsInteractively = 100_ms;
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+static constexpr Seconds accessibilityFrameGeometryUpdateDelay = 100_ms;
+#endif
 static const unsigned highlightMargin = 5;
 
 static WebCore::IntDegrees deviceOrientationForUIInterfaceOrientation(UIInterfaceOrientation orientation)
@@ -1292,6 +1295,22 @@ static void changeContentOffsetBoundedInValidRange(UIScrollView *scrollView, Web
 - (void)_layerTreeCommitComplete
 {
     _perProcessState.commitDidRestoreScrollPosition = NO;
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    // Update accessibility frame geometry after layer tree commits. Fire immediately
+    // on the first call (or if enough time has elapsed), but throttle rapid successive
+    // commits to avoid excessive updating.
+    auto timeSinceLastUpdate = MonotonicTime::now() - _lastAccessibilityFrameGeometryUpdate;
+    if (timeSinceLastUpdate >= accessibilityFrameGeometryUpdateDelay) {
+        _lastAccessibilityFrameGeometryUpdate = MonotonicTime::now();
+        _page->updateAccessibilityFrameGeometry();
+    } else if (!_pendingAccessibilityFrameGeometryUpdateTimer || !_pendingAccessibilityFrameGeometryUpdateTimer->isActive()) {
+        _pendingAccessibilityFrameGeometryUpdateTimer = RunLoop::mainSingleton().dispatchAfter(accessibilityFrameGeometryUpdateDelay, [retainedSelf = retainPtr(self)] {
+            retainedSelf->_pendingAccessibilityFrameGeometryUpdateTimer = nullptr;
+            retainedSelf->_lastAccessibilityFrameGeometryUpdate = MonotonicTime::now();
+            retainedSelf->_page->updateAccessibilityFrameGeometry();
+        });
+    }
+#endif
 }
 
 - (void)_couldNotRestorePageState


### PR DESCRIPTION
#### c63ac688a255342d4c070198841b5c881ede317d
<pre>
AX: Ensure FrameGeometry is initialized on page load to a non-zero value
<a href="https://bugs.webkit.org/show_bug.cgi?id=310781">https://bugs.webkit.org/show_bug.cgi?id=310781</a>
<a href="https://rdar.apple.com/173386398">rdar://173386398</a>

Reviewed by Tyler Wilcock.

We had a race condition, where FrameGeometry would be initialized when the AXObjectCache was initialized,
but the view hierarchy hosting the web content wasn&apos;t established. This caused bounding boxes to be
incorrect, and never recover until a scroll occured.

To fix this, we now hook into _layerTreeCommitComplete, and update screen positions (under a debouncing
timer). This not only fires once views update/lay out, but also for other important events, like resize
and scroll, so we will stay up-to-date in those cases as well.

Test: accessibility/ios-simulator/frame-geometry-initialized-on-load.html

* LayoutTests/accessibility/ios-simulator/frame-geometry-initialized-on-load-expected.txt: Added.
* LayoutTests/accessibility/ios-simulator/frame-geometry-initialized-on-load.html: Added.
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _layerTreeCommitComplete]):

Canonical link: <a href="https://commits.webkit.org/310039@main">https://commits.webkit.org/310039@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2e8b0b4921710cbbc64a0e833b7d345e1d39803

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152446 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25228 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18827 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161189 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5fda1a6e-d1f2-48d8-9539-75c1e810a8f3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25756 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25534 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117799 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e7efcffb-801b-4082-8ebb-a1adb8ba8978) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155406 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20015 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136861 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98513 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a46b12e8-d1df-4fcb-8cc7-4e2b7bca8a3a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19091 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17023 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9025 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128741 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14735 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163659 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6801 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16329 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125835 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25026 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21062 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126006 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34201 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25028 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136531 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81628 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21000 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13310 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24644 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88930 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24335 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24495 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24396 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->