### PR TITLE
[JSC] Use UniquedStringImpl* instead of Identifier* in parser

### DIFF
--- a/Source/JavaScriptCore/KeywordLookupGenerator.py
+++ b/Source/JavaScriptCore/KeywordLookupGenerator.py
@@ -143,7 +143,7 @@ class Trie:
             print(str + "if (cannotBeIdentPartOrEscapeStart(code[%d])) [[likely]] {" % (len(self.fullPrefix)))
             print(str + "    internalShift<%d>();" % len(self.fullPrefix))
             print(str + "    if (shouldCreateIdentifier)")
-            print(str + ("        data->ident = &m_vm.propertyNames->%sKeyword;" % self.fullPrefix))
+            print(str + ("        data->ident = m_vm.propertyNames->%sKeyword.impl();" % self.fullPrefix))
             print(str + "    return " + self.value + ";")
             print(str + "}")
         rootIndex = len(self.fullPrefix)

--- a/Source/JavaScriptCore/builtins/BuiltinExecutables.cpp
+++ b/Source/JavaScriptCore/builtins/BuiltinExecutables.cpp
@@ -214,8 +214,8 @@ UnlinkedFunctionExecutable* BuiltinExecutables::createExecutable(VM& vm, const S
         isInStrictContext ? StrictModeLexicallyScopedFeature : NoLexicallyScopedFeatures, constructorKind, constructorKind == ConstructorKind::Extends ? SuperBinding::Needed : SuperBinding::NotNeeded,
         parameterCount, parseMode, isArrowFunctionBodyExpression);
 
-    metadata.finishParsing(newSource, Identifier(), FunctionMode::FunctionExpression);
-    metadata.overrideName(name);
+    metadata.finishParsing(newSource, nullptr, FunctionMode::FunctionExpression);
+    metadata.overrideName(name.impl());
     metadata.setEndPosition(positionBeforeLastNewline);
 
     if (ASSERT_ENABLED || Options::validateBytecode()) [[unlikely]] {
@@ -239,12 +239,12 @@ UnlinkedFunctionExecutable* BuiltinExecutables::createExecutable(VM& vm, const S
             
             metadataFromParser->setEndPosition(positionBeforeLastNewlineFromParser);
             RELEASE_ASSERT(metadataFromParser);
-            RELEASE_ASSERT(metadataFromParser->ident().isNull());
+            RELEASE_ASSERT(!metadataFromParser->ident());
             
             // This function assumes an input string that would result in a single anonymous function expression.
             metadataFromParser->setEndPosition(positionBeforeLastNewlineFromParser);
             RELEASE_ASSERT(metadataFromParser);
-            metadataFromParser->overrideName(name);
+            metadataFromParser->overrideName(name.impl());
             metadataFromParser->setEndPosition(positionBeforeLastNewlineFromParser);
             if (metadata != *metadataFromParser || positionBeforeLastNewlineFromParser != positionBeforeLastNewline) {
                 dataLogLn("Expected Metadata:\n", metadata);

--- a/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp
@@ -67,7 +67,7 @@ static UnlinkedFunctionCodeBlock* generateUnlinkedFunctionCodeBlock(
         return nullptr;
     }
 
-    function->finishParsing(executable->name(), executable->functionMode());
+    function->finishParsing(executable->name().impl(), executable->functionMode());
     executable->recordParse(function->features(), function->lexicallyScopedFeatures(), function->hasCapturedVariables());
 
     bool isClassContext = executable->superBinding() == SuperBinding::Needed || executable->parseMode() == SourceParseMode::ClassFieldInitializerMode;
@@ -119,8 +119,8 @@ UnlinkedFunctionExecutable::UnlinkedFunctionExecutable(VM& vm, Structure* struct
     , m_evalContextType(static_cast<unsigned>(evalContextType))
     , m_unlinkedCodeBlockForCall()
     , m_unlinkedCodeBlockForConstruct()
-    , m_name(node->ident())
-    , m_ecmaName(node->ecmaName())
+    , m_name(Identifier::fromUid(vm, node->ident()))
+    , m_ecmaName(Identifier::fromUid(vm, node->ecmaName()))
 {
     // Make sure these bitfields are adequately wide.
     ASSERT(m_implementationVisibility == static_cast<unsigned>(node->implementationVisibility()));

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -221,7 +221,7 @@ ParserError BytecodeGenerator::generate(unsigned& size)
         // If we have declared a variable named "arguments" and we are using arguments then we should
         // perform that assignment now.
         if (m_needToInitializeArguments)
-            initializeVariable(variable(propertyNames().arguments), m_argumentsRegister);
+            initializeVariable(variable(propertyNames().arguments.impl()), m_argumentsRegister);
 
         {
             bool shouldHoistInEval = m_codeType == EvalCode && !m_ecmaMode.isStrict();
@@ -550,7 +550,7 @@ BytecodeGenerator::BytecodeGenerator(VM& vm, FunctionNode* functionNode, Unlinke
         break;
     case ConstructorKind::Naked:
         if (!isConstructor()) {
-            String constructorName = functionNode->ident().string();
+            String constructorName(functionNode->ident());
             if (!constructorName || constructorName.isEmpty())
                 emitThrowTypeError("Cannot call a constructor without |new|"_s);
             else {
@@ -558,7 +558,7 @@ BytecodeGenerator::BytecodeGenerator(VM& vm, FunctionNode* functionNode, Unlinke
                 if (!errorMessageStr)
                     emitThrowTypeError("Cannot call a constructor without |new|"_s);
                 else
-                    emitThrowTypeError(Identifier::fromString(m_vm, errorMessageStr));
+                    emitThrowTypeError(Identifier::fromString(m_vm, errorMessageStr).impl());
             }
             return;
         }
@@ -566,7 +566,7 @@ BytecodeGenerator::BytecodeGenerator(VM& vm, FunctionNode* functionNode, Unlinke
     case ConstructorKind::Base:
     case ConstructorKind::Extends:
         if (!isConstructor()) {
-            String constructorName = functionNode->ident().string();
+            String constructorName(functionNode->ident());
             if (!constructorName || constructorName.isEmpty())
                 emitThrowTypeError("Cannot call a class constructor without |new|"_s);
             else {
@@ -574,7 +574,7 @@ BytecodeGenerator::BytecodeGenerator(VM& vm, FunctionNode* functionNode, Unlinke
                 if (!errorMessageStr)
                     emitThrowTypeError("Cannot call a class constructor without |new|"_s);
                 else
-                    emitThrowTypeError(Identifier::fromString(m_vm, errorMessageStr));
+                    emitThrowTypeError(Identifier::fromString(m_vm, errorMessageStr).impl());
             }
             return;
         }
@@ -585,7 +585,7 @@ BytecodeGenerator::BytecodeGenerator(VM& vm, FunctionNode* functionNode, Unlinke
         ASSERT(parseMode != SourceParseMode::GeneratorBodyMode);
         ASSERT(!isAsyncFunctionBodyParseMode(parseMode));
         bool isDynamicScope = functionNameScopeIsDynamic(usesEval(), ecmaMode.isStrict());
-        bool isFunctionNameCaptured = captures(functionNode->ident().impl());
+        bool isFunctionNameCaptured = captures(functionNode->ident());
         bool markAsCaptured = isDynamicScope || isFunctionNameCaptured;
         emitPushFunctionNameScope(functionNode->ident(), &m_calleeRegister, markAsCaptured);
     }
@@ -604,8 +604,10 @@ BytecodeGenerator::BytecodeGenerator(VM& vm, FunctionNode* functionNode, Unlinke
 
     // Need to know what our functions are called. Parameters have some goofy behaviors when it
     // comes to functions of the same name.
-    for (FunctionMetadataNode* function : functionNode->functionStack())
-        m_functions.add(function->ident().impl());
+    for (FunctionMetadataNode* function : functionNode->functionStack()) {
+        ASSERT(function->ident()); // function declarations always have names
+        m_functions.add(function->ident());
+    }
     
     if (m_needsArguments) {
         // Create the arguments object now. We may put the arguments object into the activation if
@@ -627,8 +629,8 @@ BytecodeGenerator::BytecodeGenerator(VM& vm, FunctionNode* functionNode, Unlinke
             for (size_t i = 0; i < parameters.size(); ++i) {
                 auto pattern = parameters.at(i).first;
                 ASSERT(pattern->isBindingNode());
-                const Identifier& ident = static_cast<const BindingNode*>(pattern)->boundProperty();
-                if (captures(ident.impl())) {
+                UniquedStringImpl* name = static_cast<const BindingNode*>(pattern)->boundProperty();
+                if (captures(name)) {
                     capturesAnyParameterByName = true;
                     break;
                 }
@@ -663,11 +665,8 @@ BytecodeGenerator::BytecodeGenerator(VM& vm, FunctionNode* functionNode, Unlinke
                     functionSymbolTable->set(NoLockingNecessary, name, entry);
 
 IGNORE_GCC_WARNINGS_BEGIN("dangling-reference")
-                    const Identifier& ident =
-                        static_cast<const BindingNode*>(parameters.at(i).first)->boundProperty();
+                    varOrAnonymous = addConstant(static_cast<const BindingNode*>(parameters.at(i).first)->boundProperty());
 IGNORE_GCC_WARNINGS_END
-
-                    varOrAnonymous = addConstant(ident);
                 }
 
                 OpPutToScope::emit(this, m_lexicalEnvironmentRegister, varOrAnonymous, virtualRegisterForArgumentIncludingThis(1 + i), GetPutInfo(ThrowIfNotFound, ResolvedClosureVar, InitializationMode::ScopedArgumentInitialization, ecmaMode), SymbolTableOrScopeDepth::symbolTable(VirtualRegister { symbolTableConstantIndex }), offset.offset());
@@ -705,12 +704,10 @@ IGNORE_GCC_WARNINGS_END
             
             ScopeOffset offset = functionSymbolTable->takeNextScopeOffset(NoLockingNecessary);
 IGNORE_GCC_WARNINGS_BEGIN("dangling-reference")
-            const Identifier& ident =
-                static_cast<const BindingNode*>(parameters.at(i).first)->boundProperty();
-IGNORE_GCC_WARNINGS_END
             functionSymbolTable->set(NoLockingNecessary, name, SymbolTableEntry(VarOffset(offset)));
-            
-            OpPutToScope::emit(this, m_lexicalEnvironmentRegister, addConstant(ident), virtualRegisterForArgumentIncludingThis(1 + i), GetPutInfo(ThrowIfNotFound, ResolvedClosureVar, InitializationMode::NotInitialization, ecmaMode), SymbolTableOrScopeDepth::symbolTable(VirtualRegister { symbolTableConstantIndex }), offset.offset());
+
+            OpPutToScope::emit(this, m_lexicalEnvironmentRegister, addConstant(static_cast<const BindingNode*>(parameters.at(i).first)->boundProperty()), virtualRegisterForArgumentIncludingThis(1 + i), GetPutInfo(ThrowIfNotFound, ResolvedClosureVar, InitializationMode::NotInitialization, ecmaMode), SymbolTableOrScopeDepth::symbolTable(VirtualRegister { symbolTableConstantIndex }), offset.offset());
+IGNORE_GCC_WARNINGS_END
         }
     }
     
@@ -765,15 +762,15 @@ IGNORE_GCC_WARNINGS_END
         // Do not create arguments variable in case of Arrow function. Value will be loaded from parent scope
         if (shouldCreateArgumensVariable && !shouldCreateArgumentsVariableInParameterScope) {
             createVariable(
-                propertyNames().arguments, varKind(propertyNames().arguments.impl()), functionSymbolTable);
+                propertyNames().arguments.impl(), varKind(propertyNames().arguments.impl()), functionSymbolTable);
 
             m_needToInitializeArguments = true;
         }
     }
 
     for (FunctionMetadataNode* function : functionNode->functionStack()) {
-        const Identifier& ident = function->ident();
-        createVariable(ident, varKind(ident.impl()), functionSymbolTable);
+        UniquedStringImpl* uid = function->ident();
+        createVariable(uid, varKind(uid), functionSymbolTable);
         m_functionsToInitialize.append(std::make_pair(function, NormalFunctionVariable));
     }
     for (auto& entry : functionNode->varDeclarations()) {
@@ -784,7 +781,7 @@ IGNORE_GCC_WARNINGS_END
             continue;
         if (isGeneratorOrAsyncFunctionBodyParseMode(parseMode) && generatorOrAsyncWrapperFunctionParameterNames->contains(entry.key.get()))
             continue;
-        createVariable(Identifier::fromUid(m_vm, entry.key.get()), varKind(entry.key.get()), functionSymbolTable, IgnoreExisting);
+        createVariable(entry.key.get(), varKind(entry.key.get()), functionSymbolTable, IgnoreExisting);
     }
 
 
@@ -1106,9 +1103,9 @@ BytecodeGenerator::BytecodeGenerator(VM& vm, ModuleProgramNode* moduleProgramNod
 
     // Now declare all variables.
 
-    createVariable(m_vm.propertyNames->starNamespacePrivateName, VarKind::Scope, moduleEnvironmentSymbolTable, VerifyExisting);
+    createVariable(m_vm.propertyNames->starNamespacePrivateName.impl(), VarKind::Scope, moduleEnvironmentSymbolTable, VerifyExisting);
     if (moduleProgramNode->features() & ImportMetaFeature)
-        createVariable(m_vm.propertyNames->builtinNames().metaPrivateName(), VarKind::Scope, moduleEnvironmentSymbolTable, VerifyExisting);
+        createVariable(m_vm.propertyNames->builtinNames().metaPrivateName().impl(), VarKind::Scope, moduleEnvironmentSymbolTable, VerifyExisting);
 
     for (auto& entry : moduleProgramNode->varDeclarations()) {
         ASSERT(!entry.value.isLet() && !entry.value.isConst());
@@ -1119,7 +1116,7 @@ BytecodeGenerator::BytecodeGenerator(VM& vm, ModuleProgramNode* moduleProgramNod
         // the code block, we resolve the reference to the "ModuleVar".
         if (entry.value.isImported() && !entry.value.isImportedNamespace())
             continue;
-        createVariable(Identifier::fromUid(m_vm, entry.key.get()), lookUpVarKind(entry.key.get(), entry.value), moduleEnvironmentSymbolTable, IgnoreExisting);
+        createVariable(entry.key.get(), lookUpVarKind(entry.key.get(), entry.value), moduleEnvironmentSymbolTable, IgnoreExisting);
     }
 
     VariableEnvironment& lexicalVariables = moduleProgramNode->lexicalVariables();
@@ -1148,7 +1145,7 @@ BytecodeGenerator::BytecodeGenerator(VM& vm, ModuleProgramNode* moduleProgramNod
     // So it should be called after putting our lexical environment to the TDZ stack correctly.
 
     for (FunctionMetadataNode* function : moduleProgramNode->functionStack()) {
-        const auto& iterator = moduleProgramNode->lexicalVariables().find(function->ident().impl());
+        const auto& iterator = moduleProgramNode->lexicalVariables().find(function->ident());
         RELEASE_ASSERT(iterator != moduleProgramNode->lexicalVariables().end());
         RELEASE_ASSERT(!iterator->value.isImported());
 
@@ -1211,30 +1208,31 @@ void BytecodeGenerator::initializeDefaultParameterValuesAndSetupFunctionScopeSta
     FunctionParameters& parameters, bool isSimpleParameterList, FunctionNode* functionNode, SymbolTable* functionSymbolTable, 
     int symbolTableConstantIndex, const ScopedLambda<bool (UniquedStringImpl*)>& captures, bool shouldCreateArgumentsVariableInParameterScope)
 {
-    Vector<std::pair<Identifier, RefPtr<RegisterID>>> valuesToMoveIntoVars;
+    Vector<std::pair<RefPtr<UniquedStringImpl>, RefPtr<RegisterID>>> valuesToMoveIntoVars;
     ASSERT(!(isSimpleParameterList && shouldCreateArgumentsVariableInParameterScope));
     if (!isSimpleParameterList) {
         // Refer to the ES6 spec section 9.2.12: http://www.ecma-international.org/ecma-262/6.0/index.html#sec-functiondeclarationinstantiation
         // This implements step 21.
         VariableEnvironment environment;
-        Vector<Identifier> allParameterNames; 
+        Vector<Identifier> allParameterNames;
         for (unsigned i = 0; i < parameters.size(); i++)
-            parameters.at(i).first->collectBoundIdentifiers(allParameterNames);
+            parameters.at(i).first->collectBoundIdentifiers(m_vm, allParameterNames);
         if (shouldCreateArgumentsVariableInParameterScope)
             allParameterNames.append(propertyNames().arguments);
         IdentifierSet parameterSet;
-        for (auto& ident : allParameterNames) {
-            parameterSet.add(ident.impl());
-            auto addResult = environment.add(ident);
+        for (auto& name : allParameterNames) {
+            ASSERT(name.impl()); // parameter names are always non-null (set from token identifiers)
+            parameterSet.add(name.impl());
+            auto addResult = environment.add(name.impl());
             addResult.iterator->value.setIsLet(); // When we have default parameter expressions, parameters act like "let" variables.
-            if (captures(ident.impl()))
+            if (captures(name.impl()))
                 addResult.iterator->value.setIsCaptured();
         }
         // This implements step 25 of section 9.2.12.
         pushLexicalScopeInternal(environment, TDZCheckOptimization::Optimize, NestedScopeType::IsNotNested, nullptr, TDZRequirement::UnderTDZ, ScopeType::LetConstScope, ScopeRegisterType::Block);
 
         if (shouldCreateArgumentsVariableInParameterScope) {
-            Variable argumentsVariable = variable(propertyNames().arguments); 
+            Variable argumentsVariable = variable(propertyNames().arguments.impl());
             initializeVariable(argumentsVariable, m_argumentsRegister);
             liftTDZCheckIfPossible(argumentsVariable);
         }
@@ -1271,11 +1269,11 @@ void BytecodeGenerator::initializeDefaultParameterValuesAndSetupFunctionScopeSta
                 continue;
 
             if (parameterSet.contains(entry.key)) {
-                Identifier ident = Identifier::fromUid(m_vm, entry.key.get());
-                Variable var = variable(ident);
+                RefPtr uid = entry.key.get();
+                Variable var = variable(uid);
                 RegisterID* scope = emitResolveScope(nullptr, var);
                 RefPtr<RegisterID> value = emitGetFromScope(newTemporary(), scope, var, DoNotThrowIfNotFound);
-                valuesToMoveIntoVars.append(std::make_pair(ident, value));
+                valuesToMoveIntoVars.append(std::make_pair(WTF::move(uid), value));
             }
         }
 
@@ -1335,19 +1333,19 @@ void BytecodeGenerator::initializeArrowFunctionContextScopeIfNeeded(SymbolTable*
     VariableEnvironment environment;
 
     if (isThisUsedInInnerArrowFunction()) {
-        auto addResult = environment.add(propertyNames().builtinNames().thisPrivateName());
+        auto addResult = environment.add(propertyNames().builtinNames().thisPrivateName().impl());
         addResult.iterator->value.setIsCaptured();
         addResult.iterator->value.setIsLet();
     }
     
     if (m_codeType == FunctionCode && isNewTargetUsedInInnerArrowFunction()) {
-        auto addTarget = environment.add(propertyNames().builtinNames().newTargetLocalPrivateName());
+        auto addTarget = environment.add(propertyNames().builtinNames().newTargetLocalPrivateName().impl());
         addTarget.iterator->value.setIsCaptured();
         addTarget.iterator->value.setIsLet();
     }
 
     if (needsDerivedConstructorInArrowFunctionLexicalEnvironment()) {
-        auto derivedConstructor = environment.add(propertyNames().builtinNames().derivedConstructorPrivateName());
+        auto derivedConstructor = environment.add(propertyNames().builtinNames().derivedConstructorPrivateName().impl());
         derivedConstructor.iterator->value.setIsCaptured();
         derivedConstructor.iterator->value.setIsLet();
     }
@@ -1415,9 +1413,9 @@ void BytecodeGenerator::initializeVarLexicalEnvironment(int symbolTableConstantI
 UniquedStringImpl* BytecodeGenerator::visibleNameForParameter(DestructuringPatternNode* pattern)
 {
     if (pattern->isBindingNode()) {
-        const Identifier& ident = static_cast<const BindingNode*>(pattern)->boundProperty();
-        if (!m_functions.contains(ident.impl()))
-            return ident.impl();
+        UniquedStringImpl* name = static_cast<const BindingNode*>(pattern)->boundProperty();
+        if (!m_functions.contains(name))
+            return name;
     }
     return nullptr;
 }
@@ -1429,7 +1427,7 @@ RegisterID* BytecodeGenerator::newBlockScopeVariable()
     return newRegister();
 }
 
-Ref<LabelScope> BytecodeGenerator::newLabelScope(LabelScope::Type type, const Identifier* name)
+Ref<LabelScope> BytecodeGenerator::newLabelScope(LabelScope::Type type, UniquedStringImpl* name)
 {
     shrinkToFit(m_labelScopes);
 
@@ -1642,18 +1640,18 @@ void BytecodeGenerator::recordHasOwnPropertyInForInLoop(ForInContext& context, u
     context.addHasOwnPropertyJump(branchOffset, genericPath.location());
 }
 
-bool BytecodeGenerator::hasConstant(const Identifier& ident) const
+bool BytecodeGenerator::hasConstant(UniquedStringImpl* uid) const
 {
-    UniquedStringImpl* rep = ident.impl();
-    return m_identifierMap.contains(rep);
+    ASSERT(uid);
+    return m_identifierMap.contains(uid);
 }
 
-unsigned BytecodeGenerator::addConstant(const Identifier& ident)
+unsigned BytecodeGenerator::addConstant(UniquedStringImpl* uid)
 {
-    UniquedStringImpl* rep = ident.impl();
-    IdentifierMap::AddResult result = m_identifierMap.add(rep, m_codeBlock->numberOfIdentifiers());
+    ASSERT(uid);
+    IdentifierMap::AddResult result = m_identifierMap.add(uid, m_codeBlock->numberOfIdentifiers());
     if (result.isNewEntry)
-        m_codeBlock->addIdentifier(ident);
+        m_codeBlock->addIdentifier(Identifier::fromUid(m_vm, uid));
 
     return result.iterator->value;
 }
@@ -1853,7 +1851,7 @@ RegisterID* BytecodeGenerator::emitBinaryOp(OpcodeID opcodeID, RegisterID* dst, 
     }
 }
 
-RegisterID* BytecodeGenerator::emitToObject(RegisterID* dst, RegisterID* src, const Identifier& message)
+RegisterID* BytecodeGenerator::emitToObject(RegisterID* dst, RegisterID* src, UniquedStringImpl* message)
 {
     OpToObject::emit(this, dst, src, addConstant(message), nextValueProfileIndex());
     return dst;
@@ -2043,12 +2041,12 @@ RegisterID* BytecodeGenerator::emitLoad(RegisterID* dst, bool b)
     return emitLoad(dst, jsBoolean(b));
 }
 
-RegisterID* BytecodeGenerator::emitLoad(RegisterID* dst, const Identifier& identifier)
+RegisterID* BytecodeGenerator::emitLoad(RegisterID* dst, UniquedStringImpl* uid)
 {
-    ASSERT(!identifier.isSymbol());
-    JSString*& stringInMap = m_stringMap.add(identifier.impl(), nullptr).iterator->value;
+    ASSERT(!uid->isSymbol());
+    JSString*& stringInMap = m_stringMap.add(uid, nullptr).iterator->value;
     if (!stringInMap)
-        stringInMap = jsOwnedString(vm(), identifier.string());
+        stringInMap = jsOwnedString(vm(), uid);
 
     return emitLoad(dst, JSValue(stringInMap));
 }
@@ -2319,12 +2317,12 @@ void BytecodeGenerator::initializeBlockScopedFunctions(VariableEnvironment& envi
     RefPtr<RegisterID> temp = newTemporary();
     int symbolTableIndex = constantSymbolTable ? constantSymbolTable->index() : 0;
     for (FunctionMetadataNode* function : functionStack) {
-        const Identifier& name = function->ident();
-        auto iter = environment.find(name.impl());
+        UniquedStringImpl* name = function->ident();
+        auto iter = environment.find(name);
         RELEASE_ASSERT(iter != environment.end());
         RELEASE_ASSERT(iter->value.isFunction());
         // We purposefully don't hold the symbol table lock around this loop because emitNewFunctionExpressionCommon may GC.
-        SymbolTableEntry entry = symbolTable->get(NoLockingNecessary, name.impl()); 
+        SymbolTableEntry entry = symbolTable->get(NoLockingNecessary, name);
         RELEASE_ASSERT(!entry.isNull());
         emitNewFunctionExpressionCommon(temp.get(), function);
         bool isLexicallyScoped = true;
@@ -2335,11 +2333,11 @@ void BytecodeGenerator::initializeBlockScopedFunctions(VariableEnvironment& envi
 void BytecodeGenerator::hoistSloppyModeFunctionIfNecessary(FunctionMetadataNode* metadata)
 {
     if (metadata->isSloppyModeHoistedFunction()) {
-        const Identifier& functionName = metadata->ident();
+        UniquedStringImpl* functionName = metadata->ident();
 
         if (isGeneratorOrAsyncFunctionBodyParseMode(parseMode())) {
             RELEASE_ASSERT(m_generatorOrAsyncWrapperFunctionParameterNames);
-            if (m_generatorOrAsyncWrapperFunctionParameterNames->contains(functionName))
+            if (m_generatorOrAsyncWrapperFunctionParameterNames->contains(Identifier::fromUid(m_vm, functionName)))
                 return;
         }
 
@@ -2359,8 +2357,8 @@ void BytecodeGenerator::hoistSloppyModeFunctionIfNecessary(FunctionMetadataNode*
             LexicalScopeStackEntry varScope = m_lexicalScopeStack[*m_varScopeLexicalScopeStackIndex];
             SymbolTable* varSymbolTable = varScope.m_symbolTable;
             ASSERT(varSymbolTable->scopeType() == SymbolTable::ScopeType::VarScope);
-            SymbolTableEntry entry = varSymbolTable->get(NoLockingNecessary, functionName.impl());
-            if (functionName == propertyNames().arguments && entry.isNull()) {
+            SymbolTableEntry entry = varSymbolTable->get(NoLockingNecessary, functionName);
+            if (functionName == propertyNames().arguments.impl() && entry.isNull()) {
                 // "arguments" might be put in the parameter scope when we have a non-simple
                 // parameter list since "arguments" is visible to expressions inside the
                 // parameter evaluation list.
@@ -2369,7 +2367,7 @@ void BytecodeGenerator::hoistSloppyModeFunctionIfNecessary(FunctionMetadataNode*
                 RELEASE_ASSERT(*m_varScopeLexicalScopeStackIndex > 0);
                 varScope = m_lexicalScopeStack[*m_varScopeLexicalScopeStackIndex - 1];
                 SymbolTable* parameterSymbolTable = varScope.m_symbolTable;
-                entry = parameterSymbolTable->get(NoLockingNecessary, functionName.impl());
+                entry = parameterSymbolTable->get(NoLockingNecessary, functionName);
             }
             RELEASE_ASSERT(!entry.isNull());
             bool isLexicallyScoped = false;
@@ -2392,7 +2390,7 @@ void BytecodeGenerator::hoistSloppyModeFunctionIfNecessary(FunctionMetadataNode*
     }
 }
 
-RegisterID* BytecodeGenerator::emitResolveScopeForHoistingFuncDeclInEval(RegisterID* dst, const Identifier& property)
+RegisterID* BytecodeGenerator::emitResolveScopeForHoistingFuncDeclInEval(RegisterID* dst, UniquedStringImpl* property)
 {
     RefPtr<RegisterID> result = finalDestination(dst);
     RefPtr<RegisterID> scope = newTemporary();
@@ -2478,17 +2476,15 @@ void BytecodeGenerator::prepareLexicalScopeForNextForLoopIteration(VariableEnvir
         SymbolTable* symbolTable;
     } symbolTableWithoutLocks { symbolTable };
 
-    auto activationValuesToCopyOver = WTF::compactMap(symbolTableWithoutLocks, [&](auto& pair) -> std::optional<std::pair<RegisterID*, Identifier>> {
+    auto activationValuesToCopyOver = WTF::compactMap(symbolTableWithoutLocks, [&](auto& pair) -> std::optional<std::pair<RegisterID*, RefPtr<UniquedStringImpl>>> {
         if (!pair.value.varOffset().isScope())
             return std::nullopt;
 
-        RefPtr ident = pair.key;
-        auto identifier = Identifier::fromUid(m_vm, ident.get());
-
+        RefPtr uid = pair.key;
         auto* transitionValue = newBlockScopeVariable();
         transitionValue->ref();
-        emitGetFromScope(transitionValue, loopScope, variableForLocalEntry(identifier, pair.value, loopSymbolTable->index(), true), DoNotThrowIfNotFound);
-        return std::make_pair(transitionValue, identifier);
+        emitGetFromScope(transitionValue, loopScope, variableForLocalEntry(uid, pair.value, loopSymbolTable->index(), true), DoNotThrowIfNotFound);
+        return std::make_pair(transitionValue, WTF::move(uid));
     });
 
     // We need this dynamic behavior of the executing code to ensure
@@ -2505,21 +2501,21 @@ void BytecodeGenerator::prepareLexicalScopeForNextForLoopIteration(VariableEnvir
 
     {
         for (const auto& pair : activationValuesToCopyOver) {
-            const Identifier& identifier = pair.second;
-            SymbolTableEntry entry = symbolTable->get(NoLockingNecessary, identifier.impl());
+            UniquedStringImpl* uid = pair.second;
+            SymbolTableEntry entry = symbolTable->get(NoLockingNecessary, uid);
             RELEASE_ASSERT(!entry.isNull());
             RegisterID* transitionValue = pair.first;
-            emitPutToScope(loopScope, variableForLocalEntry(identifier, entry, loopSymbolTable->index(), true), transitionValue, DoNotThrowIfNotFound, InitializationMode::NotInitialization);
+            emitPutToScope(loopScope, variableForLocalEntry(uid, entry, loopSymbolTable->index(), true), transitionValue, DoNotThrowIfNotFound, InitializationMode::NotInitialization);
             transitionValue->deref();
         }
     }
 }
 
-Variable BytecodeGenerator::variable(const Identifier& property, ThisResolutionType thisResolutionType)
+Variable BytecodeGenerator::variable(UniquedStringImpl* property, ThisResolutionType thisResolutionType)
 {
-    if (property == propertyNames().builtinNames().thisPrivateName() && thisResolutionType == ThisResolutionType::Local)
+    if (property == propertyNames().builtinNames().thisPrivateName().impl() && thisResolutionType == ThisResolutionType::Local)
         return Variable(property, VarOffset(thisRegister()->virtualRegister()), thisRegister(), static_cast<unsigned>(PropertyAttribute::ReadOnly), Variable::SpecialVariable, 0, false);
-    
+
     // We can optimize lookups if the lexical variable is found before a "with" or "catch"
     // scope because we're guaranteed static resolution. If we have to pass through
     // a "with" or "catch" scope we loose this guarantee.
@@ -2544,7 +2540,7 @@ Variable BytecodeGenerator::variable(const Identifier& property, ThisResolutionT
         if (stackEntry.m_isWithScope)
             return Variable(property);
         SymbolTable* symbolTable = stackEntry.m_symbolTable;
-        SymbolTableEntry symbolTableEntry = symbolTable->get(NoLockingNecessary, property.impl());
+        SymbolTableEntry symbolTableEntry = symbolTable->get(NoLockingNecessary, property);
         if (symbolTableEntry.isNull())
             continue;
         bool resultIsCallee = false;
@@ -2562,50 +2558,50 @@ Variable BytecodeGenerator::variable(const Identifier& property, ThisResolutionT
             result.setIsReadOnly();
         return result;
     }
-    
+
     return Variable(property);
 }
 
 Variable BytecodeGenerator::variableForLocalEntry(
-    const Identifier& property, const SymbolTableEntry& entry, int symbolTableConstantIndex, bool isLexicallyScoped)
+    UniquedStringImpl* property, const SymbolTableEntry& entry, int symbolTableConstantIndex, bool isLexicallyScoped)
 {
     VarOffset offset = entry.varOffset();
-    
+
     RegisterID* local;
     if (offset.isStack())
         local = &registerFor(offset.stackOffset());
     else
         local = nullptr;
-    
+
     return Variable(property, offset, local, entry.getAttributes(), Variable::NormalVariable, symbolTableConstantIndex, isLexicallyScoped);
 }
 
 void BytecodeGenerator::createVariable(
-    const Identifier& property, VarKind varKind, SymbolTable* symbolTable, ExistingVariableMode existingVariableMode)
+    UniquedStringImpl* property, VarKind varKind, SymbolTable* symbolTable, ExistingVariableMode existingVariableMode)
 {
-    ASSERT(property != propertyNames().builtinNames().thisPrivateName());
-    SymbolTableEntry entry = symbolTable->get(NoLockingNecessary, property.impl());
-    
+    ASSERT(property != propertyNames().builtinNames().thisPrivateName().impl());
+    SymbolTableEntry entry = symbolTable->get(NoLockingNecessary, property);
+
     if (!entry.isNull()) {
         if (existingVariableMode == IgnoreExisting)
             return;
-        
+
         // Do some checks to ensure that the variable we're being asked to create is sufficiently
         // compatible with the one we have already created.
 
         VarOffset offset = entry.varOffset();
-        
+
         // We can't change our minds about whether it's captured.
         if (offset.kind() != varKind) {
             dataLog(
-                "Trying to add variable called ", property, " as ", varKind,
+                "Trying to add variable called ", StringView(property), " as ", varKind,
                 " but it was already added as ", offset, ".\n");
             RELEASE_ASSERT_NOT_REACHED();
         }
 
         return;
     }
-    
+
     VarOffset varOffset;
     if (varKind == VarKind::Scope)
         varOffset = VarOffset(symbolTable->takeNextScopeOffset(NoLockingNecessary));
@@ -2614,8 +2610,8 @@ void BytecodeGenerator::createVariable(
         varOffset = VarOffset(virtualRegisterForLocal(m_calleeLocals.size()));
     }
     SymbolTableEntry newEntry(varOffset, 0);
-    symbolTable->add(NoLockingNecessary, property.impl(), newEntry);
-    
+    symbolTable->add(NoLockingNecessary, property, newEntry);
+
     if (varKind == VarKind::Stack) {
         RegisterID* local = addVar();
         RELEASE_ASSERT(local->index() == varOffset.stackOffset().offset());
@@ -2625,14 +2621,14 @@ void BytecodeGenerator::createVariable(
 std::optional<Variable> BytecodeGenerator::tryResolveVariable(ExpressionNode* expr)
 {
     if (expr->isResolveNode())
-        return variable(static_cast<ResolveNode*>(expr)->identifier());
+        return variable(static_cast<ResolveNode*>(expr)->ident());
 
     if (expr->isAssignResolveNode())
-        return variable(static_cast<AssignResolveNode*>(expr)->identifier());
+        return variable(static_cast<AssignResolveNode*>(expr)->ident());
 
     if (expr->isThisNode()) {
         // After generator.ensureThis (which must be invoked in |base|'s materialization), we can ensure that |this| is in local this-register.
-        return variable(propertyNames().builtinNames().thisPrivateName(), ThisResolutionType::Local);
+        return variable(propertyNames().builtinNames().thisPrivateName().impl(), ThisResolutionType::Local);
     }
 
     if (expr->isCommaNode()) {
@@ -2686,7 +2682,7 @@ RegisterID* BytecodeGenerator::emitResolveScope(RegisterID* dst, const Variable&
             // scope and the resolved scope.
             RELEASE_ASSERT(!stackEntry.m_isWithScope);
 
-            if (stackEntry.m_symbolTable->get(NoLockingNecessary, variable.ident().impl()).isNull())
+            if (stackEntry.m_symbolTable->get(NoLockingNecessary, variable.ident()).isNull())
                 continue;
             
             RegisterID* scope = stackEntry.m_scope;
@@ -2770,7 +2766,7 @@ RegisterID* BytecodeGenerator::emitPutToScope(RegisterID* scope, const Variable&
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-RegisterID* BytecodeGenerator::emitPutToScopeDynamic(RegisterID* scope, const Identifier& ident, RegisterID* value, ResolveMode resolveMode, InitializationMode initializationMode)
+RegisterID* BytecodeGenerator::emitPutToScopeDynamic(RegisterID* scope, UniquedStringImpl* ident, RegisterID* value, ResolveMode resolveMode, InitializationMode initializationMode)
 {
     GetPutInfo getPutInfo(resolveMode, Dynamic, initializationMode, ecmaMode());
     unsigned scopeOffset = 0;
@@ -2807,7 +2803,7 @@ RegisterID* BytecodeGenerator::emitInByVal(RegisterID* dst, RegisterID* property
     return dst;
 }
 
-RegisterID* BytecodeGenerator::emitInById(RegisterID* dst, RegisterID* base, const Identifier& property)
+RegisterID* BytecodeGenerator::emitInById(RegisterID* dst, RegisterID* base, UniquedStringImpl* property)
 {
     OpInById::emit(this, dst, base, addConstant(property));
     return dst;
@@ -2819,36 +2815,36 @@ RegisterID* BytecodeGenerator::emitGetLength(RegisterID* dst, RegisterID* base)
     return dst;
 }
 
-RegisterID* BytecodeGenerator::emitGetById(RegisterID* dst, RegisterID* base, const Identifier& property)
+RegisterID* BytecodeGenerator::emitGetById(RegisterID* dst, RegisterID* base, UniquedStringImpl* property)
 {
-    ASSERT_WITH_MESSAGE(!parseIndex(property), "Indexed properties should be handled with get_by_val.");
+    ASSERT_WITH_MESSAGE(!parseIndex(PropertyName(property)), "Indexed properties should be handled with get_by_val.");
 
-    if (property == m_vm.propertyNames->length)
+    if (property == m_vm.propertyNames->length.impl())
         OpGetLength::emit(this, kill(dst), base, nextValueProfileIndex());
     else
         OpGetById::emit(this, kill(dst), base, addConstant(property), nextValueProfileIndex());
     return dst;
 }
 
-RegisterID* BytecodeGenerator::emitGetById(RegisterID* dst, RegisterID* base, RegisterID* thisVal, const Identifier& property)
+RegisterID* BytecodeGenerator::emitGetById(RegisterID* dst, RegisterID* base, RegisterID* thisVal, UniquedStringImpl* property)
 {
-    ASSERT_WITH_MESSAGE(!parseIndex(property), "Indexed properties should be handled with get_by_val.");
+    ASSERT_WITH_MESSAGE(!parseIndex(PropertyName(property)), "Indexed properties should be handled with get_by_val.");
 
     OpGetByIdWithThis::emit(this, kill(dst), base, thisVal, addConstant(property), nextValueProfileIndex());
     return dst;
 }
 
-RegisterID* BytecodeGenerator::emitDirectGetById(RegisterID* dst, RegisterID* base, const Identifier& property)
+RegisterID* BytecodeGenerator::emitDirectGetById(RegisterID* dst, RegisterID* base, UniquedStringImpl* property)
 {
-    ASSERT_WITH_MESSAGE(!parseIndex(property), "Indexed properties should be handled with get_by_val_direct.");
+    ASSERT_WITH_MESSAGE(!parseIndex(PropertyName(property)), "Indexed properties should be handled with get_by_val_direct.");
 
     OpGetByIdDirect::emit(this, kill(dst), base, addConstant(property), nextValueProfileIndex());
     return dst;
 }
 
-RegisterID* BytecodeGenerator::emitPutById(RegisterID* base, const Identifier& property, RegisterID* value)
+RegisterID* BytecodeGenerator::emitPutById(RegisterID* base, UniquedStringImpl* property, RegisterID* value)
 {
-    ASSERT_WITH_MESSAGE(!parseIndex(property), "Indexed properties should be handled with put_by_val.");
+    ASSERT_WITH_MESSAGE(!parseIndex(PropertyName(property)), "Indexed properties should be handled with put_by_val.");
 
     unsigned propertyIndex = addConstant(property);
 
@@ -2858,9 +2854,9 @@ RegisterID* BytecodeGenerator::emitPutById(RegisterID* base, const Identifier& p
     return value;
 }
 
-RegisterID* BytecodeGenerator::emitPutById(RegisterID* base, RegisterID* thisValue, const Identifier& property, RegisterID* value)
+RegisterID* BytecodeGenerator::emitPutById(RegisterID* base, RegisterID* thisValue, UniquedStringImpl* property, RegisterID* value)
 {
-    ASSERT_WITH_MESSAGE(!parseIndex(property), "Indexed properties should be handled with put_by_val.");
+    ASSERT_WITH_MESSAGE(!parseIndex(PropertyName(property)), "Indexed properties should be handled with put_by_val.");
 
     unsigned propertyIndex = addConstant(property);
 
@@ -2869,9 +2865,9 @@ RegisterID* BytecodeGenerator::emitPutById(RegisterID* base, RegisterID* thisVal
     return value;
 }
 
-RegisterID* BytecodeGenerator::emitDirectPutById(RegisterID* base, const Identifier& property, RegisterID* value)
+RegisterID* BytecodeGenerator::emitDirectPutById(RegisterID* base, UniquedStringImpl* property, RegisterID* value)
 {
-    ASSERT_WITH_MESSAGE(!parseIndex(property), "Indexed properties should be handled with put_by_val(direct).");
+    ASSERT_WITH_MESSAGE(!parseIndex(PropertyName(property)), "Indexed properties should be handled with put_by_val(direct).");
 
     unsigned propertyIndex = addConstant(property);
 
@@ -2882,7 +2878,7 @@ RegisterID* BytecodeGenerator::emitDirectPutById(RegisterID* base, const Identif
     return value;
 }
 
-void BytecodeGenerator::emitPutGetterById(RegisterID* base, const Identifier& property, unsigned attributes, RegisterID* getter)
+void BytecodeGenerator::emitPutGetterById(RegisterID* base, UniquedStringImpl* property, unsigned attributes, RegisterID* getter)
 {
     unsigned propertyIndex = addConstant(property);
     m_staticPropertyAnalyzer.putById(base, propertyIndex);
@@ -2890,7 +2886,7 @@ void BytecodeGenerator::emitPutGetterById(RegisterID* base, const Identifier& pr
     OpPutGetterById::emit(this, base, propertyIndex, attributes, getter);
 }
 
-void BytecodeGenerator::emitPutSetterById(RegisterID* base, const Identifier& property, unsigned attributes, RegisterID* setter)
+void BytecodeGenerator::emitPutSetterById(RegisterID* base, UniquedStringImpl* property, unsigned attributes, RegisterID* setter)
 {
     unsigned propertyIndex = addConstant(property);
     m_staticPropertyAnalyzer.putById(base, propertyIndex);
@@ -2898,7 +2894,7 @@ void BytecodeGenerator::emitPutSetterById(RegisterID* base, const Identifier& pr
     OpPutSetterById::emit(this, base, propertyIndex, attributes, setter);
 }
 
-void BytecodeGenerator::emitPutGetterSetter(RegisterID* base, const Identifier& property, unsigned attributes, RegisterID* getter, RegisterID* setter)
+void BytecodeGenerator::emitPutGetterSetter(RegisterID* base, UniquedStringImpl* property, unsigned attributes, RegisterID* getter, RegisterID* setter)
 {
     unsigned propertyIndex = addConstant(property);
 
@@ -2935,7 +2931,7 @@ void BytecodeGenerator::emitPutAsyncGeneratorFields(RegisterID* nextFunction)
     emitPutInternalField(m_generatorRegister, static_cast<unsigned>(JSAsyncGenerator::Field::This), &m_thisRegister);
 }
 
-RegisterID* BytecodeGenerator::emitDeleteById(RegisterID* dst, RegisterID* base, const Identifier& property)
+RegisterID* BytecodeGenerator::emitDeleteById(RegisterID* dst, RegisterID* base, UniquedStringImpl* property)
 {
     OpDelById::emit(this, dst, base, addConstant(property), ecmaMode());
     return dst;
@@ -3066,14 +3062,14 @@ void BytecodeGenerator::emitCreatePrivateBrand(const JSTextPosition& divot, cons
     emitLoad(arguments.argumentRegister(0), jsEmptyString(m_vm));
     RegisterID* newSymbol = emitCall(finalDestination(nullptr, createPrivateSymbol.get()), createPrivateSymbol.get(), NoExpectedFunction, arguments, divot, divotStart, divotEnd, DebuggableCall::No);
 
-    Variable privateBrandVar = variable(propertyNames().builtinNames().privateBrandPrivateName());
+    Variable privateBrandVar = variable(propertyNames().builtinNames().privateBrandPrivateName().impl());
 
     emitPutToScope(scopeRegister(), privateBrandVar, newSymbol, DoNotThrowIfNotFound, InitializationMode::ConstInitialization);
 }
 
 void BytecodeGenerator::emitInstallPrivateBrand(RegisterID* target)
 {
-    Variable privateBrandVar = variable(propertyNames().builtinNames().privateBrandPrivateName());
+    Variable privateBrandVar = variable(propertyNames().builtinNames().privateBrandPrivateName().impl());
     RefPtr<RegisterID> privateBrandVarScope = emitResolveScope(nullptr, privateBrandVar);
     bool isStatic = false;
     RegisterID* privateBrandSymbol = emitGetPrivateBrand(newTemporary(), privateBrandVarScope.get(), isStatic);
@@ -3082,7 +3078,7 @@ void BytecodeGenerator::emitInstallPrivateBrand(RegisterID* target)
 
 void BytecodeGenerator::emitInstallPrivateClassBrand(RegisterID* target)
 {
-    Variable privateBrandVar = variable(propertyNames().builtinNames().privateClassBrandPrivateName());
+    Variable privateBrandVar = variable(propertyNames().builtinNames().privateClassBrandPrivateName().impl());
     emitPutToScope(scopeRegister(), privateBrandVar, target, DoNotThrowIfNotFound, InitializationMode::ConstInitialization);
 }
 
@@ -3093,7 +3089,7 @@ RegisterID* BytecodeGenerator::emitGetPrivateBrand(RegisterID* dst, RegisterID* 
         this,
         kill(dst),
         scope,
-        addConstant(isStatic ? propertyNames().builtinNames().privateClassBrandPrivateName() : propertyNames().builtinNames().privateBrandPrivateName()),
+        addConstant(isStatic ? propertyNames().builtinNames().privateClassBrandPrivateName().impl() : propertyNames().builtinNames().privateBrandPrivateName().impl()),
         GetPutInfo(ThrowIfNotFound, ResolvedClosureVar, InitializationMode::NotInitialization, ecmaMode()),
         0,
         isStatic ? PrivateNameEntry::privateClassBrandOffset : PrivateNameEntry::privateBrandOffset,
@@ -3209,7 +3205,7 @@ RegisterID* BytecodeGenerator::emitInstanceFieldInitializationIfNeeded(RegisterI
     if (!(isConstructor() || isDerivedConstructorContext()) || needsClassFieldInitializer() == NeedsClassFieldInitializer::No)
         return dst;
 
-    RefPtr<RegisterID> initializer = emitDirectGetById(newTemporary(), constructor, propertyNames().builtinNames().instanceFieldInitializerPrivateName());
+    RefPtr<RegisterID> initializer = emitDirectGetById(newTemporary(), constructor, propertyNames().builtinNames().instanceFieldInitializerPrivateName().impl());
     CallArguments args(*this, nullptr);
     emitMove(args.thisRegister(), dst);
     emitCallIgnoreResult(newTemporary(), initializer.get(), NoExpectedFunction, args, divot, divotStart, divotEnd, DebuggableCall::No);
@@ -3225,7 +3221,7 @@ void BytecodeGenerator::emitTDZCheck(RegisterID* target)
 bool BytecodeGenerator::needsTDZCheck(const Variable& variable)
 {
     for (unsigned i = m_TDZStack.size(); i--;) {
-        auto iter = m_TDZStack[i].first.find(variable.ident().impl());
+        auto iter = m_TDZStack[i].first.find(variable.ident());
         if (iter == m_TDZStack[i].first.end())
             continue;
         return iter->value != TDZNecessityLevel::NotNeeded;
@@ -3234,7 +3230,7 @@ bool BytecodeGenerator::needsTDZCheck(const Variable& variable)
     {
         TDZEnvironmentLink* environment = m_cachedParentTDZ.get();
         while (environment) {
-            if (environment->contains(variable.ident().impl()))
+            if (environment->contains(variable.ident()))
                 return true;
             environment = environment->parent();
         }
@@ -3257,7 +3253,7 @@ void BytecodeGenerator::emitTDZCheckIfNecessary(const Variable& variable, Regist
 
 void BytecodeGenerator::liftTDZCheckIfPossible(const Variable& variable)
 {
-    UniquedStringImpl* identifier = variable.ident().impl();
+    UniquedStringImpl* identifier = variable.ident();
     for (unsigned i = m_TDZStack.size(); i--;) {
         auto iter = m_TDZStack[i].first.find(identifier);
         if (iter != m_TDZStack[i].first.end()) {
@@ -3269,11 +3265,11 @@ void BytecodeGenerator::liftTDZCheckIfPossible(const Variable& variable)
 }
 
 // This should be called only with PrivateNames available.
-PrivateNameEntry BytecodeGenerator::getPrivateTraits(const Identifier& ident)
+PrivateNameEntry BytecodeGenerator::getPrivateTraits(UniquedStringImpl* uid)
 {
     for (unsigned i = m_privateNamesStack.size(); i--; ) {
         auto& map = m_privateNamesStack[i];
-        auto it = map.find(ident.impl());
+        auto it = map.find(uid);
         if (it != map.end())
             return it->value;
     }
@@ -3323,7 +3319,7 @@ Vector<Identifier> BytecodeGenerator::getParameterNames() const
     FunctionParameters& parameters = *static_cast<FunctionNode*>(m_scopeNode)->parameters();
     Vector<Identifier> parameterNames;
     for (unsigned i = 0; i < parameters.size(); i++)
-        parameters.at(i).first->collectBoundIdentifiers(parameterNames);
+        parameters.at(i).first->collectBoundIdentifiers(m_vm, parameterNames);
     return parameterNames;
 }
 
@@ -3403,14 +3399,14 @@ RegisterID* BytecodeGenerator::emitNewObject(RegisterID* dst)
     return dst;
 }
 
-JSValue BytecodeGenerator::addBigIntConstant(const Identifier& identifier, uint8_t radix, bool sign)
+JSValue BytecodeGenerator::addBigIntConstant(UniquedStringImpl* uid, uint8_t radix, bool sign)
 {
-    return m_bigIntMap.ensure(BigIntMapEntry(identifier.impl(), radix, sign), [&] {
+    return m_bigIntMap.ensure(BigIntMapEntry(uid, radix, sign), [&] {
         VM& vm = this->vm();
         DeferTermination deferScope(vm);
         auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
         auto parseIntSign = sign ? JSBigInt::ParseIntSign::Signed : JSBigInt::ParseIntSign::Unsigned;
-        JSValue bigIntInMap = JSBigInt::parseInt(nullptr, vm, identifier.string(), radix, JSBigInt::ErrorParseMode::ThrowExceptions, parseIntSign);
+        JSValue bigIntInMap = JSBigInt::parseInt(nullptr, vm, String(uid), radix, JSBigInt::ErrorParseMode::ThrowExceptions, parseIntSign);
         scope.assertNoException();
         addConstantValue(bigIntInMap);
 
@@ -3418,11 +3414,11 @@ JSValue BytecodeGenerator::addBigIntConstant(const Identifier& identifier, uint8
     }).iterator->value;
 }
 
-JSString* BytecodeGenerator::addStringConstant(const Identifier& identifier)
+JSString* BytecodeGenerator::addStringConstant(UniquedStringImpl* uid)
 {
-    JSString*& stringInMap = m_stringMap.add(identifier.impl(), nullptr).iterator->value;
+    JSString*& stringInMap = m_stringMap.add(uid, nullptr).iterator->value;
     if (!stringInMap) {
-        stringInMap = jsString(vm(), identifier.string());
+        stringInMap = jsString(vm(), String(uid));
         addConstantValue(stringInMap);
     }
     return stringInMap;
@@ -3594,7 +3590,7 @@ RegisterID* BytecodeGenerator::emitNewClassFieldInitializerFunction(RegisterID* 
     ConstructAbility constructAbility = ConstructAbility::CannotConstruct;
 
     FunctionMetadataNode metadata(parserArena(), JSTokenLocation(), JSTokenLocation(), 0, 0, 0, 0, 0, ImplementationVisibility::Private, StrictModeLexicallyScopedFeature, ConstructorKind::None, superBinding, 0, parseMode, false);
-    metadata.finishParsing(m_scopeNode->source(), Identifier(), FunctionMode::MethodDefinition);
+    metadata.finishParsing(m_scopeNode->source(), nullptr, FunctionMode::MethodDefinition);
     auto initializer = UnlinkedFunctionExecutable::create(m_vm, m_scopeNode->source(), &metadata, isBuiltinFunction() ? UnlinkedBuiltinFunction : UnlinkedNormalFunction, constructAbility, InlineAttribute::Always, scriptMode(), WTF::move(variablesUnderTDZ), { }, WTF::move(parentPrivateNameEnvironment), newDerivedContextType, EvalContextType::InstanceFieldEvalContext, NeedsClassFieldInitializer::No, PrivateBrandRequirement::None);
     initializer->setClassElementDefinitions(WTF::move(classElementDefinitions));
 
@@ -3621,13 +3617,13 @@ bool BytecodeGenerator::shouldSetFunctionName(ExpressionNode* node)
 {
     if (node->isBaseFuncExprNode()) {
         FunctionMetadataNode* metadata = static_cast<BaseFuncExprNode*>(node)->metadata();
-        if (!metadata->ecmaName().isNull())
+        if (metadata->ecmaName())
             return false;
     } else if (node->isClassExprNode()) {
         ClassExprNode* classExprNode = static_cast<ClassExprNode*>(node);
-        if (!classExprNode->ecmaName().isNull())
+        if (classExprNode->ecmaName())
             return false;
-        if (classExprNode->hasStaticProperty(m_vm.propertyNames->name))
+        if (classExprNode->hasStaticProperty(m_vm.propertyNames->name.impl()))
             return false;
     } else
         return false;
@@ -3637,7 +3633,7 @@ bool BytecodeGenerator::shouldSetFunctionName(ExpressionNode* node)
 
 void BytecodeGenerator::emitSetFunctionName(RegisterID* value, const Identifier& ident)
 {
-    RefPtr<RegisterID> name = emitLoad(newTemporary(), ident);
+    RefPtr<RegisterID> name = emitLoad(newTemporary(), ident.impl());
 
     // FIXME: We should use an op_call to an internal function here instead.
     // https://bugs.webkit.org/show_bug.cgi?id=155547
@@ -3677,13 +3673,13 @@ RegisterID* BytecodeGenerator::emitCallDirectEval(RegisterID* dst, RegisterID* f
     return emitCall<OpCallDirectEval>(dst, func, NoExpectedFunction, callArguments, divot, divotStart, divotEnd, debuggableCall);
 }
 
-ExpectedFunction BytecodeGenerator::expectedFunctionForIdentifier(const Identifier& identifier)
+ExpectedFunction BytecodeGenerator::expectedFunctionForIdentifier(UniquedStringImpl* uid)
 {
     if (shouldEmitDebugHooks()) [[unlikely]]
         return NoExpectedFunction;
-    if (identifier == propertyNames().Object || identifier == propertyNames().builtinNames().ObjectPrivateName())
+    if (uid == propertyNames().Object.impl() || uid == propertyNames().builtinNames().ObjectPrivateName().impl())
         return ExpectObjectConstructor;
-    if (identifier == propertyNames().Array || identifier == propertyNames().builtinNames().ArrayPrivateName())
+    if (uid == propertyNames().Array.impl() || uid == propertyNames().builtinNames().ArrayPrivateName().impl())
         return ExpectArrayConstructor;
     return NoExpectedFunction;
 }
@@ -3944,7 +3940,9 @@ RegisterID* BytecodeGenerator::emitReturn(RegisterID* src)
                 emitJumpIfTrue(emitIsUndefined(newTemporary(), src), isUndefinedLabel.get());
 
                 ASSERT(m_scopeNode->isFunctionNode());
-                String className = static_cast<FunctionNode*>(m_scopeNode)->ident().string();
+                String className;
+                if (auto* uid = static_cast<FunctionNode*>(m_scopeNode)->ident())
+                    className = String(uid);
                 if (!className || className.isEmpty())
                     emitThrowTypeError("Cannot return a non-object type in the constructor of a derived class."_s);
                 else {
@@ -3952,7 +3950,7 @@ RegisterID* BytecodeGenerator::emitReturn(RegisterID* src)
                     if (!errorMessageStr) [[unlikely]]
                         emitThrowTypeError("Cannot return a non-object type in the constructor of a derived class."_s);
                     else
-                        emitThrowTypeError(Identifier::fromString(m_vm, errorMessageStr));
+                        emitThrowTypeError(Identifier::fromString(m_vm, errorMessageStr).impl());
                 }
 
                 emitLabel(isUndefinedLabel.get());
@@ -4145,7 +4143,7 @@ void BytecodeGenerator::popFinallyControlFlowScope()
     m_controlFlowScopeStack.removeLast();
 }
 
-LabelScope* BytecodeGenerator::breakTarget(const Identifier& name)
+LabelScope* BytecodeGenerator::breakTarget(UniquedStringImpl* name)
 {
     shrinkToFit(m_labelScopes);
 
@@ -4155,7 +4153,7 @@ LabelScope* BytecodeGenerator::breakTarget(const Identifier& name)
     // We special-case the following, which is a syntax error in Firefox:
     // label:
     //     break;
-    if (name.isEmpty()) {
+    if (!name) {
         for (int i = m_labelScopes.size() - 1; i >= 0; --i) {
             LabelScope& scope = m_labelScopes[i];
             if (scope.type() != LabelScope::NamedLabel)
@@ -4166,20 +4164,20 @@ LabelScope* BytecodeGenerator::breakTarget(const Identifier& name)
 
     for (int i = m_labelScopes.size() - 1; i >= 0; --i) {
         LabelScope& scope = m_labelScopes[i];
-        if (scope.name() && *scope.name() == name)
+        if (scope.name() && scope.name() == name)
             return &scope;
     }
     return nullptr;
 }
 
-LabelScope* BytecodeGenerator::continueTarget(const Identifier& name)
+LabelScope* BytecodeGenerator::continueTarget(UniquedStringImpl* name)
 {
     shrinkToFit(m_labelScopes);
 
     if (!m_labelScopes.size())
         return nullptr;
 
-    if (name.isEmpty()) {
+    if (!name) {
         for (int i = m_labelScopes.size() - 1; i >= 0; --i) {
             LabelScope& scope = m_labelScopes[i];
             if (scope.type() == LabelScope::Loop) {
@@ -4199,7 +4197,7 @@ LabelScope* BytecodeGenerator::continueTarget(const Identifier& name)
             ASSERT(scope.continueTarget());
             result = &scope;
         }
-        if (scope.name() && *scope.name() == name)
+        if (scope.name() && scope.name() == name)
             return result; // may be null.
     }
     return nullptr;
@@ -4329,37 +4327,37 @@ void BytecodeGenerator::emitThrowStaticError(ErrorTypeWithExtension errorType, R
     OpThrowStaticError::emit(this, message.get(), errorType);
 }
 
-void BytecodeGenerator::emitThrowStaticError(ErrorTypeWithExtension errorType, const Identifier& message)
+void BytecodeGenerator::emitThrowStaticError(ErrorTypeWithExtension errorType, UniquedStringImpl* message)
 {
     OpThrowStaticError::emit(this, addConstantValue(addStringConstant(message)), errorType);
 }
 
 void BytecodeGenerator::emitThrowReferenceError(ASCIILiteral message)
 {
-    emitThrowStaticError(ErrorTypeWithExtension::ReferenceError, Identifier::fromString(m_vm, message));
+    emitThrowStaticError(ErrorTypeWithExtension::ReferenceError, Identifier::fromString(m_vm, message).impl());
 }
 
 void BytecodeGenerator::emitThrowTypeError(ASCIILiteral message)
 {
-    emitThrowStaticError(ErrorTypeWithExtension::TypeError, Identifier::fromString(m_vm, message));
+    emitThrowStaticError(ErrorTypeWithExtension::TypeError, Identifier::fromString(m_vm, message).impl());
 }
 
-void BytecodeGenerator::emitThrowTypeError(const Identifier& message)
+void BytecodeGenerator::emitThrowTypeError(UniquedStringImpl* message)
 {
     emitThrowStaticError(ErrorTypeWithExtension::TypeError, message);
 }
 
-void BytecodeGenerator::emitThrowRangeError(const Identifier& message)
+void BytecodeGenerator::emitThrowRangeError(UniquedStringImpl* message)
 {
     emitThrowStaticError(ErrorTypeWithExtension::RangeError, message);
 }
 
 void BytecodeGenerator::emitThrowOutOfMemoryError()
 {
-    emitThrowStaticError(ErrorTypeWithExtension::OutOfMemoryError, m_vm.propertyNames->emptyIdentifier);
+    emitThrowStaticError(ErrorTypeWithExtension::OutOfMemoryError, m_vm.propertyNames->emptyIdentifier.impl());
 }
 
-void BytecodeGenerator::emitPushFunctionNameScope(const Identifier& property, RegisterID* callee, bool isCaptured)
+void BytecodeGenerator::emitPushFunctionNameScope(UniquedStringImpl* property, RegisterID* callee, bool isCaptured)
 {
     // There is some nuance here:
     // If we're in strict mode code, the function name scope variable acts exactly like a "const" variable.
@@ -4367,7 +4365,7 @@ void BytecodeGenerator::emitPushFunctionNameScope(const Identifier& property, Re
     // This means any assignment to the variable won't throw, but it won't actually assign a new value to it.
     // To accomplish this, we don't report that this scope is a lexical scope. This will prevent
     // any throws when trying to assign to the variable (while still ensuring it keeps its original
-    // value). There is some ugliness and exploitation of a leaky abstraction here, but it's better than 
+    // value). There is some ugliness and exploitation of a leaky abstraction here, but it's better than
     // having a completely new op code and a class to handle name scopes which are so close in functionality
     // to lexical environments.
     VariableEnvironment nameScopeEnvironment;
@@ -4379,7 +4377,7 @@ void BytecodeGenerator::emitPushFunctionNameScope(const Identifier& property, Re
     pushLexicalScopeInternal(nameScopeEnvironment, TDZCheckOptimization::Optimize, NestedScopeType::IsNotNested, nullptr, TDZRequirement::NotUnderTDZ, ScopeType::FunctionNameScope, ScopeRegisterType::Var);
     ASSERT_UNUSED(numVars, m_codeBlock->numVars() == numVars + 1); // Should have only created one new "var" for the function name scope.
     bool shouldTreatAsLexicalVariable = ecmaMode().isStrict();
-    Variable functionVar = variableForLocalEntry(property, m_lexicalScopeStack.last().m_symbolTable->get(NoLockingNecessary, property.impl()), m_lexicalScopeStack.last().m_symbolTableConstantIndex, shouldTreatAsLexicalVariable);
+    Variable functionVar = variableForLocalEntry(property, m_lexicalScopeStack.last().m_symbolTable->get(NoLockingNecessary, property), m_lexicalScopeStack.last().m_symbolTableConstantIndex, shouldTreatAsLexicalVariable);
     emitPutToScope(m_lexicalScopeStack.last().m_scope, functionVar, callee, ThrowIfNotFound, InitializationMode::NotInitialization);
 }
 
@@ -4465,7 +4463,7 @@ void BytecodeGenerator::endSwitch(const Vector<Ref<Label>, 8>& labels, Expressio
                 key = extracted - min;
             } else {
                 ASSERT(nodes[i]->isString());
-                StringImpl* clause = static_cast<StringNode*>(nodes[i])->value().impl();
+                StringImpl* clause = static_cast<StringNode*>(nodes[i])->value();
                 ASSERT(clause->length() == 1);
                 int32_t extracted = (*clause)[0];
                 ASSERT(extracted >= min);
@@ -4496,11 +4494,10 @@ void BytecodeGenerator::endSwitch(const Vector<Ref<Label>, 8>& labels, Expressio
                 double value = static_cast<NumberNode*>(nodes[i])->value();
                 key = static_cast<int32_t>(value);
             } else {
-                StringImpl* clause = static_cast<StringNode*>(nodes[i])->value().impl();
+                StringImpl* clause = static_cast<StringNode*>(nodes[i])->value();
                 ASSERT(clause->length() == 1);
                 key = (*clause)[0];
             }
-
             // There is a chance that we may list up duplicate keys. In this case, the first one wins.
             if (!alreadyHandled.add(key).isNewEntry)
                 continue;
@@ -4522,7 +4519,7 @@ void BytecodeGenerator::endSwitch(const Vector<Ref<Label>, 8>& labels, Expressio
             ASSERT(!labels[i]->isForward());
 
             ASSERT(nodes[i]->isString());
-            UniquedStringImpl* clause = static_cast<StringNode*>(nodes[i])->value().impl();
+            UniquedStringImpl* clause = static_cast<StringNode*>(nodes[i])->value();
             ASSERT(clause->isAtom());
             auto result = jumpTable.m_offsetTable.add(clause, UnlinkedStringJumpTable::OffsetLocation { labels[i]->bind(switchInfo.bytecodeOffset), 0 });
             if (result.isNewEntry) {
@@ -4583,9 +4580,9 @@ RegisterID* BytecodeGenerator::emitThrowExpressionTooDeepException()
     return newTemporary();
 }
 
-bool BytecodeGenerator::isArgumentNumber(const Identifier& ident, int argumentNumber)
+bool BytecodeGenerator::isArgumentNumber(UniquedStringImpl* uid, int argumentNumber)
 {
-    RegisterID* registerID = variable(ident).local();
+    RegisterID* registerID = variable(uid).local();
     if (!registerID)
         return false;
     return registerID->index() == CallFrame::argumentOffset(argumentNumber);
@@ -4596,7 +4593,7 @@ bool BytecodeGenerator::emitReadOnlyExceptionIfNeeded(const Variable& variable)
     // If we're in strict mode, we always throw.
     // If we're not in strict mode, we throw for "const" variables but not the function callee.
     if (ecmaMode().isStrict() || variable.isConst()) {
-        emitThrowTypeError(Identifier::fromString(m_vm, ReadonlyPropertyWriteError));
+        emitThrowTypeError(Identifier::fromString(m_vm, ReadonlyPropertyWriteError).impl());
         return true;
     }
     return false;
@@ -4905,7 +4902,7 @@ void BytecodeGenerator::emitGenericEnumeration(ThrowableExpressionData* node, Ex
     RefPtr<RegisterID> subject = newTemporary();
     emitNode(subject.get(), subjectNode);
     RefPtr<RegisterID> iterator = isForAwait ? emitGetAsyncIterator(subject.get(), node) : emitGetGenericIterator(subject.get(), node);
-    RefPtr<RegisterID> nextMethod = emitGetById(newTemporary(), iterator.get(), propertyNames().next);
+    RefPtr<RegisterID> nextMethod = emitGetById(newTemporary(), iterator.get(), propertyNames().next.impl());
 
     Ref<Label> loopDone = newLabel();
 
@@ -4942,8 +4939,8 @@ void BytecodeGenerator::emitGenericEnumeration(ThrowableExpressionData* node, Ex
         {
             emitIteratorGenericNext(value.get(), nextMethod.get(), iterator.get(), node, shouldEmitAwait);
 
-            emitJumpIfTrue(emitGetById(newTemporary(), value.get(), propertyNames().done), loopDone.get());
-            emitGetById(value.get(), value.get(), propertyNames().value);
+            emitJumpIfTrue(emitGetById(newTemporary(), value.get(), propertyNames().done.impl()), loopDone.get());
+            emitGetById(value.get(), value.get(), propertyNames().value.impl());
             emitJump(loopStart.get());
         }
 
@@ -4974,7 +4971,7 @@ void BytecodeGenerator::emitEnumeration(ThrowableExpressionData* node, Expressio
     RefPtr<RegisterID> iterator = newTemporary();
     {
         emitExpressionInfo(node->divot(), node->divotStart(), node->divotEnd());
-        RefPtr<RegisterID> iteratorSymbol = emitGetById(newTemporary(), iterable.get(), propertyNames().iteratorSymbol);
+        RefPtr<RegisterID> iteratorSymbol = emitGetById(newTemporary(), iterable.get(), propertyNames().iteratorSymbol.impl());
         CallArguments args(*this, nullptr, 0);
         move(args.thisRegister(), iterable.get());
         emitIteratorOpen(iterator.get(), nextOrIndex.get(), iteratorSymbol.get(), args, node);
@@ -5040,11 +5037,11 @@ RegisterID* BytecodeGenerator::emitGetTemplateObject(RegisterID* dst, TaggedTemp
     for (; templateString; templateString = templateString->next()) {
         auto* string = templateString->value();
         ASSERT(string->raw());
-        rawStrings.append(string->raw()->impl());
+        rawStrings.append(String(string->raw()));
         if (!string->cooked())
             cookedStrings.append(std::nullopt);
         else
-            cookedStrings.append(string->cooked()->impl());
+            cookedStrings.append(String(string->cooked()));
     }
     RefPtr<RegisterID> constant = addTemplateObjectConstant(TemplateObjectDescriptor::create(WTF::move(rawStrings), WTF::move(cookedStrings)), taggedTemplate->endOffset());
     if (!dst)
@@ -5052,7 +5049,7 @@ RegisterID* BytecodeGenerator::emitGetTemplateObject(RegisterID* dst, TaggedTemp
     return move(dst, constant.get());
 }
 
-RegisterID* BytecodeGenerator::emitGetGlobalPrivate(RegisterID* dst, const Identifier& property)
+RegisterID* BytecodeGenerator::emitGetGlobalPrivate(RegisterID* dst, UniquedStringImpl* property)
 {
     dst = tempDestination(dst);
     Variable var = variable(property);
@@ -5123,7 +5120,7 @@ RegisterID* BytecodeGenerator::emitIsEmpty(RegisterID* dst, RegisterID* src)
     return dst;
 }
 
-RegisterID* BytecodeGenerator::emitLoadArrowFunctionLexicalEnvironment(const Identifier& identifier)
+RegisterID* BytecodeGenerator::emitLoadArrowFunctionLexicalEnvironment(UniquedStringImpl* identifier)
 {
     ASSERT(m_codeBlock->isArrowFunction() || m_codeBlock->isArrowFunctionContext() || constructorKind() == ConstructorKind::Extends || m_codeType == EvalCode || m_codeBlock->parseMode() == SourceParseMode::ClassFieldInitializerMode);
 
@@ -5132,21 +5129,21 @@ RegisterID* BytecodeGenerator::emitLoadArrowFunctionLexicalEnvironment(const Ide
 
 void BytecodeGenerator::emitLoadThisFromArrowFunctionLexicalEnvironment()
 {
-    emitGetFromScope(thisRegister(), emitLoadArrowFunctionLexicalEnvironment(propertyNames().builtinNames().thisPrivateName()), variable(propertyNames().builtinNames().thisPrivateName(), ThisResolutionType::Scoped), DoNotThrowIfNotFound);
+    emitGetFromScope(thisRegister(), emitLoadArrowFunctionLexicalEnvironment(propertyNames().builtinNames().thisPrivateName().impl()), variable(propertyNames().builtinNames().thisPrivateName().impl(), ThisResolutionType::Scoped), DoNotThrowIfNotFound);
 }
     
 RegisterID* BytecodeGenerator::emitLoadNewTargetFromArrowFunctionLexicalEnvironment()
 {
-    Variable newTargetVar = variable(propertyNames().builtinNames().newTargetLocalPrivateName());
+    Variable newTargetVar = variable(propertyNames().builtinNames().newTargetLocalPrivateName().impl());
 
-    return emitGetFromScope(m_newTargetRegister, emitLoadArrowFunctionLexicalEnvironment(propertyNames().builtinNames().newTargetLocalPrivateName()), newTargetVar, ThrowIfNotFound);
+    return emitGetFromScope(m_newTargetRegister, emitLoadArrowFunctionLexicalEnvironment(propertyNames().builtinNames().newTargetLocalPrivateName().impl()), newTargetVar, ThrowIfNotFound);
     
 }
 
 RegisterID* BytecodeGenerator::emitLoadDerivedConstructorFromArrowFunctionLexicalEnvironment()
 {
-    Variable protoScopeVar = variable(propertyNames().builtinNames().derivedConstructorPrivateName());
-    return emitGetFromScope(newTemporary(), emitLoadArrowFunctionLexicalEnvironment(propertyNames().builtinNames().derivedConstructorPrivateName()), protoScopeVar, ThrowIfNotFound);
+    Variable protoScopeVar = variable(propertyNames().builtinNames().derivedConstructorPrivateName().impl());
+    return emitGetFromScope(newTemporary(), emitLoadArrowFunctionLexicalEnvironment(propertyNames().builtinNames().derivedConstructorPrivateName().impl()), protoScopeVar, ThrowIfNotFound);
 }
 
 RegisterID* BytecodeGenerator::emitLoadDerivedConstructor()
@@ -5199,7 +5196,7 @@ void BytecodeGenerator::emitPutNewTargetToArrowFunctionContextScope()
     if (isNewTargetUsedInInnerArrowFunction()) {
         ASSERT(m_arrowFunctionContextLexicalEnvironmentRegister);
         
-        Variable newTargetVar = variable(propertyNames().builtinNames().newTargetLocalPrivateName());
+        Variable newTargetVar = variable(propertyNames().builtinNames().newTargetLocalPrivateName().impl());
         emitPutToScope(m_arrowFunctionContextLexicalEnvironmentRegister, newTargetVar, newTarget(), DoNotThrowIfNotFound, InitializationMode::Initialization);
     }
 }
@@ -5209,7 +5206,7 @@ void BytecodeGenerator::emitPutDerivedConstructorToArrowFunctionContextScope()
     if (needsDerivedConstructorInArrowFunctionLexicalEnvironment()) {
         ASSERT(m_arrowFunctionContextLexicalEnvironmentRegister);
 
-        Variable protoScope = variable(propertyNames().builtinNames().derivedConstructorPrivateName());
+        Variable protoScope = variable(propertyNames().builtinNames().derivedConstructorPrivateName().impl());
         emitPutToScope(m_arrowFunctionContextLexicalEnvironmentRegister, protoScope, &m_calleeRegister, DoNotThrowIfNotFound, InitializationMode::Initialization);
     }
 }
@@ -5219,8 +5216,8 @@ void BytecodeGenerator::emitPutThisToArrowFunctionContextScope()
     if (isThisUsedInInnerArrowFunction() || (m_scopeNode->usesSuperCall() && m_codeType == EvalCode)) {
         ASSERT(isDerivedConstructorContext() || m_arrowFunctionContextLexicalEnvironmentRegister != nullptr);
 
-        Variable thisVar = variable(propertyNames().builtinNames().thisPrivateName(), ThisResolutionType::Scoped);
-        RegisterID* scope = isDerivedConstructorContext() ? emitLoadArrowFunctionLexicalEnvironment(propertyNames().builtinNames().thisPrivateName()) : m_arrowFunctionContextLexicalEnvironmentRegister;
+        Variable thisVar = variable(propertyNames().builtinNames().thisPrivateName().impl(), ThisResolutionType::Scoped);
+        RegisterID* scope = isDerivedConstructorContext() ? emitLoadArrowFunctionLexicalEnvironment(propertyNames().builtinNames().thisPrivateName().impl()) : m_arrowFunctionContextLexicalEnvironmentRegister;
     
         emitPutToScope(scope, thisVar, thisRegister(), ThrowIfNotFound, InitializationMode::NotInitialization);
     }
@@ -5259,17 +5256,17 @@ void BytecodeGenerator::emitRequireObjectCoercible(RegisterID* value, ASCIILiter
     emitLabel(target.get());
 }
 
-void BytecodeGenerator::emitRequireObjectCoercibleForDestructuring(RegisterID* value, const Identifier* propertyName)
+void BytecodeGenerator::emitRequireObjectCoercibleForDestructuring(RegisterID* value, UniquedStringImpl* propertyName)
 {
     Ref<Label> target = newLabel();
     OpJnundefinedOrNull::emit(this, value, target->bind(this));
 
-    if (propertyName && !propertyName->isNull()) {
-        auto errorMessageStr = tryMakeString("Cannot destructure property '"_s, propertyName->string(), "' from null or undefined value"_s);
+    if (propertyName) {
+        auto errorMessageStr = tryMakeString("Cannot destructure property '"_s, String(propertyName), "' from null or undefined value"_s);
         if (!errorMessageStr) [[unlikely]]
             emitThrowTypeError("Cannot destructure null or undefined value"_s);
         else
-            emitThrowTypeError(Identifier::fromString(m_vm, errorMessageStr));
+            emitThrowTypeError(Identifier::fromString(m_vm, errorMessageStr).impl());
     } else
         emitThrowTypeError("Cannot destructure null or undefined value"_s);
 
@@ -5403,7 +5400,7 @@ void BytecodeGenerator::emitIteratorNext(RegisterID* done, RegisterID* value, Re
 RegisterID* BytecodeGenerator::emitGetGenericIterator(RegisterID* argument, ThrowableExpressionData* node)
 {
     emitExpressionInfo(node->divot(), node->divotStart(), node->divotEnd());
-    RefPtr<RegisterID> iterator = emitGetById(newTemporary(), argument, propertyNames().iteratorSymbol);
+    RefPtr<RegisterID> iterator = emitGetById(newTemporary(), argument, propertyNames().iteratorSymbol.impl());
     emitCallIterator(iterator.get(), argument, node);
 
     return iterator.unsafeGet();
@@ -5443,7 +5440,7 @@ RegisterID* BytecodeGenerator::emitIteratorGenericNextWithValue(RegisterID* dst,
 void BytecodeGenerator::emitIteratorGenericClose(RegisterID* iterator, const ThrowableExpressionData* node, EmitAwait doEmitAwait)
 {
     Ref<Label> done = newLabel();
-    RefPtr<RegisterID> returnMethod = emitGetById(newTemporary(), iterator, propertyNames().returnKeyword);
+    RefPtr<RegisterID> returnMethod = emitGetById(newTemporary(), iterator, propertyNames().returnKeyword.impl());
     emitJumpIfTrue(emitIsUndefinedOrNull(newTemporary(), returnMethod.get()), done.get());
 
     RefPtr<RegisterID> value = newTemporary();
@@ -5463,7 +5460,7 @@ void BytecodeGenerator::emitIteratorGenericClose(RegisterID* iterator, const Thr
 RegisterID* BytecodeGenerator::emitGetAsyncIterator(RegisterID* argument, ThrowableExpressionData* node)
 {
     emitExpressionInfo(node->divot(), node->divotStart(), node->divotEnd());
-    RefPtr<RegisterID> iterator = emitGetById(newTemporary(), argument, propertyNames().asyncIteratorSymbol);
+    RefPtr<RegisterID> iterator = emitGetById(newTemporary(), argument, propertyNames().asyncIteratorSymbol.impl());
     Ref<Label> asyncIteratorNotFound = newLabel();
     Ref<Label> asyncIteratorFound = newLabel();
     Ref<Label> iteratorReceived = newLabel();
@@ -5476,7 +5473,7 @@ RegisterID* BytecodeGenerator::emitGetAsyncIterator(RegisterID* argument, Throwa
     RefPtr<RegisterID> commonIterator = emitGetGenericIterator(argument, node);
     move(iterator.get(), commonIterator.get());
 
-    RefPtr<RegisterID> nextMethod = emitGetById(newTemporary(), iterator.get(), propertyNames().next);
+    RefPtr<RegisterID> nextMethod = emitGetById(newTemporary(), iterator.get(), propertyNames().next.impl());
 
     RefPtr<RegisterID> createAsyncFromSyncIterator = moveLinkTimeConstant(nullptr, LinkTimeConstant::createAsyncFromSyncIterator);
 
@@ -5503,7 +5500,7 @@ RegisterID* BytecodeGenerator::emitDelegateYield(RegisterID* argument, Throwable
     RefPtr<RegisterID> value = newTemporary();
     {
         RefPtr<RegisterID> iterator = parseMode() == SourceParseMode::AsyncGeneratorBodyMode ? emitGetAsyncIterator(argument, node) : emitGetGenericIterator(argument, node);
-        RefPtr<RegisterID> nextMethod = emitGetById(newTemporary(), iterator.get(), propertyNames().next);
+        RefPtr<RegisterID> nextMethod = emitGetById(newTemporary(), iterator.get(), propertyNames().next.impl());
 
         Ref<Label> loopDone = newLabel();
         {
@@ -5533,7 +5530,7 @@ RegisterID* BytecodeGenerator::emitDelegateYield(RegisterID* argument, Throwable
                 // Throw.
                 {
                     Ref<Label> throwMethodFound = newLabel();
-                    RefPtr<RegisterID> throwMethod = emitGetById(newTemporary(), iterator.get(), propertyNames().throwKeyword);
+                    RefPtr<RegisterID> throwMethod = emitGetById(newTemporary(), iterator.get(), propertyNames().throwKeyword.impl());
                     emitJumpIfFalse(emitIsUndefinedOrNull(newTemporary(), throwMethod.get()), throwMethodFound.get());
 
                     EmitAwait emitAwaitInIteratorClose = parseMode() == SourceParseMode::AsyncGeneratorBodyMode ? EmitAwait::Yes : EmitAwait::No;
@@ -5554,7 +5551,7 @@ RegisterID* BytecodeGenerator::emitDelegateYield(RegisterID* argument, Throwable
                 emitLabel(returnLabel.get());
                 {
                     Ref<Label> returnMethodFound = newLabel();
-                    RefPtr<RegisterID> returnMethod = emitGetById(newTemporary(), iterator.get(), propertyNames().returnKeyword);
+                    RefPtr<RegisterID> returnMethod = emitGetById(newTemporary(), iterator.get(), propertyNames().returnKeyword.impl());
                     emitJumpIfFalse(emitIsUndefinedOrNull(newTemporary(), returnMethod.get()), returnMethodFound.get());
 
                     if (parseMode() == SourceParseMode::AsyncGeneratorBodyMode)
@@ -5579,13 +5576,13 @@ RegisterID* BytecodeGenerator::emitDelegateYield(RegisterID* argument, Throwable
                     emitLabel(returnIteratorResultIsObject.get());
 
                     Ref<Label> returnFromGenerator = newLabel();
-                    emitJumpIfTrue(emitGetById(newTemporary(), value.get(), propertyNames().done), returnFromGenerator.get());
+                    emitJumpIfTrue(emitGetById(newTemporary(), value.get(), propertyNames().done.impl()), returnFromGenerator.get());
 
-                    emitGetById(value.get(), value.get(), propertyNames().value);
+                    emitGetById(value.get(), value.get(), propertyNames().value.impl());
                     emitJump(loopStart.get());
 
                     emitLabel(returnFromGenerator.get());
-                    emitGetById(value.get(), value.get(), propertyNames().value);
+                    emitGetById(value.get(), value.get(), propertyNames().value.impl());
 
                     emitLabel(returnSequence.get());
                     bool hasFinally = emitReturnViaFinallyIfNeeded(value.get());
@@ -5610,15 +5607,15 @@ RegisterID* BytecodeGenerator::emitDelegateYield(RegisterID* argument, Throwable
             emitThrowTypeError("Iterator result interface is not an object."_s);
             emitLabel(iteratorValueIsObject.get());
 
-            emitJumpIfTrue(emitGetById(newTemporary(), value.get(), propertyNames().done), loopDone.get());
-            emitGetById(value.get(), value.get(), propertyNames().value);
+            emitJumpIfTrue(emitGetById(newTemporary(), value.get(), propertyNames().done.impl()), loopDone.get());
+            emitGetById(value.get(), value.get(), propertyNames().value.impl());
 
             emitJump(loopStart.get());
         }
         emitLabel(loopDone.get());
     }
 
-    emitGetById(value.get(), value.get(), propertyNames().value);
+    emitGetById(value.get(), value.get(), propertyNames().value.impl());
     return value.unsafeGet();
 }
 

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
@@ -102,9 +102,9 @@ namespace JSC {
         enum VariableKind { NormalVariable, SpecialVariable };
 
         Variable() = default;
-        
-        Variable(const Identifier& ident)
-            : m_ident(ident)
+
+        Variable(UniquedStringImpl* uid)
+            : m_ident(uid)
             , m_local(nullptr)
             , m_attributes(0)
             , m_kind(NormalVariable) // This is somewhat meaningless here for this kind of Variable.
@@ -113,8 +113,8 @@ namespace JSC {
         {
         }
 
-        Variable(const Identifier& ident, VarOffset offset, RegisterID* local, unsigned attributes, VariableKind kind, int symbolTableConstantIndex, bool isLexicallyScoped)
-            : m_ident(ident)
+        Variable(UniquedStringImpl* uid, VarOffset offset, RegisterID* local, unsigned attributes, VariableKind kind, int symbolTableConstantIndex, bool isLexicallyScoped)
+            : m_ident(uid)
             , m_offset(offset)
             , m_local(local)
             , m_attributes(attributes)
@@ -129,9 +129,9 @@ namespace JSC {
         // direct arguments object.
         bool isResolved() const { return !!m_offset; }
         int symbolTableConstantIndex() const { ASSERT(isResolved() && !isSpecial()); return m_symbolTableConstantIndex; }
-        
-        const Identifier& ident() const { return m_ident; }
-        
+
+        UniquedStringImpl* ident() const { return m_ident; }
+
         VarOffset offset() const { return m_offset; }
         bool isLocal() const { return m_offset.isStack(); }
         RegisterID* local() const { return m_local; }
@@ -146,7 +146,7 @@ namespace JSC {
         friend bool operator==(const Variable&, const Variable&) = default;
 
     private:
-        Identifier m_ident;
+        RefPtr<UniquedStringImpl> m_ident;
         VarOffset m_offset { };
         RegisterID* m_local { nullptr };
         unsigned m_attributes { 0 };
@@ -413,12 +413,12 @@ namespace JSC {
             return result;
         }
 
-        bool isArgumentNumber(const Identifier&, int);
+        bool isArgumentNumber(UniquedStringImpl*, int);
 
-        Variable variable(const Identifier&, ThisResolutionType = ThisResolutionType::Local);
-        
+        Variable variable(UniquedStringImpl*, ThisResolutionType = ThisResolutionType::Local);
+
         enum ExistingVariableMode { VerifyExisting, IgnoreExisting };
-        void createVariable(const Identifier&, VarKind, SymbolTable*, ExistingVariableMode = VerifyExisting); // Creates the variable, or asserts that the already-created variable is sufficiently compatible.
+        void createVariable(UniquedStringImpl*, VarKind, SymbolTable*, ExistingVariableMode = VerifyExisting); // Creates the variable, or asserts that the already-created variable is sufficiently compatible.
         
         // Returns the register storing "this"
         RegisterID* thisRegister() { return &m_thisRegister; }
@@ -483,7 +483,7 @@ namespace JSC {
             return dst == ignoredResult() ? nullptr : (dst && dst != src) ? emitMove(dst, src) : src;
         }
 
-        Ref<LabelScope> newLabelScope(LabelScope::Type, const Identifier* = nullptr);
+        Ref<LabelScope> newLabelScope(LabelScope::Type, UniquedStringImpl* = nullptr);
 
         void emitNode(RegisterID* dst, StatementNode* n)
         {
@@ -703,14 +703,14 @@ namespace JSC {
 
         void emitProfileControlFlow(int);
         
-        RegisterID* emitLoadArrowFunctionLexicalEnvironment(const Identifier&);
+        RegisterID* emitLoadArrowFunctionLexicalEnvironment(UniquedStringImpl*);
         RegisterID* ensureThis();
         void emitLoadThisFromArrowFunctionLexicalEnvironment();
         RegisterID* emitLoadNewTargetFromArrowFunctionLexicalEnvironment();
 
         unsigned addConstantIndex();
         RegisterID* emitLoad(RegisterID* dst, bool);
-        RegisterID* emitLoad(RegisterID* dst, const Identifier&);
+        RegisterID* emitLoad(RegisterID* dst, UniquedStringImpl*);
         RegisterID* emitLoad(RegisterID* dst, JSValue, SourceCodeRepresentation = SourceCodeRepresentation::Other);
         RegisterID* emitLoad(RegisterID* dst, IdentifierSet&& excludedList);
 
@@ -791,7 +791,7 @@ namespace JSC {
         RegisterID* emitToNumber(RegisterID* dst, RegisterID* src);
         RegisterID* emitToNumeric(RegisterID* dst, RegisterID* src);
         RegisterID* emitToString(RegisterID* dst, RegisterID* src);
-        RegisterID* emitToObject(RegisterID* dst, RegisterID* src, const Identifier& message);
+        RegisterID* emitToObject(RegisterID* dst, RegisterID* src, UniquedStringImpl* message);
         RegisterID* emitToThis(RegisterID* srcDst);
         RegisterID* emitInc(RegisterID* srcDst);
         RegisterID* emitDec(RegisterID* srcDst);
@@ -799,16 +799,16 @@ namespace JSC {
         RegisterID* emitInstanceof(RegisterID* dst, RegisterID* value, RegisterID* constructor, RegisterID* hasInstanceOrPrototype);
         RegisterID* emitTypeOf(RegisterID* dst, RegisterID* src);
         RegisterID* emitInByVal(RegisterID* dst, RegisterID* property, RegisterID* base);
-        RegisterID* emitInById(RegisterID* dst, RegisterID* base, const Identifier& property);
+        RegisterID* emitInById(RegisterID* dst, RegisterID* base, UniquedStringImpl* property);
 
         RegisterID* emitGetLength(RegisterID* dst, RegisterID* base);
-        RegisterID* emitGetById(RegisterID* dst, RegisterID* base, const Identifier& property);
-        RegisterID* emitGetById(RegisterID* dst, RegisterID* base, RegisterID* thisVal, const Identifier& property);
-        RegisterID* emitDirectGetById(RegisterID* dst, RegisterID* base, const Identifier& property);
-        RegisterID* emitPutById(RegisterID* base, const Identifier& property, RegisterID* value);
-        RegisterID* emitPutById(RegisterID* base, RegisterID* thisValue, const Identifier& property, RegisterID* value);
-        RegisterID* emitDirectPutById(RegisterID* base, const Identifier& property, RegisterID* value);
-        RegisterID* emitDeleteById(RegisterID* dst, RegisterID* base, const Identifier&);
+        RegisterID* emitGetById(RegisterID* dst, RegisterID* base, UniquedStringImpl* property);
+        RegisterID* emitGetById(RegisterID* dst, RegisterID* base, RegisterID* thisVal, UniquedStringImpl* property);
+        RegisterID* emitDirectGetById(RegisterID* dst, RegisterID* base, UniquedStringImpl* property);
+        RegisterID* emitPutById(RegisterID* base, UniquedStringImpl* property, RegisterID* value);
+        RegisterID* emitPutById(RegisterID* base, RegisterID* thisValue, UniquedStringImpl* property, RegisterID* value);
+        RegisterID* emitDirectPutById(RegisterID* base, UniquedStringImpl* property, RegisterID* value);
+        RegisterID* emitDeleteById(RegisterID* dst, RegisterID* base, UniquedStringImpl*);
         RegisterID* emitGetByVal(RegisterID* dst, RegisterID* base, RegisterID* property);
         RegisterID* emitGetByVal(RegisterID* dst, RegisterID* base, RegisterID* thisValue, RegisterID* property);
         RegisterID* emitGetPrototypeOf(RegisterID* dst, RegisterID* value);
@@ -855,9 +855,9 @@ namespace JSC {
         RegisterID* emitIdWithProfile(RegisterID* src, SpeculatedType profile);
         void emitUnreachable();
 
-        void emitPutGetterById(RegisterID* base, const Identifier& property, unsigned propertyDescriptorOptions, RegisterID* getter);
-        void emitPutSetterById(RegisterID* base, const Identifier& property, unsigned propertyDescriptorOptions, RegisterID* setter);
-        void emitPutGetterSetter(RegisterID* base, const Identifier& property, unsigned attributes, RegisterID* getter, RegisterID* setter);
+        void emitPutGetterById(RegisterID* base, UniquedStringImpl* property, unsigned propertyDescriptorOptions, RegisterID* getter);
+        void emitPutSetterById(RegisterID* base, UniquedStringImpl* property, unsigned propertyDescriptorOptions, RegisterID* setter);
+        void emitPutGetterSetter(RegisterID* base, UniquedStringImpl* property, unsigned attributes, RegisterID* getter, RegisterID* setter);
         void emitPutGetterByVal(RegisterID* base, RegisterID* property, unsigned propertyDescriptorOptions, RegisterID* getter);
         void emitPutSetterByVal(RegisterID* base, RegisterID* property, unsigned propertyDescriptorOptions, RegisterID* setter);
 
@@ -868,7 +868,7 @@ namespace JSC {
         
         void emitPutAsyncGeneratorFields(RegisterID* nextFunction);
 
-        ExpectedFunction NODELETE expectedFunctionForIdentifier(const Identifier&);
+        ExpectedFunction NODELETE expectedFunctionForIdentifier(UniquedStringImpl*);
         RegisterID* emitCall(RegisterID* dst, RegisterID* func, ExpectedFunction, CallArguments&, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd, DebuggableCall);
         RegisterID* emitCallInTailPosition(RegisterID* dst, RegisterID* func, ExpectedFunction, CallArguments&, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd, DebuggableCall);
         RegisterID* emitCallDirectEval(RegisterID* dst, RegisterID* func, CallArguments&, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd, DebuggableCall);
@@ -898,7 +898,7 @@ namespace JSC {
         void emitEnumeration(ThrowableExpressionData* enumerationNode, ExpressionNode* subjectNode, const ScopedLambda<void(BytecodeGenerator&, RegisterID*)>& callBack, ForOfNode* = nullptr, RegisterID* forLoopSymbolTable = nullptr);
 
         RegisterID* emitGetTemplateObject(RegisterID* dst, TaggedTemplateNode*);
-        RegisterID* emitGetGlobalPrivate(RegisterID* dst, const Identifier& property);
+        RegisterID* emitGetGlobalPrivate(RegisterID* dst, UniquedStringImpl* property);
 
         RegisterID* emitReturn(RegisterID* src);
 
@@ -914,9 +914,9 @@ namespace JSC {
         RegisterID* emitResolveScope(RegisterID* dst, const Variable&);
         RegisterID* emitGetFromScope(RegisterID* dst, RegisterID* scope, const Variable&, ResolveMode);
         RegisterID* emitPutToScope(RegisterID* scope, const Variable&, RegisterID* value, ResolveMode, InitializationMode);
-        RegisterID* emitPutToScopeDynamic(RegisterID* scope, const Identifier&, RegisterID* value, ResolveMode, InitializationMode);
+        RegisterID* emitPutToScopeDynamic(RegisterID* scope, UniquedStringImpl*, RegisterID* value, ResolveMode, InitializationMode);
 
-        RegisterID* emitResolveScopeForHoistingFuncDeclInEval(RegisterID* dst, const Identifier&);
+        RegisterID* emitResolveScopeForHoistingFuncDeclInEval(RegisterID* dst, UniquedStringImpl*);
 
         RegisterID* initializeVariable(const Variable&, RegisterID* value);
 
@@ -972,7 +972,7 @@ namespace JSC {
         RegisterID* emitIsDisposableStack(RegisterID* dst, RegisterID* src) { return emitIsCellWithType(dst, src, DisposableStackType); }
         RegisterID* emitIsAsyncDisposableStack(RegisterID* dst, RegisterID* src) { return emitIsCellWithType(dst, src, AsyncDisposableStackType); }
         void emitRequireObjectCoercible(RegisterID* value, ASCIILiteral error);
-        void emitRequireObjectCoercibleForDestructuring(RegisterID* value, const Identifier* propertyName);
+        void emitRequireObjectCoercibleForDestructuring(RegisterID* value, UniquedStringImpl* propertyName);
 
         void emitIteratorOpen(RegisterID* iterator, RegisterID* nextOrIndex, RegisterID* symbolIterator, CallArguments& iterable, const ThrowableExpressionData*);
         void emitIteratorNext(RegisterID* done, RegisterID* value, RegisterID* iterable, RegisterID* nextOrIndex, CallArguments& iterator, const ThrowableExpressionData*);
@@ -1032,11 +1032,11 @@ namespace JSC {
         RegisterID* emitArgumentCount(RegisterID*);
 
         void emitThrowStaticError(ErrorTypeWithExtension, RegisterID*);
-        void emitThrowStaticError(ErrorTypeWithExtension, const Identifier& message);
+        void emitThrowStaticError(ErrorTypeWithExtension, UniquedStringImpl* message);
         void emitThrowReferenceError(ASCIILiteral message);
         void emitThrowTypeError(ASCIILiteral message);
-        void emitThrowTypeError(const Identifier& message);
-        void emitThrowRangeError(const Identifier& message);
+        void emitThrowTypeError(UniquedStringImpl* message);
+        void emitThrowRangeError(UniquedStringImpl* message);
         void emitThrowOutOfMemoryError();
 
         void emitPushCatchScope(VariableEnvironment&, ScopeType);
@@ -1078,8 +1078,8 @@ namespace JSC {
         void pushForInScope(RegisterID* local, RegisterID* propertyName, RegisterID* propertyOffset, RegisterID* enumerator, RegisterID* mode, std::optional<Variable> base);
         void popForInScope(RegisterID* local);
 
-        LabelScope* NODELETE breakTarget(const Identifier&);
-        LabelScope* NODELETE continueTarget(const Identifier&);
+        LabelScope* NODELETE breakTarget(UniquedStringImpl*);
+        LabelScope* NODELETE continueTarget(UniquedStringImpl*);
 
         void beginSwitch(RegisterID*, SwitchInfo::SwitchType);
         void endSwitch(const Vector<Ref<Label>, 8>&, ExpressionNode**, Label& defaultLabel, int32_t min, int32_t range);
@@ -1130,7 +1130,7 @@ namespace JSC {
         bool instantiateLexicalVariables(const VariableEnvironment&, ScopeType, SymbolTable*, ScopeRegisterType, LookUpVarKindFunctor);
         void emitPrefillStackTDZVariables(const VariableEnvironment&, SymbolTable*);
         RegisterID* emitGetParentScope(RegisterID* dst, RegisterID* scope);
-        void emitPushFunctionNameScope(const Identifier& property, RegisterID* value, bool isCaptured);
+        void emitPushFunctionNameScope(UniquedStringImpl* property, RegisterID* value, bool isCaptured);
         void emitNewFunctionExpressionCommon(RegisterID*, FunctionMetadataNode*);
         
         bool NODELETE isNewTargetUsedInInnerArrowFunction();
@@ -1157,7 +1157,7 @@ namespace JSC {
 
     private:
         ParserError generate(unsigned&);
-        Variable NODELETE variableForLocalEntry(const Identifier&, const SymbolTableEntry&, int symbolTableConstantIndex, bool isLexicallyScoped);
+        Variable NODELETE variableForLocalEntry(UniquedStringImpl*, const SymbolTableEntry&, int symbolTableConstantIndex, bool isLexicallyScoped);
 
         RegisterID* kill(RegisterID* dst)
         {
@@ -1209,8 +1209,8 @@ namespace JSC {
             return m_parameters[reg.toArgument()];
         }
 
-        bool NODELETE hasConstant(const Identifier&) const;
-        unsigned addConstant(const Identifier&);
+        bool NODELETE hasConstant(UniquedStringImpl*) const;
+        unsigned addConstant(UniquedStringImpl*);
         RegisterID* addConstantValue(JSValue, SourceCodeRepresentation = SourceCodeRepresentation::Other);
         RegisterID* addConstantEmptyValue();
 
@@ -1276,8 +1276,8 @@ namespace JSC {
         typedef UncheckedKeyHashMap<RefPtr<UniquedStringImpl>, TDZNecessityLevel, IdentifierRepHash> TDZMap;
 
     public:
-        JSString* addStringConstant(const Identifier&);
-        JSValue addBigIntConstant(const Identifier&, uint8_t radix, bool sign);
+        JSString* addStringConstant(UniquedStringImpl*);
+        JSValue addBigIntConstant(UniquedStringImpl*, uint8_t radix, bool sign);
         RegisterID* addTemplateObjectConstant(Ref<TemplateObjectDescriptor>&&, int);
 
         const JSInstructionStreamWriter& instructions() const LIFETIME_BOUND { return m_writer; }
@@ -1309,7 +1309,7 @@ namespace JSC {
             m_lastInstruction = prevLastInstruction;
         }
 
-        PrivateNameEntry NODELETE getPrivateTraits(const Identifier&);
+        PrivateNameEntry NODELETE getPrivateTraits(UniquedStringImpl*);
 
         void pushPrivateAccessNames(const PrivateNameEnvironment*);
         void popPrivateAccessNames();

--- a/Source/JavaScriptCore/bytecompiler/LabelScope.h
+++ b/Source/JavaScriptCore/bytecompiler/LabelScope.h
@@ -29,17 +29,16 @@
 #pragma once
 
 #include "Label.h"
+#include <wtf/text/UniquedStringImpl.h>
 
 namespace JSC {
-
-class Identifier;
 
 class LabelScope {
 WTF_MAKE_NONCOPYABLE(LabelScope);
 public:
     enum Type { Loop, Switch, NamedLabel };
 
-    LabelScope(Type type, const Identifier* name, int scopeDepth, Ref<Label>&& breakTarget, RefPtr<Label>&& continueTarget)
+    LabelScope(Type type, UniquedStringImpl* name, int scopeDepth, Ref<Label>&& breakTarget, RefPtr<Label>&& continueTarget)
         : m_refCount(0)
         , m_type(type)
         , m_name(name)
@@ -53,7 +52,7 @@ public:
     Label* continueTarget() const { return m_continueTarget.get(); }
 
     Type type() const { return m_type; }
-    const Identifier* name() const { return m_name; }
+    UniquedStringImpl* name() const { return m_name; }
     int scopeDepth() const { return m_scopeDepth; }
 
     void ref() { ++m_refCount; }
@@ -77,7 +76,7 @@ public:
 private:
     int m_refCount;
     Type m_type;
-    const Identifier* m_name;
+    SUPPRESS_UNCOUNTED_MEMBER UniquedStringImpl* m_name;
     int m_scopeDepth;
     const Ref<Label> m_breakTarget;
     const RefPtr<Label> m_continueTarget;

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -167,13 +167,13 @@ RegisterID* RegExpNode::emitBytecode(BytecodeGenerator& generator, RegisterID* d
     if (dst == generator.ignoredResult())
         return nullptr;
 
-    auto flags = Yarr::parseFlags(m_flags.string());
+    auto flags = Yarr::parseFlags(StringView { m_flags });
     ASSERT(flags);
-    RegExp* regExp = RegExp::create(generator.vm(), m_pattern.string(), flags.value());
+    RegExp* regExp = RegExp::create(generator.vm(), String(m_pattern), flags.value());
     if (regExp->isValid())
         return generator.emitNewRegExp(generator.finalDestination(dst), regExp);
 
-    auto& message = generator.parserArena().identifierArena().makeIdentifier(generator.vm(), regExp->errorMessage().span8());
+    auto* message = generator.parserArena().identifierArena().makeIdentifier(generator.vm(), regExp->errorMessage().span8());
     generator.emitThrowStaticError(ErrorTypeWithExtension::SyntaxError, message);
     return generator.emitLoad(generator.finalDestination(dst), jsUndefined());
 }
@@ -198,12 +198,12 @@ static RegisterID* emitHomeObjectForCallee(BytecodeGenerator& generator)
 {
     if ((generator.isDerivedClassContext() || generator.isDerivedConstructorContext()) && generator.parseMode() != SourceParseMode::ClassFieldInitializerMode) {
         RegisterID* derivedConstructor = generator.emitLoadDerivedConstructorFromArrowFunctionLexicalEnvironment();
-        return generator.emitGetById(generator.newTemporary(), derivedConstructor, generator.propertyNames().builtinNames().homeObjectPrivateName());
+        return generator.emitGetById(generator.newTemporary(), derivedConstructor, generator.propertyNames().builtinNames().homeObjectPrivateName().impl());
     }
 
     RegisterID callee;
     callee.setIndex(CallFrameSlot::callee);
-    return generator.emitGetById(generator.newTemporary(), &callee, generator.propertyNames().builtinNames().homeObjectPrivateName());
+    return generator.emitGetById(generator.newTemporary(), &callee, generator.propertyNames().builtinNames().homeObjectPrivateName().impl());
 }
 
 static RegisterID* emitSuperBaseForCallee(BytecodeGenerator& generator)
@@ -282,17 +282,17 @@ bool ResolveNode::getFromScopeCanThrow(BytecodeGenerator& generator) const
 RegisterID* ResolveNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)
 {
     Variable var = generator.variable(m_ident);
-    JSTextPosition divot = m_start + m_ident.length();
+    JSTextPosition divot = m_start + m_ident->length();
     if (RegisterID* local = var.local()) {
         generator.emitExpressionInfo(divot, m_start, divot);
         generator.emitTDZCheckIfNecessary(var, local, nullptr);
         if (dst == generator.ignoredResult())
             return nullptr;
 
-        generator.emitProfileType(local, var, m_position, m_position + m_ident.length());
+        generator.emitProfileType(local, var, m_position, m_position + m_ident->length());
         return generator.move(dst, local);
     }
-    
+
     generator.emitExpressionInfo(divot, m_start, divot);
     RefPtr<RegisterID> scope = generator.emitResolveScope(dst, var);
     RegisterID* finalDest = generator.finalDestination(dst);
@@ -304,7 +304,7 @@ RegisterID* ResolveNode::emitBytecode(BytecodeGenerator& generator, RegisterID* 
         generator.emitTDZCheck(uncheckedResult.get());
         generator.move(finalDest, uncheckedResult.get());
     }
-    generator.emitProfileType(finalDest, var, m_position, m_position + m_ident.length());
+    generator.emitProfileType(finalDest, var, m_position, m_position + m_ident->length());
     return finalDest;
 }
 
@@ -315,7 +315,7 @@ RegisterID* TemplateStringNode::emitBytecode(BytecodeGenerator& generator, Regis
     if (dst == generator.ignoredResult())
         return nullptr;
     ASSERT(cooked());
-    return generator.emitLoad(dst, JSValue(generator.addStringConstant(*cooked())));
+    return generator.emitLoad(dst, JSValue(generator.addStringConstant(cooked())));
 }
 
 // ------------------------------ TemplateLiteralNode -----------------------------------
@@ -371,10 +371,10 @@ RegisterID* TaggedTemplateNode::emitBytecode(BytecodeGenerator& generator, Regis
         tag = generator.emitNode(tag.get(), m_tag);
     } else if (m_tag->isResolveNode()) {
         ResolveNode* resolve = static_cast<ResolveNode*>(m_tag);
-        const Identifier& identifier = resolve->identifier();
-        expectedFunction = generator.expectedFunctionForIdentifier(identifier);
+        UniquedStringImpl* uid = resolve->ident();
+        expectedFunction = generator.expectedFunctionForIdentifier(uid);
 
-        Variable var = generator.variable(identifier);
+        Variable var = generator.variable(uid);
         if (RegisterID* local = var.local()) {
             generator.emitTDZCheckIfNecessary(var, local, nullptr);
             tag = generator.move(generator.newTemporary(), local);
@@ -382,7 +382,7 @@ RegisterID* TaggedTemplateNode::emitBytecode(BytecodeGenerator& generator, Regis
             tag = generator.newTemporary();
             base = generator.newTemporary();
 
-            JSTextPosition newDivot = divotStart() + identifier.length();
+            JSTextPosition newDivot = divotStart() + uid->length();
             generator.emitExpressionInfo(newDivot, divotStart(), newDivot);
             generator.move(base.get(), generator.emitResolveScope(base.get(), var));
             generator.emitGetFromScope(tag.get(), base.get(), var, ThrowIfNotFound);
@@ -521,7 +521,7 @@ RegisterID* ArrayNode::emitBytecode(BytecodeGenerator& generator, RegisterID* ds
 
     if (m_elision) {
         RegisterID* value = generator.emitLoad(nullptr, jsNumber(m_elision + length));
-        generator.emitPutById(array.get(), generator.propertyNames().length, value);
+        generator.emitPutById(array.get(), generator.propertyNames().length.impl(), value);
     }
 
     return generator.move(dst, array.get());
@@ -547,7 +547,7 @@ handleSpread:
     
     if (m_elision) {
         generator.emitBinaryOp<OpAdd>(index.get(), index.get(), generator.emitLoad(nullptr, jsNumber(m_elision)), OperandTypes(ResultType::numberTypeIsInt32(), ResultType::numberTypeIsInt32()));
-        generator.emitPutById(array.get(), generator.propertyNames().length, index.get());
+        generator.emitPutById(array.get(), generator.propertyNames().length.impl(), index.get());
     }
     return generator.move(dst, array.get());
 }
@@ -640,7 +640,7 @@ RegisterID* ObjectLiteralNode::emitBytecode(BytecodeGenerator& generator, Regist
 
 static inline void emitPutHomeObject(BytecodeGenerator& generator, RegisterID* function, RegisterID* homeObject)
 {
-    generator.emitPutById(function, generator.propertyNames().builtinNames().homeObjectPrivateName(), homeObject);
+    generator.emitPutById(function, generator.propertyNames().builtinNames().homeObjectPrivateName().impl(), homeObject);
 }
 
 void PropertyListNode::emitDeclarePrivateFieldNames(BytecodeGenerator& generator, RegisterID* scope)
@@ -655,10 +655,10 @@ void PropertyListNode::emitDeclarePrivateFieldNames(BytecodeGenerator& generator
 
             CallArguments arguments(generator, nullptr, 1);
             generator.emitLoad(arguments.thisRegister(), jsUndefined());
-            generator.emitLoad(arguments.argumentRegister(0), *node.name());
+            generator.emitLoad(arguments.argumentRegister(0), node.name());
             RefPtr<RegisterID> symbol = generator.emitCall(generator.finalDestination(nullptr, createPrivateSymbol.get()), createPrivateSymbol.get(), NoExpectedFunction, arguments, position(), position(), position(), DebuggableCall::No);
 
-            Variable var = generator.variable(*node.name());
+            Variable var = generator.variable(node.name());
             generator.emitPutToScope(scope, var, symbol.get(), DoNotThrowIfNotFound, InitializationMode::ConstInitialization);
         }
     }
@@ -673,7 +673,7 @@ static ALWAYS_INLINE bool needsHomeObject(ExpressionNode* node)
 
 RegisterID* PropertyListNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dstOrConstructor, RegisterID* prototype, Vector<UnlinkedFunctionExecutable::ClassElementDefinition>* instanceElementDefinitions, Vector<UnlinkedFunctionExecutable::ClassElementDefinition>* staticElementDefinitions)
 {
-    auto makeClassElementDefinition = [](const PropertyListNode* p) {
+    auto makeClassElementDefinition = [&generator](const PropertyListNode* p) {
         using Kind = UnlinkedFunctionExecutable::ClassElementDefinition::Kind;
 
         std::optional<JSTextPosition> initializerPosition;
@@ -688,7 +688,7 @@ RegisterID* PropertyListNode::emitBytecode(BytecodeGenerator& generator, Registe
         else if (p->m_node->isPrivate())
             kind = Kind::FieldWithPrivatePropertyKey;
 
-        return UnlinkedFunctionExecutable::ClassElementDefinition { *p->m_node->name(), p->position(), initializerPosition, kind };
+        return UnlinkedFunctionExecutable::ClassElementDefinition { Identifier::fromUid(generator.vm(), p->m_node->name()), p->position(), initializerPosition, kind };
     };
 
     using GetterSetterPair = std::pair<PropertyNode*, PropertyNode*>;
@@ -703,7 +703,7 @@ RegisterID* PropertyListNode::emitBytecode(BytecodeGenerator& generator, Registe
 
             // We group private getters and setters to store them in a object
             GetterSetterPair pair(propertyList->m_node, static_cast<PropertyNode*>(nullptr));
-            GetterSetterMap::AddResult result = privateAccessorMap.add(propertyList->m_node->name()->impl(), pair);
+            GetterSetterMap::AddResult result = privateAccessorMap.add(propertyList->m_node->name(), pair);
             auto& resultPair = result.iterator->value;
             // If the map already contains an element with node->name(),
             // we need to store this node in the second part.
@@ -726,8 +726,8 @@ RegisterID* PropertyListNode::emitBytecode(BytecodeGenerator& generator, Registe
                 if (propertyNode->needsSuperBinding())
                     emitPutHomeObject(generator, value.get(), base);
                 auto setterOrGetterIdent = propertyNode->m_type & PropertyNode::PrivateGetter
-                    ? generator.propertyNames().builtinNames().getPrivateName()
-                    : generator.propertyNames().builtinNames().setPrivateName();
+                    ? generator.propertyNames().builtinNames().getPrivateName().impl()
+                    : generator.propertyNames().builtinNames().setPrivateName().impl();
                 generator.emitDirectPutById(getterSetterObj.get(), setterOrGetterIdent, value.get());
             };
 
@@ -737,7 +737,7 @@ RegisterID* PropertyListNode::emitBytecode(BytecodeGenerator& generator, Registe
             if (pair.second)
                 emitPutAccessor(pair.second);
 
-            Variable var = generator.variable(*pair.first->name());
+            Variable var = generator.variable(pair.first->name());
             generator.emitPutToScope(generator.scopeRegister(), var, getterSetterObj.get(), DoNotThrowIfNotFound, InitializationMode::ConstInitialization);
         }
     }
@@ -790,7 +790,7 @@ RegisterID* PropertyListNode::emitBytecode(BytecodeGenerator& generator, Registe
 
             GetterSetterMap& map = node->isStaticClassProperty() ? staticMap : instanceMap;
             if (node->m_type & PropertyNode::Constant) {
-                if (map.contains(node->name()->impl())) {
+                if (map.contains(node->name())) {
                     canOverrideProperties = true;
                     break;
                 }
@@ -799,7 +799,7 @@ RegisterID* PropertyListNode::emitBytecode(BytecodeGenerator& generator, Registe
 
             // Duplicates are possible.
             GetterSetterPair pair(node, static_cast<PropertyNode*>(nullptr));
-            GetterSetterMap::AddResult result = map.add(node->name()->impl(), pair);
+            GetterSetterMap::AddResult result = map.add(node->name(), pair);
             auto& resultPair = result.iterator->value;
             if (!result.isNewEntry) {
                 if (resultPair.first->m_type == node->m_type) {
@@ -871,15 +871,15 @@ RegisterID* PropertyListNode::emitBytecode(BytecodeGenerator& generator, Registe
                 }
 
                 if (node->m_type & PropertyNode::Getter)
-                    generator.emitPutGetterById(dst, *node->name(), attributes, value.get());
+                    generator.emitPutGetterById(dst, node->name(), attributes, value.get());
                 else
-                    generator.emitPutSetterById(dst, *node->name(), attributes, value.get());
+                    generator.emitPutSetterById(dst, node->name(), attributes, value.get());
                 continue;
             }
 
             // This is a get/set property pair.
             GetterSetterMap& map = node->isStaticClassProperty() ? staticMap : instanceMap;
-            GetterSetterMap::iterator it = map.find(node->name()->impl());
+            GetterSetterMap::iterator it = map.find(node->name());
             ASSERT(it != map.end());
             GetterSetterPair& pair = it->value;
 
@@ -916,7 +916,7 @@ RegisterID* PropertyListNode::emitBytecode(BytecodeGenerator& generator, Registe
                     emitPutHomeObject(generator, secondReg, dst);
             }
 
-            generator.emitPutGetterSetter(dst, *node->name(), attributes, getterReg.get(), setterReg.get());
+            generator.emitPutGetterSetter(dst, node->name(), attributes, getterReg.get(), setterReg.get());
         }
     }
 
@@ -955,14 +955,14 @@ void PropertyListNode::emitPutConstantProperty(BytecodeGenerator& generator, Reg
         ASSERT(!(node.type() & PropertyNode::PrivateGetter));
 
         if (node.type() & PropertyNode::PrivateMethod) {
-            Variable var = generator.variable(*node.name());
+            Variable var = generator.variable(node.name());
             generator.emitPutToScope(generator.scopeRegister(), var, value.get(), DoNotThrowIfNotFound, InitializationMode::ConstInitialization);
             return;
         }
 
         RefPtr<RegisterID> propertyNameRegister;
         if (node.name())
-            propertyName = generator.emitLoad(nullptr, *node.name());
+            propertyName = generator.emitLoad(nullptr, node.name());
 
         if (shouldSetFunctionName)
             generator.emitSetFunctionName(value.get(), propertyName.get());
@@ -970,11 +970,11 @@ void PropertyListNode::emitPutConstantProperty(BytecodeGenerator& generator, Reg
         return;
     }
 
-    if (const auto* identifier = node.name()) {
+    if (auto* identifier = node.name()) {
         ASSERT(!propertyName);
         std::optional<uint32_t> optionalIndex = parseIndex(*identifier);
         if (!optionalIndex) {
-            generator.emitDirectPutById(newObj, *identifier, value.get());
+            generator.emitDirectPutById(newObj, identifier, value.get());
             return;
         }
 
@@ -993,8 +993,7 @@ void PropertyListNode::emitSaveComputedFieldName(BytecodeGenerator& generator, P
     ASSERT(node.isComputedClassField());
 
     // The 'name' refers to a synthetic private name in the class scope, where the property key is saved for later use.
-    const Identifier& description = *node.name();
-    Variable var = generator.variable(description);
+    Variable var = generator.variable(node.name());
     ASSERT(!var.local());
 
     RefPtr<RegisterID> propertyExpr = generator.emitNode(node.m_expression);
@@ -1002,7 +1001,7 @@ void PropertyListNode::emitSaveComputedFieldName(BytecodeGenerator& generator, P
 
     if (node.isStaticClassField()) {
         Ref<Label> validPropertyNameLabel = generator.newLabel();
-        RefPtr<RegisterID> prototypeString = generator.emitLoad(nullptr, JSValue(generator.addStringConstant(generator.propertyNames().prototype)));
+        RefPtr<RegisterID> prototypeString = generator.emitLoad(nullptr, JSValue(generator.addStringConstant(generator.propertyNames().prototype.impl())));
         generator.emitJumpIfFalse(generator.emitBinaryOp<OpStricteq>(generator.newTemporary(), prototypeString.get(), propertyName.get(), OperandTypes(ResultType::stringType(), ResultType::stringType())), validPropertyNameLabel.get());
         generator.emitThrowTypeError("Cannot declare a static field named 'prototype'"_s);
         generator.emitLabel(validPropertyNameLabel.get());
@@ -1027,9 +1026,8 @@ RegisterID* BracketAccessorNode::emitBytecode(BytecodeGenerator& generator, Regi
         RefPtr<RegisterID> superBase = emitSuperBaseForCallee(generator);
 
         if (isNonIndexStringElement(*m_subscript)) {
-            const Identifier& id = static_cast<StringNode*>(m_subscript)->value();
             generator.emitExpressionInfo(divot(), divotStart(), divotEnd());
-            generator.emitGetById(finalDest.get(), superBase.get(), thisValue.get(), id);
+            generator.emitGetById(finalDest.get(), superBase.get(), thisValue.get(), static_cast<StringNode*>(m_subscript)->value());
         } else  {
             RefPtr<RegisterID> subscript = generator.emitNodeForProperty(m_subscript);
             generator.emitExpressionInfo(divot(), divotStart(), divotEnd());
@@ -1094,10 +1092,9 @@ RegisterID* DotAccessorNode::emitBytecode(BytecodeGenerator& generator, Register
 RegisterID* BaseDotNode::emitGetPropertyValue(BytecodeGenerator& generator, RegisterID* dst, RegisterID* base, RefPtr<RegisterID>& thisValue)
 {
     if (isPrivateMember()) {
-        auto identifierName = identifier();
-        auto privateTraits = generator.getPrivateTraits(identifierName);
+        auto privateTraits = generator.getPrivateTraits(ident());
         if (privateTraits.isMethod()) {
-            Variable var = generator.variable(identifierName);
+            Variable var = generator.variable(ident());
             RefPtr<RegisterID> scope = generator.emitResolveScope(nullptr, var);
             ASSERT(scope); // Private names are always captured.
             RefPtr<RegisterID> privateBrandSymbol = generator.emitGetPrivateBrand(generator.newTemporary(), scope.get(), privateTraits.isStatic());
@@ -1107,14 +1104,14 @@ RegisterID* BaseDotNode::emitGetPropertyValue(BytecodeGenerator& generator, Regi
         }
 
         if (privateTraits.isGetter()) {
-            Variable var = generator.variable(identifierName);
+            Variable var = generator.variable(ident());
             RefPtr<RegisterID> scope = generator.emitResolveScope(nullptr, var);
             ASSERT(scope); // Private names are always captured.
             RefPtr<RegisterID> privateBrandSymbol = generator.emitGetPrivateBrand(generator.newTemporary(), scope.get(), privateTraits.isStatic());
             generator.emitCheckPrivateBrand(base, privateBrandSymbol.get(), privateTraits.isStatic());
 
             RefPtr<RegisterID> getterSetterObj = generator.emitGetFromScope(generator.newTemporary(), scope.get(), var, ThrowIfNotFound);
-            RefPtr<RegisterID> getterFunction = generator.emitDirectGetById(generator.newTemporary(), getterSetterObj.get(), generator.propertyNames().builtinNames().getPrivateName());
+            RefPtr<RegisterID> getterFunction = generator.emitDirectGetById(generator.newTemporary(), getterSetterObj.get(), generator.propertyNames().builtinNames().getPrivateName().impl());
             CallArguments args(generator, nullptr);
             generator.move(args.thisRegister(), base);
             return generator.emitCall(dst, getterFunction.get(), NoExpectedFunction, args, m_position, m_position, m_position, DebuggableCall::Yes);
@@ -1122,7 +1119,7 @@ RegisterID* BaseDotNode::emitGetPropertyValue(BytecodeGenerator& generator, Regi
 
         if (privateTraits.isSetter()) {
             // We need to perform brand check to follow the spec
-            Variable var = generator.variable(identifierName);
+            Variable var = generator.variable(ident());
             RefPtr<RegisterID> scope = generator.emitResolveScope(nullptr, var);
             ASSERT(scope); // Private names are always captured.
             RefPtr<RegisterID> privateBrandSymbol = generator.emitGetPrivateBrand(generator.newTemporary(), scope.get(), privateTraits.isStatic());
@@ -1132,7 +1129,7 @@ RegisterID* BaseDotNode::emitGetPropertyValue(BytecodeGenerator& generator, Regi
         }
 
         ASSERT(privateTraits.isField());
-        Variable var = generator.variable(m_ident);
+        Variable var = generator.variable(ident());
         ASSERT_WITH_MESSAGE(!var.local(), "Private Field names must be stored in captured variables");
 
         RefPtr<RegisterID> scope = generator.emitResolveScope(nullptr, var);
@@ -1160,17 +1157,16 @@ RegisterID* BaseDotNode::emitGetPropertyValue(BytecodeGenerator& generator, Regi
 RegisterID* BaseDotNode::emitPutProperty(BytecodeGenerator& generator, RegisterID* base, RegisterID* value, RefPtr<RegisterID>& thisValue)
 {
     if (isPrivateMember()) {
-        auto identifierName = identifier();
-        auto privateTraits = generator.getPrivateTraits(identifierName);
+        auto privateTraits = generator.getPrivateTraits(ident());
         if (privateTraits.isSetter()) {
-            Variable var = generator.variable(identifierName);
+            Variable var = generator.variable(ident());
             RefPtr<RegisterID> scope = generator.emitResolveScope(nullptr, var);
             ASSERT(scope); // Private names are always captured.
             RefPtr<RegisterID> privateBrandSymbol = generator.emitGetPrivateBrand(generator.newTemporary(), scope.get(), privateTraits.isStatic());
             generator.emitCheckPrivateBrand(base, privateBrandSymbol.get(), privateTraits.isStatic());
 
             RefPtr<RegisterID> getterSetterObj = generator.emitGetFromScope(generator.newTemporary(), scope.get(), var, ThrowIfNotFound);
-            RefPtr<RegisterID> setterFunction = generator.emitDirectGetById(generator.newTemporary(), getterSetterObj.get(), generator.propertyNames().builtinNames().setPrivateName());
+            RefPtr<RegisterID> setterFunction = generator.emitDirectGetById(generator.newTemporary(), getterSetterObj.get(), generator.propertyNames().builtinNames().setPrivateName().impl());
             CallArguments args(generator, nullptr, 1);
             generator.move(args.thisRegister(), base);
             generator.move(args.argumentRegister(0), value);
@@ -1180,7 +1176,7 @@ RegisterID* BaseDotNode::emitPutProperty(BytecodeGenerator& generator, RegisterI
         }
 
         if (privateTraits.isGetter() || privateTraits.isMethod()) {
-            Variable var = generator.variable(identifierName);
+            Variable var = generator.variable(ident());
             RefPtr<RegisterID> scope = generator.emitResolveScope(nullptr, var);
             ASSERT(scope); // Private names are always captured.
             RefPtr<RegisterID> privateBrandSymbol = generator.emitGetPrivateBrand(generator.newTemporary(), scope.get(), privateTraits.isStatic());
@@ -1191,7 +1187,7 @@ RegisterID* BaseDotNode::emitPutProperty(BytecodeGenerator& generator, RegisterI
         }
 
         ASSERT(privateTraits.isField());
-        Variable var = generator.variable(m_ident);
+        Variable var = generator.variable(ident());
         ASSERT_WITH_MESSAGE(!var.local(), "Private Field names must be stored in captured variables");
 
         RefPtr<RegisterID> scope = generator.emitResolveScope(nullptr, var);
@@ -1230,7 +1226,7 @@ RegisterID* NewExprNode::emitBytecode(BytecodeGenerator& generator, RegisterID* 
 {
     ExpectedFunction expectedFunction;
     if (m_expr->isResolveNode())
-        expectedFunction = generator.expectedFunctionForIdentifier(static_cast<ResolveNode*>(m_expr)->identifier());
+        expectedFunction = generator.expectedFunctionForIdentifier(static_cast<ResolveNode*>(m_expr)->ident());
     else
         expectedFunction = NoExpectedFunction;
 
@@ -1294,7 +1290,7 @@ RegisterID* EvalFunctionCallNode::emitBytecode(BytecodeGenerator& generator, Reg
     if (generator.constructorKind() == ConstructorKind::Extends && generator.needsToUpdateArrowFunctionContext() && generator.isThisUsedInInnerArrowFunction())
         generator.emitLoadThisFromArrowFunctionLexicalEnvironment();
 
-    Variable var = generator.variable(generator.propertyNames().eval);
+    Variable var = generator.variable(generator.propertyNames().eval.impl());
     RefPtr<RegisterID> local = var.local();
     RefPtr<RegisterID> func;
     if (local) {
@@ -1426,7 +1422,7 @@ RegisterID* StaticBlockFunctionCallNode::emitBytecode(BytecodeGenerator& generat
 RegisterID* FunctionCallResolveNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)
 {
     if (!ASSERT_ENABLED) {
-        if (m_ident == generator.vm().propertyNames->builtinNames().assertPrivateName()) [[unlikely]]
+        if (m_ident == generator.vm().propertyNames->builtinNames().assertPrivateName().impl()) [[unlikely]]
             return generator.move(dst, generator.emitLoad(nullptr, jsUndefined()));
     }
 
@@ -1435,7 +1431,7 @@ RegisterID* FunctionCallResolveNode::emitBytecode(BytecodeGenerator& generator, 
     Variable var = generator.variable(m_ident);
     RefPtr<RegisterID> local = var.local();
     RefPtr<RegisterID> func;
-    JSTextPosition newDivot = divotStart() + m_ident.length();
+    JSTextPosition newDivot = divotStart() + m_ident->length();
     if (local) {
         generator.emitExpressionInfo(newDivot, divotStart(), newDivot);
         generator.emitTDZCheckIfNecessary(var, local.get(), nullptr);
@@ -1487,9 +1483,8 @@ RegisterID* BytecodeIntrinsicNode::emit_intrinsic_getByIdDirect(BytecodeGenerato
     RefPtr<RegisterID> base = generator.emitNode(node);
     node = node->m_next;
     ASSERT(node->m_expr->isString());
-    const Identifier& ident = static_cast<StringNode*>(node->m_expr)->value();
     ASSERT(!node->m_next);
-    return generator.emitDirectGetById(generator.finalDestination(dst), base.get(), ident);
+    return generator.emitDirectGetById(generator.finalDestination(dst), base.get(), static_cast<StringNode*>(node->m_expr)->value());
 }
 
 RegisterID* BytecodeIntrinsicNode::emit_intrinsic_getByIdDirectPrivate(BytecodeGenerator& generator, RegisterID* dst)
@@ -1498,7 +1493,7 @@ RegisterID* BytecodeIntrinsicNode::emit_intrinsic_getByIdDirectPrivate(BytecodeG
     RefPtr<RegisterID> base = generator.emitNode(node);
     node = node->m_next;
     ASSERT(node->m_expr->isString());
-    SymbolImpl* symbol = generator.vm().propertyNames->builtinNames().lookUpPrivateName(static_cast<StringNode*>(node->m_expr)->value());
+    SymbolImpl* symbol = generator.vm().propertyNames->builtinNames().lookUpPrivateName(String(static_cast<StringNode*>(node->m_expr)->value()));
     ASSERT(symbol);
     ASSERT(!node->m_next);
     return generator.emitDirectGetById(generator.finalDestination(dst), base.get(), generator.parserArena().identifierArena().makeIdentifier(generator.vm(), symbol));
@@ -1852,13 +1847,13 @@ RegisterID* BytecodeIntrinsicNode::emit_intrinsic_putByIdDirect(BytecodeGenerato
     RefPtr<RegisterID> base = generator.emitNode(node);
     node = node->m_next;
     ASSERT(node->m_expr->isString());
-    const Identifier& ident = static_cast<StringNode*>(node->m_expr)->value();
+    UniquedStringImpl* uid = static_cast<StringNode*>(node->m_expr)->value();
     node = node->m_next;
     RefPtr<RegisterID> value = generator.emitNode(node);
 
     ASSERT(!node->m_next);
 
-    return generator.move(dst, generator.emitDirectPutById(base.get(), ident, value.get()));
+    return generator.move(dst, generator.emitDirectPutById(base.get(), uid, value.get()));
 }
 
 RegisterID* BytecodeIntrinsicNode::emit_intrinsic_putByIdDirectPrivate(BytecodeGenerator& generator, RegisterID* dst)
@@ -1867,7 +1862,7 @@ RegisterID* BytecodeIntrinsicNode::emit_intrinsic_putByIdDirectPrivate(BytecodeG
     RefPtr<RegisterID> base = generator.emitNode(node);
     node = node->m_next;
     ASSERT(node->m_expr->isString());
-    SymbolImpl* symbol = generator.vm().propertyNames->builtinNames().lookUpPrivateName(static_cast<StringNode*>(node->m_expr)->value());
+    SymbolImpl* symbol = generator.vm().propertyNames->builtinNames().lookUpPrivateName(String(static_cast<StringNode*>(node->m_expr)->value()));
     ASSERT(symbol);
     node = node->m_next;
     RefPtr<RegisterID> value = generator.emitNode(node);
@@ -1994,8 +1989,7 @@ RegisterID* BytecodeIntrinsicNode::emit_intrinsic_throwTypeError(BytecodeGenerat
     ArgumentListNode* node = m_args->m_listNode;
     ASSERT(!node->m_next);
     if (node->m_expr->isString()) {
-        const Identifier& ident = static_cast<StringNode*>(node->m_expr)->value();
-        generator.emitThrowTypeError(ident);
+        generator.emitThrowTypeError(static_cast<StringNode*>(node->m_expr)->value());
     } else {
         RefPtr<RegisterID> message = generator.emitNode(node);
         generator.emitThrowStaticError(ErrorTypeWithExtension::TypeError, message.get());
@@ -2008,8 +2002,7 @@ RegisterID* BytecodeIntrinsicNode::emit_intrinsic_throwRangeError(BytecodeGenera
     ArgumentListNode* node = m_args->m_listNode;
     ASSERT(!node->m_next);
     if (node->m_expr->isString()) {
-        const Identifier& ident = static_cast<StringNode*>(node->m_expr)->value();
-        generator.emitThrowRangeError(ident);
+        generator.emitThrowRangeError(static_cast<StringNode*>(node->m_expr)->value());
     } else {
         RefPtr<RegisterID> message = generator.emitNode(node);
         generator.emitThrowStaticError(ErrorTypeWithExtension::RangeError, message.get());
@@ -2062,11 +2055,10 @@ RegisterID* BytecodeIntrinsicNode::emit_intrinsic_toObject(BytecodeGenerator& ge
     RefPtr<RegisterID> temp = generator.tempDestination(dst);
     if (node) {
         ASSERT(node->m_expr->isString());
-        const Identifier& message = static_cast<StringNode*>(node->m_expr)->value();
         ASSERT(!node->m_next);
-        return generator.move(dst, generator.emitToObject(temp.get(), src.get(), message));
+        return generator.move(dst, generator.emitToObject(temp.get(), src.get(), static_cast<StringNode*>(node->m_expr)->value()));
     }
-    return generator.move(dst, generator.emitToObject(temp.get(), src.get(), generator.vm().propertyNames->emptyIdentifier));
+    return generator.move(dst, generator.emitToObject(temp.get(), src.get(), generator.vm().propertyNames->emptyIdentifier.impl()));
 }
 
 RegisterID* BytecodeIntrinsicNode::emit_intrinsic_toThis(BytecodeGenerator& generator, RegisterID* dst)
@@ -2087,8 +2079,8 @@ RegisterID* BytecodeIntrinsicNode::emit_intrinsic_idWithProfile(BytecodeGenerato
     while (node->m_next) {
         node = node->m_next;
         ASSERT(node->m_expr->isString());
-        const Identifier& ident = static_cast<StringNode*>(node->m_expr)->value();
-        speculation |= speculationFromString(ident.utf8().data());
+        UniquedStringImpl* uid = static_cast<StringNode*>(node->m_expr)->value();
+        speculation |= speculationFromString(String(uid).utf8().data());
     }
 
     return generator.move(dst, generator.emitIdWithProfile(idValue.get(), speculation));
@@ -2348,9 +2340,9 @@ RegisterID* CallFunctionCallDotNode::emitBytecode(BytecodeGenerator& generator, 
     auto makeFunction = [&] {
         if (m_base->isSuperNode()) {
             RefPtr<RegisterID> thisValue = generator.ensureThis();
-            function = generator.emitGetById(generator.tempDestination(dst), base.get(), thisValue.get(), generator.propertyNames().builtinNames().callPublicName());
+            function = generator.emitGetById(generator.tempDestination(dst), base.get(), thisValue.get(), generator.propertyNames().builtinNames().callPublicName().impl());
         } else
-            function = generator.emitGetById(generator.tempDestination(dst), base.get(), generator.propertyNames().builtinNames().callPublicName());
+            function = generator.emitGetById(generator.tempDestination(dst), base.get(), generator.propertyNames().builtinNames().callPublicName().impl());
 
         if (isOptionalCall())
             generator.emitOptionalCheck(function.get());
@@ -2422,7 +2414,7 @@ RegisterID* HasOwnPropertyFunctionCallDotNode::emitBytecode(BytecodeGenerator& g
 
     generator.emitExpressionInfo(subexpressionDivot(), subexpressionStart(), subexpressionEnd());
 
-    RefPtr<RegisterID> function = generator.emitGetById(generator.newTemporary(), base.get(), generator.propertyNames().hasOwnProperty);
+    RefPtr<RegisterID> function = generator.emitGetById(generator.newTemporary(), base.get(), generator.propertyNames().hasOwnProperty.impl());
     if (isOptionalCall())
         generator.emitOptionalCheck(function.get());
 
@@ -2430,7 +2422,7 @@ RegisterID* HasOwnPropertyFunctionCallDotNode::emitBytecode(BytecodeGenerator& g
     ExpressionNode* argument = m_args->m_listNode->m_expr;
     RELEASE_ASSERT(argument->isResolveNode());
     ForInContext* context = nullptr;
-    Variable argumentVariable = generator.variable(static_cast<ResolveNode*>(argument)->identifier());
+    Variable argumentVariable = generator.variable(static_cast<ResolveNode*>(argument)->ident());
     if (argumentVariable.isLocal()) {
         RegisterID* property = argumentVariable.local();
         context = generator.findForInContext(property);
@@ -2442,11 +2434,11 @@ RegisterID* HasOwnPropertyFunctionCallDotNode::emitBytecode(BytecodeGenerator& g
         if (!context->baseVariable())
             return false;
         if (m_base->isResolveNode())
-            return generator.variable(static_cast<ResolveNode*>(m_base)->identifier()) == context->baseVariable().value();
+            return generator.variable(static_cast<ResolveNode*>(m_base)->ident()) == context->baseVariable().value();
         if (m_base->isThisNode()) {
             // After generator.ensureThis (which must be invoked in |base|'s materialization), we can ensure that |this| is in local this-register.
             ASSERT(base);
-            return generator.variable(generator.propertyNames().builtinNames().thisPrivateName(), ThisResolutionType::Local) == context->baseVariable().value();
+            return generator.variable(generator.propertyNames().builtinNames().thisPrivateName().impl(), ThisResolutionType::Local) == context->baseVariable().value();
         }
         return false;
     };
@@ -2504,9 +2496,9 @@ RegisterID* ApplyFunctionCallDotNode::emitBytecode(BytecodeGenerator& generator,
     auto makeFunction = [&] {
         if (m_base->isSuperNode()) {
             RefPtr<RegisterID> thisValue = generator.ensureThis();
-            function = generator.emitGetById(generator.tempDestination(dst), base.get(), thisValue.get(), generator.propertyNames().builtinNames().applyPublicName());
+            function = generator.emitGetById(generator.tempDestination(dst), base.get(), thisValue.get(), generator.propertyNames().builtinNames().applyPublicName().impl());
         } else
-            function = generator.emitGetById(generator.tempDestination(dst), base.get(), generator.propertyNames().builtinNames().applyPublicName());
+            function = generator.emitGetById(generator.tempDestination(dst), base.get(), generator.propertyNames().builtinNames().applyPublicName().impl());
 
         if (isOptionalCall())
             generator.emitOptionalCheck(function.get());
@@ -2527,7 +2519,7 @@ RegisterID* ApplyFunctionCallDotNode::emitBytecode(BytecodeGenerator& generator,
     generator.emitExpressionInfo(subexpressionDivot(), subexpressionStart(), subexpressionEnd());
     if (emitCallCheck) {
         makeFunction();
-        ASSERT(!m_base->isResolveNode() || static_cast<ResolveNode*>(m_base)->identifier() != "Reflect"_s);
+        ASSERT(!m_base->isResolveNode() || StringView { static_cast<ResolveNode*>(m_base)->ident() } != "Reflect"_s);
         generator.emitJumpIfNotFunctionApply(function.get(), realCall.get());
     }
     if (mayBeCall) {
@@ -2631,10 +2623,9 @@ RegisterID* PostfixNode::emitResolve(BytecodeGenerator& generator, RegisterID* d
 
     ASSERT(m_expr->isResolveNode());
     ResolveNode* resolve = static_cast<ResolveNode*>(m_expr);
-    const Identifier& ident = resolve->identifier();
 
-    Variable var = generator.variable(ident);
-    JSTextPosition newDivot = divotStart() + ident.length();
+    Variable var = generator.variable(resolve->ident());
+    JSTextPosition newDivot = divotStart() + resolve->ident()->length();
     if (RegisterID* local = var.local()) {
         generator.emitExpressionInfo(newDivot, divotStart(), newDivot);
         generator.emitTDZCheckIfNecessary(var, local, nullptr);
@@ -2712,7 +2703,7 @@ RegisterID* PostfixNode::emitDot(BytecodeGenerator& generator, RegisterID* dst)
     DotAccessorNode* dotAccessor = static_cast<DotAccessorNode*>(m_expr);
     ExpressionNode* baseNode = dotAccessor->base();
     bool baseIsSuper = baseNode->isSuperNode();
-    const Identifier& ident = dotAccessor->identifier();
+    UniquedStringImpl* uid = dotAccessor->ident();
 
     RefPtr<RegisterID> base = generator.emitNode(baseNode);
 
@@ -2720,10 +2711,10 @@ RegisterID* PostfixNode::emitDot(BytecodeGenerator& generator, RegisterID* dst)
 
     if (dotAccessor->isPrivateMember()) {
         ASSERT(!baseIsSuper);
-        auto privateTraits = generator.getPrivateTraits(ident);
+        auto privateTraits = generator.getPrivateTraits(uid);
 
         if (privateTraits.isField()) {
-            Variable var = generator.variable(ident);
+            Variable var = generator.variable(uid);
             RefPtr<RegisterID> scope = generator.emitResolveScope(nullptr, var);
             ASSERT(scope); // Private names are always captured.
             RefPtr<RegisterID> privateName = generator.newTemporary();
@@ -2738,7 +2729,7 @@ RegisterID* PostfixNode::emitDot(BytecodeGenerator& generator, RegisterID* dst)
         }
 
         if (privateTraits.isMethod()) {
-            Variable var = generator.variable(ident);
+            Variable var = generator.variable(uid);
             RefPtr<RegisterID> scope = generator.emitResolveScope(nullptr, var);
             ASSERT(scope); // Private names are always captured.
             RefPtr<RegisterID> privateBrandSymbol = generator.emitGetPrivateBrand(generator.newTemporary(), scope.get(), privateTraits.isStatic());
@@ -2749,7 +2740,7 @@ RegisterID* PostfixNode::emitDot(BytecodeGenerator& generator, RegisterID* dst)
             return generator.tempDestination(dst);
         }
 
-        Variable var = generator.variable(ident);
+        Variable var = generator.variable(uid);
         RefPtr<RegisterID> scope = generator.emitResolveScope(nullptr, var);
         ASSERT(scope); // Private names are always captured.
         RefPtr<RegisterID> privateBrandSymbol = generator.emitGetPrivateBrand(generator.newTemporary(), scope.get(), privateTraits.isStatic());
@@ -2758,7 +2749,7 @@ RegisterID* PostfixNode::emitDot(BytecodeGenerator& generator, RegisterID* dst)
         RefPtr<RegisterID> value;
         if (privateTraits.isGetter()) {
             RefPtr<RegisterID> getterSetterObj = generator.emitGetFromScope(generator.newTemporary(), scope.get(), var, ThrowIfNotFound);
-            RefPtr<RegisterID> getterFunction = generator.emitDirectGetById(generator.newTemporary(), getterSetterObj.get(), generator.propertyNames().builtinNames().getPrivateName());
+            RefPtr<RegisterID> getterFunction = generator.emitDirectGetById(generator.newTemporary(), getterSetterObj.get(), generator.propertyNames().builtinNames().getPrivateName().impl());
             CallArguments args(generator, nullptr);
             generator.move(args.thisRegister(), base.get());
             value = generator.emitCall(generator.newTemporary(), getterFunction.get(), NoExpectedFunction, args, m_position, m_position, m_position, DebuggableCall::Yes);
@@ -2772,7 +2763,7 @@ RegisterID* PostfixNode::emitDot(BytecodeGenerator& generator, RegisterID* dst)
 
         if (privateTraits.isSetter()) {
             RefPtr<RegisterID> getterSetterObj = generator.emitGetFromScope(generator.newTemporary(), scope.get(), var, ThrowIfNotFound);
-            RefPtr<RegisterID> setterFunction = generator.emitDirectGetById(generator.newTemporary(), getterSetterObj.get(), generator.propertyNames().builtinNames().setPrivateName());
+            RefPtr<RegisterID> setterFunction = generator.emitDirectGetById(generator.newTemporary(), getterSetterObj.get(), generator.propertyNames().builtinNames().setPrivateName().impl());
             CallArguments args(generator, nullptr, 1);
             generator.move(args.thisRegister(), base.get());
             generator.move(args.argumentRegister(0), value.get());
@@ -2789,15 +2780,15 @@ RegisterID* PostfixNode::emitDot(BytecodeGenerator& generator, RegisterID* dst)
     RefPtr<RegisterID> thisValue;
     if (baseIsSuper) {
         thisValue = generator.ensureThis();
-        value = generator.emitGetById(generator.newTemporary(), base.get(), thisValue.get(), ident);
+        value = generator.emitGetById(generator.newTemporary(), base.get(), thisValue.get(), uid);
     } else
-        value = generator.emitGetById(generator.newTemporary(), base.get(), ident);
+        value = generator.emitGetById(generator.newTemporary(), base.get(), uid);
     RegisterID* oldValue = emitPostIncOrDec(generator, generator.tempDestination(dst), value.get(), m_operator);
     generator.emitExpressionInfo(divot(), divotStart(), divotEnd());
     if (baseIsSuper)
-        generator.emitPutById(base.get(), thisValue.get(), ident, value.get());
+        generator.emitPutById(base.get(), thisValue.get(), uid, value.get());
     else
-        generator.emitPutById(base.get(), ident, value.get());
+        generator.emitPutById(base.get(), uid, value.get());
     generator.emitProfileType(value.get(), divotStart(), divotEnd());
     return generator.move(dst, oldValue);
 }
@@ -2894,7 +2885,7 @@ RegisterID* VoidNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst
 RegisterID* TypeOfResolveNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)
 {
     Variable var = generator.variable(m_ident);
-    JSTextPosition newDivot = divotEnd() - m_ident.length();
+    JSTextPosition newDivot = divotEnd() - m_ident->length();
     if (RegisterID* local = var.local()) {
         generator.emitExpressionInfo(newDivot, newDivot, divotEnd());
         generator.emitTDZCheckIfNecessary(var, local, nullptr);
@@ -2930,9 +2921,8 @@ RegisterID* PrefixNode::emitResolve(BytecodeGenerator& generator, RegisterID* ds
 {
     ASSERT(m_expr->isResolveNode());
     ResolveNode* resolve = static_cast<ResolveNode*>(m_expr);
-    const Identifier& ident = resolve->identifier();
 
-    Variable var = generator.variable(ident);
+    Variable var = generator.variable(resolve->ident());
     if (RegisterID* local = var.local()) {
         generator.emitTDZCheckIfNecessary(var, local, nullptr);
         RefPtr<RegisterID> localReg = local;
@@ -3009,7 +2999,7 @@ RegisterID* PrefixNode::emitDot(BytecodeGenerator& generator, RegisterID* dst)
     ASSERT(m_expr->isDotAccessorNode());
     DotAccessorNode* dotAccessor = static_cast<DotAccessorNode*>(m_expr);
     ExpressionNode* baseNode = dotAccessor->base();
-    const Identifier& ident = dotAccessor->identifier();
+    UniquedStringImpl* uid = dotAccessor->ident();
 
     RefPtr<RegisterID> base = generator.emitNode(baseNode);
     RefPtr<RegisterID> propDst = generator.tempDestination(dst);
@@ -3017,10 +3007,10 @@ RegisterID* PrefixNode::emitDot(BytecodeGenerator& generator, RegisterID* dst)
     generator.emitExpressionInfo(dotAccessor->divot(), dotAccessor->divotStart(), dotAccessor->divotEnd());
     RegisterID* value;
     if (dotAccessor->isPrivateMember()) {
-        auto privateTraits = generator.getPrivateTraits(ident);
+        auto privateTraits = generator.getPrivateTraits(uid);
         if (privateTraits.isField()) {
             ASSERT(!baseNode->isSuperNode());
-            Variable var = generator.variable(ident);
+            Variable var = generator.variable(uid);
             RefPtr<RegisterID> scope = generator.emitResolveScope(nullptr, var);
             RefPtr<RegisterID> privateName = generator.newTemporary();
             generator.emitGetFromScope(privateName.get(), scope.get(), var, DoNotThrowIfNotFound);
@@ -3034,7 +3024,7 @@ RegisterID* PrefixNode::emitDot(BytecodeGenerator& generator, RegisterID* dst)
         }
 
         if (privateTraits.isMethod()) {
-            Variable var = generator.variable(ident);
+            Variable var = generator.variable(uid);
             RefPtr<RegisterID> scope = generator.emitResolveScope(nullptr, var);
             ASSERT(scope); // Private names are always captured.
             RefPtr<RegisterID> privateBrandSymbol = generator.emitGetPrivateBrand(generator.newTemporary(), scope.get(), privateTraits.isStatic());
@@ -3045,7 +3035,7 @@ RegisterID* PrefixNode::emitDot(BytecodeGenerator& generator, RegisterID* dst)
             return generator.move(dst, propDst.get());
         }
 
-        Variable var = generator.variable(ident);
+        Variable var = generator.variable(uid);
         RefPtr<RegisterID> scope = generator.emitResolveScope(nullptr, var);
         ASSERT(scope); // Private names are always captured.
         RefPtr<RegisterID> privateBrandSymbol = generator.emitGetPrivateBrand(generator.newTemporary(), scope.get(), privateTraits.isStatic());
@@ -3053,7 +3043,7 @@ RegisterID* PrefixNode::emitDot(BytecodeGenerator& generator, RegisterID* dst)
 
         if (privateTraits.isGetter()) {
             RefPtr<RegisterID> getterSetterObj = generator.emitGetFromScope(generator.newTemporary(), scope.get(), var, ThrowIfNotFound);
-            RefPtr<RegisterID> getterFunction = generator.emitDirectGetById(generator.newTemporary(), getterSetterObj.get(), generator.propertyNames().builtinNames().getPrivateName());
+            RefPtr<RegisterID> getterFunction = generator.emitDirectGetById(generator.newTemporary(), getterSetterObj.get(), generator.propertyNames().builtinNames().getPrivateName().impl());
             CallArguments args(generator, nullptr);
             generator.move(args.thisRegister(), base.get());
             value = generator.emitCall(propDst.get(), getterFunction.get(), NoExpectedFunction, args, m_position, m_position, m_position, DebuggableCall::Yes);
@@ -3067,7 +3057,7 @@ RegisterID* PrefixNode::emitDot(BytecodeGenerator& generator, RegisterID* dst)
 
         if (privateTraits.isSetter()) {
             RefPtr<RegisterID> getterSetterObj = generator.emitGetFromScope(generator.newTemporary(), scope.get(), var, ThrowIfNotFound);
-            RefPtr<RegisterID> setterFunction = generator.emitDirectGetById(generator.newTemporary(), getterSetterObj.get(), generator.propertyNames().builtinNames().setPrivateName());
+            RefPtr<RegisterID> setterFunction = generator.emitDirectGetById(generator.newTemporary(), getterSetterObj.get(), generator.propertyNames().builtinNames().setPrivateName().impl());
             CallArguments args(generator, nullptr, 1);
             generator.move(args.thisRegister(), base.get());
             generator.move(args.argumentRegister(0), value);
@@ -3083,15 +3073,15 @@ RegisterID* PrefixNode::emitDot(BytecodeGenerator& generator, RegisterID* dst)
     RefPtr<RegisterID> thisValue;
     if (baseNode->isSuperNode()) {
         thisValue = generator.ensureThis();
-        value = generator.emitGetById(propDst.get(), base.get(), thisValue.get(), ident);
+        value = generator.emitGetById(propDst.get(), base.get(), thisValue.get(), uid);
     } else
-        value = generator.emitGetById(propDst.get(), base.get(), ident);
+        value = generator.emitGetById(propDst.get(), base.get(), uid);
     emitIncOrDec(generator, value, m_operator);
     generator.emitExpressionInfo(divot(), divotStart(), divotEnd());
     if (baseNode->isSuperNode())
-        generator.emitPutById(base.get(), thisValue.get(), ident, value);
+        generator.emitPutById(base.get(), thisValue.get(), uid, value);
     else
-        generator.emitPutById(base.get(), ident, value);
+        generator.emitPutById(base.get(), uid, value);
     generator.emitProfileType(value, divotStart(), divotEnd());
     return generator.move(dst, propDst.get());
 }
@@ -3500,9 +3490,9 @@ RegisterID* InNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)
     if (m_expr1->isPrivateIdentifier()) {
         RefPtr<RegisterID> base = generator.emitNode(m_expr2);
 
-        auto identifier = static_cast<PrivateIdentifierNode*>(m_expr1)->value();
-        auto privateTraits = generator.getPrivateTraits(identifier);
-        Variable var = generator.variable(identifier);
+        auto* uid = static_cast<PrivateIdentifierNode*>(m_expr1)->ident();
+        auto privateTraits = generator.getPrivateTraits(uid);
+        Variable var = generator.variable(uid);
         RefPtr<RegisterID> scope = generator.emitResolveScope(nullptr, var);
         ASSERT(scope); // Private names are always captured.
 
@@ -3780,7 +3770,7 @@ static ALWAYS_INLINE RegisterID* emitReadModifyAssignment(BytecodeGenerator& gen
 
 RegisterID* ReadModifyResolveNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)
 {
-    JSTextPosition newDivot = divotStart() + m_ident.length();
+    JSTextPosition newDivot = divotStart() + m_ident->length();
     Variable var = generator.variable(m_ident);
     if (RegisterID* local = var.local()) {
         generator.emitTDZCheckIfNecessary(var, local, nullptr);
@@ -3842,7 +3832,7 @@ static ALWAYS_INLINE void emitShortCircuitAssignment(BytecodeGenerator& generato
 
 RegisterID* ShortCircuitReadModifyResolveNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)
 {
-    JSTextPosition newDivot = divotStart() + m_ident.length();
+    JSTextPosition newDivot = divotStart() + m_ident->length();
 
     Variable var = generator.variable(m_ident);
     bool isReadOnly = var.isReadOnly();
@@ -3949,7 +3939,7 @@ RegisterID* AssignResolveNode::emitBytecode(BytecodeGenerator& generator, Regist
 {
     Variable var = generator.variable(m_ident);
     bool isReadOnly = var.isReadOnly() && m_assignmentContext != AssignmentContext::ConstDeclarationStatement && !isUsingOrAwaitUsingAssignmentContext(m_assignmentContext);
-    JSTextPosition newDivot = divotStart() + m_ident.length();
+    JSTextPosition newDivot = divotStart() + m_ident->length();
     if (RegisterID* local = var.local()) {
         RegisterID* result = nullptr;
 
@@ -4089,7 +4079,7 @@ RegisterID* AssignBracketNode::emitBytecode(BytecodeGenerator& generator, Regist
 {
     ForInContext* context = nullptr;
     if (m_subscript->isResolveNode()) {
-        Variable argumentVariable = generator.variable(static_cast<ResolveNode*>(m_subscript)->identifier());
+        Variable argumentVariable = generator.variable(static_cast<ResolveNode*>(m_subscript)->ident());
         if (argumentVariable.isLocal()) {
             RegisterID* property = argumentVariable.local();
             context = generator.findForInContext(property);
@@ -4296,11 +4286,11 @@ RegisterID* EmptyVarExpression::emitBytecode(BytecodeGenerator& generator, Regis
 
     Variable var = generator.variable(m_ident);
     if (RegisterID* local = var.local())
-        generator.emitProfileType(local, var, position(), position() + m_ident.length());
+        generator.emitProfileType(local, var, position(), position() + m_ident->length());
     else {
         RefPtr<RegisterID> scope = generator.emitResolveScope(nullptr, var);
         RefPtr<RegisterID> value = generator.emitGetFromScope(generator.newTemporary(), scope.get(), var, DoNotThrowIfNotFound);
-        generator.emitProfileType(value.get(), var, position(), position() + m_ident.length());
+        generator.emitProfileType(value.get(), var, position(), position() + m_ident->length());
     }
 
     return nullptr;
@@ -4315,12 +4305,12 @@ RegisterID* EmptyLetExpression::emitBytecode(BytecodeGenerator& generator, Regis
     Variable var = generator.variable(m_ident);
     if (RegisterID* local = var.local()) {
         generator.emitLoad(local, jsUndefined());
-        generator.emitProfileType(local, var, position(), position() + m_ident.length());
+        generator.emitProfileType(local, var, position(), position() + m_ident->length());
     } else {
         RefPtr<RegisterID> scope = generator.emitResolveScope(nullptr, var);
         RefPtr<RegisterID> value = generator.emitLoad(nullptr, jsUndefined());
         generator.emitPutToScope(scope.get(), var, value.get(), generator.ecmaMode().isStrict() ? ThrowIfNotFound : DoNotThrowIfNotFound, InitializationMode::Initialization);
-        generator.emitProfileType(value.get(), var, position(), position() + m_ident.length()); 
+        generator.emitProfileType(value.get(), var, position(), position() + m_ident->length()); 
     }
 
     generator.liftTDZCheckIfPossible(var);
@@ -4507,8 +4497,7 @@ void ForNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)
 RegisterID* ForInNode::tryGetBoundLocal(BytecodeGenerator& generator)
 {
     if (m_lexpr->isResolveNode()) {
-        const Identifier& ident = static_cast<ResolveNode*>(m_lexpr)->identifier();
-        return generator.variable(ident).local();
+        return generator.variable(static_cast<ResolveNode*>(m_lexpr)->ident()).local();
     }
 
     if (m_lexpr->isDestructuringNode()) {
@@ -4518,8 +4507,7 @@ RegisterID* ForInNode::tryGetBoundLocal(BytecodeGenerator& generator)
             return nullptr;
 
         auto simpleBinding = static_cast<BindingNode*>(binding);
-        const Identifier& ident = simpleBinding->boundProperty();
-        Variable var = generator.variable(ident);
+        Variable var = generator.variable(simpleBinding->boundProperty());
         if (var.isSpecial())
             return nullptr;
         return var.local();
@@ -4530,8 +4518,8 @@ RegisterID* ForInNode::tryGetBoundLocal(BytecodeGenerator& generator)
 
 void ForInNode::emitLoopHeader(BytecodeGenerator& generator, RegisterID* propertyName)
 {
-    auto lambdaEmitResolveVariable = [&] (const Identifier& ident) {
-        Variable var = generator.variable(ident);
+    auto lambdaEmitResolveVariable = [&] (UniquedStringImpl* uid) {
+        Variable var = generator.variable(uid);
         if (RegisterID* local = var.local()) {
             if (var.isReadOnly())
                 generator.emitReadOnlyExceptionIfNeeded(var);
@@ -4545,18 +4533,16 @@ void ForInNode::emitLoopHeader(BytecodeGenerator& generator, RegisterID* propert
             generator.emitExpressionInfo(divot(), divotStart(), divotEnd());
             generator.emitPutToScope(scope.get(), var, propertyName, generator.ecmaMode().isStrict() ? ThrowIfNotFound : DoNotThrowIfNotFound, InitializationMode::NotInitialization);
         }
-        generator.emitProfileType(propertyName, var, m_lexpr->position(), m_lexpr->position() + ident.length());
+        generator.emitProfileType(propertyName, var, m_lexpr->position(), m_lexpr->position() + uid->length());
     };
 
     if (m_lexpr->isResolveNode()) {
-        const Identifier& ident = static_cast<ResolveNode*>(m_lexpr)->identifier();
-        lambdaEmitResolveVariable(ident);
+        lambdaEmitResolveVariable(static_cast<ResolveNode*>(m_lexpr)->ident());
         return;
     }
 
     if (m_lexpr->isAssignResolveNode()) {
-        const Identifier& ident = static_cast<AssignResolveNode*>(m_lexpr)->identifier();
-        lambdaEmitResolveVariable(ident);
+        lambdaEmitResolveVariable(static_cast<AssignResolveNode*>(m_lexpr)->ident());
         return;
     }
 
@@ -4592,8 +4578,7 @@ void ForInNode::emitLoopHeader(BytecodeGenerator& generator, RegisterID* propert
         }
 
         auto simpleBinding = static_cast<BindingNode*>(binding);
-        const Identifier& ident = simpleBinding->boundProperty();
-        Variable var = generator.variable(ident);
+        Variable var = generator.variable(simpleBinding->boundProperty());
         if (!var.local() || var.isSpecial()) {
             assignNode->bindings()->bindValue(generator, propertyName);
             return;
@@ -4692,8 +4677,8 @@ void ForOfNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)
     {
         auto emitBody = [&](BytecodeGenerator& generator) {
             if (m_lexpr->isResolveNode()) {
-                const Identifier& ident = static_cast<ResolveNode*>(m_lexpr)->identifier();
-                Variable var = generator.variable(ident);
+                UniquedStringImpl* uid = static_cast<ResolveNode*>(m_lexpr)->ident();
+                Variable var = generator.variable(uid);
                 if (RegisterID* local = var.local()) {
                     if (var.isReadOnly() && !isUsingDeclaration)
                         generator.emitReadOnlyExceptionIfNeeded(var);
@@ -4707,7 +4692,7 @@ void ForOfNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)
                     generator.emitExpressionInfo(divot(), divotStart(), divotEnd());
                     generator.emitPutToScope(scope.get(), var, value, generator.ecmaMode().isStrict() ? ThrowIfNotFound : DoNotThrowIfNotFound, isUsingDeclaration ? InitializationMode::ConstInitialization : InitializationMode::NotInitialization);
                 }
-                generator.emitProfileType(value, var, m_lexpr->position(), m_lexpr->position() + ident.length());
+                generator.emitProfileType(value, var, m_lexpr->position(), m_lexpr->position() + uid->length());
                 if (isUsingDeclaration)
                     generator.emitPrepareDisposable(value, divotStart(), isAwaitUsingDeclaration);
             } else if (m_lexpr->isDotAccessorNode()) {
@@ -4903,7 +4888,7 @@ static void processClauseList(ClauseListNode* list, Vector<ExpressionNode*, 8>& 
                 typeForTable = SwitchNeither;
                 break;
             }
-            auto& value = static_cast<StringNode*>(clauseExpression)->value().string();
+            StringView value { static_cast<StringNode*>(clauseExpression)->value() };
             if (singleCharacterSwitch &= value.length() == 1) {
                 int32_t intVal = value[0];
                 if (intVal < min_num)
@@ -5045,7 +5030,7 @@ void LabelNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)
 {
     ASSERT(!generator.breakTarget(m_name));
 
-    Ref<LabelScope> scope = generator.newLabelScope(LabelScope::NamedLabel, &m_name);
+    Ref<LabelScope> scope = generator.newLabelScope(LabelScope::NamedLabel, m_name);
     generator.emitNodeInTailPosition(dst, m_statement);
 
     generator.emitLabel(scope->breakTarget());
@@ -5670,13 +5655,13 @@ void DefineFieldNode::emitBytecode(BytecodeGenerator& generator, RegisterID*)
         generator.emitNode(value.get(), m_assign);
         shouldSetFunctionName = generator.shouldSetFunctionName(m_assign);
         if (shouldSetFunctionName && m_type != DefineFieldNode::Type::ComputedName)
-            generator.emitSetFunctionName(value.get(), m_ident);
+            generator.emitSetFunctionName(value.get(), Identifier::fromUid(generator.vm(), m_ident));
     }
 
     switch (m_type) {
     case DefineFieldNode::Type::Name: {
         StrictModeScope strictModeScope(generator);
-        if (auto index = parseIndex(m_ident)) {
+        if (auto index = parseIndex(*m_ident)) {
             RefPtr<RegisterID> propertyName = generator.emitLoad(nullptr, jsNumber(index.value()));
             generator.emitDirectPutByVal(generator.thisRegister(), propertyName.get(), value.get());
         } else
@@ -5687,7 +5672,7 @@ void DefineFieldNode::emitBytecode(BytecodeGenerator& generator, RegisterID*)
         Variable var = generator.variable(m_ident);
         ASSERT_WITH_MESSAGE(!var.local(), "Private Field names must be stored in captured variables");
 
-        generator.emitExpressionInfo(position(), position(), position() + m_ident.length());
+        generator.emitExpressionInfo(position(), position(), position() + m_ident->length());
         RefPtr<RegisterID> scope = generator.emitResolveScope(nullptr, var);
         RefPtr<RegisterID> privateName = generator.newTemporary();
         generator.emitGetFromScope(privateName.get(), scope.get(), var, DoNotThrowIfNotFound);
@@ -5706,7 +5691,7 @@ void DefineFieldNode::emitBytecode(BytecodeGenerator& generator, RegisterID*)
         generator.emitGetFromScope(privateName.get(), scope.get(), var, ThrowIfNotFound);
         if (shouldSetFunctionName)
             generator.emitSetFunctionName(value.get(), privateName.get());
-        generator.emitProfileType(privateName.get(), var, m_position, m_position + m_ident.length());
+        generator.emitProfileType(privateName.get(), var, m_position, m_position + m_ident->length());
         {
             StrictModeScope strictModeScope(generator);
             generator.emitDirectPutByVal(generator.thisRegister(), privateName.get(), value.get());
@@ -5729,7 +5714,7 @@ RegisterID* ClassExprNode::emitBytecode(BytecodeGenerator& generator, RegisterID
 {
     StrictModeScope strictModeScope(generator);
 
-    if (!m_name.isNull())
+    if (m_name)
         generator.pushClassHeadLexicalScope(m_classHeadEnvironment);
 
     // Class heritage must be evaluated outside of private fields access.
@@ -5765,7 +5750,7 @@ RegisterID* ClassExprNode::emitBytecode(BytecodeGenerator& generator, RegisterID
         constructor = generator.emitNode(constructor.get(), m_constructorExpression);
         needsHomeObject = m_classHeritage || metadata->superBinding() == SuperBinding::Needed;
     } else
-        constructor = generator.emitNewDefaultConstructor(constructor.get(), m_classHeritage ? ConstructorKind::Extends : ConstructorKind::Base, m_name, ecmaName(), m_classSource, needsClassFieldInitializer, privateBrandRequirement);
+        constructor = generator.emitNewDefaultConstructor(constructor.get(), m_classHeritage ? ConstructorKind::Extends : ConstructorKind::Base, Identifier::fromUid(generator.vm(), m_name), Identifier::fromUid(generator.vm(), ecmaName()), m_classSource, needsClassFieldInitializer, privateBrandRequirement);
 
     const auto& propertyNames = generator.propertyNames();
     RefPtr<RegisterID> prototype = generator.emitNewObject(generator.newTemporary());
@@ -5782,7 +5767,7 @@ RegisterID* ClassExprNode::emitBytecode(BytecodeGenerator& generator, RegisterID
         generator.emitExpressionInfo(divot(), divotStart(), divotEnd());
         generator.emitThrowTypeError("The superclass is not a constructor."_s);
         generator.emitLabel(superclassIsConstructorLabel.get());
-        generator.emitGetById(protoParent.get(), superclass.get(), generator.propertyNames().prototype);
+        generator.emitGetById(protoParent.get(), superclass.get(), generator.propertyNames().prototype.impl());
 
         generator.emitDirectSetPrototypeOf<InvalidPrototypeMode::Throw>(constructor.get(), superclass.get(), m_position, m_position, m_position); // never actually throws
         generator.emitLabel(superclassIsNullLabel.get());
@@ -5792,11 +5777,11 @@ RegisterID* ClassExprNode::emitBytecode(BytecodeGenerator& generator, RegisterID
     if (needsHomeObject)
         emitPutHomeObject(generator, constructor.get(), prototype.get());
 
-    RefPtr<RegisterID> constructorNameRegister = generator.emitLoad(nullptr, propertyNames.constructor);
+    RefPtr<RegisterID> constructorNameRegister = generator.emitLoad(nullptr, propertyNames.constructor.impl());
     generator.emitCallDefineProperty(prototype.get(), constructorNameRegister.get(), constructor.get(), nullptr, nullptr,
         BytecodeGenerator::PropertyConfigurable | BytecodeGenerator::PropertyWritable, m_position);
 
-    RefPtr<RegisterID> prototypeNameRegister = generator.emitLoad(nullptr, propertyNames.prototype);
+    RefPtr<RegisterID> prototypeNameRegister = generator.emitLoad(nullptr, propertyNames.prototype.impl());
     generator.emitCallDefineProperty(constructor.get(), prototypeNameRegister.get(), prototype.get(), nullptr, nullptr, 0, m_position);
 
     Vector<UnlinkedFunctionExecutable::ClassElementDefinition> staticElementDefinitions;
@@ -5812,11 +5797,11 @@ RegisterID* ClassExprNode::emitBytecode(BytecodeGenerator& generator, RegisterID
             // https://bugs.webkit.org/show_bug.cgi?id=196867
             emitPutHomeObject(generator, instanceFieldInitializer.get(), prototype.get());
 
-            generator.emitDirectPutById(constructor.get(), generator.propertyNames().builtinNames().instanceFieldInitializerPrivateName(), instanceFieldInitializer.get());
+            generator.emitDirectPutById(constructor.get(), generator.propertyNames().builtinNames().instanceFieldInitializerPrivateName().impl(), instanceFieldInitializer.get());
         }
     }
 
-    if (!m_name.isNull()) {
+    if (m_name) {
         Variable classNameVar = generator.variable(m_name);
         RELEASE_ASSERT(classNameVar.isResolved());
         RefPtr<RegisterID> scope = generator.emitResolveScope(nullptr, classNameVar);
@@ -5843,7 +5828,7 @@ RegisterID* ClassExprNode::emitBytecode(BytecodeGenerator& generator, RegisterID
     if (m_needsLexicalScope)
         generator.popLexicalScope(this);
 
-    if (!m_name.isNull())
+    if (m_name)
         generator.popClassHeadLexicalScope(m_classHeadEnvironment);
 
     return generator.move(generator.finalDestination(dst, constructor.get()), constructor.get());
@@ -5911,7 +5896,7 @@ void ArrayPatternNode::bindValue(BytecodeGenerator& generator, RegisterID* rhs) 
     RefPtr<RegisterID> nextOrIndex = generator.newTemporary();
     {
         generator.emitExpressionInfo(divot(), divotStart(), divotEnd());
-        RefPtr<RegisterID> iteratorSymbol = generator.emitGetById(generator.newTemporary(), iterable.get(), generator.propertyNames().iteratorSymbol);
+        RefPtr<RegisterID> iteratorSymbol = generator.emitGetById(generator.newTemporary(), iterable.get(), generator.propertyNames().iteratorSymbol.impl());
         CallArguments args(generator, nullptr, 0);
         generator.move(args.thisRegister(), iterable.get());
         generator.emitIteratorOpen(iterator.get(), nextOrIndex.get(), iteratorSymbol.get(), args, this);
@@ -6069,11 +6054,11 @@ void ArrayPatternNode::toString(StringBuilder& builder) const
     builder.append(']');
 }
 
-void ArrayPatternNode::collectBoundIdentifiers(Vector<Identifier>& identifiers) const
+void ArrayPatternNode::collectBoundIdentifiers(VM& vm, Vector<Identifier>& identifiers) const
 {
     for (size_t i = 0; i < m_targetPatterns.size(); i++) {
         if (DestructuringPatternNode* node = m_targetPatterns[i].pattern)
-            node->collectBoundIdentifiers(identifiers);
+            node->collectBoundIdentifiers(vm, identifiers);
     }
 }
 
@@ -6082,9 +6067,9 @@ void ObjectPatternNode::toString(StringBuilder& builder) const
     builder.append('{');
     for (size_t i = 0; i < m_targetPatterns.size(); i++) {
         if (m_targetPatterns[i].wasString)
-            builder.appendQuotedJSONString(m_targetPatterns[i].propertyName.string());
+            builder.appendQuotedJSONString(String(m_targetPatterns[i].propertyName));
         else
-            builder.append(m_targetPatterns[i].propertyName.string());
+            builder.append(StringView { m_targetPatterns[i].propertyName });
         builder.append(':');
         m_targetPatterns[i].pattern->toString(builder);
         if (i < m_targetPatterns.size() - 1)
@@ -6095,11 +6080,13 @@ void ObjectPatternNode::toString(StringBuilder& builder) const
     
 void ObjectPatternNode::bindValue(BytecodeGenerator& generator, RegisterID* rhs) const
 {
-    const Identifier* firstPropertyName = nullptr;
+    UniquedStringImpl* firstPropertyName = nullptr;
     if (!m_targetPatterns.isEmpty()) {
         const auto& firstTarget = m_targetPatterns[0];
-        if (!firstTarget.propertyExpression && !firstTarget.propertyName.isNull() && !firstTarget.propertyName.isPrivateName())
-            firstPropertyName = &firstTarget.propertyName;
+        auto* uid = firstTarget.propertyName;
+        bool isPrivate = uid && uid->isSymbol() && static_cast<const SymbolImpl*>(uid)->isPrivate();
+        if (!firstTarget.propertyExpression && uid && !isPrivate)
+            firstPropertyName = uid;
     }
     generator.emitRequireObjectCoercibleForDestructuring(rhs, firstPropertyName);
 
@@ -6169,7 +6156,7 @@ void ObjectPatternNode::bindValue(BytecodeGenerator& generator, RegisterID* rhs)
                 if (!target.propertyExpression) {
                     if (target.pattern->isAssignmentElementNode())
                         targetBaseAndPropertyName = static_cast<AssignmentElementNode*>(target.pattern)->emitNodesForDestructuring(generator);
-                    std::optional<uint32_t> optionalIndex = parseIndex(target.propertyName);
+                    std::optional<uint32_t> optionalIndex = parseIndex(*target.propertyName);
                     if (!optionalIndex)
                         generator.emitGetById(temp.get(), rhs, target.propertyName);
                     else {
@@ -6177,7 +6164,7 @@ void ObjectPatternNode::bindValue(BytecodeGenerator& generator, RegisterID* rhs)
                         generator.emitGetByVal(temp.get(), rhs, propertyIndex.get());
                     }
                     if (m_containsRestElement)
-                        excludedSet.add(target.propertyName.impl());
+                        excludedSet.add(target.propertyName);
                 } else {
                     RefPtr<RegisterID> propertyName;
                     if (m_containsRestElement)
@@ -6236,10 +6223,10 @@ void ObjectPatternNode::bindValue(BytecodeGenerator& generator, RegisterID* rhs)
     generator.restoreTDZStack(preservedTDZStack);
 }
 
-void ObjectPatternNode::collectBoundIdentifiers(Vector<Identifier>& identifiers) const
+void ObjectPatternNode::collectBoundIdentifiers(VM& vm, Vector<Identifier>& identifiers) const
 {
     for (size_t i = 0; i < m_targetPatterns.size(); i++)
-        m_targetPatterns[i].pattern->collectBoundIdentifiers(identifiers);
+        m_targetPatterns[i].pattern->collectBoundIdentifiers(vm, identifiers);
 }
 
 
@@ -6323,12 +6310,12 @@ void BindingNode::bindValue(BytecodeGenerator& generator, RegisterID* value) con
 
 void BindingNode::toString(StringBuilder& builder) const
 {
-    builder.append(m_boundProperty.string());
+    builder.append(StringView { m_boundProperty });
 }
 
-void BindingNode::collectBoundIdentifiers(Vector<Identifier>& identifiers) const
+void BindingNode::collectBoundIdentifiers(VM& vm, Vector<Identifier>& identifiers) const
 {
-    identifiers.append(m_boundProperty);
+    identifiers.append(Identifier::fromUid(vm, m_boundProperty));
 }
 
 std::optional<AssignmentElementNode::BaseAndPropertyName> AssignmentElementNode::emitNodesForDestructuring(BytecodeGenerator& generator, RefPtr<RegisterID> base, RefPtr<RegisterID> propertyName) const
@@ -6382,7 +6369,7 @@ bool AssignmentElementNode::bindValueCanThrow(BytecodeGenerator& generator) cons
 {
     if (m_assignmentTarget->isResolveNode()) {
         ResolveNode* lhs = static_cast<ResolveNode*>(m_assignmentTarget);
-        Variable var = generator.variable(lhs->identifier());
+        Variable var = generator.variable(lhs->ident());
         if (var.offset().isStack() || var.offset().isScope())
             return var.isReadOnly() || generator.needsTDZCheck(var);
     }
@@ -6395,7 +6382,7 @@ RegisterID* AssignmentElementNode::writableDirectBindingIfPossible(BytecodeGener
     if (!m_assignmentTarget->isResolveNode())
         return nullptr;
     ResolveNode* lhs = static_cast<ResolveNode*>(m_assignmentTarget);
-    Variable var = generator.variable(lhs->identifier());
+    Variable var = generator.variable(lhs->ident());
     bool isReadOnly = var.isReadOnly();
     if (RegisterID* local = var.local()) {
         if (generator.needsTDZCheck(var))
@@ -6411,12 +6398,12 @@ void AssignmentElementNode::finishDirectBindingAssignment(BytecodeGenerator& gen
 {
     ASSERT_UNUSED(generator, writableDirectBindingIfPossible(generator));
     ResolveNode* lhs = static_cast<ResolveNode*>(m_assignmentTarget);
-    Variable var = generator.variable(lhs->identifier());
+    Variable var = generator.variable(lhs->ident());
     RegisterID* local = var.local();
     generator.emitProfileType(local, divotStart(), divotEnd());
 }
 
-void AssignmentElementNode::collectBoundIdentifiers(Vector<Identifier>&) const
+void AssignmentElementNode::collectBoundIdentifiers(VM&, Vector<Identifier>&) const
 {
 }
 
@@ -6424,7 +6411,7 @@ void AssignmentElementNode::bindValue(BytecodeGenerator& generator, RegisterID* 
 {
     if (m_assignmentTarget->isResolveNode()) {
         ResolveNode* lhs = static_cast<ResolveNode*>(m_assignmentTarget);
-        Variable var = generator.variable(lhs->identifier());
+        Variable var = generator.variable(lhs->ident());
         bool isReadOnly = var.isReadOnly();
         if (RegisterID* local = var.local()) {
             generator.emitTDZCheckIfNecessary(var, local, nullptr);
@@ -6474,12 +6461,12 @@ void AssignmentElementNode::bindValue(BytecodeGenerator& generator, RegisterID* 
 void AssignmentElementNode::toString(StringBuilder& builder) const
 {
     if (m_assignmentTarget->isResolveNode())
-        builder.append(static_cast<ResolveNode*>(m_assignmentTarget)->identifier().string());
+        builder.append(StringView { static_cast<ResolveNode*>(m_assignmentTarget)->ident() });
 }
 
-void RestParameterNode::collectBoundIdentifiers(Vector<Identifier>& identifiers) const
+void RestParameterNode::collectBoundIdentifiers(VM& vm, Vector<Identifier>& identifiers) const
 {
-    m_pattern->collectBoundIdentifiers(identifiers);
+    m_pattern->collectBoundIdentifiers(vm, identifiers);
 }
 
 void RestParameterNode::toString(StringBuilder& builder) const

--- a/Source/JavaScriptCore/parser/ASTBuilder.h
+++ b/Source/JavaScriptCore/parser/ASTBuilder.h
@@ -198,22 +198,22 @@ public:
     bool isMetaProperty(ExpressionNode* node) { return node->isMetaProperty(); }
     bool isNewTarget(ExpressionNode* node) { return node->isNewTarget(); }
     bool isImportMeta(ExpressionNode* node) { return node->isImportMeta(); }
-    ExpressionNode* createResolve(const JSTokenLocation& location, const Identifier& ident, const JSTextPosition& start, const JSTextPosition& end, const bool needToCheckUsesArguments = true)
+    ExpressionNode* createResolve(const JSTokenLocation& location, UniquedStringImpl* uid, const JSTextPosition& start, const JSTextPosition& end, const bool needToCheckUsesArguments = true)
     {
-        if (needToCheckUsesArguments && m_vm.propertyNames->arguments == ident)
+        if (needToCheckUsesArguments && uid == m_vm.propertyNames->arguments.impl())
             usesArguments();
 
-        if (ident.isSymbol()) {
-            auto entry = m_vm.bytecodeIntrinsicRegistry().lookup(ident);
+        if (uid->isSymbol()) {
+            auto entry = m_vm.bytecodeIntrinsicRegistry().lookup(Identifier::fromUid(m_vm, uid));
             if (entry)
-                return new (m_parserArena) BytecodeIntrinsicNode(BytecodeIntrinsicNode::Type::Constant, location, entry.value(), ident, nullptr, start, start, end);
+                return new (m_parserArena) BytecodeIntrinsicNode(BytecodeIntrinsicNode::Type::Constant, location, entry.value(), uid, nullptr, start, start, end);
         }
 
-        return new (m_parserArena) ResolveNode(location, ident, start);
+        return new (m_parserArena) ResolveNode(location, uid, start);
     }
-    ExpressionNode* createPrivateIdentifierNode(const JSTokenLocation& location, const Identifier& ident)
+    ExpressionNode* createPrivateIdentifierNode(const JSTokenLocation& location, UniquedStringImpl* uid)
     {
-        return new (m_parserArena) PrivateIdentifierNode(location, ident);
+        return new (m_parserArena) PrivateIdentifierNode(location, uid);
     }
     ExpressionNode* createObjectLiteral(const JSTokenLocation& location) { return new (m_parserArena) ObjectLiteralNode(location); }
     ExpressionNode* createObjectLiteral(const JSTokenLocation& location, PropertyListNode* properties) { return new (m_parserArena) ObjectLiteralNode(location, properties); }
@@ -243,17 +243,17 @@ public:
         return new (m_parserArena) IntegerNode(location, d);
     }
     
-    ExpressionNode* createBigInt(const JSTokenLocation& location, const Identifier* bigInt, uint8_t radix)
+    ExpressionNode* createBigInt(const JSTokenLocation& location, UniquedStringImpl* bigInt, uint8_t radix)
     {
         incConstants();
-        return new (m_parserArena) BigIntNode(location, *bigInt, radix);
+        return new (m_parserArena) BigIntNode(location, bigInt, radix);
     }
 
-    ExpressionNode* createString(const JSTokenLocation& location, const Identifier* string)
+    ExpressionNode* createString(const JSTokenLocation& location, UniquedStringImpl* string)
     {
         ASSERT(string);
         incConstants();
-        return new (m_parserArena) StringNode(location, *string);
+        return new (m_parserArena) StringNode(location, string);
     }
 
     ExpressionNode* createBoolean(const JSTokenLocation& location, bool b)
@@ -278,12 +278,12 @@ public:
         return node;
     }
 
-    ExpressionNode* createDotAccess(const JSTokenLocation& location, ExpressionNode* base, const Identifier* property, DotType type, const JSTextPosition& start, const JSTextPosition& divot, const JSTextPosition& end)
+    ExpressionNode* createDotAccess(const JSTokenLocation& location, ExpressionNode* base, UniquedStringImpl* property, DotType type, const JSTextPosition& start, const JSTextPosition& divot, const JSTextPosition& end)
     {
         if (base->isSuperNode())
             usesSuperProperty();
-        
-        DotAccessorNode* node = new (m_parserArena) DotAccessorNode(location, base, *property, type);
+
+        DotAccessorNode* node = new (m_parserArena) DotAccessorNode(location, base, property, type);
         setExceptionLocation(node, start, divot, end);
         return node;
     }
@@ -302,7 +302,7 @@ public:
         return node;
     }
 
-    TemplateStringNode* createTemplateString(const JSTokenLocation& location, const Identifier* cooked, const Identifier* raw)
+    TemplateStringNode* createTemplateString(const JSTokenLocation& location, UniquedStringImpl* cooked, UniquedStringImpl* raw)
     {
         return new (m_parserArena) TemplateStringNode(location, cooked, raw);
     }
@@ -345,12 +345,12 @@ public:
         return node;
     }
 
-    ExpressionNode* createRegExp(const JSTokenLocation& location, const Identifier& pattern, const Identifier& flags, const JSTextPosition& start, bool skipSyntaxCheck)
+    ExpressionNode* createRegExp(const JSTokenLocation& location, UniquedStringImpl* pattern, UniquedStringImpl* flags, const JSTextPosition& start, bool skipSyntaxCheck)
     {
-        if (!skipSyntaxCheck && Yarr::hasError(Yarr::checkSyntax(pattern.string(), flags.string())))
+        if (!skipSyntaxCheck && Yarr::hasError(Yarr::checkSyntax(StringView { pattern }, StringView { flags })))
             return nullptr;
         RegExpNode* node = new (m_parserArena) RegExpNode(location, pattern, flags);
-        int size = pattern.length() + 2; // + 2 for the two /'s
+        int size = pattern->length() + 2; // + 2 for the two /'s
         JSTextPosition end = start + size;
         setExceptionLocation(node, start, end, end);
         return node;
@@ -382,16 +382,16 @@ public:
         return new (m_parserArena) ConditionalNode(location, condition, lhs, rhs);
     }
 
-    ExpressionNode* createAssignResolve(const JSTokenLocation& location, const Identifier& ident, ExpressionNode* rhs, const JSTextPosition& start, const JSTextPosition& divot, const JSTextPosition& end, AssignmentContext assignmentContext)
+    ExpressionNode* createAssignResolve(const JSTokenLocation& location, UniquedStringImpl* uid, ExpressionNode* rhs, const JSTextPosition& start, const JSTextPosition& divot, const JSTextPosition& end, AssignmentContext assignmentContext)
     {
         if (rhs->isBaseFuncExprNode()) {
             auto metadata = static_cast<BaseFuncExprNode*>(rhs)->metadata();
-            metadata->setEcmaName(ident);
+            metadata->setEcmaName(uid);
         } else if (rhs->isClassExprNode())
-            static_cast<ClassExprNode*>(rhs)->setEcmaName(ident);
+            static_cast<ClassExprNode*>(rhs)->setEcmaName(uid);
         if (assignmentContext == AssignmentContext::AwaitUsingDeclarationStatement)
             usesAwait();
-        AssignResolveNode* node = new (m_parserArena) AssignResolveNode(location, ident, rhs, assignmentContext);
+        AssignResolveNode* node = new (m_parserArena) AssignResolveNode(location, uid, rhs, assignmentContext);
         setExceptionLocation(node, start, divot, end);
         return node;
     }
@@ -417,61 +417,61 @@ public:
         return node;
     }
 
-    DefineFieldNode* createDefineField(const JSTokenLocation& location, const Identifier& ident, ExpressionNode* initializer, DefineFieldNode::Type type)
+    DefineFieldNode* createDefineField(const JSTokenLocation& location, UniquedStringImpl* uid, ExpressionNode* initializer, DefineFieldNode::Type type)
     {
         if (initializer && type != DefineFieldNode::Type::ComputedName) {
             if (initializer->isBaseFuncExprNode())
-                static_cast<BaseFuncExprNode*>(initializer)->metadata()->setEcmaName(ident);
+                static_cast<BaseFuncExprNode*>(initializer)->metadata()->setEcmaName(uid);
             else if (initializer->isClassExprNode())
-                static_cast<ClassExprNode*>(initializer)->setEcmaName(ident);
+                static_cast<ClassExprNode*>(initializer)->setEcmaName(uid);
         }
-        return new (m_parserArena) DefineFieldNode(location, ident, initializer, type);
+        return new (m_parserArena) DefineFieldNode(location, uid, initializer, type);
     }
 
     ClassExprNode* createClassExpr(const JSTokenLocation& location, const ParserClassInfo<ASTBuilder>& classInfo, VariableEnvironment&& classHeadEnvironment, VariableEnvironment&& classEnvironment, ExpressionNode* constructor,
         ExpressionNode* parentClass, PropertyListNode* classElements, const JSTextPosition& start, const JSTextPosition& divot, const JSTextPosition& end)
     {
         SourceCode source = m_sourceCode->subExpression(classInfo.startOffset, classInfo.endOffset, classInfo.startLine, classInfo.startColumn);
-        ClassExprNode* node = new (m_parserArena) ClassExprNode(location, *classInfo.className, source, WTF::move(classHeadEnvironment), WTF::move(classEnvironment), constructor, parentClass, classElements);
+        ClassExprNode* node = new (m_parserArena) ClassExprNode(location, classInfo.className, source, WTF::move(classHeadEnvironment), WTF::move(classEnvironment), constructor, parentClass, classElements);
         setExceptionLocation(node, start, divot, end);
         return node;
     }
 
     ExpressionNode* createFunctionExpr(const JSTokenLocation& location, const ParserFunctionInfo<ASTBuilder>& functionInfo)
     {
-        FuncExprNode* result = new (m_parserArena) FuncExprNode(location, *functionInfo.name, functionInfo.body,
+        FuncExprNode* result = new (m_parserArena) FuncExprNode(location, functionInfo.name, functionInfo.body,
             m_sourceCode->subExpression(functionInfo.startOffset, functionInfo.endOffset, functionInfo.startLine, functionInfo.parametersStartColumn));
         functionInfo.body->setLoc(functionInfo.startLine, functionInfo.endLine, location.startOffset, location.lineStartOffset);
         return result;
     }
 
-    ExpressionNode* createGeneratorFunctionBody(const JSTokenLocation& location, const ParserFunctionInfo<ASTBuilder>& functionInfo, const Identifier& name)
+    ExpressionNode* createGeneratorFunctionBody(const JSTokenLocation& location, const ParserFunctionInfo<ASTBuilder>& functionInfo, UniquedStringImpl* name)
     {
         FuncExprNode* result = static_cast<FuncExprNode*>(createFunctionExpr(location, functionInfo));
-        if (!name.isNull())
+        if (name)
             result->metadata()->setEcmaName(name);
         return result;
     }
 
-    ExpressionNode* createAsyncFunctionBody(const JSTokenLocation& location, const ParserFunctionInfo<ASTBuilder>& functionInfo, SourceParseMode parseMode, const Identifier& name)
+    ExpressionNode* createAsyncFunctionBody(const JSTokenLocation& location, const ParserFunctionInfo<ASTBuilder>& functionInfo, SourceParseMode parseMode, UniquedStringImpl* name)
     {
         if (parseMode == SourceParseMode::AsyncArrowFunctionBodyMode) {
             SourceCode source = m_sourceCode->subExpression(functionInfo.startOffset, functionInfo.body->isArrowFunctionBodyExpression() ? functionInfo.endOffset - 1 : functionInfo.endOffset, functionInfo.startLine, functionInfo.parametersStartColumn);
-            FuncExprNode* result = new (m_parserArena) FuncExprNode(location, *functionInfo.name, functionInfo.body, source);
-            if (!name.isNull())
+            FuncExprNode* result = new (m_parserArena) FuncExprNode(location, functionInfo.name, functionInfo.body, source);
+            if (name)
                 result->metadata()->setEcmaName(name);
             functionInfo.body->setLoc(functionInfo.startLine, functionInfo.endLine, location.startOffset, location.lineStartOffset);
             return result;
         }
         FuncExprNode* result =  static_cast<FuncExprNode*>(createFunctionExpr(location, functionInfo));
-        if (!name.isNull())
+        if (name)
             result->metadata()->setEcmaName(name);
         return result;
     }
 
     ExpressionNode* createMethodDefinition(const JSTokenLocation& location, const ParserFunctionInfo<ASTBuilder>& functionInfo)
     {
-        MethodDefinitionNode* result = new (m_parserArena) MethodDefinitionNode(location, *functionInfo.name, functionInfo.body,
+        MethodDefinitionNode* result = new (m_parserArena) MethodDefinitionNode(location, functionInfo.name, functionInfo.body,
             m_sourceCode->subExpression(functionInfo.startOffset, functionInfo.endOffset, functionInfo.startLine, functionInfo.parametersStartColumn));
         functionInfo.body->setLoc(functionInfo.startLine, functionInfo.endLine, location.startOffset, location.lineStartOffset);
         return result;
@@ -496,7 +496,7 @@ public:
     {
         usesArrowFunction();
         SourceCode source = m_sourceCode->subExpression(functionInfo.startOffset, functionInfo.body->isArrowFunctionBodyExpression() ? functionInfo.endOffset - 1 : functionInfo.endOffset, functionInfo.startLine, functionInfo.parametersStartColumn);
-        ArrowFuncExprNode* result = new (m_parserArena) ArrowFuncExprNode(location, *functionInfo.name, functionInfo.body, source);
+        ArrowFuncExprNode* result = new (m_parserArena) ArrowFuncExprNode(location, functionInfo.name, functionInfo.body, source);
         functionInfo.body->setLoc(functionInfo.startLine, functionInfo.endLine, location.startOffset, location.lineStartOffset);
         return result;
     }
@@ -507,14 +507,14 @@ public:
     ArgumentListNode* createArgumentsList(const JSTokenLocation& location, ArgumentListNode* args, ExpressionNode* arg) { return new (m_parserArena) ArgumentListNode(location, args, arg); }
 
     NEVER_INLINE PropertyNode* createGetterOrSetterProperty(const JSTokenLocation& location, PropertyNode::Type type,
-        const Identifier* name, const ParserFunctionInfo<ASTBuilder>& functionInfo, ClassElementTag tag)
+        UniquedStringImpl* name, const ParserFunctionInfo<ASTBuilder>& functionInfo, ClassElementTag tag)
     {
         ASSERT(name);
         functionInfo.body->setLoc(functionInfo.startLine, functionInfo.endLine, location.startOffset, location.lineStartOffset);
-        functionInfo.body->setEcmaName(*name);
+        functionInfo.body->setEcmaName(name);
         SourceCode source = m_sourceCode->subExpression(functionInfo.startOffset, functionInfo.endOffset, functionInfo.startLine, functionInfo.parametersStartColumn);
-        MethodDefinitionNode* methodDef = new (m_parserArena) MethodDefinitionNode(location, m_vm.propertyNames->nullIdentifier, functionInfo.body, source);
-        return new (m_parserArena) PropertyNode(*name, methodDef, type, SuperBinding::Needed, tag);
+        MethodDefinitionNode* methodDef = new (m_parserArena) MethodDefinitionNode(location, nullptr, functionInfo.body, source);
+        return new (m_parserArena) PropertyNode(name, methodDef, type, SuperBinding::Needed, tag);
     }
 
     NEVER_INLINE PropertyNode* createGetterOrSetterProperty(const JSTokenLocation& location, PropertyNode::Type type,
@@ -523,7 +523,7 @@ public:
         ASSERT(name);
         functionInfo.body->setLoc(functionInfo.startLine, functionInfo.endLine, location.startOffset, location.lineStartOffset);
         SourceCode source = m_sourceCode->subExpression(functionInfo.startOffset, functionInfo.endOffset, functionInfo.startLine, functionInfo.parametersStartColumn);
-        MethodDefinitionNode* methodDef = new (m_parserArena) MethodDefinitionNode(location, m_vm.propertyNames->nullIdentifier, functionInfo.body, source);
+        MethodDefinitionNode* methodDef = new (m_parserArena) MethodDefinitionNode(location, nullptr, functionInfo.body, source);
         return new (m_parserArena) PropertyNode(name, methodDef, type, SuperBinding::Needed, tag);
     }
 
@@ -531,27 +531,27 @@ public:
         double name, const ParserFunctionInfo<ASTBuilder>& functionInfo, ClassElementTag tag)
     {
         functionInfo.body->setLoc(functionInfo.startLine, functionInfo.endLine, location.startOffset, location.lineStartOffset);
-        const Identifier& ident = parserArena.identifierArena().makeNumericIdentifier(vm, name);
-        functionInfo.body->setEcmaName(ident);
+        SUPPRESS_UNCOUNTED_LOCAL UniquedStringImpl* uid = parserArena.identifierArena().makeNumericIdentifier(vm, name);
+        functionInfo.body->setEcmaName(uid);
         SourceCode source = m_sourceCode->subExpression(functionInfo.startOffset, functionInfo.endOffset, functionInfo.startLine, functionInfo.parametersStartColumn);
-        MethodDefinitionNode* methodDef = new (m_parserArena) MethodDefinitionNode(location, vm.propertyNames->nullIdentifier, functionInfo.body, source);
-        return new (m_parserArena) PropertyNode(ident, methodDef, type, SuperBinding::Needed, tag);
+        MethodDefinitionNode* methodDef = new (m_parserArena) MethodDefinitionNode(location, nullptr, functionInfo.body, source);
+        return new (m_parserArena) PropertyNode(uid, methodDef, type, SuperBinding::Needed, tag);
     }
 
-    PropertyNode* createProperty(const Identifier* propertyName, PropertyNode::Type type, SuperBinding superBinding, ClassElementTag tag)
+    PropertyNode* createProperty(UniquedStringImpl* propertyName, PropertyNode::Type type, SuperBinding superBinding, ClassElementTag tag)
     {
-        return new (m_parserArena) PropertyNode(*propertyName, type, superBinding, tag);
+        return new (m_parserArena) PropertyNode(propertyName, type, superBinding, tag);
     }
-    PropertyNode* createProperty(const Identifier* propertyName, ExpressionNode* node, PropertyNode::Type type, SuperBinding superBinding, InferName inferName, ClassElementTag tag)
+    PropertyNode* createProperty(UniquedStringImpl* propertyName, ExpressionNode* node, PropertyNode::Type type, SuperBinding superBinding, InferName inferName, ClassElementTag tag)
     {
         if (inferName == InferName::Allowed) {
             if (node->isBaseFuncExprNode()) {
                 auto metadata = static_cast<BaseFuncExprNode*>(node)->metadata();
-                metadata->setEcmaName(*propertyName);
+                metadata->setEcmaName(propertyName);
             } else if (node->isClassExprNode())
-                static_cast<ClassExprNode*>(node)->setEcmaName(*propertyName);
+                static_cast<ClassExprNode*>(node)->setEcmaName(propertyName);
         }
-        return new (m_parserArena) PropertyNode(*propertyName, node, type, superBinding, tag);
+        return new (m_parserArena) PropertyNode(propertyName, node, type, superBinding, tag);
     }
     PropertyNode* createProperty(ExpressionNode* node, PropertyNode::Type type, SuperBinding superBinding, ClassElementTag tag)
     {
@@ -562,7 +562,7 @@ public:
         return new (m_parserArena) PropertyNode(parserArena.identifierArena().makeNumericIdentifier(vm, propertyName), node, type, superBinding, tag);
     }
     PropertyNode* createProperty(ExpressionNode* propertyName, ExpressionNode* node, PropertyNode::Type type, SuperBinding superBinding, ClassElementTag tag) { return new (m_parserArena) PropertyNode(propertyName, node, type, superBinding, tag); }
-    PropertyNode* createProperty(const Identifier* identifier, ExpressionNode* propertyName, ExpressionNode* node, PropertyNode::Type type, SuperBinding superBinding, ClassElementTag tag) { return new (m_parserArena) PropertyNode(*identifier, propertyName, node, type, superBinding, tag); }
+    PropertyNode* createProperty(UniquedStringImpl* identifier, ExpressionNode* propertyName, ExpressionNode* node, PropertyNode::Type type, SuperBinding superBinding, ClassElementTag tag) { return new (m_parserArena) PropertyNode(identifier, propertyName, node, type, superBinding, tag); }
     PropertyListNode* createPropertyList(const JSTokenLocation& location, PropertyNode* property) { return new (m_parserArena) PropertyListNode(location, property); }
     PropertyListNode* createPropertyList(const JSTokenLocation& location, PropertyNode* property, PropertyListNode* tail) { return new (m_parserArena) PropertyListNode(location, property, tail); }
 
@@ -593,9 +593,9 @@ public:
 
     StatementNode* createFuncDeclStatement(const JSTokenLocation& location, const ParserFunctionInfo<ASTBuilder>& functionInfo)
     {
-        FuncDeclNode* decl = new (m_parserArena) FuncDeclNode(location, *functionInfo.name, functionInfo.body,
+        FuncDeclNode* decl = new (m_parserArena) FuncDeclNode(location, functionInfo.name, functionInfo.body,
             m_sourceCode->subExpression(functionInfo.startOffset, functionInfo.endOffset, functionInfo.startLine, functionInfo.parametersStartColumn));
-        if (*functionInfo.name == m_vm.propertyNames->arguments)
+        if (functionInfo.name == m_vm.propertyNames->arguments.impl())
             usesArguments();
         functionInfo.body->setLoc(functionInfo.startLine, functionInfo.endLine, location.startOffset, location.lineStartOffset);
         return decl;
@@ -604,7 +604,7 @@ public:
     StatementNode* createClassDeclStatement(const JSTokenLocation& location, ClassExprNode* classExpression,
         const JSTextPosition& classStart, const JSTextPosition& classEnd, unsigned startLine, unsigned endLine)
     {
-        ExpressionNode* assign = createAssignResolve(location, classExpression->name(), classExpression, classStart, classStart + 1, classEnd, AssignmentContext::DeclarationStatement);
+        SUPPRESS_UNCOUNTED_ARG ExpressionNode* assign = createAssignResolve(location, classExpression->name(), classExpression, classStart, classStart + 1, classEnd, AssignmentContext::DeclarationStatement);
         ClassDeclNode* decl = new (m_parserArena) ClassDeclNode(location, assign);
         decl->setLoc(startLine, endLine, location.startOffset, location.lineStartOffset);
         return decl;
@@ -723,14 +723,14 @@ public:
         return result;
     }
 
-    ExpressionNode* createEmptyVarExpression(const JSTokenLocation& location, const Identifier& identifier)
+    ExpressionNode* createEmptyVarExpression(const JSTokenLocation& location, UniquedStringImpl* uid)
     {
-        return new (m_parserArena) EmptyVarExpression(location, identifier);
+        return new (m_parserArena) EmptyVarExpression(location, uid);
     }
 
-    ExpressionNode* createEmptyLetExpression(const JSTokenLocation& location, const Identifier& identifier)
+    ExpressionNode* createEmptyLetExpression(const JSTokenLocation& location, UniquedStringImpl* uid)
     {
-        return new (m_parserArena) EmptyLetExpression(location, identifier);
+        return new (m_parserArena) EmptyLetExpression(location, uid);
     }
 
     StatementNode* createReturnStatement(const JSTokenLocation& location, ExpressionNode* expression, const JSTextPosition& start, const JSTextPosition& end)
@@ -741,17 +741,17 @@ public:
         return result;
     }
 
-    StatementNode* createBreakStatement(const JSTokenLocation& location, const Identifier* ident, const JSTextPosition& start, const JSTextPosition& end)
+    StatementNode* createBreakStatement(const JSTokenLocation& location, UniquedStringImpl* uid, const JSTextPosition& start, const JSTextPosition& end)
     {
-        BreakNode* result = new (m_parserArena) BreakNode(location, *ident);
+        BreakNode* result = new (m_parserArena) BreakNode(location, uid);
         setExceptionLocation(result, start, end, end);
         result->setLoc(start.line, end.line, start.offset, start.lineStartOffset);
         return result;
     }
 
-    StatementNode* createContinueStatement(const JSTokenLocation& location, const Identifier* ident, const JSTextPosition& start, const JSTextPosition& end)
+    StatementNode* createContinueStatement(const JSTokenLocation& location, UniquedStringImpl* uid, const JSTextPosition& start, const JSTextPosition& end)
     {
-        ContinueNode* result = new (m_parserArena) ContinueNode(location, *ident);
+        ContinueNode* result = new (m_parserArena) ContinueNode(location, uid);
         setExceptionLocation(result, start, end, end);
         result->setLoc(start.line, end.line, start.offset, start.lineStartOffset);
         return result;
@@ -786,9 +786,9 @@ public:
         return result;
     }
 
-    StatementNode* createLabelStatement(const JSTokenLocation& location, const Identifier* ident, StatementNode* statement, const JSTextPosition& start, const JSTextPosition& end)
+    StatementNode* createLabelStatement(const JSTokenLocation& location, UniquedStringImpl* uid, StatementNode* statement, const JSTextPosition& start, const JSTextPosition& end)
     {
-        LabelNode* result = new (m_parserArena) LabelNode(location, *ident, statement);
+        LabelNode* result = new (m_parserArena) LabelNode(location, uid, statement);
         setExceptionLocation(result, start, end, end);
         return result;
     }
@@ -816,12 +816,12 @@ public:
         return result;
     }
 
-    ModuleNameNode* createModuleName(const JSTokenLocation& location, const Identifier& moduleName)
+    ModuleNameNode* createModuleName(const JSTokenLocation& location, UniquedStringImpl* moduleName)
     {
         return new (m_parserArena) ModuleNameNode(location, moduleName);
     }
 
-    ImportSpecifierNode* createImportSpecifier(const JSTokenLocation& location, const Identifier& importedName, const Identifier& localName)
+    ImportSpecifierNode* createImportSpecifier(const JSTokenLocation& location, UniquedStringImpl* importedName, UniquedStringImpl* localName)
     {
         return new (m_parserArena) ImportSpecifierNode(location, importedName, localName);
     }
@@ -841,7 +841,7 @@ public:
         return new (m_parserArena) ImportAttributesListNode();
     }
 
-    void appendImportAttribute(ImportAttributesListNode* attributesList, const Identifier& key, const Identifier& value)
+    void appendImportAttribute(ImportAttributesListNode* attributesList, UniquedStringImpl* key, UniquedStringImpl* value)
     {
         attributesList->append(key, value);
     }
@@ -856,7 +856,7 @@ public:
         return new (m_parserArena) ExportAllDeclarationNode(location, moduleName, importAttributesList);
     }
 
-    StatementNode* createExportDefaultDeclaration(const JSTokenLocation& location, StatementNode* declaration, const Identifier& localName)
+    StatementNode* createExportDefaultDeclaration(const JSTokenLocation& location, StatementNode* declaration, UniquedStringImpl* localName)
     {
         return new (m_parserArena) ExportDefaultDeclarationNode(location, declaration, localName);
     }
@@ -871,7 +871,7 @@ public:
         return new (m_parserArena) ExportNamedDeclarationNode(location, exportSpecifierList, moduleName, importAttributesList);
     }
 
-    ExportSpecifierNode* createExportSpecifier(const JSTokenLocation& location, const Identifier& localName, const Identifier& exportedName)
+    ExportSpecifierNode* createExportSpecifier(const JSTokenLocation& location, UniquedStringImpl* localName, UniquedStringImpl* exportedName)
     {
         return new (m_parserArena) ExportSpecifierNode(location, localName, exportedName);
     }
@@ -1042,7 +1042,7 @@ public:
         return new (m_parserArena) ObjectPatternNode();
     }
 
-    void appendObjectPatternEntry(ObjectPattern node, const JSTokenLocation& location, bool wasString, const Identifier& identifier, DestructuringPattern pattern, ExpressionNode* defaultValue)
+    void appendObjectPatternEntry(ObjectPattern node, const JSTokenLocation& location, bool wasString, UniquedStringImpl* identifier, DestructuringPattern pattern, ExpressionNode* defaultValue)
     {
         node->appendEntry(location, identifier, wasString, pattern, defaultValue, ObjectPatternNode::BindingType::Element);
         tryInferNameInPattern(pattern, defaultValue);
@@ -1074,7 +1074,7 @@ public:
         setExceptionLocation(node, divotStart, divot, divotEnd);
     }
 
-    BindingPattern createBindingLocation(const JSTokenLocation&, const Identifier& boundProperty, const JSTextPosition& start, const JSTextPosition& end, AssignmentContext context)
+    BindingPattern createBindingLocation(const JSTokenLocation&, UniquedStringImpl* boundProperty, const JSTextPosition& start, const JSTextPosition& end, AssignmentContext context)
     {
         if (context == AssignmentContext::AwaitUsingDeclarationStatement)
             usesAwait();
@@ -1170,7 +1170,7 @@ private:
     {
         return new (m_parserArena) DoubleNode(location, d);
     }
-    ExpressionNode* createBigIntWithSign(const JSTokenLocation& location, const Identifier& bigInt, uint8_t radix, bool sign)
+    ExpressionNode* createBigIntWithSign(const JSTokenLocation& location, UniquedStringImpl* bigInt, uint8_t radix, bool sign)
     {
         return new (m_parserArena) BigIntNode(location, bigInt, radix, sign);
     }
@@ -1197,24 +1197,24 @@ private:
             return;
 
         if (pattern->isBindingNode()) {
-            const Identifier& ident = static_cast<BindingNode*>(pattern)->boundProperty();
-            tryInferNameInPatternWithIdentifier(ident, defaultValue);
+            SUPPRESS_UNCOUNTED_LOCAL UniquedStringImpl* uid = static_cast<BindingNode*>(pattern)->boundProperty();
+            tryInferNameInPatternWithIdentifier(uid, defaultValue);
         } else if (pattern->isAssignmentElementNode()) {
             const ExpressionNode* assignmentTarget = static_cast<AssignmentElementNode*>(pattern)->assignmentTarget();
             if (assignmentTarget->isResolveNode()) {
-                const Identifier& ident = static_cast<const ResolveNode*>(assignmentTarget)->identifier();
-                tryInferNameInPatternWithIdentifier(ident, defaultValue);
+                SUPPRESS_UNCOUNTED_LOCAL UniquedStringImpl* uid = static_cast<const ResolveNode*>(assignmentTarget)->ident();
+                tryInferNameInPatternWithIdentifier(uid, defaultValue);
             }
         }
     }
 
-    void tryInferNameInPatternWithIdentifier(const Identifier& ident, ExpressionNode* defaultValue)
+    void tryInferNameInPatternWithIdentifier(UniquedStringImpl* uid, ExpressionNode* defaultValue)
     {
         if (defaultValue->isBaseFuncExprNode()) {
             auto metadata = static_cast<BaseFuncExprNode*>(defaultValue)->metadata();
-            metadata->setEcmaName(ident);
+            metadata->setEcmaName(uid);
         } else if (defaultValue->isClassExprNode())
-            static_cast<ClassExprNode*>(defaultValue)->setEcmaName(ident);
+            static_cast<ClassExprNode*>(defaultValue)->setEcmaName(uid);
     }
 
     VM& m_vm;
@@ -1232,7 +1232,7 @@ ExpressionNode* ASTBuilder::makeTypeOfNode(const JSTokenLocation& location, Expr
 {
     if (expr->isResolveNode()) {
         ResolveNode* resolve = static_cast<ResolveNode*>(expr);
-        return new (m_parserArena) TypeOfResolveNode(location, resolve->identifier(), start, divot, end);
+        return new (m_parserArena) TypeOfResolveNode(location, resolve->ident(), start, divot, end);
     }
     return new (m_parserArena) TypeOfValueNode(location, expr);
 }
@@ -1252,7 +1252,7 @@ ExpressionNode* ASTBuilder::makeDeleteNode(const JSTokenLocation& location, Expr
         return new (m_parserArena) DeleteValueNode(location, expr);
     if (expr->isResolveNode()) {
         ResolveNode* resolve = static_cast<ResolveNode*>(expr);
-        return new (m_parserArena) DeleteResolveNode(location, resolve->identifier(), divot, start, end);
+        return new (m_parserArena) DeleteResolveNode(location, resolve->ident(), divot, start, end);
     }
     if (expr->isBracketAccessorNode()) {
         BracketAccessorNode* bracket = static_cast<BracketAccessorNode*>(expr);
@@ -1261,7 +1261,7 @@ ExpressionNode* ASTBuilder::makeDeleteNode(const JSTokenLocation& location, Expr
     ASSERT(expr->isDotAccessorNode());
     checkArgumentsLengthModification(expr);
     DotAccessorNode* dot = static_cast<DotAccessorNode*>(expr);
-    return new (m_parserArena) DeleteDotNode(location, dot->base(), dot->identifier(), divot, start, end);
+    return new (m_parserArena) DeleteDotNode(location, dot->base(), dot->ident(), divot, start, end);
 }
 
 ExpressionNode* ASTBuilder::makeNegateNode(const JSTokenLocation& location, ExpressionNode* n)
@@ -1475,7 +1475,7 @@ ExpressionNode* ASTBuilder::makeFunctionCallNode(const JSTokenLocation& location
         ASSERT(!isOptionalCall);
         BytecodeIntrinsicNode* intrinsic = static_cast<BytecodeIntrinsicNode*>(func);
         if (intrinsic->type() == BytecodeIntrinsicNode::Type::Constant && intrinsic->entry().type() == BytecodeIntrinsicRegistry::Type::Emitter)
-            return new (m_parserArena) BytecodeIntrinsicNode(BytecodeIntrinsicNode::Type::Function, location, intrinsic->entry(), intrinsic->identifier(), args, divot, divotStart, divotEnd);
+            return new (m_parserArena) BytecodeIntrinsicNode(BytecodeIntrinsicNode::Type::Function, location, intrinsic->entry(), intrinsic->ident(), args, divot, divotStart, divotEnd);
     }
 
     if (func->isOptionalChain()) {
@@ -1494,12 +1494,12 @@ ExpressionNode* ASTBuilder::makeFunctionCallNode(const JSTokenLocation& location
         return new (m_parserArena) FunctionCallValueNode(location, func, args, divot, divotStart, divotEnd, isOptionalCall);
     if (func->isResolveNode()) {
         ResolveNode* resolve = static_cast<ResolveNode*>(func);
-        const Identifier& identifier = resolve->identifier();
-        if (identifier == m_vm.propertyNames->eval && !isOptionalCall) {
+        UniquedStringImpl* uid = resolve->ident();
+        if (uid == m_vm.propertyNames->eval.impl() && !isOptionalCall) {
             usesEval();
             return new (m_parserArena) EvalFunctionCallNode(location, args, divot, divotStart, divotEnd);
         }
-        return new (m_parserArena) FunctionCallResolveNode(location, identifier, args, divot, divotStart, divotEnd, isOptionalCall);
+        return new (m_parserArena) FunctionCallResolveNode(location, uid, args, divot, divotStart, divotEnd, isOptionalCall);
     }
     if (func->isBracketAccessorNode()) {
         BracketAccessorNode* bracket = static_cast<BracketAccessorNode*>(func);
@@ -1510,15 +1510,15 @@ ExpressionNode* ASTBuilder::makeFunctionCallNode(const JSTokenLocation& location
     ASSERT(func->isDotAccessorNode());
     DotAccessorNode* dot = static_cast<DotAccessorNode*>(func);
     FunctionCallDotNode* node = nullptr;
-    if (!previousBaseWasSuper && (dot->identifier() == m_vm.propertyNames->builtinNames().callPublicName() || dot->identifier() == m_vm.propertyNames->builtinNames().callPrivateName()))
-        node = new (m_parserArena) CallFunctionCallDotNode(location, dot->base(), dot->identifier(), dot->type(), args, divot, divotStart, divotEnd, isOptionalCall, callOrApplyChildDepth);
-    else if (!previousBaseWasSuper && (dot->identifier() == m_vm.propertyNames->builtinNames().applyPublicName() || dot->identifier() == m_vm.propertyNames->builtinNames().applyPrivateName())) {
+    if (!previousBaseWasSuper && (dot->ident() == m_vm.propertyNames->builtinNames().callPublicName().impl() || dot->ident() == m_vm.propertyNames->builtinNames().callPrivateName().impl()))
+        node = new (m_parserArena) CallFunctionCallDotNode(location, dot->base(), dot->ident(), dot->type(), args, divot, divotStart, divotEnd, isOptionalCall, callOrApplyChildDepth);
+    else if (!previousBaseWasSuper && (dot->ident() == m_vm.propertyNames->builtinNames().applyPublicName().impl() || dot->ident() == m_vm.propertyNames->builtinNames().applyPrivateName().impl())) {
         // FIXME: This check is only needed because we haven't taught the bytecode generator to inline
         // Reflect.apply yet. See https://bugs.webkit.org/show_bug.cgi?id=190668.
-        if (!dot->base()->isResolveNode() || static_cast<ResolveNode*>(dot->base())->identifier() != m_vm.propertyNames->Reflect)
-            node = new (m_parserArena) ApplyFunctionCallDotNode(location, dot->base(), dot->identifier(), dot->type(), args, divot, divotStart, divotEnd, isOptionalCall, callOrApplyChildDepth);
-    } else if (!previousBaseWasSuper 
-        && dot->identifier() == m_vm.propertyNames->hasOwnProperty
+        if (!dot->base()->isResolveNode() || static_cast<ResolveNode*>(dot->base())->ident() != m_vm.propertyNames->Reflect.impl())
+            node = new (m_parserArena) ApplyFunctionCallDotNode(location, dot->base(), dot->ident(), dot->type(), args, divot, divotStart, divotEnd, isOptionalCall, callOrApplyChildDepth);
+    } else if (!previousBaseWasSuper
+        && dot->ident() == m_vm.propertyNames->hasOwnProperty.impl()
         && args->m_listNode
         && args->m_listNode->m_expr
         && args->m_listNode->m_expr->isResolveNode()
@@ -1528,10 +1528,10 @@ ExpressionNode* ASTBuilder::makeFunctionCallNode(const JSTokenLocation& location
         // <resolveNode|thisNode>.hasOwnProperty(<resolveNode>)
         // i.e:
         // o.hasOwnProperty(p)
-        node = new (m_parserArena) HasOwnPropertyFunctionCallDotNode(location, dot->base(), dot->identifier(), dot->type(), args, divot, divotStart, divotEnd, isOptionalCall);
+        node = new (m_parserArena) HasOwnPropertyFunctionCallDotNode(location, dot->base(), dot->ident(), dot->type(), args, divot, divotStart, divotEnd, isOptionalCall);
     }
     if (!node)
-        node = new (m_parserArena) FunctionCallDotNode(location, dot->base(), dot->identifier(), dot->type(), args, divot, divotStart, divotEnd, isOptionalCall);
+        node = new (m_parserArena) FunctionCallDotNode(location, dot->base(), dot->ident(), dot->type(), args, divot, divotStart, divotEnd, isOptionalCall);
     node->setSubexpressionInfo(dot->divot(), dot->divotEnd().offset);
     return node;
 }
@@ -1637,10 +1637,10 @@ ExpressionNode* ASTBuilder::makeAssignNode(const JSTokenLocation& location, Expr
         if (op == Operator::Equal) {
             if (expr->isBaseFuncExprNode()) {
                 auto metadata = static_cast<BaseFuncExprNode*>(expr)->metadata();
-                metadata->setEcmaName(resolve->identifier());
+                SUPPRESS_UNCOUNTED_ARG metadata->setEcmaName(resolve->ident());
             } else if (expr->isClassExprNode())
-                static_cast<ClassExprNode*>(expr)->setEcmaName(resolve->identifier());
-            AssignResolveNode* node = new (m_parserArena) AssignResolveNode(location, resolve->identifier(), expr, AssignmentContext::AssignmentExpression);
+                SUPPRESS_UNCOUNTED_ARG static_cast<ClassExprNode*>(expr)->setEcmaName(resolve->ident());
+            AssignResolveNode* node = new (m_parserArena) AssignResolveNode(location, resolve->ident(), expr, AssignmentContext::AssignmentExpression);
             setExceptionLocation(node, start, divot, end);
             return node;
         }
@@ -1648,13 +1648,13 @@ ExpressionNode* ASTBuilder::makeAssignNode(const JSTokenLocation& location, Expr
         if (op == Operator::CoalesceEq || op == Operator::OrEq || op == Operator::AndEq) {
             if (expr->isBaseFuncExprNode()) {
                 auto metadata = static_cast<BaseFuncExprNode*>(expr)->metadata();
-                metadata->setEcmaName(resolve->identifier());
+                SUPPRESS_UNCOUNTED_ARG metadata->setEcmaName(resolve->ident());
             } else if (expr->isClassExprNode())
-                static_cast<ClassExprNode*>(expr)->setEcmaName(resolve->identifier());
-            return new (m_parserArena) ShortCircuitReadModifyResolveNode(location, resolve->identifier(), op, expr, exprHasAssignments, divot, start, end);
+                SUPPRESS_UNCOUNTED_ARG static_cast<ClassExprNode*>(expr)->setEcmaName(resolve->ident());
+            return new (m_parserArena) ShortCircuitReadModifyResolveNode(location, resolve->ident(), op, expr, exprHasAssignments, divot, start, end);
         }
 
-        return new (m_parserArena) ReadModifyResolveNode(location, resolve->identifier(), op, expr, exprHasAssignments, divot, start, end);
+        return new (m_parserArena) ReadModifyResolveNode(location, resolve->ident(), op, expr, exprHasAssignments, divot, start, end);
     }
 
     if (loc->isBracketAccessorNode()) {
@@ -1678,15 +1678,15 @@ ExpressionNode* ASTBuilder::makeAssignNode(const JSTokenLocation& location, Expr
     DotAccessorNode* dot = static_cast<DotAccessorNode*>(loc);
 
     if (op == Operator::Equal)
-        return new (m_parserArena) AssignDotNode(location, dot->base(), dot->identifier(), dot->type(), expr, exprHasAssignments, dot->divot(), start, end);
+        return new (m_parserArena) AssignDotNode(location, dot->base(), dot->ident(), dot->type(), expr, exprHasAssignments, dot->divot(), start, end);
 
     if (op == Operator::CoalesceEq || op == Operator::OrEq || op == Operator::AndEq) {
-        auto* node = new (m_parserArena) ShortCircuitReadModifyDotNode(location, dot->base(), dot->identifier(), dot->type(), op, expr, exprHasAssignments, divot, start, end);
+        auto* node = new (m_parserArena) ShortCircuitReadModifyDotNode(location, dot->base(), dot->ident(), dot->type(), op, expr, exprHasAssignments, divot, start, end);
         node->setSubexpressionInfo(dot->divot(), dot->divotEnd().offset);
         return node;
     }
 
-    ReadModifyDotNode* node = new (m_parserArena) ReadModifyDotNode(location, dot->base(), dot->identifier(), dot->type(), op, expr, exprHasAssignments, divot, start, end);
+    ReadModifyDotNode* node = new (m_parserArena) ReadModifyDotNode(location, dot->base(), dot->ident(), dot->type(), op, expr, exprHasAssignments, divot, start, end);
     node->setSubexpressionInfo(dot->divot(), dot->divotEnd().offset);
     return node;
 }

--- a/Source/JavaScriptCore/parser/Lexer.cpp
+++ b/Source/JavaScriptCore/parser/Lexer.cpp
@@ -925,7 +925,7 @@ template<typename CharacterType> inline void Lexer<CharacterType>::recordUnicode
 }
 
 #if ASSERT_ENABLED
-bool isSafeBuiltinIdentifier(VM& vm, const Identifier* ident)
+bool isSafeBuiltinIdentifier(VM& vm, UniquedStringImpl* ident)
 {
     if (!ident)
         return true;
@@ -933,13 +933,13 @@ bool isSafeBuiltinIdentifier(VM& vm, const Identifier* ident)
      * be used as a safety net while implementing builtins.
      */
     // FIXME: How can a debug-only assertion be a safety net?
-    if (*ident == vm.propertyNames->builtinNames().callPublicName())
+    if (ident == vm.propertyNames->builtinNames().callPublicName().impl())
         return false;
-    if (*ident == vm.propertyNames->builtinNames().applyPublicName())
+    if (ident == vm.propertyNames->builtinNames().applyPublicName().impl())
         return false;
-    if (*ident == vm.propertyNames->eval)
+    if (ident == vm.propertyNames->eval.impl())
         return false;
-    if (*ident == vm.propertyNames->Function)
+    if (ident == vm.propertyNames->Function.impl())
         return false;
     return true;
 }
@@ -1012,26 +1012,26 @@ template <bool shouldCreateIdentifier> ALWAYS_INLINE JSTokenType Lexer<Latin1Cha
     if (m_current == '\\') [[unlikely]]
         return parseIdentifierSlowCase<shouldCreateIdentifier>(tokenData, lexerFlags, strictMode, identifierStart);
 
-    const Identifier* ident = nullptr;
-    
+    SUPPRESS_UNCOUNTED_LOCAL UniquedStringImpl* ident = nullptr;
+
     if (shouldCreateIdentifier || m_parsingBuiltinFunction) {
         std::span identifierSpan { identifierStart, static_cast<size_t>(currentSourcePtr() - identifierStart) };
         if (m_parsingBuiltinFunction && isBuiltinName) {
             if (isWellKnownSymbol)
-                ident = &m_arena->makeIdentifier(m_vm, m_vm.propertyNames->builtinNames().lookUpWellKnownSymbol(identifierSpan));
+                SUPPRESS_UNCOUNTED_LOCAL ident = m_arena->makeIdentifier(m_vm, m_vm.propertyNames->builtinNames().lookUpWellKnownSymbol(identifierSpan));
             else
-                ident = &m_arena->makeIdentifier(m_vm, m_vm.propertyNames->builtinNames().lookUpPrivateName(identifierSpan));
+                SUPPRESS_UNCOUNTED_LOCAL ident = m_arena->makeIdentifier(m_vm, m_vm.propertyNames->builtinNames().lookUpPrivateName(identifierSpan));
             if (!ident)
                 return INVALID_PRIVATE_NAME_ERRORTOK;
         } else {
-            ident = makeIdentifier(identifierSpan);
+            SUPPRESS_UNCOUNTED_LOCAL ident = makeIdentifier(identifierSpan);
             if (m_parsingBuiltinFunction) {
                 if (!isSafeBuiltinIdentifier(m_vm, ident)) {
-                    m_lexErrorMessage = makeString("The use of '"_s, ident->string(), "' is disallowed in builtin functions."_s);
+                    m_lexErrorMessage = makeString("The use of '"_s, StringView { ident }, "' is disallowed in builtin functions."_s);
                     return ERRORTOK;
                 }
-                if (*ident == m_vm.propertyNames->undefinedKeyword)
-                    tokenData->ident = &m_vm.propertyNames->undefinedPrivateName;
+                if (ident == m_vm.propertyNames->undefinedKeyword.impl())
+                    tokenData->ident = m_vm.propertyNames->undefinedPrivateName.impl();
             }
         }
         tokenData->ident = ident;
@@ -1042,7 +1042,7 @@ template <bool shouldCreateIdentifier> ALWAYS_INLINE JSTokenType Lexer<Latin1Cha
     if ((remaining < maxTokenLength) && !lexerFlags.contains(LexerFlags::IgnoreReservedWords)) [[unlikely]] {
         if (!isBuiltinName) {
             ASSERT(shouldCreateIdentifier);
-            const HashTableValue* entry = JSC::mainTable.entry(*ident);
+            const HashTableValue* entry = JSC::mainTable.entry(ident);
             ASSERT((remaining < maxTokenLength) || !entry);
             if (!entry)
                 return identType;
@@ -1115,31 +1115,30 @@ template <bool shouldCreateIdentifier> ALWAYS_INLINE JSTokenType Lexer<char16_t>
         return parseIdentifierSlowCase<shouldCreateIdentifier>(tokenData, lexerFlags, strictMode, identifierStart);
 
     bool isAll8Bit = !(orAllChars & ~0xff);
-    const Identifier* ident = nullptr;
-    
-    if (shouldCreateIdentifier) {
+    if constexpr (shouldCreateIdentifier) {
+        SUPPRESS_UNCOUNTED_LOCAL UniquedStringImpl* ident = nullptr;
         if (isAll8Bit)
-            ident = makeLatin1Identifier(std::span { identifierStart, currentSourcePtr() });
+            SUPPRESS_UNCOUNTED_LOCAL ident = makeLatin1Identifier(std::span { identifierStart, currentSourcePtr() });
         else
-            ident = makeIdentifier(std::span { identifierStart, currentSourcePtr() });
+            SUPPRESS_UNCOUNTED_LOCAL ident = makeIdentifier(std::span { identifierStart, currentSourcePtr() });
         tokenData->ident = ident;
-    } else
-        tokenData->ident = nullptr;
-    
-    if (isPrivateName)
-        return PRIVATENAME;
 
-    if ((remaining < maxTokenLength) && !lexerFlags.contains(LexerFlags::IgnoreReservedWords)) [[unlikely]] {
-        ASSERT(shouldCreateIdentifier);
-        const HashTableValue* entry = JSC::mainTable.entry(*ident);
-        ASSERT((remaining < maxTokenLength) || !entry);
-        if (!entry)
-            return IDENT;
-        JSTokenType token = static_cast<JSTokenType>(entry->lexerValue());
-        return (token != RESERVED_IF_STRICT) || strictMode ? token : IDENT;
+        if (isPrivateName)
+            return PRIVATENAME;
+
+        if ((remaining < maxTokenLength) && !lexerFlags.contains(LexerFlags::IgnoreReservedWords)) [[unlikely]] {
+            const HashTableValue* entry = JSC::mainTable.entry(ident);
+            ASSERT((remaining < maxTokenLength) || !entry);
+            if (!entry)
+                return IDENT;
+            JSTokenType token = static_cast<JSTokenType>(entry->lexerValue());
+            return (token != RESERVED_IF_STRICT) || strictMode ? token : IDENT;
+        }
+        return IDENT;
     }
 
-    return IDENT;
+    tokenData->ident = nullptr;
+    return isPrivateName ? PRIVATENAME : IDENT;
 }
 
 template<typename CharacterType>
@@ -1174,7 +1173,7 @@ JSTokenType Lexer<CharacterType>::parseIdentifierSlowCase(JSTokenData* tokenData
                 return character.isIncomplete() ? UNTERMINATED_IDENTIFIER_UNICODE_ESCAPE_ERRORTOK : INVALID_IDENTIFIER_UNICODE_ESCAPE_ERRORTOK;
             if (isStart ? !isIdentStart(character.value()) : !isIdentPart(character.value())) [[unlikely]]
                 return INVALID_IDENTIFIER_UNICODE_ESCAPE_ERRORTOK;
-            if (shouldCreateIdentifier)
+            if constexpr (shouldCreateIdentifier)
                 recordUnicodeCodePoint(character.value());
             identifierStart = currentSourcePtr();
             return identType;
@@ -1213,26 +1212,24 @@ JSTokenType Lexer<CharacterType>::parseIdentifierSlowCase(JSTokenData* tokenData
             return type;
     }
 
-    const Identifier* ident = nullptr;
-    if (shouldCreateIdentifier) {
+    if constexpr (shouldCreateIdentifier) {
         if (identifierStart != currentSourcePtr())
             m_buffer16.append(std::span(identifierStart, currentSourcePtr() - identifierStart));
-        ident = makeIdentifier(m_buffer16.span());
-
+        SUPPRESS_UNCOUNTED_LOCAL auto* ident = makeIdentifier(m_buffer16.span());
         tokenData->ident = ident;
-    } else
+        m_buffer16.shrink(0);
+
+        if (!lexerFlags.contains(LexerFlags::IgnoreReservedWords)) [[likely]] {
+            const HashTableValue* entry = JSC::mainTable.entry(ident);
+            if (!entry)
+                return identType;
+            JSTokenType token = static_cast<JSTokenType>(entry->lexerValue());
+            if ((token != RESERVED_IF_STRICT) || strictMode)
+                return ESCAPED_KEYWORD;
+        }
+    } else {
         tokenData->ident = nullptr;
-
-    m_buffer16.shrink(0);
-
-    if (!lexerFlags.contains(LexerFlags::IgnoreReservedWords)) [[likely]] {
-        ASSERT(shouldCreateIdentifier);
-        const HashTableValue* entry = JSC::mainTable.entry(*ident);
-        if (!entry)
-            return identType;
-        JSTokenType token = static_cast<JSTokenType>(entry->lexerValue());
-        if ((token != RESERVED_IF_STRICT) || strictMode)
-            return ESCAPED_KEYWORD;
+        m_buffer16.shrink(0);
     }
 
     return identType;
@@ -2512,7 +2509,7 @@ start:
             else {
                 token = BIGINT;
                 shift();
-                tokenData->bigIntString = std::get<const Identifier*>(*parseNumberResult);
+                tokenData->bigIntString = std::get<UniquedStringImpl*>(*parseNumberResult);
                 tokenData->radix = 16;
             }
 
@@ -2551,7 +2548,7 @@ start:
             else {
                 token = BIGINT;
                 shift();
-                tokenData->bigIntString = std::get<const Identifier*>(*parseNumberResult);
+                tokenData->bigIntString = std::get<UniquedStringImpl*>(*parseNumberResult);
                 tokenData->radix = 2;
             }
 
@@ -2591,7 +2588,7 @@ start:
             else {
                 token = BIGINT;
                 shift();
-                tokenData->bigIntString = std::get<const Identifier*>(*parseNumberResult);
+                tokenData->bigIntString = std::get<UniquedStringImpl*>(*parseNumberResult);
                 tokenData->radix = 8;
             }
 
@@ -2683,7 +2680,7 @@ start:
                 } else {
                     token = BIGINT;
                     shift();
-                    tokenData->bigIntString = std::get<const Identifier*>(*parseNumberResult);
+                    tokenData->bigIntString = std::get<UniquedStringImpl*>(*parseNumberResult);
                     tokenData->radix = 10;
                 }
             } else {

--- a/Source/JavaScriptCore/parser/Lexer.h
+++ b/Source/JavaScriptCore/parser/Lexer.h
@@ -163,12 +163,12 @@ private:
     ALWAYS_INLINE void setCodeStart(StringView);
 
     template<typename CharacterType>
-    ALWAYS_INLINE const Identifier* makeIdentifier(std::span<const CharacterType>);
+    ALWAYS_INLINE UniquedStringImpl* makeIdentifier(std::span<const CharacterType>);
 
-    ALWAYS_INLINE const Identifier* makeLatin1Identifier(std::span<const Latin1Character>);
-    ALWAYS_INLINE const Identifier* makeLatin1Identifier(std::span<const char16_t>);
-    ALWAYS_INLINE const Identifier* makeRightSizedIdentifier(std::span<const char16_t>, char16_t orAllChars);
-    ALWAYS_INLINE const Identifier* makeEmptyIdentifier();
+    ALWAYS_INLINE UniquedStringImpl* makeLatin1Identifier(std::span<const Latin1Character>);
+    ALWAYS_INLINE UniquedStringImpl* makeLatin1Identifier(std::span<const char16_t>);
+    ALWAYS_INLINE UniquedStringImpl* makeRightSizedIdentifier(std::span<const char16_t>, char16_t orAllChars);
+    ALWAYS_INLINE UniquedStringImpl* makeEmptyIdentifier();
 
     ALWAYS_INLINE void skipWhitespace();
 
@@ -188,7 +188,7 @@ private:
     template <bool shouldBuildStrings> ALWAYS_INLINE StringParseResult parseComplexEscape(bool strictMode);
     ALWAYS_INLINE StringParseResult parseTemplateLiteral(JSTokenData*, RawStringsBuildMode);
     
-    using NumberParseResult = Variant<double, const Identifier*>;
+    using NumberParseResult = Variant<double, UniquedStringImpl*>;
     ALWAYS_INLINE std::optional<NumberParseResult> parseHex();
     ALWAYS_INLINE std::optional<NumberParseResult> parseBinary();
     ALWAYS_INLINE std::optional<NumberParseResult> parseOctal();
@@ -296,30 +296,30 @@ inline char16_t Lexer<T>::convertUnicode(int c1, int c2, int c3, int c4)
 
 template<typename T>
 template<typename CharacterType>
-ALWAYS_INLINE const Identifier* Lexer<T>::makeIdentifier(std::span<const CharacterType> characters)
+ALWAYS_INLINE UniquedStringImpl* Lexer<T>::makeIdentifier(std::span<const CharacterType> characters)
 {
-    return &m_arena->makeIdentifier(m_vm, characters);
+    return m_arena->makeIdentifier(m_vm, characters);
 }
 
 template <>
-ALWAYS_INLINE const Identifier* Lexer<Latin1Character>::makeRightSizedIdentifier(std::span<const char16_t> characters, char16_t)
+ALWAYS_INLINE UniquedStringImpl* Lexer<Latin1Character>::makeRightSizedIdentifier(std::span<const char16_t> characters, char16_t)
 {
-    return &m_arena->makeLatin1Identifier(m_vm, characters);
+    return m_arena->makeLatin1Identifier(m_vm, characters);
 }
 
 template <>
-ALWAYS_INLINE const Identifier* Lexer<char16_t>::makeRightSizedIdentifier(std::span<const char16_t> characters, char16_t orAllChars)
+ALWAYS_INLINE UniquedStringImpl* Lexer<char16_t>::makeRightSizedIdentifier(std::span<const char16_t> characters, char16_t orAllChars)
 {
     if (!(orAllChars & ~0xff))
-        return &m_arena->makeLatin1Identifier(m_vm, characters);
+        return m_arena->makeLatin1Identifier(m_vm, characters);
 
-    return &m_arena->makeIdentifier(m_vm, characters);
+    return m_arena->makeIdentifier(m_vm, characters);
 }
 
 template <typename T>
-ALWAYS_INLINE const Identifier* Lexer<T>::makeEmptyIdentifier()
+ALWAYS_INLINE UniquedStringImpl* Lexer<T>::makeEmptyIdentifier()
 {
-    return &m_arena->makeEmptyIdentifier(m_vm);
+    return m_arena->makeEmptyIdentifier(m_vm);
 }
 
 template <>
@@ -337,21 +337,21 @@ ALWAYS_INLINE void Lexer<char16_t>::setCodeStart(StringView sourceString)
 }
 
 template <typename T>
-ALWAYS_INLINE const Identifier* Lexer<T>::makeLatin1Identifier(std::span<const Latin1Character> characters)
+ALWAYS_INLINE UniquedStringImpl* Lexer<T>::makeLatin1Identifier(std::span<const Latin1Character> characters)
 {
-    return &m_arena->makeIdentifier(m_vm, characters);
+    return m_arena->makeIdentifier(m_vm, characters);
 }
 
 template <typename T>
-ALWAYS_INLINE const Identifier* Lexer<T>::makeLatin1Identifier(std::span<const char16_t> characters)
+ALWAYS_INLINE UniquedStringImpl* Lexer<T>::makeLatin1Identifier(std::span<const char16_t> characters)
 {
-    return &m_arena->makeLatin1Identifier(m_vm, characters);
+    return m_arena->makeLatin1Identifier(m_vm, characters);
 }
 
 #if ASSERT_ENABLED
-bool isSafeBuiltinIdentifier(VM&, const Identifier*);
+bool isSafeBuiltinIdentifier(VM&, UniquedStringImpl*);
 #else
-ALWAYS_INLINE bool isSafeBuiltinIdentifier(VM&, const Identifier*) { return true; }
+ALWAYS_INLINE bool isSafeBuiltinIdentifier(VM&, UniquedStringImpl*) { return true; }
 #endif // ASSERT_ENABLED
 
 template <typename T>

--- a/Source/JavaScriptCore/parser/ModuleScopeData.h
+++ b/Source/JavaScriptCore/parser/ModuleScopeData.h
@@ -42,17 +42,17 @@ public:
 
     const IdentifierAliasMap& exportedBindings() const LIFETIME_BOUND { return m_exportedBindings; }
 
-    bool exportName(const Identifier& exportedName)
+    bool exportName(UniquedStringImpl* exportedName)
     {
-        return m_exportedNames.add(exportedName.impl()).isNewEntry;
+        return m_exportedNames.add(exportedName).isNewEntry;
     }
 
-    void exportBinding(const Identifier& localName, const Identifier& exportedName)
+    void exportBinding(UniquedStringImpl* localName, UniquedStringImpl* exportedName)
     {
-        m_exportedBindings.add(localName.impl(), Vector<RefPtr<UniquedStringImpl>>()).iterator->value.append(exportedName.impl());
+        m_exportedBindings.add(localName, Vector<RefPtr<UniquedStringImpl>>()).iterator->value.append(exportedName);
     }
 
-    void exportBinding(const Identifier& localName)
+    void exportBinding(UniquedStringImpl* localName)
     {
         exportBinding(localName, localName);
     }

--- a/Source/JavaScriptCore/parser/NodeConstructors.h
+++ b/Source/JavaScriptCore/parser/NodeConstructors.h
@@ -90,15 +90,15 @@ namespace JSC {
     {
     }
 
-    inline BigIntNode::BigIntNode(const JSTokenLocation& location, const Identifier& value, uint8_t radix)
+    inline BigIntNode::BigIntNode(const JSTokenLocation& location, UniquedStringImpl* value, uint8_t radix)
         : ConstantNode(location, ResultType::bigIntType())
         , m_value(value)
         , m_radix(radix)
         , m_sign(false)
     {
     }
-    
-    inline BigIntNode::BigIntNode(const JSTokenLocation& location, const Identifier& value, uint8_t radix, bool sign)
+
+    inline BigIntNode::BigIntNode(const JSTokenLocation& location, UniquedStringImpl* value, uint8_t radix, bool sign)
         : ConstantNode(location, ResultType::bigIntType())
         , m_value(value)
         , m_radix(radix)
@@ -106,7 +106,7 @@ namespace JSC {
     {
     }
 
-    inline StringNode::StringNode(const JSTokenLocation& location, const Identifier& value)
+    inline StringNode::StringNode(const JSTokenLocation& location, UniquedStringImpl* value)
         : ConstantNode(location, ResultType::stringType())
         , m_value(value)
     {
@@ -123,7 +123,7 @@ namespace JSC {
         previous->m_next = this;
     }
 
-    inline TemplateStringNode::TemplateStringNode(const JSTokenLocation& location, const Identifier* cooked, const Identifier* raw)
+    inline TemplateStringNode::TemplateStringNode(const JSTokenLocation& location, UniquedStringImpl* cooked, UniquedStringImpl* raw)
         : ExpressionNode(location)
         , m_cooked(cooked)
         , m_raw(raw)
@@ -162,7 +162,7 @@ namespace JSC {
     {
     }
 
-    inline RegExpNode::RegExpNode(const JSTokenLocation& location, const Identifier& pattern, const Identifier& flags)
+    inline RegExpNode::RegExpNode(const JSTokenLocation& location, UniquedStringImpl* pattern, UniquedStringImpl* flags)
         : ExpressionNode(location)
         , m_pattern(pattern)
         , m_flags(flags)
@@ -203,17 +203,17 @@ namespace JSC {
     {
     }
 
-    inline ResolveNode::ResolveNode(const JSTokenLocation& location, const Identifier& ident, const JSTextPosition& start)
+    inline ResolveNode::ResolveNode(const JSTokenLocation& location, UniquedStringImpl* uid, const JSTextPosition& start)
         : ExpressionNode(location)
-        , m_ident(ident)
+        , m_ident(uid)
         , m_start(start)
     {
         ASSERT(m_start.offset >= m_start.lineStartOffset);
     }
 
-    inline PrivateIdentifierNode::PrivateIdentifierNode(const JSTokenLocation& location, const Identifier& ident)
+    inline PrivateIdentifierNode::PrivateIdentifierNode(const JSTokenLocation& location, UniquedStringImpl* uid)
         : ExpressionNode(location)
-        , m_ident(ident)
+        , m_ident(uid)
     {
     }
 
@@ -251,23 +251,23 @@ namespace JSC {
     {
     }
 
-    inline PropertyNode::PropertyNode(const Identifier& name, Type type, SuperBinding superBinding, ClassElementTag tag)
-        : m_name(&name)
+    inline PropertyNode::PropertyNode(UniquedStringImpl* name, Type type, SuperBinding superBinding, ClassElementTag tag)
+        : m_name(name)
         , m_type(type)
         , m_needsSuperBinding(superBinding == SuperBinding::Needed)
         , m_classElementTag(static_cast<unsigned>(tag))
     {
-        ASSERT(name.impl());
+        ASSERT(name);
     }
 
-    inline PropertyNode::PropertyNode(const Identifier& name, ExpressionNode* assign, Type type, SuperBinding superBinding, ClassElementTag tag)
-        : m_name(&name)
+    inline PropertyNode::PropertyNode(UniquedStringImpl* name, ExpressionNode* assign, Type type, SuperBinding superBinding, ClassElementTag tag)
+        : m_name(name)
         , m_assign(assign)
         , m_type(type)
         , m_needsSuperBinding(superBinding == SuperBinding::Needed)
         , m_classElementTag(static_cast<unsigned>(tag))
     {
-        ASSERT(name.impl());
+        ASSERT(name);
     }
     
     inline PropertyNode::PropertyNode(ExpressionNode* assign, Type type, SuperBinding superBinding, ClassElementTag tag)
@@ -287,15 +287,15 @@ namespace JSC {
     {
     }
 
-    inline PropertyNode::PropertyNode(const Identifier& ident, ExpressionNode* name, ExpressionNode* assign, Type type, SuperBinding superBinding, ClassElementTag tag)
-        : m_name(&ident)
+    inline PropertyNode::PropertyNode(UniquedStringImpl* ident, ExpressionNode* name, ExpressionNode* assign, Type type, SuperBinding superBinding, ClassElementTag tag)
+        : m_name(ident)
         , m_expression(name)
         , m_assign(assign)
         , m_type(type)
         , m_needsSuperBinding(superBinding == SuperBinding::Needed)
         , m_classElementTag(static_cast<unsigned>(tag))
     {
-        ASSERT(ident.impl());
+        ASSERT(ident);
     }
 
     inline PropertyListNode::PropertyListNode(const JSTokenLocation& location, PropertyNode* node)
@@ -331,16 +331,16 @@ namespace JSC {
     {
     }
 
-    inline BaseDotNode::BaseDotNode(const JSTokenLocation& location, ExpressionNode* base, const Identifier& ident, DotType type)
+    inline BaseDotNode::BaseDotNode(const JSTokenLocation& location, ExpressionNode* base, UniquedStringImpl* uid, DotType type)
         : ExpressionNode(location)
         , m_base(base)
-        , m_ident(ident)
+        , m_ident(uid)
         , m_type(type)
     {
     }
 
-    inline DotAccessorNode::DotAccessorNode(const JSTokenLocation& location, ExpressionNode* base, const Identifier& ident, DotType type)
-        : BaseDotNode(location, base, ident, type)
+    inline DotAccessorNode::DotAccessorNode(const JSTokenLocation& location, ExpressionNode* base, UniquedStringImpl* uid, DotType type)
+        : BaseDotNode(location, base, uid, type)
     {
     }
     
@@ -420,10 +420,10 @@ namespace JSC {
         ASSERT(divot.offset >= divotStart.offset);
     }
 
-    inline FunctionCallResolveNode::FunctionCallResolveNode(const JSTokenLocation& location, const Identifier& ident, ArgumentsNode* args, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd, bool isOptionalCall)
+    inline FunctionCallResolveNode::FunctionCallResolveNode(const JSTokenLocation& location, UniquedStringImpl* uid, ArgumentsNode* args, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd, bool isOptionalCall)
         : ExpressionNode(location)
         , ThrowableExpressionData(divot, divotStart, divotEnd)
-        , m_ident(ident)
+        , m_ident(uid)
         , m_args(args)
         , m_isOptionalCall(isOptionalCall)
     {
@@ -440,38 +440,38 @@ namespace JSC {
     {
     }
 
-    inline FunctionCallDotNode::FunctionCallDotNode(const JSTokenLocation& location, ExpressionNode* base, const Identifier& ident, DotType type, ArgumentsNode* args, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd, bool isOptionalCall)
-        : BaseDotNode(location, base, ident, type)
+    inline FunctionCallDotNode::FunctionCallDotNode(const JSTokenLocation& location, ExpressionNode* base, UniquedStringImpl* uid, DotType type, ArgumentsNode* args, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd, bool isOptionalCall)
+        : BaseDotNode(location, base, uid, type)
         , ThrowableSubExpressionData(divot, divotStart, divotEnd)
         , m_args(args)
         , m_isOptionalCall(isOptionalCall)
     {
     }
 
-    inline BytecodeIntrinsicNode::BytecodeIntrinsicNode(Type type, const JSTokenLocation& location, BytecodeIntrinsicRegistry::Entry entry, const Identifier& ident, ArgumentsNode* args, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd)
+    inline BytecodeIntrinsicNode::BytecodeIntrinsicNode(Type type, const JSTokenLocation& location, BytecodeIntrinsicRegistry::Entry entry, UniquedStringImpl* uid, ArgumentsNode* args, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd)
         : ExpressionNode(location)
         , ThrowableExpressionData(divot, divotStart, divotEnd)
         , m_entry(entry)
-        , m_ident(ident)
+        , m_ident(uid)
         , m_args(args)
         , m_type(type)
     {
     }
 
-    inline CallFunctionCallDotNode::CallFunctionCallDotNode(const JSTokenLocation& location, ExpressionNode* base, const Identifier& ident, DotType type, ArgumentsNode* args, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd, bool isOptionalCall, size_t distanceToInnermostCallOrApply)
-        : FunctionCallDotNode(location, base, ident, type, args, divot, divotStart, divotEnd, isOptionalCall)
+    inline CallFunctionCallDotNode::CallFunctionCallDotNode(const JSTokenLocation& location, ExpressionNode* base, UniquedStringImpl* uid, DotType type, ArgumentsNode* args, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd, bool isOptionalCall, size_t distanceToInnermostCallOrApply)
+        : FunctionCallDotNode(location, base, uid, type, args, divot, divotStart, divotEnd, isOptionalCall)
         , m_distanceToInnermostCallOrApply(distanceToInnermostCallOrApply)
     {
     }
 
-    inline ApplyFunctionCallDotNode::ApplyFunctionCallDotNode(const JSTokenLocation& location, ExpressionNode* base, const Identifier& ident, DotType type, ArgumentsNode* args, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd, bool isOptionalCall, size_t distanceToInnermostCallOrApply)
-        : FunctionCallDotNode(location, base, ident, type, args, divot, divotStart, divotEnd, isOptionalCall)
+    inline ApplyFunctionCallDotNode::ApplyFunctionCallDotNode(const JSTokenLocation& location, ExpressionNode* base, UniquedStringImpl* uid, DotType type, ArgumentsNode* args, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd, bool isOptionalCall, size_t distanceToInnermostCallOrApply)
+        : FunctionCallDotNode(location, base, uid, type, args, divot, divotStart, divotEnd, isOptionalCall)
         , m_distanceToInnermostCallOrApply(distanceToInnermostCallOrApply)
     {
     }
 
-    inline HasOwnPropertyFunctionCallDotNode::HasOwnPropertyFunctionCallDotNode(const JSTokenLocation& location, ExpressionNode* base, const Identifier& ident, DotType type, ArgumentsNode* args, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd, bool isOptionalCall)
-        : FunctionCallDotNode(location, base, ident, type, args, divot, divotStart, divotEnd, isOptionalCall)
+    inline HasOwnPropertyFunctionCallDotNode::HasOwnPropertyFunctionCallDotNode(const JSTokenLocation& location, ExpressionNode* base, UniquedStringImpl* uid, DotType type, ArgumentsNode* args, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd, bool isOptionalCall)
+        : FunctionCallDotNode(location, base, uid, type, args, divot, divotStart, divotEnd, isOptionalCall)
     {
     }
 
@@ -480,10 +480,10 @@ namespace JSC {
     {
     }
 
-    inline DeleteResolveNode::DeleteResolveNode(const JSTokenLocation& location, const Identifier& ident, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd)
+    inline DeleteResolveNode::DeleteResolveNode(const JSTokenLocation& location, UniquedStringImpl* uid, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd)
         : ExpressionNode(location)
         , ThrowableExpressionData(divot, divotStart, divotEnd)
-        , m_ident(ident)
+        , m_ident(uid)
     {
     }
 
@@ -495,11 +495,11 @@ namespace JSC {
     {
     }
 
-    inline DeleteDotNode::DeleteDotNode(const JSTokenLocation& location, ExpressionNode* base, const Identifier& ident, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd)
+    inline DeleteDotNode::DeleteDotNode(const JSTokenLocation& location, ExpressionNode* base, UniquedStringImpl* uid, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd)
         : ExpressionNode(location)
         , ThrowableExpressionData(divot, divotStart, divotEnd)
         , m_base(base)
-        , m_ident(ident)
+        , m_ident(uid)
     {
     }
 
@@ -515,10 +515,10 @@ namespace JSC {
     {
     }
 
-    inline TypeOfResolveNode::TypeOfResolveNode(const JSTokenLocation& location, const Identifier& ident, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd)
+    inline TypeOfResolveNode::TypeOfResolveNode(const JSTokenLocation& location, UniquedStringImpl* uid, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd)
         : ExpressionNode(location, ResultType::stringType())
         , ThrowableExpressionData(divot, divotStart, divotEnd)
-        , m_ident(ident)
+        , m_ident(uid)
     {
     }
 
@@ -735,29 +735,29 @@ namespace JSC {
     {
     }
 
-    inline ReadModifyResolveNode::ReadModifyResolveNode(const JSTokenLocation& location, const Identifier& ident, Operator oper, ExpressionNode*  right, bool rightHasAssignments, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd)
+    inline ReadModifyResolveNode::ReadModifyResolveNode(const JSTokenLocation& location, UniquedStringImpl* uid, Operator oper, ExpressionNode*  right, bool rightHasAssignments, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd)
         : ExpressionNode(location)
         , ThrowableExpressionData(divot, divotStart, divotEnd)
-        , m_ident(ident)
+        , m_ident(uid)
         , m_right(right)
         , m_operator(oper)
         , m_rightHasAssignments(rightHasAssignments)
     {
     }
 
-    inline ShortCircuitReadModifyResolveNode::ShortCircuitReadModifyResolveNode(const JSTokenLocation& location, const Identifier& ident, Operator oper, ExpressionNode* right, bool rightHasAssignments, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd)
+    inline ShortCircuitReadModifyResolveNode::ShortCircuitReadModifyResolveNode(const JSTokenLocation& location, UniquedStringImpl* uid, Operator oper, ExpressionNode* right, bool rightHasAssignments, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd)
         : ExpressionNode(location)
         , ThrowableExpressionData(divot, divotStart, divotEnd)
-        , m_ident(ident)
+        , m_ident(uid)
         , m_right(right)
         , m_operator(oper)
         , m_rightHasAssignments(rightHasAssignments)
     {
     }
 
-    inline AssignResolveNode::AssignResolveNode(const JSTokenLocation& location, const Identifier& ident, ExpressionNode* right, AssignmentContext assignmentContext)
+    inline AssignResolveNode::AssignResolveNode(const JSTokenLocation& location, UniquedStringImpl* uid, ExpressionNode* right, AssignmentContext assignmentContext)
         : ExpressionNode(location)
-        , m_ident(ident)
+        , m_ident(uid)
         , m_right(right)
         , m_assignmentContext(assignmentContext)
     {
@@ -799,16 +799,16 @@ namespace JSC {
     {
     }
 
-    inline AssignDotNode::AssignDotNode(const JSTokenLocation& location, ExpressionNode* base, const Identifier& ident, DotType type, ExpressionNode* right, bool rightHasAssignments, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd)
-        : BaseDotNode(location, base, ident, type)
+    inline AssignDotNode::AssignDotNode(const JSTokenLocation& location, ExpressionNode* base, UniquedStringImpl* uid, DotType type, ExpressionNode* right, bool rightHasAssignments, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd)
+        : BaseDotNode(location, base, uid, type)
         , ThrowableExpressionData(divot, divotStart, divotEnd)
         , m_right(right)
         , m_rightHasAssignments(rightHasAssignments)
     {
     }
 
-    inline ReadModifyDotNode::ReadModifyDotNode(const JSTokenLocation& location, ExpressionNode* base, const Identifier& ident, DotType type, Operator oper, ExpressionNode* right, bool rightHasAssignments, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd)
-        : BaseDotNode(location, base, ident, type)
+    inline ReadModifyDotNode::ReadModifyDotNode(const JSTokenLocation& location, ExpressionNode* base, UniquedStringImpl* uid, DotType type, Operator oper, ExpressionNode* right, bool rightHasAssignments, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd)
+        : BaseDotNode(location, base, uid, type)
         , ThrowableSubExpressionData(divot, divotStart, divotEnd)
         , m_right(right)
         , m_operator(oper)
@@ -816,8 +816,8 @@ namespace JSC {
     {
     }
 
-    inline ShortCircuitReadModifyDotNode::ShortCircuitReadModifyDotNode(const JSTokenLocation& location, ExpressionNode* base, const Identifier& ident, DotType type, Operator oper, ExpressionNode* right, bool rightHasAssignments, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd)
-        : BaseDotNode(location, base, ident, type)
+    inline ShortCircuitReadModifyDotNode::ShortCircuitReadModifyDotNode(const JSTokenLocation& location, ExpressionNode* base, UniquedStringImpl* uid, DotType type, Operator oper, ExpressionNode* right, bool rightHasAssignments, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd)
+        : BaseDotNode(location, base, uid, type)
         , ThrowableSubExpressionData(divot, divotStart, divotEnd)
         , m_right(right)
         , m_operator(oper)
@@ -869,13 +869,13 @@ namespace JSC {
     {
     }
 
-    inline ModuleNameNode::ModuleNameNode(const JSTokenLocation& location, const Identifier& moduleName)
+    inline ModuleNameNode::ModuleNameNode(const JSTokenLocation& location, UniquedStringImpl* moduleName)
         : Node(location)
         , m_moduleName(moduleName)
     {
     }
 
-    inline ImportSpecifierNode::ImportSpecifierNode(const JSTokenLocation& location, const Identifier& importedName, const Identifier& localName)
+    inline ImportSpecifierNode::ImportSpecifierNode(const JSTokenLocation& location, UniquedStringImpl* importedName, UniquedStringImpl* localName)
         : Node(location)
         , m_importedName(importedName)
         , m_localName(localName)
@@ -898,7 +898,7 @@ namespace JSC {
     {
     }
 
-    inline ExportDefaultDeclarationNode::ExportDefaultDeclarationNode(const JSTokenLocation& location, StatementNode* declaration, const Identifier& localName)
+    inline ExportDefaultDeclarationNode::ExportDefaultDeclarationNode(const JSTokenLocation& location, StatementNode* declaration, UniquedStringImpl* localName)
         : ModuleDeclarationNode(location)
         , m_declaration(declaration)
         , m_localName(localName)
@@ -919,22 +919,22 @@ namespace JSC {
     {
     }
 
-    inline ExportSpecifierNode::ExportSpecifierNode(const JSTokenLocation& location, const Identifier& localName, const Identifier& exportedName)
+    inline ExportSpecifierNode::ExportSpecifierNode(const JSTokenLocation& location, UniquedStringImpl* localName, UniquedStringImpl* exportedName)
         : Node(location)
         , m_localName(localName)
         , m_exportedName(exportedName)
     {
     }
 
-    inline EmptyVarExpression::EmptyVarExpression(const JSTokenLocation& location, const Identifier& ident)
+    inline EmptyVarExpression::EmptyVarExpression(const JSTokenLocation& location, UniquedStringImpl* uid)
         : ExpressionNode(location)
-        , m_ident(ident)
+        , m_ident(uid)
     {
     }
 
-    inline EmptyLetExpression::EmptyLetExpression(const JSTokenLocation& location, const Identifier& ident)
+    inline EmptyLetExpression::EmptyLetExpression(const JSTokenLocation& location, UniquedStringImpl* uid)
         : ExpressionNode(location)
-        , m_ident(ident)
+        , m_ident(uid)
     {
     }
     
@@ -972,15 +972,15 @@ namespace JSC {
         ASSERT(statement);
     }
 
-    inline ContinueNode::ContinueNode(const JSTokenLocation& location, const Identifier& ident)
+    inline ContinueNode::ContinueNode(const JSTokenLocation& location, UniquedStringImpl* uid)
         : StatementNode(location)
-        , m_ident(ident)
+        , m_ident(uid)
     {
     }
-    
-    inline BreakNode::BreakNode(const JSTokenLocation& location, const Identifier& ident)
+
+    inline BreakNode::BreakNode(const JSTokenLocation& location, UniquedStringImpl* uid)
         : StatementNode(location)
-        , m_ident(ident)
+        , m_ident(uid)
     {
     }
     
@@ -999,7 +999,7 @@ namespace JSC {
     {
     }
 
-    inline LabelNode::LabelNode(const JSTokenLocation& location, const Identifier& name, StatementNode* statement)
+    inline LabelNode::LabelNode(const JSTokenLocation& location, UniquedStringImpl* name, StatementNode* statement)
         : StatementNode(location)
         , m_name(name)
         , m_statement(statement)
@@ -1027,37 +1027,37 @@ namespace JSC {
     }
 
     
-    inline BaseFuncExprNode::BaseFuncExprNode(const JSTokenLocation& location, const Identifier& ident, FunctionMetadataNode* metadata, const SourceCode& source, FunctionMode functionMode)
+    inline BaseFuncExprNode::BaseFuncExprNode(const JSTokenLocation& location, UniquedStringImpl* uid, FunctionMetadataNode* metadata, const SourceCode& source, FunctionMode functionMode)
         : ExpressionNode(location)
         , m_metadata(metadata)
     {
-        m_metadata->finishParsing(source, ident, functionMode);
+        m_metadata->finishParsing(source, uid, functionMode);
     }
 
-    inline FuncExprNode::FuncExprNode(const JSTokenLocation& location, const Identifier& ident, FunctionMetadataNode* metadata, const SourceCode& source)
-        : BaseFuncExprNode(location, ident, metadata, source, FunctionMode::FunctionExpression)
+    inline FuncExprNode::FuncExprNode(const JSTokenLocation& location, UniquedStringImpl* uid, FunctionMetadataNode* metadata, const SourceCode& source)
+        : BaseFuncExprNode(location, uid, metadata, source, FunctionMode::FunctionExpression)
     {
     }
 
-    inline FuncExprNode::FuncExprNode(const JSTokenLocation& location, const Identifier& ident, FunctionMetadataNode* metadata, const SourceCode& source, FunctionMode functionMode)
-        : BaseFuncExprNode(location, ident, metadata, source, functionMode)
+    inline FuncExprNode::FuncExprNode(const JSTokenLocation& location, UniquedStringImpl* uid, FunctionMetadataNode* metadata, const SourceCode& source, FunctionMode functionMode)
+        : BaseFuncExprNode(location, uid, metadata, source, functionMode)
     {
     }
-    
-    inline FuncDeclNode::FuncDeclNode(const JSTokenLocation& location, const Identifier& ident, FunctionMetadataNode* metadata, const SourceCode& source)
+
+    inline FuncDeclNode::FuncDeclNode(const JSTokenLocation& location, UniquedStringImpl* uid, FunctionMetadataNode* metadata, const SourceCode& source)
         : StatementNode(location)
         , m_metadata(metadata)
     {
-        m_metadata->finishParsing(source, ident, FunctionMode::FunctionDeclaration);
+        m_metadata->finishParsing(source, uid, FunctionMode::FunctionDeclaration);
     }
 
-    inline ArrowFuncExprNode::ArrowFuncExprNode(const JSTokenLocation& location, const Identifier& ident, FunctionMetadataNode* metadata, const SourceCode& source)
-        : BaseFuncExprNode(location, ident, metadata, source, FunctionMode::FunctionExpression)
+    inline ArrowFuncExprNode::ArrowFuncExprNode(const JSTokenLocation& location, UniquedStringImpl* uid, FunctionMetadataNode* metadata, const SourceCode& source)
+        : BaseFuncExprNode(location, uid, metadata, source, FunctionMode::FunctionExpression)
     {
     }
 
-    inline MethodDefinitionNode::MethodDefinitionNode(const JSTokenLocation& location, const Identifier& ident, FunctionMetadataNode* metadata, const SourceCode& source)
-        : FuncExprNode(location, ident, metadata, source, FunctionMode::MethodDefinition)
+    inline MethodDefinitionNode::MethodDefinitionNode(const JSTokenLocation& location, UniquedStringImpl* uid, FunctionMetadataNode* metadata, const SourceCode& source)
+        : FuncExprNode(location, uid, metadata, source, FunctionMode::MethodDefinition)
     {
     }
     
@@ -1074,9 +1074,9 @@ namespace JSC {
     {
     }
 
-    inline DefineFieldNode::DefineFieldNode(const JSTokenLocation& location, const Identifier& ident, ExpressionNode* assign, Type type)
+    inline DefineFieldNode::DefineFieldNode(const JSTokenLocation& location, UniquedStringImpl* uid, ExpressionNode* assign, Type type)
         : StatementNode(location)
-        , m_ident(ident)
+        , m_ident(uid)
         , m_assign(assign)
         , m_type(type)
     {
@@ -1088,13 +1088,12 @@ namespace JSC {
     {
     }
 
-    inline ClassExprNode::ClassExprNode(const JSTokenLocation& location, const Identifier& name, const SourceCode& classSource, VariableEnvironment&& classHeadEnvironment, VariableEnvironment&& classEnvironment, ExpressionNode* constructorExpression, ExpressionNode* classHeritage, PropertyListNode* classElements)
+    inline ClassExprNode::ClassExprNode(const JSTokenLocation& location, UniquedStringImpl* name, const SourceCode& classSource, VariableEnvironment&& classHeadEnvironment, VariableEnvironment&& classEnvironment, ExpressionNode* constructorExpression, ExpressionNode* classHeritage, PropertyListNode* classElements)
         : ExpressionNode(location)
         , VariableEnvironmentNode(WTF::move(classEnvironment))
         , m_classHeadEnvironment(WTF::move(classHeadEnvironment))
         , m_classSource(classSource)
         , m_name(name)
-        , m_ecmaName(&name)
         , m_constructorExpression(constructorExpression)
         , m_classHeritage(classHeritage)
         , m_classElements(classElements)
@@ -1176,7 +1175,7 @@ namespace JSC {
     {
     }
     
-    inline BindingNode::BindingNode(const Identifier& boundProperty, const JSTextPosition& start, const JSTextPosition& end, AssignmentContext context)
+    inline BindingNode::BindingNode(UniquedStringImpl* boundProperty, const JSTextPosition& start, const JSTextPosition& end, AssignmentContext context)
         : DestructuringPatternNode()
         , m_divotStart(start)
         , m_divotEnd(end)

--- a/Source/JavaScriptCore/parser/Nodes.cpp
+++ b/Source/JavaScriptCore/parser/Nodes.cpp
@@ -249,10 +249,10 @@ FunctionMetadataNode::FunctionMetadataNode(
     ASSERT(m_constructorKind == static_cast<unsigned>(constructorKind));
 }
 
-void FunctionMetadataNode::finishParsing(const SourceCode& source, const Identifier& ident, FunctionMode functionMode)
+void FunctionMetadataNode::finishParsing(const SourceCode& source, UniquedStringImpl* uid, FunctionMode functionMode)
 {
     m_source = source;
-    m_ident = ident;
+    m_ident = uid;
     m_functionMode = functionMode;
 }
 
@@ -296,8 +296,8 @@ void FunctionMetadataNode::dump(PrintStream& stream) const
     stream.println("m_constructorKind ", m_constructorKind);
     stream.println("m_isArrowFunctionBodyExpression ", m_isArrowFunctionBodyExpression);
     stream.println("m_isSloppyModeHoistedFunction ", m_isSloppyModeHoistedFunction);
-    stream.println("m_ident ", m_ident);
-    stream.println("m_ecmaName ", m_ecmaName);
+    stream.println("m_ident ", m_ident ? protect(m_ident)->utf8() : "<null>"_s);
+    stream.println("m_ecmaName ", m_ecmaName ? protect(m_ecmaName)->utf8() : "<null>"_s);
     stream.println("m_functionMode ", static_cast<uint32_t>(m_functionMode));
     stream.println("m_startColumn ", m_startColumn);
     stream.println("m_endColumn ", m_endColumn);
@@ -323,20 +323,20 @@ FunctionNode::FunctionNode(ParserArena& parserArena, const JSTokenLocation& star
 {
 }
 
-void FunctionNode::finishParsing(const Identifier& ident, FunctionMode functionMode)
+void FunctionNode::finishParsing(UniquedStringImpl* uid, FunctionMode functionMode)
 {
     ASSERT(!source().isNull());
-    m_ident = ident;
+    m_ident = uid;
     m_functionMode = functionMode;
 }
 
-bool PropertyListNode::hasStaticallyNamedProperty(const Identifier& propName)
+bool PropertyListNode::hasStaticallyNamedProperty(UniquedStringImpl* propName)
 {
     PropertyListNode* list = this;
     while (list) {
         if (list->m_node->isStaticClassProperty()) {
-            const Identifier* currentNodeName = list->m_node->name();
-            if (currentNodeName && *currentNodeName == propName)
+            UniquedStringImpl* currentNodeName = list->m_node->name();
+            if (currentNodeName && currentNodeName == propName)
                 return true;
         }
         list = list->m_next;

--- a/Source/JavaScriptCore/parser/Nodes.h
+++ b/Source/JavaScriptCore/parser/Nodes.h
@@ -355,23 +355,23 @@ namespace JSC {
 
     class StringNode final : public ConstantNode {
     public:
-        StringNode(const JSTokenLocation&, const Identifier&);
-        const Identifier& value() { return m_value; }
+        StringNode(const JSTokenLocation&, UniquedStringImpl*);
+        UniquedStringImpl* value() { return m_value; }
 
     private:
         bool isString() const final { return true; }
         JSValue jsValue(BytecodeGenerator&) const final;
 
-        const Identifier& m_value;
+        SUPPRESS_UNCOUNTED_MEMBER UniquedStringImpl* const m_value;
     };
 
     class BigIntNode final : public ConstantNode {
     public:
-        BigIntNode(const JSTokenLocation&, const Identifier&, uint8_t radix);
-        BigIntNode(const JSTokenLocation&, const Identifier&, uint8_t radix, bool sign);
-        const Identifier& value() { return m_value; }
+        BigIntNode(const JSTokenLocation&, UniquedStringImpl*, uint8_t radix);
+        BigIntNode(const JSTokenLocation&, UniquedStringImpl*, uint8_t radix, bool sign);
+        UniquedStringImpl* value() { return m_value; }
 
-        const Identifier& identifier() const { return m_value; }
+        UniquedStringImpl* identifier() const { return m_value; }
         uint8_t radix() const { return m_radix; }
         bool sign() const { return m_sign; }
 
@@ -379,7 +379,7 @@ namespace JSC {
         bool isBigInt() const final { return true; }
         JSValue jsValue(BytecodeGenerator&) const final;
 
-        const Identifier& m_value;
+        SUPPRESS_UNCOUNTED_MEMBER UniquedStringImpl* const m_value;
         const uint8_t m_radix;
         const bool m_sign;
     };
@@ -550,16 +550,16 @@ namespace JSC {
 
     class TemplateStringNode final : public ExpressionNode {
     public:
-        TemplateStringNode(const JSTokenLocation&, const Identifier* cooked, const Identifier* raw);
+        TemplateStringNode(const JSTokenLocation&, UniquedStringImpl* cooked, UniquedStringImpl* raw);
 
-        const Identifier* cooked() { return m_cooked; }
-        const Identifier* raw() { return m_raw; }
+        UniquedStringImpl* cooked() { return m_cooked; }
+        UniquedStringImpl* raw() { return m_raw; }
 
     private:
         RegisterID* emitBytecode(BytecodeGenerator&, RegisterID* = nullptr) final;
 
-        const Identifier* m_cooked;
-        const Identifier* m_raw;
+        SUPPRESS_UNCOUNTED_MEMBER UniquedStringImpl* const m_cooked;
+        SUPPRESS_UNCOUNTED_MEMBER UniquedStringImpl* const m_raw;
     };
 
     class TemplateStringListNode final : public ParserArenaFreeable {
@@ -605,13 +605,13 @@ namespace JSC {
 
     class RegExpNode final : public ExpressionNode, public ThrowableExpressionData {
     public:
-        RegExpNode(const JSTokenLocation&, const Identifier& pattern, const Identifier& flags);
+        RegExpNode(const JSTokenLocation&, UniquedStringImpl* pattern, UniquedStringImpl* flags);
 
     private:
         RegisterID* emitBytecode(BytecodeGenerator&, RegisterID* = nullptr) final;
 
-        const Identifier& m_pattern;
-        const Identifier& m_flags;
+        SUPPRESS_UNCOUNTED_MEMBER UniquedStringImpl* const m_pattern;
+        SUPPRESS_UNCOUNTED_MEMBER UniquedStringImpl* const m_flags;
     };
 
     class ThisNode final : public ExpressionNode {
@@ -675,10 +675,10 @@ namespace JSC {
 
     class ResolveNode final : public ExpressionNode {
     public:
-        ResolveNode(const JSTokenLocation&, const Identifier&, const JSTextPosition& start);
+        ResolveNode(const JSTokenLocation&, UniquedStringImpl*, const JSTextPosition& start);
 
-        const Identifier& identifier() const { return m_ident; }
-        bool isArguments(VM& vm) const final { return m_ident == vm.propertyNames->arguments; }
+        UniquedStringImpl* ident() const { return m_ident; }
+        bool isArguments(VM& vm) const final { return m_ident == vm.propertyNames->arguments.impl(); }
         bool getFromScopeCanThrow(BytecodeGenerator&) const;
 
     private:
@@ -688,23 +688,23 @@ namespace JSC {
         bool isLocation() const final { return true; }
         bool isResolveNode() const final { return true; }
 
-        const Identifier& m_ident;
+        SUPPRESS_UNCOUNTED_MEMBER UniquedStringImpl* const m_ident;
         JSTextPosition m_start;
     };
 
     // Dummy expression to hold the LHS of `#x in obj`.
     class PrivateIdentifierNode final : public ExpressionNode {
     public:
-        PrivateIdentifierNode(const JSTokenLocation&, const Identifier&);
+        PrivateIdentifierNode(const JSTokenLocation&, UniquedStringImpl*);
 
-        const Identifier& value() const { return m_ident; }
+        UniquedStringImpl* ident() const { return m_ident; }
 
     private:
         RegisterID* emitBytecode(BytecodeGenerator&, RegisterID* = nullptr) final { RELEASE_ASSERT_NOT_REACHED(); }
 
         bool isPrivateIdentifier() const final { return true; }
 
-        const Identifier& m_ident;
+        SUPPRESS_UNCOUNTED_MEMBER UniquedStringImpl* const m_ident;
     };
 
     class ElementNode final : public ParserArenaFreeable {
@@ -749,14 +749,14 @@ namespace JSC {
 
         enum Type : uint16_t { Constant = 1, Getter = 2, Setter = 4, Computed = 8, Shorthand = 16, Spread = 32, PrivateField = 64, PrivateMethod = 128, PrivateSetter = 256, PrivateGetter = 512, Block = 1024 };
 
-        PropertyNode(const Identifier&, Type, SuperBinding, ClassElementTag);
-        PropertyNode(const Identifier&, ExpressionNode*, Type, SuperBinding, ClassElementTag);
+        PropertyNode(UniquedStringImpl*, Type, SuperBinding, ClassElementTag);
+        PropertyNode(UniquedStringImpl*, ExpressionNode*, Type, SuperBinding, ClassElementTag);
         PropertyNode(ExpressionNode*, Type, SuperBinding, ClassElementTag);
         PropertyNode(ExpressionNode* propertyName, ExpressionNode*, Type, SuperBinding, ClassElementTag);
-        PropertyNode(const Identifier&, ExpressionNode* propertyName, ExpressionNode*, Type, SuperBinding, ClassElementTag);
+        PropertyNode(UniquedStringImpl*, ExpressionNode* propertyName, ExpressionNode*, Type, SuperBinding, ClassElementTag);
 
         ExpressionNode* expressionName() const { return m_expression; }
-        const Identifier* name() const { return m_name; }
+        UniquedStringImpl* name() const { return m_name; }
 
         Type type() const { return static_cast<Type>(m_type); }
         bool needsSuperBinding() const { return m_needsSuperBinding; }
@@ -779,14 +779,14 @@ namespace JSC {
             return isUnderscoreProtoSetter(vm, node.name(), node.type(), node.needsSuperBinding(), node.isClassProperty());
         }
 
-        ALWAYS_INLINE static bool isUnderscoreProtoSetter(VM& vm, const Identifier* name, Type type, bool needsSuperBinding, bool isClassProperty)
+        ALWAYS_INLINE static bool isUnderscoreProtoSetter(VM& vm, UniquedStringImpl* name, Type type, bool needsSuperBinding, bool isClassProperty)
         {
-            return name && *name == vm.propertyNames->underscoreProto && type == Type::Constant && !needsSuperBinding && !isClassProperty;
+            return name && name == vm.propertyNames->underscoreProto.impl() && type == Type::Constant && !needsSuperBinding && !isClassProperty;
         }
 
     private:
         friend class PropertyListNode;
-        const Identifier* m_name { nullptr };
+        SUPPRESS_UNCOUNTED_MEMBER UniquedStringImpl* m_name { nullptr };
         ExpressionNode* m_expression { nullptr };
         ExpressionNode* m_assign { nullptr };
         unsigned m_type : 11;
@@ -803,7 +803,7 @@ namespace JSC {
         PropertyListNode(const JSTokenLocation&, PropertyNode*);
         PropertyListNode(const JSTokenLocation&, PropertyNode*, PropertyListNode*);
 
-        bool NODELETE hasStaticallyNamedProperty(const Identifier& propName);
+        bool NODELETE hasStaticallyNamedProperty(UniquedStringImpl* propName);
         bool isComputedClassField() const
         {
             return m_node->isComputedClassField();
@@ -893,13 +893,13 @@ namespace JSC {
     enum class DotType { Name, PrivateMember };
     class BaseDotNode : public ExpressionNode {
     public:
-        BaseDotNode(const JSTokenLocation&, ExpressionNode* base, const Identifier&, DotType);
+        BaseDotNode(const JSTokenLocation&, ExpressionNode* base, UniquedStringImpl*, DotType);
 
         ExpressionNode* base() const { return m_base; }
-        const Identifier& identifier() const { return m_ident; }
+        UniquedStringImpl* ident() const { return m_ident; }
         DotType type() const { return m_type; }
         bool isPrivateMember() const { return m_type == DotType::PrivateMember; }
-        bool isArgumentsLengthAccess(VM& vm) const final { return m_base->isArguments(vm) && identifier() == vm.propertyNames->length; }
+        bool isArgumentsLengthAccess(VM& vm) const final { return m_base->isArguments(vm) && ident() == vm.propertyNames->length.impl(); }
 
         RegisterID* emitGetPropertyValue(BytecodeGenerator&, RegisterID* dst, RegisterID* base, RefPtr<RegisterID>& thisValue);
         RegisterID* emitGetPropertyValue(BytecodeGenerator&, RegisterID* dst, RegisterID* base);
@@ -908,16 +908,16 @@ namespace JSC {
 
     protected:
         ExpressionNode* m_base;
-        const Identifier& m_ident;
+        SUPPRESS_UNCOUNTED_MEMBER UniquedStringImpl* const m_ident;
         DotType m_type;
     };
 
     class DotAccessorNode final : public BaseDotNode, public ThrowableExpressionData {
     public:
-        DotAccessorNode(const JSTokenLocation&, ExpressionNode* base, const Identifier&, DotType);
+        DotAccessorNode(const JSTokenLocation&, ExpressionNode* base, UniquedStringImpl*, DotType);
 
         ExpressionNode* base() const { return m_base; }
-        const Identifier& identifier() const { return m_ident; }
+        UniquedStringImpl* ident() const { return m_ident; }
 
     private:
         RegisterID* emitBytecode(BytecodeGenerator&, RegisterID* = nullptr) final;
@@ -1029,7 +1029,7 @@ namespace JSC {
 
     class FunctionCallResolveNode final : public ExpressionNode, public ThrowableExpressionData {
     public:
-        FunctionCallResolveNode(const JSTokenLocation&, const Identifier&, ArgumentsNode*, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd, bool isOptionalCall);
+        FunctionCallResolveNode(const JSTokenLocation&, UniquedStringImpl*, ArgumentsNode*, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd, bool isOptionalCall);
 
     private:
         RegisterID* emitBytecode(BytecodeGenerator&, RegisterID* = nullptr) final;
@@ -1037,7 +1037,7 @@ namespace JSC {
         bool isFunctionCall() const final { return true; }
         bool isOptionalCall() const final { return m_isOptionalCall; }
 
-        const Identifier& m_ident;
+        SUPPRESS_UNCOUNTED_MEMBER UniquedStringImpl* const m_ident;
         ArgumentsNode* m_args;
         bool m_isOptionalCall;
     };
@@ -1061,7 +1061,7 @@ namespace JSC {
 
     class FunctionCallDotNode : public BaseDotNode, public ThrowableSubExpressionData {
     public:
-        FunctionCallDotNode(const JSTokenLocation&, ExpressionNode* base, const Identifier&, DotType, ArgumentsNode*, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd, bool isOptionalCall);
+        FunctionCallDotNode(const JSTokenLocation&, ExpressionNode* base, UniquedStringImpl*, DotType, ArgumentsNode*, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd, bool isOptionalCall);
 
     private:
         RegisterID* emitBytecode(BytecodeGenerator&, RegisterID* = nullptr) override;
@@ -1081,13 +1081,13 @@ namespace JSC {
             Function
         };
 
-        BytecodeIntrinsicNode(Type, const JSTokenLocation&, BytecodeIntrinsicRegistry::Entry, const Identifier&, ArgumentsNode*, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd);
+        BytecodeIntrinsicNode(Type, const JSTokenLocation&, BytecodeIntrinsicRegistry::Entry, UniquedStringImpl*, ArgumentsNode*, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd);
 
         bool isBytecodeIntrinsicNode() const final { return true; }
 
         Type type() const { return m_type; }
         BytecodeIntrinsicRegistry::Entry entry() const { return m_entry; }
-        const Identifier& identifier() const { return m_ident; }
+        UniquedStringImpl* ident() const { return m_ident; }
 
 #define JSC_DECLARE_BYTECODE_INTRINSIC_FUNCTIONS(name) RegisterID* emit_intrinsic_##name(BytecodeGenerator&, RegisterID*);
         JSC_COMMON_BYTECODE_INTRINSIC_FUNCTIONS_EACH_NAME(JSC_DECLARE_BYTECODE_INTRINSIC_FUNCTIONS)
@@ -1100,23 +1100,23 @@ namespace JSC {
         bool isFunctionCall() const final { return m_type == Type::Function; }
 
         BytecodeIntrinsicRegistry::Entry m_entry;
-        const Identifier& m_ident;
+        SUPPRESS_UNCOUNTED_MEMBER UniquedStringImpl* const m_ident;
         ArgumentsNode* m_args;
         Type m_type;
     };
 
     class CallFunctionCallDotNode final : public FunctionCallDotNode {
     public:
-        CallFunctionCallDotNode(const JSTokenLocation&, ExpressionNode* base, const Identifier&, DotType, ArgumentsNode*, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd, bool isOptionalCall, size_t distanceToInnermostCallOrApply);
+        CallFunctionCallDotNode(const JSTokenLocation&, ExpressionNode* base, UniquedStringImpl*, DotType, ArgumentsNode*, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd, bool isOptionalCall, size_t distanceToInnermostCallOrApply);
 
     private:
         RegisterID* emitBytecode(BytecodeGenerator&, RegisterID* = nullptr) final;
         size_t m_distanceToInnermostCallOrApply;
     };
-    
+
     class ApplyFunctionCallDotNode final : public FunctionCallDotNode {
     public:
-        ApplyFunctionCallDotNode(const JSTokenLocation&, ExpressionNode* base, const Identifier&, DotType, ArgumentsNode*, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd, bool isOptionalCall, size_t distanceToInnermostCallOrApply);
+        ApplyFunctionCallDotNode(const JSTokenLocation&, ExpressionNode* base, UniquedStringImpl*, DotType, ArgumentsNode*, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd, bool isOptionalCall, size_t distanceToInnermostCallOrApply);
 
     private:
         RegisterID* emitBytecode(BytecodeGenerator&, RegisterID* = nullptr) final;
@@ -1125,7 +1125,7 @@ namespace JSC {
 
     class HasOwnPropertyFunctionCallDotNode final : public FunctionCallDotNode {
     public:
-        HasOwnPropertyFunctionCallDotNode(const JSTokenLocation&, ExpressionNode* base, const Identifier&, DotType, ArgumentsNode*, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd, bool isOptionalCall);
+        HasOwnPropertyFunctionCallDotNode(const JSTokenLocation&, ExpressionNode* base, UniquedStringImpl*, DotType, ArgumentsNode*, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd, bool isOptionalCall);
 
     private:
         RegisterID* emitBytecode(BytecodeGenerator&, RegisterID* = nullptr) final;
@@ -1133,14 +1133,14 @@ namespace JSC {
 
     class DeleteResolveNode final : public ExpressionNode, public ThrowableExpressionData {
     public:
-        DeleteResolveNode(const JSTokenLocation&, const Identifier&, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd);
+        DeleteResolveNode(const JSTokenLocation&, UniquedStringImpl*, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd);
 
     private:
         RegisterID* emitBytecode(BytecodeGenerator&, RegisterID* = nullptr) final;
 
         bool isDeleteNode() const final { return true; }
 
-        const Identifier& m_ident;
+        SUPPRESS_UNCOUNTED_MEMBER UniquedStringImpl* const m_ident;
     };
 
     class DeleteBracketNode final : public ExpressionNode, public ThrowableExpressionData {
@@ -1158,7 +1158,7 @@ namespace JSC {
 
     class DeleteDotNode final : public ExpressionNode, public ThrowableExpressionData {
     public:
-        DeleteDotNode(const JSTokenLocation&, ExpressionNode* base, const Identifier&, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd);
+        DeleteDotNode(const JSTokenLocation&, ExpressionNode* base, UniquedStringImpl*, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd);
 
     private:
         RegisterID* emitBytecode(BytecodeGenerator&, RegisterID* = nullptr) final;
@@ -1166,7 +1166,7 @@ namespace JSC {
         bool isDeleteNode() const final { return true; }
 
         ExpressionNode* m_base;
-        const Identifier& m_ident;
+        SUPPRESS_UNCOUNTED_MEMBER UniquedStringImpl* const m_ident;
     };
 
     class DeleteValueNode final : public ExpressionNode {
@@ -1193,14 +1193,14 @@ namespace JSC {
 
     class TypeOfResolveNode final : public ExpressionNode, public ThrowableExpressionData {
     public:
-        TypeOfResolveNode(const JSTokenLocation&, const Identifier&, const JSTextPosition&, const JSTextPosition&, const JSTextPosition&);
+        TypeOfResolveNode(const JSTokenLocation&, UniquedStringImpl*, const JSTextPosition&, const JSTextPosition&, const JSTextPosition&);
 
-        const Identifier& identifier() const { return m_ident; }
+        UniquedStringImpl* ident() const { return m_ident; }
 
     private:
         RegisterID* emitBytecode(BytecodeGenerator&, RegisterID* = nullptr) final;
 
-        const Identifier& m_ident;
+        SUPPRESS_UNCOUNTED_MEMBER UniquedStringImpl* const m_ident;
     };
 
     class TypeOfValueNode final : public ExpressionNode {
@@ -1508,12 +1508,12 @@ namespace JSC {
 
     class ReadModifyResolveNode final : public ExpressionNode, public ThrowableExpressionData {
     public:
-        ReadModifyResolveNode(const JSTokenLocation&, const Identifier&, Operator, ExpressionNode*  right, bool rightHasAssignments, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd);
+        ReadModifyResolveNode(const JSTokenLocation&, UniquedStringImpl*, Operator, ExpressionNode*  right, bool rightHasAssignments, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd);
 
     private:
         RegisterID* emitBytecode(BytecodeGenerator&, RegisterID* = nullptr) final;
 
-        const Identifier& m_ident;
+        SUPPRESS_UNCOUNTED_MEMBER UniquedStringImpl* const m_ident;
         ExpressionNode* m_right;
         Operator m_operator;
         bool m_rightHasAssignments;
@@ -1521,12 +1521,12 @@ namespace JSC {
 
     class ShortCircuitReadModifyResolveNode final : public ExpressionNode, public ThrowableExpressionData {
     public:
-        ShortCircuitReadModifyResolveNode(const JSTokenLocation&, const Identifier&, Operator, ExpressionNode*  right, bool rightHasAssignments, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd);
+        ShortCircuitReadModifyResolveNode(const JSTokenLocation&, UniquedStringImpl*, Operator, ExpressionNode*  right, bool rightHasAssignments, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd);
 
     private:
         RegisterID* emitBytecode(BytecodeGenerator&, RegisterID* = nullptr) final;
 
-        const Identifier& m_ident;
+        SUPPRESS_UNCOUNTED_MEMBER UniquedStringImpl* const m_ident;
         ExpressionNode* m_right;
         Operator m_operator;
         bool m_rightHasAssignments;
@@ -1534,14 +1534,14 @@ namespace JSC {
 
     class AssignResolveNode final : public ExpressionNode, public ThrowableExpressionData {
     public:
-        AssignResolveNode(const JSTokenLocation&, const Identifier&, ExpressionNode* right, AssignmentContext);
+        AssignResolveNode(const JSTokenLocation&, UniquedStringImpl*, ExpressionNode* right, AssignmentContext);
         bool isAssignResolveNode() const final { return true; }
-        const Identifier& identifier() const { return m_ident; }
+        UniquedStringImpl* ident() const { return m_ident; }
 
     private:
         RegisterID* emitBytecode(BytecodeGenerator&, RegisterID* = nullptr) final;
 
-        const Identifier& m_ident;
+        SUPPRESS_UNCOUNTED_MEMBER UniquedStringImpl* const m_ident;
         ExpressionNode* m_right;
         AssignmentContext m_assignmentContext;
     };
@@ -1592,7 +1592,7 @@ namespace JSC {
 
     class AssignDotNode final : public BaseDotNode, public ThrowableExpressionData {
     public:
-        AssignDotNode(const JSTokenLocation&, ExpressionNode* base, const Identifier&, DotType, ExpressionNode* right, bool rightHasAssignments, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd);
+        AssignDotNode(const JSTokenLocation&, ExpressionNode* base, UniquedStringImpl*, DotType, ExpressionNode* right, bool rightHasAssignments, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd);
 
     private:
         RegisterID* emitBytecode(BytecodeGenerator&, RegisterID* = nullptr) final;
@@ -1603,7 +1603,7 @@ namespace JSC {
 
     class ReadModifyDotNode final : public BaseDotNode, public ThrowableSubExpressionData {
     public:
-        ReadModifyDotNode(const JSTokenLocation&, ExpressionNode* base, const Identifier&, DotType, Operator, ExpressionNode* right, bool rightHasAssignments, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd);
+        ReadModifyDotNode(const JSTokenLocation&, ExpressionNode* base, UniquedStringImpl*, DotType, Operator, ExpressionNode* right, bool rightHasAssignments, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd);
 
     private:
         RegisterID* emitBytecode(BytecodeGenerator&, RegisterID* = nullptr) final;
@@ -1615,7 +1615,7 @@ namespace JSC {
 
     class ShortCircuitReadModifyDotNode final : public BaseDotNode, public ThrowableSubExpressionData {
     public:
-        ShortCircuitReadModifyDotNode(const JSTokenLocation&, ExpressionNode* base, const Identifier&, DotType, Operator, ExpressionNode* right, bool rightHasAssignments, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd);
+        ShortCircuitReadModifyDotNode(const JSTokenLocation&, ExpressionNode* base, UniquedStringImpl*, DotType, Operator, ExpressionNode* right, bool rightHasAssignments, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd);
 
     private:
         RegisterID* emitBytecode(BytecodeGenerator&, RegisterID* = nullptr) final;
@@ -1741,22 +1741,22 @@ namespace JSC {
 
     class EmptyVarExpression final : public ExpressionNode {
     public:
-        EmptyVarExpression(const JSTokenLocation&, const Identifier&);
+        EmptyVarExpression(const JSTokenLocation&, UniquedStringImpl*);
 
     private:
         RegisterID* emitBytecode(BytecodeGenerator&, RegisterID* = nullptr) final;
 
-        const Identifier& m_ident;
+        SUPPRESS_UNCOUNTED_MEMBER UniquedStringImpl* const m_ident;
     };
 
     class EmptyLetExpression final : public ExpressionNode {
     public:
-        EmptyLetExpression(const JSTokenLocation&, const Identifier&);
+        EmptyLetExpression(const JSTokenLocation&, UniquedStringImpl*);
 
     private:
         RegisterID* emitBytecode(BytecodeGenerator&, RegisterID* = nullptr) final;
 
-        const Identifier& m_ident;
+        SUPPRESS_UNCOUNTED_MEMBER UniquedStringImpl* const m_ident;
     };
 
     class IfElseNode final : public StatementNode {
@@ -1853,7 +1853,7 @@ namespace JSC {
 
     class ContinueNode final : public StatementNode, public ThrowableExpressionData {
     public:
-        ContinueNode(const JSTokenLocation&, const Identifier&);
+        ContinueNode(const JSTokenLocation&, UniquedStringImpl*);
         Label* NODELETE trivialTarget(BytecodeGenerator&);
 
     private:
@@ -1862,12 +1862,12 @@ namespace JSC {
         bool isContinue() const final { return true; }
         void emitBytecode(BytecodeGenerator&, RegisterID* = nullptr) final;
 
-        const Identifier& m_ident;
+        SUPPRESS_UNCOUNTED_MEMBER UniquedStringImpl* const m_ident;
     };
 
     class BreakNode final : public StatementNode, public ThrowableExpressionData {
     public:
-        BreakNode(const JSTokenLocation&, const Identifier&);
+        BreakNode(const JSTokenLocation&, UniquedStringImpl*);
         Label* NODELETE trivialTarget(BytecodeGenerator&);
 
     private:
@@ -1876,7 +1876,7 @@ namespace JSC {
         bool isBreak() const final { return true; }
         void emitBytecode(BytecodeGenerator&, RegisterID* = nullptr) final;
 
-        const Identifier& m_ident;
+        SUPPRESS_UNCOUNTED_MEMBER UniquedStringImpl* const m_ident;
     };
 
     class ReturnNode final : public StatementNode, public ThrowableExpressionData {
@@ -1908,7 +1908,7 @@ namespace JSC {
 
     class LabelNode final : public StatementNode, public ThrowableExpressionData {
     public:
-        LabelNode(const JSTokenLocation&, const Identifier& name, StatementNode*);
+        LabelNode(const JSTokenLocation&, UniquedStringImpl* name, StatementNode*);
 
         bool isLabel() const final { return true; }
 
@@ -1917,7 +1917,7 @@ namespace JSC {
         bool hasEarlyBreakOrContinue() const final { return m_statement->hasEarlyBreakOrContinue(); }
         void emitBytecode(BytecodeGenerator&, RegisterID* = nullptr) final;
 
-        const Identifier& m_name;
+        SUPPRESS_UNCOUNTED_MEMBER UniquedStringImpl* const m_name;
         StatementNode* m_statement;
     };
 
@@ -1987,7 +1987,6 @@ namespace JSC {
         bool needsActivation() const { return (hasCapturedVariables()) || (m_features & (EvalFeature | WithFeature)); }
         bool hasCapturedVariables() const { return m_varDeclarations.hasCapturedVariables(); }
         bool captures(UniquedStringImpl* uid) { return m_varDeclarations.captures(uid); }
-        bool captures(const Identifier& ident) { return captures(ident.impl()); }
         bool usesNonSimpleParameterList() const { return m_features & NonSimpleParameterListFeature; }
 
         bool needsNewTargetRegisterForThisScope() const
@@ -2085,24 +2084,24 @@ namespace JSC {
 
     class ModuleNameNode final : public Node {
     public:
-        ModuleNameNode(const JSTokenLocation&, const Identifier& moduleName);
+        ModuleNameNode(const JSTokenLocation&, UniquedStringImpl* moduleName);
 
-        const Identifier& moduleName() { return m_moduleName; }
+        UniquedStringImpl* moduleName() { return m_moduleName; }
 
     private:
-        const Identifier& m_moduleName;
+        SUPPRESS_UNCOUNTED_MEMBER UniquedStringImpl* const m_moduleName;
     };
 
     class ImportSpecifierNode final : public Node {
     public:
-        ImportSpecifierNode(const JSTokenLocation&, const Identifier& importedName, const Identifier& localName);
+        ImportSpecifierNode(const JSTokenLocation&, UniquedStringImpl* importedName, UniquedStringImpl* localName);
 
-        const Identifier& importedName() { return m_importedName; }
-        const Identifier& localName() { return m_localName; }
+        UniquedStringImpl* importedName() { return m_importedName; }
+        UniquedStringImpl* localName() { return m_localName; }
 
     private:
-        const Identifier& m_importedName;
-        const Identifier& m_localName;
+        SUPPRESS_UNCOUNTED_MEMBER UniquedStringImpl* const m_importedName;
+        SUPPRESS_UNCOUNTED_MEMBER UniquedStringImpl* const m_localName;
     };
 
     class ImportSpecifierListNode final : public ParserArenaDeletable {
@@ -2123,12 +2122,12 @@ namespace JSC {
     class ImportAttributesListNode final : public ParserArenaDeletable {
         JSC_MAKE_PARSER_ARENA_DELETABLE_ALLOCATED(ImportAttributesListNode);
     public:
-        using Attributes = Vector<std::tuple<const Identifier*, const Identifier*>, 3>;
+        using Attributes = Vector<std::tuple<UniquedStringImpl*, UniquedStringImpl*>, 3>;
 
         const Attributes& attributes() const LIFETIME_BOUND { return m_attributes; }
-        void append(const Identifier& key, const Identifier& value)
+        void append(UniquedStringImpl* key, UniquedStringImpl* value)
         {
-            m_attributes.append(std::tuple { &key, &value });
+            m_attributes.append(std::tuple { key, value });
         }
 
     private:
@@ -2184,16 +2183,16 @@ namespace JSC {
 
     class ExportDefaultDeclarationNode final : public ModuleDeclarationNode {
     public:
-        ExportDefaultDeclarationNode(const JSTokenLocation&, StatementNode*, const Identifier& localName);
+        ExportDefaultDeclarationNode(const JSTokenLocation&, StatementNode*, UniquedStringImpl* localName);
 
         const StatementNode& declaration() const { return *m_declaration; }
-        const Identifier& localName() const { return m_localName; }
+        UniquedStringImpl* localName() const { return m_localName; }
 
     private:
         void emitBytecode(BytecodeGenerator&, RegisterID* = nullptr) final;
         bool analyzeModule(ModuleAnalyzer&) final;
         StatementNode* m_declaration;
-        const Identifier& m_localName;
+        SUPPRESS_UNCOUNTED_MEMBER UniquedStringImpl* const m_localName;
     };
 
     class ExportLocalDeclarationNode final : public ModuleDeclarationNode {
@@ -2210,14 +2209,14 @@ namespace JSC {
 
     class ExportSpecifierNode final : public Node {
     public:
-        ExportSpecifierNode(const JSTokenLocation&, const Identifier& localName, const Identifier& exportedName);
+        ExportSpecifierNode(const JSTokenLocation&, UniquedStringImpl* localName, UniquedStringImpl* exportedName);
 
-        const Identifier& exportedName() { return m_exportedName; }
-        const Identifier& localName() { return m_localName; }
+        UniquedStringImpl* exportedName() { return m_exportedName; }
+        UniquedStringImpl* localName() { return m_localName; }
 
     private:
-        const Identifier& m_localName;
-        const Identifier& m_exportedName;
+        SUPPRESS_UNCOUNTED_MEMBER UniquedStringImpl* const m_localName;
+        SUPPRESS_UNCOUNTED_MEMBER UniquedStringImpl* const m_exportedName;
     };
 
     class ExportSpecifierListNode final : public ParserArenaDeletable {
@@ -2269,12 +2268,12 @@ namespace JSC {
 
         void dump(PrintStream&) const;
 
-        void finishParsing(const SourceCode&, const Identifier&, FunctionMode);
-        
-        void overrideName(const Identifier& ident) { m_ident = ident; }
-        const Identifier& ident() { return m_ident; }
-        void setEcmaName(const Identifier& ecmaName) { m_ecmaName = ecmaName; }
-        const Identifier& ecmaName() { return m_ident.isEmpty() ? m_ecmaName : m_ident; }
+        void finishParsing(const SourceCode&, UniquedStringImpl*, FunctionMode);
+
+        void overrideName(UniquedStringImpl* uid) { m_ident = uid; }
+        UniquedStringImpl* ident() { return m_ident.get(); }
+        void setEcmaName(UniquedStringImpl* uid) { m_ecmaName = uid; }
+        UniquedStringImpl* ecmaName() { return m_ident ? m_ident.get() : m_ecmaName.get(); }
 
         void setPrivateBrandRequirement(PrivateBrandRequirement privateBrandRequirement) { m_privateBrandRequirement = static_cast<unsigned>(privateBrandRequirement); }
         PrivateBrandRequirement privateBrandRequirement() { return static_cast<PrivateBrandRequirement>(m_privateBrandRequirement); }
@@ -2333,8 +2332,8 @@ namespace JSC {
         unsigned m_privateBrandRequirement : 1;
         SourceParseMode m_parseMode;
         FunctionMode m_functionMode;
-        Identifier m_ident;
-        Identifier m_ecmaName;
+        RefPtr<UniquedStringImpl> m_ident;
+        RefPtr<UniquedStringImpl> m_ecmaName;
         unsigned m_startColumn;
         unsigned m_endColumn;
         unsigned m_functionStart;
@@ -2357,9 +2356,9 @@ namespace JSC {
 
         bool isFunctionNode() const final { return true; }
 
-        void finishParsing(const Identifier&, FunctionMode);
-        
-        const Identifier& ident() { return m_ident; }
+        void finishParsing(UniquedStringImpl*, FunctionMode);
+
+        UniquedStringImpl* ident() { return m_ident.get(); }
 
         FunctionMode functionMode() const { return m_functionMode; }
 
@@ -2369,7 +2368,7 @@ namespace JSC {
         static constexpr bool scopeIsFunction = true;
 
     private:
-        Identifier m_ident;
+        RefPtr<UniquedStringImpl> m_ident;
         FunctionMode m_functionMode;
         FunctionParameters* m_parameters;
         unsigned m_startColumn;
@@ -2383,7 +2382,7 @@ namespace JSC {
         bool isBaseFuncExprNode() const override { return true; }
 
     protected:
-        BaseFuncExprNode(const JSTokenLocation&, const Identifier&, FunctionMetadataNode*, const SourceCode&, FunctionMode);
+        BaseFuncExprNode(const JSTokenLocation&, UniquedStringImpl*, FunctionMetadataNode*, const SourceCode&, FunctionMode);
 
         FunctionMetadataNode* m_metadata;
     };
@@ -2391,10 +2390,10 @@ namespace JSC {
 
     class FuncExprNode : public BaseFuncExprNode {
     public:
-        FuncExprNode(const JSTokenLocation&, const Identifier&, FunctionMetadataNode*, const SourceCode&);
+        FuncExprNode(const JSTokenLocation&, UniquedStringImpl*, FunctionMetadataNode*, const SourceCode&);
 
     protected:
-        FuncExprNode(const JSTokenLocation&, const Identifier&, FunctionMetadataNode*, const SourceCode&, FunctionMode);
+        FuncExprNode(const JSTokenLocation&, UniquedStringImpl*, FunctionMetadataNode*, const SourceCode&, FunctionMode);
 
     private:
         RegisterID* emitBytecode(BytecodeGenerator&, RegisterID* = nullptr) override;
@@ -2404,7 +2403,7 @@ namespace JSC {
 
     class ArrowFuncExprNode final : public BaseFuncExprNode {
     public:
-        ArrowFuncExprNode(const JSTokenLocation&, const Identifier&, FunctionMetadataNode*, const SourceCode&);
+        ArrowFuncExprNode(const JSTokenLocation&, UniquedStringImpl*, FunctionMetadataNode*, const SourceCode&);
 
     private:
         RegisterID* emitBytecode(BytecodeGenerator&, RegisterID* = nullptr) final;
@@ -2414,7 +2413,7 @@ namespace JSC {
 
     class MethodDefinitionNode final : public FuncExprNode {
     public:
-        MethodDefinitionNode(const JSTokenLocation&, const Identifier&, FunctionMetadataNode*, const SourceCode&);
+        MethodDefinitionNode(const JSTokenLocation&, UniquedStringImpl*, FunctionMetadataNode*, const SourceCode&);
         
     private:
         RegisterID* emitBytecode(BytecodeGenerator&, RegisterID* = nullptr) final;
@@ -2449,14 +2448,14 @@ namespace JSC {
     class DefineFieldNode final : public StatementNode {
     public:
         enum class Type { Name, PrivateName, ComputedName };
-        DefineFieldNode(const JSTokenLocation&, const Identifier&, ExpressionNode*, Type);
+        DefineFieldNode(const JSTokenLocation&, UniquedStringImpl*, ExpressionNode*, Type);
 
     private:
         void emitBytecode(BytecodeGenerator&, RegisterID* destination = nullptr) final;
 
         bool isDefineFieldNode() const final { return true; }
 
-        Identifier m_ident;
+        SUPPRESS_UNCOUNTED_MEMBER UniquedStringImpl* const m_ident;
         ExpressionNode* m_assign;
         Type m_type;
     };
@@ -2464,15 +2463,15 @@ namespace JSC {
     class ClassExprNode final : public ExpressionNode, public ThrowableExpressionData, public VariableEnvironmentNode {
         JSC_MAKE_PARSER_ARENA_DELETABLE_ALLOCATED(ClassExprNode);
     public:
-        ClassExprNode(const JSTokenLocation&, const Identifier&, const SourceCode& classSource,
+        ClassExprNode(const JSTokenLocation&, UniquedStringImpl* name, const SourceCode& classSource,
             VariableEnvironment&& classHeadEnvironment, VariableEnvironment&& classEnvironment, ExpressionNode* constructorExpresssion,
             ExpressionNode* parentClass, PropertyListNode* classElements);
 
-        const Identifier& name() { return m_name; }
-        const Identifier& ecmaName() { return m_ecmaName ? *m_ecmaName : m_name; }
-        void setEcmaName(const Identifier& name) { m_ecmaName = m_name.isNull() ? &name : &m_name; }
+        UniquedStringImpl* name() { return m_name.get(); }
+        UniquedStringImpl* ecmaName() { return m_ecmaName ? m_ecmaName.get() : m_name.get(); }
+        void setEcmaName(UniquedStringImpl* uid) { if (!m_name) m_ecmaName = uid; }
 
-        bool hasStaticProperty(const Identifier& propName) { return m_classElements && m_classElements->hasStaticallyNamedProperty(propName); }
+        bool hasStaticProperty(UniquedStringImpl* propName) { return m_classElements && m_classElements->hasStaticallyNamedProperty(propName); }
         bool hasInstanceFields() const { return m_classElements && m_classElements->hasInstanceFields(); }
 
     private:
@@ -2482,8 +2481,8 @@ namespace JSC {
 
         VariableEnvironment m_classHeadEnvironment;
         SourceCode m_classSource;
-        const Identifier& m_name;
-        const Identifier* m_ecmaName;
+        RefPtr<UniquedStringImpl> m_name;
+        RefPtr<UniquedStringImpl> m_ecmaName;
         ExpressionNode* m_constructorExpression;
         ExpressionNode* m_classHeritage;
         PropertyListNode* m_classElements;
@@ -2495,7 +2494,7 @@ namespace JSC {
         using BaseAndPropertyName = std::pair<RefPtr<RegisterID>, RefPtr<RegisterID>>;
 
         virtual ~DestructuringPatternNode() { }
-        virtual void collectBoundIdentifiers(Vector<Identifier>&) const = 0;
+        virtual void collectBoundIdentifiers(VM&, Vector<Identifier>&) const = 0;
         virtual void bindValue(BytecodeGenerator&, RegisterID* source) const = 0;
         virtual void toString(StringBuilder&) const = 0;
 
@@ -2532,7 +2531,8 @@ namespace JSC {
             DestructuringPatternNode* pattern;
             ExpressionNode* defaultValue;
         };
-        void collectBoundIdentifiers(Vector<Identifier>&) const final;
+
+        void collectBoundIdentifiers(VM&, Vector<Identifier>&) const final;
         void bindValue(BytecodeGenerator&, RegisterID*) const final;
         void toString(StringBuilder&) const final;
 
@@ -2547,14 +2547,14 @@ namespace JSC {
             Element,
             RestElement
         };
-        void appendEntry(const JSTokenLocation&, const Identifier& identifier, bool wasString, DestructuringPatternNode* pattern, ExpressionNode* defaultValue, BindingType bindingType)
+        void appendEntry(const JSTokenLocation&, UniquedStringImpl* identifier, bool wasString, DestructuringPatternNode* pattern, ExpressionNode* defaultValue, BindingType bindingType)
         {
-            m_targetPatterns.append(Entry{ identifier, nullptr, wasString, pattern, defaultValue, bindingType });  
+            m_targetPatterns.append(Entry{ identifier, nullptr, wasString, pattern, defaultValue, bindingType });
         }
 
-        void appendEntry(VM& vm, const JSTokenLocation&, ExpressionNode* propertyExpression, DestructuringPatternNode* pattern, ExpressionNode* defaultValue, BindingType bindingType)
+        void appendEntry(VM&, const JSTokenLocation&, ExpressionNode* propertyExpression, DestructuringPatternNode* pattern, ExpressionNode* defaultValue, BindingType bindingType)
         {
-            m_targetPatterns.append(Entry{ vm.propertyNames->nullIdentifier, propertyExpression, false, pattern, defaultValue, bindingType });
+            m_targetPatterns.append(Entry{ nullptr, propertyExpression, false, pattern, defaultValue, bindingType });
         }
         
         void setContainsRestElement(bool containsRestElement)
@@ -2568,11 +2568,11 @@ namespace JSC {
         }
 
     private:
-        void collectBoundIdentifiers(Vector<Identifier>&) const final;
+        void collectBoundIdentifiers(VM&, Vector<Identifier>&) const final;
         void bindValue(BytecodeGenerator&, RegisterID*) const final;
         void toString(StringBuilder&) const final;
         struct Entry {
-            const Identifier& propertyName;
+            SUPPRESS_UNCOUNTED_MEMBER UniquedStringImpl* const propertyName;
             ExpressionNode* propertyExpression;
             bool wasString;
             DestructuringPatternNode* pattern;
@@ -2586,8 +2586,8 @@ namespace JSC {
 
     class BindingNode final: public DestructuringPatternNode {
     public:
-        BindingNode(const Identifier& boundProperty, const JSTextPosition& start, const JSTextPosition& end, AssignmentContext);
-        const Identifier& boundProperty() const { return m_boundProperty; }
+        BindingNode(UniquedStringImpl* boundProperty, const JSTextPosition& start, const JSTextPosition& end, AssignmentContext);
+        UniquedStringImpl* boundProperty() const { return m_boundProperty; }
 
         const JSTextPosition& divotStart() const LIFETIME_BOUND { return m_divotStart; }
         const JSTextPosition& divotEnd() const LIFETIME_BOUND { return m_divotEnd; }
@@ -2595,17 +2595,17 @@ namespace JSC {
         bool bindValueCanThrow(BytecodeGenerator&) const final;
         RegisterID* writableDirectBindingIfPossible(BytecodeGenerator&) const final;
         void finishDirectBindingAssignment(BytecodeGenerator&) const;
-        
+
     private:
-        void collectBoundIdentifiers(Vector<Identifier>&) const final;
+        void collectBoundIdentifiers(VM&, Vector<Identifier>&) const final;
         void bindValue(BytecodeGenerator&, RegisterID*) const final;
         void toString(StringBuilder&) const final;
-        
+
         bool isBindingNode() const final { return true; }
 
         JSTextPosition m_divotStart;
         JSTextPosition m_divotEnd;
-        const Identifier& m_boundProperty;
+        SUPPRESS_UNCOUNTED_MEMBER UniquedStringImpl* const m_boundProperty;
         AssignmentContext m_bindingContext;
     };
 
@@ -2618,7 +2618,7 @@ namespace JSC {
         void emit(BytecodeGenerator&);
 
     private:
-        void collectBoundIdentifiers(Vector<Identifier>&) const final;
+        void collectBoundIdentifiers(VM&, Vector<Identifier>&) const final;
         void bindValue(BytecodeGenerator&, RegisterID*) const final;
         void toString(StringBuilder&) const final;
 
@@ -2642,7 +2642,7 @@ namespace JSC {
         void bindValueWithEmittedNodes(BytecodeGenerator&, BaseAndPropertyName, RegisterID*) const;
 
     private:
-        void collectBoundIdentifiers(Vector<Identifier>&) const final;
+        void collectBoundIdentifiers(VM&, Vector<Identifier>&) const final;
         void bindValue(BytecodeGenerator&, RegisterID*) const final;
         void toString(StringBuilder&) const final;
 
@@ -2700,7 +2700,7 @@ namespace JSC {
 
     class FuncDeclNode final : public StatementNode {
     public:
-        FuncDeclNode(const JSTokenLocation&, const Identifier&, FunctionMetadataNode*, const SourceCode&);
+        FuncDeclNode(const JSTokenLocation&, UniquedStringImpl*, FunctionMetadataNode*, const SourceCode&);
 
         bool hasCompletionValue() const final { return false; }
         bool isFuncDeclNode() const final { return true; }

--- a/Source/JavaScriptCore/parser/NodesAnalyzeModule.cpp
+++ b/Source/JavaScriptCore/parser/NodesAnalyzeModule.cpp
@@ -43,15 +43,15 @@ static Expected<RefPtr<ScriptFetchParameters>, std::tuple<ErrorType, String>> tr
     // Currently, only "type" is supported.
     std::optional<ScriptFetchParameters::Type> type;
     for (auto& [key, value] : attributesList->attributes()) {
-        if (*key != vm.propertyNames->type)
-            return makeUnexpected(std::tuple { ErrorType::SyntaxError, makeString("Import attribute \""_s, StringView(key->impl()), "\" is not supported"_s) });
+        if (key != vm.propertyNames->type.impl())
+            return makeUnexpected(std::tuple { ErrorType::SyntaxError, makeString("Import attribute \""_s, StringView { key }, "\" is not supported"_s) });
     }
 
     for (auto& [key, value] : attributesList->attributes()) {
-        if (*key == vm.propertyNames->type) {
-            type = ScriptFetchParameters::parseType(value->impl());
+        if (key == vm.propertyNames->type.impl()) {
+            type = ScriptFetchParameters::parseType(value);
             if (!type)
-                return makeUnexpected(std::tuple { ErrorType::TypeError, makeString("Import attribute type \""_s, StringView(value->impl()), "\" is not valid"_s) });
+                return makeUnexpected(std::tuple { ErrorType::TypeError, makeString("Import attribute type \""_s, StringView { value }, "\" is not valid"_s) });
         }
     }
 
@@ -84,16 +84,17 @@ bool ImportDeclarationNode::analyzeModule(ModuleAnalyzer& analyzer)
         return false;
     }
 
+    VM& vm = analyzer.vm();
     auto phase = m_type == ImportType::Deferred ? AbstractModuleRecord::ModulePhase::Defer : AbstractModuleRecord::ModulePhase::Evaluation;
-    analyzer.appendRequestedModule(m_moduleName->moduleName(), WTF::move(result.value()), phase);
+    SUPPRESS_UNCOUNTED_ARG analyzer.appendRequestedModule(Identifier::fromUid(vm, m_moduleName->moduleName()), WTF::move(result.value()), phase);
     for (auto* specifier : m_specifierList->specifiers()) {
-        analyzer.moduleRecord()->addImportEntry(JSModuleRecord::ImportEntry {
-            specifier->importedName() == analyzer.vm().propertyNames->starNamespacePrivateName
+        SUPPRESS_UNCOUNTED_ARG analyzer.moduleRecord()->addImportEntry(JSModuleRecord::ImportEntry {
+            specifier->importedName() == vm.propertyNames->starNamespacePrivateName.impl()
                 ? JSModuleRecord::ImportEntryType::Namespace : JSModuleRecord::ImportEntryType::Single,
             phase,
-            m_moduleName->moduleName(),
-            specifier->importedName(),
-            specifier->localName(),
+            Identifier::fromUid(vm, m_moduleName->moduleName()),
+            Identifier::fromUid(vm, specifier->importedName()),
+            Identifier::fromUid(vm, specifier->localName()),
         });
     }
     return true;
@@ -107,8 +108,8 @@ bool ExportAllDeclarationNode::analyzeModule(ModuleAnalyzer& analyzer)
         return false;
     }
 
-    analyzer.appendRequestedModule(m_moduleName->moduleName(), WTF::move(result.value()));
-    analyzer.moduleRecord()->addStarExportEntry(m_moduleName->moduleName());
+    SUPPRESS_UNCOUNTED_ARG analyzer.appendRequestedModule(Identifier::fromUid(analyzer.vm(), m_moduleName->moduleName()), WTF::move(result.value()));
+    SUPPRESS_UNCOUNTED_ARG analyzer.moduleRecord()->addStarExportEntry(Identifier::fromUid(analyzer.vm(), m_moduleName->moduleName()));
     return true;
 }
 
@@ -131,7 +132,7 @@ bool ExportNamedDeclarationNode::analyzeModule(ModuleAnalyzer& analyzer)
             return false;
         }
 
-        analyzer.appendRequestedModule(m_moduleName->moduleName(), WTF::move(result.value()));
+        SUPPRESS_UNCOUNTED_ARG analyzer.appendRequestedModule(Identifier::fromUid(analyzer.vm(), m_moduleName->moduleName()), WTF::move(result.value()));
     }
 
     for (auto* specifier : m_specifierList->specifiers()) {
@@ -144,10 +145,10 @@ bool ExportNamedDeclarationNode::analyzeModule(ModuleAnalyzer& analyzer)
             // export * as v from "mod"
             //
             // If it is namespace export, we should use createNamespace.
-            if (specifier->localName() == analyzer.vm().propertyNames->starNamespacePrivateName)
-                analyzer.moduleRecord()->addExportEntry(JSModuleRecord::ExportEntry::createNamespace(specifier->exportedName(), m_moduleName->moduleName()));
+            if (specifier->localName() == analyzer.vm().propertyNames->starNamespacePrivateName.impl())
+                SUPPRESS_UNCOUNTED_ARG analyzer.moduleRecord()->addExportEntry(JSModuleRecord::ExportEntry::createNamespace(Identifier::fromUid(analyzer.vm(), specifier->exportedName()), Identifier::fromUid(analyzer.vm(), m_moduleName->moduleName())));
             else
-                analyzer.moduleRecord()->addExportEntry(JSModuleRecord::ExportEntry::createIndirect(specifier->exportedName(), specifier->localName(), m_moduleName->moduleName()));
+                SUPPRESS_UNCOUNTED_ARG analyzer.moduleRecord()->addExportEntry(JSModuleRecord::ExportEntry::createIndirect(Identifier::fromUid(analyzer.vm(), specifier->exportedName()), Identifier::fromUid(analyzer.vm(), specifier->localName()), Identifier::fromUid(analyzer.vm(), m_moduleName->moduleName())));
         }
     }
     return true;

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -257,8 +257,8 @@ Expected<typename Parser<LexerType>::ParseInnerResult, String> Parser<LexerType>
         }
     }
 
-    if (functionNameIsInScope(calleeName, functionMode()))
-        scope->declareCallee(&calleeName);
+    if (functionNameIsInScope(calleeName.impl(), functionMode()))
+        scope->declareCallee(calleeName.impl());
 
     if (m_lexer->isReparsingFunction())
         m_statementDepth--;
@@ -267,15 +267,15 @@ Expected<typename Parser<LexerType>::ParseInnerResult, String> Parser<LexerType>
     // The only way we can error this early is if we reparse a function and we run out of stack space.
     if (!hasError()) {
         if (isAsyncFunctionWrapperParseMode(parseMode))
-            sourceElements = parseAsyncFunctionSourceElements(context, calleeName, isArrowFunctionBodyExpression, CheckForStrictMode);
+            sourceElements = parseAsyncFunctionSourceElements(context, calleeName.impl(), isArrowFunctionBodyExpression, CheckForStrictMode);
         else if (isArrowFunctionBodyExpression)
             sourceElements = parseArrowFunctionSingleExpressionBodySourceElements(context);
         else if (isModuleParseMode(parseMode))
             sourceElements = parseModuleSourceElements(context);
         else if (isGeneratorWrapperParseMode(parseMode))
-            sourceElements = parseGeneratorFunctionSourceElements(context, calleeName, CheckForStrictMode);
+            sourceElements = parseGeneratorFunctionSourceElements(context, calleeName.impl(), CheckForStrictMode);
         else if (isAsyncGeneratorWrapperParseMode(parseMode))
-            sourceElements = parseAsyncGeneratorFunctionSourceElements(context, calleeName, isArrowFunctionBodyExpression, CheckForStrictMode);
+            sourceElements = parseAsyncGeneratorFunctionSourceElements(context, calleeName.impl(), isArrowFunctionBodyExpression, CheckForStrictMode);
         else if (parsingContext == ParsingContext::FunctionConstructor)
             sourceElements = parseSingleFunction(context, functionConstructorParametersEndPosition);
         else if (parseMode == SourceParseMode::ClassFieldInitializerMode) {
@@ -406,7 +406,7 @@ template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseSourceEl
 {
     const unsigned lengthOfUseStrictLiteral = 12; // "use strict".length
     TreeSourceElements sourceElements = context.createSourceElements();
-    const Identifier* directive = nullptr;
+    UniquedStringImpl* directive = nullptr;
     unsigned directiveLiteralLength = 0;
     std::optional<SavePoint> savePoint;
     bool shouldCheckForUseStrict = mode == CheckForStrictMode;
@@ -417,16 +417,16 @@ template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseSourceEl
         if (shouldCheckForUseStrict) {
             if (directive) {
                 // "use strict" must be the exact literal without escape sequences or line continuation.
-                if (directiveLiteralLength == lengthOfUseStrictLiteral && m_vm.propertyNames->useStrictIdentifier == *directive) {
+                if (directiveLiteralLength == lengthOfUseStrictLiteral && m_vm.propertyNames->useStrictIdentifier.impl() == directive) {
                     setStrictMode();
                     shouldCheckForUseStrict = false; // We saw "use strict", there is no need to keep checking for it.
                     if (!isValidStrictMode()) {
                         if (m_parserState.lastFunctionName) {
-                            semanticFailIfTrue(m_vm.propertyNames->arguments == *m_parserState.lastFunctionName, "Cannot name a function 'arguments' in strict mode");
-                            semanticFailIfTrue(m_vm.propertyNames->eval == *m_parserState.lastFunctionName, "Cannot name a function 'eval' in strict mode");
+                            semanticFailIfTrue(m_vm.propertyNames->arguments.impl() == m_parserState.lastFunctionName, "Cannot name a function 'arguments' in strict mode");
+                            semanticFailIfTrue(m_vm.propertyNames->eval.impl() == m_parserState.lastFunctionName, "Cannot name a function 'eval' in strict mode");
                         }
-                        semanticFailIfTrue(hasDeclaredVariable(m_vm.propertyNames->arguments), "Cannot declare a variable named 'arguments' in strict mode");
-                        semanticFailIfTrue(hasDeclaredVariable(m_vm.propertyNames->eval), "Cannot declare a variable named 'eval' in strict mode");
+                        semanticFailIfTrue(hasDeclaredVariable(m_vm.propertyNames->arguments.impl()), "Cannot declare a variable named 'arguments' in strict mode");
+                        semanticFailIfTrue(hasDeclaredVariable(m_vm.propertyNames->eval.impl()), "Cannot declare a variable named 'eval' in strict mode");
                         semanticFailIfTrue(currentScope()->hasNonSimpleParameterList(), "'use strict' directive not allowed inside a function with a non-simple parameter list");
                         semanticFailIfFalse(isValidStrictMode(), "Invalid parameters or function name in strict mode");
                     }
@@ -485,7 +485,7 @@ template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseModuleSo
         }
 
         default: {
-            const Identifier* directive = nullptr;
+            UniquedStringImpl* directive = nullptr;
             unsigned directiveLiteralLength = 0;
             if (sourceParseMode() == SourceParseMode::ModuleAnalyzeMode) {
                 if (!parseStatementListItem(syntaxChecker, directive, &directiveLiteralLength))
@@ -524,7 +524,7 @@ end:
 }
 
 template <typename LexerType>
-template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseGeneratorFunctionSourceElements(TreeBuilder& context, const Identifier& name, SourceElementsMode mode)
+template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseGeneratorFunctionSourceElements(TreeBuilder& context, UniquedStringImpl* name, SourceElementsMode mode)
 {
     auto sourceElements = context.createSourceElements();
 
@@ -536,7 +536,6 @@ template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseGenerato
     int parametersStart = functionNameStart;
 
     ParserFunctionInfo<TreeBuilder> info;
-    info.name = &m_vm.propertyNames->nullIdentifier;
     createGeneratorParameters(context, info.parameterCount);
     info.startOffset = parametersStart;
     info.startLine = tokenLine();
@@ -568,7 +567,7 @@ template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseGenerato
 }
 
 template <typename LexerType>
-template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseAsyncFunctionSourceElements(TreeBuilder& context, const Identifier& calleeName, bool isArrowFunctionBodyExpression, SourceElementsMode mode)
+template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseAsyncFunctionSourceElements(TreeBuilder& context, UniquedStringImpl* calleeName, bool isArrowFunctionBodyExpression, SourceElementsMode mode)
 {
     ASSERT(isAsyncFunctionOrAsyncGeneratorWrapperParseMode(sourceParseMode()));
 
@@ -634,7 +633,6 @@ template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseAsyncFun
     auto sourceElements = context.createSourceElements();
 
     ParserFunctionInfo<TreeBuilder> info;
-    info.name = &m_vm.propertyNames->nullIdentifier;
     createGeneratorParameters(context, info.parameterCount);
     info.startOffset = parametersStart;
     info.startLine = startLine;
@@ -657,7 +655,7 @@ template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseAsyncFun
 }
 
 template <typename LexerType>
-template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseAsyncGeneratorFunctionSourceElements(TreeBuilder& context, const Identifier& calleeName, bool isArrowFunctionBodyExpression, SourceElementsMode mode)
+template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseAsyncGeneratorFunctionSourceElements(TreeBuilder& context, UniquedStringImpl* calleeName, bool isArrowFunctionBodyExpression, SourceElementsMode mode)
 {
     ASSERT(isAsyncGeneratorWrapperParseMode(sourceParseMode()));
     auto sourceElements = context.createSourceElements();
@@ -670,7 +668,6 @@ template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseAsyncGen
     int parametersStart = functionNameStart;
 
     ParserFunctionInfo<TreeBuilder> info;
-    info.name = &m_vm.propertyNames->nullIdentifier;
     createGeneratorParameters(context, info.parameterCount);
     info.startOffset = parametersStart;
     info.startLine = tokenLine();
@@ -720,7 +717,7 @@ template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseSingleFu
         statement = parseFunctionDeclaration(context, FunctionDeclarationType::Declaration, ExportType::NotExported, DeclarationDefaultContext::Standard, functionConstructorParametersEndPosition);
         break;
     case IDENT:
-        if (*m_token.m_data.ident == m_vm.propertyNames->async && !m_token.m_data.escaped) [[likely]] {
+        if (m_token.m_data.ident == m_vm.propertyNames->async.impl() && !m_token.m_data.escaped) [[likely]] {
             unsigned functionStart = m_token.m_startPosition;
             next();
             failIfFalse(match(FUNCTION) && !m_lexer->hasLineTerminatorBeforeToken(), "Cannot parse the async function");
@@ -743,7 +740,7 @@ template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseSingleFu
 
     
 template <typename LexerType>
-template <class TreeBuilder> TreeStatement Parser<LexerType>::parseStatementListItem(TreeBuilder& context, const Identifier*& directive, unsigned* directiveLiteralLength)
+template <class TreeBuilder> TreeStatement Parser<LexerType>::parseStatementListItem(TreeBuilder& context, UniquedStringImpl*& directive, unsigned* directiveLiteralLength)
 {
     // The grammar is documented here:
     // http://www.ecma-international.org/ecma-262/6.0/index.html#sec-statements
@@ -794,7 +791,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseStatementList
         [[fallthrough]];
     case IDENT:
         if (Options::useExplicitResourceManagement()
-            && *m_token.m_data.ident == m_vm.propertyNames->usingIdentifier
+            && m_token.m_data.ident == m_vm.propertyNames->usingIdentifier.impl()
             && !m_token.m_data.escaped) [[unlikely]] {
             SavePoint savePoint = createSavePoint(context);
             next();
@@ -808,7 +805,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseStatementList
             }
             restoreSavePoint(context, savePoint);
         }
-        if (*m_token.m_data.ident == m_vm.propertyNames->async && !m_token.m_data.escaped) [[unlikely]] {
+        if (m_token.m_data.ident == m_vm.propertyNames->async.impl() && !m_token.m_data.escaped) [[unlikely]] {
             // Eagerly parse as AsyncFunctionDeclaration. This is the uncommon case,
             // but could be mistakenly parsed as an AsyncFunctionExpression.
             SavePoint savePoint = createSavePoint(context);
@@ -830,7 +827,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseStatementList
             next();
             if (!m_lexer->hasLineTerminatorBeforeToken()
                 && match(IDENT)
-                && *m_token.m_data.ident == m_vm.propertyNames->usingIdentifier
+                && m_token.m_data.ident == m_vm.propertyNames->usingIdentifier.impl()
                 && !m_token.m_data.escaped) {
                 next();
                 if (!m_lexer->hasLineTerminatorBeforeToken() && matchSpecIdentifier()) {
@@ -904,7 +901,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseDoWhileStatem
     ASSERT(match(DO));
     int startLine = tokenLine();
     next();
-    const Identifier* unused = nullptr;
+    UniquedStringImpl* unused = nullptr;
     startLoop();
     TreeStatement statement = parseStatement(context, unused);
     endLoop();
@@ -938,7 +935,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseWhileStatemen
     int endLine = tokenLine();
     handleProductionOrFail(CLOSEPAREN, ")", "end", "while loop condition");
 
-    const Identifier* unused = nullptr;
+    UniquedStringImpl* unused = nullptr;
     startLoop();
     TreeStatement statement = parseStatement(context, unused);
     endLoop();
@@ -953,7 +950,7 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseVariableDecl
     TreeExpression head = 0;
     JSTokenLocation headLocation;
     TreeExpression tail = 0;
-    const Identifier* lastIdent;
+    UniquedStringImpl* lastIdent;
     JSToken lastIdentToken;
     AssignmentContext assignmentContext = assignmentContextFromDeclarationType(declarationType);
     bool isUsingDeclaration = declarationType == DeclarationType::UsingDeclaration || declarationType == DeclarationType::AwaitUsingDeclaration;
@@ -963,7 +960,7 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseVariableDecl
         JSTokenLocation location(tokenLocation());
         next();
         if (!head && declarationType == DeclarationType::AwaitUsingDeclaration) {
-            ASSERT(match(IDENT) && *m_token.m_data.ident == m_vm.propertyNames->usingIdentifier);
+            ASSERT(match(IDENT) && m_token.m_data.ident == m_vm.propertyNames->usingIdentifier.impl());
             next();
         }
         if (head) {
@@ -988,25 +985,25 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseVariableDecl
             JSTextPosition varStart = tokenStartPosition();
             JSTokenLocation varStartLocation(tokenLocation());
             identStart = varStart;
-            const Identifier* name = m_token.m_data.ident;
+            UniquedStringImpl* name = m_token.m_data.ident;
             lastIdent = name;
             lastIdentToken = m_token;
             next();
             hasInitializer = match(EQUAL);
             DeclarationResultMask declarationResult = declareVariable(name, declarationType);
             if (declarationResult != DeclarationResult::Valid) {
-                failIfTrueIfStrict(declarationResult & DeclarationResult::InvalidStrictMode, "Cannot declare a variable named ", name->impl(), " in strict mode");
+                failIfTrueIfStrict(declarationResult & DeclarationResult::InvalidStrictMode, "Cannot declare a variable named ", name, " in strict mode");
                 if (declarationResult & DeclarationResult::InvalidDuplicateDeclaration) [[unlikely]] {
-                    semanticFailIfTrue(declarationType == DeclarationType::LetDeclaration, "Cannot declare a let variable twice: '", name->impl(), "'");
-                    semanticFailIfTrue(declarationType == DeclarationType::ConstDeclaration, "Cannot declare a const variable twice: '", name->impl(), "'");
-                    semanticFailIfTrue(isUsingDeclaration, "Cannot declare a using variable twice: '", name->impl(), "'");
+                    semanticFailIfTrue(declarationType == DeclarationType::LetDeclaration, "Cannot declare a let variable twice: '", name, "'");
+                    semanticFailIfTrue(declarationType == DeclarationType::ConstDeclaration, "Cannot declare a const variable twice: '", name, "'");
+                    semanticFailIfTrue(isUsingDeclaration, "Cannot declare a using variable twice: '", name, "'");
                     ASSERT(declarationType == DeclarationType::VarDeclaration);
-                    semanticFail("Cannot declare a var variable that shadows a let/const/class variable: '", name->impl(), "'");
+                    semanticFail("Cannot declare a var variable that shadows a let/const/class variable: '", name, "'");
                 }
             }
             if (exportType == ExportType::Exported) {
-                semanticFailIfFalse(exportName(*name), "Cannot export a duplicate name '", name->impl(), "'");
-                m_moduleScopeData->exportBinding(*name);
+                semanticFailIfFalse(exportName(name), "Cannot export a duplicate name '", name, "'");
+                m_moduleScopeData->exportBinding(name);
             }
 
             if (hasInitializer) {
@@ -1017,9 +1014,9 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseVariableDecl
                 TreeExpression initializer = parseAssignmentExpression(context);
                 initEnd = lastTokenEndPosition();
                 lastInitializer = initializer;
-                failIfFalse(initializer, "Expected expression as the intializer for the variable '", name->impl(), "'");
+                failIfFalse(initializer, "Expected expression as the intializer for the variable '", name, "'");
 
-                node = context.createAssignResolve(location, *name, initializer, varStart, varDivot, lastTokenEndPosition(), assignmentContext);
+                node = context.createAssignResolve(location, name, initializer, varStart, varDivot, lastTokenEndPosition(), assignmentContext);
             } else {
                 if (isUsingDeclaration) {
                     if (declarationListContext == ForLoopContext)
@@ -1029,11 +1026,11 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseVariableDecl
                 }
                 if (declarationListContext == ForLoopContext && declarationType == DeclarationType::ConstDeclaration)
                     forLoopConstDoesNotHaveInitializer = true;
-                failIfTrue(declarationListContext != ForLoopContext && declarationType == DeclarationType::ConstDeclaration, "const declared variable '", name->impl(), "'", " must have an initializer");
+                failIfTrue(declarationListContext != ForLoopContext && declarationType == DeclarationType::ConstDeclaration, "const declared variable '", name, "'", " must have an initializer");
                 if (declarationType == DeclarationType::VarDeclaration)
-                    node = context.createEmptyVarExpression(varStartLocation, *name);
+                    node = context.createEmptyVarExpression(varStartLocation, name);
                 else
-                    node = context.createEmptyLetExpression(varStartLocation, *name);
+                    node = context.createEmptyLetExpression(varStartLocation, name);
             }
         } else {
             lastIdent = nullptr;
@@ -1073,57 +1070,57 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseVariableDecl
         }
     } while (match(COMMA));
     if (lastIdent)
-        lastPattern = context.createBindingLocation(lastIdentToken.location(), *lastIdent, lastIdentToken.m_startPosition, lastIdentToken.m_endPosition, assignmentContext);
+        lastPattern = context.createBindingLocation(lastIdentToken.location(), lastIdent, lastIdentToken.m_startPosition, lastIdentToken.m_endPosition, assignmentContext);
 
     return head;
 }
 
 template <typename LexerType>
-bool Parser<LexerType>::declareRestOrNormalParameter(const Identifier& name, const Identifier** duplicateIdentifier)
+bool Parser<LexerType>::declareRestOrNormalParameter(UniquedStringImpl* name, UniquedStringImpl** duplicateIdentifier)
 {
-    DeclarationResultMask declarationResult = declareParameter(&name);
+    DeclarationResultMask declarationResult = declareParameter(name);
     if ((declarationResult & DeclarationResult::InvalidStrictMode) && strictMode()) [[unlikely]] {
-        semanticFailIfTrue(isEvalOrArguments(&name), "Cannot destructure to a parameter name '", name.impl(), "' in strict mode");
-        if (m_parserState.lastFunctionName && name == *m_parserState.lastFunctionName)
-            semanticFail("Cannot declare a parameter named '", name.impl(), "' as it shadows the name of a strict mode function");
+        semanticFailIfTrue(isEvalOrArguments(name), "Cannot destructure to a parameter name '", name, "' in strict mode");
+        if (m_parserState.lastFunctionName && name == m_parserState.lastFunctionName)
+            semanticFail("Cannot declare a parameter named '", name, "' as it shadows the name of a strict mode function");
         semanticFailureDueToKeyword("parameter name");
         if (!m_lexer->isReparsingFunction() && hasDeclaredParameter(name))
-            semanticFail("Cannot declare a parameter named '", name.impl(), "' in strict mode as it has already been declared");
-        semanticFail("Cannot declare a parameter named '", name.impl(), "' in strict mode");
+            semanticFail("Cannot declare a parameter named '", name, "' in strict mode as it has already been declared");
+        semanticFail("Cannot declare a parameter named '", name, "' in strict mode");
     }
     if (declarationResult & DeclarationResult::InvalidDuplicateDeclaration) {
         // It's not always an error to define a duplicate parameter.
         // It's only an error when there are default parameter values or destructuring parameters.
         // We note this value now so we can check it later.
         if (duplicateIdentifier)
-            *duplicateIdentifier = &name;
+            *duplicateIdentifier = name;
     }
 
     return true;
 }
 
 template <typename LexerType>
-template <class TreeBuilder> TreeDestructuringPattern Parser<LexerType>::createBindingPattern(TreeBuilder& context, DestructuringKind kind, ExportType exportType, const Identifier& name, const JSToken& token, AssignmentContext bindingContext, const Identifier** duplicateIdentifier)
+template <class TreeBuilder> TreeDestructuringPattern Parser<LexerType>::createBindingPattern(TreeBuilder& context, DestructuringKind kind, ExportType exportType, UniquedStringImpl* name, const JSToken& token, AssignmentContext bindingContext, UniquedStringImpl** duplicateIdentifier)
 {
-    ASSERT(!name.isNull());
-    
-    ASSERT(name.impl()->isAtom() || name.impl()->isSymbol());
+    ASSERT(name);
+
+    ASSERT(name->isAtom() || name->isSymbol());
 
     switch (kind) {
     case DestructuringKind::DestructureToVariables: {
-        DeclarationResultMask declarationResult = declareVariable(&name);
-        failIfTrueIfStrict(declarationResult & DeclarationResult::InvalidStrictMode, "Cannot declare a variable named '", name.impl(), "' in strict mode");
-        semanticFailIfTrue(declarationResult & DeclarationResult::InvalidDuplicateDeclaration, "Cannot declare a var variable that shadows a let/const/class variable: '", name.impl(), "'");
+        DeclarationResultMask declarationResult = declareVariable(name);
+        failIfTrueIfStrict(declarationResult & DeclarationResult::InvalidStrictMode, "Cannot declare a variable named '", name, "' in strict mode");
+        semanticFailIfTrue(declarationResult & DeclarationResult::InvalidDuplicateDeclaration, "Cannot declare a var variable that shadows a let/const/class variable: '", name, "'");
         break;
     }
 
     case DestructuringKind::DestructureToLet:
     case DestructuringKind::DestructureToConst:
     case DestructuringKind::DestructureToCatchParameters: {
-        DeclarationResultMask declarationResult = declareVariable(&name, kind == DestructuringKind::DestructureToConst ? DeclarationType::ConstDeclaration : DeclarationType::LetDeclaration);
+        DeclarationResultMask declarationResult = declareVariable(name, kind == DestructuringKind::DestructureToConst ? DeclarationType::ConstDeclaration : DeclarationType::LetDeclaration);
         if (declarationResult != DeclarationResult::Valid) {
-            failIfTrueIfStrict(declarationResult & DeclarationResult::InvalidStrictMode, "Cannot destructure to a variable named '", name.impl(), "' in strict mode");
-            failIfTrue(declarationResult & DeclarationResult::InvalidDuplicateDeclaration, "Cannot declare a lexical variable twice: '", name.impl(), "'");
+            failIfTrueIfStrict(declarationResult & DeclarationResult::InvalidStrictMode, "Cannot destructure to a variable named '", name, "' in strict mode");
+            failIfTrue(declarationResult & DeclarationResult::InvalidDuplicateDeclaration, "Cannot declare a lexical variable twice: '", name, "'");
         }
         break;
     }
@@ -1140,7 +1137,7 @@ template <class TreeBuilder> TreeDestructuringPattern Parser<LexerType>::createB
     }
 
     if (exportType == ExportType::Exported) {
-        semanticFailIfFalse(exportName(name), "Cannot export a duplicate name '", name.impl(), "'");
+        semanticFailIfFalse(exportName(name), "Cannot export a duplicate name '", name, "'");
         m_moduleScopeData->exportBinding(name);
     }
     return context.createBindingLocation(token.location(), name, token.m_startPosition, token.m_endPosition, bindingContext);
@@ -1184,7 +1181,7 @@ template <class TreeBuilder> TreeDestructuringPattern Parser<LexerType>::tryPars
 }
 
 template <typename LexerType>
-template <class TreeBuilder> TreeDestructuringPattern Parser<LexerType>::parseBindingOrAssignmentElement(TreeBuilder& context, DestructuringKind kind, ExportType exportType, const Identifier** duplicateIdentifier, bool* hasDestructuringPattern, AssignmentContext bindingContext, int depth)
+template <class TreeBuilder> TreeDestructuringPattern Parser<LexerType>::parseBindingOrAssignmentElement(TreeBuilder& context, DestructuringKind kind, ExportType exportType, UniquedStringImpl** duplicateIdentifier, bool* hasDestructuringPattern, AssignmentContext bindingContext, int depth)
 {
     if (kind == DestructuringKind::DestructureToExpressions)
         return parseAssignmentElement(context, kind, exportType, duplicateIdentifier, hasDestructuringPattern, bindingContext, depth);
@@ -1199,15 +1196,15 @@ template <class TreeBuilder> TreeDestructuringPattern Parser<LexerType>::parseOb
 
     semanticFailIfTrue(!element || !context.isAssignmentLocation(element), "Invalid destructuring assignment target");
     if (strictMode() && m_parserState.lastIdentifier && context.isResolve(element)) {
-        bool isEvalOrArguments = m_vm.propertyNames->eval == *m_parserState.lastIdentifier || m_vm.propertyNames->arguments == *m_parserState.lastIdentifier;
-        failIfTrue(isEvalOrArguments, "Cannot modify '", m_parserState.lastIdentifier->impl(), "' in strict mode");
+        bool isEvalOrArguments = m_vm.propertyNames->eval.impl() == m_parserState.lastIdentifier || m_vm.propertyNames->arguments.impl() == m_parserState.lastIdentifier;
+        failIfTrue(isEvalOrArguments, "Cannot modify '", m_parserState.lastIdentifier, "' in strict mode");
     }
 
     return createAssignmentElement(context, element, startPosition, lastTokenEndPosition());
 }
 
 template <typename LexerType>
-template <class TreeBuilder> TreeDestructuringPattern Parser<LexerType>::parseAssignmentElement(TreeBuilder& context, DestructuringKind kind, ExportType exportType, const Identifier** duplicateIdentifier, bool* hasDestructuringPattern, AssignmentContext bindingContext, int depth)
+template <class TreeBuilder> TreeDestructuringPattern Parser<LexerType>::parseAssignmentElement(TreeBuilder& context, DestructuringKind kind, ExportType exportType, UniquedStringImpl** duplicateIdentifier, bool* hasDestructuringPattern, AssignmentContext bindingContext, int depth)
 {
     TreeDestructuringPattern assignmentTarget = 0;
 
@@ -1225,8 +1222,8 @@ template <class TreeBuilder> TreeDestructuringPattern Parser<LexerType>::parseAs
     semanticFailIfFalse(element && context.isAssignmentLocation(element), "Invalid destructuring assignment target");
 
     if (strictMode() && m_parserState.lastIdentifier && context.isResolve(element)) {
-        bool isEvalOrArguments = m_vm.propertyNames->eval == *m_parserState.lastIdentifier || m_vm.propertyNames->arguments == *m_parserState.lastIdentifier;
-        failIfTrueIfStrict(isEvalOrArguments, "Cannot modify '", m_parserState.lastIdentifier->impl(), "' in strict mode");
+        bool isEvalOrArguments = m_vm.propertyNames->eval.impl() == m_parserState.lastIdentifier || m_vm.propertyNames->arguments.impl() == m_parserState.lastIdentifier;
+        failIfTrueIfStrict(isEvalOrArguments, "Cannot modify '", m_parserState.lastIdentifier, "' in strict mode");
     }
 
     return createAssignmentElement(context, element, startPosition, lastTokenEndPosition());
@@ -1252,25 +1249,25 @@ static const char* NODELETE destructuringKindToVariableKindName(DestructuringKin
 }
 
 template <typename LexerType>
-template <class TreeBuilder> TreeDestructuringPattern Parser<LexerType>::parseObjectRestElement(TreeBuilder& context, DestructuringKind kind, ExportType exportType, const Identifier** duplicateIdentifier, AssignmentContext bindingContext)
+template <class TreeBuilder> TreeDestructuringPattern Parser<LexerType>::parseObjectRestElement(TreeBuilder& context, DestructuringKind kind, ExportType exportType, UniquedStringImpl** duplicateIdentifier, AssignmentContext bindingContext)
 {
     ASSERT(kind != DestructuringKind::DestructureToExpressions);
     failIfStackOverflow();
     TreeDestructuringPattern pattern;
-    
+
     if (!matchSpecIdentifier()) [[unlikely]] {
         semanticFailureDueToKeyword(destructuringKindToVariableKindName(kind));
         failWithMessage("Expected a binding element");
     }
     failIfTrue(match(LET) && (kind == DestructuringKind::DestructureToLet || kind == DestructuringKind::DestructureToConst), "Cannot use 'let' as an identifier name for a LexicalDeclaration");
     semanticFailIfTrue(isDisallowedIdentifierAwait(m_token), "Cannot use 'await' as a ", destructuringKindToVariableKindName(kind), " ", disallowedIdentifierAwaitReason());
-    pattern = createBindingPattern(context, kind, exportType, *m_token.m_data.ident, m_token, bindingContext, duplicateIdentifier);
+    pattern = createBindingPattern(context, kind, exportType, m_token.m_data.ident, m_token, bindingContext, duplicateIdentifier);
     next();
     return pattern;
 }
 
 template <typename LexerType>
-template <class TreeBuilder> TreeDestructuringPattern Parser<LexerType>::parseObjectRestBindingOrAssignmentElement(TreeBuilder& context, DestructuringKind kind, ExportType exportType, const Identifier** duplicateIdentifier, AssignmentContext bindingContext)
+template <class TreeBuilder> TreeDestructuringPattern Parser<LexerType>::parseObjectRestBindingOrAssignmentElement(TreeBuilder& context, DestructuringKind kind, ExportType exportType, UniquedStringImpl** duplicateIdentifier, AssignmentContext bindingContext)
 {
     if (kind == DestructuringKind::DestructureToExpressions)
         return parseObjectRestAssignmentElement(context);
@@ -1278,7 +1275,7 @@ template <class TreeBuilder> TreeDestructuringPattern Parser<LexerType>::parseOb
 }
 
 template <typename LexerType>
-template <class TreeBuilder> TreeDestructuringPattern Parser<LexerType>::parseDestructuringPattern(TreeBuilder& context, DestructuringKind kind, ExportType exportType, const Identifier** duplicateIdentifier, bool* hasDestructuringPattern, AssignmentContext bindingContext, int depth)
+template <class TreeBuilder> TreeDestructuringPattern Parser<LexerType>::parseDestructuringPattern(TreeBuilder& context, DestructuringKind kind, ExportType exportType, UniquedStringImpl** duplicateIdentifier, bool* hasDestructuringPattern, AssignmentContext bindingContext, int depth)
 {
     failIfStackOverflow();
     m_parserState.assignmentCount++;
@@ -1361,7 +1358,7 @@ template <class TreeBuilder> TreeDestructuringPattern Parser<LexerType>::parseDe
                 break;
             }
 
-            const Identifier* propertyName = nullptr;
+            UniquedStringImpl* propertyName = nullptr;
             TreeExpression propertyExpression = 0;
             TreeDestructuringPattern innerPattern = 0;
             JSTokenLocation location = m_token.location();
@@ -1375,30 +1372,30 @@ template <class TreeBuilder> TreeDestructuringPattern Parser<LexerType>::parseDe
                     innerPattern = parseBindingOrAssignmentElement(context, kind, exportType, duplicateIdentifier, hasDestructuringPattern, bindingContext, depth + 1);
                 else {
                     semanticFailIfTrue(letMatched && (kind == DestructuringKind::DestructureToLet || kind == DestructuringKind::DestructureToConst), "Cannot use the keyword 'let' as a lexical variable name");
-                    semanticFailIfTrue(escapedKeyword, "Cannot use abbreviated destructuring syntax for keyword '", propertyName->impl(), "'");
+                    semanticFailIfTrue(escapedKeyword, "Cannot use abbreviated destructuring syntax for keyword '", propertyName, "'");
                     semanticFailIfTrue(isDisallowedIdentifierAwait(identifierToken), "Cannot use 'await' as a ", destructuringKindToVariableKindName(kind), " ", disallowedIdentifierAwaitReason());
                     if (kind == DestructuringKind::DestructureToExpressions) {
-                        bool isEvalOrArguments = m_vm.propertyNames->eval == *propertyName || m_vm.propertyNames->arguments == *propertyName;
-                        failIfTrueIfStrict(isEvalOrArguments, "Cannot modify '", propertyName->impl(), "' in strict mode");
+                        bool isEvalOrArguments = m_vm.propertyNames->eval.impl() == propertyName || m_vm.propertyNames->arguments.impl() == propertyName;
+                        failIfTrueIfStrict(isEvalOrArguments, "Cannot modify '", propertyName, "' in strict mode");
 
                         if (match(EQUAL))
-                            currentScope()->useVariable(propertyName, m_vm.propertyNames->eval == *propertyName);
+                            currentScope()->useVariable(propertyName, m_vm.propertyNames->eval.impl() == propertyName);
                     }
-                    innerPattern = createBindingPattern(context, kind, exportType, *propertyName, identifierToken, bindingContext, duplicateIdentifier);
+                    innerPattern = createBindingPattern(context, kind, exportType, propertyName, identifierToken, bindingContext, duplicateIdentifier);
                 }
             } else {
                 JSTokenType tokenType = m_token.m_type;
                 switch (m_token.m_type) {
                 case DOUBLE:
                 case INTEGER:
-                    propertyName = &m_parserArena.identifierArena().makeNumericIdentifier(const_cast<VM&>(m_vm), m_token.m_data.doubleValue);
+                    propertyName = m_parserArena.identifierArena().makeNumericIdentifier(const_cast<VM&>(m_vm), m_token.m_data.doubleValue);
                     break;
                 case STRING:
                     propertyName = m_token.m_data.ident;
                     wasString = true;
                     break;
                 case BIGINT:
-                    propertyName = m_parserArena.identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), *m_token.m_data.bigIntString, m_token.m_data.radix);
+                    propertyName = m_parserArena.identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), m_token.m_data.bigIntString, m_token.m_data.radix);
                     failIfFalse(propertyName, "Cannot parse big int property name");
                     break;
                 case OPENBRACKET:
@@ -1420,9 +1417,9 @@ template <class TreeBuilder> TreeDestructuringPattern Parser<LexerType>::parseDe
                 if (!consume(COLON)) {
                     if (kind == DestructuringKind::DestructureToExpressions) [[likely]]
                         return 0;
-                    semanticFailIfTrue(tokenType == RESERVED, "Cannot use abbreviated destructuring syntax for reserved name '", propertyName->impl(), "'");
-                    semanticFailIfTrue(tokenType == RESERVED_IF_STRICT, "Cannot use abbreviated destructuring syntax for reserved name '", propertyName->impl(), "' in strict mode");
-                    semanticFailIfTrue(tokenType & KeywordTokenFlag, "Cannot use abbreviated destructuring syntax for keyword '", propertyName->impl(), "'");
+                    semanticFailIfTrue(tokenType == RESERVED, "Cannot use abbreviated destructuring syntax for reserved name '", propertyName, "'");
+                    semanticFailIfTrue(tokenType == RESERVED_IF_STRICT, "Cannot use abbreviated destructuring syntax for reserved name '", propertyName, "' in strict mode");
+                    semanticFailIfTrue(tokenType & KeywordTokenFlag, "Cannot use abbreviated destructuring syntax for keyword '", propertyName, "'");
                     failWithMessage("Expected a ':' prior to a named destructuring property");
                 }
                 innerPattern = parseBindingOrAssignmentElement(context, kind, exportType, duplicateIdentifier, hasDestructuringPattern, bindingContext, depth + 1);
@@ -1437,7 +1434,7 @@ template <class TreeBuilder> TreeDestructuringPattern Parser<LexerType>::parseDe
                 context.setContainsComputedProperty(objectPattern, true);
             } else {
                 ASSERT(propertyName);
-                context.appendObjectPatternEntry(objectPattern, location, wasString, *propertyName, innerPattern, defaultValue);
+                context.appendObjectPatternEntry(objectPattern, location, wasString, propertyName, innerPattern, defaultValue);
             }
         } while (consume(COMMA));
 
@@ -1459,7 +1456,7 @@ template <class TreeBuilder> TreeDestructuringPattern Parser<LexerType>::parseDe
         }
         failIfTrue(match(LET) && (kind == DestructuringKind::DestructureToLet || kind == DestructuringKind::DestructureToConst), "Cannot use 'let' as an identifier name for a LexicalDeclaration");
         semanticFailIfTrue(isDisallowedIdentifierAwait(m_token), "Cannot use 'await' as a ", destructuringKindToVariableKindName(kind), " ", disallowedIdentifierAwaitReason());
-        pattern = createBindingPattern(context, kind, exportType, *m_token.m_data.ident, m_token, bindingContext, duplicateIdentifier);
+        pattern = createBindingPattern(context, kind, exportType, m_token.m_data.ident, m_token, bindingContext, duplicateIdentifier);
         next();
         break;
     }
@@ -1509,12 +1506,12 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseForStatement(
     bool isUsingDeclaration = false;
     bool isAwaitUsingDeclaration = false;
     if (Options::useExplicitResourceManagement() && match(IDENT)
-        && *m_token.m_data.ident == m_vm.propertyNames->usingIdentifier
+        && m_token.m_data.ident == m_vm.propertyNames->usingIdentifier.impl()
         && !m_token.m_data.escaped) {
         SavePoint savePoint = createSavePoint(context);
         next();
         if (!m_lexer->hasLineTerminatorBeforeToken() && matchSpecIdentifier()) {
-            if (matchContextualKeyword(m_vm.propertyNames->of)) {
+            if (matchContextualKeyword(m_vm.propertyNames->of.impl())) {
                 // "for (using of ..." - the spec has [lookahead != `using` `of`] on ForDeclaration,
                 // so this is only a using declaration if 'of' is a binding name with an initializer.
                 // "for (using of = init; ...)" -> using declaration, 'of' is binding name
@@ -1534,7 +1531,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseForStatement(
         next();
         if (!m_lexer->hasLineTerminatorBeforeToken()
             && match(IDENT)
-            && *m_token.m_data.ident == m_vm.propertyNames->usingIdentifier
+            && m_token.m_data.ident == m_vm.propertyNames->usingIdentifier.impl()
             && !m_token.m_data.escaped) {
             next();
             // Note: unlike sync `using`, there is no [lookahead != `of`] constraint for `await using`,
@@ -1607,7 +1604,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseForStatement(
         JSTextPosition inLocation = tokenStartPosition();
         bool isOfEnumeration = false;
         if (!match(INTOKEN)) {
-            failIfFalse(matchContextualKeyword(m_vm.propertyNames->of), "Expected either 'in' or 'of' in enumeration syntax");
+            failIfFalse(matchContextualKeyword(m_vm.propertyNames->of.impl()), "Expected either 'in' or 'of' in enumeration syntax");
             isOfEnumeration = true;
             next();
         } else {
@@ -1637,7 +1634,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseForStatement(
         
         handleProductionOrFail(CLOSEPAREN, ")", "end", (isOfEnumeration ? "for-of header" : "for-in header"));
         
-        const Identifier* unused = nullptr;
+        UniquedStringImpl* unused = nullptr;
         startLoop();
         TreeStatement statement = parseStatement(context, unused);
         endLoop();
@@ -1655,7 +1652,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseForStatement(
         if (match(OPENBRACE) || match(OPENBRACKET)) {
             SavePoint savePoint = createSavePoint(context);
             pattern = tryParseDestructuringPatternExpression(context, AssignmentContext::AssignmentExpression);
-            if (pattern && (match(INTOKEN) || matchContextualKeyword(m_vm.propertyNames->of)))
+            if (pattern && (match(INTOKEN) || matchContextualKeyword(m_vm.propertyNames->of.impl())))
                 goto enumerationLoop;
             pattern = TreeDestructuringPattern(0);
             restoreSavePoint(context, savePoint);
@@ -1693,7 +1690,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseForStatement(
         }
         int endLine = tokenLine();
         handleProductionOrFail(CLOSEPAREN, ")", "end", "for-loop header");
-        const Identifier* unused = nullptr;
+        UniquedStringImpl* unused = nullptr;
         startLoop();
         TreeStatement statement = parseStatement(context, unused);
         endLoop();
@@ -1708,7 +1705,7 @@ enumerationLoop:
     bool isOfEnumeration = false;
     JSTextPosition inLocation = tokenStartPosition();
     if (!match(INTOKEN)) {
-        failIfFalse(matchContextualKeyword(m_vm.propertyNames->of), "Expected either 'in' or 'of' in enumeration syntax");
+        failIfFalse(matchContextualKeyword(m_vm.propertyNames->of.impl()), "Expected either 'in' or 'of' in enumeration syntax");
         isOfEnumeration = true;
         next();
     } else {
@@ -1729,7 +1726,7 @@ enumerationLoop:
     int endLine = tokenLine();
     
     handleProductionOrFail(CLOSEPAREN, ")", "end", (isOfEnumeration ? "for-of header" : "for-in header"));
-    const Identifier* unused = nullptr;
+    UniquedStringImpl* unused = nullptr;
     startLoop();
     TreeStatement statement = parseStatement(context, unused);
     endLoop();
@@ -1769,11 +1766,11 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseBreakStatemen
 
     if (autoSemiColon()) {
         semanticFailIfFalse(isBreakValid.value_or(breakIsValid()), "'break' is only valid inside a switch or loop statement");
-        return context.createBreakStatement(location, &m_vm.propertyNames->nullIdentifier, start, end);
+        return context.createBreakStatement(location, nullptr, start, end);
     }
     failIfFalse(matchSpecIdentifier(), "Expected an identifier as the target for a break statement");
-    const Identifier* ident = m_token.m_data.ident;
-    semanticFailIfFalse(getLabel(ident), "Cannot use the undeclared label '", ident->impl(), "'");
+    UniquedStringImpl* ident = m_token.m_data.ident;
+    semanticFailIfFalse(getLabel(ident), "Cannot use the undeclared label '", ident, "'");
     end = tokenEndPosition();
     next();
     failIfFalse(autoSemiColon(), "Expected a ';' following a targeted break statement");
@@ -1797,13 +1794,13 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseContinueState
 
     if (autoSemiColon()) {
         semanticFailIfFalse(isContinueValid.value_or(continueIsValid()), "'continue' is only valid inside a loop statement");
-        return context.createContinueStatement(location, &m_vm.propertyNames->nullIdentifier, start, end);
+        return context.createContinueStatement(location, nullptr, start, end);
     }
     failIfFalse(matchSpecIdentifier(), "Expected an identifier as the target for a continue statement");
-    const Identifier* ident = m_token.m_data.ident;
+    UniquedStringImpl* ident = m_token.m_data.ident;
     ScopeLabelInfo* label = getLabel(ident);
-    semanticFailIfFalse(label, "Cannot use the undeclared label '", ident->impl(), "'");
-    semanticFailIfFalse(label->isLoop, "Cannot continue to the label '", ident->impl(), "' as it is not targeting a loop");
+    semanticFailIfFalse(label, "Cannot use the undeclared label '", ident, "'");
+    semanticFailIfFalse(label->isLoop, "Cannot continue to the label '", ident, "' as it is not targeting a loop");
     end = tokenEndPosition();
     next();
     failIfFalse(autoSemiColon(), "Expected a ';' following a targeted continue statement");
@@ -1878,7 +1875,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseWithStatement
     withScope->setTaintedByWithScope();
     withScope->preventAllVariableDeclarations();
 
-    const Identifier* unused = nullptr;
+    UniquedStringImpl* unused = nullptr;
     TreeStatement statement = parseStatement(context, unused);
     failIfFalse(statement, "A 'with' statement must have a body");
     
@@ -2002,13 +1999,13 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseTryStatement(
             AutoPopScope catchScope(this, pushScope());
             catchScope->setIsLexicalScope();
             catchScope->preventVarDeclarations();
-            const Identifier* ident = nullptr;
+            UniquedStringImpl* ident = nullptr;
             if (matchSpecIdentifier()) {
                 catchScope->setIsSimpleCatchParameterScope();
                 ident = m_token.m_data.ident;
-                catchPattern = context.createBindingLocation(m_token.location(), *ident, m_token.m_startPosition, m_token.m_endPosition, AssignmentContext::DeclarationStatement);
+                catchPattern = context.createBindingLocation(m_token.location(), ident, m_token.m_startPosition, m_token.m_endPosition, AssignmentContext::DeclarationStatement);
                 next();
-                failIfTrueIfStrict(catchScope->declareLexicalVariable(ident, false) & DeclarationResult::InvalidStrictMode, "Cannot declare a catch variable named '", ident->impl(), "' in strict mode");
+                failIfTrueIfStrict(catchScope->declareLexicalVariable(ident, false) & DeclarationResult::InvalidStrictMode, "Cannot declare a catch variable named '", ident, "' in strict mode");
             } else {
                 catchPattern = parseDestructuringPattern(context, DestructuringKind::DestructureToCatchParameters, ExportType::NotExported);
                 failIfFalse(catchPattern, "Cannot parse this destructuring pattern");
@@ -2018,11 +2015,11 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseTryStatement(
             catchBlock = parseBlockStatement(context, BlockType::CatchBlock);
             failIfFalse(catchBlock, "Unable to parse 'catch' block");
             // Handle `try { } catch (/* never used */ error) { }`
-            if (ident && !catchScope->usedVariablesContains(ident->impl()) && !catchScope->usesEval() && !catchScope->hasVariableBeingHoisted(ident->impl()))
+            if (ident && !catchScope->usedVariablesContains(ident) && !catchScope->usesEval() && !catchScope->hasVariableBeingHoisted(ident))
                 catchPattern = 0;
             std::tie(catchEnvironment, functionStack) = popScope(catchScope, TreeBuilder::NeedsFreeVariableInfo);
             ASSERT(functionStack.isEmpty());
-            RELEASE_ASSERT(!ident || (catchEnvironment.size() == 1 && catchEnvironment.contains(ident->impl())));
+            RELEASE_ASSERT(!ident || (catchEnvironment.size() == 1 && catchEnvironment.contains(ident)));
         }
     }
     
@@ -2121,7 +2118,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseBlockStatemen
 }
 
 template <typename LexerType>
-template <class TreeBuilder> TreeStatement Parser<LexerType>::parseStatement(TreeBuilder& context, const Identifier*& directive, unsigned* directiveLiteralLength)
+template <class TreeBuilder> TreeStatement Parser<LexerType>::parseStatement(TreeBuilder& context, UniquedStringImpl*& directive, unsigned* directiveLiteralLength)
 {
     DepthManager statementDepth(&m_statementDepth);
     m_statementDepth++;
@@ -2277,17 +2274,17 @@ template <class TreeBuilder> bool Parser<LexerType>::parseFormalParameters(TreeB
 {
 #define failIfDuplicateIfViolation() \
     if (duplicateParameter) {\
-        semanticFailIfTrue(hasDefaultParameterValues, "Duplicate parameter '", duplicateParameter->impl(), "' not allowed in function with default parameter values");\
-        semanticFailIfTrue(hasDestructuringPattern, "Duplicate parameter '", duplicateParameter->impl(), "' not allowed in function with destructuring parameters");\
-        semanticFailIfTrue(isRestParameter, "Duplicate parameter '", duplicateParameter->impl(), "' not allowed in function with a rest parameter");\
-        semanticFailIfTrue(isArrowFunction, "Duplicate parameter '", duplicateParameter->impl(), "' not allowed in an arrow function");\
-        semanticFailIfTrue(isMethod, "Duplicate parameter '", duplicateParameter->impl(), "' not allowed in a method");\
+        semanticFailIfTrue(hasDefaultParameterValues, "Duplicate parameter '", duplicateParameter, "' not allowed in function with default parameter values");\
+        semanticFailIfTrue(hasDestructuringPattern, "Duplicate parameter '", duplicateParameter, "' not allowed in function with destructuring parameters");\
+        semanticFailIfTrue(isRestParameter, "Duplicate parameter '", duplicateParameter, "' not allowed in function with a rest parameter");\
+        semanticFailIfTrue(isArrowFunction, "Duplicate parameter '", duplicateParameter, "' not allowed in an arrow function");\
+        semanticFailIfTrue(isMethod, "Duplicate parameter '", duplicateParameter, "' not allowed in a method");\
     }
 
     bool hasDefaultParameterValues = false;
     bool hasDestructuringPattern = false;
     bool isRestParameter = false;
-    const Identifier* duplicateParameter = nullptr;
+    UniquedStringImpl* duplicateParameter = nullptr;
     unsigned restParameterStart = 0;
     do {
         TreeDestructuringPattern parameter = 0;
@@ -2515,14 +2512,14 @@ template <typename LexerType> template <class TreeBuilder, class FunctionInfoTyp
         functionInfo.parameterCount = 0;
     } else if (mode == SourceParseMode::SetterMode) {
         failIfTrue(match(CLOSEPAREN), "setter functions must have one parameter");
-        const Identifier* duplicateParameter = nullptr;
+        UniquedStringImpl* duplicateParameter = nullptr;
         bool hasDestructuringPattern = false;
         auto parameter = parseDestructuringPattern(context, DestructuringKind::DestructureToParameters, ExportType::NotExported, &duplicateParameter, &hasDestructuringPattern);
         failIfFalse(parameter, "setter functions must have one parameter");
         auto defaultValue = parseDefaultValueForDestructuringPattern(context);
         propagateError();
         if (defaultValue || hasDestructuringPattern) {
-            semanticFailIfTrue(duplicateParameter, "Duplicate parameter '", duplicateParameter->impl(), "' not allowed in function with non-simple parameter list");
+            semanticFailIfTrue(duplicateParameter, "Duplicate parameter '", duplicateParameter, "' not allowed in function with non-simple parameter list");
             currentScope()->setHasNonSimpleParameterList();
         }
         context.appendParameter(parameterList, parameter, defaultValue);
@@ -2551,23 +2548,23 @@ template <class TreeBuilder> typename TreeBuilder::FormalParameterList Parser<Le
     JSTokenLocation location(tokenLocation());
     JSTextPosition position = tokenStartPosition();
 
-    auto addParameter = [&](const Identifier& name) {
-        declareParameter(&name);
+    auto addParameter = [&](UniquedStringImpl* name) {
+        declareParameter(name);
         auto binding = context.createBindingLocation(location, name, position, position, AssignmentContext::DeclarationStatement);
         context.appendParameter(parameters, binding, 0);
         ++parameterCount;
     };
 
     // @generator
-    addParameter(m_vm.propertyNames->generatorPrivateName);
+    addParameter(m_vm.propertyNames->generatorPrivateName.impl());
     // @generatorState
-    addParameter(m_vm.propertyNames->generatorStatePrivateName);
+    addParameter(m_vm.propertyNames->generatorStatePrivateName.impl());
     // @generatorValue
-    addParameter(m_vm.propertyNames->generatorValuePrivateName);
+    addParameter(m_vm.propertyNames->generatorValuePrivateName.impl());
     // @generatorResumeMode
-    addParameter(m_vm.propertyNames->generatorResumeModePrivateName);
+    addParameter(m_vm.propertyNames->generatorResumeModePrivateName.impl());
     // @generatorFrame
-    addParameter(m_vm.propertyNames->generatorFramePrivateName);
+    addParameter(m_vm.propertyNames->generatorFramePrivateName.impl());
 
     return parameters;
 }
@@ -2593,7 +2590,7 @@ template <class TreeBuilder> bool Parser<LexerType>::parseFunctionInfo(TreeBuild
 
     SetForScope functionParsePhasePoisoner(m_parserState.functionParsePhase, FunctionParsePhase::Body);
     int functionNameStart = m_token.m_startPosition.offset;
-    const Identifier* lastFunctionName = m_parserState.lastFunctionName;
+    UniquedStringImpl* lastFunctionName = m_parserState.lastFunctionName;
     m_parserState.lastFunctionName = nullptr;
     int parametersStart = -1;
     JSTokenLocation startLocation;
@@ -2735,7 +2732,6 @@ template <class TreeBuilder> bool Parser<LexerType>::parseFunctionInfo(TreeBuild
             canUseYield &= !parentScope->isGeneratorFunction();
 
         if (requirements != FunctionNameRequirements::Unnamed) {
-            ASSERT_WITH_MESSAGE(!(requirements == FunctionNameRequirements::None && !functionInfo.name), "When specifying FunctionNameRequirements::None, we need to initialize functionInfo.name with the default value in the caller side.");
             if (matchSpecIdentifier(canUseYield, functionNameIsAwait)) {
                 functionInfo.name = m_token.m_data.ident;
                 m_parserState.lastFunctionName = functionInfo.name;
@@ -2747,7 +2743,7 @@ template <class TreeBuilder> bool Parser<LexerType>::parseFunctionInfo(TreeBuild
                     semanticFail("Cannot declare ", stringForFunctionMode(mode), " named 'yield'");
                 next();
                 if (!nameIsInContainingScope)
-                    failIfTrueIfStrict(functionScope->declareCallee(functionInfo.name) & DeclarationResult::InvalidStrictMode, "'", functionInfo.name->impl(), "' is not a valid ", stringForFunctionMode(mode), " name in strict mode");
+                    failIfTrueIfStrict(functionScope->declareCallee(functionInfo.name) & DeclarationResult::InvalidStrictMode, "'", functionInfo.name, "' is not a valid ", stringForFunctionMode(mode), " name in strict mode");
             } else if (requirements == FunctionNameRequirements::Named) [[unlikely]] {
                 if (match(OPENPAREN)) {
                     semanticFailIfTrue(mode == SourceParseMode::NormalFunctionMode, "Function statements must have a name");
@@ -2756,7 +2752,7 @@ template <class TreeBuilder> bool Parser<LexerType>::parseFunctionInfo(TreeBuild
                 semanticFailureDueToKeyword(stringForFunctionMode(mode), " name");
                 failDueToUnexpectedToken();
             }
-            ASSERT(functionInfo.name);
+            // Note: functionInfo.name may be null for FunctionNameRequirements::None (anonymous function expressions).
         }
 
         startLocation = tokenLocation();
@@ -2848,11 +2844,11 @@ template <class TreeBuilder> bool Parser<LexerType>::parseFunctionInfo(TreeBuild
     failIfFalse(functionInfo.body, "Cannot parse the body of this ", stringForFunctionMode(mode));
     context.setEndOffset(functionInfo.body, m_lexer->currentOffset());
     if (functionScope->strictMode() && requirements != FunctionNameRequirements::Unnamed) {
-        ASSERT(functionInfo.name);
+        ASSERT(requirements != FunctionNameRequirements::Named || functionInfo.name);
         RELEASE_ASSERT(SourceParseModeSet(SourceParseMode::NormalFunctionMode, SourceParseMode::MethodMode, SourceParseMode::ArrowFunctionMode, SourceParseMode::GeneratorBodyMode, SourceParseMode::GeneratorWrapperFunctionMode, SourceParseMode::ClassStaticBlockMode).contains(mode) || isAsyncFunctionOrAsyncGeneratorWrapperParseMode(mode));
-        semanticFailIfTrue(m_vm.propertyNames->arguments == *functionInfo.name, "'", functionInfo.name->impl(), "' is not a valid function name in strict mode");
-        semanticFailIfTrue(m_vm.propertyNames->eval == *functionInfo.name, "'", functionInfo.name->impl(), "' is not a valid function name in strict mode");
-        semanticFailIfTrue(m_vm.propertyNames->yieldKeyword == *functionInfo.name, "'", functionInfo.name->impl(), "' is not a valid function name in strict mode");
+        semanticFailIfTrue(m_vm.propertyNames->arguments.impl() == functionInfo.name, "'", functionInfo.name, "' is not a valid function name in strict mode");
+        semanticFailIfTrue(m_vm.propertyNames->eval.impl() == functionInfo.name, "'", functionInfo.name, "' is not a valid function name in strict mode");
+        semanticFailIfTrue(m_vm.propertyNames->yieldKeyword.impl() == functionInfo.name, "'", functionInfo.name, "' is not a valid function name in strict mode");
     }
 
     JSTokenLocation location = m_token.location();
@@ -2958,7 +2954,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseFunctionDecla
         //
         // In this case, we use "*default*" as this function declaration's name.
         requirements = FunctionNameRequirements::None;
-        functionInfo.name = &m_vm.propertyNames->starDefaultPrivateName;
+        functionInfo.name = m_vm.propertyNames->starDefaultPrivateName.impl();
     }
 
     failIfFalse((parseFunctionInfo(context, requirements, true, ConstructorKind::None, SuperBinding::NotNeeded, functionStart, functionInfo, FunctionDefinitionType::Declaration, functionConstructorParametersEndPosition)), "Cannot parse this function");
@@ -2966,12 +2962,12 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseFunctionDecla
 
     std::pair<DeclarationResultMask, Scope*> functionDeclaration = declareFunction(functionInfo.name);
     DeclarationResultMask declarationResult = functionDeclaration.first;
-    failIfTrueIfStrict(declarationResult & DeclarationResult::InvalidStrictMode, "Cannot declare a function named '", functionInfo.name->impl(), "' in strict mode");
-    semanticFailIfTrue(declarationResult & DeclarationResult::InvalidDuplicateDeclaration, "Cannot declare a function that shadows a let/const/class/function variable '", functionInfo.name->impl(), "'");
+    failIfTrueIfStrict(declarationResult & DeclarationResult::InvalidStrictMode, "Cannot declare a function named '", functionInfo.name, "' in strict mode");
+    semanticFailIfTrue(declarationResult & DeclarationResult::InvalidDuplicateDeclaration, "Cannot declare a function that shadows a let/const/class/function variable '", functionInfo.name, "'");
     if (exportType == ExportType::Exported) {
         ASSERT_WITH_MESSAGE(declarationDefaultContext != DeclarationDefaultContext::ExportDefault, "Export default case will export the name and binding in the caller.");
-        semanticFailIfFalse(exportName(*functionInfo.name), "Cannot export a duplicate function name: '", functionInfo.name->impl(), "'");
-        m_moduleScopeData->exportBinding(*functionInfo.name);
+        semanticFailIfFalse(exportName(functionInfo.name), "Cannot export a duplicate function name: '", functionInfo.name, "'");
+        m_moduleScopeData->exportBinding(functionInfo.name);
     }
 
     TreeStatement result = context.createFuncDeclStatement(location, functionInfo);
@@ -3029,7 +3025,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseAsyncFunction
         //
         // In this case, we use "*default*" as this function declaration's name.
         requirements = FunctionNameRequirements::None;
-        functionInfo.name = &m_vm.propertyNames->starDefaultPrivateName;
+        functionInfo.name = m_vm.propertyNames->starDefaultPrivateName.impl();
     }
 
     failIfFalse((parseFunctionInfo(context, requirements, true, ConstructorKind::None, SuperBinding::NotNeeded, functionStart, functionInfo, FunctionDefinitionType::Declaration, functionConstructorParametersEndPosition)), "Cannot parse this async function");
@@ -3037,11 +3033,11 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseAsyncFunction
 
     std::pair<DeclarationResultMask, Scope*> functionDeclaration = declareFunction(functionInfo.name);
     DeclarationResultMask declarationResult = functionDeclaration.first;
-    failIfTrueIfStrict(declarationResult & DeclarationResult::InvalidStrictMode, "Cannot declare an async function named '", functionInfo.name->impl(), "' in strict mode");
-    semanticFailIfTrue(declarationResult & DeclarationResult::InvalidDuplicateDeclaration, "Cannot declare an async function that shadows a let/const/class/function variable '", functionInfo.name->impl(), "'");
+    failIfTrueIfStrict(declarationResult & DeclarationResult::InvalidStrictMode, "Cannot declare an async function named '", functionInfo.name, "' in strict mode");
+    semanticFailIfTrue(declarationResult & DeclarationResult::InvalidDuplicateDeclaration, "Cannot declare an async function that shadows a let/const/class/function variable '", functionInfo.name, "'");
     if (exportType == ExportType::Exported) {
-        semanticFailIfFalse(exportName(*functionInfo.name), "Cannot export a duplicate function name: '", functionInfo.name->impl(), "'");
-        m_moduleScopeData->exportBinding(*functionInfo.name);
+        semanticFailIfFalse(exportName(functionInfo.name), "Cannot export a duplicate function name: '", functionInfo.name, "'");
+        m_moduleScopeData->exportBinding(functionInfo.name);
     }
 
     TreeStatement result = context.createFuncDeclStatement(location, functionInfo);
@@ -3074,7 +3070,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseClassDeclarat
         //
         // In this case, we use "*default*" as this class declaration's name.
         requirements = FunctionNameRequirements::None;
-        info.className = &m_vm.propertyNames->starDefaultPrivateName;
+        info.className = m_vm.propertyNames->starDefaultPrivateName.impl();
     }
 
     TreeClassExpression classExpr = parseClass(context, requirements, info);
@@ -3082,11 +3078,11 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseClassDeclarat
     ASSERT(info.className);
 
     DeclarationResultMask declarationResult = declareVariable(info.className, DeclarationType::LetDeclaration);
-    semanticFailIfTrue(declarationResult & DeclarationResult::InvalidDuplicateDeclaration, "Cannot declare a class twice: '", info.className->impl(), "'");
+    semanticFailIfTrue(declarationResult & DeclarationResult::InvalidDuplicateDeclaration, "Cannot declare a class twice: '", info.className, "'");
     if (exportType == ExportType::Exported) {
         ASSERT_WITH_MESSAGE(declarationDefaultContext != DeclarationDefaultContext::ExportDefault, "Export default case will export the name and binding in the caller.");
-        semanticFailIfFalse(exportName(*info.className), "Cannot export a duplicate class name: '", info.className->impl(), "'");
-        m_moduleScopeData->exportBinding(*info.className);
+        semanticFailIfFalse(exportName(info.className), "Cannot export a duplicate class name: '", info.className, "'");
+        m_moduleScopeData->exportBinding(info.className);
     }
 
     JSTextPosition classEnd = lastTokenEndPosition();
@@ -3131,17 +3127,16 @@ template <class TreeBuilder> TreeClassExpression Parser<LexerType>::parseClass(T
     semanticFailIfTrue(currentScope()->isStaticBlock() && match(AWAIT), "Cannot use 'await' as a class name within static block");
 
     ASSERT_WITH_MESSAGE(requirements != FunctionNameRequirements::Unnamed, "Currently, there is no caller that uses FunctionNameRequirements::Unnamed for class syntax.");
-    ASSERT_WITH_MESSAGE(!(requirements == FunctionNameRequirements::None && !info.className), "When specifying FunctionNameRequirements::None, we need to initialize info.className with the default value in the caller side.");
     if (match(IDENT) || isAllowedIdentifierAwait(m_token)) {
         info.className = m_token.m_data.ident;
         next();
-        failIfTrue(classHeadScope->declareLexicalVariable(info.className, true) & DeclarationResult::InvalidStrictMode, "'", info.className->impl(), "' is not a valid class name");
+        failIfTrue(classHeadScope->declareLexicalVariable(info.className, true) & DeclarationResult::InvalidStrictMode, "'", info.className, "' is not a valid class name");
     } else if (requirements == FunctionNameRequirements::Named) [[unlikely]] {
         semanticFailIfTrue(match(OPENBRACE), "Class statements must have a name");
         semanticFailureDueToKeyword("class name");
         failDueToUnexpectedToken();
     }
-    ASSERT(info.className);
+    ASSERT(requirements == FunctionNameRequirements::None || info.className);
 
     JSTextPosition divot = start;
     TreeExpression parentClass = 0;
@@ -3182,7 +3177,7 @@ template <class TreeBuilder> TreeClassExpression Parser<LexerType>::parseClass(T
         ClassElementTag tag = ClassElementTag::Instance;
         SourceParseMode parseMode = SourceParseMode::MethodMode;
         auto type = PropertyNode::Constant;
-        if (match(RESERVED_IF_STRICT) && *m_token.m_data.ident == m_vm.propertyNames->staticKeyword) {
+        if (match(RESERVED_IF_STRICT) && m_token.m_data.ident == m_vm.propertyNames->staticKeyword.impl()) {
             SavePoint savePoint = createSavePoint(context);
             next();
             if (match(OPENPAREN) || match(SEMICOLON) || match(EQUAL)) {
@@ -3198,7 +3193,7 @@ template <class TreeBuilder> TreeClassExpression Parser<LexerType>::parseClass(T
 
         // FIXME: Figure out a way to share more code with parseProperty.
         const CommonIdentifiers& propertyNames = *m_vm.propertyNames;
-        const Identifier* ident = &propertyNames.nullIdentifier;
+        UniquedStringImpl* ident = nullptr;
         TreeExpression computedPropertyName = 0;
         bool isGetter = false;
         bool isSetter = false;
@@ -3214,18 +3209,18 @@ parseMethod:
             next();
             break;
         case BIGINT:
-            ident = m_parserArena.identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), *m_token.m_data.bigIntString, m_token.m_data.radix);
+            ident = m_parserArena.identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), m_token.m_data.bigIntString, m_token.m_data.radix);
             failIfFalse(ident, "Cannot parse big int property name");
             next();
             break;
         case ESCAPED_KEYWORD:
         case IDENT:
-            if (*m_token.m_data.ident == m_vm.propertyNames->async && !m_token.m_data.escaped) [[unlikely]] {
+            if (m_token.m_data.ident == m_vm.propertyNames->async.impl() && !m_token.m_data.escaped) [[unlikely]] {
                 if (!isGeneratorMethodParseMode(parseMode) && !isAsyncMethodParseMode(parseMode)) {
                     next();
                     // We match SEMICOLON as a special case for a field called 'async' without initializer.
                     if (match(OPENPAREN) || match(COLON) || match(SEMICOLON) || match(EQUAL) || m_lexer->hasLineTerminatorBeforeToken()) {
-                        ident = &m_vm.propertyNames->async;
+                        ident = m_vm.propertyNames->async.impl();
                         break;
                     }
                     if (consume(TIMES)) [[unlikely]]
@@ -3242,14 +3237,14 @@ parseMethod:
             ASSERT(ident);
             next();
             if (parseMode == SourceParseMode::MethodMode && !escaped && (matchIdentifierOrKeyword() || match(STRING) || match(DOUBLE) || match(INTEGER) || match(BIGINT) || match(OPENBRACKET) || match(PRIVATENAME))) {
-                isGetter = *ident == propertyNames.get;
-                isSetter = *ident == propertyNames.set;
+                isGetter = ident == propertyNames.get.impl();
+                isSetter = ident == propertyNames.set.impl();
             }
             break;
         }
         case DOUBLE:
         case INTEGER:
-            ident = &m_parserArena.identifierArena().makeNumericIdentifier(const_cast<VM&>(m_vm), m_token.m_data.doubleValue);
+            ident = m_parserArena.identifierArena().makeNumericIdentifier(const_cast<VM&>(m_vm), m_token.m_data.doubleValue);
             ASSERT(ident);
             next();
             break;
@@ -3267,8 +3262,8 @@ parseMethod:
             ASSERT(ident);
             next();
             if (match(OPENPAREN)) {
-                semanticFailIfTrue(classScope->declarePrivateMethod(*ident, tag) & DeclarationResult::InvalidDuplicateDeclaration, "Cannot declare private method twice");
-                semanticFailIfTrue(*ident == propertyNames.constructorPrivateField, "Cannot declare a private method named '#constructor'");
+                semanticFailIfTrue(classScope->declarePrivateMethod(ident, tag) & DeclarationResult::InvalidDuplicateDeclaration, "Cannot declare private method twice");
+                semanticFailIfTrue(ident == propertyNames.constructorPrivateField.impl(), "Cannot declare a private method named '#constructor'");
 
                 if (tag == ClassElementTag::Static)
                     declaresStaticPrivateMethod = true;
@@ -3280,7 +3275,7 @@ parseMethod:
             }
 
             failIfTrue(match(OPENPAREN), "Cannot parse class method with private name");
-            semanticFailIfTrue(classScope->declarePrivateField(*ident) & DeclarationResult::InvalidDuplicateDeclaration, "Cannot declare private field twice");
+            semanticFailIfTrue(classScope->declarePrivateField(ident) & DeclarationResult::InvalidDuplicateDeclaration, "Cannot declare private field twice");
             type = static_cast<PropertyNode::Type>(type | PropertyNode::PrivateField);
             break;
         }
@@ -3299,7 +3294,7 @@ parseMethod:
             if (match(PRIVATENAME)) {
                 ident = m_token.m_data.ident;
 
-                auto declarationResult = isSetter ? classScope->declarePrivateSetter(*ident, tag) : classScope->declarePrivateGetter(*ident, tag);
+                auto declarationResult = isSetter ? classScope->declarePrivateSetter(ident, tag) : classScope->declarePrivateGetter(ident, tag);
                 semanticFailIfTrue(declarationResult & DeclarationResult::InvalidDuplicateDeclaration, "Declared private setter with an already used name");
                 if (tag == ClassElementTag::Static) {
                     semanticFailIfTrue(declarationResult & DeclarationResult::InvalidPrivateStaticNonStatic, "Cannot declare a private static ", (isSetter ? "setter" : "getter")  , " if there is a non-static private ", (isSetter ? "getter" : "setter"), " with used name");
@@ -3311,7 +3306,7 @@ parseMethod:
 
                 if (isSetter)
                     type = static_cast<PropertyNode::Type>(type | PropertyNode::PrivateSetter);
-                else 
+                else
                     type = static_cast<PropertyNode::Type>(type | PropertyNode::PrivateGetter);
             } else {
                 type = static_cast<PropertyNode::Type>(type & ~PropertyNode::Constant);
@@ -3322,21 +3317,21 @@ parseMethod:
         } else if (!match(OPENPAREN) && parseMode == SourceParseMode::MethodMode) {
             ASSERT(!isGetter && !isSetter);
             if (ident) {
-                semanticFailIfTrue(*ident == propertyNames.constructor, "Cannot declare class field named 'constructor'");
-                semanticFailIfTrue(*ident == propertyNames.constructorPrivateField, "Cannot declare private class field named '#constructor'");
+                semanticFailIfTrue(ident == propertyNames.constructor.impl(), "Cannot declare class field named 'constructor'");
+                semanticFailIfTrue(ident == propertyNames.constructorPrivateField.impl(), "Cannot declare private class field named '#constructor'");
                 if (tag == ClassElementTag::Static)
-                    semanticFailIfTrue(*ident == propertyNames.prototype, "Cannot declare a static field named 'prototype'");
+                    semanticFailIfTrue(ident == propertyNames.prototype.impl(), "Cannot declare a static field named 'prototype'");
             }
 
             if (computedPropertyName) {
                 if (tag == ClassElementTag::Instance)
-                    ident = &m_parserArena.identifierArena().makePrivateIdentifier(m_vm, instanceComputedNamePrefix, nextInstanceComputedFieldID++);
+                    ident = m_parserArena.identifierArena().makePrivateIdentifier(m_vm, instanceComputedNamePrefix, nextInstanceComputedFieldID++);
                 else
-                    ident = &m_parserArena.identifierArena().makePrivateIdentifier(m_vm, staticComputedNamePrefix, nextStaticComputedFieldID++);
+                    ident = m_parserArena.identifierArena().makePrivateIdentifier(m_vm, staticComputedNamePrefix, nextStaticComputedFieldID++);
                 DeclarationResultMask declarationResult = classScope->declareLexicalVariable(ident, true);
                 ASSERT_UNUSED(declarationResult, declarationResult == DeclarationResult::Valid);
                 classScope->useVariable(ident, false);
-                classScope->addClosedVariableCandidateUnconditionally(ident->impl());
+                classScope->addClosedVariableCandidateUnconditionally(ident);
             }
 
             TreeExpression initializer = 0;
@@ -3365,12 +3360,12 @@ parseMethod:
             m_statementDepth = 0;
             failIfFalse(parseBlockStatement(context, BlockType::StaticBlock), "Cannot parse class static block");
             auto* symbolImpl = std::bit_cast<SymbolImpl*>(m_vm.propertyNames->builtinNames().staticInitializerBlockPrivateName().impl());
-            ident = &m_parserArena.identifierArena().makeIdentifier(const_cast<VM&>(m_vm), symbolImpl);
+            ident = m_parserArena.identifierArena().makeIdentifier(const_cast<VM&>(m_vm), symbolImpl);
             property = context.createProperty(ident, type, SuperBinding::Needed, tag);
             classScope->markLastUsedVariablesSetAsCaptured(usedVariablesSize);
         } else {
             ParserFunctionInfo<TreeBuilder> methodInfo;
-            bool isConstructor = tag == ClassElementTag::Instance && *ident == propertyNames.constructor;
+            bool isConstructor = tag == ClassElementTag::Instance && ident == propertyNames.constructor.impl();
             semanticFailIfTrue(isConstructor && parseMode != SourceParseMode::MethodMode,
                 "Cannot declare ", stringArticleForFunctionMode(parseMode), stringForFunctionMode(parseMode), " named 'constructor'");
 
@@ -3385,7 +3380,7 @@ parseMethod:
                 continue;
             }
 
-            semanticFailIfTrue(tag == ClassElementTag::Static && methodInfo.name && *methodInfo.name == propertyNames.prototype,
+            semanticFailIfTrue(tag == ClassElementTag::Static && methodInfo.name && methodInfo.name == propertyNames.prototype.impl(),
                 "Cannot declare a static method named 'prototype'");
 
             if (computedPropertyName)
@@ -3406,16 +3401,16 @@ parseMethod:
     if (declaresPrivateMethod || declaresPrivateAccessor || declaresStaticPrivateMethod || declaresStaticPrivateAccessor) {
         {
             Identifier privateBrandIdentifier = m_vm.propertyNames->builtinNames().privateBrandPrivateName();
-            DeclarationResultMask declarationResult = classScope->declareLexicalVariable(&privateBrandIdentifier, true);
+            DeclarationResultMask declarationResult = classScope->declareLexicalVariable(privateBrandIdentifier.impl(), true);
             ASSERT_UNUSED(declarationResult, declarationResult == DeclarationResult::Valid);
-            classScope->useVariable(&privateBrandIdentifier, false);
+            classScope->useVariable(privateBrandIdentifier.impl(), false);
             classScope->addClosedVariableCandidateUnconditionally(privateBrandIdentifier.impl());
         }
         {
             Identifier privateClassBrandIdentifier = m_vm.propertyNames->builtinNames().privateClassBrandPrivateName();
-            DeclarationResultMask declarationResult = classScope->declareLexicalVariable(&privateClassBrandIdentifier, true);
+            DeclarationResultMask declarationResult = classScope->declareLexicalVariable(privateClassBrandIdentifier.impl(), true);
             ASSERT_UNUSED(declarationResult, declarationResult == DeclarationResult::Valid);
-            classScope->useVariable(&privateClassBrandIdentifier, false);
+            classScope->useVariable(privateClassBrandIdentifier.impl(), false);
             classScope->addClosedVariableCandidateUnconditionally(privateClassBrandIdentifier.impl());
         }
     }
@@ -3461,12 +3456,11 @@ template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseClassFie
             JSTextPosition startPosition = tokenStartPosition();
             unsigned expressionStart = tokenStart();
 
-            ASSERT(match(RESERVED_IF_STRICT) && *m_token.m_data.ident == m_vm.propertyNames->staticKeyword);
+            ASSERT(match(RESERVED_IF_STRICT) && m_token.m_data.ident == m_vm.propertyNames->staticKeyword.impl());
             next();
 
             ParserFunctionInfo<TreeBuilder> functionInfo;
-            functionInfo.name = &m_vm.propertyNames->nullIdentifier;
-            SetForScope setInnerParseMode(m_parseMode, SourceParseMode::ClassStaticBlockMode);
+                    SetForScope setInnerParseMode(m_parseMode, SourceParseMode::ClassStaticBlockMode);
             failIfFalse((parseFunctionInfo(context, FunctionNameRequirements::None, false, ConstructorKind::None, SuperBinding::Needed, expressionStart, functionInfo, FunctionDefinitionType::Expression)), "Cannot parse static block function");
             TreeExpression expression = context.createFunctionExpr(startLocation, functionInfo);
 
@@ -3503,7 +3497,7 @@ template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseClassFie
                 currentScope()->useVariable(definition.ident.impl(), false);
             }
 
-            statement = context.createDefineField(location, definition.ident, initializer, type);
+            statement = context.createDefineField(location, definition.ident.impl(), initializer, type);
         }
 
         context.appendStatement(sourceElements, statement);
@@ -3516,14 +3510,14 @@ template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseClassFie
 }
 
 struct LabelInfo {
-    LabelInfo(const Identifier* ident, const JSTextPosition& start, const JSTextPosition& end)
+    LabelInfo(UniquedStringImpl* ident, const JSTextPosition& start, const JSTextPosition& end)
     : m_ident(ident)
     , m_start(start)
     , m_end(end)
     {
     }
-    
-    const Identifier* m_ident;
+
+    SUPPRESS_UNCOUNTED_MEMBER UniquedStringImpl* m_ident;
     JSTextPosition m_start;
     JSTextPosition m_end;
 };
@@ -3549,7 +3543,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseExpressionOrL
         semanticFailIfTrue(isDisallowedIdentifierAwait(m_token), "Cannot use 'await' as a label ", disallowedIdentifierAwaitReason());
         semanticFailIfTrue(isDisallowedIdentifierYield(m_token), "Cannot use 'yield' as a label ", disallowedIdentifierYieldReason());
 
-        const Identifier* ident = m_token.m_data.ident;
+        UniquedStringImpl* ident = m_token.m_data.ident;
         JSTextPosition start = tokenStartPosition();
         JSTextPosition end = tokenEndPosition();
         location = tokenLocation();
@@ -3559,8 +3553,8 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseExpressionOrL
         // This is O(N^2) over the current list of consecutive labels, but I
         // have never seen more than one label in a row in the real world.
         for (size_t i = 0; i < labels.size(); i++)
-            failIfTrue(ident->impl() == labels[i].m_ident->impl(), "Attempted to redeclare the label '", ident->impl(), "'");
-        failIfTrue(getLabel(ident), "Cannot find scope for the label '", ident->impl(), "'");
+            failIfTrue(ident == labels[i].m_ident, "Attempted to redeclare the label '", ident, "'");
+        failIfTrue(getLabel(ident), "Cannot find scope for the label '", ident, "'");
         labels.append(LabelInfo(ident, start, end));
     } while (matchSpecIdentifier());
     bool isLoop = false;
@@ -3574,7 +3568,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseExpressionOrL
     default:
         break;
     }
-    const Identifier* unused = nullptr;
+    UniquedStringImpl* unused = nullptr;
     Scope* labelScope = currentScope();
     for (auto& label : labels)
         pushLabel(label.m_ident, isLoop);
@@ -3608,7 +3602,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseExpressionSta
         break;
     }
     case IDENT:
-        if (*m_token.m_data.ident == m_vm.propertyNames->async && !m_token.m_data.escaped) [[unlikely]] {
+        if (m_token.m_data.ident == m_vm.propertyNames->async.impl() && !m_token.m_data.escaped) [[unlikely]] {
             SavePoint savePoint = createSavePoint(context);
             next();
             failIfTrue(match(FUNCTION) && !m_lexer->hasLineTerminatorBeforeToken(), "Cannot use async function declaration in single-statement context");
@@ -3643,7 +3637,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseIfStatement(T
     int end = tokenLine();
     handleProductionOrFail2(CLOSEPAREN, ")", "end", "'if' condition");
 
-    const Identifier* unused = nullptr;
+    UniquedStringImpl* unused = nullptr;
     m_immediateParentAllowsFunctionDeclarationInStatement = true;
     TreeStatement trueBlock = parseStatement(context, unused);
     failIfFalse(trueBlock, "Expected a statement as the body of an if block");
@@ -3658,7 +3652,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseIfStatement(T
         JSTokenLocation tempLocation = tokenLocation();
         next();
         if (!match(IF)) {
-            const Identifier* unused = nullptr;
+            UniquedStringImpl* unused = nullptr;
             m_immediateParentAllowsFunctionDeclarationInStatement = true;
             TreeStatement block = parseStatement(context, unused);
             failIfFalse(block, "Expected a statement as the body of an else block");
@@ -3676,7 +3670,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseIfStatement(T
         recordPauseLocation(context.breakpointLocation(innerCondition));
         int innerEnd = tokenLine();
         handleProductionOrFail2(CLOSEPAREN, ")", "end", "'if' condition");
-        const Identifier* unused = nullptr;
+        UniquedStringImpl* unused = nullptr;
         m_immediateParentAllowsFunctionDeclarationInStatement = true;
         TreeStatement innerTrueBlock = parseStatement(context, unused);
         failIfFalse(innerTrueBlock, "Expected a statement as the body of an if block");
@@ -3712,9 +3706,9 @@ template <class TreeBuilder> typename TreeBuilder::ModuleName Parser<LexerType>:
     // http://www.ecma-international.org/ecma-262/6.0/#sec-exports
     JSTokenLocation specifierLocation(tokenLocation());
     failIfFalse(match(STRING), "Imported modules names must be string literals");
-    const Identifier* moduleName = m_token.m_data.ident;
+    UniquedStringImpl* moduleName = m_token.m_data.ident;
     next();
-    return context.createModuleName(specifierLocation, *moduleName);
+    return context.createModuleName(specifierLocation, moduleName);
 }
 
 template <typename LexerType>
@@ -3725,8 +3719,8 @@ template <class TreeBuilder> typename TreeBuilder::ImportSpecifier Parser<LexerT
     // http://www.ecma-international.org/ecma-262/6.0/#sec-imports
     JSTokenLocation specifierLocation(tokenLocation());
     JSToken localNameToken;
-    const Identifier* importedName = nullptr;
-    const Identifier* localName = nullptr;
+    UniquedStringImpl* importedName = nullptr;
+    UniquedStringImpl* localName = nullptr;
 
     switch (specifierType) {
     case ImportSpecifierType::NamespaceImport: {
@@ -3735,10 +3729,10 @@ template <class TreeBuilder> typename TreeBuilder::ImportSpecifier Parser<LexerT
         // e.g.
         //     * as namespace
         ASSERT(match(TIMES));
-        importedName = &m_vm.propertyNames->starNamespacePrivateName;
+        importedName = m_vm.propertyNames->starNamespacePrivateName.impl();
         next();
 
-        failIfFalse(matchContextualKeyword(m_vm.propertyNames->as), "Expected 'as' before imported binding name");
+        failIfFalse(matchContextualKeyword(m_vm.propertyNames->as.impl()), "Expected 'as' before imported binding name");
         next();
 
         failIfFalse(matchSpecIdentifier(), "Expected a variable name for the import declaration");
@@ -3762,10 +3756,10 @@ template <class TreeBuilder> typename TreeBuilder::ImportSpecifier Parser<LexerT
         importedName = localName;
         localNameToken = m_token;
         if (isModuleExportName)
-            failIfTrue(hasUnpairedSurrogate(localName->string()), "Expected a well-formed-unicode string for the module export name");
+            failIfTrue(hasUnpairedSurrogate(StringView { localName }), "Expected a well-formed-unicode string for the module export name");
         next();
 
-        bool useAs = matchContextualKeyword(m_vm.propertyNames->as);
+        bool useAs = matchContextualKeyword(m_vm.propertyNames->as.impl());
         if (isModuleExportName)
             failIfFalse(useAs, "Expected 'as' after the module export name string");
         if (useAs) {
@@ -3784,7 +3778,7 @@ template <class TreeBuilder> typename TreeBuilder::ImportSpecifier Parser<LexerT
         ASSERT(matchSpecIdentifier());
         localNameToken = m_token;
         localName = m_token.m_data.ident;
-        importedName = &m_vm.propertyNames->defaultKeyword;
+        importedName = m_vm.propertyNames->defaultKeyword.impl();
         next();
         break;
     }
@@ -3794,11 +3788,11 @@ template <class TreeBuilder> typename TreeBuilder::ImportSpecifier Parser<LexerT
     semanticFailIfTrue(localNameToken.m_type & KeywordTokenFlag, "Cannot use keyword as imported binding name");
     DeclarationResultMask declarationResult = declareVariable(localName, DeclarationType::ConstDeclaration, (specifierType == ImportSpecifierType::NamespaceImport) ? DeclarationImportType::ImportedNamespace : DeclarationImportType::Imported);
     if (declarationResult != DeclarationResult::Valid) {
-        failIfTrueIfStrict(declarationResult & DeclarationResult::InvalidStrictMode, "Cannot declare an imported binding named ", localName->impl(), " in strict mode");
-        semanticFailIfTrue(declarationResult & DeclarationResult::InvalidDuplicateDeclaration, "Cannot declare an imported binding name twice: '", localName->impl(), "'");
+        failIfTrueIfStrict(declarationResult & DeclarationResult::InvalidStrictMode, "Cannot declare an imported binding named ", localName, " in strict mode");
+        semanticFailIfTrue(declarationResult & DeclarationResult::InvalidDuplicateDeclaration, "Cannot declare an imported binding name twice: '", localName, "'");
     }
 
-    return context.createImportSpecifier(specifierLocation, *importedName, *localName);
+    return context.createImportSpecifier(specifierLocation, importedName, localName);
 }
 
 template <typename LexerType>
@@ -3810,13 +3804,13 @@ template <class TreeBuilder> typename TreeBuilder::ImportAttributesList Parser<L
     while (!match(CLOSEBRACE)) {
         failIfFalse(matchIdentifierOrKeyword() || match(STRING), "Expected an attribute key");
         auto key = m_token.m_data.ident;
-        failIfFalse(keys.add(key->impl()).isNewEntry, "A duplicate key for import attributes '", key->impl(), "'");
+        failIfFalse(keys.add(key).isNewEntry, "A duplicate key for import attributes '", key, "'");
         next();
         consumeOrFail(COLON, "Expected ':' after attribute key");
         failIfFalse(match(STRING), "Expected an attribute value");
         auto value = m_token.m_data.ident;
         next();
-        context.appendImportAttribute(attributesList, *key, *value);
+        context.appendImportAttribute(attributesList, key, value);
         if (!consume(COMMA))
             break;
     }
@@ -3854,7 +3848,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseImportDeclara
 
     bool isFinishedParsingImport = false;
     bool hasImportDefer = false;
-    if (Options::useImportDefer() && matchContextualKeyword(m_vm.propertyNames->deferKeyword)) [[unlikely]] {
+    if (Options::useImportDefer() && matchContextualKeyword(m_vm.propertyNames->deferKeyword.impl())) [[unlikely]] {
         SavePoint deferSavePoint = createSavePoint(context);
         next();
         if (match(TIMES)) {
@@ -3905,7 +3899,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseImportDeclara
     // FromClause :
     // from ModuleSpecifier
 
-    failIfFalse(matchContextualKeyword(m_vm.propertyNames->from), "Expected 'from' before imported module name");
+    failIfFalse(matchContextualKeyword(m_vm.propertyNames->from.impl()), "Expected 'from' before imported module name");
     next();
 
     auto moduleName = parseModuleName(context);
@@ -3925,7 +3919,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseImportDeclara
 }
 
 template <typename LexerType>
-template <class TreeBuilder> typename TreeBuilder::ExportSpecifier Parser<LexerType>::parseExportSpecifier(TreeBuilder& context, Vector<std::pair<const Identifier*, const Identifier*>, 8>& maybeExportedLocalNames, bool& hasKeywordForLocalBindings, bool& hasReferencedModuleExportNames)
+template <class TreeBuilder> typename TreeBuilder::ExportSpecifier Parser<LexerType>::parseExportSpecifier(TreeBuilder& context, Vector<std::pair<UniquedStringImpl*, UniquedStringImpl*>, 8>& maybeExportedLocalNames, bool& hasKeywordForLocalBindings, bool& hasReferencedModuleExportNames)
 {
     // ExportSpecifier :
     // IdentifierName
@@ -3937,29 +3931,29 @@ template <class TreeBuilder> typename TreeBuilder::ExportSpecifier Parser<LexerT
     // http://www.ecma-international.org/ecma-262/6.0/#sec-exports
     ASSERT(matchIdentifierOrKeyword() || match(STRING));
     JSTokenLocation specifierLocation(tokenLocation());
-    const Identifier* localName = m_token.m_data.ident;
-    const Identifier* exportedName = localName;
+    UniquedStringImpl* localName = m_token.m_data.ident;
+    UniquedStringImpl* exportedName = localName;
     if (match(STRING)) {
         hasReferencedModuleExportNames = true;
-        failIfTrue(hasUnpairedSurrogate(exportedName->string()), "Expected a well-formed-unicode string for the module export name");
+        failIfTrue(hasUnpairedSurrogate(StringView { exportedName }), "Expected a well-formed-unicode string for the module export name");
     } else {
         if (m_token.m_type & KeywordTokenFlag)
             hasKeywordForLocalBindings = true;
     }
     next();
 
-    if (matchContextualKeyword(m_vm.propertyNames->as)) {
+    if (matchContextualKeyword(m_vm.propertyNames->as.impl())) {
         next();
         failIfFalse(matchIdentifierOrKeyword() || match(STRING), "Expected an exported name or a module export name string for the export declaration");
         exportedName = m_token.m_data.ident;
         if (match(STRING))
-            failIfTrue(hasUnpairedSurrogate(exportedName->string()), "Expected a well-formed-unicode string for the module export name");
+            failIfTrue(hasUnpairedSurrogate(StringView { exportedName }), "Expected a well-formed-unicode string for the module export name");
         next();
     }
 
-    semanticFailIfFalse(exportName(*exportedName), "Cannot export a duplicate name '", exportedName->impl(), "'");
+    semanticFailIfFalse(exportName(exportedName), "Cannot export a duplicate name '", exportedName, "'");
     maybeExportedLocalNames.append(std::make_pair(localName, exportedName));
-    return context.createExportSpecifier(specifierLocation, *localName, *exportedName);
+    return context.createExportSpecifier(specifierLocation, localName, exportedName);
 }
 
 template <typename LexerType>
@@ -3977,19 +3971,19 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseExportDeclara
         // export * as ModuleExportName FromClause ;
         next();
 
-        const Identifier* exportedName = nullptr;
+        UniquedStringImpl* exportedName = nullptr;
         JSTokenLocation specifierLocation;
-        if (matchContextualKeyword(m_vm.propertyNames->as)) {
+        if (matchContextualKeyword(m_vm.propertyNames->as.impl())) {
             next();
             specifierLocation = JSTokenLocation(tokenLocation());
             failIfFalse(matchIdentifierOrKeyword() || match(STRING), "Expected an exported name or a module export name string for the export declaration");
             exportedName = m_token.m_data.ident;
             if (match(STRING))
-                failIfTrue(hasUnpairedSurrogate(exportedName->string()), "Expected a well-formed-unicode string for the module export name");
+                failIfTrue(hasUnpairedSurrogate(StringView { exportedName }), "Expected a well-formed-unicode string for the module export name");
             next();
         }
 
-        failIfFalse(matchContextualKeyword(m_vm.propertyNames->from), "Expected 'from' before exported module name");
+        failIfFalse(matchContextualKeyword(m_vm.propertyNames->from.impl()), "Expected 'from' before exported module name");
         next();
         auto moduleName = parseModuleName(context);
         failIfFalse(moduleName, "Cannot parse the 'from' clause");
@@ -4005,10 +3999,10 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseExportDeclara
         failIfFalse(autoSemiColon(), "Expected a ';' following a targeted export declaration");
 
         if (exportedName) {
-            semanticFailIfFalse(exportName(*exportedName), "Cannot export a duplicate name '", exportedName->impl(), "'");
+            semanticFailIfFalse(exportName(exportedName), "Cannot export a duplicate name '", exportedName, "'");
             auto specifierList = context.createExportSpecifierList();
-            auto localName = &m_vm.propertyNames->starNamespacePrivateName;
-            auto specifier = context.createExportSpecifier(specifierLocation, *localName, *exportedName);
+            auto localName = m_vm.propertyNames->starNamespacePrivateName.impl();
+            auto specifier = context.createExportSpecifier(specifierLocation, localName, exportedName);
             context.appendExportSpecifier(specifierList, specifier);
             return context.createExportNamedDeclaration(exportLocation, specifierList, moduleName, attributesList);
         }
@@ -4025,7 +4019,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseExportDeclara
 
         TreeStatement result = 0;
         bool isFunctionOrClassDeclaration = false;
-        const Identifier* localName = nullptr;
+        UniquedStringImpl* localName = nullptr;
 
         bool startsWithFunction = match(FUNCTION);
         if (startsWithFunction || match(CLASSTOKEN)) {
@@ -4039,7 +4033,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseExportDeclara
             if (match(IDENT))
                 localName = m_token.m_data.ident;
             restoreSavePoint(context, savePoint);
-        } else if (matchContextualKeyword(m_vm.propertyNames->async)) {
+        } else if (matchContextualKeyword(m_vm.propertyNames->async.impl())) {
             // export default async function xxx() { }
             // export default async function * yyy() { }
             SavePoint savePoint = createSavePoint(context);
@@ -4056,7 +4050,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseExportDeclara
         }
 
         if (!localName)
-            localName = &m_vm.propertyNames->starDefaultPrivateName;
+            localName = m_vm.propertyNames->starDefaultPrivateName.impl();
 
         if (isFunctionOrClassDeclaration) {
             if (startsWithFunction) {
@@ -4067,7 +4061,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseExportDeclara
             } else if (match(CLASSTOKEN)) {
                 result = parseClassDeclaration(context, ExportType::NotExported, DeclarationDefaultContext::ExportDefault);
             } else {
-                ASSERT(matchContextualKeyword(m_vm.propertyNames->async));
+                ASSERT(matchContextualKeyword(m_vm.propertyNames->async.impl()));
                 unsigned functionStart = m_token.m_startPosition;
                 next();
                 DepthManager statementDepth(&m_statementDepth);
@@ -4089,18 +4083,18 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseExportDeclara
             TreeExpression expression = parseAssignmentExpression(context);
             failIfFalse(expression, "Cannot parse expression");
 
-            DeclarationResultMask declarationResult = declareVariable(&m_vm.propertyNames->starDefaultPrivateName, DeclarationType::ConstDeclaration);
+            DeclarationResultMask declarationResult = declareVariable(m_vm.propertyNames->starDefaultPrivateName.impl(), DeclarationType::ConstDeclaration);
             semanticFailIfTrue(declarationResult & DeclarationResult::InvalidDuplicateDeclaration, "Only one 'default' export is allowed");
 
-            TreeExpression assignment = context.createAssignResolve(location, m_vm.propertyNames->starDefaultPrivateName, expression, start, start, tokenEndPosition(), AssignmentContext::ConstDeclarationStatement);
+            TreeExpression assignment = context.createAssignResolve(location, m_vm.propertyNames->starDefaultPrivateName.impl(), expression, start, start, tokenEndPosition(), AssignmentContext::ConstDeclarationStatement);
             result = context.createExprStatement(location, assignment, start, tokenEndPosition());
             failIfFalse(autoSemiColon(), "Expected a ';' following a targeted export declaration");
         }
         failIfFalse(result, "Cannot parse the declaration");
 
-        semanticFailIfFalse(exportName(m_vm.propertyNames->defaultKeyword), "Only one 'default' export is allowed");
-        m_moduleScopeData->exportBinding(*localName, m_vm.propertyNames->defaultKeyword);
-        return context.createExportDefaultDeclaration(exportLocation, result, *localName);
+        semanticFailIfFalse(exportName(m_vm.propertyNames->defaultKeyword.impl()), "Only one 'default' export is allowed");
+        m_moduleScopeData->exportBinding(localName, m_vm.propertyNames->defaultKeyword.impl());
+        return context.createExportDefaultDeclaration(exportLocation, result, localName);
     }
 
     case OPENBRACE: {
@@ -4119,7 +4113,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseExportDeclara
         next();
 
         auto specifierList = context.createExportSpecifierList();
-        Vector<std::pair<const Identifier*, const Identifier*>, 8> maybeExportedLocalNames;
+        Vector<std::pair<UniquedStringImpl*, UniquedStringImpl*>, 8> maybeExportedLocalNames;
 
         bool hasKeywordForLocalBindings = false;
         bool hasReferencedModuleExportNames = false;
@@ -4135,7 +4129,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseExportDeclara
 
         typename TreeBuilder::ModuleName moduleName = 0;
         typename TreeBuilder::ImportAttributesList attributesList = 0;
-        if (matchContextualKeyword(m_vm.propertyNames->from)) {
+        if (matchContextualKeyword(m_vm.propertyNames->from.impl())) {
             next();
             moduleName = parseModuleName(context);
             failIfFalse(moduleName, "Cannot parse the 'from' clause");
@@ -4161,9 +4155,9 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseExportDeclara
             //   export { A, B, C as D }
             // will reference the current module's bindings.
             for (const auto& pair : maybeExportedLocalNames) {
-                const Identifier* localName = pair.first;
-                const Identifier* exportedName = pair.second;
-                m_moduleScopeData->exportBinding(*localName, *exportedName);
+                UniquedStringImpl* localName = pair.first;
+                UniquedStringImpl* exportedName = pair.second;
+                m_moduleScopeData->exportBinding(localName, exportedName);
             }
         }
 
@@ -4199,7 +4193,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseExportDeclara
             break;
 
         case IDENT:
-            if (*m_token.m_data.ident == m_vm.propertyNames->async && !m_token.m_data.escaped) [[likely]] {
+            if (m_token.m_data.ident == m_vm.propertyNames->async.impl() && !m_token.m_data.escaped) [[likely]] {
                 unsigned functionStart = m_token.m_startPosition;
                 next();
                 semanticFailIfFalse(match(FUNCTION) && !m_lexer->hasLineTerminatorBeforeToken(), "Expected 'function' keyword following 'async' keyword with no preceding line terminator");
@@ -4328,7 +4322,7 @@ template <typename TreeBuilder> TreeExpression Parser<LexerType>::parseAssignmen
         if (!lhs || isArrowFunctionToken) {
             SavePointWithError errorRestorationSavePoint = swapSavePointForError(context, *savePoint);
             bool isAsync = false;
-            if (matchContextualKeyword(m_vm.propertyNames->async)) {
+            if (matchContextualKeyword(m_vm.propertyNames->async.impl())) {
                 next();
                 if (!m_lexer->hasLineTerminatorBeforeToken() && (match(OPENPAREN) || matchSpecIdentifier()))
                     isAsync = true;
@@ -4418,8 +4412,8 @@ template <typename TreeBuilder> TreeExpression Parser<LexerType>::parseAssignmen
         m_parserState.assignmentCount++;
         next(TreeBuilder::DontBuildStrings);
         if (strictMode() && m_parserState.lastIdentifier && context.isResolve(lhs)) {
-            failIfTrueIfStrict(m_vm.propertyNames->eval == *m_parserState.lastIdentifier, "Cannot modify 'eval' in strict mode");
-            failIfTrueIfStrict(m_vm.propertyNames->arguments == *m_parserState.lastIdentifier, "Cannot modify 'arguments' in strict mode");
+            failIfTrueIfStrict(m_vm.propertyNames->eval.impl() == m_parserState.lastIdentifier, "Cannot modify 'eval' in strict mode");
+            failIfTrueIfStrict(m_vm.propertyNames->arguments.impl() == m_parserState.lastIdentifier, "Cannot modify 'arguments' in strict mode");
             m_parserState.lastIdentifier = nullptr;
         }
         lhs = parseAssignmentExpression(context);
@@ -4553,13 +4547,13 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseBinaryExpres
 
         TreeExpression current = 0;
         if (match(PRIVATENAME)) {
-            const Identifier* ident = m_token.m_data.ident;
+            UniquedStringImpl* ident = m_token.m_data.ident;
             ASSERT(ident);
-            currentScope()->usePrivateName(*ident);
+            currentScope()->usePrivateName(ident);
             m_seenPrivateNameUseInNonReparsingFunctionMode = true;
             next();
             semanticFailIfTrue(m_token.m_type != INTOKEN || previousOperator >= INTOKEN, "Bare private name can only be used as the left-hand side of an `in` expression");
-            current = context.createPrivateIdentifierNode(location, *ident);
+            current = context.createPrivateIdentifierNode(location, ident);
         } else
             current = parseUnaryExpression(context);
         failIfFalse(current, "Cannot parse expression");
@@ -4647,7 +4641,7 @@ parseProperty:
     switch (m_token.m_type) {
     case ESCAPED_KEYWORD:
     case IDENT:
-        if (*m_token.m_data.ident == m_vm.propertyNames->async && !m_token.m_data.escaped) [[unlikely]] {
+        if (m_token.m_data.ident == m_vm.propertyNames->async.impl() && !m_token.m_data.escaped) [[unlikely]] {
             asyncPosition = m_token.m_startPosition;
             if (parseMode == SourceParseMode::MethodMode) {
                 SavePoint savePoint = createSavePoint(context);
@@ -4674,13 +4668,13 @@ parseProperty:
         [[fallthrough]];
     case STRING: {
 namedProperty:
-        const Identifier* ident = m_token.m_data.ident;
+        UniquedStringImpl* ident = m_token.m_data.ident;
         bool wasUnescapedIdent = wasIdent && !m_token.m_data.escaped;
         unsigned getterOrSetterStartOffset = tokenStart();
         unsigned functionStart = timesPosition.value_or(asyncPosition.value_or(m_token.m_startPosition));
         JSToken identToken = m_token;
 
-        if (wasUnescapedIdent && !isGeneratorMethodParseMode(parseMode) && (*ident == m_vm.propertyNames->get || *ident == m_vm.propertyNames->set))
+        if (wasUnescapedIdent && !isGeneratorMethodParseMode(parseMode) && (ident == m_vm.propertyNames->get.impl() || ident == m_vm.propertyNames->set.impl()))
             nextExpectIdentifier(LexerFlags::IgnoreReservedWords);
         else
             nextExpectIdentifier(TreeBuilder::DontBuildKeywords | LexerFlags::IgnoreReservedWords);
@@ -4690,7 +4684,7 @@ namedProperty:
             TreeExpression node = parseAssignmentExpression(context);
             failIfFalse(node, "Cannot parse expression for property declaration");
             context.setEndOffset(node, m_lexer->currentOffset());
-            InferName inferName = ident && *ident == m_vm.propertyNames->underscoreProto ? InferName::Disallowed : InferName::Allowed;
+            InferName inferName = ident && ident == m_vm.propertyNames->underscoreProto.impl() ? InferName::Disallowed : InferName::Allowed;
             return context.createProperty(ident, node, PropertyNode::Constant, SuperBinding::NotNeeded, inferName, ClassElementTag::No);
         }
 
@@ -4708,34 +4702,34 @@ namedProperty:
             semanticFailureDueToKeywordCheckingToken(identToken, "shorthand property name");
             JSTextPosition start = tokenStartPosition();
             JSTokenLocation location(tokenLocation());
-            currentScope()->useVariable(ident, m_vm.propertyNames->eval == *ident);
+            currentScope()->useVariable(ident, m_vm.propertyNames->eval.impl() == ident);
             if (currentScope()->isArrowFunction())
                 currentScope()->setInnerArrowFunctionUsesEval();
-            TreeExpression node = context.createResolve(location, *ident, start, lastTokenEndPosition());
+            TreeExpression node = context.createResolve(location, ident, start, lastTokenEndPosition());
             return context.createProperty(ident, node, static_cast<PropertyNode::Type>(PropertyNode::Constant | PropertyNode::Shorthand), SuperBinding::NotNeeded, InferName::Allowed, ClassElementTag::No);
         }
 
         std::optional<PropertyNode::Type> type;
         if (wasUnescapedIdent) {
-            if (*ident == m_vm.propertyNames->get)
+            if (ident == m_vm.propertyNames->get.impl())
                 type = PropertyNode::Getter;
-            else if (*ident == m_vm.propertyNames->set)
+            else if (ident == m_vm.propertyNames->set.impl())
                 type = PropertyNode::Setter;
         }
-        failIfFalse(type, "Expected a ':' following the property name '", ident->impl(), "'");
+        failIfFalse(type, "Expected a ':' following the property name '", ident, "'");
         return parseGetterSetter(context, type.value(), getterOrSetterStartOffset, ConstructorKind::None, ClassElementTag::No);
     }
     case DOUBLE:
     case INTEGER: {
         unsigned functionStart = timesPosition.value_or(asyncPosition.value_or(m_token.m_startPosition));
-        const Identifier& ident = m_parserArena.identifierArena().makeNumericIdentifier(const_cast<VM&>(m_vm), m_token.m_data.doubleValue);
+        UniquedStringImpl* ident = m_parserArena.identifierArena().makeNumericIdentifier(const_cast<VM&>(m_vm), m_token.m_data.doubleValue);
         next();
 
         if (match(OPENPAREN)) {
             SetForScope innerParseMode(m_parseMode, parseMode);
-            auto method = parsePropertyMethod(context, &ident, functionStart);
+            auto method = parsePropertyMethod(context, ident, functionStart);
             propagateError();
-            return context.createProperty(&ident, method, PropertyNode::Constant, SuperBinding::Needed, InferName::Allowed, ClassElementTag::No);
+            return context.createProperty(ident, method, PropertyNode::Constant, SuperBinding::Needed, InferName::Allowed, ClassElementTag::No);
         }
         failIfTrue(parseMode != SourceParseMode::MethodMode, "Expected a parenthesis for argument list");
 
@@ -4743,10 +4737,10 @@ namedProperty:
         TreeExpression node = parseAssignmentExpression(context);
         failIfFalse(node, "Cannot parse expression for property declaration");
         context.setEndOffset(node, m_lexer->currentOffset());
-        return context.createProperty(&ident, node, PropertyNode::Constant, SuperBinding::NotNeeded, InferName::Allowed, ClassElementTag::No);
+        return context.createProperty(ident, node, PropertyNode::Constant, SuperBinding::NotNeeded, InferName::Allowed, ClassElementTag::No);
     }
     case BIGINT: {
-        const Identifier* ident = m_parserArena.identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), *m_token.m_data.bigIntString, m_token.m_data.radix);
+        UniquedStringImpl* ident = m_parserArena.identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), m_token.m_data.bigIntString, m_token.m_data.radix);
         failIfFalse(ident, "Cannot parse big int property name");
         unsigned functionStart = timesPosition.value_or(asyncPosition.value_or(m_token.m_startPosition));
         next();
@@ -4774,7 +4768,7 @@ namedProperty:
 
         if (match(OPENPAREN)) {
             SetForScope innerParseMode(m_parseMode, parseMode);
-            auto method = parsePropertyMethod(context, &m_vm.propertyNames->nullIdentifier, functionStart);
+            auto method = parsePropertyMethod(context, nullptr, functionStart);
             propagateError();
             return context.createProperty(propertyName, method, static_cast<PropertyNode::Type>(PropertyNode::Constant | PropertyNode::Computed), SuperBinding::Needed, ClassElementTag::No);
         }
@@ -4804,7 +4798,7 @@ namedProperty:
 }
 
 template <typename LexerType>
-template <class TreeBuilder> TreeExpression Parser<LexerType>::parsePropertyMethod(TreeBuilder& context, const Identifier* methodName, unsigned functionStart)
+template <class TreeBuilder> TreeExpression Parser<LexerType>::parsePropertyMethod(TreeBuilder& context, UniquedStringImpl* methodName, unsigned functionStart)
 {
     ASSERT(isMethodParseMode(sourceParseMode()));
     JSTokenLocation methodLocation(tokenLocation());
@@ -4818,7 +4812,7 @@ template <typename LexerType>
 template <class TreeBuilder> TreeProperty Parser<LexerType>::parseGetterSetter(TreeBuilder& context, PropertyNode::Type type, unsigned getterOrSetterStartOffset,
     ConstructorKind constructorKind, ClassElementTag tag)
 {
-    const Identifier* stringPropertyName = nullptr;
+    UniquedStringImpl* stringPropertyName = nullptr;
     double numericPropertyName = 0;
     TreeExpression computedPropertyName = 0;
 
@@ -4827,11 +4821,11 @@ template <class TreeBuilder> TreeProperty Parser<LexerType>::parseGetterSetter(T
     bool matchesPrivateName = match(PRIVATENAME);
     if (matchSpecIdentifier() || match(STRING) || matchesPrivateName || m_token.m_type & KeywordTokenFlag) {
         stringPropertyName = m_token.m_data.ident;
-        semanticFailIfTrue(tag == ClassElementTag::Static && *stringPropertyName == m_vm.propertyNames->prototype,
+        semanticFailIfTrue(tag == ClassElementTag::Static && stringPropertyName == m_vm.propertyNames->prototype.impl(),
             "Cannot declare a static method named 'prototype'");
-        semanticFailIfTrue(tag == ClassElementTag::Instance && *stringPropertyName == m_vm.propertyNames->constructor,
+        semanticFailIfTrue(tag == ClassElementTag::Instance && stringPropertyName == m_vm.propertyNames->constructor.impl(),
             "Cannot declare a getter or setter named 'constructor'");
-        semanticFailIfTrue(*stringPropertyName == m_vm.propertyNames->constructorPrivateField, "Cannot declare a private accessor named '#constructor'");
+        semanticFailIfTrue(stringPropertyName == m_vm.propertyNames->constructorPrivateField.impl(), "Cannot declare a private accessor named '#constructor'");
 
         if (match(PRIVATENAME))
             semanticFailIfTrue(tag == ClassElementTag::No, "Cannot declare a private setter or getter outside a class");
@@ -4840,7 +4834,7 @@ template <class TreeBuilder> TreeProperty Parser<LexerType>::parseGetterSetter(T
         numericPropertyName = m_token.m_data.doubleValue;
         next();
     } else if (match(BIGINT)) {
-        stringPropertyName = m_parserArena.identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), *m_token.m_data.bigIntString, m_token.m_data.radix);
+        stringPropertyName = m_parserArena.identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), m_token.m_data.bigIntString, m_token.m_data.radix);
         failIfFalse(stringPropertyName, "Cannot parse big int property name");
         next();
     } else if (consume(OPENBRACKET)) [[likely]] {
@@ -5015,7 +5009,6 @@ template <class TreeBuilder> TreeClassExpression Parser<LexerType>::parseClassEx
     ASSERT(match(CLASSTOKEN));
     SetForScope nonLHSCountScope(m_parserState.nonLHSCount);
     ParserClassInfo<TreeBuilder> info;
-    info.className = &m_vm.propertyNames->nullIdentifier;
     return parseClass(context, FunctionNameRequirements::None, info);
 }
 
@@ -5028,7 +5021,6 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseFunctionExpr
     unsigned functionStart = tokenStart();
     next();
     ParserFunctionInfo<TreeBuilder> functionInfo;
-    functionInfo.name = &m_vm.propertyNames->nullIdentifier;
     SourceParseMode parseMode = SourceParseMode::NormalFunctionMode;
     if (consume(TIMES))
         parseMode = SourceParseMode::GeneratorWrapperFunctionMode;
@@ -5053,7 +5045,6 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseAsyncFunctio
     SetForScope setInnerParseMode(m_parseMode, parseMode);
 
     ParserFunctionInfo<TreeBuilder> functionInfo;
-    functionInfo.name = &m_vm.propertyNames->nullIdentifier;
     failIfFalse(parseFunctionInfo(context, FunctionNameRequirements::None, false, ConstructorKind::None, SuperBinding::NotNeeded, location.startOffset, functionInfo, FunctionDefinitionType::Expression), parseMode == SourceParseMode::AsyncFunctionMode ? "Cannot parse async function expression" : "Cannot parse async generator function expression");
     return context.createFunctionExpr(location, functionInfo);
 }
@@ -5069,8 +5060,8 @@ template <class TreeBuilder> typename TreeBuilder::TemplateString Parser<LexerTy
     // Re-scan the token to recognize it as Template Element.
     m_token.m_type = m_lexer->scanTemplateString(&m_token, rawStringsBuildMode);
     matchOrFail(TEMPLATE, "Expected an template element");
-    const Identifier* cooked = m_token.m_data.cooked;
-    const Identifier* raw = m_token.m_data.raw;
+    UniquedStringImpl* cooked = m_token.m_data.cooked;
+    UniquedStringImpl* raw = m_token.m_data.raw;
     elementIsTail = m_token.m_data.isTail;
     JSTokenLocation location(tokenLocation());
     next();
@@ -5121,11 +5112,11 @@ template <class TreeBuilder> typename TreeBuilder::TemplateLiteral Parser<LexerT
 }
 
 template <class LexerType>
-template <class TreeBuilder> TreeExpression Parser<LexerType>::createResolveAndUseVariable(TreeBuilder& context, const Identifier* ident, bool isEval, const JSTextPosition& start, const JSTokenLocation& location)
+template <class TreeBuilder> TreeExpression Parser<LexerType>::createResolveAndUseVariable(TreeBuilder& context, UniquedStringImpl* ident, bool isEval, const JSTextPosition& start, const JSTokenLocation& location)
 {
     currentScope()->useVariable(ident, isEval);
     m_parserState.lastIdentifier = ident;
-    return context.createResolve(location, *ident, start, lastTokenEndPosition());
+    return context.createResolve(location, ident, start, lastTokenEndPosition());
 }
 
 template <typename LexerType>
@@ -5155,16 +5146,16 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::tryParseArguments
     if (match(DOT)) {
         SavePoint argumentsDotSavePoint = createSavePoint(context);
         next();
-        if (match(IDENT) && *m_token.m_data.ident == m_vm.propertyNames->length) {
+        if (match(IDENT) && m_token.m_data.ident == m_vm.propertyNames->length.impl()) {
             m_seenArgumentsDotLength = true;
 
             bool isEval = false;
-            const Identifier* argumentsIdentifier = &m_vm.propertyNames->arguments;
+            UniquedStringImpl* argumentsIdentifier = m_vm.propertyNames->arguments.impl();
             currentScope()->useVariable(argumentsIdentifier, isEval);
             m_parserState.lastIdentifier = argumentsIdentifier;
 
             bool needToCheckUsesArguments = false;
-            TreeExpression argumentsDotExpression = context.createResolve(primaryLocation, *argumentsIdentifier, primaryStart, lastTokenEndPosition(), needToCheckUsesArguments);
+            TreeExpression argumentsDotExpression = context.createResolve(primaryLocation, argumentsIdentifier, primaryStart, lastTokenEndPosition(), needToCheckUsesArguments);
             restoreSavePoint(context, argumentsDotSavePoint);
             return argumentsDotExpression;
         }
@@ -5210,9 +5201,9 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parsePrimaryExpre
         goto identifierExpression;
     case IDENT: {
         semanticFailIfTrue(currentScope()->isStaticBlock() && isArgumentsIdentifier(), "Cannot use 'arguments' as an identifier in static block");
-        if (*m_token.m_data.ident == m_vm.propertyNames->async && !m_token.m_data.escaped) [[unlikely]] {
+        if (m_token.m_data.ident == m_vm.propertyNames->async.impl() && !m_token.m_data.escaped) [[unlikely]] {
             JSTextPosition functionStart = tokenStartPosition();
-            const Identifier* ident = m_token.m_data.ident;
+            UniquedStringImpl* ident = m_token.m_data.ident;
             JSTokenLocation location(tokenLocation());
             next();
             if (match(FUNCTION) && !m_lexer->hasLineTerminatorBeforeToken())
@@ -5229,8 +5220,8 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parsePrimaryExpre
             failIfTrue(isArgumentsIdentifier(), "Cannot reference 'arguments' in class field initializer");
     identifierExpression:
         JSTextPosition start = tokenStartPosition();
-        const Identifier* ident = m_token.m_data.ident;
-        if (*ident == m_vm.propertyNames->arguments) [[unlikely]]
+        UniquedStringImpl* ident = m_token.m_data.ident;
+        if (ident == m_vm.propertyNames->arguments.impl()) [[unlikely]]
             failIfTrue(closestScopeOwningArguments()->evalContextType() == EvalContextType::InstanceFieldEvalContext, "arguments is not valid in this context");
         JSTokenLocation location(tokenLocation());
         next();
@@ -5239,17 +5230,17 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parsePrimaryExpre
         if (match(ARROWFUNCTION)) [[unlikely]]
             return 0;
 
-        return createResolveAndUseVariable(context, ident, *ident == m_vm.propertyNames->eval, start, location);
+        return createResolveAndUseVariable(context, ident, ident == m_vm.propertyNames->eval.impl(), start, location);
     }
     case BIGINT: {
-        const Identifier* ident = m_token.m_data.bigIntString;
+        UniquedStringImpl* ident = m_token.m_data.bigIntString;
         uint8_t radix = m_token.m_data.radix;
         JSTokenLocation location(tokenLocation());
         next();
         return context.createBigInt(location, ident, radix);
     }
     case STRING: {
-        const Identifier* ident = m_token.m_data.ident;
+        UniquedStringImpl* ident = m_token.m_data.ident;
         JSTokenLocation location(tokenLocation());
         next();
         return context.createString(location, ident);
@@ -5290,14 +5281,14 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parsePrimaryExpre
             m_token.m_type = m_lexer->scanRegExp(&m_token);
         matchOrFail(REGEXP, "Invalid regular expression");
 
-        const Identifier* pattern = m_token.m_data.pattern;
-        const Identifier* flags = m_token.m_data.flags;
+        UniquedStringImpl* pattern = m_token.m_data.pattern;
+        UniquedStringImpl* flags = m_token.m_data.flags;
         JSTextPosition start = tokenStartPosition();
         JSTokenLocation location(tokenLocation());
         next();
-        TreeExpression re = context.createRegExp(location, *pattern, *flags, start, m_lexer->isReparsingFunction());
+        TreeExpression re = context.createRegExp(location, pattern, flags, start, m_lexer->isReparsingFunction());
         if (!re) [[unlikely]] {
-            Yarr::ErrorCode errorCode = Yarr::checkSyntax(pattern->string(), flags->string());
+            Yarr::ErrorCode errorCode = Yarr::checkSyntax(StringView { pattern }, StringView { flags });
             regexFail(String::fromLatin1(Yarr::errorMessage(errorCode)));
         }
         return re;
@@ -5397,7 +5388,7 @@ static inline void recordCallOrApplyDepth(ParserType* parser, VM& vm, std::optio
     if constexpr (std::is_same_v<TreeBuilder, ASTBuilder>) {
         if (expression->isDotAccessorNode()) {
             DotAccessorNode* dot = static_cast<DotAccessorNode*>(expression);
-            bool isCallOrApply = dot->identifier() == vm.propertyNames->builtinNames().callPublicName() || dot->identifier() == vm.propertyNames->builtinNames().applyPublicName();
+            bool isCallOrApply = dot->ident() == vm.propertyNames->builtinNames().callPublicName().impl() || dot->ident() == vm.propertyNames->builtinNames().applyPublicName().impl();
             if (isCallOrApply)
                 callOrApplyDepthScope.emplace(parser);
         }
@@ -5424,7 +5415,7 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseMemberExpres
     bool baseIsAsyncKeyword = false;
 
     if (newCount && consume(DOT)) {
-        if (matchContextualKeyword(m_vm.propertyNames->target)) [[likely]] {
+        if (matchContextualKeyword(m_vm.propertyNames->target.impl())) [[likely]] {
             Scope* closestOrdinaryFunctionScope = closestParentOrdinaryFunctionNonLexicalScope();
             bool isClassFieldInitializer = m_parserState.isParsingClassFieldInitializer;
             bool isFunctionEvalContextType = m_isInsideOrdinaryFunction && (closestOrdinaryFunctionScope->evalContextType() == EvalContextType::FunctionEvalContext || closestOrdinaryFunctionScope->evalContextType() == EvalContextType::InstanceFieldEvalContext);
@@ -5472,13 +5463,13 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseMemberExpres
         bool isImportMeta = false;
         bool deferred = false;
         if (consume(DOT)) {
-            if (matchContextualKeyword(m_vm.propertyNames->builtinNames().metaPublicName())) [[likely]] {
+            if (matchContextualKeyword(m_vm.propertyNames->builtinNames().metaPublicName().impl())) [[likely]] {
                 semanticFailIfFalse(m_scriptMode == JSParserScriptMode::Module, "import.meta is only valid inside modules");
-                base = context.createImportMetaExpr(location, createResolveAndUseVariable(context, &m_vm.propertyNames->metaPrivateName, false, expressionStart, location));
+                base = context.createImportMetaExpr(location, createResolveAndUseVariable(context, m_vm.propertyNames->metaPrivateName.impl(), false, expressionStart, location));
                 currentScope()->setUsesImportMeta();
                 isImportMeta = true;
                 next();
-            } else if (Options::useImportDefer() && matchContextualKeyword(m_vm.propertyNames->deferKeyword)) {
+            } else if (Options::useImportDefer() && matchContextualKeyword(m_vm.propertyNames->deferKeyword.impl())) {
                 // ImportCall : import . defer ImportCallArguments
                 // https://tc39.es/proposal-defer-import-eval/#sec-import-call-runtime-semantics-evaluation
                 deferred = true;
@@ -5507,7 +5498,7 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseMemberExpres
             base = context.createImportExpr(location, expr, optionExpression, deferred, expressionStart, expressionEnd, lastTokenEndPosition());
         }
     } else {
-        const bool isAsync = matchContextualKeyword(m_vm.propertyNames->async);
+        const bool isAsync = matchContextualKeyword(m_vm.propertyNames->async.impl());
 
         if (TreeExpression argumentsDotLengthExpression = tryParseArgumentsDotLengthForFastPath(context))
             base = argumentsDotLengthExpression;
@@ -5613,14 +5604,14 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseMemberExpres
                 m_parserState.nonTrivialExpressionCount++;
                 JSTextPosition expressionDivot = tokenStartPosition();
                 nextExpectIdentifier(TreeBuilder::DontBuildKeywords | LexerFlags::IgnoreReservedWords);
-                const Identifier* ident = m_token.m_data.ident;
+                UniquedStringImpl* ident = m_token.m_data.ident;
                 auto type = DotType::Name;
                 if (match(PRIVATENAME)) {
                     ASSERT(ident);
                     failIfTrue(baseIsSuper, "Cannot access private names from super");
                     if (currentScope()->evalContextType() == EvalContextType::InstanceFieldEvalContext) [[unlikely]]
-                        semanticFailIfFalse(currentScope()->hasPrivateName(*ident), "Cannot reference undeclared private field '", ident->impl(), "'");
-                    currentScope()->usePrivateName(*ident);
+                        semanticFailIfFalse(currentScope()->hasPrivateName(ident), "Cannot reference undeclared private field '", ident, "'");
+                    currentScope()->usePrivateName(ident);
                     m_seenPrivateNameUseInNonReparsingFunctionMode = true;
                     m_parserState.lastPrivateName = ident;
                     type = DotType::PrivateMember;
@@ -5666,7 +5657,6 @@ template <typename LexerType>
 template <class TreeBuilder> TreeExpression Parser<LexerType>::parseArrowFunctionExpression(TreeBuilder& context, bool isAsync, const JSTokenLocation& location)
 {
     ParserFunctionInfo<TreeBuilder> info;
-    info.name = &m_vm.propertyNames->nullIdentifier;
 
     SetForScope innerParseMode(m_parseMode, isAsync ? SourceParseMode::AsyncArrowFunctionMode : SourceParseMode::ArrowFunctionMode);
     failIfFalse((parseFunctionInfo(context, FunctionNameRequirements::Unnamed, true, ConstructorKind::None, SuperBinding::NotNeeded, location.startOffset, info, FunctionDefinitionType::Expression)), "Cannot parse arrow function expression");
@@ -5751,9 +5741,9 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseUnaryExpress
     bool isEvalOrArguments = false;
     if (strictMode()) {
         if (context.isResolve(expr))
-            isEvalOrArguments = *m_parserState.lastIdentifier == m_vm.propertyNames->eval || *m_parserState.lastIdentifier == m_vm.propertyNames->arguments;
+            isEvalOrArguments = m_parserState.lastIdentifier == m_vm.propertyNames->eval.impl() || m_parserState.lastIdentifier == m_vm.propertyNames->arguments.impl();
     }
-    failIfTrueIfStrict(isEvalOrArguments && hasPrefixUpdateOp, "Cannot modify '", m_parserState.lastIdentifier->impl(), "' in strict mode");
+    failIfTrueIfStrict(isEvalOrArguments && hasPrefixUpdateOp, "Cannot modify '", m_parserState.lastIdentifier, "' in strict mode");
     switch (m_token.m_type) {
     case PLUSPLUS:
         semanticFailIfTrue(context.isMetaProperty(expr), metaPropertyName(context, expr), " can't come before a postfix operator");
@@ -5762,7 +5752,7 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseUnaryExpress
         m_parserState.nonLHSCount++;
         expr = context.makePostfixNode(location, expr, Operator::PlusPlus, subExprStart, lastTokenEndPosition(), tokenEndPosition());
         m_parserState.assignmentCount++;
-        failIfTrueIfStrict(isEvalOrArguments, "Cannot modify '", m_parserState.lastIdentifier->impl(), "' in strict mode");
+        failIfTrueIfStrict(isEvalOrArguments, "Cannot modify '", m_parserState.lastIdentifier, "' in strict mode");
         semanticFailIfTrue(hasPrefixUpdateOp, "The ", operatorString(false, lastOperator), " operator requires a reference expression");
         next();
         break;
@@ -5773,7 +5763,7 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseUnaryExpress
         m_parserState.nonLHSCount++;
         expr = context.makePostfixNode(location, expr, Operator::MinusMinus, subExprStart, lastTokenEndPosition(), tokenEndPosition());
         m_parserState.assignmentCount++;
-        failIfTrueIfStrict(isEvalOrArguments, "'", m_parserState.lastIdentifier->impl(), "' cannot be modified in strict mode");
+        failIfTrueIfStrict(isEvalOrArguments, "'", m_parserState.lastIdentifier, "' cannot be modified in strict mode");
         semanticFailIfTrue(hasPrefixUpdateOp, "The ", operatorString(false, lastOperator), " operator requires a reference expression");
         next();
         break;
@@ -5817,8 +5807,8 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseUnaryExpress
             expr = context.createVoid(location, expr);
             break;
         case DELETETOKEN:
-            failIfTrueIfStrict(context.isResolve(expr), "Cannot delete unqualified property '", m_parserState.lastIdentifier->impl(), "' in strict mode");
-            semanticFailIfTrue(context.isPrivateLocation(expr), "Cannot delete private field ", m_parserState.lastPrivateName->impl());
+            failIfTrueIfStrict(context.isResolve(expr), "Cannot delete unqualified property '", m_parserState.lastIdentifier, "' in strict mode");
+            semanticFailIfTrue(context.isPrivateLocation(expr), "Cannot delete private field ", m_parserState.lastPrivateName);
             expr = context.makeDeleteNode(location, expr, context.unaryTokenStackLastStart(tokenStackDepth), end, end);
             break;
         default:

--- a/Source/JavaScriptCore/parser/Parser.h
+++ b/Source/JavaScriptCore/parser/Parser.h
@@ -127,15 +127,15 @@ struct ScopeLabelInfo {
     bool isLoop;
 };
 
-ALWAYS_INLINE static bool isArguments(const VM& vm, const Identifier* ident)
+ALWAYS_INLINE static bool isArguments(const VM& vm, UniquedStringImpl* ident)
 {
-    return vm.propertyNames->arguments == *ident;
+    return vm.propertyNames->arguments.impl() == ident;
 }
-ALWAYS_INLINE static bool isEval(const VM& vm, const Identifier* ident)
+ALWAYS_INLINE static bool isEval(const VM& vm, UniquedStringImpl* ident)
 {
-    return vm.propertyNames->eval == *ident;
+    return vm.propertyNames->eval.impl() == ident;
 }
-ALWAYS_INLINE static bool isEvalOrArgumentsIdentifier(const VM& vm, const Identifier* ident)
+ALWAYS_INLINE static bool isEvalOrArgumentsIdentifier(const VM& vm, UniquedStringImpl* ident)
 {
     return isEval(vm, ident) || isArguments(vm, ident);
 }
@@ -189,11 +189,11 @@ public:
     bool breakIsValid() { return m_loopDepth || m_switchDepth; }
     bool continueIsValid() { return m_loopDepth; }
 
-    void pushLabel(const Identifier* label, bool isLoop)
+    void pushLabel(UniquedStringImpl* label, bool isLoop)
     {
         if (!m_labels)
             m_labels = makeUnique<LabelStack>();
-        m_labels->append(ScopeLabelInfo { label->impl(), isLoop });
+        m_labels->append(ScopeLabelInfo { label, isLoop });
     }
 
     void popLabel()
@@ -203,12 +203,12 @@ public:
         m_labels->removeLast();
     }
 
-    ScopeLabelInfo* getLabel(const Identifier* label)
+    ScopeLabelInfo* getLabel(UniquedStringImpl* label)
     {
         if (!m_labels)
             return nullptr;
         for (int i = m_labels->size(); i > 0; i--) {
-            if (m_labels->at(i - 1).uid == label->impl())
+            if (m_labels->at(i - 1).uid == label)
                 return &m_labels->at(i - 1);
         }
         return nullptr;
@@ -365,9 +365,9 @@ public:
         }
     }
 
-    DeclarationResultMask declareCallee(const Identifier* ident)
+    DeclarationResultMask declareCallee(UniquedStringImpl* ident)
     {
-        auto addResult = m_declaredVariables.add(ident->impl());
+        auto addResult = m_declaredVariables.add(ident);
         // We want to track if callee is captured, but we don't want to act like it's a 'var'
         // because that would cause the BytecodeGenerator to emit bad code.
         addResult.iterator->value.clearIsVar();
@@ -378,20 +378,20 @@ public:
         return result;
     }
 
-    DeclarationResultMask declareVariable(const Identifier* ident)
+    DeclarationResultMask declareVariable(UniquedStringImpl* ident)
     {
         ASSERT(m_allowsVarDeclarations);
         DeclarationResultMask result = DeclarationResult::Valid;
         bool isValidStrictMode = !isEvalOrArgumentsIdentifier(m_vm, ident);
         m_isValidStrictMode = m_isValidStrictMode && isValidStrictMode;
-        auto addResult = m_declaredVariables.add(ident->impl());
+        auto addResult = m_declaredVariables.add(ident);
         addResult.iterator->value.setIsVar();
         if (!isValidStrictMode)
             result |= DeclarationResult::InvalidStrictMode;
         return result;
     }
 
-    DeclarationResultMask declareFunctionAsVar(const Identifier* ident)
+    DeclarationResultMask declareFunctionAsVar(UniquedStringImpl* ident)
     {
         ASSERT(m_allowsVarDeclarations);
         DeclarationResultMask result = DeclarationResult::Valid;
@@ -400,16 +400,16 @@ public:
             result |= DeclarationResult::InvalidStrictMode;
         m_isValidStrictMode = m_isValidStrictMode && isValidStrictMode;
 
-        auto addResult = m_declaredVariables.add(ident->impl());
+        auto addResult = m_declaredVariables.add(ident);
         addResult.iterator->value.setIsVar();
         addResult.iterator->value.setIsFunction();
 
-        if (m_lexicalVariables.contains(ident->impl()))
+        if (m_lexicalVariables.contains(ident))
             result |= DeclarationResult::InvalidDuplicateDeclaration;
         return result;
     }
 
-    DeclarationResultMask declareFunctionAsLet(const Identifier* ident, bool isFunctionDeclaration)
+    DeclarationResultMask declareFunctionAsLet(UniquedStringImpl* ident, bool isFunctionDeclaration)
     {
         ASSERT(m_allowsLexicalDeclarations);
         DeclarationResultMask result = DeclarationResult::Valid;
@@ -418,12 +418,12 @@ public:
             result |= DeclarationResult::InvalidStrictMode;
         m_isValidStrictMode = m_isValidStrictMode && isValidStrictMode;
 
-        auto addResult = m_lexicalVariables.add(ident->impl());
+        auto addResult = m_lexicalVariables.add(ident);
         if (!addResult.isNewEntry) {
             if (strictMode() || !addResult.iterator->value.isFunctionDeclaration() || !isFunctionDeclaration)
                 result |= DeclarationResult::InvalidDuplicateDeclaration;
         }
-        if (m_declaredVariables.contains(ident->impl()) || m_variablesBeingHoisted.contains(ident->impl()))
+        if (m_declaredVariables.contains(ident) || m_variablesBeingHoisted.contains(ident))
             result |= DeclarationResult::InvalidDuplicateDeclaration;
 
         addResult.iterator->value.setIsLet();
@@ -434,10 +434,10 @@ public:
         return result;
     }
 
-    void addVariableBeingHoisted(const Identifier* ident)
+    void addVariableBeingHoisted(UniquedStringImpl* ident)
     {
         ASSERT(!m_allowsVarDeclarations);
-        m_variablesBeingHoisted.add(ident->impl());
+        m_variablesBeingHoisted.add(ident);
     }
 
     enum class NeedsDuplicateDeclarationCheck : bool { No, Yes };
@@ -457,13 +457,13 @@ public:
     DeclarationStacks::FunctionStack takeFunctionDeclarations() { return WTF::move(m_functionDeclarations); }
     
 
-    DeclarationResultMask declareLexicalVariable(const Identifier* ident, bool isConstant, DeclarationImportType importType = DeclarationImportType::NotImported, bool isUsing = false, bool isAwaitUsing = false)
+    DeclarationResultMask declareLexicalVariable(UniquedStringImpl* ident, bool isConstant, DeclarationImportType importType = DeclarationImportType::NotImported, bool isUsing = false, bool isAwaitUsing = false)
     {
         ASSERT(m_allowsLexicalDeclarations);
         DeclarationResultMask result = DeclarationResult::Valid;
         bool isValidStrictMode = !isEvalOrArgumentsIdentifier(m_vm, ident);
         m_isValidStrictMode = m_isValidStrictMode && isValidStrictMode;
-        auto addResult = m_lexicalVariables.add(ident->impl());
+        auto addResult = m_lexicalVariables.add(ident);
         if (isConstant)
             addResult.iterator->value.setIsConst();
         else
@@ -480,7 +480,7 @@ public:
             addResult.iterator->value.setIsImportedNamespace();
         }
 
-        if (!addResult.isNewEntry || m_variablesBeingHoisted.contains(ident->impl()))
+        if (!addResult.isNewEntry || m_variablesBeingHoisted.contains(ident))
             result |= DeclarationResult::InvalidDuplicateDeclaration;
         if (!isValidStrictMode)
             result |= DeclarationResult::InvalidStrictMode;
@@ -490,13 +490,17 @@ public:
 
     ALWAYS_INLINE bool hasDeclaredGlobalArguments()
     {
-        const Identifier& ident = m_vm.propertyNames->arguments;
+        UniquedStringImpl* ident = m_vm.propertyNames->arguments.impl();
         return hasLexicallyDeclaredVariable(ident) || hasDeclaredVariable(ident) || shadowsArguments();
     }
 
-    ALWAYS_INLINE bool hasDeclaredVariable(const Identifier& ident)
+    bool hasDeclaredVariable(UniquedStringImpl* ident)
     {
-        return hasDeclaredVariable(ident.impl());
+        auto iter = m_declaredVariables.find(ident);
+        if (iter == m_declaredVariables.end())
+            return false;
+        VariableEnvironmentEntry entry = iter->value;
+        return entry.isVar(); // The callee isn't a "var".
     }
 
     bool hasDeclaredVariable(const UniquedStringImpl* ident)
@@ -508,9 +512,9 @@ public:
         return entry.isVar(); // The callee isn't a "var".
     }
 
-    ALWAYS_INLINE bool hasLexicallyDeclaredVariable(const Identifier& ident)
+    ALWAYS_INLINE bool hasLexicallyDeclaredVariable(UniquedStringImpl* ident)
     {
-        return hasLexicallyDeclaredVariable(ident.impl());
+        return hasLexicallyDeclaredVariable(static_cast<const UniquedStringImpl*>(ident));
     }
 
     bool hasLexicallyDeclaredVariable(const UniquedStringImpl* ident) const
@@ -523,16 +527,19 @@ public:
         return m_variablesBeingHoisted.contains(ident);
     }
 
-    bool hasPrivateName(const Identifier& ident)
+    bool hasPrivateName(UniquedStringImpl* ident)
     {
         return m_lexicalVariables.hasPrivateName(ident);
     }
 
-    DeclarationResultMask declarePrivateMethod(const Identifier& ident, ClassElementTag tag)
+    DeclarationResultMask declarePrivateMethod(UniquedStringImpl* ident, ClassElementTag tag)
     {
         ASSERT(m_allowsLexicalDeclarations);
         DeclarationResultMask result = DeclarationResult::Valid;
-        bool addResult = tag == ClassElementTag::Static ? m_lexicalVariables.declareStaticPrivateMethod(ident) : m_lexicalVariables.declarePrivateMethod(ident);
+        auto traits = tag == ClassElementTag::Static
+            ? static_cast<PrivateNameEntry::Traits>(PrivateNameEntry::Traits::IsMethod | PrivateNameEntry::Traits::IsStatic)
+            : PrivateNameEntry::Traits::IsMethod;
+        bool addResult = m_lexicalVariables.declarePrivateMethod(RefPtr<UniquedStringImpl>(ident), traits);
 
         if (!addResult) {
             result |= DeclarationResult::InvalidDuplicateDeclaration;
@@ -544,14 +551,15 @@ public:
 
     enum class PrivateAccessorType { Setter, Getter };
 
-    DeclarationResultMask declarePrivateAccessor(const Identifier& ident, ClassElementTag tag, PrivateAccessorType accessorType)
+    DeclarationResultMask declarePrivateAccessor(UniquedStringImpl* ident, ClassElementTag tag, PrivateAccessorType accessorType)
     {
         DeclarationResultMask result = DeclarationResult::Valid;
         VariableEnvironment::PrivateDeclarationResult addResult;
+        auto staticTraits = tag == ClassElementTag::Static ? PrivateNameEntry::Traits::IsStatic : PrivateNameEntry::Traits::None;
         if (accessorType == PrivateAccessorType::Setter)
-            addResult = tag == ClassElementTag::Static ? m_lexicalVariables.declareStaticPrivateSetter(ident) : m_lexicalVariables.declarePrivateSetter(ident);
+            addResult = m_lexicalVariables.declarePrivateSetter(RefPtr<UniquedStringImpl>(ident), staticTraits);
         else
-            addResult = tag == ClassElementTag::Static ? m_lexicalVariables.declareStaticPrivateGetter(ident) : m_lexicalVariables.declarePrivateGetter(ident);
+            addResult = m_lexicalVariables.declarePrivateGetter(RefPtr<UniquedStringImpl>(ident), staticTraits);
 
         if (addResult == VariableEnvironment::PrivateDeclarationResult::DuplicatedName)
             result |= DeclarationResult::InvalidDuplicateDeclaration;
@@ -562,38 +570,33 @@ public:
         return result;
     }
 
-    DeclarationResultMask declarePrivateSetter(const Identifier& ident, ClassElementTag tag)
+    DeclarationResultMask declarePrivateSetter(UniquedStringImpl* ident, ClassElementTag tag)
     {
         ASSERT(m_allowsLexicalDeclarations);
         return declarePrivateAccessor(ident, tag, PrivateAccessorType::Setter);
     }
 
-    DeclarationResultMask declarePrivateGetter(const Identifier& ident, ClassElementTag tag)
+    DeclarationResultMask declarePrivateGetter(UniquedStringImpl* ident, ClassElementTag tag)
     {
         ASSERT(m_allowsLexicalDeclarations);
         return declarePrivateAccessor(ident, tag, PrivateAccessorType::Getter);
     }
 
-    DeclarationResultMask declarePrivateField(const Identifier& ident)
+    DeclarationResultMask declarePrivateField(UniquedStringImpl* ident)
     {
         ASSERT(m_allowsLexicalDeclarations);
         DeclarationResultMask result = DeclarationResult::Valid;
-        auto addResult = m_lexicalVariables.declarePrivateField(ident);
+        auto addResult = m_lexicalVariables.declarePrivateField(RefPtr<UniquedStringImpl>(ident));
         if (!addResult.isNewEntry)
             result |= DeclarationResult::InvalidDuplicateDeclaration;
         return result;
     }
 
-    ALWAYS_INLINE bool hasDeclaredParameter(const Identifier& ident)
-    {
-        return hasDeclaredParameter(ident.impl());
-    }
-
-    bool hasDeclaredParameter(UniquedStringImpl* ident)
+    ALWAYS_INLINE bool hasDeclaredParameter(UniquedStringImpl* ident)
     {
         return m_declaredParameters.contains(ident) || hasDeclaredVariable(ident);
     }
-    
+
     void preventAllVariableDeclarations()
     {
         m_allowsVarDeclarations = false; 
@@ -603,18 +606,18 @@ public:
     bool allowsVarDeclarations() const { return m_allowsVarDeclarations; }
     bool allowsLexicalDeclarations() const { return m_allowsLexicalDeclarations; }
 
-    DeclarationResultMask declareParameter(const Identifier* ident)
+    DeclarationResultMask declareParameter(UniquedStringImpl* ident)
     {
         ASSERT(m_allowsVarDeclarations);
         DeclarationResultMask result = DeclarationResult::Valid;
         bool isArgumentsIdent = isArguments(m_vm, ident);
-        auto addResult = m_declaredVariables.add(ident->impl());
+        auto addResult = m_declaredVariables.add(ident);
         bool isDuplicateParameter = !addResult.isNewEntry && addResult.iterator->value.isParameter();
-        bool isValidStrictMode = !isDuplicateParameter && m_vm.propertyNames->eval != *ident && !isArgumentsIdent;
+        bool isValidStrictMode = !isDuplicateParameter && m_vm.propertyNames->eval.impl() != ident && !isArgumentsIdent;
         addResult.iterator->value.clearIsVar();
         addResult.iterator->value.setIsParameter();
         m_isValidStrictMode = m_isValidStrictMode && isValidStrictMode;
-        m_declaredParameters.add(ident->impl());
+        m_declaredParameters.add(ident);
         if (!isValidStrictMode)
             result |= DeclarationResult::InvalidStrictMode;
         if (isArgumentsIdent)
@@ -643,18 +646,14 @@ public:
             }
         }
     }
-    void useVariable(const Identifier* ident, bool isEval)
-    {
-        useVariable(ident->impl(), isEval);
-    }
     void useVariable(UniquedStringImpl* impl, bool isEval)
     {
         m_usesEval |= isEval;
         m_usedVariables.last().add(impl);
     }
-    void usePrivateName(const Identifier& ident)
+    void usePrivateName(UniquedStringImpl* ident)
     {
-        useVariable(&ident, false);
+        useVariable(ident, false);
     }
 
     void setUsesImportMeta() { m_usesImportMeta = true; }
@@ -778,7 +777,7 @@ public:
             // that function's name. Note that we would only cause a syntax error if we had a let/const/class
             // variable with the same name.
             FunctionMetadataNode* metadata = iter.key;
-            auto* function = metadata->ident().impl();
+            auto* function = metadata->ident();
             if (!m_lexicalVariables.contains(function)) {
                 auto addResult = m_declaredVariables.add(function);
                 if (addResult.isNewEntry)
@@ -797,7 +796,7 @@ public:
         for (const auto& iter : m_sloppyModeFunctionHoistingCandidates) {
             FunctionMetadataNode* metadata = iter.key;
             bool needsCheck = iter.value == NeedsDuplicateDeclarationCheck::Yes;
-            if (!needsCheck || !m_lexicalVariables.contains(metadata->ident().impl()) || isSimpleCatchParameterScope())
+            if (!needsCheck || !m_lexicalVariables.contains(metadata->ident()) || isSimpleCatchParameterScope())
                 parentScope->addSloppyModeFunctionHoistingCandidate<NeedsDuplicateDeclarationCheck::Yes>(metadata);
         }
     }
@@ -1222,7 +1221,7 @@ private:
 
     ALWAYS_INLINE SourceParseMode sourceParseMode() const { return m_parseMode; }
     ALWAYS_INLINE FunctionMode functionMode() const { return m_functionMode; }
-    ALWAYS_INLINE bool isEvalOrArguments(const Identifier* ident) { return isEvalOrArgumentsIdentifier(m_vm, ident); }
+    ALWAYS_INLINE bool isEvalOrArguments(UniquedStringImpl* ident) { return isEvalOrArgumentsIdentifier(m_vm, ident); }
 
     Scope* upperScope(int n)
     {
@@ -1393,12 +1392,12 @@ private:
         return popScopeInternal(scope, shouldTrackClosedVariables);
     }
 
-    NEVER_INLINE DeclarationResultMask declareHoistedVariable(const Identifier* ident)
+    NEVER_INLINE DeclarationResultMask declareHoistedVariable(UniquedStringImpl* ident)
     {
         Scope* scope = currentScope();
         while (true) {
             // Annex B.3.5 exempts `try {} catch (e) { var e; }` from being a syntax error.
-            if (scope->hasLexicallyDeclaredVariable(*ident) && !scope->isSimpleCatchParameterScope())
+            if (scope->hasLexicallyDeclaredVariable(ident) && !scope->isSimpleCatchParameterScope())
                 return DeclarationResult::InvalidDuplicateDeclaration;
 
             if (scope->allowsVarDeclarations())
@@ -1408,19 +1407,19 @@ private:
             scope = scope->containingScope();
         }
     }
-    
-    DeclarationResultMask declareVariable(const Identifier* ident, DeclarationType type = DeclarationType::VarDeclaration, DeclarationImportType importType = DeclarationImportType::NotImported)
+
+    DeclarationResultMask declareVariable(UniquedStringImpl* ident, DeclarationType type = DeclarationType::VarDeclaration, DeclarationImportType importType = DeclarationImportType::NotImported)
     {
         if (type == DeclarationType::VarDeclaration)
             return declareHoistedVariable(ident);
 
         ASSERT(type == DeclarationType::LetDeclaration || type == DeclarationType::ConstDeclaration || type == DeclarationType::UsingDeclaration || type == DeclarationType::AwaitUsingDeclaration);
         // Lexical variables declared at a top level scope that shadow arguments or vars are not allowed.
-        if (!m_lexer->isReparsingFunction() && m_statementDepth == 1 && (hasDeclaredParameter(*ident) || hasDeclaredVariable(*ident)))
+        if (!m_lexer->isReparsingFunction() && m_statementDepth == 1 && (hasDeclaredParameter(ident) || hasDeclaredVariable(ident)))
             return DeclarationResult::InvalidDuplicateDeclaration;
 
         Scope* scope = currentLexicalDeclarationScope();
-        if (scope->isCatchBlockScope() && scope->containingScope()->hasLexicallyDeclaredVariable(*ident))
+        if (scope->isCatchBlockScope() && scope->containingScope()->hasLexicallyDeclaredVariable(ident))
             return DeclarationResult::InvalidDuplicateDeclaration;
 
         bool isAwaitUsing = type == DeclarationType::AwaitUsingDeclaration;
@@ -1428,7 +1427,7 @@ private:
         return scope->declareLexicalVariable(ident, type == DeclarationType::ConstDeclaration || isUsing, importType, isUsing, isAwaitUsing);
     }
 
-    std::pair<DeclarationResultMask, Scope*> declareFunction(const Identifier* ident)
+    std::pair<DeclarationResultMask, Scope*> declareFunction(UniquedStringImpl* ident)
     {
         if (m_statementDepth == 1 && !currentScope()->isModuleCode()) {
             // Functions declared at the top-most scope (both in sloppy and strict mode) are declared as vars
@@ -1439,14 +1438,14 @@ private:
         }
 
         Scope* lexicalVariableScope = currentLexicalDeclarationScope();
-        if (lexicalVariableScope->isCatchBlockScope() && lexicalVariableScope->containingScope()->hasLexicallyDeclaredVariable(*ident))
+        if (lexicalVariableScope->isCatchBlockScope() && lexicalVariableScope->containingScope()->hasLexicallyDeclaredVariable(ident))
             return std::make_pair(DeclarationResult::InvalidDuplicateDeclaration, lexicalVariableScope);
 
         bool isFunctionDeclaration = m_parseMode == SourceParseMode::NormalFunctionMode;
         return std::make_pair(lexicalVariableScope->declareFunctionAsLet(ident, isFunctionDeclaration), lexicalVariableScope);
     }
 
-    NEVER_INLINE bool hasDeclaredVariable(const Identifier& ident)
+    NEVER_INLINE bool hasDeclaredVariable(UniquedStringImpl* ident)
     {
         Scope* scope = currentScope();
         while (!scope->allowsVarDeclarations())
@@ -1454,7 +1453,7 @@ private:
         return scope->hasDeclaredVariable(ident);
     }
 
-    NEVER_INLINE bool hasDeclaredParameter(const Identifier& ident)
+    NEVER_INLINE bool hasDeclaredParameter(UniquedStringImpl* ident)
     {
         // FIXME: hasDeclaredParameter() is not valid during reparsing of generator or async function bodies, because their formal
         // parameters are declared in a scope unavailable during reparsing. Note that it is redundant to call this function during
@@ -1473,8 +1472,8 @@ private:
         }
         return scope->hasDeclaredParameter(ident);
     }
-    
-    bool exportName(const Identifier& ident)
+
+    bool exportName(UniquedStringImpl* ident)
     {
         ASSERT(!currentScope()->containingScope());
         ASSERT(m_moduleScopeData);
@@ -1508,9 +1507,9 @@ private:
         int returnStatementCount { 0 };
         int unaryTokenStackDepth { 0 };
         FunctionParsePhase functionParsePhase { FunctionParsePhase::Body };
-        const Identifier* lastIdentifier { nullptr };
-        const Identifier* lastFunctionName { nullptr };
-        const Identifier* lastPrivateName { nullptr };
+        UniquedStringImpl* lastIdentifier { nullptr };
+        UniquedStringImpl* lastFunctionName { nullptr };
+        UniquedStringImpl* lastPrivateName { nullptr };
         bool allowAwait { true };
         bool isParsingClassFieldInitializer { false };
         bool classFieldInitMasksAsync { false };
@@ -1607,9 +1606,9 @@ private:
         return false;
     }
     
-    ALWAYS_INLINE bool matchContextualKeyword(const Identifier& identifier)
+    ALWAYS_INLINE bool matchContextualKeyword(UniquedStringImpl* identifier)
     {
-        return m_token.m_type == IDENT && *m_token.m_data.ident == identifier && !m_token.m_data.escaped;
+        return m_token.m_type == IDENT && m_token.m_data.ident == identifier && !m_token.m_data.escaped;
     }
 
     ALWAYS_INLINE bool matchIdentifierOrKeyword()
@@ -1699,8 +1698,8 @@ private:
             return m_currentScope->containingScope()->isValidStrictMode();
         return true;
     }
-    DeclarationResultMask declareParameter(const Identifier* ident) { return currentScope()->declareParameter(ident); }
-    bool declareRestOrNormalParameter(const Identifier&, const Identifier**);
+    DeclarationResultMask declareParameter(UniquedStringImpl* ident) { return currentScope()->declareParameter(ident); }
+    bool declareRestOrNormalParameter(UniquedStringImpl*, UniquedStringImpl**);
 
     bool breakIsValid()
     {
@@ -1722,9 +1721,9 @@ private:
         }
         return true;
     }
-    void pushLabel(const Identifier* label, bool isLoop) { currentScope()->pushLabel(label, isLoop); }
+    void pushLabel(UniquedStringImpl* label, bool isLoop) { currentScope()->pushLabel(label, isLoop); }
     void popLabel(Scope* scope) { scope->popLabel(); }
-    ScopeLabelInfo* getLabel(const Identifier* label)
+    ScopeLabelInfo* getLabel(UniquedStringImpl* label)
     {
         Scope* current = currentScope();
         ScopeLabelInfo* result = nullptr;
@@ -1753,13 +1752,13 @@ private:
     }
 
     template <class TreeBuilder> TreeSourceElements parseSourceElements(TreeBuilder&, SourceElementsMode);
-    template <class TreeBuilder> TreeSourceElements parseGeneratorFunctionSourceElements(TreeBuilder&, const Identifier& name, SourceElementsMode);
-    template <class TreeBuilder> TreeSourceElements parseAsyncFunctionSourceElements(TreeBuilder&, const Identifier& calleeName, bool isArrowFunctionBodyExpression, SourceElementsMode);
-    template <class TreeBuilder> TreeSourceElements parseAsyncGeneratorFunctionSourceElements(TreeBuilder&, const Identifier& calleeName, bool isArrowFunctionBodyExpression, SourceElementsMode);
+    template <class TreeBuilder> TreeSourceElements parseGeneratorFunctionSourceElements(TreeBuilder&, UniquedStringImpl* name, SourceElementsMode);
+    template <class TreeBuilder> TreeSourceElements parseAsyncFunctionSourceElements(TreeBuilder&, UniquedStringImpl* calleeName, bool isArrowFunctionBodyExpression, SourceElementsMode);
+    template <class TreeBuilder> TreeSourceElements parseAsyncGeneratorFunctionSourceElements(TreeBuilder&, UniquedStringImpl* calleeName, bool isArrowFunctionBodyExpression, SourceElementsMode);
     template <class TreeBuilder> TreeSourceElements parseSingleFunction(TreeBuilder&, std::optional<int> functionConstructorParametersEndPosition);
     template <class TreeBuilder> TreeSourceElements parseClassFieldInitializerSourceElements(TreeBuilder&, const FixedVector<UnlinkedFunctionExecutable::ClassElementDefinition>&);
-    template <class TreeBuilder> TreeStatement parseStatementListItem(TreeBuilder&, const Identifier*& directive, unsigned* directiveLiteralLength);
-    template <class TreeBuilder> TreeStatement parseStatement(TreeBuilder&, const Identifier*& directive, unsigned* directiveLiteralLength = nullptr);
+    template <class TreeBuilder> TreeStatement parseStatementListItem(TreeBuilder&, UniquedStringImpl*& directive, unsigned* directiveLiteralLength);
+    template <class TreeBuilder> TreeStatement parseStatement(TreeBuilder&, UniquedStringImpl*& directive, unsigned* directiveLiteralLength = nullptr);
     enum class ExportType { Exported, NotExported };
     template <class TreeBuilder> TreeStatement parseClassDeclaration(TreeBuilder&, ExportType = ExportType::NotExported, DeclarationDefaultContext = DeclarationDefaultContext::Standard);
     enum class FunctionDeclarationType { Declaration, Statement };
@@ -1803,7 +1802,7 @@ private:
     template <class TreeBuilder> ALWAYS_INLINE TreeArguments parseArguments(TreeBuilder&);
     template <class TreeBuilder> ALWAYS_INLINE TreeExpression parseArgument(TreeBuilder&, ArgumentType&);
     template <class TreeBuilder> TreeProperty parseProperty(TreeBuilder&);
-    template <class TreeBuilder> TreeExpression parsePropertyMethod(TreeBuilder& context, const Identifier* methodName, unsigned functionStart);
+    template <class TreeBuilder> TreeExpression parsePropertyMethod(TreeBuilder& context, UniquedStringImpl* methodName, unsigned functionStart);
     template <class TreeBuilder> TreeProperty parseGetterSetter(TreeBuilder&, PropertyNode::Type, unsigned getterOrSetterStartOffset, ConstructorKind, ClassElementTag);
     template <class TreeBuilder> ALWAYS_INLINE TreeFunctionBody parseFunctionBody(TreeBuilder&, SyntaxChecker&, const JSTokenLocation&, int, unsigned functionStart, int functionNameStart, int parametersStart, ConstructorKind, SuperBinding, FunctionBodyType, unsigned);
     template <class TreeBuilder> ALWAYS_INLINE bool parseFormalParameters(TreeBuilder&, TreeFormalParameterList, bool isArrowFunction, bool isMethod, unsigned&);
@@ -1811,14 +1810,14 @@ private:
     template <class TreeBuilder> TreeExpression parseVariableDeclarationList(TreeBuilder&, int& declarations, TreeDestructuringPattern& lastPattern, TreeExpression& lastInitializer, JSTextPosition& identStart, JSTextPosition& initStart, JSTextPosition& initEnd, VarDeclarationListContext, DeclarationType, ExportType, bool& forLoopConstDoesNotHaveInitializer);
     template <class TreeBuilder> TreeSourceElements parseArrowFunctionSingleExpressionBodySourceElements(TreeBuilder&);
     template <class TreeBuilder> TreeExpression parseArrowFunctionExpression(TreeBuilder&, bool isAsync, const JSTokenLocation&);
-    template <class TreeBuilder> NEVER_INLINE TreeDestructuringPattern createBindingPattern(TreeBuilder&, DestructuringKind, ExportType, const Identifier&, const JSToken&, AssignmentContext, const Identifier** duplicateIdentifier);
+    template <class TreeBuilder> NEVER_INLINE TreeDestructuringPattern createBindingPattern(TreeBuilder&, DestructuringKind, ExportType, UniquedStringImpl*, const JSToken&, AssignmentContext, UniquedStringImpl** duplicateIdentifier);
     template <class TreeBuilder> NEVER_INLINE TreeDestructuringPattern createAssignmentElement(TreeBuilder&, TreeExpression&, const JSTextPosition&, const JSTextPosition&);
-    template <class TreeBuilder> NEVER_INLINE TreeDestructuringPattern parseObjectRestBindingOrAssignmentElement(TreeBuilder& context, DestructuringKind, ExportType, const Identifier** duplicateIdentifier, AssignmentContext bindingContext);
-    template <class TreeBuilder> NEVER_INLINE TreeDestructuringPattern parseBindingOrAssignmentElement(TreeBuilder& context, DestructuringKind, ExportType, const Identifier** duplicateIdentifier, bool* hasDestructuringPattern, AssignmentContext bindingContext, int depth);
+    template <class TreeBuilder> NEVER_INLINE TreeDestructuringPattern parseObjectRestBindingOrAssignmentElement(TreeBuilder& context, DestructuringKind, ExportType, UniquedStringImpl** duplicateIdentifier, AssignmentContext bindingContext);
+    template <class TreeBuilder> NEVER_INLINE TreeDestructuringPattern parseBindingOrAssignmentElement(TreeBuilder& context, DestructuringKind, ExportType, UniquedStringImpl** duplicateIdentifier, bool* hasDestructuringPattern, AssignmentContext bindingContext, int depth);
     template <class TreeBuilder> NEVER_INLINE TreeDestructuringPattern parseObjectRestAssignmentElement(TreeBuilder& context);
-    template <class TreeBuilder> NEVER_INLINE TreeDestructuringPattern parseAssignmentElement(TreeBuilder& context, DestructuringKind, ExportType, const Identifier** duplicateIdentifier, bool* hasDestructuringPattern, AssignmentContext bindingContext, int depth);
-    template <class TreeBuilder> NEVER_INLINE TreeDestructuringPattern parseObjectRestElement(TreeBuilder&, DestructuringKind, ExportType, const Identifier** duplicateIdentifier = nullptr, AssignmentContext = AssignmentContext::DeclarationStatement);
-    template <class TreeBuilder> NEVER_INLINE TreeDestructuringPattern parseDestructuringPattern(TreeBuilder&, DestructuringKind, ExportType, const Identifier** duplicateIdentifier = nullptr, bool* hasDestructuringPattern = nullptr, AssignmentContext = AssignmentContext::DeclarationStatement, int depth = 0);
+    template <class TreeBuilder> NEVER_INLINE TreeDestructuringPattern parseAssignmentElement(TreeBuilder& context, DestructuringKind, ExportType, UniquedStringImpl** duplicateIdentifier, bool* hasDestructuringPattern, AssignmentContext bindingContext, int depth);
+    template <class TreeBuilder> NEVER_INLINE TreeDestructuringPattern parseObjectRestElement(TreeBuilder&, DestructuringKind, ExportType, UniquedStringImpl** duplicateIdentifier = nullptr, AssignmentContext = AssignmentContext::DeclarationStatement);
+    template <class TreeBuilder> NEVER_INLINE TreeDestructuringPattern parseDestructuringPattern(TreeBuilder&, DestructuringKind, ExportType, UniquedStringImpl** duplicateIdentifier = nullptr, bool* hasDestructuringPattern = nullptr, AssignmentContext = AssignmentContext::DeclarationStatement, int depth = 0);
     template <class TreeBuilder> NEVER_INLINE TreeDestructuringPattern tryParseDestructuringPatternExpression(TreeBuilder&, AssignmentContext);
     template <class TreeBuilder> NEVER_INLINE TreeExpression parseDefaultValueForDestructuringPattern(TreeBuilder&);
     template <class TreeBuilder> TreeSourceElements parseModuleSourceElements(TreeBuilder&);
@@ -1827,10 +1826,10 @@ private:
     template <class TreeBuilder> typename TreeBuilder::ModuleName parseModuleName(TreeBuilder&);
     template <class TreeBuilder> typename TreeBuilder::ImportAttributesList parseImportAttributes(TreeBuilder&);
     template <class TreeBuilder> TreeStatement parseImportDeclaration(TreeBuilder&);
-    template <class TreeBuilder> typename TreeBuilder::ExportSpecifier parseExportSpecifier(TreeBuilder& context, Vector<std::pair<const Identifier*, const Identifier*>, 8>& maybeExportedLocalNames, bool& hasKeywordForLocalBindings, bool& hasReferencedModuleExportNames);
+    template <class TreeBuilder> typename TreeBuilder::ExportSpecifier parseExportSpecifier(TreeBuilder& context, Vector<std::pair<UniquedStringImpl*, UniquedStringImpl*>, 8>& maybeExportedLocalNames, bool& hasKeywordForLocalBindings, bool& hasReferencedModuleExportNames);
     template <class TreeBuilder> TreeStatement parseExportDeclaration(TreeBuilder&);
 
-    template <class TreeBuilder> ALWAYS_INLINE TreeExpression createResolveAndUseVariable(TreeBuilder&, const Identifier*, bool isEval, const JSTextPosition&, const JSTokenLocation&);
+    template <class TreeBuilder> ALWAYS_INLINE TreeExpression createResolveAndUseVariable(TreeBuilder&, UniquedStringImpl*, bool isEval, const JSTextPosition&, const JSTokenLocation&);
 
     enum class FunctionDefinitionType { Expression, Declaration, Method };
     template <class TreeBuilder> NEVER_INLINE bool parseFunctionInfo(TreeBuilder&, FunctionNameRequirements, bool nameIsInContainingScope, ConstructorKind, SuperBinding, unsigned functionStart, ParserFunctionInfo<TreeBuilder>&, FunctionDefinitionType, std::optional<int> functionConstructorParametersEndPosition = std::nullopt);
@@ -1885,7 +1884,7 @@ private:
     {
         if (token.m_type == LET)
             return true;
-        if (token.m_type == ESCAPED_KEYWORD && *token.m_data.ident == m_vm.propertyNames->letKeyword) [[unlikely]]
+        if (token.m_type == ESCAPED_KEYWORD && token.m_data.ident == m_vm.propertyNames->letKeyword.impl()) [[unlikely]]
             return true;
         return false;
     }
@@ -1904,7 +1903,7 @@ private:
     {
         if (token.m_type == AWAIT)
             return true;
-        if (token.m_type == ESCAPED_KEYWORD && *token.m_data.ident == m_vm.propertyNames->awaitKeyword) [[unlikely]]
+        if (token.m_type == ESCAPED_KEYWORD && token.m_data.ident == m_vm.propertyNames->awaitKeyword.impl()) [[unlikely]]
             return true;
         return false;
     }
@@ -1928,7 +1927,7 @@ private:
     {
         if (token.m_type == YIELD)
             return true;
-        if (token.m_type == ESCAPED_KEYWORD && *token.m_data.ident == m_vm.propertyNames->yieldKeyword) [[unlikely]]
+        if (token.m_type == ESCAPED_KEYWORD && token.m_data.ident == m_vm.propertyNames->yieldKeyword.impl()) [[unlikely]]
             return true;
         return false;
     }
@@ -1941,9 +1940,9 @@ private:
     bool matchAllowedEscapedContextualKeyword()
     {
         ASSERT(m_token.m_type == ESCAPED_KEYWORD);
-        return (*m_token.m_data.ident == m_vm.propertyNames->letKeyword && !strictMode())
-            || (*m_token.m_data.ident == m_vm.propertyNames->awaitKeyword && canUseIdentifierAwait())
-            || (*m_token.m_data.ident == m_vm.propertyNames->yieldKeyword && canUseIdentifierYield());
+        return (m_token.m_data.ident == m_vm.propertyNames->letKeyword.impl() && !strictMode())
+            || (m_token.m_data.ident == m_vm.propertyNames->awaitKeyword.impl() && canUseIdentifierAwait())
+            || (m_token.m_data.ident == m_vm.propertyNames->yieldKeyword.impl() && canUseIdentifierYield());
     }
 
     const char* disallowedIdentifierLetReason()
@@ -1976,7 +1975,7 @@ private:
 
     ALWAYS_INLINE bool isArgumentsIdentifier()
     {
-        return *m_token.m_data.ident == m_vm.propertyNames->arguments;
+        return m_token.m_data.ident == m_vm.propertyNames->arguments.impl();
     }
 
     // If you're using this directly, you probably should be using

--- a/Source/JavaScriptCore/parser/ParserArena.cpp
+++ b/Source/JavaScriptCore/parser/ParserArena.cpp
@@ -82,14 +82,14 @@ void ParserArena::allocateFreeablePool()
     ASSERT(freeablePool() == pool);
 }
 
-const Identifier* IdentifierArena::makeBigIntDecimalIdentifier(VM& vm, const Identifier& identifier, uint8_t radix)
+UniquedStringImpl* IdentifierArena::makeBigIntDecimalIdentifier(VM& vm, UniquedStringImpl* identifier, uint8_t radix)
 {
     if (radix == 10)
-        return &identifier;
+        return identifier;
 
     DeferTermination deferScope(vm);
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-    JSValue bigInt = JSBigInt::parseInt(nullptr, vm, identifier.string(), radix, JSBigInt::ErrorParseMode::ThrowExceptions, JSBigInt::ParseIntSign::Unsigned);
+    JSValue bigInt = JSBigInt::parseInt(nullptr, vm, StringView { identifier }, radix, JSBigInt::ErrorParseMode::ThrowExceptions, JSBigInt::ParseIntSign::Unsigned);
     scope.assertNoException();
 
     if (bigInt.isEmpty()) {
@@ -114,16 +114,17 @@ const Identifier* IdentifierArena::makeBigIntDecimalIdentifier(VM& vm, const Ide
 #endif
         heapBigInt = bigInt.asHeapBigInt();
 
-    m_identifiers.append(Identifier::fromString(vm, JSBigInt::tryGetString(vm, heapBigInt, 10)));
-    return &m_identifiers.last();
+    m_identifiers.append(Ref { *Identifier::fromString(vm, JSBigInt::tryGetString(vm, heapBigInt, 10)).impl() });
+    return m_identifiers.last().ptr();
 }
 
-const Identifier& IdentifierArena::makePrivateIdentifier(VM& vm, ASCIILiteral prefix, unsigned identifier)
+UniquedStringImpl* IdentifierArena::makePrivateIdentifier(VM& vm, ASCIILiteral prefix, unsigned identifier)
 {
     auto symbolName = makeString(prefix, identifier);
-    auto symbol = protect(vm.privateSymbolRegistry())->symbolForKey(symbolName);
-    m_identifiers.append(Identifier::fromUid(symbol));
-    return m_identifiers.last();
+    Ref<RegisteredSymbolImpl> symbol = protect(vm.privateSymbolRegistry())->symbolForKey(symbolName);
+    SUPPRESS_UNCOUNTED_LOCAL UniquedStringImpl* ptr = static_cast<UniquedStringImpl*>(&symbol.get());
+    m_identifiers.append(Ref<UniquedStringImpl> { *ptr });
+    return ptr;
 }
 
 }

--- a/Source/JavaScriptCore/parser/ParserArena.h
+++ b/Source/JavaScriptCore/parser/ParserArena.h
@@ -30,6 +30,7 @@
 #include <JavaScriptCore/MathCommon.h>
 #include <array>
 #include <type_traits>
+#include <wtf/Ref.h>
 #include <wtf/SegmentedVector.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -48,18 +49,18 @@ namespace JSC {
         }
 
         template <typename T>
-        ALWAYS_INLINE const Identifier& makeIdentifier(VM&, std::span<const T> characters);
-        ALWAYS_INLINE const Identifier& makeEmptyIdentifier(VM&);
-        ALWAYS_INLINE const Identifier& makeLatin1Identifier(VM&, std::span<const char16_t> characters);
-        ALWAYS_INLINE const Identifier& makeIdentifier(VM&, SymbolImpl*);
+        ALWAYS_INLINE UniquedStringImpl* makeIdentifier(VM&, std::span<const T> characters);
+        ALWAYS_INLINE UniquedStringImpl* makeEmptyIdentifier(VM&);
+        ALWAYS_INLINE UniquedStringImpl* makeLatin1Identifier(VM&, std::span<const char16_t> characters);
+        ALWAYS_INLINE UniquedStringImpl* makeIdentifier(VM&, SymbolImpl*);
 
-        const Identifier* makeBigIntDecimalIdentifier(VM&, const Identifier&, uint8_t radix);
-        const Identifier& makeNumericIdentifier(VM&, double number);
-        const Identifier& makePrivateIdentifier(VM&, ASCIILiteral, unsigned);
+        UniquedStringImpl* makeBigIntDecimalIdentifier(VM&, UniquedStringImpl*, uint8_t radix);
+        UniquedStringImpl* makeNumericIdentifier(VM&, double number);
+        UniquedStringImpl* makePrivateIdentifier(VM&, ASCIILiteral, unsigned);
 
     public:
         static const int MaximumCachableCharacter = 128;
-        typedef SegmentedVector<Identifier, 64> IdentifierVector;
+        typedef SegmentedVector<Ref<UniquedStringImpl>, 64> IdentifierVector;
         void clear()
         {
             m_identifiers.clear();
@@ -71,78 +72,78 @@ namespace JSC {
 
     private:
         IdentifierVector m_identifiers;
-        std::array<Identifier*, MaximumCachableCharacter> m_shortIdentifiers;
-        std::array<Identifier*, MaximumCachableCharacter> m_recentIdentifiers;
+        std::array<UniquedStringImpl*, MaximumCachableCharacter> m_shortIdentifiers { };
+        std::array<UniquedStringImpl*, MaximumCachableCharacter> m_recentIdentifiers { };
     };
 
     template <typename T>
-    ALWAYS_INLINE const Identifier& IdentifierArena::makeIdentifier(VM& vm, std::span<const T> characters)
+    ALWAYS_INLINE UniquedStringImpl* IdentifierArena::makeIdentifier(VM& vm, std::span<const T> characters)
     {
         if (characters.empty())
-            return vm.propertyNames->emptyIdentifier;
+            return vm.propertyNames->emptyIdentifier.impl();
         if (characters.front() >= MaximumCachableCharacter) {
-            m_identifiers.append(Identifier::fromString(vm, characters));
-            return m_identifiers.last();
+            m_identifiers.append(Ref { *Identifier::fromString(vm, characters).impl() });
+            return m_identifiers.last().ptr();
         }
         if (characters.size() == 1) {
-            if (Identifier* ident = m_shortIdentifiers[characters.front()])
-                return *ident;
-            m_identifiers.append(Identifier::fromString(vm, characters));
-            m_shortIdentifiers[characters.front()] = &m_identifiers.last();
-            return m_identifiers.last();
+            if (SUPPRESS_UNCOUNTED_LOCAL UniquedStringImpl* impl = m_shortIdentifiers[characters.front()])
+                return impl;
+            m_identifiers.append(Ref { *Identifier::fromString(vm, characters).impl() });
+            m_shortIdentifiers[characters.front()] = m_identifiers.last().ptr();
+            return m_identifiers.last().ptr();
         }
-        Identifier* ident = m_recentIdentifiers[characters.front()];
-        if (ident && Identifier::equal(ident->impl(), characters))
-            return *ident;
-        m_identifiers.append(Identifier::fromString(vm, characters));
-        m_recentIdentifiers[characters.front()] = &m_identifiers.last();
-        return m_identifiers.last();
+        SUPPRESS_UNCOUNTED_LOCAL UniquedStringImpl* impl = m_recentIdentifiers[characters.front()];
+        if (impl && Identifier::equal(impl, characters))
+            return impl;
+        m_identifiers.append(Ref { *Identifier::fromString(vm, characters).impl() });
+        m_recentIdentifiers[characters.front()] = m_identifiers.last().ptr();
+        return m_identifiers.last().ptr();
     }
 
-    ALWAYS_INLINE const Identifier& IdentifierArena::makeIdentifier(VM&, SymbolImpl* symbol)
+    ALWAYS_INLINE UniquedStringImpl* IdentifierArena::makeIdentifier(VM&, SymbolImpl* symbol)
     {
         ASSERT(symbol);
-        m_identifiers.append(Identifier::fromUid(*symbol));
-        return m_identifiers.last();
+        m_identifiers.append(Ref { *symbol });
+        return symbol;
     }
 
-    ALWAYS_INLINE const Identifier& IdentifierArena::makeEmptyIdentifier(VM& vm)
+    ALWAYS_INLINE UniquedStringImpl* IdentifierArena::makeEmptyIdentifier(VM& vm)
     {
-        return vm.propertyNames->emptyIdentifier;
+        return vm.propertyNames->emptyIdentifier.impl();
     }
 
-    ALWAYS_INLINE const Identifier& IdentifierArena::makeLatin1Identifier(VM& vm, std::span<const char16_t> characters)
+    ALWAYS_INLINE UniquedStringImpl* IdentifierArena::makeLatin1Identifier(VM& vm, std::span<const char16_t> characters)
     {
         if (characters.empty())
-            return vm.propertyNames->emptyIdentifier;
+            return vm.propertyNames->emptyIdentifier.impl();
         if (characters.front() >= MaximumCachableCharacter) {
-            m_identifiers.append(Identifier::createLatin1(vm, characters));
-            return m_identifiers.last();
+            m_identifiers.append(Ref { *Identifier::createLatin1(vm, characters).impl() });
+            return m_identifiers.last().ptr();
         }
         if (characters.size() == 1) {
-            if (Identifier* ident = m_shortIdentifiers[characters.front()])
-                return *ident;
-            m_identifiers.append(Identifier::fromString(vm, characters));
-            m_shortIdentifiers[characters.front()] = &m_identifiers.last();
-            return m_identifiers.last();
+            if (UniquedStringImpl* impl = m_shortIdentifiers[characters.front()])
+                return impl;
+            m_identifiers.append(Ref { *Identifier::fromString(vm, characters).impl() });
+            m_shortIdentifiers[characters.front()] = m_identifiers.last().ptr();
+            return m_identifiers.last().ptr();
         }
-        Identifier* ident = m_recentIdentifiers[characters.front()];
-        if (ident && Identifier::equal(ident->impl(), characters))
-            return *ident;
-        m_identifiers.append(Identifier::createLatin1(vm, characters));
-        m_recentIdentifiers[characters.front()] = &m_identifiers.last();
-        return m_identifiers.last();
+        SUPPRESS_UNCOUNTED_LOCAL UniquedStringImpl* impl = m_recentIdentifiers[characters.front()];
+        if (impl && Identifier::equal(impl, characters))
+            return impl;
+        m_identifiers.append(Ref { *Identifier::createLatin1(vm, characters).impl() });
+        m_recentIdentifiers[characters.front()] = m_identifiers.last().ptr();
+        return m_identifiers.last().ptr();
     }
-    
-    inline const Identifier& IdentifierArena::makeNumericIdentifier(VM& vm, double number)
+
+    inline UniquedStringImpl* IdentifierArena::makeNumericIdentifier(VM& vm, double number)
     {
         Identifier token;
         if (auto int32Value = tryConvertToStrictInt32(number))
             token = Identifier::from(vm, int32Value.value());
         else
             token = Identifier::from(vm, number);
-        m_identifiers.append(WTF::move(token));
-        return m_identifiers.last();
+        m_identifiers.append(Ref { *token.impl() });
+        return m_identifiers.last().ptr();
     }
 
     DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(ParserArena);

--- a/Source/JavaScriptCore/parser/ParserFunctionInfo.h
+++ b/Source/JavaScriptCore/parser/ParserFunctionInfo.h
@@ -25,26 +25,26 @@
 
 #pragma once
 
-#include <JavaScriptCore/Identifier.h>
+#include <wtf/text/UniquedStringImpl.h>
 
 namespace JSC {
 
 template <class TreeBuilder>
 struct ParserFunctionInfo {
-    const Identifier* name = nullptr;
-    typename TreeBuilder::FunctionBody body = 0;
-    unsigned parameterCount = 0;
-    unsigned functionLength = 0;
-    unsigned startOffset = 0;
-    unsigned endOffset = 0;
-    int startLine = 0;
-    int endLine = 0;
-    unsigned parametersStartColumn = 0;
+    SUPPRESS_UNCOUNTED_MEMBER UniquedStringImpl* name { nullptr };
+    typename TreeBuilder::FunctionBody body { 0 };
+    unsigned parameterCount { 0 };
+    unsigned functionLength { 0 };
+    unsigned startOffset { 0 };
+    unsigned endOffset { 0 };
+    int startLine { 0 };
+    int endLine { 0 };
+    unsigned parametersStartColumn { 0 };
 };
 
 template <class TreeBuilder>
 struct ParserClassInfo {
-    const Identifier* className { nullptr };
+    SUPPRESS_UNCOUNTED_MEMBER UniquedStringImpl* className { nullptr };
     unsigned startOffset { 0 };
     unsigned endOffset { 0 };
     int startLine { 0 };

--- a/Source/JavaScriptCore/parser/ParserModes.h
+++ b/Source/JavaScriptCore/parser/ParserModes.h
@@ -298,9 +298,9 @@ ALWAYS_INLINE ConstructAbility constructAbilityForParseMode(SourceParseMode pars
     return ConstructAbility::CannotConstruct;
 }
 
-inline bool functionNameIsInScope(const Identifier& name, FunctionMode functionMode)
+inline bool functionNameIsInScope(UniquedStringImpl* name, FunctionMode functionMode)
 {
-    if (name.isNull())
+    if (!name)
         return false;
 
     if (functionMode != FunctionMode::FunctionExpression)

--- a/Source/JavaScriptCore/parser/ParserTokens.h
+++ b/Source/JavaScriptCore/parser/ParserTokens.h
@@ -29,14 +29,13 @@
 #include <stdint.h>
 #include <wtf/Assertions.h>
 #include <wtf/Compiler.h>
+#include <wtf/text/UniquedStringImpl.h>
 
 namespace WTF {
 class PrintStream;
 }
 
 namespace JSC {
-
-class Identifier;
 
 #define BINARY_OP_PRECEDENCE(prec) (((prec) << BinaryOpTokenPrecedenceShift) | ((prec) << (BinaryOpTokenPrecedenceShift + BinaryOpTokenAllowsInPrecedenceAdditionalShift)))
 #define IN_OP_PRECEDENCE(prec) ((prec) << (BinaryOpTokenPrecedenceShift + BinaryOpTokenAllowsInPrecedenceAdditionalShift))
@@ -241,8 +240,8 @@ struct JSTextPosition {
 
 union JSTokenData {
     struct {
-        const Identifier* cooked;
-        const Identifier* raw;
+        SUPPRESS_UNCOUNTED_MEMBER UniquedStringImpl* cooked;
+        SUPPRESS_UNCOUNTED_MEMBER UniquedStringImpl* raw;
         bool isTail;
     };
     struct {
@@ -252,16 +251,16 @@ union JSTokenData {
     };
     double doubleValue;
     struct {
-        const Identifier* ident;
+        SUPPRESS_UNCOUNTED_MEMBER UniquedStringImpl* ident;
         bool escaped;
     };
     struct {
-        const Identifier* bigIntString;
+        SUPPRESS_UNCOUNTED_MEMBER UniquedStringImpl* bigIntString;
         uint8_t radix;
     };
     struct {
-        const Identifier* pattern;
-        const Identifier* flags;
+        SUPPRESS_UNCOUNTED_MEMBER UniquedStringImpl* pattern;
+        SUPPRESS_UNCOUNTED_MEMBER UniquedStringImpl* flags;
     };
 };
 

--- a/Source/JavaScriptCore/parser/SyntaxChecker.h
+++ b/Source/JavaScriptCore/parser/SyntaxChecker.h
@@ -173,34 +173,34 @@ public:
     ALWAYS_INLINE bool isMetaProperty(ExpressionType type) { return type & MetaPropertyBit; }
     ALWAYS_INLINE bool isNewTarget(ExpressionType type) { return type == NewTargetExpr; }
     ALWAYS_INLINE bool isImportMeta(ExpressionType type) { return type == ImportMetaExpr; }
-    ExpressionType createResolve(const JSTokenLocation&, const Identifier&, int, int, const bool = true) { return ResolveExpr; }
-    ExpressionType createPrivateIdentifierNode(const JSTokenLocation&, const Identifier&) { return PrivateIdentifier; }
+    ExpressionType createResolve(const JSTokenLocation&, UniquedStringImpl*, int, int, const bool = true) { return ResolveExpr; }
+    ExpressionType createPrivateIdentifierNode(const JSTokenLocation&, UniquedStringImpl*) { return PrivateIdentifier; }
     ExpressionType createObjectLiteral(const JSTokenLocation&) { return ObjectLiteralExpr; }
     ExpressionType createObjectLiteral(const JSTokenLocation&, int) { return ObjectLiteralExpr; }
     ExpressionType createArray(const JSTokenLocation&, int) { return ArrayLiteralExpr; }
     ExpressionType createArray(const JSTokenLocation&, int, int) { return ArrayLiteralExpr; }
     ExpressionType createDoubleExpr(const JSTokenLocation&, double) { return DoubleExpr; }
     ExpressionType createIntegerExpr(const JSTokenLocation&, double) { return IntegerExpr; }
-    ExpressionType createBigInt(const JSTokenLocation&, const Identifier*, int) { return BigIntExpr; }
-    ExpressionType createString(const JSTokenLocation&, const Identifier*) { return StringExpr; }
+    ExpressionType createBigInt(const JSTokenLocation&, UniquedStringImpl*, int) { return BigIntExpr; }
+    ExpressionType createString(const JSTokenLocation&, UniquedStringImpl*) { return StringExpr; }
     ExpressionType createBoolean(const JSTokenLocation&, bool) { return BoolExpr; }
     ExpressionType createNull(const JSTokenLocation&) { return NullExpr; }
     ExpressionType createBracketAccess(const JSTokenLocation&, ExpressionType, ExpressionType, bool, int, int, int) { return BracketExpr; }
-    ExpressionType createDotAccess(const JSTokenLocation&, ExpressionType, const Identifier*, DotType type, int, int, int) { return type == DotType::PrivateMember ? PrivateDotExpr : DotExpr; }
-    ExpressionType createRegExp(const JSTokenLocation&, const Identifier& pattern, const Identifier& flags, int, bool skipSyntaxCheck) { return !skipSyntaxCheck && Yarr::hasError(Yarr::checkSyntax(pattern.string(), flags.string())) ? 0 : RegExpExpr; }
+    ExpressionType createDotAccess(const JSTokenLocation&, ExpressionType, UniquedStringImpl*, DotType type, int, int, int) { return type == DotType::PrivateMember ? PrivateDotExpr : DotExpr; }
+    ExpressionType createRegExp(const JSTokenLocation&, UniquedStringImpl* pattern, UniquedStringImpl* flags, int, bool skipSyntaxCheck) { return !skipSyntaxCheck && Yarr::hasError(Yarr::checkSyntax(StringView { pattern }, StringView { flags })) ? 0 : RegExpExpr; }
     ExpressionType createNewExpr(const JSTokenLocation&, ExpressionType, int, int, int, int) { return NewExpr; }
     ExpressionType createNewExpr(const JSTokenLocation&, ExpressionType, int, int, int) { return NewExpr; }
     ExpressionType createOptionalChain(const JSTokenLocation&, ExpressionType, ExpressionType, bool) { return OptionalChain; }
     ExpressionType createConditionalExpr(const JSTokenLocation&, ExpressionType, ExpressionType, ExpressionType) { return ConditionalExpr; }
-    ExpressionType createAssignResolve(const JSTokenLocation&, const Identifier&, ExpressionType, int, int, int, AssignmentContext) { return AssignmentExpr; }
-    ExpressionType createEmptyVarExpression(const JSTokenLocation&, const Identifier&) { return AssignmentExpr; }
-    ExpressionType createEmptyLetExpression(const JSTokenLocation&, const Identifier&) { return AssignmentExpr; }
+    ExpressionType createAssignResolve(const JSTokenLocation&, UniquedStringImpl*, ExpressionType, int, int, int, AssignmentContext) { return AssignmentExpr; }
+    ExpressionType createEmptyVarExpression(const JSTokenLocation&, UniquedStringImpl*) { return AssignmentExpr; }
+    ExpressionType createEmptyLetExpression(const JSTokenLocation&, UniquedStringImpl*) { return AssignmentExpr; }
     ExpressionType createYield(const JSTokenLocation&) { return YieldExpr; }
     ExpressionType createYield(const JSTokenLocation&, ExpressionType, bool, int, int, int) { return YieldExpr; }
     ExpressionType createAwait(const JSTokenLocation&, ExpressionType, int, int, int) { return AwaitExpr; }
     ClassExpression createClassExpr(const JSTokenLocation&, const ParserClassInfo<SyntaxChecker>&, VariableEnvironment&&, VariableEnvironment&&, ExpressionType, ExpressionType, PropertyList, int, int, int) { return ClassExpr; }
     ExpressionType createFunctionExpr(const JSTokenLocation&, const ParserFunctionInfo<SyntaxChecker>&) { return FunctionExpr; }
-    ExpressionType createGeneratorFunctionBody(const JSTokenLocation&, const ParserFunctionInfo<SyntaxChecker>&, const Identifier&) { return FunctionExpr; }
+    ExpressionType createGeneratorFunctionBody(const JSTokenLocation&, const ParserFunctionInfo<SyntaxChecker>&, UniquedStringImpl*) { return FunctionExpr; }
     ExpressionType createAsyncFunctionBody(const JSTokenLocation&, const ParserFunctionInfo<SyntaxChecker>&) { return FunctionExpr; }
     int createFunctionMetadata(const JSTokenLocation&, const JSTokenLocation&, unsigned, unsigned, int, int, int, ImplementationVisibility, LexicallyScopedFeatures, ConstructorKind, SuperBinding, unsigned, SourceParseMode, bool) { return FunctionBodyResult; }
     ExpressionType createArrowFunctionExpr(const JSTokenLocation&, const ParserFunctionInfo<SyntaxChecker>&) { return FunctionExpr; }
@@ -210,7 +210,7 @@ public:
     int createArguments(int, bool) { return ArgumentsResult; }
     ExpressionType createSpreadExpression(const JSTokenLocation&, ExpressionType, int, int, int) { return SpreadExpr; }
     ExpressionType createObjectSpreadExpression(const JSTokenLocation&, ExpressionType, int, int, int) { return ObjectSpreadExpr; }
-    TemplateString createTemplateString(const JSTokenLocation&, const Identifier*, const Identifier*) { return TemplateStringResult; }
+    TemplateString createTemplateString(const JSTokenLocation&, UniquedStringImpl*, UniquedStringImpl*) { return TemplateStringResult; }
     TemplateStringList createTemplateStringList(TemplateString) { return TemplateStringListResult; }
     TemplateStringList createTemplateStringList(TemplateStringList, TemplateString) { return TemplateStringListResult; }
     TemplateExpressionList createTemplateExpressionList(Expression) { return TemplateExpressionListResult; }
@@ -221,7 +221,7 @@ public:
 
     int createArgumentsList(const JSTokenLocation&, int) { return ArgumentsListResult; }
     int createArgumentsList(const JSTokenLocation&, int, int) { return ArgumentsListResult; }
-    Property createProperty(const Identifier* name, int, PropertyNode::Type type, SuperBinding superBinding, InferName, ClassElementTag tag)
+    Property createProperty(UniquedStringImpl* name, int, PropertyNode::Type type, SuperBinding superBinding, InferName, ClassElementTag tag)
     {
         bool needsSuperBinding = superBinding == SuperBinding::Needed;
         bool isClassProperty = tag != ClassElementTag::No;
@@ -239,11 +239,11 @@ public:
     {
         return Property(type);
     }
-    Property createProperty(const Identifier*, int, int, PropertyNode::Type type, SuperBinding, ClassElementTag)
+    Property createProperty(UniquedStringImpl*, int, int, PropertyNode::Type type, SuperBinding, ClassElementTag)
     {
         return Property(type);
     }
-    Property createProperty(const Identifier*, PropertyNode::Type type, SuperBinding, ClassElementTag)
+    Property createProperty(UniquedStringImpl*, PropertyNode::Type type, SuperBinding, ClassElementTag)
     {
         return Property(type);
     }
@@ -258,7 +258,7 @@ public:
     int createClauseList(int) { return ClauseListResult; }
     int createClauseList(int, int) { return ClauseListResult; }
     int createFuncDeclStatement(const JSTokenLocation&, const ParserFunctionInfo<SyntaxChecker>&) { return StatementResult; }
-    int createDefineField(const JSTokenLocation&, const Identifier&, int, DefineFieldNode::Type) { return 0; }
+    int createDefineField(const JSTokenLocation&, UniquedStringImpl*, int, DefineFieldNode::Type) { return 0; }
     int createClassDeclStatement(const JSTokenLocation&, ClassExpression,
         const JSTextPosition&, const JSTextPosition&, int, int) { return StatementResult; }
     int createBlockStatement(const JSTokenLocation&, int, int, int, VariableEnvironment&&, DeclarationStacks::FunctionStack&&) { return StatementResult; }
@@ -272,35 +272,36 @@ public:
     int createDeclarationStatement(const JSTokenLocation&, int, int, int) { return StatementResult; }
     int createReturnStatement(const JSTokenLocation&, int, int, int) { return StatementResult; }
     int createBreakStatement(const JSTokenLocation&, int, int) { return StatementResult; }
-    int createBreakStatement(const JSTokenLocation&, const Identifier*, int, int) { return StatementResult; }
+    int createBreakStatement(const JSTokenLocation&, UniquedStringImpl*, int, int) { return StatementResult; }
     int createContinueStatement(const JSTokenLocation&, int, int) { return StatementResult; }
-    int createContinueStatement(const JSTokenLocation&, const Identifier*, int, int) { return StatementResult; }
+    int createContinueStatement(const JSTokenLocation&, UniquedStringImpl*, int, int) { return StatementResult; }
     int createTryStatement(const JSTokenLocation&, int, int, int, int, int, int, VariableEnvironment&&) { return StatementResult; }
     int createSwitchStatement(const JSTokenLocation&, int, int, int, int, int, int, VariableEnvironment&&, DeclarationStacks::FunctionStack&&) { return StatementResult; }
     int createWhileStatement(const JSTokenLocation&, int, int, int, int) { return StatementResult; }
     int createWithStatement(const JSTokenLocation&, int, int, int, int, int, int) { return StatementResult; }
     int createDoWhileStatement(const JSTokenLocation&, int, int, int, int) { return StatementResult; }
-    int createLabelStatement(const JSTokenLocation&, const Identifier*, int, int, int) { return StatementResult; }
+    int createLabelStatement(const JSTokenLocation&, UniquedStringImpl*, int, int, int) { return StatementResult; }
     int createThrowStatement(const JSTokenLocation&, int, int, int) { return StatementResult; }
     int createDebugger(const JSTokenLocation&, int, int) { return StatementResult; }
     int createConstStatement(const JSTokenLocation&, int, int, int) { return StatementResult; }
-    int createModuleName(const JSTokenLocation&, const Identifier&) { return ModuleNameResult; }
-    ImportSpecifier createImportSpecifier(const JSTokenLocation&, const Identifier&, const Identifier&) { return ImportSpecifierResult; }
+    int createModuleName(const JSTokenLocation&, UniquedStringImpl*) { return ModuleNameResult; }
+    ImportSpecifier createImportSpecifier(const JSTokenLocation&, UniquedStringImpl*, UniquedStringImpl*) { return ImportSpecifierResult; }
     ImportSpecifierList createImportSpecifierList() { return ImportSpecifierListResult; }
     void appendImportSpecifier(ImportSpecifierList, ImportSpecifier) { }
     ImportAttributesList createImportAttributesList() { return ImportAttributesListResult; }
-    void appendImportAssertion(ImportAttributesList, const Identifier&, const Identifier&) { }
+    void appendImportAttribute(ImportAttributesList, UniquedStringImpl*, UniquedStringImpl*) { }
+    void appendImportAssertion(ImportAttributesList, UniquedStringImpl*, UniquedStringImpl*) { }
     int createImportDeclaration(const JSTokenLocation&, ImportSpecifierList, ModuleName, ImportAttributesList) { return StatementResult; }
     int createExportAllDeclaration(const JSTokenLocation&, ModuleName, ImportAttributesList) { return StatementResult; }
-    int createExportDefaultDeclaration(const JSTokenLocation&, int, const Identifier&) { return StatementResult; }
+    int createExportDefaultDeclaration(const JSTokenLocation&, int, UniquedStringImpl*) { return StatementResult; }
     int createExportLocalDeclaration(const JSTokenLocation&, int) { return StatementResult; }
     int createExportNamedDeclaration(const JSTokenLocation&, ExportSpecifierList, ModuleName, ImportAttributesList) { return StatementResult; }
-    ExportSpecifier createExportSpecifier(const JSTokenLocation&, const Identifier&, const Identifier&) { return ExportSpecifierResult; }
+    ExportSpecifier createExportSpecifier(const JSTokenLocation&, UniquedStringImpl*, UniquedStringImpl*) { return ExportSpecifierResult; }
     ExportSpecifierList createExportSpecifierList() { return ExportSpecifierListResult; }
     void appendExportSpecifier(ExportSpecifierList, ExportSpecifier) { }
 
-    int appendConstDecl(const JSTokenLocation&, int, const Identifier*, int) { return StatementResult; }
-    Property createGetterOrSetterProperty(const JSTokenLocation&, PropertyNode::Type type, const Identifier*, const ParserFunctionInfo<SyntaxChecker>&, ClassElementTag)
+    int appendConstDecl(const JSTokenLocation&, int, UniquedStringImpl*, int) { return StatementResult; }
+    Property createGetterOrSetterProperty(const JSTokenLocation&, PropertyNode::Type type, UniquedStringImpl*, const ParserFunctionInfo<SyntaxChecker>&, ClassElementTag)
     {
         return Property(type);
     }
@@ -370,7 +371,7 @@ public:
     {
         return ObjectDestructuring;
     }
-    void appendObjectPatternEntry(ObjectPattern, const JSTokenLocation&, bool, const Identifier&, DestructuringPattern, int)
+    void appendObjectPatternEntry(ObjectPattern, const JSTokenLocation&, bool, UniquedStringImpl*, DestructuringPattern, int)
     {
     }
     void appendObjectPatternEntry(VM&, ObjectPattern, const JSTokenLocation&, Expression, DestructuringPattern, Expression)
@@ -389,7 +390,7 @@ public:
     {
     }
 
-    DestructuringPattern createBindingLocation(const JSTokenLocation&, const Identifier&, const JSTextPosition&, const JSTextPosition&, AssignmentContext)
+    DestructuringPattern createBindingLocation(const JSTokenLocation&, UniquedStringImpl*, const JSTextPosition&, const JSTextPosition&, AssignmentContext)
     {
         return BindingDestructuring;
     }

--- a/Source/JavaScriptCore/parser/VariableEnvironment.h
+++ b/Source/JavaScriptCore/parser/VariableEnvironment.h
@@ -172,10 +172,7 @@ public:
     ALWAYS_INLINE Map::const_iterator begin() const { return m_map.begin(); }
     ALWAYS_INLINE Map::const_iterator end() const { return m_map.end(); }
     ALWAYS_INLINE Map::AddResult add(const RefPtr<UniquedStringImpl>& identifier) { return m_map.add(identifier, VariableEnvironmentEntry()); }
-    ALWAYS_INLINE Map::AddResult add(const Identifier& identifier) { return add(identifier.impl()); }
 
-    // Defined in VariableEnvironmentInlines.h.
-    PrivateNameEnvironment::AddResult addPrivateName(const Identifier& identifier);
     // Defined in VariableEnvironmentInlines.h.
     PrivateNameEnvironment::AddResult addPrivateName(const RefPtr<UniquedStringImpl>& identifier);
 
@@ -218,11 +215,6 @@ public:
 
     using PrivateNamesRange = WTF::IteratorRange<PrivateNameEnvironment::iterator>;
 
-    // Defined in VariableEnvironmentInlines.h.
-    Map::AddResult declarePrivateField(const Identifier& identifier);
-
-    // Defined in VariableEnvironmentInlines.h.
-    bool declarePrivateMethod(const Identifier& identifier);
     bool declarePrivateMethod(const RefPtr<UniquedStringImpl>& identifier, PrivateNameEntry::Traits addionalTraits = PrivateNameEntry::Traits::None);
 
     enum class PrivateDeclarationResult {
@@ -233,19 +225,13 @@ public:
 
     PrivateDeclarationResult declarePrivateAccessor(const RefPtr<UniquedStringImpl>&, PrivateNameEntry accessorTraits);
 
-    // Defined in VariableEnvironmentInlines.h.
-    bool declareStaticPrivateMethod(const Identifier& identifier);
+    bool declareStaticPrivateMethod(UniquedStringImpl* identifier)
+    {
+        return declarePrivateMethod(RefPtr<UniquedStringImpl>(identifier), static_cast<PrivateNameEntry::Traits>(PrivateNameEntry::Traits::IsMethod | PrivateNameEntry::Traits::IsStatic));
+    }
 
-    // Defined in VariableEnvironmentInlines.h.
-    PrivateDeclarationResult declarePrivateSetter(const Identifier& identifier);
-    // Defined in VariableEnvironmentInlines.h.
-    PrivateDeclarationResult declareStaticPrivateSetter(const Identifier& identifier);
     PrivateDeclarationResult declarePrivateSetter(const RefPtr<UniquedStringImpl>& identifier, PrivateNameEntry::Traits modifierTraits = PrivateNameEntry::Traits::None);
 
-    // Defined in VariableEnvironmentInlines.h.
-    PrivateDeclarationResult declarePrivateGetter(const Identifier& identifier);
-    // Defined in VariableEnvironmentInlines.h.
-    PrivateDeclarationResult declareStaticPrivateGetter(const Identifier& identifier);
     PrivateDeclarationResult declarePrivateGetter(const RefPtr<UniquedStringImpl>& identifier, PrivateNameEntry::Traits modifierTraits = PrivateNameEntry::Traits::None);
 
     Map::AddResult declarePrivateField(const RefPtr<UniquedStringImpl>&);
@@ -304,11 +290,11 @@ public:
         return false;
     }
 
-    ALWAYS_INLINE bool hasPrivateName(const Identifier& identifier)
+    ALWAYS_INLINE bool hasPrivateName(UniquedStringImpl* identifier)
     {
         if (!m_rareData)
             return false;
-        return m_rareData->m_privateNames.contains(identifier.impl());
+        return m_rareData->m_privateNames.contains(identifier);
     }
 
     // Defined in VariableEnvironmentInlines.h.

--- a/Source/JavaScriptCore/parser/VariableEnvironmentInlines.h
+++ b/Source/JavaScriptCore/parser/VariableEnvironmentInlines.h
@@ -29,41 +29,6 @@
 
 namespace JSC {
 
-ALWAYS_INLINE VariableEnvironment::Map::AddResult VariableEnvironment::declarePrivateField(const Identifier& identifier)
-{
-    return declarePrivateField(identifier.impl());
-}
-
-inline bool VariableEnvironment::declarePrivateMethod(const Identifier& identifier)
-{
-    return declarePrivateMethod(identifier.impl());
-}
-
-inline bool VariableEnvironment::declareStaticPrivateMethod(const Identifier& identifier)
-{
-    return declarePrivateMethod(identifier.impl(), static_cast<PrivateNameEntry::Traits>(PrivateNameEntry::Traits::IsMethod | PrivateNameEntry::Traits::IsStatic));
-}
-
-inline VariableEnvironment::PrivateDeclarationResult VariableEnvironment::declarePrivateSetter(const Identifier& identifier)
-{
-    return declarePrivateSetter(identifier.impl());
-}
-
-inline VariableEnvironment::PrivateDeclarationResult VariableEnvironment::declareStaticPrivateSetter(const Identifier& identifier)
-{
-    return declarePrivateSetter(identifier.impl(), PrivateNameEntry::Traits::IsStatic);
-}
-
-inline VariableEnvironment::PrivateDeclarationResult VariableEnvironment::declarePrivateGetter(const Identifier& identifier)
-{
-    return declarePrivateGetter(identifier.impl());
-}
-
-inline VariableEnvironment::PrivateDeclarationResult VariableEnvironment::declareStaticPrivateGetter(const Identifier& identifier)
-{
-    return declarePrivateGetter(identifier.impl(), PrivateNameEntry::Traits::IsStatic);
-}
-
 inline TDZEnvironment& CompactTDZEnvironment::toTDZEnvironment() const
 {
     if (std::holds_alternative<Inflated>(m_variables))
@@ -93,11 +58,6 @@ inline VariableEnvironment::VariableEnvironment(const VariableEnvironment& other
     , m_hasAwaitUsingDeclaration(other.m_hasAwaitUsingDeclaration)
     , m_rareData(other.m_rareData ? WTF::makeUnique<VariableEnvironment::RareData>(*other.m_rareData) : nullptr)
 {
-}
-
-ALWAYS_INLINE PrivateNameEnvironment::AddResult VariableEnvironment::addPrivateName(const Identifier& identifier)
-{
-    return addPrivateName(identifier.impl());
 }
 
 ALWAYS_INLINE PrivateNameEnvironment::AddResult VariableEnvironment::addPrivateName(const RefPtr<UniquedStringImpl>& identifier)

--- a/Source/JavaScriptCore/runtime/CodeCache.cpp
+++ b/Source/JavaScriptCore/runtime/CodeCache.cpp
@@ -250,7 +250,7 @@ UnlinkedFunctionExecutable* CodeCache::getUnlinkedGlobalFunctionExecutable(VM& v
     if (!metadata)
         return nullptr;
     
-    metadata->overrideName(name);
+    metadata->overrideName(name.impl());
     metadata->setEndPosition(positionBeforeLastNewline);
     // The Function constructor only has access to global variables, so no variables will be under TDZ unless they're
     // in the global lexical environment, which we always TDZ check accesses from.

--- a/Source/JavaScriptCore/runtime/IdentifierInlines.h
+++ b/Source/JavaScriptCore/runtime/IdentifierInlines.h
@@ -123,7 +123,9 @@ inline Identifier Identifier::createLatin1(VM& vm, std::span<const char16_t> str
 
 SUPPRESS_NODELETE inline Identifier Identifier::fromUid(VM& vm, UniquedStringImpl* uid)
 {
-    if (!uid || !uid->isSymbol())
+    if (!uid)
+        return Identifier();
+    if (!uid->isSymbol())
         return Identifier(vm, uid);
     return static_cast<SymbolImpl&>(*uid);
 }


### PR DESCRIPTION
#### e3a1e4c7d93d2ce36f7950d92ec1437f434d18b7
<pre>
[JSC] Use UniquedStringImpl* instead of Identifier* in parser
<a href="https://bugs.webkit.org/show_bug.cgi?id=310837">https://bugs.webkit.org/show_bug.cgi?id=310837</a>
<a href="https://rdar.apple.com/173444693">rdar://173444693</a>

Reviewed by NOBODY (OOPS!).

This patch moves Identifier* use to UniquedStringImpl* in parser.
Identiefier* is weird thing as it is something like UniquedStringImpl**.
Let&apos;s just use UniquedStringImpl* instead in this case.

This is also a preparation for embedding UniquedStringImpl* into
SyntaxChecker&apos;s expression when necessary, to make our parser more
efficient.

* Source/JavaScriptCore/KeywordLookupGenerator.py:
(Trie.printSubTreeAsC):
* Source/JavaScriptCore/builtins/BuiltinExecutables.cpp:
(JSC::BuiltinExecutables::createExecutable):
* Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp:
(JSC::generateUnlinkedFunctionCodeBlock):
(JSC::UnlinkedFunctionExecutable::UnlinkedFunctionExecutable):
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::generate):
(JSC::BytecodeGenerator::BytecodeGenerator):
(JSC::BytecodeGenerator::initializeDefaultParameterValuesAndSetupFunctionScopeStack):
(JSC::BytecodeGenerator::initializeArrowFunctionContextScopeIfNeeded):
(JSC::BytecodeGenerator::visibleNameForParameter):
(JSC::BytecodeGenerator::newLabelScope):
(JSC::BytecodeGenerator::hasConstant const):
(JSC::BytecodeGenerator::addConstant):
(JSC::BytecodeGenerator::emitToObject):
(JSC::BytecodeGenerator::emitLoad):
(JSC::BytecodeGenerator::initializeBlockScopedFunctions):
(JSC::BytecodeGenerator::hoistSloppyModeFunctionIfNecessary):
(JSC::BytecodeGenerator::emitResolveScopeForHoistingFuncDeclInEval):
(JSC::BytecodeGenerator::prepareLexicalScopeForNextForLoopIteration):
(JSC::BytecodeGenerator::variable):
(JSC::BytecodeGenerator::variableForLocalEntry):
(JSC::BytecodeGenerator::createVariable):
(JSC::BytecodeGenerator::tryResolveVariable):
(JSC::BytecodeGenerator::emitResolveScope):
(JSC::BytecodeGenerator::emitPutToScopeDynamic):
(JSC::BytecodeGenerator::emitInById):
(JSC::BytecodeGenerator::emitGetById):
(JSC::BytecodeGenerator::emitDirectGetById):
(JSC::BytecodeGenerator::emitPutById):
(JSC::BytecodeGenerator::emitDirectPutById):
(JSC::BytecodeGenerator::emitPutGetterById):
(JSC::BytecodeGenerator::emitPutSetterById):
(JSC::BytecodeGenerator::emitPutGetterSetter):
(JSC::BytecodeGenerator::emitDeleteById):
(JSC::BytecodeGenerator::emitCreatePrivateBrand):
(JSC::BytecodeGenerator::emitInstallPrivateBrand):
(JSC::BytecodeGenerator::emitInstallPrivateClassBrand):
(JSC::BytecodeGenerator::emitGetPrivateBrand):
(JSC::BytecodeGenerator::emitInstanceFieldInitializationIfNeeded):
(JSC::BytecodeGenerator::needsTDZCheck):
(JSC::BytecodeGenerator::liftTDZCheckIfPossible):
(JSC::BytecodeGenerator::getPrivateTraits):
(JSC::BytecodeGenerator::getParameterNames const):
(JSC::BytecodeGenerator::addBigIntConstant):
(JSC::BytecodeGenerator::addStringConstant):
(JSC::BytecodeGenerator::emitNewClassFieldInitializerFunction):
(JSC::BytecodeGenerator::shouldSetFunctionName):
(JSC::BytecodeGenerator::emitSetFunctionName):
(JSC::BytecodeGenerator::expectedFunctionForIdentifier):
(JSC::BytecodeGenerator::emitReturn):
(JSC::BytecodeGenerator::breakTarget):
(JSC::BytecodeGenerator::continueTarget):
(JSC::BytecodeGenerator::emitThrowStaticError):
(JSC::BytecodeGenerator::emitThrowReferenceError):
(JSC::BytecodeGenerator::emitThrowTypeError):
(JSC::BytecodeGenerator::emitThrowRangeError):
(JSC::BytecodeGenerator::emitThrowOutOfMemoryError):
(JSC::BytecodeGenerator::emitPushFunctionNameScope):
(JSC::BytecodeGenerator::endSwitch):
(JSC::BytecodeGenerator::isArgumentNumber):
(JSC::BytecodeGenerator::emitReadOnlyExceptionIfNeeded):
(JSC::BytecodeGenerator::emitGenericEnumeration):
(JSC::BytecodeGenerator::emitEnumeration):
(JSC::BytecodeGenerator::emitGetTemplateObject):
(JSC::BytecodeGenerator::emitGetGlobalPrivate):
(JSC::BytecodeGenerator::emitLoadArrowFunctionLexicalEnvironment):
(JSC::BytecodeGenerator::emitLoadThisFromArrowFunctionLexicalEnvironment):
(JSC::BytecodeGenerator::emitLoadNewTargetFromArrowFunctionLexicalEnvironment):
(JSC::BytecodeGenerator::emitLoadDerivedConstructorFromArrowFunctionLexicalEnvironment):
(JSC::BytecodeGenerator::emitPutNewTargetToArrowFunctionContextScope):
(JSC::BytecodeGenerator::emitPutDerivedConstructorToArrowFunctionContextScope):
(JSC::BytecodeGenerator::emitPutThisToArrowFunctionContextScope):
(JSC::BytecodeGenerator::emitRequireObjectCoercibleForDestructuring):
(JSC::BytecodeGenerator::emitGetGenericIterator):
(JSC::BytecodeGenerator::emitIteratorGenericClose):
(JSC::BytecodeGenerator::emitGetAsyncIterator):
(JSC::BytecodeGenerator::emitDelegateYield):
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h:
(JSC::Variable::Variable):
(JSC::Variable::ident const):
* Source/JavaScriptCore/bytecompiler/LabelScope.h:
(JSC::LabelScope::LabelScope):
(JSC::LabelScope::name const):
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::RegExpNode::emitBytecode):
(JSC::emitHomeObjectForCallee):
(JSC::ResolveNode::emitBytecode):
(JSC::TemplateStringNode::emitBytecode):
(JSC::TaggedTemplateNode::emitBytecode):
(JSC::ArrayNode::emitBytecode):
(JSC::emitPutHomeObject):
(JSC::PropertyListNode::emitDeclarePrivateFieldNames):
(JSC::PropertyListNode::emitBytecode):
(JSC::PropertyListNode::emitPutConstantProperty):
(JSC::PropertyListNode::emitSaveComputedFieldName):
(JSC::BracketAccessorNode::emitBytecode):
(JSC::BaseDotNode::emitGetPropertyValue):
(JSC::BaseDotNode::emitPutProperty):
(JSC::NewExprNode::emitBytecode):
(JSC::EvalFunctionCallNode::emitBytecode):
(JSC::FunctionCallResolveNode::emitBytecode):
(JSC::BytecodeIntrinsicNode::emit_intrinsic_getByIdDirect):
(JSC::BytecodeIntrinsicNode::emit_intrinsic_getByIdDirectPrivate):
(JSC::BytecodeIntrinsicNode::emit_intrinsic_putByIdDirect):
(JSC::BytecodeIntrinsicNode::emit_intrinsic_putByIdDirectPrivate):
(JSC::BytecodeIntrinsicNode::emit_intrinsic_throwTypeError):
(JSC::BytecodeIntrinsicNode::emit_intrinsic_throwRangeError):
(JSC::BytecodeIntrinsicNode::emit_intrinsic_toObject):
(JSC::BytecodeIntrinsicNode::emit_intrinsic_idWithProfile):
(JSC::CallFunctionCallDotNode::emitBytecode):
(JSC::HasOwnPropertyFunctionCallDotNode::emitBytecode):
(JSC::ApplyFunctionCallDotNode::emitBytecode):
(JSC::PostfixNode::emitResolve):
(JSC::PostfixNode::emitDot):
(JSC::TypeOfResolveNode::emitBytecode):
(JSC::PrefixNode::emitResolve):
(JSC::PrefixNode::emitDot):
(JSC::InNode::emitBytecode):
(JSC::ReadModifyResolveNode::emitBytecode):
(JSC::ShortCircuitReadModifyResolveNode::emitBytecode):
(JSC::AssignResolveNode::emitBytecode):
(JSC::AssignBracketNode::emitBytecode):
(JSC::EmptyVarExpression::emitBytecode):
(JSC::EmptyLetExpression::emitBytecode):
(JSC::ForInNode::tryGetBoundLocal):
(JSC::ForInNode::emitLoopHeader):
(JSC::ForOfNode::emitBytecode):
(JSC::processClauseList):
(JSC::LabelNode::emitBytecode):
(JSC::DefineFieldNode::emitBytecode):
(JSC::ClassExprNode::emitBytecode):
(JSC::ArrayPatternNode::bindValue const):
(JSC::ArrayPatternNode::collectBoundIdentifiers const):
(JSC::ObjectPatternNode::toString const):
(JSC::ObjectPatternNode::bindValue const):
(JSC::ObjectPatternNode::collectBoundIdentifiers const):
(JSC::BindingNode::toString const):
(JSC::BindingNode::collectBoundIdentifiers const):
(JSC::AssignmentElementNode::bindValueCanThrow const):
(JSC::AssignmentElementNode::writableDirectBindingIfPossible const):
(JSC::AssignmentElementNode::finishDirectBindingAssignment const):
(JSC::AssignmentElementNode::collectBoundIdentifiers const):
(JSC::AssignmentElementNode::bindValue const):
(JSC::AssignmentElementNode::toString const):
(JSC::RestParameterNode::collectBoundIdentifiers const):
* Source/JavaScriptCore/parser/ASTBuilder.h:
(JSC::ASTBuilder::createResolve):
(JSC::ASTBuilder::createPrivateIdentifierNode):
(JSC::ASTBuilder::createBigInt):
(JSC::ASTBuilder::createString):
(JSC::ASTBuilder::createDotAccess):
(JSC::ASTBuilder::createTemplateString):
(JSC::ASTBuilder::createRegExp):
(JSC::ASTBuilder::createAssignResolve):
(JSC::ASTBuilder::createDefineField):
(JSC::ASTBuilder::createClassExpr):
(JSC::ASTBuilder::createFunctionExpr):
(JSC::ASTBuilder::createGeneratorFunctionBody):
(JSC::ASTBuilder::createAsyncFunctionBody):
(JSC::ASTBuilder::createMethodDefinition):
(JSC::ASTBuilder::createArrowFunctionExpr):
(JSC::ASTBuilder::createGetterOrSetterProperty):
(JSC::ASTBuilder::createProperty):
(JSC::ASTBuilder::createFuncDeclStatement):
(JSC::ASTBuilder::createClassDeclStatement):
(JSC::ASTBuilder::createEmptyVarExpression):
(JSC::ASTBuilder::createEmptyLetExpression):
(JSC::ASTBuilder::createBreakStatement):
(JSC::ASTBuilder::createContinueStatement):
(JSC::ASTBuilder::createLabelStatement):
(JSC::ASTBuilder::createModuleName):
(JSC::ASTBuilder::createImportSpecifier):
(JSC::ASTBuilder::appendImportAttribute):
(JSC::ASTBuilder::createExportDefaultDeclaration):
(JSC::ASTBuilder::createExportSpecifier):
(JSC::ASTBuilder::appendObjectPatternEntry):
(JSC::ASTBuilder::createBindingLocation):
(JSC::ASTBuilder::createBigIntWithSign):
(JSC::ASTBuilder::tryInferNameInPattern):
(JSC::ASTBuilder::tryInferNameInPatternWithIdentifier):
(JSC::ASTBuilder::makeTypeOfNode):
(JSC::ASTBuilder::makeDeleteNode):
(JSC::ASTBuilder::makeFunctionCallNode):
(JSC::ASTBuilder::makeAssignNode):
* Source/JavaScriptCore/parser/Lexer.cpp:
(JSC::isSafeBuiltinIdentifier):
(JSC::Lexer&lt;Latin1Character&gt;::parseIdentifier):
(JSC::Lexer&lt;char16_t&gt;::parseIdentifier):
(JSC::Lexer&lt;CharacterType&gt;::parseIdentifierSlowCase):
(JSC::Lexer&lt;T&gt;::lexWithoutClearingLineTerminator):
* Source/JavaScriptCore/parser/Lexer.h:
(JSC::Lexer&lt;T&gt;::makeIdentifier):
(JSC::Lexer&lt;Latin1Character&gt;::makeRightSizedIdentifier):
(JSC::Lexer&lt;char16_t&gt;::makeRightSizedIdentifier):
(JSC::Lexer&lt;T&gt;::makeEmptyIdentifier):
(JSC::Lexer&lt;T&gt;::makeLatin1Identifier):
(JSC::isSafeBuiltinIdentifier):
* Source/JavaScriptCore/parser/ModuleScopeData.h:
(JSC::ModuleScopeData::exportName):
(JSC::ModuleScopeData::exportBinding):
* Source/JavaScriptCore/parser/NodeConstructors.h:
(JSC::BigIntNode::BigIntNode):
(JSC::StringNode::StringNode):
(JSC::TemplateStringNode::TemplateStringNode):
(JSC::RegExpNode::RegExpNode):
(JSC::ResolveNode::ResolveNode):
(JSC::PrivateIdentifierNode::PrivateIdentifierNode):
(JSC::PropertyNode::PropertyNode):
(JSC::BaseDotNode::BaseDotNode):
(JSC::DotAccessorNode::DotAccessorNode):
(JSC::FunctionCallResolveNode::FunctionCallResolveNode):
(JSC::FunctionCallDotNode::FunctionCallDotNode):
(JSC::BytecodeIntrinsicNode::BytecodeIntrinsicNode):
(JSC::CallFunctionCallDotNode::CallFunctionCallDotNode):
(JSC::ApplyFunctionCallDotNode::ApplyFunctionCallDotNode):
(JSC::HasOwnPropertyFunctionCallDotNode::HasOwnPropertyFunctionCallDotNode):
(JSC::DeleteResolveNode::DeleteResolveNode):
(JSC::DeleteDotNode::DeleteDotNode):
(JSC::TypeOfResolveNode::TypeOfResolveNode):
(JSC::ReadModifyResolveNode::ReadModifyResolveNode):
(JSC::ShortCircuitReadModifyResolveNode::ShortCircuitReadModifyResolveNode):
(JSC::AssignResolveNode::AssignResolveNode):
(JSC::AssignDotNode::AssignDotNode):
(JSC::ReadModifyDotNode::ReadModifyDotNode):
(JSC::ShortCircuitReadModifyDotNode::ShortCircuitReadModifyDotNode):
(JSC::ModuleNameNode::ModuleNameNode):
(JSC::ImportSpecifierNode::ImportSpecifierNode):
(JSC::ExportDefaultDeclarationNode::ExportDefaultDeclarationNode):
(JSC::ExportSpecifierNode::ExportSpecifierNode):
(JSC::EmptyVarExpression::EmptyVarExpression):
(JSC::EmptyLetExpression::EmptyLetExpression):
(JSC::ContinueNode::ContinueNode):
(JSC::BreakNode::BreakNode):
(JSC::LabelNode::LabelNode):
(JSC::BaseFuncExprNode::BaseFuncExprNode):
(JSC::FuncExprNode::FuncExprNode):
(JSC::FuncDeclNode::FuncDeclNode):
(JSC::ArrowFuncExprNode::ArrowFuncExprNode):
(JSC::MethodDefinitionNode::MethodDefinitionNode):
(JSC::DefineFieldNode::DefineFieldNode):
(JSC::ClassExprNode::ClassExprNode):
(JSC::BindingNode::BindingNode):
* Source/JavaScriptCore/parser/Nodes.cpp:
(JSC::FunctionMetadataNode::finishParsing):
(JSC::FunctionMetadataNode::dump const):
(JSC::FunctionNode::finishParsing):
(JSC::PropertyListNode::hasStaticallyNamedProperty):
* Source/JavaScriptCore/parser/Nodes.h:
(JSC::BaseDotNode::ident const):
(JSC::ScopeNode::captures):
(JSC::BaseDotNode::identifier const): Deleted.
* Source/JavaScriptCore/parser/NodesAnalyzeModule.cpp:
(JSC::tryCreateAttributes):
(JSC::ImportDeclarationNode::analyzeModule):
(JSC::ExportAllDeclarationNode::analyzeModule):
(JSC::ExportNamedDeclarationNode::analyzeModule):
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseInner):
(JSC::Parser&lt;LexerType&gt;::parseSourceElements):
(JSC::Parser&lt;LexerType&gt;::parseModuleSourceElements):
(JSC::Parser&lt;LexerType&gt;::parseGeneratorFunctionSourceElements):
(JSC::Parser&lt;LexerType&gt;::parseAsyncFunctionSourceElements):
(JSC::Parser&lt;LexerType&gt;::parseAsyncGeneratorFunctionSourceElements):
(JSC::Parser&lt;LexerType&gt;::parseSingleFunction):
(JSC::Parser&lt;LexerType&gt;::parseStatementListItem):
(JSC::Parser&lt;LexerType&gt;::parseDoWhileStatement):
(JSC::Parser&lt;LexerType&gt;::parseWhileStatement):
(JSC::Parser&lt;LexerType&gt;::parseVariableDeclarationList):
(JSC::Parser&lt;LexerType&gt;::declareRestOrNormalParameter):
(JSC::Parser&lt;LexerType&gt;::createBindingPattern):
(JSC::Parser&lt;LexerType&gt;::parseBindingOrAssignmentElement):
(JSC::Parser&lt;LexerType&gt;::parseObjectRestAssignmentElement):
(JSC::Parser&lt;LexerType&gt;::parseAssignmentElement):
(JSC::Parser&lt;LexerType&gt;::parseObjectRestElement):
(JSC::Parser&lt;LexerType&gt;::parseObjectRestBindingOrAssignmentElement):
(JSC::Parser&lt;LexerType&gt;::parseDestructuringPattern):
(JSC::Parser&lt;LexerType&gt;::parseForStatement):
(JSC::Parser&lt;LexerType&gt;::parseBreakStatement):
(JSC::Parser&lt;LexerType&gt;::parseContinueStatement):
(JSC::Parser&lt;LexerType&gt;::parseWithStatement):
(JSC::Parser&lt;LexerType&gt;::parseTryStatement):
(JSC::Parser&lt;LexerType&gt;::parseStatement):
(JSC::Parser&lt;LexerType&gt;::parseFormalParameters):
(JSC::Parser&lt;LexerType&gt;::parseFunctionParameters):
(JSC::Parser&lt;LexerType&gt;::createGeneratorParameters):
(JSC::Parser&lt;LexerType&gt;::parseFunctionInfo):
(JSC::Parser&lt;LexerType&gt;::parseFunctionDeclaration):
(JSC::Parser&lt;LexerType&gt;::parseAsyncFunctionDeclaration):
(JSC::Parser&lt;LexerType&gt;::parseClassDeclaration):
(JSC::Parser&lt;LexerType&gt;::parseClass):
(JSC::Parser&lt;LexerType&gt;::parseClassFieldInitializerSourceElements):
(JSC::LabelInfo::LabelInfo):
(JSC::Parser&lt;LexerType&gt;::parseExpressionOrLabelStatement):
(JSC::Parser&lt;LexerType&gt;::parseExpressionStatement):
(JSC::Parser&lt;LexerType&gt;::parseIfStatement):
(JSC::Parser&lt;LexerType&gt;::parseModuleName):
(JSC::Parser&lt;LexerType&gt;::parseImportClauseItem):
(JSC::Parser&lt;LexerType&gt;::parseImportAttributes):
(JSC::Parser&lt;LexerType&gt;::parseImportDeclaration):
(JSC::Parser&lt;LexerType&gt;::parseExportSpecifier):
(JSC::Parser&lt;LexerType&gt;::parseExportDeclaration):
(JSC::Parser&lt;LexerType&gt;::parseAssignmentExpression):
(JSC::Parser&lt;LexerType&gt;::parseBinaryExpression):
(JSC::Parser&lt;LexerType&gt;::parseProperty):
(JSC::Parser&lt;LexerType&gt;::parsePropertyMethod):
(JSC::Parser&lt;LexerType&gt;::parseGetterSetter):
(JSC::Parser&lt;LexerType&gt;::parseClassExpression):
(JSC::Parser&lt;LexerType&gt;::parseFunctionExpression):
(JSC::Parser&lt;LexerType&gt;::parseAsyncFunctionExpression):
(JSC::Parser&lt;LexerType&gt;::parseTemplateString):
(JSC::Parser&lt;LexerType&gt;::createResolveAndUseVariable):
(JSC::Parser&lt;LexerType&gt;::tryParseArgumentsDotLengthForFastPath):
(JSC::Parser&lt;LexerType&gt;::parsePrimaryExpression):
(JSC::recordCallOrApplyDepth):
(JSC::Parser&lt;LexerType&gt;::parseMemberExpression):
(JSC::Parser&lt;LexerType&gt;::parseArrowFunctionExpression):
(JSC::Parser&lt;LexerType&gt;::parseUnaryExpression):
* Source/JavaScriptCore/parser/Parser.h:
(JSC::isArguments):
(JSC::isEval):
(JSC::isEvalOrArgumentsIdentifier):
(JSC::Scope::pushLabel):
(JSC::Scope::getLabel):
(JSC::Scope::declareCallee):
(JSC::Scope::declareVariable):
(JSC::Scope::declareFunctionAsVar):
(JSC::Scope::declareFunctionAsLet):
(JSC::Scope::addVariableBeingHoisted):
(JSC::Scope::declareLexicalVariable):
(JSC::Scope::hasDeclaredGlobalArguments):
(JSC::Scope::hasDeclaredVariable):
(JSC::Scope::hasLexicallyDeclaredVariable):
(JSC::Scope::hasPrivateName):
(JSC::Scope::declarePrivateMethod):
(JSC::Scope::declarePrivateAccessor):
(JSC::Scope::declarePrivateSetter):
(JSC::Scope::declarePrivateGetter):
(JSC::Scope::declarePrivateField):
(JSC::Scope::hasDeclaredParameter):
(JSC::Scope::declareParameter):
(JSC::Scope::forEachUsedVariable):
(JSC::Scope::usePrivateName):
(JSC::Scope::finalizeSloppyModeFunctionHoisting):
(JSC::Scope::bubbleSloppyModeFunctionHoistingCandidates):
* Source/JavaScriptCore/parser/ParserArena.cpp:
(JSC::IdentifierArena::makeBigIntDecimalIdentifier):
(JSC::IdentifierArena::makePrivateIdentifier):
* Source/JavaScriptCore/parser/ParserArena.h:
(JSC::IdentifierArena::makeIdentifier):
(JSC::IdentifierArena::makeEmptyIdentifier):
(JSC::IdentifierArena::makeLatin1Identifier):
(JSC::IdentifierArena::makeNumericIdentifier):
* Source/JavaScriptCore/parser/ParserFunctionInfo.h:
* Source/JavaScriptCore/parser/ParserModes.h:
(JSC::functionNameIsInScope):
* Source/JavaScriptCore/parser/ParserTokens.h:
* Source/JavaScriptCore/parser/SyntaxChecker.h:
(JSC::SyntaxChecker::createResolve):
(JSC::SyntaxChecker::createPrivateIdentifierNode):
(JSC::SyntaxChecker::createBigInt):
(JSC::SyntaxChecker::createString):
(JSC::SyntaxChecker::createDotAccess):
(JSC::SyntaxChecker::createRegExp):
(JSC::SyntaxChecker::createAssignResolve):
(JSC::SyntaxChecker::createEmptyVarExpression):
(JSC::SyntaxChecker::createEmptyLetExpression):
(JSC::SyntaxChecker::createGeneratorFunctionBody):
(JSC::SyntaxChecker::createTemplateString):
(JSC::SyntaxChecker::createProperty):
(JSC::SyntaxChecker::createDefineField):
(JSC::SyntaxChecker::createBreakStatement):
(JSC::SyntaxChecker::createContinueStatement):
(JSC::SyntaxChecker::createLabelStatement):
(JSC::SyntaxChecker::createModuleName):
(JSC::SyntaxChecker::createImportSpecifier):
(JSC::SyntaxChecker::appendImportAttribute):
(JSC::SyntaxChecker::appendImportAssertion):
(JSC::SyntaxChecker::createExportDefaultDeclaration):
(JSC::SyntaxChecker::createExportSpecifier):
(JSC::SyntaxChecker::appendConstDecl):
(JSC::SyntaxChecker::createGetterOrSetterProperty):
(JSC::SyntaxChecker::operatorStackPop):
* Source/JavaScriptCore/parser/VariableEnvironment.h:
(JSC::VariableEnvironment::add):
(JSC::VariableEnvironment::declareStaticPrivateMethod):
(JSC::VariableEnvironment::hasPrivateName):
* Source/JavaScriptCore/parser/VariableEnvironmentInlines.h:
(JSC::VariableEnvironment::declarePrivateField): Deleted.
(JSC::VariableEnvironment::declarePrivateMethod): Deleted.
(JSC::VariableEnvironment::declareStaticPrivateMethod): Deleted.
(JSC::VariableEnvironment::declarePrivateSetter): Deleted.
(JSC::VariableEnvironment::declareStaticPrivateSetter): Deleted.
(JSC::VariableEnvironment::declarePrivateGetter): Deleted.
(JSC::VariableEnvironment::declareStaticPrivateGetter): Deleted.
* Source/JavaScriptCore/runtime/CodeCache.cpp:
(JSC::CodeCache::getUnlinkedGlobalFunctionExecutable):
* Source/JavaScriptCore/runtime/IdentifierInlines.h:
(JSC::Identifier::fromUid):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3a1e4c7d93d2ce36f7950d92ec1437f434d18b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172610 "8 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46528 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39962 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182068 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130166 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/016178ea-d170-4a37-8a5b-4ba3b574166f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47821 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46201 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134259 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94743 "2 flakes 22 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c736674d-dc0b-48eb-b8b2-12c185b40b37) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175568 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37663 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154788 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114731 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8820cbd2-b9d7-4b19-af46-7b03b3bc8f3e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36298 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34607 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30667 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3316 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146727 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34293 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184601 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33871 "Built successfully and passed tests") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37300 "Found 1 new failure in parser/Lexer.cpp") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38809 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143044 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46200 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142922 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46878 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31131 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111770 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37938 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118630 "Found 1 new failure in parser/Lexer.cpp") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205288 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45395 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9240 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54806 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44795 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45027 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44854 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->