### PR TITLE
Relax memory ordering for CanMakeThreadSafeCheckedPtr atomic operations

### DIFF
--- a/Source/WTF/wtf/CheckedRef.h
+++ b/Source/WTF/wtf/CheckedRef.h
@@ -350,6 +350,13 @@ enum class DefaultedOperatorEqual : bool { No, Yes };
 // DO NOT make use of this enum in new code. An object which supports CanMakeCheckedPtr must be heap allocated on its own.
 enum class CheckedPtrDeleteCheckException : bool { No, Yes };
 
+template<typename T>
+concept AtomicLike = requires(T t) {
+    t.load(std::memory_order_relaxed);
+    t.fetch_add(1, std::memory_order_relaxed);
+    t.fetch_sub(1, std::memory_order_relaxed);
+};
+
 template <typename StorageType, typename PtrCounterType, typename DeletionFlagType, CheckedPtrDeleteCheckException deleteException> class CanMakeCheckedPtrBase {
 public:
     CanMakeCheckedPtrBase() = default;
@@ -364,7 +371,13 @@ public:
     }
 
     PtrCounterType checkedPtrCount() const { return m_checkedPtrCount; }
-    void incrementCheckedPtrCount() const { ++m_checkedPtrCount; }
+    void incrementCheckedPtrCount() const
+    {
+        if constexpr (AtomicLike<StorageType>)
+            m_checkedPtrCount.fetch_add(1, std::memory_order_relaxed);
+        else
+            ++m_checkedPtrCount;
+    }
     ALWAYS_INLINE void decrementCheckedPtrCount() const
     {
         // In normal execution, a CheckedPtr always points to an object with a non-zero checkedPtrCount().
@@ -372,13 +385,16 @@ public:
         // When we check checkedPtrCountWithoutThreadCheck() here, we're checking for a scribbled object.
         if (!checkedPtrCountWithoutThreadCheck()) [[unlikely]]
             crashDueToCheckedPtrToDeadObject();
-        --m_checkedPtrCount;
+        if constexpr (AtomicLike<StorageType>)
+            m_checkedPtrCount.fetch_sub(1, std::memory_order_release);
+        else
+            --m_checkedPtrCount;
     }
 
     ALWAYS_INLINE PtrCounterType checkedPtrCountWithoutThreadCheck() const
     {
-        if constexpr (std::is_same_v<StorageType, std::atomic<uint32_t>>)
-            return m_checkedPtrCount;
+        if constexpr (AtomicLike<StorageType>)
+            return m_checkedPtrCount.load(std::memory_order_acquire);
         else
             return m_checkedPtrCount.valueWithoutThreadCheck();
     }


### PR DESCRIPTION
#### bca037abbb7d0977175b2cc6207e7c183a43d967
<pre>
Relax memory ordering for CanMakeThreadSafeCheckedPtr atomic operations
<a href="https://bugs.webkit.org/show_bug.cgi?id=310854">https://bugs.webkit.org/show_bug.cgi?id=310854</a>

Reviewed by Geoffrey Garen.

CanMakeCheckedPtrBase used seq_cst (the default for std::atomic operators)
for all checked pointer count operations. This is stronger than necessary.
The checked pointer count is a diagnostic counter for zombie detection, not
a reference count that guards data access or triggers deallocation.

Use the same memory ordering strategy proven by std::shared_ptr and
Boost.Atomic for reference counting:

- Increment: memory_order_relaxed. A new CheckedPtr/CheckedRef can only be
  created from an existing reference, and communicating that reference across
  threads already provides the necessary synchronization. This is the same
  argument that makes relaxed safe for std::shared_ptr increments.

- Decrement: memory_order_release. The release ensures that all prior
  accesses through the CheckedPtr happen-before the count drops. Unlike
  std::shared_ptr, the decrement never triggers destruction, so the acquire
  side is not needed on the decrement itself. The destroying delete path
  reads the count via checkedPtrCountWithoutThreadCheck() which uses
  memory_order_acquire, forming a valid release/acquire pair.

- Read (checkedPtrCountWithoutThreadCheck): memory_order_acquire. This
  synchronizes with release decrements so the destroying delete path
  reliably sees all outstanding references when deciding whether to enter
  the zombie path.

On ARM64, this replaces full memory barriers (dmb ish) with lighter
instructions: relaxed increment becomes a plain ldadd, release decrement
becomes stlr/ldaddl, and acquire load becomes ldar.

Also introduces an AtomicLike concept to dispatch between atomic and
non-atomic storage, replacing the previous `std::is_same_v&lt;StorageType,
std::atomic&lt;uint32_t&gt;&gt;` check. This is more expressive (describes the
required interface rather than a specific type) and would work with any
atomic-like wrapper, not just `std::atomic&lt;uint32_t&gt;`.

No behavior change for the single-threaded CanMakeCheckedPtr path, which
continues to use plain integer operations with thread assertions.

* Source/WTF/wtf/CheckedRef.h:
(WTF::requires):
(WTF::CanMakeCheckedPtrBase::incrementCheckedPtrCount const):
(WTF::CanMakeCheckedPtrBase::decrementCheckedPtrCount const):
(WTF::CanMakeCheckedPtrBase::checkedPtrCountWithoutThreadCheck const):

Canonical link: <a href="https://commits.webkit.org/310266@main">https://commits.webkit.org/310266@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20e55e8edcf4627b9beb01311b01b749981f9f02

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152669 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25450 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19049 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161413 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106125 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25978 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25756 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117979 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83588 "5 flakes 2 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f671da49-a23b-4f2f-931e-4b8445fc0d39) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155628 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20203 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137064 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98692 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/459b4f59-9597-48cc-ae64-5b9668656741) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19278 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17220 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9248 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144680 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128929 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14938 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163884 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13474 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7023 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16532 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126036 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25248 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21259 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126195 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34376 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25250 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136734 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81854 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21158 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13513 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184301 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24866 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89152 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47047 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24558 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24717 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24618 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->