### PR TITLE
Keep Navigation wrapper alive as long as it has pending activity

### DIFF
--- a/LayoutTests/navigation-api/navigation-navigate-event-after-gc-expected.txt
+++ b/LayoutTests/navigation-api/navigation-navigate-event-after-gc-expected.txt
@@ -1,0 +1,10 @@
+Tests that the Navigation wrapper is not garbage collected while it has pending navigation activity (regression test for rdar://162816815).
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS collected is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/navigation-api/navigation-navigate-event-after-gc.html
+++ b/LayoutTests/navigation-api/navigation-navigate-event-after-gc.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/gc.js"></script>
+<script>
+description("Tests that the Navigation wrapper is not garbage collected while it has pending navigation activity (regression test for rdar://162816815).");
+
+jsTestIsAsync = true;
+
+var collected;
+
+window.onload = () => {
+    let iframe = document.createElement("iframe");
+    iframe.src = "resources/navigate-with-intercept.html";
+
+    window.addEventListener("message", (e) => {
+        if (e.data !== "ready")
+            return;
+
+        // The iframe has an ongoing intercepted navigation (pending
+        // activity).  Observe GC of its JSNavigation wrapper.  observeGC
+        // holds only a weak reference, so this does not prevent collection.
+        let observation = internals.observeGC(iframe.contentWindow.navigation);
+
+        // Remove the iframe so its frame detaches and JSDOMWindow is
+        // no longer a GC root.
+        iframe.remove();
+        iframe = null;
+
+        // Defer the GC to a new task so the current call stack (which may
+        // still hold transient references) is fully unwound.
+        setTimeout(() => {
+            gc();
+            gc();
+            gc();
+
+            collected = observation.wasCollected;
+            shouldBeFalse("collected");
+
+            finishJSTest();
+        }, 0);
+    });
+
+    document.body.appendChild(iframe);
+};
+</script>

--- a/LayoutTests/navigation-api/resources/navigate-with-intercept.html
+++ b/LayoutTests/navigation-api/resources/navigate-with-intercept.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<script>
+navigation.addEventListener("navigate", (e) => {
+    if (e.destination.sameDocument)
+        e.intercept({ handler: () => new Promise(() => { /* never resolves */ }) });
+});
+navigation.navigate("#test");
+parent.postMessage("ready", "*");
+</script>

--- a/Source/WebCore/bindings/js/JSNavigationCustom.cpp
+++ b/Source/WebCore/bindings/js/JSNavigationCustom.cpp
@@ -28,8 +28,27 @@
 
 #include "JSNavigateEvent.h"
 #include "NavigateEvent.h"
+#include "WebCoreOpaqueRootInlines.h"
 
 namespace WebCore {
+
+bool JSNavigationOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, JSC::AbstractSlotVisitor& visitor, ASCIILiteral* reason)
+{
+    auto& navigation = JSC::jsCast<JSNavigation*>(handle.slot()->asCell())->wrapped();
+    auto* window = navigation.window();
+    if (!window)
+        return false;
+
+    if (navigation.hasPendingActivity()) {
+        if (reason) [[unlikely]]
+            *reason = "Has Pending Activity"_s;
+        return true;
+    }
+
+    if (reason) [[unlikely]]
+        *reason = "Reachable from Window"_s;
+    return containsWebCoreOpaqueRoot(visitor, window);
+}
 
 template<typename Visitor>
 void JSNavigation::visitAdditionalChildrenInGCThread(Visitor& visitor)

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -161,6 +161,7 @@ public:
 
     // EventTarget.
     ScriptExecutionContext* scriptExecutionContext() const final;
+    bool hasPendingActivity() const { return m_ongoingNavigateEvent || m_transition; }
 
     void rejectFinishedPromise(NavigationAPIMethodTracker*);
     NavigationAPIMethodTracker* upcomingTraverseMethodTracker(const String& key) const;

--- a/Source/WebCore/page/Navigation.idl
+++ b/Source/WebCore/page/Navigation.idl
@@ -27,7 +27,7 @@
 
 [
   EnabledBySetting=NavigationAPIEnabled,
-  GenerateIsReachable=ReachableFromDOMWindow,
+  CustomIsReachable,
   JSCustomMarkFunction,
   Exposed=Window
 ] interface Navigation : EventTarget {


### PR DESCRIPTION
#### b51aa3ed6b4fcbf66554e5ac76faf810a5aba413
<pre>
Keep Navigation wrapper alive as long as it has pending activity
<a href="https://bugs.webkit.org/show_bug.cgi?id=310813">https://bugs.webkit.org/show_bug.cgi?id=310813</a>
<a href="https://rdar.apple.com/162816815">rdar://162816815</a>

Reviewed by NOBODY (OOPS!).

In certain edge cases tying its lifetime to the global does not work.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b51aa3ed6b4fcbf66554e5ac76faf810a5aba413

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152593 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25375 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18974 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161338 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106050 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154467 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25903 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25681 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117913 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83555 "4 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/67064ee7-3b18-4e6f-87c9-7710d76e10a3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155553 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20138 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136994 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98626 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9248495f-b2f1-4208-869f-e9aac1605f7d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19213 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17153 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9172 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128863 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14868 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163809 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6948 "Found 2 new failures in bindings/js/JSNavigationCustom.cpp") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16462 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125971 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25173 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21192 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126132 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25175 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136664 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81777 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21103 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13443 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24791 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89077 "Found 2 new failures in bindings/js/JSNavigationCustom.cpp") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24483 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24642 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24543 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->