### PR TITLE
[css-values-5 attr()] Implement in terms of argument grammar

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4429,6 +4429,7 @@ imported/w3c/web-platform-tests/css/css-values/viewport-units-scrollbars-dynamic
 imported/w3c/web-platform-tests/css/css-values/viewport-units-scrollbars-scroll-vw-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-values/attr-namespace-non-existing.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-values/attr-namespace-valid.xhtml [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-values/attr-namespace-wildcard.html [ ImageOnlyFailure ]
 
 # wpt css-sizing failures
 webkit.org/b/308648 imported/w3c/web-platform-tests/css/css-sizing/abspos-auto-sizing-fit-content-percentage-005.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/css/attr-parsing-expected.txt
+++ b/LayoutTests/fast/css/attr-parsing-expected.txt
@@ -3,37 +3,37 @@ SUCCESS
 Rules from the stylesheet:
 
 #a { content: attr(b); }
-#c { }
-#d { }
-#e { }
-#f { }
-#g { }
+#c { content: attr("x"); }
+#d { content: attr(0); }
+#e { content: attr(0.0); }
+#f { content: attr(0%); }
+#g { content: attr(0px); }
 #h { }
-#i { }
+#i { content: attr(+0); }
 #j { content: attr(-k); }
-#l { }
-#n { }
-#q { }
-#r { }
-#s { }
-#t { }
-#u { }
+#l { content: attr(0m); }
+#n { content: attr(-0p); }
+#q { content: attr(url(http\:\/\/webkit\.org)); }
+#r { content: attr(U/**/+0020); }
+#s { content: attr(U/**/+0020/**/-00FF); }
+#t { content: attr(#123456); }
+#u { content: attr(#); }
 Expected result:
 
 #a { content: attr(b); }
-#c { }
-#d { }
-#e { }
-#f { }
-#g { }
+#c { content: attr("x"); }
+#d { content: attr(0); }
+#e { content: attr(0.0); }
+#f { content: attr(0%); }
+#g { content: attr(0px); }
 #h { }
-#i { }
+#i { content: attr(+0); }
 #j { content: attr(-k); }
-#l { }
-#n { }
-#q { }
-#r { }
-#s { }
-#t { }
-#u { }
+#l { content: attr(0m); }
+#n { content: attr(-0p); }
+#q { content: attr(url(http\:\/\/webkit\.org)); }
+#r { content: attr(U/**/+0020); }
+#s { content: attr(U/**/+0020/**/-00FF); }
+#t { content: attr(#123456); }
+#u { content: attr(#); }
 

--- a/LayoutTests/fast/css/attr-parsing.html
+++ b/LayoutTests/fast/css/attr-parsing.html
@@ -26,21 +26,21 @@
 <p>Expected result:</p>
 
 <pre id="expected">#a { content: attr(b); }
-#c { }
-#d { }
-#e { }
-#f { }
-#g { }
+#c { content: attr("x"); }
+#d { content: attr(0); }
+#e { content: attr(0.0); }
+#f { content: attr(0%); }
+#g { content: attr(0px); }
 #h { }
-#i { }
+#i { content: attr(+0); }
 #j { content: attr(-k); }
-#l { }
-#n { }
-#q { }
-#r { }
-#s { }
-#t { }
-#u { }
+#l { content: attr(0m); }
+#n { content: attr(-0p); }
+#q { content: attr(url(http\:\/\/webkit\.org)); }
+#r { content: attr(U/**/+0020); }
+#s { content: attr(U/**/+0020/**/-00FF); }
+#t { content: attr(#123456); }
+#u { content: attr(#); }
 </pre>
 
 <script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-all-types-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-all-types-expected.txt
@@ -40,7 +40,7 @@ PASS CSS Values and Units Test: attr 36
 PASS CSS Values and Units Test: attr 37
 PASS CSS Values and Units Test: attr 38
 PASS CSS Values and Units Test: attr 39
-FAIL CSS Values and Units Test: attr 40 assert_equals: Value 'attr(data-foo type(<number>))', where 'data-foo=attr(data-bar type(<number>) 3)' should be valid for the property 'font-weight'. expected "400" but got "3"
+PASS CSS Values and Units Test: attr 40
 PASS CSS Values and Units Test: attr 41
 PASS CSS Values and Units Test: attr 42
 PASS CSS Values and Units Test: attr 43

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-argument-grammar-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-argument-grammar-expected.txt
@@ -1,14 +1,17 @@
 
-FAIL CSS Values and Units Test: attr() argument grammar assert_equals: Value 'attr(var(--x))', where 'data-foo=10' should be valid for the property 'font-weight'. expected "10" but got "400"
-FAIL CSS Values and Units Test: attr() argument grammar 1 assert_equals: Value 'attr(var(--x),)', where 'data-foo=10' should be valid for the property 'font-weight'. expected "10" but got "400"
-FAIL CSS Values and Units Test: attr() argument grammar 2 assert_equals: Value 'attr(var(--x), 10)', where 'data-foo=invalid' should be valid for the property 'font-weight'. expected "10" but got "400"
+PASS CSS Values and Units Test: attr() argument grammar
+PASS CSS Values and Units Test: attr() argument grammar 1
+PASS CSS Values and Units Test: attr() argument grammar 2
 PASS CSS Values and Units Test: attr() argument grammar 3
 PASS CSS Values and Units Test: attr() argument grammar 4
 PASS CSS Values and Units Test: attr() argument grammar 5
 PASS CSS Values and Units Test: attr() argument grammar 6
 PASS CSS Values and Units Test: attr() argument grammar 7
 PASS CSS Values and Units Test: attr() argument grammar 8
-FAIL CSS Values and Units Test: attr() argument grammar 9 assert_equals: Value 'attr(var(--y), 3px)', where 'data-foo=var(--y)' should be valid for the property '--x'. expected "3px" but got "data-foo type(<number>), 10"
+PASS CSS Values and Units Test: attr() argument grammar 9
 PASS CSS Values and Units Test: attr() argument grammar 10
 PASS CSS Values and Units Test: attr() argument grammar 11
+PASS CSS Values and Units Test: attr() argument grammar 12
+PASS CSS Values and Units Test: attr() argument grammar 13
+PASS CSS Values and Units Test: attr() argument grammar 14
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-argument-grammar.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-argument-grammar.html
@@ -55,4 +55,14 @@
     test_attr('--x', 'attr(var(--y), 3px)', 'var(--x)', '');
     document.getElementById("attr").style.setProperty('--y', null);
 
+    // var() in the type position only.
+    document.getElementById("attr").style.setProperty('--type', 'type(<number>)');
+    test_attr('font-weight', 'attr(data-foo var(--type))', '42', '42');
+    test_attr('font-weight', 'attr(data-foo var(--type), 100)', 'invalid', '100');
+    document.getElementById("attr").style.setProperty('--type', null);
+
+    document.getElementById("attr").style.setProperty('--unit', 'number');
+    test_attr('font-weight', 'attr(data-foo var(--unit))', '42', '42');
+    document.getElementById("attr").style.setProperty('--unit', null);
+
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/serialize-values-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/serialize-values-expected.txt
@@ -324,13 +324,13 @@ PASS content: counter(par-num, decimal)
 PASS content: counter(par-num, upper-roman)
 PASS content: attr(foo-bar)
 PASS content: attr(foo_bar)
-FAIL content: attr(|bar) assert_equals: content raw inline style declaration expected "attr(bar)" but got ""
-FAIL content: attr( |bar ) assert_equals: content raw inline style declaration expected "attr(bar)" but got ""
+FAIL content: attr(|bar) assert_equals: content raw inline style declaration expected "attr(bar)" but got "attr(|bar)"
+FAIL content: attr( |bar ) assert_equals: content raw inline style declaration expected "attr(bar)" but got "attr( |bar )"
 PASS content: attr(foo-bar, "fallback")
 PASS content: attr(foo_bar, "fallback")
-FAIL content: attr(|bar, "fallback") assert_equals: content raw inline style declaration expected "attr(bar, \"fallback\")" but got ""
+FAIL content: attr(|bar, "fallback") assert_equals: content raw inline style declaration expected "attr(bar, \"fallback\")" but got "attr(|bar, \"fallback\")"
 FAIL content: attr(foo, "") assert_equals: content raw inline style declaration expected "attr(foo, \"\")" but got "attr(foo)"
-FAIL content: attr( |foo ,  "" ) assert_equals: content raw inline style declaration expected "attr(foo)" but got ""
+FAIL content: attr( |foo ,  "" ) assert_equals: content raw inline style declaration expected "attr(foo)" but got "attr( |foo ,  \"\" )"
 PASS content: inherit
 PASS cursor: auto
 PASS cursor: crosshair

--- a/Source/WebCore/css/parser/CSSSubstitutionParser.cpp
+++ b/Source/WebCore/css/parser/CSSSubstitutionParser.cpp
@@ -242,57 +242,29 @@ bool isValidDashedFunction(CSSParserTokenRange range, const CSSParserContext& pa
 }
 
 // https://drafts.csswg.org/css-values-5/#funcdef-attr
-// <attr()>    = attr( <attr-name> <attr-type>? , <declaration-value>?)
-// <attr-name> = [ <ident-token> '|' ]? <ident-token>
-// <attr-type> = type( <syntax> ) | raw-string | number | <attr-unit>
+// <attr-args> = attr( <declaration-value>, <declaration-value>? )
+// Validate using the argument grammar. Detailed parsing of <attr-name> <attr-type>?
+// happens at substitution time.
 bool isValidAttrReference(CSSParserTokenRange range, const CSSParserContext& parserContext)
 {
     range.consumeWhitespace();
 
-    // Consume <attr-name>.
-    if (range.peek().type() != IdentToken)
+    // Split at the first literal comma into two arguments.
+    auto firstArgStart = range;
+    while (!range.atEnd() && range.peek().type() != CommaToken)
+        range.consumeComponentValue();
+    auto firstArgRange = firstArgStart.rangeUntil(range);
+
+    // The first arg (<declaration-value>) must be non-empty.
+    if (firstArgRange.atEnd())
         return false;
-    range.consumeIncludingWhitespace();
 
-    if (range.atEnd())
-        return true;
-
-    auto consumeAttrType = [&] {
-        // type( <syntax> )
-        if (range.peek().type() == FunctionToken)
-            return !!CSSCustomPropertySyntax::consumeType(range);
-
-        if (range.peek().type() == IdentToken) {
-            auto value = range.peek().value();
-            if (!equalLettersIgnoringASCIICase(value, "raw-string"_s)
-                && !equalLettersIgnoringASCIICase(value, "number"_s)
-                && CSSParserToken::stringToUnitType(value) == CSSUnitType::CSS_UNKNOWN)
-                return false;
-            range.consumeIncludingWhitespace();
-            return true;
-        }
-
-        // <attr-unit>: the % delimiter.
-        if (range.peek().type() == DelimiterToken && range.peek().delimiter() == '%') {
-            range.consumeIncludingWhitespace();
-            return true;
-        }
-
+    if (!classifyBlock(firstArgRange, parserContext))
         return false;
-    };
 
-    // Consume optional <attr-type>.
-    if (range.peek().type() != CommaToken) {
-        if (!consumeAttrType())
-            return false;
-    }
-
-    if (range.atEnd())
-        return true;
-
-    // Consume optional comma and fallback <declaration-value>.
+    // Optional second arg (fallback).
     if (!CSSPropertyParserHelpers::consumeCommaIncludingWhitespace(range))
-        return false;
+        return range.atEnd();
     if (range.atEnd())
         return true;
 

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -171,16 +171,46 @@ bool SubstitutionResolver::substituteDashedFunction(StringView functionName, CSS
     return true;
 }
 
-bool SubstitutionResolver::substituteAttrFunction(CSSParserTokenRange range, Vector<CSSParserToken>& tokens, const CSSParserContext& context)
+auto SubstitutionResolver::substituteAttrArgumentGrammar(CSSParserTokenRange range, const CSSParserContext& context) -> std::optional<AttrArgumentGrammarSubstitution>
 {
-    // https://drafts.csswg.org/css-values-5/#funcdef-attr
-    // attr( <attr-name> <attr-type>? , <declaration-value>?)
+    // https://drafts.csswg.org/css-values-5/#argument-grammars
+    // <attr-args> = attr( <declaration-value>, <declaration-value>? )
+    // Splits at the first literal comma and substitutes the first argument.
 
     range.consumeWhitespace();
+
+    auto start = range;
+    while (!range.atEnd() && range.peek().type() != CommaToken)
+        range.consumeComponentValue();
+    auto firstArgRange = start.rangeUntil(range);
+
+    std::optional<CSSParserTokenRange> fallbackRange;
+    if (CSSPropertyParserHelpers::consumeCommaIncludingWhitespace(range))
+        fallbackRange = range;
+
+    auto substitutedFirstArg = substituteTokenRange(firstArgRange, context);
+    if (!substitutedFirstArg)
+        return { };
+
+    return AttrArgumentGrammarSubstitution { WTF::move(*substitutedFirstArg), fallbackRange };
+}
+
+bool SubstitutionResolver::substituteAttrFunction(CSSParserTokenRange argumentsRange, Vector<CSSParserToken>& tokens, const CSSParserContext& context)
+{
+    // https://drafts.csswg.org/css-values-5/#funcdef-attr
+
+    // <attr-args> = attr( <declaration-value>, <declaration-value>? )
+    auto attrArgs = substituteAttrArgumentGrammar(argumentsRange, context);
+    if (!attrArgs)
+        return false;
+
+    // attr() = attr( <attr-name> <attr-type>? , <declaration-value>?)
+    auto range = CSSParserTokenRange { attrArgs->firstArg };
 
     if (range.peek().type() != IdentToken)
         return false;
 
+    // Consume <attr-name>
     auto attributeName = range.consumeIncludingWhitespace().value().toAtomString();
 
     // Consume optional <attr-type>.
@@ -227,18 +257,14 @@ bool SubstitutionResolver::substituteAttrFunction(CSSParserTokenRange range, Vec
     };
 
     std::optional<AttrTypeResult> parsedAttrType;
-    if (!range.atEnd() && range.peek().type() != CommaToken) {
+    if (!range.atEnd()) {
         parsedAttrType = consumeAttrType();
         if (!parsedAttrType)
             return false;
     }
 
-    auto consumeFallbackRange = [&]() -> std::optional<CSSParserTokenRange> {
-        if (range.atEnd() || !CSSPropertyParserHelpers::consumeCommaIncludingWhitespace(range))
-            return std::nullopt;
-        return range;
-    };
-    auto fallbackRange = consumeFallbackRange();
+    if (!range.atEnd())
+        return false;
 
     m_styleBuilder.state().registerSubstitutionAttribute(attributeName);
     protect(m_styleBuilder.state().style())->setHasAttrContent();
@@ -250,23 +276,23 @@ bool SubstitutionResolver::substituteAttrFunction(CSSParserTokenRange range, Vec
     auto& attributeValue = element->getAttribute(QualifiedName { nullAtom(), attributeName, nullAtom() });
 
     // Check if this attribute is already being substituted (cycle detection).
-    auto isNewEntry = m_styleBuilder.state().m_inProgressAttrAttributes.add(attributeName).isNewEntry;
+    auto isInCycle = !m_styleBuilder.state().m_inProgressAttrAttributes.add(attributeName).isNewEntry;
     auto removeOnExit = makeScopeExit([&] {
-        if (isNewEntry)
+        if (!isInCycle)
             m_styleBuilder.state().m_inProgressAttrAttributes.remove(attributeName);
     });
 
     // Resolve fallback lazily to avoid var() cycle detection side effects during primary resolution.
     auto resolveFallback = [&]() -> std::optional<Vector<CSSParserToken>> {
-        if (!fallbackRange)
-            return std::nullopt;
-        return substituteTokenRange(*fallbackRange, context);
+        if (!attrArgs->fallbackRange)
+            return { };
+        return substituteTokenRange(*attrArgs->fallbackRange, context);
     };
 
     // https://drafts.csswg.org/css-values-5/#replace-an-attr-function
     auto substituteFailure = [&]() -> bool {
         // "If second arg is null, and syntax was omitted, return an empty CSS <string>."
-        if (!fallbackRange && !parsedAttrType) {
+        if (!attrArgs->fallbackRange && !parsedAttrType) {
             tokens.append(CSSParserToken(StringToken, emptyAtom()));
             return true;
         }
@@ -279,8 +305,7 @@ bool SubstitutionResolver::substituteAttrFunction(CSSParserTokenRange range, Vec
         return true;
     };
 
-    // Cycle detected.
-    if (!isNewEntry) {
+    if (isInCycle) {
         // Mark as in-cycle within attr() type() context for transitive detection.
         if (m_isInAttrTypeSyntax)
             m_styleBuilder.state().m_inCycleAttrAttributes.add(attributeName);

--- a/Source/WebCore/style/StyleSubstitutionResolver.h
+++ b/Source/WebCore/style/StyleSubstitutionResolver.h
@@ -59,6 +59,12 @@ private:
     bool substituteAttrFunction(CSSParserTokenRange, Vector<CSSParserToken>&, const CSSParserContext&);
     bool substituteInternalAutoBaseFunction(CSSParserTokenRange, Vector<CSSParserToken>&, const CSSParserContext&);
 
+    struct AttrArgumentGrammarSubstitution {
+        Vector<CSSParserToken> firstArg;
+        std::optional<CSSParserTokenRange> fallbackRange;
+    };
+    std::optional<AttrArgumentGrammarSubstitution> substituteAttrArgumentGrammar(CSSParserTokenRange, const CSSParserContext&);
+
     enum class FallbackResult : uint8_t { None, Valid, Invalid };
     std::pair<FallbackResult, Vector<CSSParserToken>> substituteVariableFallback(const AtomString& variableName, CSSParserTokenRange, CSSValueID functionId, const CSSParserContext&);
 


### PR DESCRIPTION
#### 9208303fc946c2789e84139920e390bdacc31901
<pre>
[css-values-5 attr()] Implement in terms of argument grammar
<a href="https://bugs.webkit.org/show_bug.cgi?id=310794">https://bugs.webkit.org/show_bug.cgi?id=310794</a>
<a href="https://rdar.apple.com/173390268">rdar://173390268</a>

Reviewed by Alan Baradlay (OOPS\!).

Some substitution functions including attr() are specified in terms argument grammar which allows arguments to
be substituted before the real grammar is applied.

<a href="https://drafts.csswg.org/css-values-5/#early-resolution">https://drafts.csswg.org/css-values-5/#early-resolution</a>

For attr() the grammar is

&lt;attr-args&gt; = attr( &lt;declaration-value&gt;, &lt;declaration-value&gt;? )

* LayoutTests/TestExpectations:

This was a spurious pass, namespaces are not implemented yet.

* LayoutTests/fast/css/attr-parsing-expected.txt:
* LayoutTests/fast/css/attr-parsing.html:

Update the expectation. We don&apos;t validate attr() arguments during parsing anymore.

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-all-types-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-argument-grammar-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-argument-grammar.html:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/serialize-values-expected.txt:
* Source/WebCore/css/parser/CSSSubstitutionParser.cpp:
(WebCore::isValidAttrReference):

Implement validation in terms of argument grammar. This is much simpler than the full grammar.

* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::SubstitutionResolver::substituteAttrArgumentGrammar):

Split the arguments on comma and run generic substitution for the first.

(WebCore::Style::SubstitutionResolver::substituteAttrFunction):

Invoke the argument grammar parsing first.

* Source/WebCore/style/StyleSubstitutionResolver.h:

Canonical link: <a href="https://commits.webkit.org/310003@main">https://commits.webkit.org/310003@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/762551d5d7690592bf26d7778dc91d70a85bc7ff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152413 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25195 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18794 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161156 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/06e07f02-10af-47b4-a714-e59643342889) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154287 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25723 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25501 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117768 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e29a3470-95b3-4a02-9473-a5b760f3cff7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155373 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136824 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98482 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d6c48c6c-0c98-49fe-b083-470cf1793e92) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/19051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16990 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8991 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14698 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163626 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6768 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16292 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125803 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24993 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21029 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125974 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34175 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24995 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136494 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81595 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20968 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13273 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24611 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/88897 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24302 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24462 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24363 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->