### PR TITLE
Web Inspector: Styles: Newly added CSS property is intermittently lost when editing a rule after changing its selector

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Models/CSSStyleDeclaration.js
+++ b/Source/WebInspectorUI/UserInterface/Models/CSSStyleDeclaration.js
@@ -198,8 +198,7 @@ WI.CSSStyleDeclaration = class CSSStyleDeclaration extends WI.Object
             return;
         }
 
-        // Allow updates from the backend when text matches because `properties` may contain warnings that need to be shown.
-        if (this._locked && !options.forceUpdate && text !== this._text)
+        if (this._locked && !options.forceUpdate)
             return;
 
         text = text || "";


### PR DESCRIPTION
#### 34544098f193a69078e4b6458d8bdfd2e17b65a3
<pre>
Web Inspector: Styles: Newly added CSS property is intermittently lost when editing a rule after changing its selector
<a href="https://bugs.webkit.org/show_bug.cgi?id=310810">https://bugs.webkit.org/show_bug.cgi?id=310810</a>
<a href="https://rdar.apple.com/164971557">rdar://164971557</a>

Reviewed by BJ Burg.

There is a race condition when editing the selector of an empty CSS rule
and inserting a new CSS property which causes the eviction of the new property
from `WI.CSSStyleDeclaration.prototype._properties` causing all subsequent input
to be discarded.

After adding a new CSS rule and changing its selector, the style body text on
both the frontend and backend is empty. The next style refresh event
(`WI.DOMNodeStyles.Event.Refreshed`) caused by committing the selector text is explicitly
ignored (`WI.DOMNodeStyles.prototype._ignoreNextContentDidChangeForStyleSheet`).

Buf if another event occurs before that and `WI.CSSStyleDeclaration.prototype.update()`
reacts to it, the early return guard that checks for the active editing state (`_locked`)
and the two empty style body texts is not satisfied.

This replaces the list of properties (`WI.CSSStyleDeclaration.prototype._properties`) with the backend&apos;s empty array, moving the locally created blank CSS property to `WI.CSSStyleDeclaration._pendingProperties`. After this, `WI.CSSStyleDeclaration.generateFormattedText()` produces an empty string
(no properties to format), so the `WI.CSSStyleDeclaration.text` setter early returns
on every keystroke (&quot;&quot; === &quot;&quot;), and `WI.DOMNodeStyles.prototype.changeStyleText()`
is never called.

This patch makes the guard in `WI.CSSStyleDeclaration.prototype.update()` uncondtional
to prevent updates while the style is being edited.

The stated reason for having a style body text check in that guard was to allow for updating
any property warnings, but that&apos;s not necessary in this step. The validity and warnings are
updated in `WI.SpreadSheetStyleProperty.prototype.updateStatus()` in response to
`WI.CSSProperty.Event.Changed` triggered by `WI.CSSProperty.update()` whenever the styles get
refreshed (`WI.DOMNodeStyles.prorotype._parseStylePropertyPayload`), regardless of the style
body text check set `WI.CSSStyleDeclaration`.

* Source/WebInspectorUI/UserInterface/Models/CSSStyleDeclaration.js:

Canonical link: <a href="https://commits.webkit.org/310921@main">https://commits.webkit.org/310921@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59e3e3cbdc10c87075ea1c49058d173dcd1527f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152449 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25231 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18830 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161192 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105906 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/85300003-78f5-4402-9525-559a5bfa21c5) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25759 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25537 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117802 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83495 "3 flakes 2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155409 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20019 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136864 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98516 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b3c1671b-c801-4045-96bf-5afb44e56230) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19095 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17022 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9028 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128745 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14738 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163662 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6804 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16332 "Found 1 new test failure: fast/images/mac/play-pause-individual-animation-context-menu-items.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125838 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25029 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21061 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126009 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34853 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25031 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136534 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81631 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21005 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13313 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24647 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88933 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24338 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24498 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24399 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->