### PR TITLE
Merge MediaSourceUseRemoteAudioVideoRenderer and WebMUseRemoteAudioVideoRenderer into one pref

### DIFF
--- a/LayoutTests/media/media-source/media-source-has-audio-video-gpu.html
+++ b/LayoutTests/media/media-source/media-source-has-audio-video-gpu.html
@@ -1,4 +1,4 @@
-<!-- webkit-test-runner [ MediaSourceUseRemoteAudioVideoRenderer=false ] -->
+<!-- webkit-test-runner [ MediaContainmentEnabled=false ] -->
 <!DOCTYPE html>
  <html>
 <head>

--- a/LayoutTests/media/video-webm-canvas-drawing.html
+++ b/LayoutTests/media/video-webm-canvas-drawing.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ WebMUseRemoteAudioVideoRenderer=true SWVPDecodersAlwaysEnabled=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ MediaContainmentEnabled=true SWVPDecodersAlwaysEnabled=true ] -->
     <head>
         <title>Drawing to canvas using video</title>
         <script src=media-file.js></script>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -5108,6 +5108,22 @@ MediaContainerTypesAllowedInLockdownMode:
     WebKit:
       default: '"video/mp4,audio/mp4,video/x-m4v,audio/x-m4a,audio/mp3,application/x-mpegURL,application/vnd.apple.mpegURL,video/mp2t,video/iso.segment,audio/aac,audio/mpeg,audio/ac3,audio/eac3,video/mpeg2,text/vtt"_str'
 
+MediaContainmentEnabled:
+  type: bool
+  status: stable
+  category: media
+  humanReadableName: "Media Containment"
+  humanReadableDescription: "Process complex media types in the web process"
+  condition: PLATFORM(COCOA) && ENABLE(VIDEO)
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: true
+    WebCore:
+      default: true
+  sharedPreferenceForWebProcess: true
+
 MediaContentTypesRequiringHardwareSupport:
   type: String
   status: embedder
@@ -5397,22 +5413,6 @@ MediaSourcePrefersDecompressionSession:
       default: false
     WebKit:
       default: WebKit::defaultMediaSourcePrefersDecompressionSession()
-    WebCore:
-      default: true
-  sharedPreferenceForWebProcess: true
-
-MediaSourceUseRemoteAudioVideoRenderer:
-  type: bool
-  status: stable
-  category: media
-  humanReadableName: "MSE player uses GPU renderer"
-  humanReadableDescription: "MSE player uses GPU renderer"
-  condition: PLATFORM(COCOA) && ENABLE(VIDEO)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
     WebCore:
       default: true
   sharedPreferenceForWebProcess: true
@@ -9668,22 +9668,6 @@ WebLocksAPIEnabled:
   disableInLockdownMode: true
   sharedPreferenceForWebProcess: true
   richJavaScript: true
-
-WebMUseRemoteAudioVideoRenderer:
-  type: bool
-  status: stable
-  category: media
-  humanReadableName: "WebM player uses GPU renderer"
-  humanReadableDescription: "WebM player uses GPU renderer"
-  condition: PLATFORM(COCOA) && ENABLE(VIDEO)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: true
-  sharedPreferenceForWebProcess: true
 
 WebPageSpatialBackdropEnabled:
   type: bool

--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -1438,7 +1438,7 @@ ExceptionOr<Ref<SourceBufferPrivate>> MediaSource::createSourceBufferPrivate(con
     MediaSourceConfiguration configuration = {
         .textTracksEnabled = protect(scriptExecutionContext())->settingsValues().textTracksInMSEEnabled,
 #if USE(MEDIAPARSERD)
-        .demuxInProcess = protect(scriptExecutionContext())->settingsValues().mediaSourceUseRemoteAudioVideoRenderer,
+        .demuxInProcess = protect(scriptExecutionContext())->settingsValues().mediaContainmentEnabled,
 #endif
 #if ENABLE(MEDIA_RECORDER_WEBM)
         .supportsLimitedMatroska = (document && document->quirks().needsLimitedMatroskaSupport()) || protect(scriptExecutionContext())->settingsValues().limitedMatroskaSupportEnabled

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5037,8 +5037,8 @@ void WebPage::updatePreferences(const WebPreferencesStore& store)
 #if ENABLE(VIDEO)
     protect(WebProcess::singleton().remoteMediaPlayerManager())->setUseGPUProcess(m_shouldPlayMediaInGPUProcess);
 #if PLATFORM(COCOA)
-    platformStrategies()->mediaStrategy()->enableRemoteRenderer(MediaPlayerMediaEngineIdentifier::CocoaWebM, settings.webMUseRemoteAudioVideoRenderer());
-    platformStrategies()->mediaStrategy()->enableRemoteRenderer(MediaPlayerMediaEngineIdentifier::AVFoundationMSE, settings.mediaSourceUseRemoteAudioVideoRenderer());
+    platformStrategies()->mediaStrategy()->enableRemoteRenderer(MediaPlayerMediaEngineIdentifier::CocoaWebM, settings.mediaContainmentEnabled());
+    platformStrategies()->mediaStrategy()->enableRemoteRenderer(MediaPlayerMediaEngineIdentifier::AVFoundationMSE, settings.mediaContainmentEnabled());
 #endif
 #endif
 #if HAVE(AVASSETREADER)


### PR DESCRIPTION
#### 883f36d61a89fe00b347580742e4b3a3f8301bbf
<pre>
Merge MediaSourceUseRemoteAudioVideoRenderer and WebMUseRemoteAudioVideoRenderer into one pref
<a href="https://bugs.webkit.org/show_bug.cgi?id=310590">https://bugs.webkit.org/show_bug.cgi?id=310590</a>
<a href="https://rdar.apple.com/173199374">rdar://173199374</a>

Reviewed by Anne van Kesteren.

Combine MediaSourceUseRemoteAudioVideoRenderer and WebMUseRemoteAudioVideoRenderer
into a single MediaContainmentEnabled preference.

Both preferences had identical definitions — enabled by default on WebKit/WebCore,
disabled on WebKitLegacy, scoped to PLATFORM(COCOA) &amp;&amp; ENABLE(VIDEO) — and controlled
the same behavior (routing media playback through the GPU renderer).
They are replaced by a single MediaContainmentEnabled preference that covers
both MSE and WebM media engines

Covered by existing tests.

* LayoutTests/media/media-source/media-source-has-audio-video-gpu.html:
* LayoutTests/media/video-webm-canvas-drawing.html:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::createSourceBufferPrivate):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::updatePreferences):

Canonical link: <a href="https://commits.webkit.org/310018@main">https://commits.webkit.org/310018@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9118c921184572577998ae789ed681abc52048b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152391 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25173 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18772 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161134 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105848 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7306c4d6-b47e-4325-ad2b-a6b36cd626cb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154265 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25701 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25479 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117752 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155351 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19957 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136815 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98466 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dd353cd9-1768-446c-9d90-49faeb678759) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19034 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16970 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8969 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144403 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128684 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14689 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163604 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13192 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6746 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16283 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125789 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24971 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21009 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125960 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34182 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24973 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136485 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81573 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20954 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13264 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184023 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24589 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88875 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46920 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24280 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24440 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24341 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->