### PR TITLE
Fix style invalidation logic error in HTMLTableElement

### DIFF
--- a/Source/WebCore/html/HTMLTableCellElement.cpp
+++ b/Source/WebCore/html/HTMLTableCellElement.cpp
@@ -62,14 +62,6 @@ unsigned HTMLTableCellElement::colSpan() const
 
 unsigned HTMLTableCellElement::rowSpan() const
 {
-    // When rowspan="0", return 0 to signal "span all remaining rows"
-    // The rendering layer (RenderTableCell::rowSpan) will calculate the actual count
-    // Per HTML spec: https://html.spec.whatwg.org/multipage/tables.html#attr-tdth-rowspan
-    return rowSpanForBindings();
-}
-
-unsigned HTMLTableCellElement::rowSpanForBindings() const
-{
     return clampHTMLNonNegativeIntegerToRange(attributeWithoutSynchronization(rowspanAttr), minRowspan, maxRowspan, defaultRowspan);
 }
 
@@ -108,11 +100,9 @@ void HTMLTableCellElement::collectPresentationalHintsForAttribute(const Qualifie
         addPropertyToPresentationalHintStyle(style, CSSPropertyTextWrapMode, CSSValueNowrap);
         break;
     case AttributeNames::widthAttr:
-        // width="0" is not allowed for compatibility with WinIE.
         addHTMLLengthToStyle(style, CSSPropertyWidth, value, AllowZeroValue::No);
         break;
     case AttributeNames::heightAttr:
-        // width="0" is not allowed for compatibility with WinIE.
         addHTMLLengthToStyle(style, CSSPropertyHeight, value, AllowZeroValue::No);
         break;
     default:
@@ -153,9 +143,9 @@ String HTMLTableCellElement::axis() const
     return attributeWithoutSynchronization(axisAttr);
 }
 
-void HTMLTableCellElement::setColSpan(unsigned n)
+void HTMLTableCellElement::setColSpan(unsigned number)
 {
-    setAttributeWithoutSynchronization(colspanAttr, AtomString::number(limitToOnlyHTMLNonNegative(n, 1)));
+    setAttributeWithoutSynchronization(colspanAttr, AtomString::number(limitToOnlyHTMLNonNegative(number, 1)));
 }
 
 String HTMLTableCellElement::headers() const
@@ -163,9 +153,9 @@ String HTMLTableCellElement::headers() const
     return attributeWithoutSynchronization(headersAttr);
 }
 
-void HTMLTableCellElement::setRowSpanForBindings(unsigned n)
+void HTMLTableCellElement::setRowSpan(unsigned number)
 {
-    setAttributeWithoutSynchronization(rowspanAttr, AtomString::number(limitToOnlyHTMLNonNegative(n, 1)));
+    setAttributeWithoutSynchronization(rowspanAttr, AtomString::number(limitToOnlyHTMLNonNegative(number, 1)));
 }
 
 const AtomString& HTMLTableCellElement::scope() const

--- a/Source/WebCore/html/HTMLTableCellElement.h
+++ b/Source/WebCore/html/HTMLTableCellElement.h
@@ -47,12 +47,11 @@ public:
 
     WEBCORE_EXPORT int NODELETE cellIndex() const;
     WEBCORE_EXPORT unsigned colSpan() const;
-    unsigned rowSpan() const;
-    WEBCORE_EXPORT unsigned rowSpanForBindings() const;
+    WEBCORE_EXPORT unsigned rowSpan() const;
 
     void setCellIndex(int);
     WEBCORE_EXPORT void setColSpan(unsigned);
-    WEBCORE_EXPORT void setRowSpanForBindings(unsigned);
+    WEBCORE_EXPORT void setRowSpan(unsigned);
 
     String NODELETE abbr() const;
     String NODELETE axis() const;

--- a/Source/WebCore/html/HTMLTableCellElement.idl
+++ b/Source/WebCore/html/HTMLTableCellElement.idl
@@ -29,7 +29,7 @@
     [CEReactions=NotNeeded, Reflect="charoff"] attribute DOMString chOff;
 
     [CEReactions=NotNeeded] attribute unsigned long colSpan;
-    [CEReactions=NotNeeded, ImplementedAs=rowSpanForBindings] attribute unsigned long rowSpan;
+    [CEReactions=NotNeeded] attribute unsigned long rowSpan;
 
     [CEReactions=NotNeeded, Reflect] attribute DOMString headers;
 

--- a/Source/WebCore/html/HTMLTableElement.cpp
+++ b/Source/WebCore/html/HTMLTableElement.cpp
@@ -263,15 +263,14 @@ static inline bool NODELETE isTableCellAncestor(const Element& element)
     return element.hasTagName(theadTag)
         || element.hasTagName(tbodyTag)
         || element.hasTagName(tfootTag)
-        || element.hasTagName(trTag)
-        || element.hasTagName(thTag);
+        || element.hasTagName(trTag);
 }
 
 static bool setTableCellsChanged(Element& element)
 {
     bool cellChanged = false;
 
-    if (element.hasTagName(tdTag))
+    if (element.hasTagName(tdTag) || element.hasTagName(thTag))
         cellChanged = true;
     else if (isTableCellAncestor(element)) {
         for (auto& child : childrenOfType<Element>(element))

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLTableCellElement.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLTableCellElement.cpp
@@ -510,7 +510,7 @@ glong webkit_dom_html_table_cell_element_get_row_span(WebKitDOMHTMLTableCellElem
     WebCore::JSMainThreadNullState state;
     g_return_val_if_fail(WEBKIT_DOM_IS_HTML_TABLE_CELL_ELEMENT(self), 0);
     WebCore::HTMLTableCellElement* item = WebKit::core(self);
-    glong result = item->rowSpanForBindings();
+    glong result = item->rowSpan();
     return result;
 }
 
@@ -519,7 +519,7 @@ void webkit_dom_html_table_cell_element_set_row_span(WebKitDOMHTMLTableCellEleme
     WebCore::JSMainThreadNullState state;
     g_return_if_fail(WEBKIT_DOM_IS_HTML_TABLE_CELL_ELEMENT(self));
     WebCore::HTMLTableCellElement* item = WebKit::core(self);
-    item->setRowSpanForBindings(value);
+    item->setRowSpan(value);
 }
 
 gchar* webkit_dom_html_table_cell_element_get_headers(WebKitDOMHTMLTableCellElement* self)

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLTableCellElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLTableCellElement.mm
@@ -121,13 +121,13 @@
 - (int)rowSpan
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->rowSpanForBindings();
+    return IMPL->rowSpan();
 }
 
 - (void)setRowSpan:(int)newRowSpan
 {
     WebCore::JSMainThreadNullState state;
-    IMPL->setRowSpanForBindings(newRowSpan);
+    IMPL->setRowSpan(newRowSpan);
 }
 
 - (NSString *)headers


### PR DESCRIPTION
#### 174790e2013656363fa2a01625403410b416ecf3
<pre>
Fix style invalidation logic error in HTMLTableElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=310791">https://bugs.webkit.org/show_bug.cgi?id=310791</a>

Reviewed by Ryosuke Niwa.

A &lt;th&gt; is not a &lt;td&gt; ancestor. It&apos;s a different kind of cell. While in
the area, we also clean up code in HTMLTableCellElement.

Canonical link: <a href="https://commits.webkit.org/310005@main">https://commits.webkit.org/310005@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5585ef5982ace377b524e3b1975673ae1cf63dcb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152442 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25224 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18823 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161185 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a608c7e6-543a-4eb0-9656-933734dc64d2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154316 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25752 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25530 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/117794 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d63b85d0-3f49-49cc-95c7-69bdef65199f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155402 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/20000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/136853 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98508 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/214a3f9e-dd18-4848-8316-0f557847920e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/19076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9021 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/14727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163655 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/6797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16321 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/125829 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25022 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/21056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126000 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25024 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136523 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81624 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23367 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20993 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/13302 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24640 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/88926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24331 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24491 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24392 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->