### PR TITLE
[Site Isolation] Should not be able to access the full URL of any arbitrary RemoteFrame

### DIFF
--- a/LayoutTests/platform/ios-site-isolation/TestExpectations
+++ b/LayoutTests/platform/ios-site-isolation/TestExpectations
@@ -438,3 +438,14 @@ svg/custom/svg-image-dark-mode-initial.html [ ImageOnlyFailure ]
 # Tests with missing expectations #
 ####################################
 fast/block/float/independent-align-positioning.html [ Missing ]
+
+####################################
+# Tests with intentional text fail #
+####################################
+# The following two tests have a different console log with Site Isolation enabled
+# vs disabled. The difference is that with Site Isolation enabled, the error message
+# only includes the protocol and origin of a RemoteFrame when with Site Isolation
+# is disabled the other frame is a LocalFrame which we log the URL with the
+# full path.
+http/tests/security/block-top-level-navigation-to-different-scheme-by-third-party-iframes.html [ Failure ]
+http/tests/security/block-top-level-navigations-by-third-party-iframes.html [ Failure ]

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -518,3 +518,14 @@ fast/history/page-cache-clearing.html [ Skip ]
 http/tests/navigation/page-cache-video.html [ Skip ]
 http/tests/referrer-policy/no-referrer/cross-origin-pson-bfcache-restoration.html [ Skip ]
 imported/w3c/web-platform-tests/cookies/third-party-cookies/third-party-cookies.tentative.https.html [ Skip ]
+
+####################################
+# Tests with intentional text fail #
+####################################
+# The following two tests have a different console log with Site Isolation enabled
+# vs disabled. The difference is that with Site Isolation enabled, the error message
+# only includes the protocol and origin of a RemoteFrame when with Site Isolation
+# is disabled the other frame is a LocalFrame which we log the URL with the
+# full path.
+http/tests/security/block-top-level-navigation-to-different-scheme-by-third-party-iframes.html [ Failure ]
+http/tests/security/block-top-level-navigations-by-third-party-iframes.html [ Failure ]

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -575,9 +575,8 @@ static bool canAccessAncestor(const SecurityOrigin& activeSecurityOrigin, Frame*
 
 static void printNavigationErrorMessage(Document& document, Frame& frame, const URL& activeURL, ASCIILiteral reason)
 {
-    frame.documentURLForConsoleLog([window = protect(document.window()), activeURL, reason] (const URL& documentURL) {
-        window->printErrorMessage(makeString("Unsafe JavaScript attempt to initiate navigation for frame with URL '"_s, documentURL.string(), "' from frame with URL '"_s, activeURL.string(), "'. "_s, reason, '\n'));
-    });
+    auto documentURL = frame.urlForConsoleLog();
+    document.window()->printErrorMessage(makeString("Unsafe JavaScript attempt to initiate navigation for frame with URL '"_s, documentURL.string(), "' from frame with URL '"_s, activeURL.string(), "'. "_s, reason, '\n'));
 }
 
 uint64_t Document::s_globalTreeVersion = 0;

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -122,7 +122,7 @@ public:
     virtual FrameView* virtualView() const = 0;
     virtual void disconnectView() = 0;
     virtual FrameLoaderClient& loaderClient() = 0;
-    virtual void documentURLForConsoleLog(CompletionHandler<void(const URL&)>&&) = 0;
+    virtual URL urlForConsoleLog() const = 0;
 
     virtual String customUserAgent() const = 0;
     virtual String customUserAgentAsSiteSpecificQuirks() const = 0;

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -1040,12 +1040,12 @@ FrameLoaderClient& LocalFrame::loaderClient()
     return loader().client();
 }
 
-void LocalFrame::documentURLForConsoleLog(CompletionHandler<void(const URL&)>&& completionHandler)
+URL LocalFrame::urlForConsoleLog() const
 {
     RefPtr document = this->document();
     if (!document)
-        return completionHandler({ });
-    completionHandler(document->url());
+        return { };
+    return document->url();
 }
 
 String LocalFrame::trackedRepaintRectsAsText() const

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -392,7 +392,7 @@ private:
     DOMWindow* NODELETE virtualWindow() const final;
     void reinitializeDocumentSecurityContext() final;
     FrameLoaderClient& NODELETE loaderClient() LIFETIME_BOUND final;
-    void documentURLForConsoleLog(CompletionHandler<void(const URL&)>&&) final;
+    URL urlForConsoleLog() const final;
 
     WeakHashSet<FrameDestructionObserver> m_destructionObservers;
 

--- a/Source/WebCore/page/RemoteFrame.cpp
+++ b/Source/WebCore/page/RemoteFrame.cpp
@@ -167,9 +167,9 @@ String RemoteFrame::customNavigatorPlatform() const
     return m_customNavigatorPlatform;
 }
 
-void RemoteFrame::documentURLForConsoleLog(CompletionHandler<void(const URL&)>&& completionHandler)
+URL RemoteFrame::urlForConsoleLog() const
 {
-    m_client->documentURLForConsoleLog(WTF::move(completionHandler));
+    return frameDocumentSecurityOrigin()->toURL();
 }
 
 OptionSet<AdvancedPrivacyProtections> RemoteFrame::advancedPrivacyProtections() const

--- a/Source/WebCore/page/RemoteFrame.h
+++ b/Source/WebCore/page/RemoteFrame.h
@@ -103,7 +103,7 @@ private:
     void loadFrameRequest(FrameLoadRequest&&, Event*) final;
     void didFinishLoadInAnotherProcess() final;
     bool isRootFrame() const final { return false; }
-    void documentURLForConsoleLog(CompletionHandler<void(const URL&)>&&) final;
+    URL urlForConsoleLog() const final;
     SecurityOrigin* NODELETE frameDocumentSecurityOrigin() const final;
     std::optional<DocumentSecurityPolicy> NODELETE frameDocumentSecurityPolicy() const final;
     String NODELETE frameURLProtocol() const final;

--- a/Source/WebCore/page/RemoteFrameClient.h
+++ b/Source/WebCore/page/RemoteFrameClient.h
@@ -70,7 +70,6 @@ public:
 #endif
     virtual void focus() = 0;
     virtual void unfocus() = 0;
-    virtual void documentURLForConsoleLog(CompletionHandler<void(const URL&)>&&) = 0;
     virtual void updateScrollingMode(ScrollbarMode scrollingMode) = 0;
     virtual void reportMixedContentViolation(bool blocked, const URL& target) = 0;
     virtual void findFocusableElementDescendingIntoRemoteFrame(FocusDirection, const FocusEventData&, ShouldFocusElement, CompletionHandler<void(FoundElementInRemoteFrame)>&&) = 0;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -17799,14 +17799,6 @@ void WebPageProxy::updateRemoteFrameAccessibilityInheritedState(WebCore::FrameId
 }
 #endif
 
-void WebPageProxy::documentURLForConsoleLog(WebCore::FrameIdentifier frameID, CompletionHandler<void(const URL&)>&& completionHandler)
-{
-    // FIXME: <rdar://125885582> Respond with an empty string if there's no inspector and no test runner.
-    if (RefPtr frame = WebFrameProxy::webFrame(frameID))
-        return completionHandler(frame->url());
-    completionHandler({ });
-}
-
 void WebPageProxy::reportMixedContentViolation(FrameIdentifier frameID, bool blocked, const URL& target)
 {
     RefPtr frame = WebFrameProxy::webFrame(frameID);

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3619,7 +3619,6 @@ private:
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     void updateRemoteFrameAccessibilityInheritedState(WebCore::FrameIdentifier, const WebCore::InheritedFrameState&);
 #endif
-    void documentURLForConsoleLog(WebCore::FrameIdentifier, CompletionHandler<void(const URL&)>&&);
     void reportMixedContentViolation(WebCore::FrameIdentifier, bool blocked, const URL& target);
     void drawFrameToSnapshot(WebCore::FrameIdentifier, const WebCore::IntRect&, RemoteSnapshotIdentifier, CompletionHandler<void(bool)>&&);
 

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -694,7 +694,6 @@ messages -> WebPageProxy {
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     [EnabledBy=SiteIsolationEnabled] UpdateRemoteFrameAccessibilityInheritedState(WebCore::FrameIdentifier frameID, struct WebCore::InheritedFrameState state)
 #endif
-    [EnabledBy=SiteIsolationEnabled] DocumentURLForConsoleLog(WebCore::FrameIdentifier frameID) -> (URL url)
     [EnabledBy=SiteIsolationEnabled] ReportMixedContentViolation(WebCore::FrameIdentifier frameID, bool blocked, URL target)
     [EnabledBy=SiteIsolationEnabled] DrawFrameToSnapshot(WebCore::FrameIdentifier frameID, WebCore::IntRect rect, WebKit::RemoteSnapshotIdentifier snapshotIdentifier) -> (bool success)
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
@@ -194,14 +194,6 @@ void WebRemoteFrameClient::unfocus()
         page->send(Messages::WebPageProxy::SetFocus(false));
 }
 
-void WebRemoteFrameClient::documentURLForConsoleLog(CompletionHandler<void(const URL&)>&& completionHandler)
-{
-    if (RefPtr page = m_frame->page())
-        page->sendWithAsyncReply(Messages::WebPageProxy::DocumentURLForConsoleLog(m_frame->frameID()), WTF::move(completionHandler));
-    else
-        completionHandler({ });
-}
-
 void WebRemoteFrameClient::dispatchDecidePolicyForNavigationAction(const NavigationAction& navigationAction, const ResourceRequest& request, const ResourceResponse& redirectResponse,
     FormState* formState, const String& clientRedirectSourceForHistory, std::optional<WebCore::NavigationIdentifier> navigationID, std::optional<HitTestResult>&& hitTestResult, bool hasOpener, NavigationUpgradeToHTTPSBehavior navigationUpgradeToHTTPSBehavior, SandboxFlags sandboxFlags, PolicyDecisionMode policyDecisionMode, FramePolicyFunction&& function)
 {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h
@@ -60,7 +60,6 @@ private:
     void closePage() final;
     void focus() final;
     void unfocus() final;
-    void documentURLForConsoleLog(CompletionHandler<void(const URL&)>&&) final;
     void dispatchDecidePolicyForNavigationAction(const WebCore::NavigationAction&, const WebCore::ResourceRequest&, const WebCore::ResourceResponse& redirectResponse, WebCore::FormState*, const String& clientRedirectSourceForHistory, std::optional<WebCore::NavigationIdentifier>, std::optional<WebCore::HitTestResult>&&, bool hasOpener, WebCore::NavigationUpgradeToHTTPSBehavior, WebCore::SandboxFlags, WebCore::PolicyDecisionMode, WebCore::FramePolicyFunction&&) final;
     void updateSandboxFlags(WebCore::SandboxFlags) final;
     void updateOpener(std::optional<WebCore::FrameIdentifier>) final;


### PR DESCRIPTION
#### f507f575da276104f24569ecbec4054eb850e13f
<pre>
[Site Isolation] Should not be able to access the full URL of any arbitrary RemoteFrame
<a href="https://bugs.webkit.org/show_bug.cgi?id=310829">https://bugs.webkit.org/show_bug.cgi?id=310829</a>
<a href="https://rdar.apple.com/173430966">rdar://173430966</a>

Reviewed by Sihui Liu.

The function `RemoteFrame::documentURLForConsoleLog` allows a
frame to access the full URL of any `RemoteFrame` with site
isolation enabled. In our site isolation threat model, we
don&apos;t want to allow frames to access any RemoteFrame&apos;s full
URL as it could contain valuable information to a compromised
WebContent process. Instead, we should follow the precedent of
other site isolation work and only allow the protocol and
domain of RemoteFrames to be shared.

This patch updates `RemoteFrame::documentURLForConsoleLog`
from fetching the full URL via async IPC to now using
the protocol and domain from frame tree sync data.

`RemoteFrame::documentURLForConsoleLog` was the only user of
the Messages::WebPageProxy::DocumentURLForConsoleLog IPC
message, so this patch removes it.

Since there&apos;s no IPC, `Frame::documentURLForConsoleLog` can
be made synchronous both in the LocalFrame and RemoteFrame
implementations

No new tests, however this changes the behavior of the following
two tests with site isolation enabled. Since this deviation
from pre site isolation behavior is intended, the tests are
marked as failing with a comment in the site isolation
specific TestExpectations files.
http/tests/security/block-top-level-navigation-to-different-scheme-by-third-party-iframes.html
http/tests/security/block-top-level-navigations-by-third-party-iframes.html

* LayoutTests/platform/ios-site-isolation/TestExpectations:
* LayoutTests/platform/mac-site-isolation/TestExpectations:
* Source/WebCore/dom/Document.cpp:
(WebCore::printNavigationErrorMessage):
* Source/WebCore/page/Frame.h:
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::urlForConsoleLog const):
(WebCore::LocalFrame::documentURLForConsoleLog): Deleted.
* Source/WebCore/page/LocalFrame.h:
* Source/WebCore/page/RemoteFrame.cpp:
(WebCore::RemoteFrame::urlForConsoleLog const):
(WebCore::RemoteFrame::documentURLForConsoleLog): Deleted.
* Source/WebCore/page/RemoteFrame.h:
* Source/WebCore/page/RemoteFrameClient.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::documentURLForConsoleLog): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp:
(WebKit::WebRemoteFrameClient::documentURLForConsoleLog): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h:

Canonical link: <a href="https://commits.webkit.org/310093@main">https://commits.webkit.org/310093@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9e3a30ffda96da3aab43007233a3d6075e66960

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152491 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25273 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18872 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161236 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105948 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/53a4ea8a-2791-4643-ba4a-dc920eca66fc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154365 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25801 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25579 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117846 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83512 "1 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f6bd2a12-1e49-481b-8a25-5a7cca498fa6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155451 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20057 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136904 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98560 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19133 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17066 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9070 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128783 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14778 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163705 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6846 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16372 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125888 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25071 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21105 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126054 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25073 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136574 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81675 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23394 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21039 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13353 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24689 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88975 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24380 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24540 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24441 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->