### PR TITLE
WTF::holdsAlternative<Variant<Ts...>>: Index-based overload uses nonexistent API

### DIFF
--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -618,7 +618,7 @@ template<typename... Ts> struct HoldsAlternative<Variant<Ts...>> {
     }
     template<size_t I> static constexpr bool holdsAlternative(const Variant<Ts...>& v)
     {
-        return std::holds_alternative<I>(v);
+        return v.index() == I;
     }
 };
 

--- a/Tools/TestWebKitAPI/Tests/WTF/StdLibExtrasTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StdLibExtrasTests.cpp
@@ -290,4 +290,39 @@ TEST(WTF_StdLibExtras, SpanReinterpretCast_NonDynamicExtent_CompileTimeErros)
 }
 */
 
+TEST(WTF_StdLibExtras, HoldsAlternativeByIndex)
+{
+    using V = Variant<int, double, float>;
+
+    V intVariant = 42;
+    EXPECT_TRUE((WTF::holdsAlternative<0>(intVariant)));
+    EXPECT_FALSE((WTF::holdsAlternative<1>(intVariant)));
+    EXPECT_FALSE((WTF::holdsAlternative<2>(intVariant)));
+
+    V doubleVariant = 3.14;
+    EXPECT_FALSE((WTF::holdsAlternative<0>(doubleVariant)));
+    EXPECT_TRUE((WTF::holdsAlternative<1>(doubleVariant)));
+    EXPECT_FALSE((WTF::holdsAlternative<2>(doubleVariant)));
+
+    V floatVariant = 1.0f;
+    EXPECT_FALSE((WTF::holdsAlternative<0>(floatVariant)));
+    EXPECT_FALSE((WTF::holdsAlternative<1>(floatVariant)));
+    EXPECT_TRUE((WTF::holdsAlternative<2>(floatVariant)));
+}
+
+TEST(WTF_StdLibExtras, HoldsAlternativeByType)
+{
+    using V = Variant<int, double, float>;
+
+    V intVariant = 42;
+    EXPECT_TRUE((WTF::holdsAlternative<int>(intVariant)));
+    EXPECT_FALSE((WTF::holdsAlternative<double>(intVariant)));
+    EXPECT_FALSE((WTF::holdsAlternative<float>(intVariant)));
+
+    V doubleVariant = 3.14;
+    EXPECT_FALSE((WTF::holdsAlternative<int>(doubleVariant)));
+    EXPECT_TRUE((WTF::holdsAlternative<double>(doubleVariant)));
+    EXPECT_FALSE((WTF::holdsAlternative<float>(doubleVariant)));
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### ab0c6006568636d451a2fe41793512a662245767
<pre>
WTF::holdsAlternative&lt;Variant&lt;Ts...&gt;&gt;: Index-based overload uses nonexistent API
<a href="https://bugs.webkit.org/show_bug.cgi?id=310786">https://bugs.webkit.org/show_bug.cgi?id=310786</a>

Reviewed by Sam Weinig and Ryosuke Niwa.

std::holds_alternative&lt;T&gt; only takes a type parameter. There is no
std::holds_alternative&lt;size_t I&gt; overload in the standard. This would
fail to compile if instantiated.

Test: Tools/TestWebKitAPI/Tests/WTF/StdLibExtrasTests.cpp

* Source/WTF/wtf/StdLibExtras.h:
* Tools/TestWebKitAPI/Tests/WTF/StdLibExtrasTests.cpp:
(TestWebKitAPI::TEST(WTF_StdLibExtras, HoldsAlternativeByIndex)):
(TestWebKitAPI::TEST(WTF_StdLibExtras, HoldsAlternativeByType)):

Canonical link: <a href="https://commits.webkit.org/310029@main">https://commits.webkit.org/310029@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b0c152e0fc72bc9112faf0de04f9cecbfed75bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152351 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25133 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18732 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161094 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105808 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1782dcc3-44de-4e8f-b784-a4aa0197d70e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154225 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25661 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25439 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117718 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83457 "3 flakes 2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155311 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19919 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136776 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98431 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/127d99a3-77b7-4248-accd-e89b630352ab) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18996 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16934 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8928 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144363 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128646 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14650 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163563 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13152 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6706 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16244 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125750 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24931 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20973 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125923 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34191 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24933 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136446 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81533 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20918 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13225 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/183983 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24549 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88835 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46909 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24240 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24400 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24301 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->