### PR TITLE
BitVector::

### DIFF
--- a/Source/WTF/wtf/BitVector.cpp
+++ b/Source/WTF/wtf/BitVector.cpp
@@ -134,7 +134,7 @@ void BitVector::mergeSlow(const BitVector& other)
     
     auto a = outOfLineBits()->wordsSpan();
     auto b = other.outOfLineBits()->wordsSpan();
-    for (size_t i = 0; i < a.size(); ++i)
+    for (size_t i = 0; i < b.size(); ++i)
         a[i] |= b[i];
 }
 

--- a/Source/WTF/wtf/BitVector.cpp
+++ b/Source/WTF/wtf/BitVector.cpp
@@ -142,7 +142,9 @@ void BitVector::filterSlow(const BitVector& other)
 {
     if (other.isInline()) {
         ASSERT(!isInline());
-        outOfLineBits()->wordsSpan().front() &= cleanseInlineBits(other.m_bitsOrPointer);
+        auto words = outOfLineBits()->wordsSpan();
+        words.front() &= cleanseInlineBits(other.m_bitsOrPointer);
+        zeroSpan(words.subspan(1));
         return;
     }
     

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -28,6 +28,7 @@ set(TestWTF_SOURCES
     Tests/WTF/AtomString.cpp
     Tests/WTF/Base64.cpp
     Tests/WTF/BitSet.cpp
+    Tests/WTF/BitVector.cpp
     Tests/WTF/BloomFilter.cpp
     Tests/WTF/BoxPtr.cpp
     Tests/WTF/BumpPointerAllocator.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1543,6 +1543,7 @@
 		FF41AC702A79CAA000AC0FA5 /* WYHash.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FF41AC682A79CAA000AC0FA5 /* WYHash.cpp */; };
 		FF5D0CB4283221AD00F3278A /* CompactRefPtr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FF5D0CB3283221AD00F3278A /* CompactRefPtr.cpp */; };
 		FF8CB40C2A88C152004AF498 /* SuperFastHash.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FF8CB4042A88C152004AF498 /* SuperFastHash.cpp */; };
+		8CC128AB2E904F3449BED524 /* BitVector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8CC128AA2E904F3449BED524 /* BitVector.cpp */; };
 		FF910EA5297A0D1100D1A24D /* FixedBitVector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FF910E9D297A0D1100D1A24D /* FixedBitVector.cpp */; };
 		FFD3FF372AF9BD8F0057C508 /* DragonBoxTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FFD3FF2F2AF9BD8F0057C508 /* DragonBoxTest.cpp */; };
 /* End PBXBuildFile section */
@@ -4549,6 +4550,7 @@
 		FF41AC682A79CAA000AC0FA5 /* WYHash.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WYHash.cpp; sourceTree = "<group>"; };
 		FF5D0CB3283221AD00F3278A /* CompactRefPtr.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CompactRefPtr.cpp; sourceTree = "<group>"; };
 		FF8CB4042A88C152004AF498 /* SuperFastHash.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SuperFastHash.cpp; sourceTree = "<group>"; };
+		8CC128AA2E904F3449BED524 /* BitVector.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BitVector.cpp; sourceTree = "<group>"; };
 		FF910E9D297A0D1100D1A24D /* FixedBitVector.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FixedBitVector.cpp; sourceTree = "<group>"; };
 		FFD3FF2F2AF9BD8F0057C508 /* DragonBoxTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DragonBoxTest.cpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -6534,6 +6536,7 @@
 				26F1B44215CA434F00D1E4BF /* AtomString.cpp */,
 				919B506E2C177055009FE7B0 /* Base64.cpp */,
 				FE2D9473245EB2DF00E48135 /* BitSet.cpp */,
+				8CC128AA2E904F3449BED524 /* BitVector.cpp */,
 				E40019301ACE9B5C001B0A2A /* BloomFilter.cpp */,
 				93A427AE180DA60F00CD24D7 /* BoxPtr.cpp */,
 				0451A5A6235E438E009DF945 /* BumpPointerAllocator.cpp */,
@@ -7727,6 +7730,7 @@
 				7C83DE991D0A590C00FEBCF3 /* AtomString.cpp in Sources */,
 				919B50762C177055009FE7B0 /* Base64.cpp in Sources */,
 				FE2D9474245EB2F400E48135 /* BitSet.cpp in Sources */,
+				8CC128AB2E904F3449BED524 /* BitVector.cpp in Sources */,
 				1ADAD1501D77A9F600212586 /* BlockPtr.mm in Sources */,
 				7C83DE9C1D0A590C00FEBCF3 /* BloomFilter.cpp in Sources */,
 				7C83DF181D0A590C00FEBCF3 /* BoxPtr.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WTF/BitVector.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/BitVector.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/BitVector.h>
+
+namespace TestWebKitAPI {
+
+// Bug: mergeSlow iterates a.size() words but indexes into b which may have
+// fewer words, causing an out-of-bounds read. This happens when `this` is
+// already larger than `other` (both out-of-line) so ensureSize() is a no-op.
+TEST(WTF_BitVector, MergeLargerIntoSmaller)
+{
+    // Create a large BitVector (256 bits = 4 words on 64-bit).
+    BitVector large(256);
+    large.quickSet(0);
+    large.quickSet(200);
+
+    // Create a smaller BitVector (128 bits = 2 words on 64-bit).
+    BitVector small(128);
+    small.quickSet(42);
+    small.quickSet(100);
+
+    // large.merge(small) should OR small's bits into large.
+    // Bug: the loop uses large's word count as the bound but indexes into
+    // small's word span, reading words out of bounds.
+    large.merge(small);
+
+    // Bits originally in large must survive.
+    EXPECT_TRUE(large.get(0));
+    EXPECT_TRUE(large.get(200));
+
+    // Bits from small must be merged in.
+    EXPECT_TRUE(large.get(42));
+    EXPECT_TRUE(large.get(100));
+
+    // Bits that were never set must remain clear.
+    EXPECT_FALSE(large.get(1));
+    EXPECT_FALSE(large.get(64));
+    EXPECT_FALSE(large.get(150));
+    EXPECT_FALSE(large.get(255));
+
+    // Total set bits should be exactly 4.
+    EXPECT_EQ(large.bitCount(), 4u);
+}
+
+} // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WTF/BitVector.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/BitVector.cpp
@@ -66,4 +66,32 @@ TEST(WTF_BitVector, MergeLargerIntoSmaller)
     EXPECT_EQ(large.bitCount(), 4u);
 }
 
+TEST(WTF_BitVector, FilterOutOfLineWithInline)
+{
+    // Create an out-of-line BitVector (256 bits = 4 words on 64-bit)
+    // with bits set across multiple words.
+    BitVector large(256);
+    large.quickSet(5);
+    large.quickSet(42);
+    large.quickSet(100); // word 1 (bits 64-127).
+    large.quickSet(200); // word 3 (bits 192-255).
+
+    // Create an inline BitVector (fits in maxInlineBits = 63 bits)
+    // with only bit 5 set.
+    BitVector small;
+    small.set(5);
+
+    // filter is AND: only bits set in both should survive.
+    // Bit 5 is in both, so it survives. Bits 42, 100, 200 are not in
+    // small (which has no bits beyond 62), so they must be cleared.
+    large.filter(small);
+
+    EXPECT_TRUE(large.get(5));
+    EXPECT_FALSE(large.get(42));
+    EXPECT_FALSE(large.get(100));
+    EXPECT_FALSE(large.get(200));
+
+    EXPECT_EQ(large.bitCount(), 1u);
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 45fe7f1cd29b625cb43ccf1a2581bd685f007acc
<pre>
BitVector::filterSlow fails to zero trailing words when other is inline
<a href="https://bugs.webkit.org/show_bug.cgi?id=310801">https://bugs.webkit.org/show_bug.cgi?id=310801</a>

Reviewed by NOBODY (OOPS!).

When other is inline and this is out-of-line, `filterSlow` only ANDs the
first word and returns, leaving words at index 1+ untouched. Since
filter is AND and an inline BitVector has no bits beyond position 62,
all higher words should be zeroed. This causes bits at positions 64+
to incorrectly survive the filter.

Fix this by zeroing the remaining words after ANDing the first. This
matches what the both-out-of-line path already does with
`zeroSpan(a.subspan(b.size()))`.

Added an API test that filters an out-of-line BitVector with bits in
multiple words against an inline BitVector.

Test: Tools/TestWebKitAPI/Tests/WTF/BitVector.cpp

* Source/WTF/wtf/BitVector.cpp:
(WTF::BitVector::filterSlow):
* Tools/TestWebKitAPI/Tests/WTF/BitVector.cpp:
(TestWebKitAPI::TEST(WTF_BitVector, FilterOutOfLineWithInline)):
</pre>
----------------------------------------------------------------------
#### beccfb0d1560546d7c9b2194a79b0fe37f3b35b1
<pre>
BitVector::mergeSlow reads out of bounds when `this` is larger than `other`
<a href="https://bugs.webkit.org/show_bug.cgi?id=310800">https://bugs.webkit.org/show_bug.cgi?id=310800</a>

Reviewed by NOBODY (OOPS!).

`mergeSlow` iterates using `a.size()` (`this-&gt;numWords()`) as the loop bound
but indexes into b (other&apos;s word span), which may have fewer words.
This happens when this is already larger than other because
`ensureSize(other.size())` is a no-op in that case, leaving `a.size() &gt;
b.size()`. The out-of-bounds read would hit an assertion in hardened
std::span.

Fix this by iterating up to `b.size()` instead. `std::min(a.size(),
b.size())` is not needed here because `ensureSize(other.size())` guarantees
`a.size() &gt;= b.size()`, so `b.size()` is already the minimum.

Added an API test that merges a small out-of-line BitVector into a
larger one to exercise this code path.

Tests: Tools/TestWebKitAPI/Tests/WTF/BitVector.cpp

* Source/WTF/wtf/BitVector.cpp:
(WTF::BitVector::mergeSlow):
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WTF/BitVector.cpp: Added.
(TestWebKitAPI::TEST(WTF_BitVector, MergeLargerIntoSmaller)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45fe7f1cd29b625cb43ccf1a2581bd685f007acc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152369 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25151 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18750 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161112 "Hash 45fe7f1c for PR 61405 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105826 "Hash 45fe7f1c for PR 61405 does not build (failure)") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5fecda71-2c0a-49cb-89ff-b4ee3d086a69) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154243 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25679 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25457 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/161112 "Hash 45fe7f1c for PR 61405 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/105826 "Hash 45fe7f1c for PR 61405 does not build (failure)") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155329 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19942 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136792 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/161112 "Hash 45fe7f1c for PR 61405 does not build (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6cfcd65a-6d70-4f17-84bc-1e136a66d313) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19019 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16949 "Passed tests") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8946 "Hash 45fe7f1c for PR 61405 does not build (failure)") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144381 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128669 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14666 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163582 "Hash 45fe7f1c for PR 61405 does not build (failure)") | | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13170 "Found unexpected failure with change (failure)") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6724 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16260 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/163582 "Hash 45fe7f1c for PR 61405 does not build (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24949 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20988 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/163582 "Hash 45fe7f1c for PR 61405 does not build (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24951 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136462 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81551 "Hash 45fe7f1c for PR 61405 does not build (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20931 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13241 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184001 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24567 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88853 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46915 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24258 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24418 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24319 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->