### PR TITLE
Use std::midpoint() in IntervalSet.h

### DIFF
--- a/Source/WTF/wtf/IntervalSet.h
+++ b/Source/WTF/wtf/IntervalSet.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <numeric>
 #include <wtf/CommaPrinter.h>
 #include <wtf/DataLog.h>
 #include <wtf/FastMalloc.h>
@@ -780,7 +781,7 @@ private:
             return false;
 
         auto leftNode = leftNodeRef->template as<NodeType>();
-        size_t newSize = (leftNodeSize + nodeSize) / 2;
+        size_t newSize = std::midpoint(leftNodeSize, nodeSize);
         ASSERT(newSize < NodeType::capacity);
         size_t numToMove = nodeSize - newSize;
         leftNode->shiftLeftFrom(leftNodeSize, node, nodeSize, numToMove);
@@ -825,7 +826,7 @@ private:
         }
         // Now, we know that insertionINdex < capacity, so if there's only one empty slot between both nodes,
         // we should put it in the left node and the insertion point will still always be in the left node.
-        size_t newSize = (rightNodeSize + nodeSize) / 2;
+        size_t newSize = std::midpoint(rightNodeSize, nodeSize);
         ASSERT(newSize < NodeType::capacity);
         size_t numToMove = nodeSize - newSize;
         node->shiftRightTo(nodeSize, rightNode, rightNodeSize, numToMove);


### PR DESCRIPTION
#### fd8f00ca49ace748f136360021b1b6f37ae73de1
<pre>
Use std::midpoint() in IntervalSet.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=310856">https://bugs.webkit.org/show_bug.cgi?id=310856</a>
<a href="https://rdar.apple.com/173461323">rdar://173461323</a>

Reviewed by Chris Dumez.

Use C++20&apos;s std::midpoint() [1] in IntervalSet.h to compute the
midpoint of two size_t values. std::midpoint() is more expressive
and avoids potential overflow issues compared to (a + b) / 2.

[1] <a href="https://en.cppreference.com/w/cpp/numeric/midpoint">https://en.cppreference.com/w/cpp/numeric/midpoint</a>

* Source/WTF/wtf/IntervalSet.h:
(WTF::IntervalSet::tryRedistributeLeftAndInsert):
(WTF::IntervalSet::tryRedistributeRightAndInsert):

Canonical link: <a href="https://commits.webkit.org/310074@main">https://commits.webkit.org/310074@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b13c6edb9e4ced8de0704e7ae1dea527886c56ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152557 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25339 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18938 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161302 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106014 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25867 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25645 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117883 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155517 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20113 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136955 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98597 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19188 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17118 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9136 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144569 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128838 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14829 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163773 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13360 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6912 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16423 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125936 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25137 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21157 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126098 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34225 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25139 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136625 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81741 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21077 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13404 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184189 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24755 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89041 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46970 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24447 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24606 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24507 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->