### PR TITLE
Fix `isAnyOf()` for non-const `CheckedPtr&` to call `isAnyOf` instead of `is`

### DIFF
--- a/Source/WTF/wtf/CheckedPtr.h
+++ b/Source/WTF/wtf/CheckedPtr.h
@@ -276,7 +276,7 @@ inline bool is(const CheckedPtr<ArgType, ArgPtrTraits>& source)
 template<typename... ExpectedTypes, typename ArgType, typename ArgPtrTraits>
 inline bool isAnyOf(CheckedPtr<ArgType, ArgPtrTraits>& source)
 {
-    return is<ExpectedTypes...>(source.get());
+    return isAnyOf<ExpectedTypes...>(source.get());
 }
 
 template<typename... ExpectedTypes, typename ArgType, typename ArgPtrTraits>

--- a/Tools/TestWebKitAPI/Tests/WTF/CheckedPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CheckedPtr.cpp
@@ -31,6 +31,7 @@
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>
 #include <wtf/Threading.h>
+#include <wtf/TypeCasts.h>
 #include <wtf/UniquelyOwned.h>
 #include <wtf/UniquelyOwnedPtr.h>
 #include <wtf/Vector.h>
@@ -442,5 +443,96 @@ TEST(WTF_CheckedPtrDeathTest, UniquelyOwnedCheckedPtrCheckFailure)
 #endif
 }
 #endif
+
+class CheckedBaseForIsAnyOf : public CanMakeCheckedPtr<CheckedBaseForIsAnyOf> {
+    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(CheckedBaseForIsAnyOf);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CheckedBaseForIsAnyOf);
+public:
+    virtual ~CheckedBaseForIsAnyOf() = default;
+    virtual bool isDerivedCheckedA() const { return false; }
+    virtual bool isDerivedCheckedB() const { return false; }
+};
+
+class DerivedCheckedA : public CheckedBaseForIsAnyOf {
+    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(DerivedCheckedA);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DerivedCheckedA);
+public:
+    bool isDerivedCheckedA() const override { return true; }
+};
+
+class DerivedCheckedB : public CheckedBaseForIsAnyOf {
+    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(DerivedCheckedB);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DerivedCheckedB);
+public:
+    bool isDerivedCheckedB() const override { return true; }
+};
+
+} // namespace TestWebKitAPI
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(TestWebKitAPI::DerivedCheckedA)
+    static bool isType(const TestWebKitAPI::CheckedBaseForIsAnyOf& object) { return object.isDerivedCheckedA(); }
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(TestWebKitAPI::DerivedCheckedB)
+    static bool isType(const TestWebKitAPI::CheckedBaseForIsAnyOf& object) { return object.isDerivedCheckedB(); }
+SPECIALIZE_TYPE_TRAITS_END()
+
+namespace TestWebKitAPI {
+
+TEST(WTF_CheckedPtr, IsAnyOfNonConst)
+{
+    {
+        // Object is DerivedCheckedB. isAnyOf<DerivedCheckedA, CheckedBaseForIsAnyOf> should
+        // return true because everything is-a CheckedBaseForIsAnyOf.
+        auto object = makeUnique<DerivedCheckedB>();
+        CheckedPtr<CheckedBaseForIsAnyOf> ptr = object.get();
+
+        // Non-const overload: the bug causes this to call
+        //   is<DerivedCheckedA, CheckedBaseForIsAnyOf>(ptr.get())
+        // which resolves as is<DerivedCheckedA>(CheckedBaseForIsAnyOf*),
+        // only checking DerivedCheckedA and ignoring CheckedBaseForIsAnyOf entirely.
+        // The object is DerivedCheckedB, not DerivedCheckedA, so the buggy code returns false.
+        bool result = isAnyOf<DerivedCheckedA, CheckedBaseForIsAnyOf>(ptr);
+        EXPECT_TRUE(result);
+    }
+
+    {
+        // Same pointer value but const: uses the correct const overload which
+        // properly delegates to isAnyOf<> on the raw pointer.
+        auto object = makeUnique<DerivedCheckedB>();
+        const CheckedPtr<CheckedBaseForIsAnyOf> constPtr = object.get();
+        bool constResult = isAnyOf<DerivedCheckedA, CheckedBaseForIsAnyOf>(constPtr);
+        EXPECT_TRUE(constResult);
+    }
+
+    {
+        // Verify single-type isAnyOf works on non-const (unaffected by the bug).
+        auto object = makeUnique<DerivedCheckedA>();
+        CheckedPtr<CheckedBaseForIsAnyOf> ptr = object.get();
+        EXPECT_TRUE(isAnyOf<DerivedCheckedA>(ptr));
+        EXPECT_FALSE(isAnyOf<DerivedCheckedB>(ptr));
+    }
+
+    {
+        // Two derived types on non-const CheckedPtr: would not have compiled before the fix
+        // because is<DerivedCheckedA, DerivedCheckedB>(CheckedBaseForIsAnyOf*) requires an
+        // implicit downcast from CheckedBaseForIsAnyOf* to DerivedCheckedB*.
+        auto object = makeUnique<DerivedCheckedA>();
+        CheckedPtr<CheckedBaseForIsAnyOf> ptr = object.get();
+        bool matchesAorB = isAnyOf<DerivedCheckedA, DerivedCheckedB>(ptr);
+        EXPECT_TRUE(matchesAorB);
+
+        auto objectB = makeUnique<DerivedCheckedB>();
+        CheckedPtr<CheckedBaseForIsAnyOf> ptrB = objectB.get();
+        bool matchesBorA = isAnyOf<DerivedCheckedA, DerivedCheckedB>(ptrB);
+        EXPECT_TRUE(matchesBorA);
+
+        // Base object matches neither derived type.
+        auto base = makeUnique<CheckedBaseForIsAnyOf>();
+        CheckedPtr<CheckedBaseForIsAnyOf> ptrBase = base.get();
+        bool matchesNeither = isAnyOf<DerivedCheckedA, DerivedCheckedB>(ptrBase);
+        EXPECT_FALSE(matchesNeither);
+    }
+}
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 635d7979f0f19934201bef508f277840286fccb0
<pre>
Fix `isAnyOf()` for non-const `CheckedPtr&amp;` to call `isAnyOf` instead of `is`
<a href="https://bugs.webkit.org/show_bug.cgi?id=310851">https://bugs.webkit.org/show_bug.cgi?id=310851</a>

Reviewed by Ryosuke Niwa.

The non-const `isAnyOf(CheckedPtr&lt;&gt;&amp;)` overload incorrectly delegated to
`is&lt;ExpectedTypes...&gt;()` instead of `isAnyOf&lt;ExpectedTypes...&gt;()`. Since
`is&lt;&gt;()` takes a *single* ExpectedType parameter, calling it with multiple
types either silently gave wrong results (2 types) or failed to compile
(3+ types). The const overload was already correct.

Test: Tools/TestWebKitAPI/Tests/WTF/CheckedPtr.cpp

* Source/WTF/wtf/CheckedPtr.h:
(WTF::isAnyOf):
* Tools/TestWebKitAPI/Tests/WTF/CheckedPtr.cpp:
(TestWebKitAPI::CheckedBaseForIsAnyOf::isDerivedCheckedA const):
(TestWebKitAPI::CheckedBaseForIsAnyOf::isDerivedCheckedB const):
(isType):
(TestWebKitAPI::TEST(WTF_CheckedPtr, IsAnyOfNonConst)):

Canonical link: <a href="https://commits.webkit.org/310058@main">https://commits.webkit.org/310058@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/958029294af546ff191ec925e7d48789b9d001dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152547 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25329 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18928 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161292 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106004 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154421 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25857 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25635 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117886 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155507 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20095 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136954 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98600 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19170 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17111 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9126 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144559 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128820 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14828 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163762 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13350 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6902 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16422 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125935 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25127 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21150 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126097 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34213 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25129 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136624 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81731 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21076 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13403 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184179 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24745 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89031 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46966 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24437 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24596 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24497 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->