### PR TITLE
WTF::switchOnTupleAtIndex() implementation is wrong

### DIFF
--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -748,7 +748,7 @@ template<class F, class Tuple> ALWAYS_INLINE constexpr decltype(auto) visitTuple
     );
 }
 
-template<typename Tuple, typename... F> ALWAYS_INLINE constexpr auto switchOnTupleAtIndex(size_t index, Tuple&& tuple, F&&... f) -> decltype(visitTupleElementAtIndex(index, WTF::makeVisitor(std::forward<F>(f)...), std::forward<Tuple>(tuple)))
+template<typename Tuple, typename... F> ALWAYS_INLINE constexpr auto switchOnTupleAtIndex(size_t index, Tuple&& tuple, F&&... f) -> decltype(visitTupleElementAtIndex(WTF::makeVisitor(std::forward<F>(f)...), index, std::forward<Tuple>(tuple)))
 {
     return visitTupleElementAtIndex(WTF::makeVisitor(std::forward<F>(f)...), index, std::forward<Tuple>(tuple));
 }

--- a/Tools/TestWebKitAPI/Tests/WTF/StdLibExtrasTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StdLibExtrasTests.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 
+#include <tuple>
 #include <wtf/CryptographicallyRandomNumber.h>
 #include <wtf/MathExtras.h>
 #include <wtf/StdLibExtras.h>
@@ -323,6 +324,50 @@ TEST(WTF_StdLibExtras, HoldsAlternativeByType)
     EXPECT_FALSE((WTF::holdsAlternative<int>(doubleVariant)));
     EXPECT_TRUE((WTF::holdsAlternative<double>(doubleVariant)));
     EXPECT_FALSE((WTF::holdsAlternative<float>(doubleVariant)));
+}
+
+TEST(WTF_StdLibExtras, SwitchOnTupleAtIndex)
+{
+    std::tuple<int, double, float> tuple { 42, 3.14, 1.5f };
+
+    // Visit index 0 (int).
+    bool visitedInt = false;
+    WTF::switchOnTupleAtIndex(0, tuple,
+        [&](const int& value) { visitedInt = true; EXPECT_EQ(42, value); },
+        [&](const double&) { FAIL(); },
+        [&](const float&) { FAIL(); }
+    );
+    EXPECT_TRUE(visitedInt);
+
+    // Visit index 1 (double).
+    bool visitedDouble = false;
+    WTF::switchOnTupleAtIndex(1, tuple,
+        [&](const int&) { FAIL(); },
+        [&](const double& value) { visitedDouble = true; EXPECT_DOUBLE_EQ(3.14, value); },
+        [&](const float&) { FAIL(); }
+    );
+    EXPECT_TRUE(visitedDouble);
+
+    // Visit index 2 (float).
+    bool visitedFloat = false;
+    WTF::switchOnTupleAtIndex(2, tuple,
+        [&](const int&) { FAIL(); },
+        [&](const double&) { FAIL(); },
+        [&](const float& value) { visitedFloat = true; EXPECT_FLOAT_EQ(1.5f, value); }
+    );
+    EXPECT_TRUE(visitedFloat);
+}
+
+TEST(WTF_StdLibExtras, VisitTupleElementAtIndex)
+{
+    std::tuple<int, double, float> tuple { 10, 2.5, 0.5f };
+
+    // Verify return value works through visitTupleElementAtIndex.
+    auto result = WTF::visitTupleElementAtIndex(
+        [](const auto& value) -> double { return static_cast<double>(value); },
+        1, tuple
+    );
+    EXPECT_DOUBLE_EQ(2.5, result);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### a556285e269bb4036d53da7921d538c29568301f
<pre>
WTF::switchOnTupleAtIndex() implementation is wrong
<a href="https://bugs.webkit.org/show_bug.cgi?id=310790">https://bugs.webkit.org/show_bug.cgi?id=310790</a>

Reviewed by Ryosuke Niwa.

`switchOnTupleAtIndex` takes `(F&amp;&amp; f, size_t index, Tuple&amp;&amp; tuple)`,
but the trailing return type decltype passes arguments as `(index,
makeVisitor(...), tuple)`. `functor` and `index` are swapped.

Test: Tools/TestWebKitAPI/Tests/WTF/StdLibExtrasTests.cpp

* Source/WTF/wtf/StdLibExtras.h:
(WTF::switchOnTupleAtIndex):
* Tools/TestWebKitAPI/Tests/WTF/StdLibExtrasTests.cpp:
(TestWebKitAPI::TEST(WTF_StdLibExtras, SwitchOnTupleAtIndex)):
(TestWebKitAPI::TEST(WTF_StdLibExtras, VisitTupleElementAtIndex)):

Canonical link: <a href="https://commits.webkit.org/310032@main">https://commits.webkit.org/310032@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3df8168e208d25abc46eb72cf838c26720e1710c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152519 "3 style errors") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/25301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/18900 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/161264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154393 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25829 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25607 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/161264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155479 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/20080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/136928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/161264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/19156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/9098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144531 "Build is in progress. Recent messages:") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/14802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163733 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/13322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/6874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/16396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/125913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/25099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/21131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/126076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34194 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/25101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/136598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/81703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/25101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/13377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184151 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24717 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/89003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/46956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/24408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/24568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/24469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->