### PR TITLE
[JSC] Fix test262 failure: test/staging/sm/TypedArray/iterator-next-with-detached.js

### DIFF
--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -935,9 +935,6 @@ test/staging/sm/String/string-upper-lower-mapping.js:
 test/staging/sm/TypedArray/constructor-buffer-sequence.js:
   default: 'Test262Error: Expected a ExpectedError but got a Error'
   strict mode: 'Test262Error: Expected a ExpectedError but got a Error'
-test/staging/sm/TypedArray/iterator-next-with-detached.js:
-  default: 'TypeError: Underlying ArrayBuffer has been detached from the view or out-of-bounds'
-  strict mode: 'TypeError: Underlying ArrayBuffer has been detached from the view or out-of-bounds'
 test/staging/sm/TypedArray/slice-memcpy.js:
   default: 'Test262Error: Actual [1, 2, 1, 2, 3, 4] and expected [1, 2, 1, 2, 1, 2] should have the same contents. '
   strict mode: 'Test262Error: Actual [1, 2, 1, 2, 3, 4] and expected [1, 2, 1, 2, 1, 2] should have the same contents. '

--- a/Source/JavaScriptCore/builtins/ArrayIteratorPrototype.js
+++ b/Source/JavaScriptCore/builtins/ArrayIteratorPrototype.js
@@ -31,39 +31,40 @@ function next()
     if (!@isArrayIterator(this))
         @throwTypeError("%ArrayIteratorPrototype%.next requires that |this| be an Array Iterator instance");
 
+    var index = @getArrayIteratorInternalField(this, @arrayIteratorFieldIndex);
+    if (index === -1)
+        return { value: @undefined, done: true };
+
     var array = @getArrayIteratorInternalField(this, @arrayIteratorFieldIteratedObject);
     if (@isTypedArrayView(array) && @isDetached(array))
         @throwTypeError("Underlying ArrayBuffer has been detached from the view or out-of-bounds");
 
     var kind = @getArrayIteratorInternalField(this, @arrayIteratorFieldKind);
-    return @arrayIteratorNextHelper.@call(this, array, kind);
+    return @arrayIteratorNextHelper.@call(this, array, kind, index);
 }
 
 // FIXME: We have to have this because we can't implement this all as one function and meet our inlining heuristics.
 // Collectively, next and this have ~130 bytes of bytecodes but our limit is 120.
 @linkTimeConstant
-function arrayIteratorNextHelper(array, kind)
+function arrayIteratorNextHelper(array, kind, index)
 {
     "use strict";
     var done = true;
     var value;
 
-    var index = @getArrayIteratorInternalField(this, @arrayIteratorFieldIndex);
-    if (index !== -1) {
-        var length = @isTypedArrayView(array) ? @typedArrayLength(array) : @toLength(array.length);
-        if (index < length) {
-            @putArrayIteratorInternalField(this, @arrayIteratorFieldIndex, index + 1);
-            done = false;
-            if (kind === @iterationKindKey)
-                value = index;
-            else {
-                value = array[index];
-                if (kind === @iterationKindEntries)
-                    value = [index, value];
-            }
-        } else
-            @putArrayIteratorInternalField(this, @arrayIteratorFieldIndex, -1);
-    }
+    var length = @isTypedArrayView(array) ? @typedArrayLength(array) : @toLength(array.length);
+    if (index < length) {
+        @putArrayIteratorInternalField(this, @arrayIteratorFieldIndex, index + 1);
+        done = false;
+        if (kind === @iterationKindKey)
+            value = index;
+        else {
+            value = array[index];
+            if (kind === @iterationKindEntries)
+                value = [index, value];
+        }
+    } else
+        @putArrayIteratorInternalField(this, @arrayIteratorFieldIndex, -1);
 
     return { value, done };
 }


### PR DESCRIPTION
#### 6117e70109ac3bc316de61c1e8c4d3f4a7227f43
<pre>
[JSC] Fix test262 failure: test/staging/sm/TypedArray/iterator-next-with-detached.js
<a href="https://bugs.webkit.org/show_bug.cgi?id=310802">https://bugs.webkit.org/show_bug.cgi?id=310802</a>

Reviewed by Sosuke Suzuki.

If source is detached TypedArray and the iterator has been completed,
`%ArrayIteratorPrototype%.next()` should return `{ done: true }`
rather than throwing `TypeError` with describes the source TypedArray is detached.

This complies _step 5_ of _23.1.5.2.1 %ArrayIteratorPrototype%.next()_ in the spec.
<a href="https://tc39.es/ecma262/#sec-%arrayiteratorprototype%.next">https://tc39.es/ecma262/#sec-%arrayiteratorprototype%.next</a>

* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/builtins/ArrayIteratorPrototype.js:

Canonical link: <a href="https://commits.webkit.org/310292@main">https://commits.webkit.org/310292@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/254fc8140e362b5b6550d3cb1c5d3013b55e0e1b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153026 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25808 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19406 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161770 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106484 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26335 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26113 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118279 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83739 "layout-tests (failure) (timed out)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155985 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20514 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137380 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98992 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19588 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17526 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9606 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/145038 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129241 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15253 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164244 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13839 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7380 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16847 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126341 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25605 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21565 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126499 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34396 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25607 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137049 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/82247 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21450 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13828 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184661 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25223 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89510 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47213 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24915 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25074 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24975 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->