### PR TITLE
BitVector::mergeSlow reads out of bounds when `this` is larger than `other`

### DIFF
--- a/Source/WTF/wtf/BitVector.cpp
+++ b/Source/WTF/wtf/BitVector.cpp
@@ -134,7 +134,7 @@ void BitVector::mergeSlow(const BitVector& other)
     
     auto a = outOfLineBits()->wordsSpan();
     auto b = other.outOfLineBits()->wordsSpan();
-    for (size_t i = 0; i < a.size(); ++i)
+    for (size_t i = 0; i < b.size(); ++i)
         a[i] |= b[i];
 }
 

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -28,6 +28,7 @@ set(TestWTF_SOURCES
     Tests/WTF/AtomString.cpp
     Tests/WTF/Base64.cpp
     Tests/WTF/BitSet.cpp
+    Tests/WTF/BitVector.cpp
     Tests/WTF/BloomFilter.cpp
     Tests/WTF/BoxPtr.cpp
     Tests/WTF/BumpPointerAllocator.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1545,6 +1545,7 @@
 		FF41AC702A79CAA000AC0FA5 /* WYHash.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FF41AC682A79CAA000AC0FA5 /* WYHash.cpp */; };
 		FF5D0CB4283221AD00F3278A /* CompactRefPtr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FF5D0CB3283221AD00F3278A /* CompactRefPtr.cpp */; };
 		FF8CB40C2A88C152004AF498 /* SuperFastHash.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FF8CB4042A88C152004AF498 /* SuperFastHash.cpp */; };
+		8CC128AB2E904F3449BED524 /* BitVector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8CC128AA2E904F3449BED524 /* BitVector.cpp */; };
 		FF910EA5297A0D1100D1A24D /* FixedBitVector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FF910E9D297A0D1100D1A24D /* FixedBitVector.cpp */; };
 		FFD3FF372AF9BD8F0057C508 /* DragonBoxTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FFD3FF2F2AF9BD8F0057C508 /* DragonBoxTest.cpp */; };
 /* End PBXBuildFile section */
@@ -4554,6 +4555,7 @@
 		FF41AC682A79CAA000AC0FA5 /* WYHash.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WYHash.cpp; sourceTree = "<group>"; };
 		FF5D0CB3283221AD00F3278A /* CompactRefPtr.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CompactRefPtr.cpp; sourceTree = "<group>"; };
 		FF8CB4042A88C152004AF498 /* SuperFastHash.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SuperFastHash.cpp; sourceTree = "<group>"; };
+		8CC128AA2E904F3449BED524 /* BitVector.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BitVector.cpp; sourceTree = "<group>"; };
 		FF910E9D297A0D1100D1A24D /* FixedBitVector.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FixedBitVector.cpp; sourceTree = "<group>"; };
 		FFD3FF2F2AF9BD8F0057C508 /* DragonBoxTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DragonBoxTest.cpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -6540,6 +6542,7 @@
 				26F1B44215CA434F00D1E4BF /* AtomString.cpp */,
 				919B506E2C177055009FE7B0 /* Base64.cpp */,
 				FE2D9473245EB2DF00E48135 /* BitSet.cpp */,
+				8CC128AA2E904F3449BED524 /* BitVector.cpp */,
 				E40019301ACE9B5C001B0A2A /* BloomFilter.cpp */,
 				93A427AE180DA60F00CD24D7 /* BoxPtr.cpp */,
 				0451A5A6235E438E009DF945 /* BumpPointerAllocator.cpp */,
@@ -7734,6 +7737,7 @@
 				7C83DE991D0A590C00FEBCF3 /* AtomString.cpp in Sources */,
 				919B50762C177055009FE7B0 /* Base64.cpp in Sources */,
 				FE2D9474245EB2F400E48135 /* BitSet.cpp in Sources */,
+				8CC128AB2E904F3449BED524 /* BitVector.cpp in Sources */,
 				1ADAD1501D77A9F600212586 /* BlockPtr.mm in Sources */,
 				7C83DE9C1D0A590C00FEBCF3 /* BloomFilter.cpp in Sources */,
 				7C83DF181D0A590C00FEBCF3 /* BoxPtr.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WTF/BitVector.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/BitVector.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/BitVector.h>
+
+#include <wtf/MathExtras.h>
+
+namespace TestWebKitAPI {
+
+// Bug: mergeSlow iterates a.size() words but indexes into b which may have
+// fewer words, causing an out-of-bounds read. This happens when `this` is
+// already larger than `other` (both out-of-line) so ensureSize() is a no-op.
+TEST(WTF_BitVector, MergeLargerIntoSmaller)
+{
+    // Create a large BitVector (256 bits = 4 words on 64-bit).
+    BitVector large(256);
+    large.quickSet(0);
+    large.quickSet(200);
+
+    // Create a smaller BitVector (128 bits = 2 words on 64-bit).
+    BitVector small(128);
+    small.quickSet(42);
+    small.quickSet(100);
+
+    // large.merge(small) should OR small's bits into large.
+    // Bug: the loop uses large's word count as the bound but indexes into
+    // small's word span, reading words out of bounds.
+    large.merge(small);
+
+    // Bits originally in large must survive.
+    EXPECT_TRUE(large.get(0));
+    EXPECT_TRUE(large.get(200));
+
+    // Bits from small must be merged in.
+    EXPECT_TRUE(large.get(42));
+    EXPECT_TRUE(large.get(100));
+
+    // Bits that were never set must remain clear.
+    EXPECT_FALSE(large.get(1));
+    EXPECT_FALSE(large.get(64));
+    EXPECT_FALSE(large.get(150));
+    EXPECT_FALSE(large.get(255));
+
+    // Total set bits should be exactly 4.
+    EXPECT_EQ(large.bitCount(), 4u);
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### 3b3138e0af6cec61d82db202ee80ec544d8e1189
<pre>
BitVector::mergeSlow reads out of bounds when `this` is larger than `other`
<a href="https://bugs.webkit.org/show_bug.cgi?id=310800">https://bugs.webkit.org/show_bug.cgi?id=310800</a>

Reviewed by Ryosuke Niwa.

`mergeSlow` iterates using `a.size()` (`this-&gt;numWords()`) as the loop bound
but indexes into b (other&apos;s word span), which may have fewer words.
This happens when this is already larger than other because
`ensureSize(other.size())` is a no-op in that case, leaving `a.size() &gt;
b.size()`. The out-of-bounds read would hit an assertion in hardened
std::span.

Fix this by iterating up to `b.size()` instead. `std::min(a.size(),
b.size())` is not needed here because `ensureSize(other.size())` guarantees
`a.size() &gt;= b.size()`, so `b.size()` is already the minimum.

Added an API test that merges a small out-of-line BitVector into a
larger one to exercise this code path.

Tests: Tools/TestWebKitAPI/Tests/WTF/BitVector.cpp

* Source/WTF/wtf/BitVector.cpp:
(WTF::BitVector::mergeSlow):
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WTF/BitVector.cpp: Added.
(TestWebKitAPI::TEST(WTF_BitVector, MergeLargerIntoSmaller)):

Canonical link: <a href="https://commits.webkit.org/310027@main">https://commits.webkit.org/310027@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/420e86fd9add6e1c81cbabcc24060cc18600ab2a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152372 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25154 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18753 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161115 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105829 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fbc0b1aa-733d-4c8c-9af5-f605b6fd369c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154246 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25682 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25460 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117730 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83466 "3 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ec01a777-9dc5-453d-998c-c346f6439974) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155332 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19939 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136793 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98443 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19016 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16951 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8949 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144384 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128666 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14667 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163585 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13173 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6727 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16261 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125762 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24952 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20990 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125935 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34193 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24954 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136463 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81554 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20932 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13242 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184004 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24570 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88856 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46918 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24261 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24421 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24322 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->