### PR TITLE
[JSC] Add `emitBytecodeInConditionContext` for optional chaining

### DIFF
--- a/JSTests/stress/optional-chaining-in-condition-context.js
+++ b/JSTests/stress/optional-chaining-in-condition-context.js
@@ -1,0 +1,614 @@
+//@ requireOptions("--validateGraph=true")
+
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error(`FAIL: ${msg}: expected ${expected}, got ${actual}`);
+}
+
+function shouldThrow(fn, errorType, msg) {
+    let threw = false;
+    try {
+        fn();
+    } catch (e) {
+        threw = true;
+        if (!(e instanceof errorType))
+            throw new Error(`FAIL: ${msg}: expected ${errorType.name}, got ${e.constructor.name}`);
+    }
+    if (!threw)
+        throw new Error(`FAIL: ${msg}: expected throw, got no throw`);
+}
+
+// =========================================================================
+// Basic patterns
+// =========================================================================
+
+function testIf(a) {
+    if (a?.x)
+        return "T";
+    return "F";
+}
+noInline(testIf);
+
+function testNested(a) {
+    if (a?.b?.c)
+        return "T";
+    return "F";
+}
+noInline(testNested);
+
+function testNot(a) {
+    if (!a?.x)
+        return "T";
+    return "F";
+}
+noInline(testNot);
+
+function testAnd(a, b) {
+    if (a?.x && b?.y)
+        return "T";
+    return "F";
+}
+noInline(testAnd);
+
+function testOr(a, b) {
+    if (a?.x || b?.y)
+        return "T";
+    return "F";
+}
+noInline(testOr);
+
+function testTernary(a) {
+    return a?.x ? "T" : "F";
+}
+noInline(testTernary);
+
+function testWhile(n) {
+    let c = 0;
+    while (n?.next) {
+        c++;
+        n = n.next;
+    }
+    return c;
+}
+noInline(testWhile);
+
+function testDoWhile(a) {
+    let c = 0;
+    do {
+        c++;
+    } while (a?.dec && --a.dec > 0);
+    return c;
+}
+noInline(testDoWhile);
+
+function testFor(a) {
+    let c = 0;
+    for (; a?.x > 0; a.x--)
+        c++;
+    return c;
+}
+noInline(testFor);
+
+function testOptCall(a) {
+    if (a?.f?.())
+        return "T";
+    return "F";
+}
+noInline(testOptCall);
+
+function testBracket(a, k) {
+    if (a?.[k])
+        return "T";
+    return "F";
+}
+noInline(testBracket);
+
+function testDelete(a) {
+    if (delete a?.x)
+        return "T";
+    return "F";
+}
+noInline(testDelete);
+
+// =========================================================================
+// Edge cases: deep nesting
+// =========================================================================
+
+function testDeep5(a) {
+    if (a?.b?.c?.d?.e?.f)
+        return "T";
+    return "F";
+}
+noInline(testDeep5);
+
+// =========================================================================
+// Edge cases: mixed ?. and . (non-optional parts can throw)
+// =========================================================================
+
+function testMixed(a) {
+    // a?.b.c : if a is null -> short-circuit
+    //          if a.b is null -> TypeError (because .c is not optional)
+    if (a?.b.c)
+        return "T";
+    return "F";
+}
+noInline(testMixed);
+
+// =========================================================================
+// Edge cases: primitive boxing
+// =========================================================================
+
+function testPrimitive(a) {
+    if (a?.length)
+        return "T";
+    return "F";
+}
+noInline(testPrimitive);
+
+// =========================================================================
+// Edge cases: complex logical expressions
+// =========================================================================
+
+function testComplexLogic(a, b, c) {
+    if ((a?.x || b?.y) && !c?.z)
+        return "T";
+    return "F";
+}
+noInline(testComplexLogic);
+
+function testNestedTernary(a, b) {
+    return a?.x ? (b?.y ? "TT" : "TF") : (b?.y ? "FT" : "FF");
+}
+noInline(testNestedTernary);
+
+function testDoubleNot(a) {
+    if (!!a?.x)
+        return "T";
+    return "F";
+}
+noInline(testDoubleNot);
+
+// =========================================================================
+// Edge cases: side effects
+// =========================================================================
+
+let sideEffectLog = [];
+function side(v, tag) {
+    sideEffectLog.push(tag);
+    return v;
+}
+
+function testSideEffect(a, b) {
+    if (side(a, "a")?.x && side(b, "b")?.y)
+        return "T";
+    return "F";
+}
+noInline(testSideEffect);
+
+function testBracketSideEffect(a) {
+    let i = 0;
+    if (a?.[i++]?.[i++])
+        return `T${i}`;
+    return `F${i}`;
+}
+noInline(testBracketSideEffect);
+
+// =========================================================================
+// Edge cases: getters
+// =========================================================================
+
+let getterCount = 0;
+let getterObj = { get x() { getterCount++; return 1; } };
+let getterFalsy = { get x() { getterCount++; return 0; } };
+let getterThrows = { get x() { getterCount++; throw new Error("getter threw"); } };
+
+function testGetter(a) {
+    if (a?.x)
+        return "T";
+    return "F";
+}
+noInline(testGetter);
+
+function testGetterInTry(a) {
+    try {
+        if (a?.x)
+            return "T";
+        return "F";
+    } catch (e) {
+        return "E";
+    }
+}
+noInline(testGetterInTry);
+
+// =========================================================================
+// Edge cases: Proxy
+// =========================================================================
+
+function testProxy(a) {
+    if (a?.x)
+        return "T";
+    return "F";
+}
+noInline(testProxy);
+
+// =========================================================================
+// Edge cases: Symbol property
+// =========================================================================
+
+let sym = Symbol("test");
+function testSymbol(a) {
+    if (a?.[sym])
+        return "T";
+    return "F";
+}
+noInline(testSymbol);
+
+// =========================================================================
+// Edge cases: comparison in condition (not pure boolean context)
+// =========================================================================
+
+function testCompareUndef(a) {
+    // a?.x === undefined : uses value path, not condition context
+    // but the outer === is in condition context
+    if (a?.x === undefined)
+        return "T";
+    return "F";
+}
+noInline(testCompareUndef);
+
+function testCompareNull(a) {
+    if (a?.x == null)
+        return "T";
+    return "F";
+}
+noInline(testCompareNull);
+
+// =========================================================================
+// Edge cases: nullish coalescing (should NOT use condition context internally)
+// =========================================================================
+
+function testCoalesce(a) {
+    if (a?.x ?? true)
+        return "T";
+    return "F";
+}
+noInline(testCoalesce);
+
+// =========================================================================
+// Edge cases: parenthesized
+// =========================================================================
+
+function testParenthesized(a) {
+    if (((a?.x)))
+        return "T";
+    return "F";
+}
+noInline(testParenthesized);
+
+// =========================================================================
+// Edge cases: if-else chains
+// =========================================================================
+
+function testIfElseChain(a, b, c) {
+    if (a?.x)
+        return "A";
+    else if (b?.y)
+        return "B";
+    else if (c?.z)
+        return "C";
+    return "N";
+}
+noInline(testIfElseChain);
+
+// =========================================================================
+// Edge cases: switch (should NOT use condition context)
+// =========================================================================
+
+function testSwitch(a) {
+    switch (a?.x) {
+    case undefined:
+        return "U";
+    case 1:
+        return "1";
+    default:
+        return "D";
+    }
+}
+noInline(testSwitch);
+
+// =========================================================================
+// Edge cases: polymorphic types (exercise OSR)
+// =========================================================================
+
+function testPoly(a) {
+    if (a?.x)
+        return "T";
+    return "F";
+}
+noInline(testPoly);
+
+// =========================================================================
+// Edge cases: inside try-finally
+// =========================================================================
+
+function testFinally(a) {
+    let r = "N";
+    try {
+        if (a?.x)
+            r = "T";
+        else
+            r = "F";
+    } finally {
+        r += "!";
+    }
+    return r;
+}
+noInline(testFinally);
+
+// =========================================================================
+// Edge cases: inside generator
+// =========================================================================
+
+function* testGenerator(a) {
+    if (a?.x)
+        yield "T";
+    else
+        yield "F";
+}
+
+// =========================================================================
+// Edge cases: inside async
+// =========================================================================
+
+async function testAsync(a) {
+    if (a?.x)
+        return "T";
+    return "F";
+}
+
+// =========================================================================
+// Edge cases: this in optional chain
+// =========================================================================
+
+function testThis() {
+    if (this?.x)
+        return "T";
+    return "F";
+}
+noInline(testThis);
+
+// =========================================================================
+// Edge cases: nested optional chain in condition of inner optional chain
+// =========================================================================
+
+function testInnerChain(a, b) {
+    if (a?.[b?.k])
+        return "T";
+    return "F";
+}
+noInline(testInnerChain);
+
+// =========================================================================
+// Edge cases: comma operator
+// =========================================================================
+
+function testComma(a) {
+    if ((0, a?.x))
+        return "T";
+    return "F";
+}
+noInline(testComma);
+
+// =========================================================================
+// Run all tests
+// =========================================================================
+
+let proxyTrapCount = 0;
+let proxyTruthy = new Proxy({}, {
+    get(t, k) { proxyTrapCount++; return 1; },
+    has(t, k) { return true; }
+});
+
+for (let i = 0; i < testLoopCount; i++) {
+    // Basic
+    shouldBe(testIf(null), "F", "testIf(null)");
+    shouldBe(testIf(undefined), "F", "testIf(undefined)");
+    shouldBe(testIf({}), "F", "testIf({})");
+    shouldBe(testIf({x: 0}), "F", "testIf({x:0})");
+    shouldBe(testIf({x: 1}), "T", "testIf({x:1})");
+    shouldBe(testIf({x: ""}), "F", "testIf({x:''})");
+    shouldBe(testIf({x: "a"}), "T", "testIf({x:'a'})");
+    shouldBe(testIf({x: NaN}), "F", "testIf({x:NaN})");
+    shouldBe(testIf({x: false}), "F", "testIf({x:false})");
+    shouldBe(testIf({x: []}), "T", "testIf({x:[]})");
+
+    shouldBe(testNested(null), "F", "testNested(null)");
+    shouldBe(testNested({}), "F", "testNested({})");
+    shouldBe(testNested({b: null}), "F", "testNested({b:null})");
+    shouldBe(testNested({b: {}}), "F", "testNested({b:{}})");
+    shouldBe(testNested({b: {c: 1}}), "T", "testNested({b:{c:1}})");
+    shouldBe(testNested({b: {c: 0}}), "F", "testNested({b:{c:0}})");
+
+    shouldBe(testNot(null), "T", "testNot(null)");
+    shouldBe(testNot({x: 1}), "F", "testNot({x:1})");
+    shouldBe(testNot({x: 0}), "T", "testNot({x:0})");
+
+    shouldBe(testAnd(null, {y: 1}), "F", "testAnd(null,{y:1})");
+    shouldBe(testAnd({x: 1}, null), "F", "testAnd({x:1},null)");
+    shouldBe(testAnd({x: 1}, {y: 1}), "T", "testAnd({x:1},{y:1})");
+    shouldBe(testAnd({x: 0}, {y: 1}), "F", "testAnd({x:0},{y:1})");
+
+    shouldBe(testOr(null, null), "F", "testOr(null,null)");
+    shouldBe(testOr({x: 1}, null), "T", "testOr({x:1},null)");
+    shouldBe(testOr(null, {y: 1}), "T", "testOr(null,{y:1})");
+    shouldBe(testOr({x: 0}, {y: 0}), "F", "testOr({x:0},{y:0})");
+
+    shouldBe(testTernary(null), "F", "testTernary(null)");
+    shouldBe(testTernary({x: 1}), "T", "testTernary({x:1})");
+    shouldBe(testTernary({x: 0}), "F", "testTernary({x:0})");
+
+    shouldBe(testWhile(null), 0, "testWhile(null)");
+    shouldBe(testWhile({next: {next: {next: null}}}), 2, "testWhile(chain)");
+
+    shouldBe(testDoWhile(null), 1, "testDoWhile(null)");
+    shouldBe(testDoWhile({dec: 3}), 3, "testDoWhile({dec:3})");
+
+    shouldBe(testFor(null), 0, "testFor(null)");
+    shouldBe(testFor({x: 3}), 3, "testFor({x:3})");
+
+    shouldBe(testOptCall(null), "F", "testOptCall(null)");
+    shouldBe(testOptCall({}), "F", "testOptCall({})");
+    shouldBe(testOptCall({f: () => 1}), "T", "testOptCall({f:()=>1})");
+    shouldBe(testOptCall({f: () => 0}), "F", "testOptCall({f:()=>0})");
+    shouldBe(testOptCall({f: null}), "F", "testOptCall({f:null})");
+
+    shouldBe(testBracket(null, "x"), "F", "testBracket(null)");
+    shouldBe(testBracket({x: 1}, "x"), "T", "testBracket({x:1})");
+    shouldBe(testBracket([1], 0), "T", "testBracket([1],0)");
+
+    shouldBe(testDelete(null), "T", "testDelete(null)");
+    shouldBe(testDelete({x: 1}), "T", "testDelete({x:1})");
+
+    // Deep nesting
+    shouldBe(testDeep5(null), "F", "testDeep5(null)");
+    shouldBe(testDeep5({b: {c: {d: {e: {f: 1}}}}}), "T", "testDeep5(full)");
+    shouldBe(testDeep5({b: {c: null}}), "F", "testDeep5(partial)");
+
+    // Mixed ?. and .
+    shouldBe(testMixed(null), "F", "testMixed(null)");
+    shouldBe(testMixed({b: {c: 1}}), "T", "testMixed({b:{c:1}})");
+    shouldThrow(() => testMixed({b: null}), TypeError, "testMixed({b:null}) throws");
+
+    // Primitive boxing
+    shouldBe(testPrimitive(null), "F", "testPrimitive(null)");
+    shouldBe(testPrimitive(""), "F", "testPrimitive('')");
+    shouldBe(testPrimitive("hello"), "T", "testPrimitive('hello')");
+    shouldBe(testPrimitive([]), "F", "testPrimitive([])");
+    shouldBe(testPrimitive([1, 2]), "T", "testPrimitive([1,2])");
+
+    // Complex logic
+    shouldBe(testComplexLogic({x: 1}, null, null), "T", "testComplexLogic(1,_,null)");
+    shouldBe(testComplexLogic(null, {y: 1}, null), "T", "testComplexLogic(_,1,null)");
+    shouldBe(testComplexLogic({x: 1}, null, {z: 1}), "F", "testComplexLogic(1,_,1)");
+    shouldBe(testComplexLogic(null, null, null), "F", "testComplexLogic(_,_,_)");
+
+    shouldBe(testNestedTernary({x: 1}, {y: 1}), "TT", "testNestedTernary(1,1)");
+    shouldBe(testNestedTernary({x: 1}, null), "TF", "testNestedTernary(1,null)");
+    shouldBe(testNestedTernary(null, {y: 1}), "FT", "testNestedTernary(null,1)");
+    shouldBe(testNestedTernary(null, null), "FF", "testNestedTernary(null,null)");
+
+    shouldBe(testDoubleNot(null), "F", "testDoubleNot(null)");
+    shouldBe(testDoubleNot({x: 1}), "T", "testDoubleNot({x:1})");
+    shouldBe(testDoubleNot({x: 0}), "F", "testDoubleNot({x:0})");
+
+    // Side effects (run once per outer loop to avoid excessive log)
+    if (i % 100 === 0) {
+        sideEffectLog = [];
+        testSideEffect(null, {y: 1});
+        shouldBe(sideEffectLog.join(","), "a", "testSideEffect: a null -> only a evaluated");
+
+        sideEffectLog = [];
+        testSideEffect({x: 1}, null);
+        shouldBe(sideEffectLog.join(","), "a,b", "testSideEffect: a.x truthy -> b evaluated");
+
+        sideEffectLog = [];
+        testSideEffect({x: 0}, {y: 1});
+        shouldBe(sideEffectLog.join(","), "a", "testSideEffect: a.x falsy -> b not evaluated");
+    }
+
+    // Bracket side effects
+    shouldBe(testBracketSideEffect(null), "F0", "testBracketSideEffect(null) i=0");
+    shouldBe(testBracketSideEffect([[1, 2]]), "T2", "testBracketSideEffect([[1,2]]) i=2");
+    shouldBe(testBracketSideEffect([null]), "F1", "testBracketSideEffect([null]) i=1");
+    shouldBe(testBracketSideEffect([[1]]), "F2", "testBracketSideEffect([[1]]) i=2");
+
+    // Getters
+    getterCount = 0;
+    testGetter(getterObj);
+    shouldBe(getterCount, 1, "getter called once");
+    testGetter(null);
+    shouldBe(getterCount, 1, "getter not called on null");
+    testGetter(getterFalsy);
+    shouldBe(getterCount, 2, "getter falsy called once");
+
+    getterCount = 0;
+    shouldBe(testGetterInTry(getterThrows), "E", "testGetterInTry throws");
+    shouldBe(getterCount, 1, "throwing getter called once");
+    shouldBe(testGetterInTry(null), "F", "testGetterInTry(null)");
+
+    // Proxy
+    proxyTrapCount = 0;
+    shouldBe(testProxy(proxyTruthy), "T", "testProxy truthy");
+    shouldBe(proxyTrapCount, 1, "proxy trap called once");
+    shouldBe(testProxy(null), "F", "testProxy(null)");
+    shouldBe(proxyTrapCount, 1, "proxy trap not called on null");
+
+    // Symbol
+    shouldBe(testSymbol(null), "F", "testSymbol(null)");
+    shouldBe(testSymbol({[sym]: 1}), "T", "testSymbol({[sym]:1})");
+    shouldBe(testSymbol({}), "F", "testSymbol({})");
+
+    // Comparison (value path)
+    shouldBe(testCompareUndef(null), "T", "testCompareUndef(null)");
+    shouldBe(testCompareUndef({}), "T", "testCompareUndef({})");
+    shouldBe(testCompareUndef({x: 1}), "F", "testCompareUndef({x:1})");
+    shouldBe(testCompareUndef({x: undefined}), "T", "testCompareUndef({x:undefined})");
+
+    shouldBe(testCompareNull(null), "T", "testCompareNull(null)");
+    shouldBe(testCompareNull({x: null}), "T", "testCompareNull({x:null})");
+    shouldBe(testCompareNull({x: 0}), "F", "testCompareNull({x:0})");
+
+    // Nullish coalescing
+    shouldBe(testCoalesce(null), "T", "testCoalesce(null)");
+    shouldBe(testCoalesce({x: 0}), "F", "testCoalesce({x:0})");
+    shouldBe(testCoalesce({x: 1}), "T", "testCoalesce({x:1})");
+    shouldBe(testCoalesce({x: false}), "F", "testCoalesce({x:false})");
+
+    // Parenthesized
+    shouldBe(testParenthesized(null), "F", "testParenthesized(null)");
+    shouldBe(testParenthesized({x: 1}), "T", "testParenthesized({x:1})");
+
+    // If-else chain
+    shouldBe(testIfElseChain({x: 1}, null, null), "A", "testIfElseChain A");
+    shouldBe(testIfElseChain(null, {y: 1}, null), "B", "testIfElseChain B");
+    shouldBe(testIfElseChain(null, null, {z: 1}), "C", "testIfElseChain C");
+    shouldBe(testIfElseChain(null, null, null), "N", "testIfElseChain N");
+
+    // Switch (not optimized, uses value path)
+    shouldBe(testSwitch(null), "U", "testSwitch(null)");
+    shouldBe(testSwitch({x: 1}), "1", "testSwitch({x:1})");
+    shouldBe(testSwitch({x: 2}), "D", "testSwitch({x:2})");
+
+    // Polymorphic
+    shouldBe(testPoly(null), "F", "testPoly(null)");
+    shouldBe(testPoly({x: 1}), "T", "testPoly(obj)");
+    shouldBe(testPoly("str"), "F", "testPoly(str)");
+    shouldBe(testPoly(42), "F", "testPoly(num)");
+
+    // Finally
+    shouldBe(testFinally(null), "F!", "testFinally(null)");
+    shouldBe(testFinally({x: 1}), "T!", "testFinally({x:1})");
+
+    // This
+    shouldBe(testThis.call(null), "F", "testThis(null)");
+    shouldBe(testThis.call({x: 1}), "T", "testThis({x:1})");
+    shouldBe(testThis.call(undefined), "F", "testThis(undefined)");
+
+    // Inner chain
+    shouldBe(testInnerChain(null, {k: "x"}), "F", "testInnerChain(null, {k})");
+    shouldBe(testInnerChain({x: 1}, {k: "x"}), "T", "testInnerChain({x:1}, {k:x})");
+    shouldBe(testInnerChain({x: 1}, null), "F", "testInnerChain({x:1}, null)");
+
+    // Comma
+    shouldBe(testComma(null), "F", "testComma(null)");
+    shouldBe(testComma({x: 1}), "T", "testComma({x:1})");
+}
+
+// Generator (run outside hot loop)
+shouldBe(testGenerator(null).next().value, "F", "testGenerator(null)");
+shouldBe(testGenerator({x: 1}).next().value, "T", "testGenerator({x:1})");
+
+// Async (run outside hot loop)
+testAsync(null).then(v => shouldBe(v, "F", "testAsync(null)"));
+testAsync({x: 1}).then(v => shouldBe(v, "T", "testAsync({x:1})"));
+drainMicrotasks();

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -5832,6 +5832,11 @@ void BytecodeGenerator::pushOptionalChainTarget()
     m_optionalChainTargetStack.append(newLabel());
 }
 
+void BytecodeGenerator::pushOptionalChainTarget(Label& existingTarget)
+{
+    m_optionalChainTargetStack.append(existingTarget);
+}
+
 void BytecodeGenerator::popOptionalChainTarget()
 {
     ASSERT(m_optionalChainTargetStack.size());
@@ -5847,6 +5852,12 @@ void BytecodeGenerator::popOptionalChainTarget(RegisterID* dst, bool isDelete)
     emitLoad(dst, isDelete ? jsBoolean(true) : jsUndefined());
 
     emitLabel(endLabel.get());
+}
+
+void BytecodeGenerator::discardOptionalChainTarget()
+{
+    ASSERT(m_optionalChainTargetStack.size());
+    m_optionalChainTargetStack.removeLast();
 }
 
 void BytecodeGenerator::emitOptionalCheck(RegisterID* src)

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
@@ -1067,8 +1067,10 @@ namespace JSC {
         bool hasFinallyScopes() const { return m_currentFinallyContext; }
 
         void pushOptionalChainTarget();
+        void pushOptionalChainTarget(Label&);
         void popOptionalChainTarget();
         void popOptionalChainTarget(RegisterID* dst, bool isDelete);
+        void discardOptionalChainTarget();
         void emitOptionalCheck(RegisterID* src);
 
         void pushForInScope(RegisterID* local, RegisterID* propertyName, RegisterID* propertyOffset, RegisterID* enumerator, RegisterID* mode, std::optional<Variable> base);

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -3847,6 +3847,25 @@ RegisterID* OptionalChainNode::emitBytecode(BytecodeGenerator& generator, Regist
     return finalDest.unsafeGet();
 }
 
+void OptionalChainNode::emitBytecodeInConditionContext(BytecodeGenerator& generator, Label& trueTarget, Label& falseTarget, FallThroughMode fallThroughMode)
+{
+    if (needsDebugHook()) [[unlikely]]
+        generator.emitDebugHook(this);
+
+    if (m_expr->isDeleteNode()) {
+        ExpressionNode::emitBytecodeInConditionContext(generator, trueTarget, falseTarget, fallThroughMode);
+        return;
+    }
+
+    // Short-circuiting produces undefined, which is falsy. Route the optional
+    // chain bail-out straight to falseTarget instead of materializing undefined.
+    if (m_isOutermost)
+        generator.pushOptionalChainTarget(falseTarget);
+    generator.emitNodeInConditionContext(m_expr, trueTarget, falseTarget, fallThroughMode);
+    if (m_isOutermost)
+        generator.discardOptionalChainTarget();
+}
+
 // ------------------------------ ConditionalNode ------------------------------
 
 RegisterID* ConditionalNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)

--- a/Source/JavaScriptCore/parser/Nodes.h
+++ b/Source/JavaScriptCore/parser/Nodes.h
@@ -1482,6 +1482,7 @@ namespace JSC {
 
     private:
         RegisterID* emitBytecode(BytecodeGenerator&, RegisterID* = nullptr) final;
+        void emitBytecodeInConditionContext(BytecodeGenerator&, Label& trueTarget, Label& falseTarget, FallThroughMode) final;
 
         bool isOptionalChain() const final { return true; }
 


### PR DESCRIPTION
#### bfab8953b9ed56d30b5921db9a1653e6d35c3f84
<pre>
[JSC] Add `emitBytecodeInConditionContext` for optional chaining
<a href="https://bugs.webkit.org/show_bug.cgi?id=310815">https://bugs.webkit.org/show_bug.cgi?id=310815</a>

Reviewed by Yusuke Suzuki.

`if (a?.x)` emitted `mov Undefined` + `jfalse` on short-circuit, even
though undefined is always falsy. This wastes 2 instructions (8 -&gt; 6)
and requires materializing the undefined constant.

Implement OptionalChainNode::emitBytecodeInConditionContext to route
the short-circuit bail-out directly to falseTarget instead of
materializing undefined. The optimization composes with existing
condition-context handling in LogicalNotNode, LogicalOpNode, and
ConditionalNode, so patterns like `if (!a?.x)`, `if (a?.x &amp;&amp; b?.y)`,
`while (node?.next)`, and `a?.x ? 1 : 2` are optimized automatically.

`delete a?.x` is excluded since its short-circuit result is true, not
undefined.

Before:
    [ 1] jundefined_or_null arg1, -&gt;12
    [ 4] get_by_id loc5, arg1, &quot;x&quot;
    [10] jmp -&gt;15
    [12] mov loc5, Undefined
    [15] jfalse loc5, -&gt;20
    [18] ret 1
    [20] ret 2

After:
    [ 1] jundefined_or_null arg1, -&gt;15
    [ 4] get_by_id loc5, arg1, &quot;x&quot;
    [10] jfalse loc5, -&gt;15
    [13] ret 1
    [15] ret 2

Test: JSTests/stress/optional-chaining-in-condition-context.js

* JSTests/stress/optional-chaining-in-condition-context.js: Added.
(shouldBe):
(testNested):
(testNot):
(testAnd):
(testOr):
(testTernary):
(testWhile):
(testDoWhile):
(testFor):
(testOptCall):
(testBracket):
(testDelete):
(testDeep5):
(testMixed):
(testPrimitive):
(testComplexLogic):
(testNestedTernary):
(testDoubleNot):
(testSideEffect):
(testBracketSideEffect):
(let.getterObj.get x):
(let.getterFalsy.get x):
(let.getterThrows.get x):
(testGetter):
(testGetterInTry):
(testProxy):
(testSymbol):
(testCompareUndef):
(testCompareNull):
(testCoalesce):
(testParenthesized):
(testIfElseChain):
(testSwitch):
(testPoly):
(testFinally):
(testGenerator):
(async testAsync):
(testThis):
(testInnerChain):
(testComma):
(get t):
(has):
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::pushOptionalChainTarget):
(JSC::BytecodeGenerator::discardOptionalChainTarget):
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h:
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::OptionalChainNode::emitBytecodeInConditionContext):
* Source/JavaScriptCore/parser/Nodes.h:

Canonical link: <a href="https://commits.webkit.org/312001@main">https://commits.webkit.org/312001@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25a17afc490c771636a34967dc9e2af514ec462b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157921 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31258 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24451 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166749 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112004 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31394 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31260 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122295 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85860 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160879 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24596 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141825 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102961 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23652 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21937 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14522 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149972 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133334 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19627 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169239 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/18756 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/14254 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21250 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130469 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31004 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26003 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130583 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35503 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30942 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141421 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88806 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25319 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18227 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/190050 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30494 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/95677 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48794 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30015 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30245 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30142 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->