### PR TITLE
Add leftMeta/rightMeta key handling to ModifierKeys on macOS

### DIFF
--- a/LayoutTests/platform/mac/imported/w3c/web-platform-tests/uievents/keyboard/modifier-keys-combinations-expected.txt
+++ b/LayoutTests/platform/mac/imported/w3c/web-platform-tests/uievents/keyboard/modifier-keys-combinations-expected.txt
@@ -1,7 +1,0 @@
-Target
-
-PASS Check sending "Shift + y" key combination
-PASS Check sending "Control + y" key combination
-PASS Check sending "Alt + y" key combination
-FAIL Check sending "Meta + y" key combination assert_equals: expected "y" but got "leftMeta"
-

--- a/LayoutTests/platform/mac/imported/w3c/web-platform-tests/uievents/keyboard/modifier-keys-expected.txt
+++ b/LayoutTests/platform/mac/imported/w3c/web-platform-tests/uievents/keyboard/modifier-keys-expected.txt
@@ -1,7 +1,0 @@
-Target
-
-PASS Check sending Shift key
-PASS Check sending Control key
-PASS Check sending Alt key
-FAIL Check sending Meta key assert_equals: expected "Meta" but got "leftMeta"
-

--- a/Tools/TestRunnerShared/cocoa/ModifierKeys.mm
+++ b/Tools/TestRunnerShared/cocoa/ModifierKeys.mm
@@ -135,6 +135,14 @@ struct KeyMappingEntry {
         const unichar ch = 0xFFE8;
         modiferKeys->eventCharacter = [NSString stringWithCharacters:&ch length:1];
         modiferKeys->keyCode = 0x3D;
+    } else if ([character isEqualToString:@"leftMeta"]) {
+        const unichar ch = 0xFFE9;
+        modiferKeys->eventCharacter = [NSString stringWithCharacters:&ch length:1];
+        modiferKeys->keyCode = 0x37;
+    } else if ([character isEqualToString:@"rightMeta"]) {
+        const unichar ch = 0xFFEA;
+        modiferKeys->eventCharacter = [NSString stringWithCharacters:&ch length:1];
+        modiferKeys->keyCode = 0x36;
     } else if ([character isEqualToString:@"escape"]) {
         const unichar ch = 0x1B;
         modiferKeys->eventCharacter = [NSString stringWithCharacters:&ch length:1];


### PR DESCRIPTION
#### 5bb1dce804788fb9f01bd6f5f71d64bef3047911
<pre>
Add leftMeta/rightMeta key handling to ModifierKeys on macOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=310784">https://bugs.webkit.org/show_bug.cgi?id=310784</a>
<a href="https://rdar.apple.com/173386914">rdar://173386914</a>

Reviewed by Lily Spiniolas and Abrar Rahman Protyasha.

ModifierKeys.mm handled leftControl, leftShift, leftAlt and their right
variants but was missing leftMeta/rightMeta. When testdriver-vendor.js
mapped WebDriver key code 0xE03D to &apos;leftMeta&apos; and passed it to
eventSender, the key name wasn&apos;t recognized, leaving keyCode at 0 and
characters as the literal string &quot;leftMeta&quot;. This caused
PlatformEventFactoryMac::keyForKeyEvent() to miss the kVK_Command check
and return &quot;leftMeta&quot; as the DOM event.key value instead of &quot;Meta&quot;.

* Tools/TestRunnerShared/cocoa/ModifierKeys.mm:
(+[ModifierKeys modifierKeysWithKey:modifiers:keyLocation:]):

&gt; Removed platform specific expectations since now we pass last failing:
* LayoutTests/platform/mac/imported/w3c/web-platform-tests/uievents/keyboard/modifier-keys-combinations-expected.txt: Removed.
* LayoutTests/platform/mac/imported/w3c/web-platform-tests/uievents/keyboard/modifier-keys-expected.txt: Removed.

Canonical link: <a href="https://commits.webkit.org/310014@main">https://commits.webkit.org/310014@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60d9b7f16b07bec196bb713ca465a9c72411a2ac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152433 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25215 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18814 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161176 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9c188062-1f00-496f-95e5-d5b0e54a2b4b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154307 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25743 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25521 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117786 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cbecbde1-63df-455a-bc1b-99796bcf6147) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155393 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136848 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98500 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3e0bb856-5ebf-4b0f-ae24-8f0caabf775e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/19070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9011 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14722 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163646 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16316 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125823 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25013 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21048 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125994 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34178 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25015 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136518 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81615 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20989 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13297 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24631 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24322 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24482 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24383 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->