### PR TITLE
[YARR] Fix JIT crash on non-greedy ParenthesesSubpattern backtracking

### DIFF
--- a/JSTests/stress/regexp-fixedcount-nested-nongreedy-multi-alt.js
+++ b/JSTests/stress/regexp-fixedcount-nested-nongreedy-multi-alt.js
@@ -1,0 +1,36 @@
+//@ runDefault
+
+function shouldBe(actual, expected, message) {
+    if (JSON.stringify(actual) !== JSON.stringify(expected))
+        throw new Error(message + ": expected " + JSON.stringify(expected) + " but got " + JSON.stringify(actual));
+}
+
+// Test FixedCount parentheses containing nested NonGreedy multi-alternative groups.
+// When the FixedCount group backtracks, it restores frame state (including nested
+// groups' returnAddress slots). If the nested NonGreedy group matched 0 iterations
+// in that snapshot, its returnAddress was never set by NestedAlternativeBegin/Next/End.
+// The JIT must handle this gracefully (bail to interpreter) rather than jumping to
+// an uninitialized code pointer.
+
+// Minimized from rdar://173140757: the "cp" suffix forces FixedCount backtracking
+// because it can never match "aabbbccc", exercising the restore path.
+(function() {
+    var r = /((()*.|.)*?[a-c]){2}cp/s;
+    var result = r.exec('aabbbccc');
+    shouldBe(result, null, "Minimized: FixedCount {2} + NonGreedy *? multi-alt with capture");
+})();
+
+// Original fuzzer test case.
+(function() {
+    var r = new RegExp(unescape('%28%28%28%29%28%29%28%28%28%29%28%29%2A%2E%7C%28%29%28%68%3E%28%28%28%29%28%29%28%29%28%29%29%2F%6C%2E%28%1F%28%29%28%2D%28%00%5B%5C%44%C3%5D%6F%5E%8E%28%29%29%28%29%21%29%28%29%29%29%38%7E%29%40%77%EB%29%2A%3F%28%28%3F%3A%2E%29%3F%3F%29%29%5B%0A%61%2D%63%5D%29%29%7B%33%7D%63%70'),'dimsu');
+    'aabbbccc'.match(r);
+    'aabbbccc'.replace(r,'$1,$2');
+    r.exec('caffeeeee');
+})();
+
+// Variant: {3} with the same nested structure.
+(function() {
+    var r = /((()*.|.)*?[a-c]){3}cp/s;
+    var result = r.exec('aabbbccc');
+    shouldBe(result, null, "FixedCount {3} + NonGreedy *? multi-alt with capture");
+})();

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -4048,6 +4048,7 @@ class YarrGenerator final : public YarrJITInfo {
                 unsigned parenthesesFrameLocation = term->frameLocation;
 
                 storeToFrame(MacroAssembler::TrustedImm32(0), parenthesesFrameLocation + BackTrackInfoParentheses::matchAmountIndex());
+                storeToFrame(MacroAssembler::TrustedImmPtr(nullptr), parenthesesFrameLocation + BackTrackInfoParentheses::returnAddressIndex());
                 storeToFrame(MacroAssembler::TrustedImmPtr(nullptr), parenthesesFrameLocation + BackTrackInfoParentheses::parenContextHeadIndex());
 
                 // Quantifier-specific setup:
@@ -4676,6 +4677,14 @@ class YarrGenerator final : public YarrJITInfo {
                     // For FixedCount multi-alt: returnAddress was stored by NestedAlternativeBegin/Next
                     // For others: returnAddress was stored by NestedAlternativeEnd itself
                     unsigned parenthesesFrameLocation = term->frameLocation;
+                    // Guard: if returnAddress was never set (null from initialization), bail to interpreter.
+                    // This can happen when an enclosing FixedCount group restores frame state from an
+                    // iteration where this group's content never ran (NonGreedy skip with 0 matches).
+                    {
+                        const MacroAssembler::RegisterID tempRetAddr = m_regs.regT0;
+                        loadFromFrame(parenthesesFrameLocation + BackTrackInfoParentheses::returnAddressIndex(), tempRetAddr);
+                        m_abortExecution.append(m_jit.branchTestPtr(MacroAssembler::Zero, tempRetAddr));
+                    }
                     loadFromFrameAndJump(parenthesesFrameLocation + BackTrackInfoParentheses::returnAddressIndex());
 
                     // Link the DataLabelPtr associated with the end of the last alternative to this point.
@@ -5042,6 +5051,12 @@ class YarrGenerator final : public YarrJITInfo {
                 }
 
                 // Greedy/NonGreedy path: restore from context and try fewer iterations
+                // The parenContextHead can be null when this nested group's frame state was
+                // restored by an enclosing FixedCount group's backtracking (restoreParenContext
+                // restores all frame slots, including nested groups' parenContextHead). If the
+                // nested group hadn't saved any context at that point, the restored head is null.
+                MacroAssembler::Jump noContext = m_jit.branchTestPtr(MacroAssembler::Zero, currParenContextReg);
+
                 restoreParenContext(currParenContextReg, m_regs.regT2, term->parentheses.subpatternId, term->parentheses.lastSubpatternId, parenthesesFrameLocation);
 
                 m_jit.loadPtr(MacroAssembler::Address(currParenContextReg, ParenContext::nextOffset()), newParenContextReg);
@@ -5059,6 +5074,7 @@ class YarrGenerator final : public YarrJITInfo {
                 m_jit.jump(m_ops[op.m_nextOp].m_reentry);
 
                 zeroLengthMatch.link(&m_jit);
+                noContext.link(&m_jit);
 
                 // Clear the flag in the stackframe indicating we didn't run through the subpattern.
                 storeToFrame(MacroAssembler::TrustedImm32(-1), parenthesesFrameLocation + BackTrackInfoParentheses::beginIndex());


### PR DESCRIPTION
#### 229e058940996d929fd498317dd509f9b940f402
<pre>
[YARR] Fix JIT crash on non-greedy ParenthesesSubpattern backtracking
<a href="https://bugs.webkit.org/show_bug.cgi?id=310771">https://bugs.webkit.org/show_bug.cgi?id=310771</a>
<a href="https://rdar.apple.com/173140757">rdar://173140757</a>

Reviewed by NOBODY (OOPS!).

When a FixedCount parentheses group backtracks, restoreParenContext
restores all frame slots including nested groups&apos; BackTrackInfo. If a
nested NonGreedy multi-alternative group matched 0 iterations during
the saved snapshot, its returnAddress frame slot was never written by
NestedAlternativeBegin/Next/End. The uninitialized value was then
saved to the ParenContext and later restored, causing a PAC failure
(or SEGV on non-PAC hardware) when NestedAlternativeEnd.bt jumped to
the garbage pointer via loadFromFrameAndJump.

Fix by initializing the returnAddress frame slot to null in
ParenthesesSubpatternBegin forward, and adding a guard at
NestedAlternativeEnd.bt to bail to the interpreter if the
returnAddress is null. Also add a null check on parenContextHead
in the Greedy/NonGreedy BEGIN.bt path, which was similarly
unprotected when frame state was restored by an enclosing group.

Test: JSTests/stress/regexp-fixedcount-nested-nongreedy-multi-alt.js

* JSTests/stress/regexp-fixedcount-nested-nongreedy-multi-alt.js: Added.
(shouldBe):
(r):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/229e058940996d929fd498317dd509f9b940f402

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152503 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25285 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18884 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161248 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105960 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/75a84eb2-32c4-40c8-8439-d70cc7d7b508) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25813 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25591 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117848 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83517 "3 flakes 2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155463 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20058 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136911 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98562 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b0f71edf-fccc-4460-8a49-66616142b287) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19134 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17074 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9082 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144515 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128784 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14785 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163717 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13306 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6858 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16379 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125892 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25083 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21113 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126057 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25085 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136581 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81687 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21049 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13360 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184135 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24701 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88987 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46954 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24392 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24552 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24453 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->