### PR TITLE
Adopt C++20's std::popcount()

### DIFF
--- a/Source/JavaScriptCore/assembler/ARMv7Assembler.h
+++ b/Source/JavaScriptCore/assembler/ARMv7Assembler.h
@@ -1683,7 +1683,7 @@ public:
 
     ALWAYS_INLINE void pop(uint32_t registerList)
     {
-        ASSERT(WTF::bitCount(registerList) > 1);
+        ASSERT(std::popcount(registerList) > 1);
         ASSERT(!((1 << ARMRegisters::pc) & registerList) || !((1 << ARMRegisters::lr) & registerList));
         ASSERT(!((1 << ARMRegisters::sp) & registerList));
         m_formatter.twoWordOp16Imm16(OP_POP_T2, registerList);
@@ -1703,7 +1703,7 @@ public:
 
     ALWAYS_INLINE void push(uint32_t registerList)
     {
-        ASSERT(WTF::bitCount(registerList) > 1);
+        ASSERT(std::popcount(registerList) > 1);
         ASSERT(!((1 << ARMRegisters::pc) & registerList));
         ASSERT(!((1 << ARMRegisters::sp) & registerList));
         m_formatter.twoWordOp16Imm16(OP_PUSH_T2, registerList);

--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -3981,7 +3981,7 @@ private:
                 uint64_t mask = right->asInt();
                 if (!mask || mask & (mask + 1))
                     return false;
-                uint64_t width = WTF::bitCount(mask);
+                uint64_t width = std::popcount(mask);
                 uint64_t datasize = opcode == ExtractUnsignedBitfield32 ? 32 : 64;
                 uint64_t resultDataSize = 0;
                 if (!WTF::safeAdd(lsb, width, resultDataSize) || resultDataSize > datasize)
@@ -4069,7 +4069,7 @@ private:
                 uint64_t mask = maskValue->asInt();
                 if (!mask || mask & (mask + 1))
                     return false;
-                uint64_t maskBitCount = WTF::bitCount(mask);
+                uint64_t maskBitCount = std::popcount(mask);
                 uint64_t highWidth = highWidthValue->asInt();
                 uint64_t lowWidth = lowWidthValue->asInt();
                 uint64_t datasize = opcode == ExtractRegister32 ? 32 : 64;
@@ -4110,7 +4110,7 @@ private:
                 if (!mask1 || mask1 & (mask1 + 1))
                     return false;
                 uint64_t datasize = opcode == InsertBitField32 ? 32 : 64;
-                uint64_t width = WTF::bitCount(mask1);
+                uint64_t width = std::popcount(mask1);
                 uint64_t resultDataSize = 0;
                 if (!WTF::safeAdd(lsb, width, resultDataSize) || resultDataSize > datasize)
                     return false;
@@ -4160,7 +4160,7 @@ private:
                 uint64_t mask1 = maskValue1->asInt();
                 if (!mask1 || mask1 & (mask1 + 1))
                     return false;
-                uint64_t width = WTF::bitCount(mask1);
+                uint64_t width = std::popcount(mask1);
                 uint64_t datasize = opcode == ExtractInsertBitfieldAtLowEnd32 ? 32 : 64;
                 uint64_t resultDataSize = 0;
                 if (!WTF::safeAdd(lsb, width, resultDataSize) || resultDataSize > datasize)
@@ -4335,7 +4335,7 @@ private:
                     if (!mask || mask & (mask + 1))
                         return false;
 
-                    uint64_t width = WTF::bitCount(mask);
+                    uint64_t width = std::popcount(mask);
                     uint64_t datasize = opcode == InsertUnsignedBitfieldInZero32 ? 32 : 64;
                     uint64_t resultDataSize = 0;
                     if (!WTF::safeAdd(lsb, width, resultDataSize) || resultDataSize > datasize)

--- a/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
+++ b/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
@@ -783,7 +783,7 @@ private:
                 uint64_t mask1 = m_value->child(0)->child(0)->child(1)->asInt();
                 uint64_t mask2 = m_value->child(0)->child(1)->asInt();
                 uint64_t mask3 = m_value->child(1)->asInt();
-                uint64_t width = WTF::bitCount(mask1);
+                uint64_t width = std::popcount(mask1);
                 uint64_t datasize = m_value->child(0)->child(0)->type() == Int64 ? 64 : 32;
                 bool isValidMask1 = mask1 && !(mask1 & (mask1 + 1)) && width < datasize;
                 bool isValidMask2 = mask2 == mask3 && ((mask2 << 1) - 1) == mask1;
@@ -1467,7 +1467,7 @@ private:
                 uint64_t mask = m_value->child(1)->asInt();
                 bool isValidMask = mask && !(mask & (mask + 1));
                 uint64_t datasize = m_value->child(0)->child(0)->type() == Int64 ? 64 : 32;
-                uint64_t width = WTF::bitCount(mask);
+                uint64_t width = std::popcount(mask);
                 if (shiftAmount < datasize && isValidMask && shiftAmount + width >= datasize) {
                     replaceWithIdentity(m_value->child(0));
                     break;
@@ -1490,7 +1490,7 @@ private:
                 uint64_t maskShift = m_value->child(1)->asInt();
                 uint64_t maskShiftAmount = WTF::ctz(maskShift);
                 uint64_t mask = maskShift >> maskShiftAmount;
-                uint64_t width = WTF::bitCount(mask);
+                uint64_t width = std::popcount(mask);
                 uint64_t datasize = m_value->child(0)->child(0)->type() == Int64 ? 64 : 32;
                 bool isValidShiftAmount = shiftAmount == maskShiftAmount && shiftAmount < datasize;
                 bool isValidMask = mask && !(mask & (mask + 1)) && width < datasize;
@@ -1898,7 +1898,7 @@ private:
                 uint64_t maskShift = m_value->child(0)->child(1)->asInt();
                 uint64_t maskShiftAmount = WTF::ctz(maskShift);
                 uint64_t mask = maskShift >> maskShiftAmount;
-                uint64_t width = WTF::bitCount(mask);
+                uint64_t width = std::popcount(mask);
                 uint64_t datasize = m_value->child(0)->child(0)->type() == Int64 ? 64 : 32;
                 bool isValidShiftAmount = maskShiftAmount == shiftAmount && shiftAmount < datasize;
                 bool isValidMask = mask && !(mask & (mask + 1)) && width < datasize;

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -9178,7 +9178,7 @@ void ByteCodeParser::parseBlock(unsigned limit)
             auto& metadata = bytecode.metadata(codeBlock);
             uint32_t seenModes = metadata.m_iterationMetadata.seenModes;
 
-            unsigned numberOfRemainingModes = WTF::bitCount(seenModes);
+            unsigned numberOfRemainingModes = std::popcount(seenModes);
             ASSERT(numberOfRemainingModes <= numberOfIterationModes);
             bool generatedCase = false;
 
@@ -9337,7 +9337,7 @@ void ByteCodeParser::parseBlock(unsigned limit)
             auto& metadata = bytecode.metadata(codeBlock);
             uint32_t seenModes = metadata.m_iterationMetadata.seenModes;
 
-            unsigned numberOfRemainingModes = WTF::bitCount(seenModes);
+            unsigned numberOfRemainingModes = std::popcount(seenModes);
             ASSERT(numberOfRemainingModes <= numberOfIterationModes);
             bool generatedCase = false;
 

--- a/Source/WTF/wtf/BitSet.h
+++ b/Source/WTF/wtf/BitSet.h
@@ -317,7 +317,7 @@ inline constexpr size_t BitSet<bitSetSize, WordType>::count(size_t start) const
             ++result;
     }
     for (size_t i = start / wordSize; i < words; ++i)
-        result += WTF::bitCount(bits[i]);
+        result += std::popcount(bits[i]);
     return result;
 }
 

--- a/Source/WTF/wtf/BitVector.cpp
+++ b/Source/WTF/wtf/BitVector.cpp
@@ -193,7 +193,7 @@ size_t BitVector::bitCountSlow() const
     const OutOfLineBits* bits = outOfLineBits();
     size_t result = 0;
     for (auto word : bits->wordsSpan())
-        result += bitCount(word);
+        result += std::popcount(word);
     return result;
 }
 

--- a/Source/WTF/wtf/BitVector.h
+++ b/Source/WTF/wtf/BitVector.h
@@ -255,7 +255,7 @@ public:
     size_t bitCount() const
     {
         if (isInline())
-            return bitCount(cleanseInlineBits(m_bitsOrPointer));
+            return std::popcount(cleanseInlineBits(m_bitsOrPointer));
         return bitCountSlow();
     }
 
@@ -411,14 +411,7 @@ private:
     {
         return bits & ~(static_cast<uintptr_t>(1) << maxInlineBits());
     }
-    
-    static size_t bitCount(uintptr_t bits)
-    {
-        if (sizeof(uintptr_t) == 4)
-            return WTF::bitCount(static_cast<unsigned>(bits));
-        return WTF::bitCount(static_cast<uint64_t>(bits));
-    }
-    
+
     size_t findBitFast(size_t startIndex, bool value) const
     {
         if (isInline()) {

--- a/Source/WTF/wtf/FastBitVector.h
+++ b/Source/WTF/wtf/FastBitVector.h
@@ -289,7 +289,7 @@ public:
     {
         size_t result = 0;
         for (size_t index = arrayLength(); index--;)
-            result += WTF::bitCount(m_words.word(index));
+            result += std::popcount(m_words.word(index));
         return result;
     }
     

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -207,19 +207,6 @@ inline std::span<const std::byte> alignedBytes(std::span<const std::byte> buffer
     return buffer.subspan(alignedBytesCorrection(buffer, alignment));
 }
 
-// Returns a count of the number of bits set in 'bits'.
-inline size_t bitCount(unsigned bits)
-{
-    bits = bits - ((bits >> 1) & 0x55555555);
-    bits = (bits & 0x33333333) + ((bits >> 2) & 0x33333333);
-    return (((bits + (bits >> 4)) & 0xF0F0F0F) * 0x1010101) >> 24;
-}
-
-inline size_t bitCount(uint64_t bits)
-{
-    return bitCount(static_cast<unsigned>(bits)) + bitCount(static_cast<unsigned>(bits >> 32));
-}
-
 template<typename T> constexpr T mask(T value, uintptr_t mask)
 {
     static_assert(sizeof(T) == sizeof(uintptr_t), "sizeof(T) must be equal to sizeof(uintptr_t).");

--- a/Source/WebCore/contentextensions/Term.h
+++ b/Source/WebCore/contentextensions/Term.h
@@ -155,7 +155,7 @@ private:
         
         unsigned bitCount() const
         {
-            return WTF::bitCount(m_characters[0]) + WTF::bitCount(m_characters[1]);
+            return std::popcount(m_characters[0]) + std::popcount(m_characters[1]);
         }
         
         friend bool operator==(const CharacterSet&, const CharacterSet&) = default;


### PR DESCRIPTION
#### 301b227d6dedf0e9a366d6c87f61d1ffc7626e74
<pre>
Adopt C++20&apos;s std::popcount()
<a href="https://bugs.webkit.org/show_bug.cgi?id=310796">https://bugs.webkit.org/show_bug.cgi?id=310796</a>

Reviewed by Anne van Kesteren.

Adopt C++20&apos;s std::popcount():
- <a href="https://en.cppreference.com/w/cpp/numeric/popcount.html">https://en.cppreference.com/w/cpp/numeric/popcount.html</a>

* Source/JavaScriptCore/assembler/ARMv7Assembler.h:
(JSC::ARMv7Assembler::pop):
(JSC::ARMv7Assembler::push):
* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/B3ReduceStrength.cpp:
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::parseBlock):
* Source/WTF/wtf/BitSet.h:
(WTF::WordType&gt;::count const):
* Source/WTF/wtf/BitVector.cpp:
(WTF::BitVector::bitCountSlow const):
* Source/WTF/wtf/BitVector.h:
* Source/WTF/wtf/FastBitVector.h:
(WTF::FastBitVectorImpl::bitCount const):
* Source/WTF/wtf/StdLibExtras.h:
(WTF::bitCount): Deleted.
* Source/WebCore/contentextensions/Term.h:
(WebCore::ContentExtensions::Term::CharacterSet::bitCount const):

Canonical link: <a href="https://commits.webkit.org/309986@main">https://commits.webkit.org/309986@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/232cd8df1e125f7a6d45dea3dd51d7493ae1a472

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152361 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25143 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18742 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161104 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154235 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25671 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25449 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117725 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7b4f4a11-1a15-4896-98d9-16e0ec0047bd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155321 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136785 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98438 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fd32fa57-6c15-4ecc-bad7-818fca192c1d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/19009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16943 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8938 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144373 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14659 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163574 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13162 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6716 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16253 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125765 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24941 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20982 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125937 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34162 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24943 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136455 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81543 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20925 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13234 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/183993 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24559 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88845 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46911 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24250 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24410 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24311 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->