### PR TITLE
Fix two overflow bugs in CheckedArithmetic's division operations

### DIFF
--- a/Source/WTF/wtf/CheckedArithmetic.h
+++ b/Source/WTF/wtf/CheckedArithmetic.h
@@ -385,7 +385,9 @@ template<typename LHS, typename RHS, typename ResultType> struct ArithmeticOpera
 
     [[nodiscard]] static inline bool divide(LHS lhs, RHS rhs, ResultType& result)
     {
-        if (!rhs)
+        if (!rhs) [[unlikely]]
+            return false;
+        if (rhs == -1 && lhs == std::numeric_limits<ResultType>::min()) [[unlikely]]
             return false;
 
         result = lhs / rhs;
@@ -519,10 +521,12 @@ template<typename ResultType> struct ArithmeticOperations<int, unsigned, ResultT
 
     static inline bool divide(int64_t lhs, int64_t rhs, ResultType& result)
     {
-        if (!rhs)
+        if (!rhs) [[unlikely]]
             return false;
 
         int64_t temp = lhs / rhs;
+        if (!isInBounds<ResultType>(temp)) [[unlikely]]
+            return false;
         result = static_cast<ResultType>(temp);
         return true;
     }

--- a/Tools/TestWebKitAPI/Tests/WTF/CheckedArithmeticOperations.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CheckedArithmeticOperations.cpp
@@ -498,4 +498,97 @@ TEST(CheckedArithmeticTest, Division)
     EXPECT_EQ(100U, size.value());
 }
 
+// Bug 1: Signed division of MIN / -1 should report overflow.
+// INT_MIN / -1 mathematically equals INT_MAX + 1, which doesn't fit in the
+// signed type. The divide() function for signed types only checks for a zero
+// divisor but misses this case entirely. For int16_t, the C++ compiler promotes
+// both operands to int, computes 32768, then the implicit narrowing conversion
+// back to int16_t wraps to -32768 — so we get a silently wrong result instead
+// of an overflow indication. (For int32_t/int64_t this is worse: the hardware
+// idiv instruction traps, causing SIGFPE.)
+TEST(CheckedArithmeticTest, SignedDivisionMinByNegativeOneShouldOverflow)
+{
+    // int8_t: INT8_MIN / -1 = 128, doesn't fit in int8_t (max 127).
+    {
+        Checked<int8_t, RecordOverflow> a = std::numeric_limits<int8_t>::min();
+        Checked<int8_t, RecordOverflow> b = -1;
+        auto result = a / b;
+        EXPECT_TRUE(result.hasOverflowed());
+    }
+
+    // int16_t: INT16_MIN / -1 = 32768, doesn't fit in int16_t (max 32767).
+    {
+        Checked<int16_t, RecordOverflow> a = std::numeric_limits<int16_t>::min();
+        Checked<int16_t, RecordOverflow> b = -1;
+        auto result = a / b;
+        EXPECT_TRUE(result.hasOverflowed());
+    }
+
+    // Also test via operator/=.
+    {
+        Checked<int16_t, RecordOverflow> a = std::numeric_limits<int16_t>::min();
+        a /= static_cast<int16_t>(-1);
+        EXPECT_TRUE(a.hasOverflowed());
+    }
+
+    // Verify that normal signed divisions still work.
+    {
+        Checked<int16_t, RecordOverflow> a = 100;
+        auto result = a / Checked<int16_t, RecordOverflow>(-1);
+        EXPECT_FALSE(result.hasOverflowed());
+        EXPECT_EQ(static_cast<int16_t>(-100), result.value());
+    }
+}
+
+// Bug 2: Mixed-signedness division (int / unsigned) doesn't bounds-check the
+// result against the ResultType. The ResultType for <int, unsigned> is unsigned
+// (chosen by SignednessSelector). When a negative int is divided by a positive
+// unsigned, the int64_t quotient is negative, which cannot be represented in
+// unsigned — but the code does a raw static_cast without checking, producing a
+// silently wrong value (e.g. UINT_MAX) instead of signaling overflow.
+TEST(CheckedArithmeticTest, MixedSignDivisionShouldOverflowWhenResultIsNegative)
+{
+    // -1 / 1u: mathematically -1, which doesn't fit in unsigned.
+    {
+        Checked<int, RecordOverflow> a = -1;
+        Checked<unsigned, RecordOverflow> b = 1;
+        auto result = a / b;
+        EXPECT_TRUE(result.hasOverflowed());
+    }
+
+    // INT_MIN / 1u: mathematically INT_MIN (negative), doesn't fit in unsigned.
+    {
+        Checked<int, RecordOverflow> a = std::numeric_limits<int>::min();
+        Checked<unsigned, RecordOverflow> b = 1;
+        auto result = a / b;
+        EXPECT_TRUE(result.hasOverflowed());
+    }
+
+    // -10 / 3u: mathematically -3 (truncated toward zero), doesn't fit in unsigned.
+    {
+        Checked<int, RecordOverflow> a = -10;
+        Checked<unsigned, RecordOverflow> b = 3;
+        auto result = a / b;
+        EXPECT_TRUE(result.hasOverflowed());
+    }
+
+    // Verify that non-negative results still work.
+    {
+        Checked<int, RecordOverflow> a = 10;
+        Checked<unsigned, RecordOverflow> b = 3;
+        auto result = a / b;
+        EXPECT_FALSE(result.hasOverflowed());
+        EXPECT_EQ(3U, result.value());
+    }
+
+    // 0 / 5u = 0, should succeed.
+    {
+        Checked<int, RecordOverflow> a = 0;
+        Checked<unsigned, RecordOverflow> b = 5;
+        auto result = a / b;
+        EXPECT_FALSE(result.hasOverflowed());
+        EXPECT_EQ(0U, result.value());
+    }
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 88e8afba6872a87b185a62c5d4e3260c91b18ab2
<pre>
Fix two overflow bugs in CheckedArithmetic&apos;s division operations
<a href="https://bugs.webkit.org/show_bug.cgi?id=310811">https://bugs.webkit.org/show_bug.cgi?id=310811</a>

Reviewed by Geoffrey Garen.

Test: Tools/TestWebKitAPI/Tests/WTF/CheckedArithmeticOperations.cpp

* Source/WTF/wtf/CheckedArithmetic.h:
(WTF::ArithmeticOperations::divide): For signed types, detect INT_MIN / -1
as overflow instead of executing undefined behavior. On x86, this would
cause SIGFPE; on narrower types it silently wraps to the wrong value.

(WTF::ArithmeticOperations&lt;int, unsigned&gt;::divide): Add an isInBounds
check on the int64_t quotient before casting to ResultType. Without this,
dividing a negative int by an unsigned (e.g. -1 / 1u) silently produces
UINT_MAX instead of signaling overflow.

* Tools/TestWebKitAPI/Tests/WTF/CheckedArithmeticOperations.cpp:
(TestWebKitAPI::TEST(CheckedArithmeticTest, SignedDivisionMinByNegativeOneShouldOverflow)):
(TestWebKitAPI::TEST(CheckedArithmeticTest, MixedSignDivisionShouldOverflowWhenResultIsNegative)):

Canonical link: <a href="https://commits.webkit.org/310033@main">https://commits.webkit.org/310033@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71f32501cb27f4ad7594b6f3159666e04d605e55

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152392 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25174 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18773 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161135 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105849 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b3065d8d-77b3-47bb-b94b-f07476cc373c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154266 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25702 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25480 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117754 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83477 "5 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/88bbfae7-e239-4efa-895b-f9db4e88ebdc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155352 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19963 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136816 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98468 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f48c4ed6-cd97-4b7f-b1fd-42238b7d8ef9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19040 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16976 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8970 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144404 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128690 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14690 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163605 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13193 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6747 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16284 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125790 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24972 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21015 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125961 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34198 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24974 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136486 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81574 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20956 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13265 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184024 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24590 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88876 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46921 "Failed to checkout and rebase branch from PR 61413") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24281 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24441 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24342 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->