### PR TITLE
Use WebKitFontFamilyNames::systemUiFamily in non-CSS callers

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/generic-family-keywords-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/generic-family-keywords-002-expected.txt
@@ -6,7 +6,7 @@ FAIL font-family: -webkit-sans-serif treated as <font-family>, not <generic-name
 FAIL font-family: -webkit-cursive treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 26
 FAIL font-family: -webkit-fantasy treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 34
 FAIL font-family: -webkit-monospace treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 31
-PASS font-family: -webkit-system-ui treated as <font-family>, not <generic-name>
+FAIL font-family: -webkit-system-ui treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 33
 PASS font-family: -webkit-math treated as <font-family>, not <generic-name>
 FAIL font-family: -webkit-generic(fangsong) treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 25
 FAIL font-family: -webkit-generic(kai) treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 25

--- a/Source/WebCore/inspector/InspectorOverlayLabel.cpp
+++ b/Source/WebCore/inspector/InspectorOverlayLabel.cpp
@@ -35,6 +35,7 @@
 #include "FontCascadeDescription.h"
 #include "GraphicsContext.h"
 #include "Path.h"
+#include "WebKitFontFamilyNames.h"
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
@@ -63,7 +64,7 @@ InspectorOverlayLabel::InspectorOverlayLabel(const String& text, FloatPoint loca
 static FontCascade systemFont()
 {
     FontCascadeDescription fontDescription;
-    fontDescription.setFamilies({ "system-ui"_s });
+    fontDescription.setFamilies({ WebKitFontFamilyNames::systemUiFamily.get() });
     fontDescription.setWeight(FontSelectionValue(500));
     fontDescription.setComputedSize(12);
 

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -566,7 +566,7 @@ static std::optional<SpecialCaseFontLookupResult> fontDescriptorWithFamilySpecia
     else if (equalLettersIgnoringASCIICase(family, "ui-rounded"_s))
         systemDesign = SystemFontKind::UIRounded;
 
-    if (equalLettersIgnoringASCIICase(family, "-webkit-system-font"_s) || equalLettersIgnoringASCIICase(family, "-apple-system"_s) || equalLettersIgnoringASCIICase(family, "-apple-system-font"_s) || equalLettersIgnoringASCIICase(family, "system-ui"_s) || equalLettersIgnoringASCIICase(family, "ui-sans-serif"_s)) {
+    if (equalLettersIgnoringASCIICase(family, "-webkit-system-font"_s) || equalLettersIgnoringASCIICase(family, "-apple-system"_s) || equalLettersIgnoringASCIICase(family, "-apple-system-font"_s) || equalLettersIgnoringASCIICase(family, "system-ui"_s) || equalLettersIgnoringASCIICase(family, "-webkit-system-ui"_s) || equalLettersIgnoringASCIICase(family, "ui-sans-serif"_s)) {
         ASSERT(!systemDesign);
         systemDesign = SystemFontKind::SystemUI;
     }

--- a/Source/WebCore/platform/graphics/cocoa/SystemFontDatabaseCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/SystemFontDatabaseCoreText.cpp
@@ -272,6 +272,7 @@ std::optional<SystemFontKind> SystemFontDatabaseCoreText::matchSystemFontUse(con
         || equalLettersIgnoringASCIICase(string, "-apple-system"_s)
         || equalLettersIgnoringASCIICase(string, "-apple-system-font"_s)
         || equalLettersIgnoringASCIICase(string, "system-ui"_s)
+        || equalLettersIgnoringASCIICase(string, "-webkit-system-ui"_s)
         || equalLettersIgnoringASCIICase(string, "ui-sans-serif"_s))
         return SystemFontKind::SystemUI;
 

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -43,6 +43,7 @@
 #include "StyleListStyleType.h"
 #include "StyleScope.h"
 #include "TextUtil.h"
+#include "WebKitFontFamilyNames.h"
 #include <wtf/Assertions.h>
 #include <wtf/StackStats.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -181,7 +182,7 @@ struct TextRunWithUnderlyingString {
 static FontCascade disclosureMarkerFontCascade(const RenderStyle& style, Document& document)
 {
     auto fontDescription = FontCascadeDescription { style.fontDescription() };
-    fontDescription.setFamilies(Vector<AtomString> { "system-ui"_s });
+    fontDescription.setFamilies(Vector<AtomString> { WebKitFontFamilyNames::systemUiFamily.get() });
     auto fontCascade = FontCascade(WTF::move(fontDescription));
     fontCascade.update(&document.fontSelector());
     return fontCascade;


### PR DESCRIPTION
#### 61aae30315d4dcd29216880d6855aafd6a489821
<pre>
Use WebKitFontFamilyNames::systemUiFamily in non-CSS callers
<a href="https://bugs.webkit.org/show_bug.cgi?id=310820">https://bugs.webkit.org/show_bug.cgi?id=310820</a>
<a href="https://rdar.apple.com/173416854">rdar://173416854</a>

Reviewed by NOBODY (OOPS!).

Non-CSS callers (InspectorOverlayLabel, RenderListMarker) were setting
&quot;system-ui&quot; directly on FontCascadeDescription, bypassing the internal
generic family name. This switches them to use the canonical
&quot;-webkit-system-ui&quot; via WebKitFontFamilyNames::systemUiFamily. system-ui
is the only generic family that lacks a dedicated internal name, which has
led to long-standing workarounds across the codebase. This is a step
toward addressing that.

generic-family-keywords-002 now fails for -webkit-system-ui because the
platform matchers recognize it as a generic name. This is intentional and
consistent with all other -webkit- prefixed generics (-webkit-serif,
-webkit-sans-serif, etc.) which already fail the same test.

* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/generic-family-keywords-002-expected.txt:
* Source/WebCore/inspector/InspectorOverlayLabel.cpp:
(WebCore::systemFont):
* Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
(WebCore::fontDescriptorWithFamilySpecialCase):
* Source/WebCore/platform/graphics/cocoa/SystemFontDatabaseCoreText.cpp:
(WebCore::SystemFontDatabaseCoreText::matchSystemFontUse):
* Source/WebCore/rendering/RenderListMarker.cpp:
(WebCore::disclosureMarkerFontCascade):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61aae30315d4dcd29216880d6855aafd6a489821

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152488 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25270 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18869 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161232 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105945 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154362 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25798 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25576 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117833 "Found 2 new test failures: fast/html/details-marker-style-mixed.html fast/html/details-marker-style.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83509 "8 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/42d25e5a-32db-4293-8d7a-0cbdc98494e5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155448 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20045 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136899 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98547 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19121 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-fonts/generic-family-keywords-002.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17059 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9067 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128771 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14773 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163701 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6843 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16367 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125873 "Found 2 new test failures: fast/html/details-marker-style-mixed.html fast/html/details-marker-style.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25068 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21098 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126041 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25070 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136569 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81672 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21036 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13348 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24686 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88972 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24377 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24537 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24438 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->