### PR TITLE
Align stagemode orbit between ModelPlayers

### DIFF
--- a/Source/WebKit/Modules/Internal/module.modulemap
+++ b/Source/WebKit/Modules/Internal/module.modulemap
@@ -339,6 +339,12 @@ module WebKit_Internal [system] {
         requires objc
     }
 
+    module WKStageModeOrbitSimulator {
+        header "../../Shared/Model/WKStageModeOrbitSimulator.h"
+        export *
+        requires objc
+    }
+
     module WKSurroundingsEffect {
         header "../../Platform/spi/visionos/WKSurroundingsEffect.h"
         export *

--- a/Source/WebKit/Shared/Model/WKStageModeOrbitSimulator.h
+++ b/Source/WebKit/Shared/Model/WKStageModeOrbitSimulator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,27 +23,20 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "CredentialUpdaterShim.h"
+#import <Foundation/Foundation.h>
 
-#import "ModelTypes.h"
-#import "WKGroupSession.h"
-#import "WKIdentityDocumentPresentmentController.h"
-#import "WKIdentityDocumentPresentmentDelegate.h"
-#import "WKIdentityDocumentPresentmentError.h"
-#import "WKIdentityDocumentPresentmentMobileDocumentRequest.h"
-#import "WKIdentityDocumentPresentmentRawRequest.h"
-#import "WKIdentityDocumentPresentmentRequest.h"
-#import "WKIdentityDocumentPresentmentResponse.h"
-#import "WKIdentityDocumentRawRequestValidator.h"
-#import "WKIntelligenceReplacementTextEffectCoordinator.h"
-#import "WKIntelligenceSmartReplyTextEffectCoordinator.h"
-#import "WKIntelligenceTextEffectCoordinator.h"
-#import "WKMarketplaceKit.h"
-#import "WKPreviewWindowController.h"
-#import "WKRKEntity.h"
-#import "WKSExperienceController.h"
-#import "WKSLinearMediaPlayer.h"
-#import "WKSLinearMediaTypes.h"
-#import "WKStageMode.h"
-#import "WKStageModeOrbitSimulator.h"
-#import "WKTextAnimationManagerIOS.h"
+NS_HEADER_AUDIT_BEGIN(nullability, sendability)
+
+@interface WKStageModeOrbitSimulator : NSObject
+
+@property (nonatomic, readonly) float currentYaw;
+@property (nonatomic, readonly) float currentPitch;
+
+- (void)gestureDidBegin;
+- (void)gestureDidUpdateWithDeltaX:(float)dx deltaY:(float)dy;
+- (void)gestureDidEnd;
+- (BOOL)stepWithElapsedTime:(float)dt;
+
+@end
+
+NS_HEADER_AUDIT_END(nullability, sendability)

--- a/Source/WebKit/Shared/Model/WKStageModeOrbitSimulator.swift
+++ b/Source/WebKit/Shared/Model/WKStageModeOrbitSimulator.swift
@@ -1,0 +1,117 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+import Foundation
+import WebKit_Internal
+
+#if canImport(SwiftUI)
+
+@_weakLinked import SwiftUI
+
+private let pitchSettleDuration: Float = 0.4
+private let maxDecelerationDuration: Float = 2.0
+private let decelerationDampening: Float = 0.95
+private let velocityTerminationThreshold: Float = 0.0001
+
+private let pitchSettleCurve = UnitCurve.bezier(startControlPoint: UnitPoint(x: 0.08, y: 0.6), endControlPoint: UnitPoint(x: 0.4, y: 1.0))
+
+@objc
+@implementation
+extension WKStageModeOrbitSimulator {
+    var currentYaw: Float { yaw }
+    var currentPitch: Float { pitch }
+
+    private var yaw: Float = 0
+    private var pitch: Float = 0
+
+    private var yawAtGestureStart: Float = 0
+    private var pitchAtGestureStart: Float = 0
+    private var previousDeltaX: Float = 0
+    private var yawVelocity: Float = 0
+    private var isDecelerating: Bool = false
+    private var isPitchSettling: Bool = false
+    private var pitchSettleStartPitch: Float = 0
+    private var pitchSettleTime: Float = 0
+    private var decelerationTime: Float = 0
+
+    func gestureDidBegin() {
+        yawAtGestureStart = yaw
+        pitchAtGestureStart = pitch
+        previousDeltaX = 0
+        yawVelocity = 0
+        isDecelerating = false
+        isPitchSettling = false
+    }
+
+    func gestureDidUpdate(withDeltaX dx: Float, deltaY dy: Float) {
+        yaw = yawAtGestureStart + dx
+        pitch = pitchAtGestureStart + dy
+        yawVelocity = dx - previousDeltaX
+        previousDeltaX = dx
+    }
+
+    func gestureDidEnd() {
+        isDecelerating = true
+        isPitchSettling = true
+        pitchSettleStartPitch = pitch
+        pitchSettleTime = 0
+        decelerationTime = 0
+    }
+
+    func step(withElapsedTime dt: Float) -> Bool {
+        if isPitchSettling {
+            pitchSettleTime += dt
+            let t = min(pitchSettleTime / pitchSettleDuration, 1.0)
+            pitch = pitchSettleStartPitch * (1.0 - Float(pitchSettleCurve.value(at: Double(t))))
+            if t >= 1.0 {
+                isPitchSettling = false
+            }
+        }
+
+        if isDecelerating {
+            decelerationTime += dt
+            yaw += yawVelocity
+            yawVelocity *= decelerationDampening
+            if abs(yawVelocity) <= velocityTerminationThreshold || decelerationTime >= maxDecelerationDuration {
+                isDecelerating = false
+            }
+        }
+
+        return isPitchSettling || isDecelerating
+    }
+}
+
+#else
+
+@objc
+@implementation
+extension WKStageModeOrbitSimulator {
+    var currentYaw: Float { 0 }
+    var currentPitch: Float { 0 }
+    func gestureDidBegin() {}
+    func gestureDidUpdate(withDeltaX dx: Float, deltaY dy: Float) {}
+    func gestureDidEnd() {}
+    func step(withElapsedTime dt: Float) -> Bool { false }
+}
+
+#endif

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2069,6 +2069,8 @@
 		B61274A82B7D738100D8ACDA /* WebExtensionAPIWebPageNamespace.h in Headers */ = {isa = PBXBuildFile; fileRef = B61274A62B7D738100D8ACDA /* WebExtensionAPIWebPageNamespace.h */; };
 		B61AFA392950DFB3008220B1 /* WebExtensionAPIPermissions.h in Headers */ = {isa = PBXBuildFile; fileRef = B65DA1D1294BC25300DB503A /* WebExtensionAPIPermissions.h */; };
 		B61AFA4829510D0F008220B1 /* JSWebExtensionAPIPermissions.h in Headers */ = {isa = PBXBuildFile; fileRef = B61AFA4629510D0F008220B1 /* JSWebExtensionAPIPermissions.h */; };
+		B61F9E802F742CFE005CE453 /* WKStageModeOrbitSimulator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B61F9E7F2F742CFE005CE453 /* WKStageModeOrbitSimulator.swift */; };
+		B61F9E812F742CFE005CE453 /* WKStageModeOrbitSimulator.h in Headers */ = {isa = PBXBuildFile; fileRef = B61F9E7E2F742CFE005CE453 /* WKStageModeOrbitSimulator.h */; };
 		B624FF1B2ABE503000F6EDF6 /* WebExtensionScriptInjectionResultParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = B624FF1A2ABE503000F6EDF6 /* WebExtensionScriptInjectionResultParameters.h */; };
 		B626B7BE2B4F1E3A008E8DD1 /* JSWebExtensionAPIStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = B626B7BD2B4F1DF8008E8DD1 /* JSWebExtensionAPIStorage.h */; };
 		B62E7312143047B00069EC35 /* WKHitTestResult.h in Headers */ = {isa = PBXBuildFile; fileRef = B62E7311143047B00069EC35 /* WKHitTestResult.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -7810,6 +7812,8 @@
 		B61274A62B7D738100D8ACDA /* WebExtensionAPIWebPageNamespace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionAPIWebPageNamespace.h; sourceTree = "<group>"; };
 		B61AFA4629510D0F008220B1 /* JSWebExtensionAPIPermissions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSWebExtensionAPIPermissions.h; sourceTree = "<group>"; };
 		B61AFA4729510D0F008220B1 /* JSWebExtensionAPIPermissions.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPIPermissions.mm; sourceTree = "<group>"; };
+		B61F9E7E2F742CFE005CE453 /* WKStageModeOrbitSimulator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKStageModeOrbitSimulator.h; sourceTree = "<group>"; };
+		B61F9E7F2F742CFE005CE453 /* WKStageModeOrbitSimulator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKStageModeOrbitSimulator.swift; sourceTree = "<group>"; };
 		B624FF142ABE4CB000F6EDF6 /* WebExtensionContextAPIScriptingCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionContextAPIScriptingCocoa.mm; sourceTree = "<group>"; };
 		B624FF1A2ABE503000F6EDF6 /* WebExtensionScriptInjectionResultParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionScriptInjectionResultParameters.h; sourceTree = "<group>"; };
 		B624FF1C2ABE54B500F6EDF6 /* WebExtensionDynamicScripts.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WebExtensionDynamicScripts.serialization.in; sourceTree = "<group>"; };
@@ -9828,6 +9832,8 @@
 				0D078EBC2E738DB500A9B266 /* ModelConvertFromBackingContext.h */,
 				0D078EBD2E738DB500A9B266 /* ModelConvertToBackingContext.h */,
 				0D60CB352E8AFA4B00A3FF66 /* WebModelIdentifier.h */,
+				B61F9E7E2F742CFE005CE453 /* WKStageModeOrbitSimulator.h */,
+				B61F9E7F2F742CFE005CE453 /* WKStageModeOrbitSimulator.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -19452,6 +19458,7 @@
 				57FD318722B35170008D0E8B /* WKSOAuthorizationDelegate.h in Headers */,
 				93D6B7B925534A170058DD3A /* WKSpeechRecognitionPermissionCallback.h in Headers */,
 				073A63CD2DC33DA00057A3F5 /* WKStageMode.h in Headers */,
+				B61F9E812F742CFE005CE453 /* WKStageModeOrbitSimulator.h in Headers */,
 				7A78FF32224191960096483E /* WKStorageAccessAlert.h in Headers */,
 				BC407606124FF0270068F20A /* WKString.h in Headers */,
 				BC40761A124FF0370068F20A /* WKStringCF.h in Headers */,
@@ -22234,6 +22241,7 @@
 				B65437972EF31C4E00ED9855 /* WKSeparatedImageView.swift in Sources */,
 				B68905162EF46B0A009187D8 /* WKSeparatedImageViewConstants.swift in Sources */,
 				1DB01944211CF005009FB3E8 /* WKShareSheet.mm in Sources */,
+				B61F9E802F742CFE005CE453 /* WKStageModeOrbitSimulator.swift in Sources */,
 				7A78FF332241919B0096483E /* WKStorageAccessAlert.mm in Sources */,
 				9788BFD92EF4A6940038405A /* WKSurroundingsEffect.swift in Sources */,
 				97311DE42F0DB61F00B23BE9 /* WKSurroundingsEffectView.swift in Sources */,

--- a/Source/WebKit/WebKitSwift/StageMode/WKStageMode.swift
+++ b/Source/WebKit/WebKitSwift/StageMode/WKStageMode.swift
@@ -35,10 +35,6 @@ import simd
 @implementation
 extension WKStageModeInteractionDriver {
     private static let kDragToRotationMultiplier: Float = 3.0
-    private static let kPitchSettleAnimationDuration: Double = 0.4
-    private static let kMaxDecelerationDuration: Double = 2.0
-    private static let kDecelerationDampeningFactor: Float = 0.95
-    private static let kOrbitVelocityTerminationThreshold: Float = 0.0001
 
     private var stageModeOperation: WKStageModeOperation = .none
 
@@ -47,49 +43,22 @@ extension WKStageModeInteractionDriver {
     private let interactionContainer: Entity
 
     /// The nested child container on which yaw changes will be applied.
-    /// We need to separate rotation-related transforms into two entities so that we can later apply post-gesture animations along the yaw and pitch separately
     @nonobjc
     private let turntableInteractionContainer: Entity
-
-    /// A proxy entity used to trigger an animation update for the turntable deceleration
-    /// Because the turntable animation depends on the velocity of the pinch, we have to apply a separate animation for each animation tick.
-    @nonobjc
-    private let turntableAnimationProxyEntity = Entity()
 
     private let modelEntity: WKRKEntity
 
     private weak var delegate: (any WKStageModeInteractionAware)?
 
     private var driverInitialized: Bool = false
-    private var allowAnimationObservation: Bool = false
+
     @nonobjc
     private var initialManipulationPose: Transform = .identity
-    @nonobjc
-    private var previousManipulationPose: Transform = .identity
-    @nonobjc
-    private var initialTargetPose: Transform = .identity
-    @nonobjc
-    private var initialTurntablePose: Transform = .identity
 
-    private var currentOrbitVelocity: simd_float2 = .zero
+    private let simulator = WKStageModeOrbitSimulator()
 
-    // Animation Controllers
     @nonobjc
-    private var pitchSettleAnimationController: AnimationPlaybackController? = nil
-    @nonobjc
-    private var yawDecelerationAnimationController: AnimationPlaybackController? = nil
-    @nonobjc
-    private var pitchAnimationCompletionSubscription: (any Cancellable)? = nil
-    @nonobjc
-    private var yawAnimationCompletionSubscription: (any Cancellable)? = nil
-
-    private var pitchAnimationIsPlaying: Bool {
-        pitchSettleAnimationController?.isPlaying ?? false
-    }
-
-    private var yawAnimationIsPlaying: Bool {
-        yawDecelerationAnimationController?.isPlaying ?? false
-    }
+    private var sceneUpdateSubscription: (any Cancellable)?
 
     // MARK: ObjC Exposed API
     var interactionContainerRef: REEntityRef {
@@ -112,7 +81,6 @@ extension WKStageModeInteractionDriver {
         self.interactionContainer.setParent(containerEntity, preservingWorldTransform: true)
         self.turntableInteractionContainer.setPosition(self.interactionContainer.position(relativeTo: nil), relativeTo: nil)
         self.turntableInteractionContainer.setParent(self.interactionContainer, preservingWorldTransform: true)
-        self.turntableAnimationProxyEntity.setParent(self.interactionContainer.parent)
     }
 
     func setContainerTransformInPortal() {
@@ -127,24 +95,12 @@ extension WKStageModeInteractionDriver {
     }
 
     func interactionDidBegin(_ transform: simd_float4x4) {
-        pitchSettleAnimationController?.pause()
-        pitchSettleAnimationController = nil
-
-        yawDecelerationAnimationController?.pause()
-        yawDecelerationAnimationController = nil
+        sceneUpdateSubscription?.cancel()
+        sceneUpdateSubscription = nil
 
         driverInitialized = true
-        allowAnimationObservation = false
-
-        currentOrbitVelocity = .zero
-
-        let initialPoseTransform = Transform(matrix: transform)
-        initialManipulationPose = initialPoseTransform
-        previousManipulationPose = initialPoseTransform
-        initialTargetPose = interactionContainer.transform
-        initialTargetPose.rotation = .init(ix: 0, iy: 0, iz: 0, r: 1)
-        initialTurntablePose = turntableInteractionContainer.transform
-        turntableAnimationProxyEntity.setPosition(.zero, relativeTo: nil)
+        initialManipulationPose = Transform(matrix: transform)
+        simulator.gestureDidBegin()
 
         delegate?.stageModeInteractionDidUpdateModel()
     }
@@ -154,72 +110,34 @@ extension WKStageModeInteractionDriver {
         let poseTransform = Transform(matrix: transform)
         switch stageModeOperation {
         case .orbit:
-            do {
-                let xyDelta =
-                    (poseTransform.translation.inMeters - initialManipulationPose.translation.inMeters).xy
-                    * Self.kDragToRotationMultiplier
-
-                // Apply pitch along global x axis
-                let containerPitchRotation = Rotation3D(angle: .init(radians: xyDelta.y), axis: .x)
-                interactionContainer.orientation = initialTargetPose.rotation * containerPitchRotation.quaternion.quatf
-
-                // Apply yaw along local y axis
-                let turntableYawRotation = Rotation3D(angle: .init(radians: xyDelta.x), axis: .y)
-                turntableInteractionContainer.orientation = initialTurntablePose.rotation * turntableYawRotation.quaternion.quatf
-
-                currentOrbitVelocity =
-                    (poseTransform.translation.inMeters - previousManipulationPose.translation.inMeters).xy
-                    * Self.kDragToRotationMultiplier
-                break
-            }
+            let xyDelta =
+                (poseTransform.translation.inMeters - initialManipulationPose.translation.inMeters).xy
+                * Self.kDragToRotationMultiplier
+            simulator.gestureDidUpdate(withDeltaX: xyDelta.x, deltaY: xyDelta.y)
+            applySimulatorState()
         default:
             break
         }
 
-        previousManipulationPose = poseTransform
         delegate?.stageModeInteractionDidUpdateModel()
     }
 
     @objc(interactionDidEnd)
     func interactionDidEnd() {
-        allowAnimationObservation = true
-
         initialManipulationPose = .identity
-        previousManipulationPose = .identity
+        simulator.gestureDidEnd()
 
-        // Settle the pitch of the interaction container
-        pitchSettleAnimationController = interactionContainer.move(
-            to: initialTargetPose,
-            relativeTo: interactionContainer.parent,
-            duration: Self.kPitchSettleAnimationDuration,
-            timingFunction: .cubicBezier(controlPoint1: .init(0.08, 0.6), controlPoint2: .init(0.4, 1.0))
-        )
-        subscribeToPitchChanges()
-        pitchAnimationCompletionSubscription = interactionContainer.scene?
-            .subscribe(to: AnimationEvents.PlaybackCompleted.self, on: interactionContainer) { [weak self] _ in
-                guard let self else {
-                    return
+        sceneUpdateSubscription = interactionContainer.scene?
+            .subscribe(to: SceneEvents.Update.self) { [weak self] event in
+                guard let self else { return }
+                if self.simulator.step(withElapsedTime: Float(event.deltaTime)) {
+                    self.applySimulatorState()
+                    self.delegate?.stageModeInteractionDidUpdateModel()
+                } else {
+                    self.sceneUpdateSubscription?.cancel()
+                    self.sceneUpdateSubscription = nil
+                    self.driverInitialized = false
                 }
-
-                self.driverInitialized = self.yawAnimationIsPlaying || self.pitchAnimationIsPlaying
-            }
-
-        // The proxy does not actually perform the turntable animation; we instead use it to programmatically apply a deceleration curve to the yaw
-        // based on the user's current orbit velocity
-        yawDecelerationAnimationController = turntableAnimationProxyEntity.move(
-            to: Transform(scale: .one, rotation: .init(ix: 0, iy: 0, iz: 0, r: 1), translation: .init(repeating: 1)),
-            relativeTo: nil,
-            duration: Self.kMaxDecelerationDuration,
-            timingFunction: .linear
-        )
-        subscribeToYawChanges()
-        yawAnimationCompletionSubscription = turntableAnimationProxyEntity.scene?
-            .subscribe(to: AnimationEvents.PlaybackTerminated.self, on: turntableAnimationProxyEntity) { [weak self] _ in
-                guard let self else {
-                    return
-                }
-
-                self.driverInitialized = self.yawAnimationIsPlaying || self.pitchAnimationIsPlaying
             }
     }
 
@@ -239,57 +157,12 @@ extension WKStageModeInteractionDriver {
         }
     }
 
-    private func subscribeToPitchChanges() {
-        withObservationTracking {
-            #if canImport(RealityFoundation, _version: "403.0.4")
-            _ = interactionContainer.observable.components[Transform.self]
-            #endif
-        } onChange: { [self] in
-            Task { @MainActor in
-                guard allowAnimationObservation else {
-                    return
-                }
+    private func applySimulatorState() {
+        let pitchRotation = Rotation3D(angle: .init(radians: simulator.currentPitch), axis: .x)
+        interactionContainer.orientation = pitchRotation.quaternion.quatf
 
-                delegate?.stageModeInteractionDidUpdateModel()
-
-                // Because the onChange only gets called once, we need to re-subscribe to the function while we are animating
-                if pitchAnimationIsPlaying {
-                    subscribeToPitchChanges()
-                }
-            }
-        }
-    }
-
-    private func subscribeToYawChanges() {
-        withObservationTracking {
-            #if canImport(RealityFoundation, _version: "403.0.4")
-            // By default, we do not care about the proxy, but we use the update to set the deceleration of the turntable container
-            _ = turntableAnimationProxyEntity.observable.components[Transform.self]
-            #endif
-        } onChange: { [self] in
-            Task { @MainActor in
-                guard allowAnimationObservation else {
-                    return
-                }
-
-                let deltaX = currentOrbitVelocity.x
-                let turntableYawQuat = Rotation3D(angle: .init(radians: deltaX), axis: .y)
-                turntableInteractionContainer.orientation *= turntableYawQuat.quaternion.quatf
-                currentOrbitVelocity *= Self.kDecelerationDampeningFactor
-
-                delegate?.stageModeInteractionDidUpdateModel()
-
-                // Because the onChange only gets called once, we need to re-subscribe to the function while we are animating
-                // It is possible that the models stops moving even if the animation continues, so we should check for early stop
-                if abs(currentOrbitVelocity.x) <= Self.kOrbitVelocityTerminationThreshold {
-                    yawDecelerationAnimationController?.stop()
-                }
-
-                if yawAnimationIsPlaying {
-                    subscribeToYawChanges()
-                }
-            }
-        }
+        let yawRotation = Rotation3D(angle: .init(radians: simulator.currentYaw), axis: .y)
+        turntableInteractionContainer.orientation = yawRotation.quaternion.quatf
     }
 }
 

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.h
@@ -38,6 +38,7 @@
 #include <wtf/URL.h>
 
 OBJC_CLASS WKBridgeModelLoader;
+OBJC_CLASS WKStageModeOrbitSimulator;
 
 namespace WebModel {
 struct ImageAsset;
@@ -136,12 +137,10 @@ private:
         Paused
     };
     PauseState m_pauseState { PauseState::None };
-    std::optional<WebCore::LayoutPoint> m_currentPoint;
+    std::optional<WebCore::LayoutPoint> m_initialPoint;
     std::optional<Ref<WebCore::SharedBuffer>> m_environmentMap;
-    float m_yawAcceleration { 0.f };
-    float m_pitchAcceleration { 0.f };
-    float m_yaw { 0.f };
-    float m_pitch { 0.f };
+    RetainPtr<WKStageModeOrbitSimulator> m_orbitSimulator;
+    MonotonicTime m_lastUpdateTime;
     float m_playbackRate { 1.0f };
     bool m_isLooping { false };
 };

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
@@ -33,6 +33,7 @@
 #import "ModelInlineConverters.h"
 #import "ModelTypes.h"
 #import "RemoteGPUProxy.h"
+#import "WKStageModeOrbitSimulator.h"
 #import "WebKitSwiftSoftLink.h"
 #import <WebCore/Document.h>
 #import <WebCore/FloatPoint3D.h>
@@ -404,28 +405,29 @@ void WebModelPlayer::enterFullscreen()
 
 void WebModelPlayer::handleMouseDown(const WebCore::LayoutPoint& startingPoint, MonotonicTime)
 {
-    m_currentPoint = startingPoint;
-    m_yawAcceleration = 0.f;
-    m_pitchAcceleration = 0.f;
+    m_initialPoint = startingPoint;
+    if (!m_orbitSimulator)
+        m_orbitSimulator = adoptNS([[WKStageModeOrbitSimulator alloc] init]);
+    [m_orbitSimulator gestureDidBegin];
 }
 
 void WebModelPlayer::handleMouseMove(const WebCore::LayoutPoint& currentPoint, MonotonicTime)
 {
-    if (!m_currentPoint)
+    if (!m_initialPoint)
         return;
 
-    float deltaX = static_cast<float>(m_currentPoint->x() - currentPoint.x());
-    float deltaY = static_cast<float>(currentPoint.y() - m_currentPoint->y());
-    m_currentPoint = currentPoint;
-    if (RefPtr model = m_currentModel) {
-        if (m_yawAcceleration * deltaX < 0.f)
-            m_yawAcceleration = 0.f;
-        if (m_pitchAcceleration * deltaY < 0.f)
-            m_pitchAcceleration = 0.f;
+    static constexpr float kDragToRotationMultiplier = 0.005;
 
-        m_yawAcceleration += 0.1f * deltaX;
-        m_pitchAcceleration += 0.1f * deltaY;
-    }
+    float totalDeltaX = static_cast<float>(m_initialPoint->x() - currentPoint.x()) * kDragToRotationMultiplier;
+    float totalDeltaY = static_cast<float>(currentPoint.y() - m_initialPoint->y()) * kDragToRotationMultiplier;
+
+    RetainPtr orbitSimulator = m_orbitSimulator;
+    if (!orbitSimulator)
+        return;
+
+    [orbitSimulator gestureDidUpdateWithDeltaX:totalDeltaX deltaY:totalDeltaY];
+    if (RefPtr model = m_currentModel)
+        model->setRotation([orbitSimulator currentYaw], [orbitSimulator currentPitch]);
 }
 
 bool WebModelPlayer::supportsMouseInteraction()
@@ -435,7 +437,9 @@ bool WebModelPlayer::supportsMouseInteraction()
 
 void WebModelPlayer::handleMouseUp(const WebCore::LayoutPoint&, MonotonicTime)
 {
-    m_currentPoint = std::nullopt;
+    m_initialPoint = std::nullopt;
+    if (RetainPtr orbitSimulator = m_orbitSimulator)
+        [orbitSimulator gestureDidEnd];
 }
 
 void WebModelPlayer::getCamera(CompletionHandler<void(std::optional<WebCore::HTMLModelElementCamera>&&)>&&)
@@ -542,23 +546,11 @@ void WebModelPlayer::simulate(float elapsedTime)
     if (!model || !m_didFinishLoading)
         return;
 
-    m_yawAcceleration *= 0.95f;
-    m_pitchAcceleration *= 0.95f;
-
-    const float simulationEpsilon = 0.01f;
-    m_yawAcceleration = std::clamp(m_yawAcceleration, -5.f, 5.f);
-    m_pitchAcceleration = std::clamp(m_pitchAcceleration, -5.f, 5.f);
-    if (fabs(m_yawAcceleration) < simulationEpsilon)
-        m_yawAcceleration = 0.f;
-    if (fabs(m_pitchAcceleration) < simulationEpsilon)
-        m_pitchAcceleration = 0.f;
-
-    m_yaw += m_yawAcceleration * elapsedTime;
-    m_pitch += m_pitchAcceleration * elapsedTime;
-    m_pitch *= (1.f - elapsedTime);
-
-    if (m_yawAcceleration || m_pitchAcceleration)
-        model->setRotation(m_yaw, m_pitch);
+    RetainPtr orbitSimulator = m_orbitSimulator;
+    if (!orbitSimulator)
+        return;
+    if ([orbitSimulator stepWithElapsedTime:elapsedTime])
+        model->setRotation([orbitSimulator currentYaw], [orbitSimulator currentPitch]);
 }
 
 void WebModelPlayer::setPlaybackRate(double newRate, CompletionHandler<void(double effectivePlaybackRate)>&& completion)
@@ -569,7 +561,11 @@ void WebModelPlayer::setPlaybackRate(double newRate, CompletionHandler<void(doub
 
 void WebModelPlayer::update()
 {
-    constexpr float elapsedTime = 1.f / 60.f;
+    auto now = MonotonicTime::now();
+    float elapsed = m_lastUpdateTime ? static_cast<float>((now - m_lastUpdateTime).seconds()) : (1.f / 60.f);
+    float elapsedTime = std::clamp(elapsed, 1.f / 120.f, 1.f / 15.f);
+    m_lastUpdateTime = now;
+
     simulate(elapsedTime);
 
     auto timeDelta = paused() ? 0.f : (m_playbackRate * elapsedTime);


### PR DESCRIPTION
#### 750b2f96977b0283fe97a9915098919d884f9941
<pre>
Align stagemode orbit between ModelPlayers
<a href="https://bugs.webkit.org/show_bug.cgi?id=310825">https://bugs.webkit.org/show_bug.cgi?id=310825</a>
&lt;<a href="https://rdar.apple.com/172189776">rdar://172189776</a>&gt;

Reviewed by Mike Wyrzykowski.

Introduce a new WKStageModeOrbitSimulator that can be shared between
ModelPlayers. It&apos;s based on the visionOS implementation.

The `kDragToRotationMultiplier` remains platform specific since we use a
very different input system on visionOS (indirect manipulation in meters).

* Source/WebKit/Modules/Internal/module.modulemap:
* Source/WebKit/Shared/Model/WKStageModeOrbitSimulator.h: Added.
* Source/WebKit/Shared/Model/WKStageModeOrbitSimulator.swift: Added.
(WKStageModeOrbitSimulator.currentYaw):
(WKStageModeOrbitSimulator.currentPitch):
(WKStageModeOrbitSimulator.yaw):
(WKStageModeOrbitSimulator.pitch):
(WKStageModeOrbitSimulator.yawAtGestureStart):
(WKStageModeOrbitSimulator.pitchAtGestureStart):
(WKStageModeOrbitSimulator.previousDeltaX):
(WKStageModeOrbitSimulator.yawVelocity):
(WKStageModeOrbitSimulator.isDecelerating):
(WKStageModeOrbitSimulator.isPitchSettling):
(WKStageModeOrbitSimulator.pitchSettleStartPitch):
(WKStageModeOrbitSimulator.pitchSettleTime):
(WKStageModeOrbitSimulator.decelerationTime):
(WKStageModeOrbitSimulator.gestureDidBegin):
(WKStageModeOrbitSimulator.gestureDidUpdate(deltaX:deltaY:)):
(WKStageModeOrbitSimulator.gestureDidEnd):
(WKStageModeOrbitSimulator.step(elapsedTime:)):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
New simulator handling yaw and pitch during interaction, deceleration
and pitch settling.

* Source/WebKit/WebKitSwift/StageMode/WKStageMode.swift:
(WKStageModeInteractionDriver.initialManipulationPose):
(WKStageModeInteractionDriver.sceneUpdateSubscription):
(WKStageModeInteractionDriver.interactionDidBegin(_:)):
(WKStageModeInteractionDriver.interactionDidUpdate(_:)):
(WKStageModeInteractionDriver.interactionDidEnd):
(WKStageModeInteractionDriver.applySimulatorState):
(WKStageModeInteractionDriver.allowAnimationObservation): Deleted.
(WKStageModeInteractionDriver.previousManipulationPose): Deleted.
(WKStageModeInteractionDriver.initialTargetPose): Deleted.
(WKStageModeInteractionDriver.initialTurntablePose): Deleted.
(WKStageModeInteractionDriver.currentOrbitVelocity): Deleted.
(WKStageModeInteractionDriver.pitchSettleAnimationController): Deleted.
(WKStageModeInteractionDriver.yawDecelerationAnimationController): Deleted.
(WKStageModeInteractionDriver.pitchAnimationCompletionSubscription): Deleted.
(WKStageModeInteractionDriver.yawAnimationCompletionSubscription): Deleted.
(WKStageModeInteractionDriver.pitchAnimationIsPlaying): Deleted.
(WKStageModeInteractionDriver.yawAnimationIsPlaying): Deleted.
(WKStageModeInteractionDriver.subscribeToPitchChanges): Deleted.
(WKStageModeInteractionDriver.subscribeToYawChanges): Deleted.
Adopt the new WKStageModeOrbitSimulator. This removes the need for
RealityKit deceleration/pitch settling animations which greatly
simplifies the code. These animations were fully observed anyway to
report the transform back so driving the animation from Scene update
events is not an issue.

* Source/WebKit/WebKitSwift/WebKitSwift.h:
* Source/WebKit/WebProcess/Model/WebModelPlayer.h:
* Source/WebKit/WebProcess/Model/WebModelPlayer.mm:
(WebKit::WebModelPlayer::handleMouseDown):
(WebKit::WebModelPlayer::handleMouseMove):
(WebKit::WebModelPlayer::handleMouseUp):
(WebKit::WebModelPlayer::simulate):
(WebKit::WebModelPlayer::update):
Adopt the new WKStageModeOrbitSimulator. Remove the old temporary
implementation. And start tracking delta between updates instead of
using a hardcoded 1 / 60 value.

Canonical link: <a href="https://commits.webkit.org/310090@main">https://commits.webkit.org/310090@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/770a9b7258016fffde09520a26b3550a36c1864b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152618 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25400 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18999 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161363 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106075 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25928 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25706 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117931 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155578 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20155 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137014 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98644 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19230 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17172 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9197 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128880 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163834 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6973 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16482 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125989 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25198 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21211 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126150 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34239 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25200 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136684 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81803 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21122 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13463 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24816 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89102 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24508 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24667 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24568 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->