### PR TITLE
BitVector::filterSlow fails to zero trailing words when other is inline

### DIFF
--- a/Source/WTF/wtf/BitVector.cpp
+++ b/Source/WTF/wtf/BitVector.cpp
@@ -142,7 +142,9 @@ void BitVector::filterSlow(const BitVector& other)
 {
     if (other.isInline()) {
         ASSERT(!isInline());
-        outOfLineBits()->wordsSpan().front() &= cleanseInlineBits(other.m_bitsOrPointer);
+        auto words = outOfLineBits()->wordsSpan();
+        words.front() &= cleanseInlineBits(other.m_bitsOrPointer);
+        zeroSpan(words.subspan(1));
         return;
     }
     

--- a/Tools/TestWebKitAPI/Tests/WTF/BitVector.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/BitVector.cpp
@@ -194,4 +194,32 @@ TEST(WTF_BitVector, MoveAssignSelf)
     EXPECT_EQ(a.bitCount(), 1u);
 }
 
+TEST(WTF_BitVector, FilterOutOfLineWithInline)
+{
+    // Create an out-of-line BitVector (256 bits = 4 words on 64-bit)
+    // with bits set across multiple words.
+    BitVector large(256);
+    large.quickSet(5);
+    large.quickSet(42);
+    large.quickSet(100); // word 1 (bits 64-127).
+    large.quickSet(200); // word 3 (bits 192-255).
+
+    // Create an inline BitVector (fits in maxInlineBits = 63 bits)
+    // with only bit 5 set.
+    BitVector small;
+    small.set(5);
+
+    // filter is AND: only bits set in both should survive.
+    // Bit 5 is in both, so it survives. Bits 42, 100, 200 are not in
+    // small (which has no bits beyond 62), so they must be cleared.
+    large.filter(small);
+
+    EXPECT_TRUE(large.get(5));
+    EXPECT_FALSE(large.get(42));
+    EXPECT_FALSE(large.get(100));
+    EXPECT_FALSE(large.get(200));
+
+    EXPECT_EQ(large.bitCount(), 1u);
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### a7bba6da6eaff0cb9337108aa08289f4d7aa2b0b
<pre>
BitVector::filterSlow fails to zero trailing words when other is inline
<a href="https://bugs.webkit.org/show_bug.cgi?id=310801">https://bugs.webkit.org/show_bug.cgi?id=310801</a>

Reviewed by Darin Adler and Ryosuke Niwa.

When other is inline and this is out-of-line, `filterSlow` only ANDs the
first word and returns, leaving words at index 1+ untouched. Since
filter is AND and an inline BitVector has no bits beyond position 62,
all higher words should be zeroed. This causes bits at positions 64+
to incorrectly survive the filter.

Fix this by zeroing the remaining words after ANDing the first. This
matches what the both-out-of-line path already does with
`zeroSpan(a.subspan(b.size()))`.

Added an API test that filters an out-of-line BitVector with bits in
multiple words against an inline BitVector.

Test: Tools/TestWebKitAPI/Tests/WTF/BitVector.cpp

* Source/WTF/wtf/BitVector.cpp:
(WTF::BitVector::filterSlow):
* Tools/TestWebKitAPI/Tests/WTF/BitVector.cpp:
(TestWebKitAPI::TEST(WTF_BitVector, FilterOutOfLineWithInline)):

Canonical link: <a href="https://commits.webkit.org/310129@main">https://commits.webkit.org/310129@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a7fca49b65035c0d4d56b6b5fd861d5f5a92254

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152630 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25412 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19011 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161375 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106087 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4d1a0772-c1b4-4a48-85b9-48c08794a06e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154504 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25940 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25718 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117945 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83575 "3 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2f8485bd-48dd-45cc-8391-df6d177cf111) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155590 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20169 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137024 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98657 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8cee5056-d400-4ce7-8e74-c43be620bbbc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19244 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17182 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9209 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144642 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128894 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14898 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163846 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13435 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6985 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16492 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126001 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25210 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21221 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126162 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34268 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25212 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136694 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81815 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21130 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13473 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184263 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24828 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89114 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47040 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24520 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24679 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24580 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->