### PR TITLE
PiP video freezes after accessing Notification Center

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -379,6 +379,7 @@ private:
 #endif
 
     bool m_layerRequiresFlush WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
+    bool m_isInFullscreenOrPictureInPicture WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
 #if PLATFORM(IOS_FAMILY)
     bool m_applicationIsActive WTF_GUARDED_BY_CAPABILITY(mainThread) { true };
 #endif

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -717,7 +717,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::setLayerRequiresFlush()
     ALWAYS_LOG(LOGIDENTIFIER);
     m_layerRequiresFlush = true;
 #if PLATFORM(IOS_FAMILY)
-    if (m_applicationIsActive)
+    if (m_applicationIsActive || m_isInFullscreenOrPictureInPicture)
         flushVideoIfNeeded();
 #else
     flushVideoIfNeeded();
@@ -1402,6 +1402,8 @@ bool MediaPlayerPrivateMediaSourceAVFObjC::supportsLimitedMatroska() const
 
 void MediaPlayerPrivateMediaSourceAVFObjC::isInFullscreenOrPictureInPictureChanged(bool isInFullscreenOrPictureInPicture)
 {
+    assertIsMainThread();
+    m_isInFullscreenOrPictureInPicture = isInFullscreenOrPictureInPicture;
     m_renderer->isInFullscreenOrPictureInPictureChanged(isInFullscreenOrPictureInPicture);
 }
 


### PR DESCRIPTION
#### e7dc153729577d34dca4f67925ca49baaa9df73f
<pre>
PiP video freezes after accessing Notification Center
<a href="https://bugs.webkit.org/show_bug.cgi?id=310836">https://bugs.webkit.org/show_bug.cgi?id=310836</a>
<a href="https://rdar.apple.com/168296734">rdar://168296734</a>

Reviewed by Jer Noble.

When entering PiP via swipe-up from fullscreen, the app transitions to the background, setting
m_applicationIsActive to false. If the PiP window is subsequently occluded (e.g. by Notification
Center) and then revealed, AVFoundation posts a requiresFlushToResumeDecoding notification.
However, setLayerRequiresFlush() was gated on m_applicationIsActive, so the flush was skipped and
the video froze on a stale frame while audio continued playing.

Track fullscreen/PiP state via m_isInFullscreenOrPictureInPicture and allow the flush to proceed
when the video layer is still visible in a PiP window, even though the app itself is inactive.

* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::WTF_GUARDED_BY_CAPABILITY):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setLayerRequiresFlush):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::isInFullscreenOrPictureInPictureChanged):

Canonical link: <a href="https://commits.webkit.org/310100@main">https://commits.webkit.org/310100@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe3dfbf3b1ef72affe309d8d00233881a420aaff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152499 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25281 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18880 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161244 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105956 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154373 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25809 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25587 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117844 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83514 "5 flakes 2 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a0aa6163-34b0-4523-9d76-14e2d28c377d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155459 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20055 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136915 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98558 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5f2cf2e5-701b-451a-a37e-a541bbba6bfd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19131 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17071 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9078 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128781 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14789 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163713 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6854 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16383 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125887 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25079 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21110 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126053 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34247 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25081 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136585 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81683 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21044 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13364 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 4 flakes") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24697 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88983 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24388 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24548 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24449 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->