### PR TITLE
[macOS] imported/w3c/web-platform-tests/trusted-types/navigate-to-javascript-url-csp-headers.html is a flaky text failure.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/support/navigation-support.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/support/navigation-support.js
@@ -63,6 +63,11 @@ async function setLocationToJavaScriptURL(defaultpolicy) {
         } else {
           await new Promise(resolve => requestAnimationFrame(_ => requestAnimationFrame(resolve)));
         }
+        // Extra event-loop turns so the asynchronously-scheduled navigation
+        // fires and the resulting violation event is dispatched before the
+        // connect-src marker in trusted_type_violations_and_exception_for.
+        await new Promise(resolve => setTimeout(resolve, 0));
+        await new Promise(resolve => setTimeout(resolve, 0));
       });
 
   return {

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2401,8 +2401,6 @@ webkit.org/b/305660 [ Debug ] http/tests/cache-storage/cache-clearing-all.https.
 
 webkit.org/b/305671 fast/animation/css-animation-throttling.html [ Pass Failure ]
 
-webkit.org/b/310853 imported/w3c/web-platform-tests/trusted-types/navigate-to-javascript-url-csp-headers.html [ Pass Failure ]
-
 webkit.org/b/305673 [ Debug ] inspector/idl-extensions/CanvasRenderingContext2D/setPath.html [ Timeout ]
 
 webkit.org/b/305675 fast/animation/request-animation-frame-throttle-subframe-zero-size.html [ Pass Failure ]


### PR DESCRIPTION
#### 8373ca7d07e36eb02ad96ef12aaedba9cfcb4dba
<pre>
[macOS] imported/w3c/web-platform-tests/trusted-types/navigate-to-javascript-url-csp-headers.html is a flaky text failure.
<a href="https://rdar.apple.com/173459183">rdar://173459183</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=310853">https://bugs.webkit.org/show_bug.cgi?id=310853</a>

Reviewed by NOBODY (OOPS!).

This test flakily fails due to insufficient waiting in
navigation-support.js:setLocationToJavaScriptURL(). The current
implementation uses rIC/rAF which provide roughty one event loop.
This is not always enough time for all resources to arrive.

Fix in navigation-support.js:
  - Add 2 setTimeout calls in navigation-support.js to allow
    additional event loop turns before assertions.

* LayoutTests/imported/w3c/web-platform-tests/trusted-types/support/navigation-support.js:
* LayoutTests/platform/mac-wk2/TestExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8373ca7d07e36eb02ad96ef12aaedba9cfcb4dba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153264 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26048 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19646 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162009 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106722 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26574 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26351 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118490 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83905 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156223 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20733 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137601 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99203 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19810 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17754 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9844 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129456 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15471 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164483 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17065 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126549 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25843 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21788 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/semantics/structured-clone/shared.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126707 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25845 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137266 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82514 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21652 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14045 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25463 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25154 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25313 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25215 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->