### PR TITLE
[JSC] Use SIMD to scan multi-character identifiers

### DIFF
--- a/Source/JavaScriptCore/parser/Lexer.cpp
+++ b/Source/JavaScriptCore/parser/Lexer.cpp
@@ -977,6 +977,36 @@ template <bool shouldCreateIdentifier> ALWAYS_INLINE JSTokenType Lexer<Latin1Cha
         shift();
 
     ASSERT(isIdentStart(m_current) || m_current == '\\');
+
+    // Attempt SIMD scan first
+    // caseFoldMask: OR-ing with 0x20 maps 'A'-'Z' to 'a'-'z', so one range check covers both cases.
+    constexpr auto caseFoldMask = SIMD::splat<Latin1Character>(0x20);
+    constexpr auto lowerA = SIMD::splat<Latin1Character>('a');
+    constexpr auto lowerZ = SIMD::splat<Latin1Character>('z');
+    constexpr auto zero = SIMD::splat<Latin1Character>('0');
+    constexpr auto nine = SIMD::splat<Latin1Character>('9');
+    constexpr auto dollar = SIMD::splat<Latin1Character>('$');
+    constexpr auto underscore = SIMD::splat<Latin1Character>('_');
+
+    auto vectorMatch = [&](auto input) ALWAYS_INLINE_LAMBDA {
+        auto folded = SIMD::bitOr(input, caseFoldMask);
+        auto isAlpha = SIMD::bitAnd(SIMD::greaterThanOrEqual(folded, lowerA), SIMD::lessThanOrEqual(folded, lowerZ));
+        auto isDigit = SIMD::bitAnd(SIMD::greaterThanOrEqual(input, zero), SIMD::lessThanOrEqual(input, nine));
+        auto isDollar = SIMD::equal(input, dollar);
+        auto isUnderscore = SIMD::equal(input, underscore);
+        auto isIdentContinue = SIMD::bitOr(isAlpha, isDigit, isDollar, isUnderscore);
+        return SIMD::findFirstNonZeroIndex(SIMD::bitNot(isIdentContinue));
+    };
+
+    auto scalarMatch = [](Latin1Character c) ALWAYS_INLINE_LAMBDA {
+        return !isIdentPart(c);
+    };
+
+    auto* found = SIMD::find(std::span { currentSourcePtr(), m_codeEnd }, vectorMatch, scalarMatch);
+    m_code = found;
+    m_current = (found < m_codeEnd) ? *found : 0;
+
+    // Scalar fallback for non-ASCII Latin1 identifier parts
     while (isIdentPart(m_current))
         shift();
     
@@ -1050,6 +1080,36 @@ template <bool shouldCreateIdentifier> ALWAYS_INLINE JSTokenType Lexer<char16_t>
 
     char16_t orAllChars = 0;
     ASSERT(isSingleCharacterIdentStart(m_current) || U16_IS_SURROGATE(m_current) || m_current == '\\');
+
+    // Attempt SIMD scan first
+    constexpr auto caseFoldMask = SIMD::splat<uint16_t>(0x20);
+    constexpr auto lowerA = SIMD::splat<uint16_t>('a');
+    constexpr auto lowerZ = SIMD::splat<uint16_t>('z');
+    constexpr auto zero = SIMD::splat<uint16_t>('0');
+    constexpr auto nine = SIMD::splat<uint16_t>('9');
+    constexpr auto dollar = SIMD::splat<uint16_t>('$');
+    constexpr auto underscore = SIMD::splat<uint16_t>('_');
+
+    auto vectorMatch = [&](auto input) ALWAYS_INLINE_LAMBDA {
+        auto folded = SIMD::bitOr(input, caseFoldMask);
+        auto isAlpha = SIMD::bitAnd(SIMD::greaterThanOrEqual(folded, lowerA), SIMD::lessThanOrEqual(folded, lowerZ));
+        auto isDigit = SIMD::bitAnd(SIMD::greaterThanOrEqual(input, zero), SIMD::lessThanOrEqual(input, nine));
+        auto isDollar = SIMD::equal(input, dollar);
+        auto isUnderscore = SIMD::equal(input, underscore);
+        auto isIdentContinue = SIMD::bitOr(isAlpha, isDigit, isDollar, isUnderscore);
+        return SIMD::findFirstNonZeroIndex(SIMD::bitNot(isIdentContinue));
+    };
+
+    auto scalarMatch = [](char16_t c) ALWAYS_INLINE_LAMBDA {
+        return !isASCIIAlphanumeric(c) && c != '_' && c != '$';
+    };
+
+    auto* found = SIMD::find(std::span { currentSourcePtr(), m_codeEnd }, vectorMatch, scalarMatch);
+    m_code = found;
+    m_current = (found < m_codeEnd) ? *found : 0;
+    // No need to update orAllChars: all SIMD-matched chars are ASCII, so they don't affect orAllChars & ~0xFF
+
+    // Scalar fallback for non-ASCII identifier parts
     while (isSingleCharacterIdentPart(m_current)) {
         orAllChars |= m_current;
         shift();


### PR DESCRIPTION
#### b584681ad5ff45c053eb30995b8d00a71a29d48e
<pre>
[JSC] Use SIMD to scan multi-character identifiers
<a href="https://bugs.webkit.org/show_bug.cgi?id=310819">https://bugs.webkit.org/show_bug.cgi?id=310819</a>
<a href="https://rdar.apple.com/173416198">rdar://173416198</a>

Reviewed by Yusuke Suzuki.

Even minified sources include a large number of long identifiers
for DOM API names. This patch adds code to use SIMD for scanning
identifiers on the slow (non-single-character) path, only reverting
to scalar scanning when hitting characters outside of the ASCII range.

Testing: covered by existing tests.

* Source/JavaScriptCore/parser/Lexer.cpp:
(JSC::Lexer&lt;Latin1Character&gt;::parseIdentifier):
(JSC::Lexer&lt;char16_t&gt;::parseIdentifier):

Canonical link: <a href="https://commits.webkit.org/310042@main">https://commits.webkit.org/310042@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d473c56fff67bcce4c45159d52d3d70023d14521

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152484 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25266 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18865 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161227 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105941 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/519c66fe-ded9-4062-937d-a10ff3deb3a5) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25794 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25572 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117832 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105941 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4ae51145-0c23-4be6-b08c-1dee48c9f684) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155444 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20041 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136894 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98546 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2458a7dc-9620-4945-9593-37a3b9f69976) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19117 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17057 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9063 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144496 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128767 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14768 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163697 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13287 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6839 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16362 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125881 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25064 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21096 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126048 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34202 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25066 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136564 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81668 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21029 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13343 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184116 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24682 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88968 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46947 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24373 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24533 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24434 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->