### PR TITLE
LibWebRTCRtpReceiverBackend should create its source when being created

### DIFF
--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp
@@ -412,7 +412,9 @@ ExceptionOr<LibWebRTCMediaEndpoint::Backends> LibWebRTCMediaEndpoint::createTran
         return toException(result.error());
 
     auto transceiver = makeUniqueRef<LibWebRTCRtpTransceiverBackend>(toRef(result.MoveValue()));
-    return LibWebRTCMediaEndpoint::Backends { transceiver->createSenderBackend(*protect(m_peerConnectionBackend), WTF::move(source)), transceiver->createReceiverBackend(), WTF::move(transceiver) };
+
+    Ref document = downcast<Document>(*m_peerConnectionBackend->connection().scriptExecutionContext());
+    return LibWebRTCMediaEndpoint::Backends { transceiver->createSenderBackend(*protect(m_peerConnectionBackend), WTF::move(source)), transceiver->createReceiverBackend(document), WTF::move(transceiver) };
 }
 
 ExceptionOr<LibWebRTCMediaEndpoint::Backends> LibWebRTCMediaEndpoint::addTransceiver(const String& trackKind, const RTCRtpTransceiverInit& init, PeerConnectionBackend::IgnoreNegotiationNeededFlag ignoreNegotiationNeededFlag)

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h
@@ -29,6 +29,7 @@
 #include "LibWebRTCObservers.h"
 #include "LibWebRTCProvider.h"
 #include "LibWebRTCRefWrappers.h"
+#include "LibWebRTCRtpReceiverBackend.h"
 #include "LibWebRTCRtpSenderBackend.h"
 #include "RTCRtpReceiver.h"
 #include "Timer.h"
@@ -108,7 +109,7 @@ public:
 
     struct Backends {
         Ref<LibWebRTCRtpSenderBackend> senderBackend;
-        UniqueRef<LibWebRTCRtpReceiverBackend> receiverBackend;
+        LibWebRTCRtpReceiverBackendAndSource receiverBackendAndSource;
         UniqueRef<LibWebRTCRtpTransceiverBackend> transceiverBackend;
     };
     ExceptionOr<Backends> addTransceiver(const String& trackKind, const RTCRtpTransceiverInit&, PeerConnectionBackend::IgnoreNegotiationNeededFlag);

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
@@ -282,18 +282,14 @@ void LibWebRTCPeerConnectionBackend::doAddIceCandidate(RTCIceCandidate& candidat
     m_endpoint->addIceCandidate(WTF::move(rtcCandidate), WTF::move(callback));
 }
 
-Ref<RTCRtpReceiver> LibWebRTCPeerConnectionBackend::createReceiver(UniqueRef<LibWebRTCRtpReceiverBackend>&& backend)
+Ref<RTCRtpReceiver> LibWebRTCPeerConnectionBackend::createReceiver(LibWebRTCRtpReceiverBackendAndSource&& backendAndSource)
 {
     Ref document = downcast<Document>(*m_peerConnection->scriptExecutionContext());
 
-    auto source = backend->createSource(document.get());
-
-    // Remote source is initially muted and will be unmuted when receiving the first packet.
-    source->setMuted(true);
-    Ref remoteTrackPrivate = MediaStreamTrackPrivate::create(document->logger(), WTF::move(source), createVersion4UUIDString());
+    Ref remoteTrackPrivate = MediaStreamTrackPrivate::create(document->logger(), WTF::move(backendAndSource.source), createVersion4UUIDString());
     Ref remoteTrack = MediaStreamTrack::create(document.get(), WTF::move(remoteTrackPrivate));
 
-    return RTCRtpReceiver::create(*this, WTF::move(remoteTrack), WTF::move(backend));
+    return RTCRtpReceiver::create(*this, WTF::move(remoteTrack), WTF::move(backendAndSource.backend));
 }
 
 std::unique_ptr<RTCDataChannelHandler> LibWebRTCPeerConnectionBackend::createDataChannelHandler(const String& label, const RTCDataChannelInit& options)
@@ -332,7 +328,10 @@ ExceptionOr<Ref<RTCRtpSender>> LibWebRTCPeerConnectionBackend::addTrack(MediaStr
 
     Ref sender = RTCRtpSender::create(peerConnection, track, WTF::move(senderBackend));
     sender->setMediaStreamIds(mediaStreamIds);
-    Ref receiver = createReceiver(transceiverBackend->createReceiverBackend());
+
+    Ref document = downcast<Document>(*m_peerConnection->scriptExecutionContext());
+    Ref receiver = createReceiver(transceiverBackend->createReceiverBackend(document.get()));
+
     Ref transceiver = RTCRtpTransceiver::create(sender.copyRef(), WTF::move(receiver), makeUniqueRefFromNonNullUniquePtr(WTF::move(transceiverBackend)));
     peerConnection->addInternalTransceiver(WTF::move(transceiver));
     return sender;
@@ -348,7 +347,7 @@ ExceptionOr<Ref<RTCRtpTransceiver>> LibWebRTCPeerConnectionBackend::addTransceiv
     auto backends = result.releaseReturnValue();
     Ref peerConnection = m_peerConnection;
     Ref sender = RTCRtpSender::create(peerConnection, std::forward<T>(trackOrKind), WTF::move(backends.senderBackend));
-    auto receiver = createReceiver(WTF::move(backends.receiverBackend));
+    auto receiver = createReceiver(WTF::move(backends.receiverBackendAndSource));
     auto transceiver = RTCRtpTransceiver::create(WTF::move(sender), WTF::move(receiver), WTF::move(backends.transceiverBackend));
     peerConnection->addInternalTransceiver(transceiver.copyRef());
     return transceiver;
@@ -378,7 +377,10 @@ void LibWebRTCPeerConnectionBackend::addInternalTransceiver(UniqueRef<LibWebRTCR
 {
     Ref peerConnection = m_peerConnection;
     Ref sender = RTCRtpSender::create(peerConnection, type == RealtimeMediaSource::Type::Audio ? "audio"_s : "video"_s, transceiverBackend->createSenderBackend(*this, nullptr));
-    Ref receiver = createReceiver(transceiverBackend->createReceiverBackend());
+
+    Ref document = downcast<Document>(*m_peerConnection->scriptExecutionContext());
+    Ref receiver = createReceiver(transceiverBackend->createReceiverBackend(document.get()));
+
     Ref transceiver = RTCRtpTransceiver::create(WTF::move(sender), WTF::move(receiver), WTF::move(transceiverBackend));
     peerConnection->addInternalTransceiver(WTF::move(transceiver));
 }

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.h
@@ -51,6 +51,8 @@ class RealtimeMediaSource;
 class RealtimeOutgoingAudioSource;
 class RealtimeOutgoingVideoSource;
 
+struct LibWebRTCRtpReceiverBackendAndSource;
+
 class LibWebRTCPeerConnectionBackend final : public PeerConnectionBackend {
     WTF_MAKE_TZONE_ALLOCATED(LibWebRTCPeerConnectionBackend);
 public:
@@ -108,7 +110,7 @@ private:
     template<typename T>
     ExceptionOr<Ref<RTCRtpTransceiver>> addTransceiverFromTrackOrKind(T&& trackOrKind, const RTCRtpTransceiverInit&, IgnoreNegotiationNeededFlag = IgnoreNegotiationNeededFlag::No);
 
-    Ref<RTCRtpReceiver> createReceiver(UniqueRef<LibWebRTCRtpReceiverBackend>&&);
+    Ref<RTCRtpReceiver> createReceiver(LibWebRTCRtpReceiverBackendAndSource&&);
 
     void suspend() final;
     void resume() final;

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.cpp
@@ -48,9 +48,50 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(LibWebRTCRtpReceiverBackend);
 
-LibWebRTCRtpReceiverBackend::LibWebRTCRtpReceiverBackend(Ref<webrtc::RtpReceiverInterface>&& rtcReceiver)
-    : m_rtcReceiver(WTF::move(rtcReceiver))
+LibWebRTCRtpReceiverBackendAndSource LibWebRTCRtpReceiverBackend::create(Document& document, Ref<webrtc::RtpReceiverInterface>&& rtcReceiver)
 {
+    RefPtr source = [&] -> RefPtr<RealtimeMediaSource> {
+        auto rtcTrack = rtcReceiver->track();
+        switch (rtcReceiver->media_type()) {
+        case webrtc::MediaType::ANY:
+        case webrtc::MediaType::DATA:
+        case webrtc::MediaType::UNSUPPORTED:
+            break;
+        case webrtc::MediaType::AUDIO: {
+            // This is a cast from a webrtc type, not much we can do to make it safe.
+            SUPPRESS_MEMORY_UNSAFE_CAST webrtc::scoped_refptr<webrtc::AudioTrackInterface> audioTrack { static_cast<webrtc::AudioTrackInterface*>(rtcTrack.get()) };
+            Ref source = RealtimeIncomingAudioSource::create(toRef(WTF::move(audioTrack)), fromStdString(rtcTrack->id()));
+            if (document.page()) {
+                auto& webRTCProvider = downcast<LibWebRTCProvider>(document.page()->webRTCProvider());
+                source->setAudioModule(webRTCProvider.audioModule());
+            }
+            return source;
+        }
+        case webrtc::MediaType::VIDEO: {
+            // This is a cast from a webrtc type, not much we can do to make it safe.
+            SUPPRESS_MEMORY_UNSAFE_CAST webrtc::scoped_refptr<webrtc::VideoTrackInterface> videoTrack { static_cast<webrtc::VideoTrackInterface*>(rtcTrack.get()) };
+            Ref source = RealtimeIncomingVideoSource::create(toRef(WTF::move(videoTrack)), fromStdString(rtcTrack->id()));
+            if (document.settings().webRTCMediaPipelineAdditionalLoggingEnabled())
+                source->enableFrameRatedMonitoring();
+            return source;
+        }
+        }
+        return nullptr;
+    }();
+    RELEASE_ASSERT(source);
+
+    // Remote source is initially muted and will be unmuted when receiving the first packet.
+    source->setMuted(true);
+
+    auto backend = makeUniqueRef<LibWebRTCRtpReceiverBackend>(WTF::move(rtcReceiver), *source);
+    return { WTF::move(backend), source.releaseNonNull() };
+}
+
+LibWebRTCRtpReceiverBackend::LibWebRTCRtpReceiverBackend(Ref<webrtc::RtpReceiverInterface>&& rtcReceiver, RealtimeMediaSource& source)
+    : m_rtcReceiver(WTF::move(rtcReceiver))
+    , m_source(source)
+{
+    m_rtcReceiver->SetObserver(this);
 }
 
 LibWebRTCRtpReceiverBackend::~LibWebRTCRtpReceiverBackend()
@@ -116,45 +157,6 @@ Vector<RTCRtpSynchronizationSource> LibWebRTCRtpReceiverBackend::getSynchronizat
             sources.append(toRTCRtpSynchronizationSource(rtcSource, offset));
     }
     return sources;
-}
-
-Ref<RealtimeMediaSource> LibWebRTCRtpReceiverBackend::createSource(Document& document)
-{
-    RefPtr source = [&] -> RefPtr<RealtimeMediaSource> {
-        auto rtcTrack = m_rtcReceiver->track();
-        switch (m_rtcReceiver->media_type()) {
-        case webrtc::MediaType::ANY:
-        case webrtc::MediaType::DATA:
-        case webrtc::MediaType::UNSUPPORTED:
-            break;
-        case webrtc::MediaType::AUDIO: {
-            // This is a cast from a webrtc type, not much we can do to make it safe.
-            SUPPRESS_MEMORY_UNSAFE_CAST webrtc::scoped_refptr<webrtc::AudioTrackInterface> audioTrack { static_cast<webrtc::AudioTrackInterface*>(rtcTrack.get()) };
-            Ref source = RealtimeIncomingAudioSource::create(toRef(WTF::move(audioTrack)), fromStdString(rtcTrack->id()));
-            if (document.page()) {
-                auto& webRTCProvider = downcast<LibWebRTCProvider>(document.page()->webRTCProvider());
-                source->setAudioModule(webRTCProvider.audioModule());
-            }
-            return source;
-        }
-        case webrtc::MediaType::VIDEO: {
-            // This is a cast from a webrtc type, not much we can do to make it safe.
-            SUPPRESS_MEMORY_UNSAFE_CAST webrtc::scoped_refptr<webrtc::VideoTrackInterface> videoTrack { static_cast<webrtc::VideoTrackInterface*>(rtcTrack.get()) };
-            Ref source = RealtimeIncomingVideoSource::create(toRef(WTF::move(videoTrack)), fromStdString(rtcTrack->id()));
-            if (document.settings().webRTCMediaPipelineAdditionalLoggingEnabled())
-                source->enableFrameRatedMonitoring();
-            return source;
-        }
-        }
-        return nullptr;
-    }();
-
-    RELEASE_ASSERT(source);
-
-    m_source = *source;
-    m_rtcReceiver->SetObserver(this);
-
-    return source.releaseNonNull();
 }
 
 Ref<RTCRtpTransformBackend> LibWebRTCRtpReceiverBackend::rtcRtpTransformBackend()

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.h
@@ -35,19 +35,26 @@
 
 namespace WebCore {
 class Document;
+class LibWebRTCRtpReceiverBackend;
 class RealtimeMediaSource;
+
+struct LibWebRTCRtpReceiverBackendAndSource {
+    UniqueRef<LibWebRTCRtpReceiverBackend> backend;
+    Ref<RealtimeMediaSource> source;
+};
 
 class LibWebRTCRtpReceiverBackend final : public RTCRtpReceiverBackend, public webrtc::RtpReceiverObserverInterface {
     WTF_MAKE_TZONE_ALLOCATED(LibWebRTCRtpReceiverBackend);
 public:
-    explicit LibWebRTCRtpReceiverBackend(Ref<webrtc::RtpReceiverInterface>&&);
+    static LibWebRTCRtpReceiverBackendAndSource create(Document&, Ref<webrtc::RtpReceiverInterface>&&);
+
+    LibWebRTCRtpReceiverBackend(Ref<webrtc::RtpReceiverInterface>&&, RealtimeMediaSource&);
     ~LibWebRTCRtpReceiverBackend();
 
     webrtc::RtpReceiverInterface& rtcReceiver() { return m_rtcReceiver.get(); }
 
-    Ref<RealtimeMediaSource> createSource(Document&);
-
 private:
+
     // RTCRtpReceiverBackend
     bool isLibWebRTCRtpReceiverBackend() const final { return true; }
 
@@ -64,9 +71,9 @@ private:
     double webrtcToWallTimeOffset() const;
 
     const Ref<webrtc::RtpReceiverInterface> m_rtcReceiver;
+    const ThreadSafeWeakPtr<RealtimeMediaSource> m_source;
     const RefPtr<RTCRtpTransformBackend> m_transformBackend;
     mutable std::optional<double> m_webrtcToWallTimeOffset;
-    ThreadSafeWeakPtr<RealtimeMediaSource> m_source;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransceiverBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransceiverBackend.cpp
@@ -39,9 +39,9 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(LibWebRTCRtpTransceiverBackend);
 
-UniqueRef<LibWebRTCRtpReceiverBackend> LibWebRTCRtpTransceiverBackend::createReceiverBackend()
+LibWebRTCRtpReceiverBackendAndSource LibWebRTCRtpTransceiverBackend::createReceiverBackend(Document& document)
 {
-    return makeUniqueRef<LibWebRTCRtpReceiverBackend>(toRef(m_rtcTransceiver->receiver()));
+    return LibWebRTCRtpReceiverBackend::create(document, toRef(m_rtcTransceiver->receiver()));
 }
 
 Ref<LibWebRTCRtpSenderBackend> LibWebRTCRtpTransceiverBackend::createSenderBackend(LibWebRTCPeerConnectionBackend& backend, LibWebRTCRtpSenderBackend::Source&& source)

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransceiverBackend.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransceiverBackend.h
@@ -34,7 +34,7 @@
 
 namespace WebCore {
 
-class LibWebRTCRtpReceiverBackend;
+struct LibWebRTCRtpReceiverBackendAndSource;
 
 class LibWebRTCRtpTransceiverBackend final : public RTCRtpTransceiverBackend {
     WTF_MAKE_TZONE_ALLOCATED(LibWebRTCRtpTransceiverBackend);
@@ -44,7 +44,7 @@ public:
     {
     }
 
-    UniqueRef<LibWebRTCRtpReceiverBackend> createReceiverBackend();
+    LibWebRTCRtpReceiverBackendAndSource createReceiverBackend(Document&);
     Ref<LibWebRTCRtpSenderBackend> createSenderBackend(LibWebRTCPeerConnectionBackend&, LibWebRTCRtpSenderBackend::Source&&);
 
     webrtc::RtpTransceiverInterface* rtcTransceiver() { return m_rtcTransceiver.ptr(); }


### PR DESCRIPTION
#### 45162813bfc66767813bc14d3090b8712b745d6d
<pre>
LibWebRTCRtpReceiverBackend should create its source when being created
<a href="https://rdar.apple.com/173392682">rdar://173392682</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=310799">https://bugs.webkit.org/show_bug.cgi?id=310799</a>

Reviewed by Jean-Yves Avenard.

Following up on <a href="https://bugs.webkit.org/show_bug.cgi?id=310267">https://bugs.webkit.org/show_bug.cgi?id=310267</a>, we do a refactoring to create the source at the time we create the receiver backend.
This allows to make the backend source weak ptr const and clarifies the threading model of how the backend is using the source weak ptr.
It also makes it clear that a backend is only creating one source ever.

Covered by existing tests.

Canonical link: <a href="https://commits.webkit.org/310075@main">https://commits.webkit.org/310075@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4abde0857f1653b7bbdf727cea7c2c516d2e18c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152657 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25439 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19038 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161402 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5d142ca8-2b30-4ed7-ad7f-b491466cbc07) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154531 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25967 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25745 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/117967 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ce5077a0-d758-4ed2-bf5a-2613956cda81) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155617 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20182 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137042 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98679 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/19257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9237 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128907 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14916 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163873 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7012 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16510 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126021 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25237 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21244 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126181 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34228 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25239 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136712 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/81842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21148 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13491 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24855 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89141 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24547 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24706 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/24607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->