### PR TITLE
tHTMLMediaElement preservesPitch=false and playbackRate aren't correctly handled when hooked up to AudioContext

### DIFF
--- a/LayoutTests/webaudio/MediaElementAudioSource/mediaelementaudiosourcenode-playbackrate-expected.txt
+++ b/LayoutTests/webaudio/MediaElementAudioSource/mediaelementaudiosourcenode-playbackrate-expected.txt
@@ -1,0 +1,10 @@
+
+PASS # AUDIT TASK RUNNER STARTED.
+PASS Executing "mediaelementsourcenode-playbackrate"
+PASS Audit report
+PASS > [mediaelementsourcenode-playbackrate] Verify playbackRate at 2.0 generates correctly pitched audio
+PASS   frequencyData[305hz] == 0 is true.
+PASS   frequencyData[610hz] > 0 is true.
+PASS < [mediaelementsourcenode-playbackrate] All assertions passed. (total 2 assertions)
+PASS # AUDIT TASK RUNNER FINISHED: 1 tasks ran successfully.
+

--- a/LayoutTests/webaudio/MediaElementAudioSource/mediaelementaudiosourcenode-playbackrate.html
+++ b/LayoutTests/webaudio/MediaElementAudioSource/mediaelementaudiosourcenode-playbackrate.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>
+      mediaelementaudiosourcenode-playbackrate.html
+    </title>
+    <script src="../../imported/w3c/web-platform-tests/resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+    <script src="../resources/audit-util.js"></script>
+    <script src="../resources/audit.js"></script>
+  </head>
+  <body>
+    <script id="layout-test-code">
+        let audit = Audit.createTaskRunner();
+
+        function waitFor(element, type) {
+            return new Promise(resolve => {
+                element.addEventListener(type, resolve, { once: true });
+            });
+        }
+
+        function sleepFor(time) {
+            return new Promise(resolve => setTimeout(resolve, time));
+        }
+
+      audit.define(
+          {
+            label: 'mediaelementsourcenode-playbackrate',
+            description: 'Verify playbackRate at 2.0 generates correctly pitched audio'
+          },
+          async (task, should) => {
+            window.audioElement = new Audio('../resources/media/half-a-second-48000.mp3');
+            audioElement.playbackRate = 2;
+            audioElement.preservesPitch = false;
+            audioElement.loop = true;
+
+            let context = new AudioContext({sampleRate: 48000});
+            let mediaSource = context.createMediaElementSource(audioElement);
+            let analyser = context.createAnalyser();
+            let gain = context.createGain();
+
+            analyser.fftSize = 2048;
+            analyser.smoothingTimeConstant = 0;
+            analyser.minDecibels = -40;
+            let frequencyData = new Uint8Array(analyser.frequencyBinCount);
+
+            // Silence test output
+            gain.gain.value = 0;
+
+            mediaSource.connect(analyser);
+            analyser.connect(gain);
+            gain.connect(context.destination);
+
+            await context.resume();
+            await audioElement.play();
+
+            while (!audioElement.paused) {
+                analyser.getByteFrequencyData(frequencyData);
+                if (frequencyData[13] == 0 && frequencyData[26] > 0)
+                    break;
+                await sleepFor(10);
+            }
+
+            should(frequencyData[13] == 0, 'frequencyData[305hz] == 0').beTrue();
+            should(frequencyData[26] > 0, 'frequencyData[610hz] > 0').beTrue();
+
+            audioElement.pause();
+            context.suspend();
+            task.done();
+          });
+      audit.run();
+    </script>
+  </body>
+</html>

--- a/Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.cpp
@@ -69,6 +69,7 @@ ExceptionOr<Ref<MediaElementAudioSourceNode>> MediaElementAudioSourceNode::creat
 MediaElementAudioSourceNode::MediaElementAudioSourceNode(BaseAudioContext& context, Ref<HTMLMediaElement>&& mediaElement)
     : AudioNode(context, NodeTypeMediaElementAudioSource)
     , m_mediaElement(WTF::move(mediaElement))
+    , m_playbackRate { abs(m_mediaElement->reportedPlaybackRate()) }
 {
     // Default to stereo. This could change depending on what the media element .src is set to.
     addOutput(2);
@@ -103,13 +104,7 @@ void MediaElementAudioSourceNode::setFormat(size_t numberOfChannels, float sourc
         m_sourceNumberOfChannels = numberOfChannels;
         m_sourceSampleRate = sourceSampleRate;
 
-        if (sourceSampleRate != sampleRate()) {
-            double scaleFactor = sourceSampleRate / sampleRate();
-            m_multiChannelResampler = makeUnique<MultiChannelResampler>(scaleFactor, numberOfChannels, AudioUtilities::renderQuantumSize, std::bind(&MediaElementAudioSourceNode::provideInput, this, std::placeholders::_1, std::placeholders::_2));
-        } else {
-            // Bypass resampling.
-            m_multiChannelResampler = nullptr;
-        }
+        updateResamplerIfNeeded();
 
         {
             // The context must be locked when changing the number of output channels.
@@ -118,6 +113,31 @@ void MediaElementAudioSourceNode::setFormat(size_t numberOfChannels, float sourc
             // Do any necesssary re-configuration to the output's number of channels.
             protect(output(0))->setNumberOfChannels(numberOfChannels);
         }
+    }
+}
+
+void MediaElementAudioSourceNode::setPlaybackRate(double playbackRate)
+{
+    playbackRate = abs(playbackRate);
+    if (!playbackRate || playbackRate == m_playbackRate)
+        return;
+
+    Locker locker { m_processLock };
+    m_playbackRate = playbackRate;
+    updateResamplerIfNeeded();
+}
+
+void MediaElementAudioSourceNode::updateResamplerIfNeeded()
+{
+    // Account for both sample rate conversion and playback rate
+    double effectiveSampleRate = m_sourceSampleRate * m_playbackRate;
+
+    if (effectiveSampleRate != sampleRate()) {
+        double scaleFactor = effectiveSampleRate / sampleRate();
+        m_multiChannelResampler = makeUnique<MultiChannelResampler>(scaleFactor, m_sourceNumberOfChannels, AudioUtilities::renderQuantumSize, std::bind(&MediaElementAudioSourceNode::provideInput, this, std::placeholders::_1, std::placeholders::_2));
+    } else {
+        // Bypass resampling.
+        m_multiChannelResampler = nullptr;
     }
 }
 
@@ -161,11 +181,9 @@ void MediaElementAudioSourceNode::process(size_t numberOfFrames)
     }
 
     if (m_multiChannelResampler) {
-        ASSERT(m_sourceSampleRate != sampleRate());
         m_multiChannelResampler->process(outputBus.get(), numberOfFrames);
     } else {
-        // Bypass the resampler completely if the source is at the context's sample-rate.
-        ASSERT(m_sourceSampleRate == sampleRate());
+        // Bypass the resampler completely if no resampling is needed.
         provideInput(outputBus, numberOfFrames);
     }
 }

--- a/Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.h
+++ b/Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.h
@@ -56,6 +56,7 @@ public:
     
     // AudioSourceProviderClient
     void setFormat(size_t numberOfChannels, float sampleRate) final;
+    void setPlaybackRate(double);
     void ref() const final { AudioNode::ref(); }
     void deref() const final { AudioNode::deref(); }
 
@@ -64,6 +65,7 @@ public:
 private:
     MediaElementAudioSourceNode(BaseAudioContext&, Ref<HTMLMediaElement>&&);
     void provideInput(AudioBus&, size_t framesToProcess);
+    void updateResamplerIfNeeded() WTF_REQUIRES_LOCK(m_processLock);
 
     double tailTime() const override { return 0; }
     double latencyTime() const override { return 0; }
@@ -79,6 +81,7 @@ private:
 
     unsigned m_sourceNumberOfChannels WTF_GUARDED_BY_LOCK(m_processLock) { 0 };
     double m_sourceSampleRate WTF_GUARDED_BY_LOCK(m_processLock) { 0 };
+    std::atomic<double> m_playbackRate { 1.0 };
     bool m_muted WTF_GUARDED_BY_LOCK(m_processLock) { false };
 
     std::unique_ptr<MultiChannelResampler> m_multiChannelResampler WTF_GUARDED_BY_LOCK(m_processLock);

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -6087,6 +6087,12 @@ void HTMLMediaElement::mediaPlayerRateChanged()
 
     updateSleepDisabling();
 
+#if ENABLE(WEB_AUDIO)
+    // Notify the audio source node if playback rate changed
+    if (RefPtr audioSourceNode = m_audioSourceNode)
+        audioSourceNode->setPlaybackRate(m_reportedPlaybackRate);
+#endif
+
     endProcessingMediaPlayerCallback();
 }
 

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -291,6 +291,7 @@ public:
     void setDefaultPlaybackRate(double) override;
     WEBCORE_EXPORT double playbackRate() const override;
     void setPlaybackRate(double) override;
+    double reportedPlaybackRate() const { return m_reportedPlaybackRate; }
     WEBCORE_EXPORT bool NODELETE preservesPitch() const;
     WEBCORE_EXPORT void setPreservesPitch(bool);
 

--- a/Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.h
@@ -62,6 +62,7 @@ public:
 
     void setPlayerItem(AVPlayerItem *);
     void setAudioTrack(AVAssetTrack *);
+    void setPlaybackRate(double);
 
     using AudioCallback = Function<void(uint64_t startFrame, uint64_t numberOfFrames, bool needFlush)>;
     WEBCORE_EXPORT void setAudioCallback(AudioCallback&&);
@@ -108,6 +109,7 @@ private:
     enum { NoSeek = std::numeric_limits<uint64_t>::max() };
     uint64_t m_seekTo { NoSeek };
     bool m_paused { true };
+    double m_playbackRate { 1. };
     WeakPtr<AudioSourceProviderClient> m_client;
     WeakPtrFactory<AudioSourceProviderAVFObjC> m_weakFactory;
 

--- a/Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
@@ -177,6 +177,15 @@ void AudioSourceProviderAVFObjC::setAudioTrack(AVAssetTrack *avAssetTrack)
     createMixIfNeeded();
 }
 
+void AudioSourceProviderAVFObjC::setPlaybackRate(double rate)
+{
+    rate = abs(rate);
+    if (m_playbackRate == rate)
+        return;
+
+    m_playbackRate = rate;
+}
+
 void AudioSourceProviderAVFObjC::recreateAudioMixIfNeeded()
 {
     if (!m_avAudioMix)
@@ -381,7 +390,7 @@ void AudioSourceProviderAVFObjC::process(MTAudioProcessingTapRef tap, CMItemCoun
         // Only check the write-ahead time when playback begins.
         m_paused = false;
         MediaTime earlyBy = rangeStart - currentTime;
-        m_writeAheadCount = m_tapDescription->mSampleRate * earlyBy.toDouble();
+        m_writeAheadCount = m_tapDescription->mSampleRate * m_playbackRate * earlyBy.toDouble();
     }
 
     auto [startFrame, endFrame] = m_ringBuffer->getStoreTimeBounds();

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -1675,6 +1675,10 @@ void MediaPlayerPrivateAVFoundationObjC::setRateDouble(double rate)
     if (m_requestedPlaying)
         setPlayerRate(rate);
     m_wallClockAtCachedCurrentTime = std::nullopt;
+#if ENABLE(WEB_AUDIO) && USE(MEDIATOOLBOX)
+    if (RefPtr provider = m_provider)
+        provider->setPlaybackRate(rate);
+#endif
 }
 
 void MediaPlayerPrivateAVFoundationObjC::setPlayerRate(double rate, std::optional<MonotonicTime>&& hostTime)


### PR DESCRIPTION
#### 08ffa75952b7294029da4efd21197d6b697623ca
<pre>
tHTMLMediaElement preservesPitch=false and playbackRate aren&apos;t correctly handled when hooked up to AudioContext
<a href="https://rdar.apple.com/93275149">rdar://93275149</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=240405">https://bugs.webkit.org/show_bug.cgi?id=240405</a>

Reviewed by Andy Estes.

Use the existing MultiChannelResampler in MediaElementAudioSourceNode to perform a sample rate
conversion when the playback rate of the attached HTMLMediaElement is non-1x. Additionally, have
the media element notify the audio node when the reported rate changes.

Test: webaudio/MediaElementAudioSource/mediaelementaudiosourcenode-playbackrate.html

* Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.cpp:
(WebCore::MediaElementAudioSourceNode::MediaElementAudioSourceNode):
(WebCore::MediaElementAudioSourceNode::setFormat):
(WebCore::MediaElementAudioSourceNode::setPlaybackRate):
(WebCore::MediaElementAudioSourceNode::updateResamplerIfNeeded):
(WebCore::MediaElementAudioSourceNode::process):
* Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::mediaPlayerRateChanged):
* Source/WebCore/html/HTMLMediaElement.h:
(WebCore::HTMLMediaElement::reportedPlaybackRate const):

Canonical link: <a href="https://commits.webkit.org/310098@main">https://commits.webkit.org/310098@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d34a4ed13904973e4017e00e1df3e7eb796a96a5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152589 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25371 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18970 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161334 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106046 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4d442d01-ef6b-4535-b747-e16187cfe76b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154463 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25899 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25677 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117909 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83557 "7 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/259230c3-b063-4f46-b62e-5a1110f965d0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155549 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20135 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136991 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98622 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/33858f47-1a25-4458-ab78-44570f809a6a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19210 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17149 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9168 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128911 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14865 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163805 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6944 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16459 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125967 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25169 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21188 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126128 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34243 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25171 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136661 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81773 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21100 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13440 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24787 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89073 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24479 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24638 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24539 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->