### PR TITLE
[macOS release arm64]  imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/security.pattern.fillStyle.sub.html is a flaky text failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/resources/canvas-tests.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/resources/canvas-tests.js
@@ -161,10 +161,10 @@ function forEachCanvasSource(crossOriginUrl, sameOriginUrl, callback) {
       factory: () => {
         return new Promise((resolve, reject) => {
           const video = document.createElement("video");
-          video.oncanplaythrough = () => resolve(video);
+          video.onloadeddata = () => resolve(video);
           video.preload = "auto";
           video.onerror = reject;
-          video.src = getVideoURI(crossOriginUrl + "/media/movie_300");
+          video.src = getVideoURI(crossOriginUrl + "/media/movie_5");
         });
       },
     },
@@ -174,10 +174,10 @@ function forEachCanvasSource(crossOriginUrl, sameOriginUrl, callback) {
       factory: () => {
         return new Promise((resolve, reject) => {
           const video = document.createElement("video");
-          video.oncanplaythrough = () => resolve(video);
+          video.onloadeddata = () => resolve(video);
           video.preload = "auto";
           video.onerror = reject;
-          video.src = "/common/redirect.py?location=" + getVideoURI(crossOriginUrl + "/media/movie_300");
+          video.src = "/common/redirect.py?location=" + getVideoURI(crossOriginUrl + "/media/movie_5");
         });
       },
     },
@@ -187,10 +187,10 @@ function forEachCanvasSource(crossOriginUrl, sameOriginUrl, callback) {
       factory: () => {
         return new Promise((resolve, reject) => {
           const video = document.createElement("video");
-          video.oncanplaythrough = () => resolve(video);
+          video.onloadeddata = () => resolve(video);
           video.preload = "auto";
           video.onerror = reject;
-          video.src = crossOriginUrl + "/common/redirect.py?location=" + getVideoURI(sameOriginUrl + "/media/movie_300");
+          video.src = crossOriginUrl + "/common/redirect.py?location=" + getVideoURI(sameOriginUrl + "/media/movie_5");
         });
       },
     },

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/security.pattern.fillStyle.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/security.pattern.fillStyle.sub-expected.txt
@@ -2,17 +2,17 @@ Setting fillStyle to a pattern of an unclean canvas makes the canvas origin-uncl
 
 
 PASS cross-origin HTMLImageElement: Setting fillStyle to an origin-unclean pattern makes the canvas origin-unclean
-PASS cross-origin SVGImageElement: Setting fillStyle to an origin-unclean pattern makes the canvas origin-unclean
-PASS cross-origin HTMLVideoElement: Setting fillStyle to an origin-unclean pattern makes the canvas origin-unclean
-PASS redirected to cross-origin HTMLVideoElement: Setting fillStyle to an origin-unclean pattern makes the canvas origin-unclean
-PASS redirected to same-origin HTMLVideoElement: Setting fillStyle to an origin-unclean pattern makes the canvas origin-unclean
-PASS unclean HTMLCanvasElement: Setting fillStyle to an origin-unclean pattern makes the canvas origin-unclean
-PASS unclean ImageBitmap: Setting fillStyle to an origin-unclean pattern makes the canvas origin-unclean
 PASS cross-origin HTMLImageElement: Setting fillStyle to an origin-unclean offscreen canvas pattern makes the canvas origin-unclean
+PASS cross-origin SVGImageElement: Setting fillStyle to an origin-unclean pattern makes the canvas origin-unclean
 PASS cross-origin SVGImageElement: Setting fillStyle to an origin-unclean offscreen canvas pattern makes the canvas origin-unclean
+PASS cross-origin HTMLVideoElement: Setting fillStyle to an origin-unclean pattern makes the canvas origin-unclean
 PASS cross-origin HTMLVideoElement: Setting fillStyle to an origin-unclean offscreen canvas pattern makes the canvas origin-unclean
+PASS redirected to cross-origin HTMLVideoElement: Setting fillStyle to an origin-unclean pattern makes the canvas origin-unclean
 PASS redirected to cross-origin HTMLVideoElement: Setting fillStyle to an origin-unclean offscreen canvas pattern makes the canvas origin-unclean
+PASS redirected to same-origin HTMLVideoElement: Setting fillStyle to an origin-unclean pattern makes the canvas origin-unclean
 PASS redirected to same-origin HTMLVideoElement: Setting fillStyle to an origin-unclean offscreen canvas pattern makes the canvas origin-unclean
+PASS unclean HTMLCanvasElement: Setting fillStyle to an origin-unclean pattern makes the canvas origin-unclean
 PASS unclean HTMLCanvasElement: Setting fillStyle to an origin-unclean offscreen canvas pattern makes the canvas origin-unclean
+PASS unclean ImageBitmap: Setting fillStyle to an origin-unclean pattern makes the canvas origin-unclean
 PASS unclean ImageBitmap: Setting fillStyle to an origin-unclean offscreen canvas pattern makes the canvas origin-unclean
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/security.pattern.fillStyle.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/security.pattern.fillStyle.sub.html
@@ -15,8 +15,10 @@
 forEachCanvasSource(get_host_info().HTTP_REMOTE_ORIGIN,
                     get_host_info().HTTP_ORIGIN,
                     (name, factory) => {
+  const sourcePromise = factory();
+
   promise_test(_ => {
-    return factory().then(source => {
+    return sourcePromise.then(source => {
       const canvas = document.createElement('canvas');
       const ctx = canvas.getContext('2d');
       const pattern = ctx.createPattern(source, 'repeat');
@@ -26,13 +28,9 @@ forEachCanvasSource(get_host_info().HTTP_REMOTE_ORIGIN,
       assert_throws_dom("SECURITY_ERR", function() { ctx.getImageData(0, 0, 1, 1); });
     });
   }, `${name}: Setting fillStyle to an origin-unclean pattern makes the canvas origin-unclean`);
-});
 
-forEachCanvasSource(get_host_info().HTTP_REMOTE_ORIGIN,
-                    get_host_info().HTTP_ORIGIN,
-                    (name, factory) => {
   promise_test(_ => {
-    return factory().then(source => {
+    return sourcePromise.then(source => {
       const pattern = new OffscreenCanvas(10, 10)
           .getContext('2d')
           .createPattern(source, 'repeat');

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2434,8 +2434,6 @@ webkit.org/b/310217 imported/w3c/web-platform-tests/pointerevents/pointerevent_p
 
 webkit.org/b/306670 [ Debug arm64 ] http/tests/webgpu/webgpu/api/validation/render_pipeline/resource_compatibility.html [ Pass Failure Timeout ]
 
-webkit.org/b/310823 [ Release arm64 ] imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/security.pattern.fillStyle.sub.html [ Pass Failure ]
-
 webkit.org/b/306785 imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-insecure.sub.window.html [ Pass Failure ]
 webkit.org/b/306785 imported/w3c/web-platform-tests/storage-access-api/storage-access-permission.sub.https.window.html [ Pass Failure ]
 


### PR DESCRIPTION
#### 1c7cfa275a536858302d82bee2a68511fed6a201
<pre>
[macOS release arm64]  imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/security.pattern.fillStyle.sub.html is a flaky text failure
<a href="https://rdar.apple.com/173420820">rdar://173420820</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=310823">https://bugs.webkit.org/show_bug.cgi?id=310823</a>

Reviewed by NOBODY (OOPS!).

This test is failing flakily due to a test harness timeout. The timeout is caused
by excessive loads from large video files (loads a ~2MB file) and by the test file
which initializes 2 separate video factory calls.

Files changed (3):
 1. canvas-tests.js: movie_5 (31 KB) instead of movie_300 (2.7 MB) in forEachCanvasSource
    video factories. Use onloadeddata instead of oncanplaythrough.
 2. security.pattern.fillStyle.sub.html: resolved two factory() calls into one shared factory() call.
 3. security.pattern.fillStyle.sub-expected.txt: updated test output order (interleaved).

* LayoutTests/imported/w3c/web-platform-tests/html/canvas/resources/canvas-tests.js:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/security.pattern.fillStyle.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/security.pattern.fillStyle.sub.html:
* LayoutTests/platform/mac-wk2/TestExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c7cfa275a536858302d82bee2a68511fed6a201

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152532 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25314 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18913 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161277 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105989 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25842 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25620 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117867 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84798 "2 flakes 2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155492 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20081 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136937 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98581 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19157 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17095 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9111 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128807 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14811 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163746 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16405 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125914 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25112 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21134 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126077 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25114 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136607 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81716 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21061 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13386 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24730 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24421 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24581 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24482 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->