### PR TITLE
[JSC][Main] [f4f6368419e9db1b] ASAN_TRAP | DFG::DoesGCCheck::verifyCanGC; JSC::VM::verifyCanGC; JSC::Heap::acquireAccess

### DIFF
--- a/JSTests/stress/validate-does-gc-heap-bigint-compare-watchdog.js
+++ b/JSTests/stress/validate-does-gc-heap-bigint-compare-watchdog.js
@@ -1,0 +1,11 @@
+//@ runDefault("--watchdog=5000", "--watchdog-exception-ok", "--jitPolicyScale=0.1", "--useConcurrentGC=0", "--useLLInt=0", "--useConcurrentJIT=0", "--validateDoesGC=true")
+
+// Regression test for rdar://172191300
+// Stale DoesGC state from a DFG CompareLess(HeapBigIntUse) node must not
+// persist across JSLock release/acquire when the watchdog terminates execution.
+if ($vm.useJIT()) {
+    for (let i = 0; i - 4194304; i++) {
+        for (let j = 0n; j < 2n ** 31n;)
+            break;
+    }
+}

--- a/Source/JavaScriptCore/runtime/JSLock.cpp
+++ b/Source/JavaScriptCore/runtime/JSLock.cpp
@@ -118,13 +118,16 @@ void JSLock::didAcquireLock()
     // FIXME: What should happen to the per-thread identifier table if we don't have a VM?
     if (!m_vm)
         return;
-    
+
     auto& thread = Thread::currentSingleton();
     ASSERT(!m_entryAtomStringTable);
     m_entryAtomStringTable = thread.setCurrentAtomStringTable(m_vm->atomStringTable());
     ASSERT(m_entryAtomStringTable);
 
     m_vm->setLastStackTop(thread);
+
+    if constexpr (validateDFGDoesGC)
+        m_vm->setDoesGCExpectation(true, DoesGCCheck::Special::Uninitialized);
 
     if (m_vm->heap.hasAccess())
         m_shouldReleaseHeapAccess = false;


### PR DESCRIPTION
#### 95273566844f044e156b9262ac516c5770b02b61
<pre>
[JSC][Main] [f4f6368419e9db1b] ASAN_TRAP | DFG::DoesGCCheck::verifyCanGC; JSC::VM::verifyCanGC; JSC::Heap::acquireAccess
<a href="https://bugs.webkit.org/show_bug.cgi?id=310733">https://bugs.webkit.org/show_bug.cgi?id=310733</a>
<a href="https://rdar.apple.com/172191300">rdar://172191300</a>

Reviewed by NOBODY (OOPS!).

The DFG&apos;s DoesGC validation infrastructure stores per-node doesGC
expectations in vm.m_doesGC during JIT execution. When the watchdog
terminates execution mid-loop, this state can persist across lock
release/acquire boundaries. A subsequent JSLockHolder acquisition
then triggers Heap::acquireAccess() which calls verifyCanGC() and
hits a false-positive RELEASE_ASSERT on the stale doesGC=false state.

Fix by resetting m_doesGC in JSLock::didAcquireLock() before calling
acquireAccess(). The lock is continuously held during DFG execution,
so this reset only affects non-JIT contexts where m_doesGC is stale.

* JSTests/stress/validate-does-gc-heap-bigint-compare-watchdog.js: Added.
(vm.useJIT):
* Source/JavaScriptCore/runtime/JSLock.cpp:
(JSC::JSLock::didAcquireLock):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95273566844f044e156b9262ac516c5770b02b61

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152541 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25323 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18922 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161286 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105998 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25851 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25629 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117873 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83533 "7 flakes 2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155501 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20088 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136945 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98587 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19163 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17105 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9120 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144553 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128813 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14819 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163756 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13344 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6896 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16413 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125922 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25121 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21144 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126084 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25123 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136615 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81725 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21064 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13394 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184173 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24739 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89025 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46963 "Found 1 new JSC stress test failure: stress/validate-does-gc-heap-bigint-compare-watchdog.js.default (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24430 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24590 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24491 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->