### PR TITLE
Guard against use-after-free in case of self move assignment of a BlockPtr

### DIFF
--- a/Source/WTF/wtf/BlockPtr.h
+++ b/Source/WTF/wtf/BlockPtr.h
@@ -194,13 +194,8 @@ public:
 
     BlockPtr& operator=(BlockPtr&& other)
     {
-        ASSERT(this != &other);
-
-#if !__has_feature(objc_arc)
-        Block_release(m_block);
-#endif
-        m_block = std::exchange(other.m_block, nullptr);
-
+        BlockPtr moved(std::move(other));
+        std::swap(m_block, moved.m_block);
         return *this;
     }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/BlockPtr.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/BlockPtr.mm
@@ -39,6 +39,30 @@ TEST(BlockPtr, FromBlock)
     EXPECT_EQ(10u, block());
 }
 
+TEST(BlockPtr, MoveAssignmentFromBlock)
+{
+    BlockPtr<unsigned ()> block { ^{
+        return 10u;
+    } };
+
+    block = WTF::move(block);
+
+    EXPECT_TRUE(!!block);
+    EXPECT_EQ(10u, block());
+}
+
+TEST(BlockPtr, MoveAssignmentFromCallable)
+{
+    auto block = makeBlockPtr([] {
+        return 42u;
+    });
+
+    block = WTF::move(block);
+
+    EXPECT_TRUE(!!block);
+    EXPECT_EQ(42u, block());
+}
+
 TEST(BlockPtr, FromLambda)
 {
     MoveOnly moveOnly { 10 };


### PR DESCRIPTION
#### 4af68f95d78c87ad81b9803eceec63c749076f16
<pre>
Guard against use-after-free in case of self move assignment of a BlockPtr
<a href="https://bugs.webkit.org/show_bug.cgi?id=310807">https://bugs.webkit.org/show_bug.cgi?id=310807</a>

Reviewed by Geoffrey Garen.

Test: Tools/TestWebKitAPI/Tests/WTF/BlockPtr.mm

* Source/WTF/wtf/BlockPtr.h:
(WTF::BlockPtr&lt;R):
* Tools/TestWebKitAPI/Tests/WTF/BlockPtr.mm:
(TestWebKitAPI::TEST(BlockPtr, MoveAssignmentFromBlock)):
(TestWebKitAPI::TEST(BlockPtr, MoveAssignmentFromCallable)):

Canonical link: <a href="https://commits.webkit.org/310034@main">https://commits.webkit.org/310034@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/152e9c0a75e7be26c407f92d941017d11cbfd9ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152385 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25167 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18766 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161128 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105842 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/817cc2c1-f823-4750-9f3f-31bf764e4c71) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154259 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25695 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25473 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117744 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83473 "2 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/37accd56-e8a3-4612-9f60-7c927e4ceb8e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155345 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19955 "Found 1 new test failure: http/wpt/mediarecorder/MediaRecorder-audio-samplingrate-change.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136808 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98457 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19032 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16965 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8962 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144397 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128682 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14682 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163598 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13186 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6740 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16276 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125779 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24965 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21004 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125950 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34196 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24967 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136478 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81567 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20948 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13257 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184017 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24583 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88869 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46919 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24274 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24434 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24335 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->