### PR TITLE
[css-anchor-position-1] anchor()/anchor-size() fallback value should support unitless zero

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7764,7 +7764,6 @@ webkit.org/b/282024 fast/text/text-box-edge-with-margin-padding-border-simple.ht
 
 # general failures
 
-webkit.org/b/306831 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-fixed-pos-descendant.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-012.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-015.tentative.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/transform-001.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-parse-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-parse-valid-expected.txt
@@ -2355,4 +2355,6 @@ PASS e.style['top'] = "calc((anchor(--foo top) + anchor(--bar bottom)) / 2)" sho
 PASS e.style['top'] = "calc(0.5 * (anchor(--foo top) + anchor(--bar bottom)))" should set the property value
 PASS e.style['top'] = "anchor(--foo top, calc(0.5 * anchor(--bar bottom)))" should set the property value
 PASS e.style['top'] = "min(100px, 10%, anchor(--foo top), anchor(--bar bottom))" should set the property value
+PASS e.style['top'] = "anchor(--foo left, 0)" should set the property value
+PASS e.style['top'] = "calc(anchor(--foo left, 0))" should set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-parse-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-parse-valid.html
@@ -83,4 +83,8 @@ test_valid_value('top', 'calc((anchor(--foo top) + anchor(--bar bottom)) / 2)', 
 test_valid_value('top', 'calc(0.5 * (anchor(--foo top) + anchor(--bar bottom)))');
 test_valid_value('top', 'anchor(--foo top, calc(0.5 * anchor(--bar bottom)))');
 test_valid_value('top', 'min(100px, 10%, anchor(--foo top), anchor(--bar bottom))');
+
+// Should accept unitless zero
+test_valid_value('top', "anchor(--foo left, 0)", "anchor(--foo left, 0px)");
+test_valid_value('top', "calc(anchor(--foo left, 0))", "anchor(--foo left, 0px)");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-parse-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-parse-valid-expected.txt
@@ -4299,4 +4299,6 @@ PASS e.style['margin-left'] = "calc((anchor-size(--foo width) + anchor-size(--ba
 PASS e.style['margin-left'] = "calc(0.5 * (anchor-size(--foo width) + anchor-size(--bar height)))" should set the property value
 PASS e.style['margin-left'] = "anchor-size(--foo width, calc(0.5 * anchor-size(--bar height)))" should set the property value
 PASS e.style['margin-left'] = "min(100px, 10%, anchor-size(--foo width), anchor-size(--bar height))" should set the property value
+PASS e.style['width'] = "anchor-size(--foo width, 0)" should set the property value
+PASS e.style['width'] = "calc(anchor-size(--foo width, 0))" should set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-parse-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-parse-valid.html
@@ -105,4 +105,8 @@ for (const prop of ['width', 'max-width', 'margin-left']) {
   test_valid_value(prop, 'anchor-size(--foo width, calc(0.5 * anchor-size(--bar height)))');
   test_valid_value(prop, 'min(100px, 10%, anchor-size(--foo width), anchor-size(--bar height))');
 }
+
+// Should accept unitless zero
+test_valid_value('width', "anchor-size(--foo width, 0)", "anchor-size(--foo width, 0px)");
+test_valid_value('width', "calc(anchor-size(--foo width, 0))", "anchor-size(--foo width, 0px)");
 </script>

--- a/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
@@ -993,6 +993,40 @@ static std::optional<TypedChild> consumeValueWithoutSimplifyingCalc(CSSParserTok
     return typedValue;
 }
 
+// Parse the fallback value specified in anchor() and anchor-size() as a <length> or
+// <length-percentage>. Additionally, unitless zero is allowed and gets treated as 0px.
+static std::optional<TypedChild> consumeAnchorFallback(CSSParserTokenRange& tokens, int depth, ParserState& state)
+{
+    auto typedFallback = consumeValueWithoutSimplifyingCalc(tokens, depth, state);
+    if (!typedFallback)
+        return { };
+
+    auto category = typedFallback->type.calculationCategory();
+    if (!category)
+        return { };
+
+    switch (*category) {
+    case CSS::Category::Length:
+    case CSS::Category::LengthPercentage:
+        return typedFallback;
+
+    case CSS::Category::Number: {
+        if (state.parserOptions.propertyOptions.unitlessZeroLength != UnitlessZeroQuirk::Allow)
+            return { };
+
+        // Allow unitless 0.
+        auto value = std::get<Number>(typedFallback->child.value);
+        if (value.value)
+            return { };
+
+        return TypedChild { makeNumeric(0, CSSUnitType::CSS_PX), Type::makeLength() };
+    }
+
+    default:
+        return { };
+    }
+}
+
 static std::optional<TypedChild> consumeAnchor(CSSParserTokenRange& tokens, int depth, ParserState& state)
 {
     // <anchor()> = anchor( <anchor-element>? && <anchor-side>, <length-percentage>? )
@@ -1044,17 +1078,15 @@ static std::optional<TypedChild> consumeAnchor(CSSParserTokenRange& tokens, int 
     std::optional<Child> fallback;
 
     if (CSSPropertyParserHelpers::consumeCommaIncludingWhitespace(tokens)) {
-        auto typedFallback = consumeValueWithoutSimplifyingCalc(tokens, depth, state);
-        if (!typedFallback)
+        auto maybeFallback = consumeAnchorFallback(tokens, depth, state);
+        if (!maybeFallback)
             return { };
 
-        auto category = typedFallback->type.calculationCategory();
-        if (!category)
-            return { };
-        if (*category != CSS::Category::Length && *category != CSS::Category::LengthPercentage)
-            return { };
+        fallback = WTF::move(maybeFallback->child);
 
-        fallback = WTF::move(typedFallback->child);
+        auto category = maybeFallback->type.calculationCategory();
+        ASSERT(category && (category == CSS::Category::Length || category == CSS::Category::LengthPercentage));
+
         type.percentHint = Type::determinePercentHint(*category);
     }
 
@@ -1119,7 +1151,7 @@ static std::optional<TypedChild> consumeAnchorSize(CSSParserTokenRange& tokens, 
         // if a comma follows...
         if (CSSPropertyParserHelpers::consumeCommaIncludingWhitespace(tokens)) {
             // it must be followed by the fallback value.
-            fallback = consumeValueWithoutSimplifyingCalc(tokens, depth, state);
+            fallback = consumeAnchorFallback(tokens, depth, state);
             if (!fallback)
                 return { };
         }
@@ -1127,21 +1159,15 @@ static std::optional<TypedChild> consumeAnchorSize(CSSParserTokenRange& tokens, 
     } else {
         // if <anchor-element> and <anchor-size> is not present
         // then an optional fallback value follows
-        fallback = consumeValueWithoutSimplifyingCalc(tokens, depth, state);
+        fallback = consumeAnchorFallback(tokens, depth, state);
     }
 
+    // Return type of this function. It's a <length> if it can be resolved, otherwise the
+    // <length-percentage> fallback is resolved, which could be a percentage.
     auto type = Type::makeLength();
-
-    // anchor-size() resolves to a <length> if it can be resolved, otherwise the fallback
-    // value is resolved, which is of type <length-percentage>. Therefore the overall type
-    // of anchor-size() is <length> or <length-percentage>, depending on the type of the
-    // fallback value.
     if (fallback) {
         auto category = fallback->type.calculationCategory();
-        if (!category)
-            return { };
-        if (*category != CSS::Category::Length && *category != CSS::Category::LengthPercentage)
-            return { };
+        ASSERT(category && (category == CSS::Category::Length || category == CSS::Category::LengthPercentage));
 
         type.percentHint = Type::determinePercentHint(*category);
     }


### PR DESCRIPTION
#### 3e213e67f6ad8d157a05a95eb2cc714d148b81d3
<pre>
[css-anchor-position-1] anchor()/anchor-size() fallback value should support unitless zero
<a href="https://rdar.apple.com/169500991">rdar://169500991</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=306831">https://bugs.webkit.org/show_bug.cgi?id=306831</a>

Reviewed by Antti Koivisto.

This patch allows using unitless zero (&quot;0&quot;) as fallback value for
anchor() and anchor-size(), which gets treated as 0px.

Tests: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-parse-valid.html
       imported/w3c/web-platform-tests/css/css-anchor-position/anchor-parse-invalid.html
       imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-parse-valid.html
       imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-parse-invalid.html

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-parse-valid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-parse-valid.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-parse-valid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-parse-valid.html:
* Source/WebCore/css/calc/CSSCalcTree+Parser.cpp:
(WebCore::CSSCalc::consumeAnchorFallback):
(WebCore::CSSCalc::consumeAnchor):
(WebCore::CSSCalc::consumeAnchorSize):

Canonical link: <a href="https://commits.webkit.org/310108@main">https://commits.webkit.org/310108@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb012280dc5233c5c7a52023068b20556884c382

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152501 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25283 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18882 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161246 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105958 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154375 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25811 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25589 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117847 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83515 "3 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/84889fd2-245c-44fa-ab92-b722fd4cb124) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155461 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20061 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136909 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98561 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e9cd640b-d20f-432a-a16f-e0459d114747) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19137 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17072 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9080 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128787 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14783 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163715 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6856 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16377 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125890 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25081 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21111 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126055 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34250 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25083 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136579 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81685 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21045 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13358 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24699 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88985 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24390 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24550 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24451 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->