### PR TITLE
Add test coverage for 308577@main

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm
@@ -879,6 +879,23 @@ TEST(WebKit, PrintPreview)
     [previewView drawRect:CGRectMake(0, 0, 10, 10)];
 }
 
+TEST(WebKit, PrintAdjustMarginsAfterPageClose)
+{
+    done = false;
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr delegate = adoptNS([[PrintDelegate alloc] init]);
+    [webView setUIDelegate:delegate.get()];
+    [webView loadHTMLString:@"<head><title>test</title></head><body onload='print()'>content</body>" baseURL:[NSURL URLWithString:@"http://example.com/"]];
+    TestWebKitAPI::Util::run(&done);
+    RetainPtr operation = [webView _printOperationWithPrintInfo:[NSPrintInfo sharedPrintInfo]];
+    [NSPrintOperation setCurrentOperation:operation];
+    RetainPtr previewView = [operation view];
+    [webView _close];
+    // Simulate the race where the page is closed between knowsPageRange:
+    // and _adjustPrintingMarginsForHeaderAndFooter.
+    [previewView performSelector:NSSelectorFromString(@"_adjustPrintingMarginsForHeaderAndFooter")];
+}
+
 @interface PrintDelegateWithCompletionHandler : NSObject <WKUIDelegatePrivate>
 - (void)waitForPrintFrameCall;
 @end


### PR DESCRIPTION
#### 9cd737c3ca9b87a64c38657aa4bcd6be77d2e084
<pre>
Add test coverage for 308577@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=310841">https://bugs.webkit.org/show_bug.cgi?id=310841</a>
<a href="https://rdar.apple.com/173445970">rdar://173445970</a>

Reviewed by Lily Spiniolas and Wenson Hsieh.

308577@main fixed a WebPageProxy null dereference crash under
`-[WKPrintingView _adjustPrintingMarginsForHeaderAndFooter:]`.

This patch provides API test coverage for the racy condition producing
said crash.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm:
((WebKit, PrintAdjustMarginsAfterPageClose)):

Canonical link: <a href="https://commits.webkit.org/310060@main">https://commits.webkit.org/310060@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e91bddefb54720f2f2502b67e972f9ac6057364

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152513 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25295 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18894 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161258 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105970 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fc6c792c-6154-46d7-b6ce-014ec9799d15) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154387 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25823 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25601 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117859 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155473 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20077 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136923 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98573 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e9ea9542-321f-4bd6-9c71-e48f75b5a3b3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19153 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17084 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9092 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128803 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14797 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163727 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16391 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125899 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25093 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21123 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126064 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25095 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136593 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81697 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23382 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21053 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13372 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24711 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24402 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24562 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24463 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->