### PR TITLE
[CSS Zoom] lh/rlh units resolve with double-zoom when line-height is a number

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/lh-rlh-percentage-line-height-with-zoom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/lh-rlh-percentage-line-height-with-zoom-expected.txt
@@ -1,0 +1,8 @@
+
+PASS 1lh in outside
+PASS 1lh in zoomed
+PASS 1lh in inside
+PASS 1rlh in outside
+PASS 1rlh in zoomed
+PASS 1rlh in inside
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/lh-rlh-percentage-line-height-with-zoom.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/lh-rlh-percentage-line-height-with-zoom.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+<link rel="author" title="Vitor Roriz" href="https://github.com/vitorroriz">
+<link rel="help" href="https://drafts.csswg.org/css-values-4/#font-relative-lengths">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/#zoom-property">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  :root {
+    font-size: 20px;
+    line-height: 1.5;
+    zoom: 2;
+  }
+</style>
+<div id="outside"></div>
+<div id="zoomed" style="zoom: 2; font-size: 20px; line-height: 1.5;">
+  <div id="inside"></div>
+</div>
+<script>
+  function test_unit(unit, outside, zoomed, inside = zoomed) {
+    let values = { outside, zoomed, inside };
+    for (let id of ["outside", "zoomed", "inside"]) {
+      test(function() {
+        let el = document.getElementById(id);
+        el.style.height = "1" + unit;
+        let actual = el.getBoundingClientRect().height;
+        assert_approx_equals(actual, values[id], 1, `${unit} in ${id} (got ${actual})`);
+        el.style.height = "";
+      }, `1${unit} in ${id}`);
+    }
+  }
+
+  test_unit("lh", 60, 120);
+  test_unit("rlh", 60, 120);
+</script>

--- a/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
+++ b/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
@@ -312,7 +312,8 @@ double computeNonCalcLengthDouble(double value, CSS::LengthUnit lengthUnit, cons
             value *= conversionData.parentStyle() ? conversionData.parentStyle()->computedLineHeight() : conversionData.fontCascadeForFontUnits().metricsOfPrimaryFont().intLineSpacing();
         } else {
             auto* style = conversionData.style();
-            Style::LineHeightEvaluationContext context { style->computedFontSize(), style->metricsOfPrimaryFont().lineSpacing() };
+            auto computedFontSize = style->fontDescription().computedSizeForRangeZoomOption(conversionData.rangeZoomOption());
+            Style::LineHeightEvaluationContext context { computedFontSize, style->metricsOfPrimaryFont().lineSpacing() };
             value *= Style::evaluate<float>(style->lineHeight(), context, Style::ZoomFactor { conversionData.zoom() });
         }
         break;
@@ -333,7 +334,8 @@ double computeNonCalcLengthDouble(double value, CSS::LengthUnit lengthUnit, cons
             if (conversionData.computingLineHeight() || conversionData.computingFontSize())
                 value *= Style::evaluate<float>(rootStyle->specifiedLineHeight(), Style::LineHeightEvaluationContext { rootStyle->computedFontSize(), rootStyle->metricsOfPrimaryFont().lineSpacing() }, rootStyle->usedZoomForLength());
             else {
-                Style::LineHeightEvaluationContext context { rootStyle->computedFontSize(), rootStyle->metricsOfPrimaryFont().lineSpacing() };
+                auto computedFontSize = rootStyle->fontDescription().computedSizeForRangeZoomOption(conversionData.rangeZoomOption());
+                Style::LineHeightEvaluationContext context { computedFontSize, rootStyle->metricsOfPrimaryFont().lineSpacing() };
                 value *= Style::evaluate<float>(rootStyle->lineHeight(), context, Style::ZoomFactor { conversionData.zoom() });
             }
         }


### PR DESCRIPTION
#### 6a30457b6cca4252f34439883e2bddf5b1bad839
<pre>
[CSS Zoom] lh/rlh units resolve with double-zoom when line-height is a number
<a href="https://bugs.webkit.org/show_bug.cgi?id=310843">https://bugs.webkit.org/show_bug.cgi?id=310843</a>
<a href="https://rdar.apple.com/173448638">rdar://173448638</a>

Reviewed by Brent Fulgham.

When resolving lh/rlh units for evaluation-time zoom properties, the
LineHeightEvaluationContext was constructed with computedFontSize(), which
already includes zoom. For number line-heights (e.g., line-height: 1.5),
the percentage evaluation multiplies by this zoomed font size, producing
a zoomed result. Evaluation-time zoom then applies zoom again at layout,
causing double-zoom. The fix uses computedSizeForRangeZoomOption() which
returns the unzoomed font size when the target property is unzoomed.

* Source/WebCore/style/values/primitives/StyleLengthResolution.cpp:
(WebCore::computeNonCalcLengthDouble):
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/lh-rlh-percentage-line-height-with-zoom.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/lh-rlh-percentage-line-height-with-zoom-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/310043@main">https://commits.webkit.org/310043@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf8bbc98ba7a839a9b13a051faf8b47fd0ae2abc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152527 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25309 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18908 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161272 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/671076fa-25aa-4059-8238-73d97448d683) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154401 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25837 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25615 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117863 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155487 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/20071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136932 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98577 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0d48b219-bf88-431d-aeb9-c4fcd0d2f416) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/19147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9106 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14806 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163741 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6882 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16400 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125910 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25107 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21130 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126073 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34204 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25109 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136602 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81711 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21063 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13381 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24725 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89011 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24416 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24576 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24477 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->