### PR TITLE
[JSC] IndexMap::resize should not overwrite existing elements

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirTmpMap.h
+++ b/Source/JavaScriptCore/b3/air/AirTmpMap.h
@@ -50,20 +50,12 @@ public:
     {
     }
     
-    template<typename... Args>
-    void resize(Code& code, const Args&... args)
+    void resize(Code& code)
     {
-        m_gp.resize(Tmp::absoluteIndexEnd(code, GP), args...);
-        m_fp.resize(Tmp::absoluteIndexEnd(code, FP), args...);
+        m_gp.resize(Tmp::absoluteIndexEnd(code, GP));
+        m_fp.resize(Tmp::absoluteIndexEnd(code, FP));
     }
-    
-    template<typename... Args>
-    void clear(const Args&... args)
-    {
-        m_gp.remove(args...);
-        m_fp.remove(args...);
-    }
-    
+
     const Value& operator[](Tmp tmp) const
     {
         if (tmp.isGP())

--- a/Source/WTF/wtf/IndexMap.h
+++ b/Source/WTF/wtf/IndexMap.h
@@ -58,10 +58,15 @@ public:
     {
     }
 
-    template<typename... Args>
-    void resize(size_t size, Args&&... args)
+    void resize(size_t size)
     {
-        m_vector.fill(Value(std::forward<Args>(args)...), size);
+        size_t oldSize = m_vector.size();
+        m_vector.resize(size);
+        // Vector::resize doesn't initialize new elements for trivial types.
+        if constexpr (std::is_trivial_v<Value>) {
+            if (size > oldSize)
+                std::fill(m_vector.begin() + oldSize, m_vector.end(), Value());
+        }
     }
 
     template<typename... Args>


### PR DESCRIPTION
#### f8a1572e3a8eb244d7f096ecf7f17b96184c9116
<pre>
[JSC] IndexMap::resize should not overwrite existing elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=310847">https://bugs.webkit.org/show_bug.cgi?id=310847</a>
<a href="https://rdar.apple.com/173451278">rdar://173451278</a>

Reviewed by Yusuke Suzuki.

IndexMap::resize was using Vector::fill, which overwrites all elements
including existing ones. This is surprising since resize usually
means to change the size but leave existing elements in place.

So make IndexMap::resize (and TmpMap::resize) follow the standard behavior.
An upcoming change will need this true resize behavior.

All current callers resize from empty, so this is a no-op for existing
code.

Also remove TmpMap::clear which called nonexistent IndexMap::remove and
had no callers, and simplify TmpMap::resize to match.

Covered by existing JSC stress tests
* Source/JavaScriptCore/b3/air/AirTmpMap.h:
(JSC::B3::Air::TmpMap::resize):
(JSC::B3::Air::TmpMap::clear): Deleted.
* Source/WTF/wtf/IndexMap.h:
(WTF::IndexMap::resize):

Canonical link: <a href="https://commits.webkit.org/310076@main">https://commits.webkit.org/310076@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da815bae48bf013ef9c4c488863d556f38786522

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152537 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25319 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18918 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161282 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105994 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/58274c14-7da9-46c9-96ca-173d88660c3e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25847 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25625 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117869 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83530 "9 flakes 2 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fb4ba48f-c108-4002-9011-d29b74e7edf2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155497 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20090 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136941 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98583 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2ba2a2d9-8014-46fe-b2f1-c097ace742a4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19165 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17101 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9116 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144549 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128815 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14815 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163754 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13340 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6892 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16409 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125921 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25117 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21140 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126083 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34227 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25119 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136611 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81721 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21062 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13390 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184169 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24735 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89021 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46960 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24426 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24586 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24487 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->