### PR TITLE
Make member variables const in WebCore's webxr & svg

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXRHitTestResult.h
+++ b/Source/WebCore/Modules/webxr/WebXRHitTestResult.h
@@ -54,7 +54,7 @@ private:
     WebXRHitTestResult(WebXRFrame&, WebXRSpace&, const PlatformXR::FrameData::HitTestResult&);
 
     const Ref<WebXRFrame> m_frame;
-    Ref<WebXRSpace> m_space;
+    const Ref<WebXRSpace> m_space;
     PlatformXR::FrameData::HitTestResult m_result;
 };
 

--- a/Source/WebCore/Modules/webxr/WebXRHitTestSource.h
+++ b/Source/WebCore/Modules/webxr/WebXRHitTestSource.h
@@ -56,7 +56,7 @@ private:
 
     WeakPtr<WebXRSession> m_session;
     std::optional<PlatformXR::HitTestSource> m_source;
-    Ref<WebXRSpace> m_space;
+    const Ref<WebXRSpace> m_space;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webxr/WebXRRay.h
+++ b/Source/WebCore/Modules/webxr/WebXRRay.h
@@ -55,8 +55,8 @@ public:
 private:
     WebXRRay(Ref<DOMPointReadOnly>&& origin, Ref<DOMPointReadOnly>&& direction);
 
-    Ref<DOMPointReadOnly> m_origin;
-    Ref<DOMPointReadOnly> m_direction;
+    const Ref<DOMPointReadOnly> m_origin;
+    const Ref<DOMPointReadOnly> m_direction;
     RefPtr<Float32Array> m_matrix;
 };
 

--- a/Source/WebCore/Modules/webxr/WebXRTransientInputHitTestResult.h
+++ b/Source/WebCore/Modules/webxr/WebXRTransientInputHitTestResult.h
@@ -49,7 +49,7 @@ public:
 private:
     WebXRTransientInputHitTestResult(Ref<WebXRInputSource>&&, Vector<Ref<WebXRHitTestResult>>&&);
 
-    Ref<WebXRInputSource> m_inputSource;
+    const Ref<WebXRInputSource> m_inputSource;
     Vector<Ref<WebXRHitTestResult>> m_results;
 };
 

--- a/Source/WebCore/Modules/webxr/XRWebGLBinding.h
+++ b/Source/WebCore/Modules/webxr/XRWebGLBinding.h
@@ -82,7 +82,7 @@ public:
 private:
     XRWebGLBinding(Ref<WebXRSession>&&, WebXRWebGLRenderingContext&&);
 
-    Ref<WebXRSession> m_session;
+    const Ref<WebXRSession> m_session;
     WebXRWebGLRenderingContext m_context;
 };
 

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -515,7 +515,6 @@ platform/graphics/transforms/TransformOperationsSharedPrimitivesPrefix.h
 [ iOS ] platform/ios/LegacyTileGrid.mm
 [ iOS ] platform/ios/PlatformPasteboardIOS.mm
 [ iOS ] platform/ios/PlatformScreenIOS.mm
-[ iOS ] platform/ios/VideoPresentationInterfaceIOS.mm
 [ iOS ] platform/ios/WebVideoFullscreenControllerAVKit.mm
 [ iOS ] platform/ios/wak/WAKWindow.mm
 platform/mediastream/RealtimeOutgoingAudioSource.cpp

--- a/Source/WebCore/loader/cache/CachedApplicationManifest.h
+++ b/Source/WebCore/loader/cache/CachedApplicationManifest.h
@@ -47,7 +47,7 @@ private:
     void setEncoding(const String&) final;
     ASCIILiteral encoding() const final;
 
-    Ref<TextResourceDecoder> m_decoder;
+    const Ref<TextResourceDecoder> m_decoder;
     std::optional<String> m_text;
 };
 

--- a/Source/WebCore/platform/graphics/PlatformDisplay.h
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.h
@@ -121,7 +121,7 @@ public:
 protected:
     explicit PlatformDisplay(Ref<GLDisplay>&&);
 
-    Ref<GLDisplay> m_eglDisplay;
+    const Ref<GLDisplay> m_eglDisplay;
     std::unique_ptr<GLContext> m_sharingGLContext;
 
 #if ENABLE(WEBGL) && !PLATFORM(WIN)

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
@@ -273,7 +273,7 @@ private:
 
     bool m_finalizeSetupNeedsVideoContentLayer { false };
     bool m_finalizeSetupNeedsReturnVideoContentLayer { false };
-    Ref<PlaybackSessionInterfaceIOS> m_playbackSessionInterface;
+    const Ref<PlaybackSessionInterfaceIOS> m_playbackSessionInterface;
     RetainPtr<UIView> m_pipPlacard;
 
 #if HAVE(SPATIAL_AUDIO_EXPERIENCE)

--- a/Source/WebCore/svg/SVGFontFaceElement.h
+++ b/Source/WebCore/svg/SVGFontFaceElement.h
@@ -64,7 +64,7 @@ private:
 
     bool rendererIsNeeded(const RenderStyle&) final { return false; }
 
-    Ref<StyleRuleFontFace> m_fontFaceRule;
+    const Ref<StyleRuleFontFace> m_fontFaceRule;
     WeakPtr<SVGFontElement, WeakPtrImplWithEventTargetData> m_fontElement;
 };
 

--- a/Source/WebCore/svg/SVGSVGElement.h
+++ b/Source/WebCore/svg/SVGSVGElement.h
@@ -152,7 +152,7 @@ private:
     SVGSVGElement* findRootAnchor(StringView) const;
 
     bool m_useCurrentView { false };
-    Ref<SMILTimeContainer> m_timeContainer;
+    const Ref<SMILTimeContainer> m_timeContainer;
     RefPtr<SVGViewSpec> m_viewSpec;
     RefPtr<SVGViewElement> m_currentViewElement;
     String m_currentViewFragmentIdentifier;

--- a/Source/WebCore/svg/SVGTRefElement.h
+++ b/Source/WebCore/svg/SVGTRefElement.h
@@ -59,7 +59,7 @@ private:
     void detachTarget();
     void buildPendingResource() override;
 
-    Ref<SVGTRefTargetEventListener> m_targetListener;
+    const Ref<SVGTRefTargetEventListener> m_targetListener;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGTests.h
+++ b/Source/WebCore/svg/SVGTests.h
@@ -47,8 +47,8 @@ public:
     SVGStringList& systemLanguage() { return m_systemLanguage; }
 
 private:
-    Ref<SVGStringList> m_requiredExtensions;
-    Ref<SVGStringList> m_systemLanguage;
+    const Ref<SVGStringList> m_requiredExtensions;
+    const Ref<SVGStringList> m_systemLanguage;
 };
 
 class SVGTests {

--- a/Source/WebCore/svg/properties/SVGPropertyAccessorImpl.h
+++ b/Source/WebCore/svg/properties/SVGPropertyAccessorImpl.h
@@ -36,12 +36,12 @@ class SVGConditionalProcessingAttributeAccessor final : public SVGMemberAccessor
     using Base = SVGMemberAccessor<OwnerType>;
 
 public:
-    SVGConditionalProcessingAttributeAccessor(Ref<SVGStringList> SVGConditionalProcessingAttributes::*property)
+    SVGConditionalProcessingAttributeAccessor(const Ref<SVGStringList> SVGConditionalProcessingAttributes::*property)
         : m_property(property)
     {
     }
 
-    Ref<SVGStringList>& property(OwnerType& owner) const { return owner.conditionalProcessingAttributes().*m_property; }
+    const Ref<SVGStringList>& property(OwnerType& owner) const { return owner.conditionalProcessingAttributes().*m_property; }
     const Ref<SVGStringList>& property(const OwnerType& owner) const { return const_cast<OwnerType&>(owner).conditionalProcessingAttributes().*m_property; }
 
     void detach(const OwnerType& owner) const override
@@ -59,15 +59,15 @@ public:
         return this->property(owner).ptr() == &property;
     }
 
-    template<Ref<SVGStringList> SVGConditionalProcessingAttributes::*>
+    template<const Ref<SVGStringList> SVGConditionalProcessingAttributes::*>
     static const SVGMemberAccessor<OwnerType>& singleton();
 
 private:
-    Ref<SVGStringList> SVGConditionalProcessingAttributes::*m_property;
+    const Ref<SVGStringList> SVGConditionalProcessingAttributes::*m_property;
 };
 
 template<typename OwnerType>
-template<Ref<SVGStringList> SVGConditionalProcessingAttributes::*member>
+template<const Ref<SVGStringList> SVGConditionalProcessingAttributes::*member>
 const SVGMemberAccessor<OwnerType>& SVGConditionalProcessingAttributeAccessor<OwnerType>::singleton()
 {
     static NeverDestroyed<SVGConditionalProcessingAttributeAccessor<OwnerType>> propertyAccessor { member };

--- a/Source/WebCore/svg/properties/SVGPropertyOwnerRegistry.h
+++ b/Source/WebCore/svg/properties/SVGPropertyOwnerRegistry.h
@@ -69,7 +69,7 @@ public:
     {
     }
 
-    template<const LazyNeverDestroyed<const QualifiedName>& attributeName, Ref<SVGStringList> SVGConditionalProcessingAttributes::*property>
+    template<const LazyNeverDestroyed<const QualifiedName>& attributeName, const Ref<SVGStringList> SVGConditionalProcessingAttributes::*property>
     static void registerConditionalProcessingAttributeProperty()
     {
         registerProperty(attributeName, SVGConditionalProcessingAttributeAccessor<OwnerType>::template singleton<property>());


### PR DESCRIPTION
#### 0d7e929e4770441f4c6478ab1196b0eac7caf2e9
<pre>
Make member variables const in WebCore&apos;s webxr &amp; svg
<a href="https://bugs.webkit.org/show_bug.cgi?id=310798">https://bugs.webkit.org/show_bug.cgi?id=310798</a>

Reviewed by Chris Dumez.

Plus a couple in other places.

Canonical link: <a href="https://commits.webkit.org/310017@main">https://commits.webkit.org/310017@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ba8d81810b8df884671d9b87adc9f574c063db7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152436 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25218 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18817 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161179 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/326fc9be-c67c-4a05-a7bf-d92220c3ccf4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154310 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25746 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25524 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117792 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/68ec10d1-3b08-4d83-aeda-81c767caea17) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155396 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136850 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98506 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c409c53f-e59f-43d4-8f26-88e1703fd595) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19073 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17012 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9017 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128723 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14724 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163649 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6791 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16318 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125826 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25016 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21051 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125997 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25018 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136520 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81618 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23373 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20990 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13299 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24634 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/88920 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24325 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24485 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24386 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->