### PR TITLE
Remove bogus ul & li type=round support

### DIFF
--- a/Source/WebCore/html/HTMLLIElement.cpp
+++ b/Source/WebCore/html/HTMLLIElement.cpp
@@ -77,19 +77,14 @@ void HTMLLIElement::collectPresentationalHintsForAttribute(const QualifiedName& 
             addPropertyToPresentationalHintStyle(style, CSSPropertyListStyleType, CSSValueUpperRoman);
         else if (value == "1"_s)
             addPropertyToPresentationalHintStyle(style, CSSPropertyListStyleType, CSSValueDecimal);
-        else {
-            auto valueLowerCase = value.convertToASCIILowercase();
-            if (valueLowerCase == "disc"_s)
-                addPropertyToPresentationalHintStyle(style, CSSPropertyListStyleType, CSSValueDisc);
-            else if (valueLowerCase == "circle"_s)
-                addPropertyToPresentationalHintStyle(style, CSSPropertyListStyleType, CSSValueCircle);
-            else if (valueLowerCase == "round"_s)
-                addPropertyToPresentationalHintStyle(style, CSSPropertyListStyleType, CSSValueRound);
-            else if (valueLowerCase == "square"_s)
-                addPropertyToPresentationalHintStyle(style, CSSPropertyListStyleType, CSSValueSquare);
-            else if (valueLowerCase == "none"_s)
-                addPropertyToPresentationalHintStyle(style, CSSPropertyListStyleType, CSSValueNone);
-        }
+        else if (equalLettersIgnoringASCIICase(value, "disc"_s))
+            addPropertyToPresentationalHintStyle(style, CSSPropertyListStyleType, CSSValueDisc);
+        else if (equalLettersIgnoringASCIICase(value, "circle"_s))
+            addPropertyToPresentationalHintStyle(style, CSSPropertyListStyleType, CSSValueCircle);
+        else if (equalLettersIgnoringASCIICase(value, "square"_s))
+            addPropertyToPresentationalHintStyle(style, CSSPropertyListStyleType, CSSValueSquare);
+        else if (equalLettersIgnoringASCIICase(value, "none"_s))
+            addPropertyToPresentationalHintStyle(style, CSSPropertyListStyleType, CSSValueNone);
     } else if (name == valueAttr) {
         if (auto parsedValue = parseHTMLInteger(value))
             addPropertyToPresentationalHintStyle(style, CSSPropertyCounterSet, makeString("list-item "_s, *parsedValue));

--- a/Source/WebCore/html/HTMLUListElement.cpp
+++ b/Source/WebCore/html/HTMLUListElement.cpp
@@ -60,16 +60,13 @@ bool HTMLUListElement::hasPresentationalHintsForAttribute(const QualifiedName& n
 void HTMLUListElement::collectPresentationalHintsForAttribute(const QualifiedName& name, const AtomString& value, MutableStyleProperties& style)
 {
     if (name == typeAttr) {
-        auto valueLowerCase = value.convertToASCIILowercase();
-        if (valueLowerCase == "disc"_s)
+        if (equalLettersIgnoringASCIICase(value, "disc"_s))
             addPropertyToPresentationalHintStyle(style, CSSPropertyListStyleType, CSSValueDisc);
-        else if (valueLowerCase == "circle"_s)
+        else if (equalLettersIgnoringASCIICase(value, "circle"_s))
             addPropertyToPresentationalHintStyle(style, CSSPropertyListStyleType, CSSValueCircle);
-        else if (valueLowerCase == "round"_s)
-            addPropertyToPresentationalHintStyle(style, CSSPropertyListStyleType, CSSValueRound);
-        else if (valueLowerCase == "square"_s)
+        else if (equalLettersIgnoringASCIICase(value, "square"_s))
             addPropertyToPresentationalHintStyle(style, CSSPropertyListStyleType, CSSValueSquare);
-        else if (valueLowerCase == "none"_s)
+        else if (equalLettersIgnoringASCIICase(value, "none"_s))
             addPropertyToPresentationalHintStyle(style, CSSPropertyListStyleType, CSSValueNone);
     } else
         HTMLElement::collectPresentationalHintsForAttribute(name, value, style);


### PR DESCRIPTION
#### 794e39270751ac5dd2e7a6de61d6d4e5f4457b0c
<pre>
Remove bogus ul &amp; li type=round support
<a href="https://bugs.webkit.org/show_bug.cgi?id=310787">https://bugs.webkit.org/show_bug.cgi?id=310787</a>

Reviewed by Ryosuke Niwa.

This was added in 261135@main but 1) this is not part of the HTML
standard and 2) CSSValueRound is not a valid value here.

While here we also remove the string allocation as it&apos;s not needed.

Canonical link: <a href="https://commits.webkit.org/309993@main">https://commits.webkit.org/309993@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79340ded1a89628c0ab7b05bd62e282094d5cb78

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152352 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25134 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18733 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161095 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105809 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/492f12a5-5d29-43d8-885e-c08b0d9a1bf2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154226 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25662 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25440 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117712 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a30bb6b6-bd0f-4f20-b75f-77ce1480a7cb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155312 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19923 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136774 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98425 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3fde1fac-45e9-4bef-b00b-52ffdaa134cd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19000 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16932 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8929 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128650 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14648 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163564 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6707 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16242 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125746 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24932 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20971 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125919 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24934 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136444 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81534 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23362 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20917 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13223 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24550 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88836 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24241 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24401 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24302 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->