### PR TITLE
Add move constructor and move assignment operator to BitVector

### DIFF
--- a/Source/WTF/wtf/BitVector.h
+++ b/Source/WTF/wtf/BitVector.h
@@ -88,6 +88,11 @@ public:
         (*this) = other;
     }
 
+    BitVector(BitVector&& other)
+        : m_bitsOrPointer(std::exchange(other.m_bitsOrPointer, makeInlineBits(0)))
+    {
+    }
+
 #if USE(CF)
     BitVector(CFBitVectorRef bitVector)
         : BitVector(CFBitVectorGetCount(bitVector))
@@ -109,13 +114,25 @@ public:
     
     BitVector& operator=(const BitVector& other)
     {
-        if (&other == this)
+        if (&other == this) [[unlikely]]
             return *this;
 
         if (isInline() && other.isInline())
             m_bitsOrPointer = other.m_bitsOrPointer;
         else
             setSlow(other);
+        return *this;
+    }
+
+    BitVector& operator=(BitVector&& other)
+    {
+        if (&other == this) [[unlikely]]
+            return *this;
+
+        if (!isInline() && !isEmptyOrDeletedValue())
+            OutOfLineBits::destroy(outOfLineBits());
+
+        m_bitsOrPointer = std::exchange(other.m_bitsOrPointer, makeInlineBits(0));
         return *this;
     }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/BitVector.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/BitVector.cpp
@@ -27,6 +27,7 @@
 #include <wtf/BitVector.h>
 
 #include <wtf/MathExtras.h>
+#include <wtf/Vector.h>
 
 namespace TestWebKitAPI {
 
@@ -66,6 +67,131 @@ TEST(WTF_BitVector, MergeLargerIntoSmaller)
 
     // Total set bits should be exactly 4.
     EXPECT_EQ(large.bitCount(), 4u);
+}
+
+TEST(WTF_BitVector, MoveConstructInline)
+{
+    BitVector a;
+    a.set(0);
+    a.set(5);
+    a.set(62);
+
+    BitVector b(WTF::move(a));
+
+    EXPECT_TRUE(b.get(0));
+    EXPECT_TRUE(b.get(5));
+    EXPECT_TRUE(b.get(62));
+    EXPECT_EQ(b.bitCount(), 3u);
+
+    // Source should be empty after move.
+    EXPECT_TRUE(a.isEmpty());
+    EXPECT_EQ(a.bitCount(), 0u);
+}
+
+TEST(WTF_BitVector, MoveConstructOutOfLine)
+{
+    BitVector a(256);
+    a.quickSet(0);
+    a.quickSet(100);
+    a.quickSet(200);
+
+    BitVector b(WTF::move(a));
+
+    EXPECT_TRUE(b.get(0));
+    EXPECT_TRUE(b.get(100));
+    EXPECT_TRUE(b.get(200));
+    EXPECT_EQ(b.bitCount(), 3u);
+    EXPECT_GE(b.size(), 256u);
+
+    // Source should be empty inline after move.
+    EXPECT_TRUE(a.isEmpty());
+    EXPECT_EQ(a.bitCount(), 0u);
+}
+
+TEST(WTF_BitVector, MoveAssignInline)
+{
+    BitVector a;
+    a.set(3);
+    a.set(10);
+
+    BitVector b;
+    b.set(7);
+
+    b = WTF::move(a);
+
+    EXPECT_TRUE(b.get(3));
+    EXPECT_TRUE(b.get(10));
+    EXPECT_FALSE(b.get(7));
+    EXPECT_EQ(b.bitCount(), 2u);
+
+    EXPECT_TRUE(a.isEmpty());
+}
+
+TEST(WTF_BitVector, MoveAssignOutOfLine)
+{
+    BitVector a(256);
+    a.quickSet(50);
+    a.quickSet(150);
+
+    BitVector b(128);
+    b.quickSet(0);
+
+    b = WTF::move(a);
+
+    EXPECT_TRUE(b.get(50));
+    EXPECT_TRUE(b.get(150));
+    EXPECT_FALSE(b.get(0));
+    EXPECT_EQ(b.bitCount(), 2u);
+    EXPECT_GE(b.size(), 256u);
+
+    EXPECT_TRUE(a.isEmpty());
+}
+
+TEST(WTF_BitVector, MoveAssignOutOfLineToOutOfLine)
+{
+    // Both source and destination are out-of-line. The destination's
+    // allocation should be freed.
+    BitVector a(200);
+    a.quickSet(100);
+
+    BitVector b(300);
+    b.quickSet(250);
+
+    b = WTF::move(a);
+
+    EXPECT_TRUE(b.get(100));
+    EXPECT_FALSE(b.get(250));
+    EXPECT_EQ(b.bitCount(), 1u);
+
+    EXPECT_TRUE(a.isEmpty());
+}
+
+TEST(WTF_BitVector, MoveInVector)
+{
+    Vector<BitVector> vec;
+    for (unsigned i = 0; i < 100; ++i) {
+        BitVector bv(256);
+        bv.quickSet(i);
+        vec.append(WTF::move(bv));
+    }
+
+    for (unsigned i = 0; i < 100; ++i) {
+        EXPECT_TRUE(vec[i].get(i));
+        EXPECT_EQ(vec[i].bitCount(), 1u);
+    }
+}
+
+TEST(WTF_BitVector, MoveAssignSelf)
+{
+    BitVector a(256);
+    a.quickSet(42);
+
+    auto& ref = a;
+    a = WTF::move(ref);
+
+    // Should survive self-move-assignment.
+    EXPECT_TRUE(a.get(42));
+    EXPECT_EQ(a.bitCount(), 1u);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 6b907580f29ee7928bdb47b3addcafe6273ec3b3
<pre>
Add move constructor and move assignment operator to BitVector
<a href="https://bugs.webkit.org/show_bug.cgi?id=310857">https://bugs.webkit.org/show_bug.cgi?id=310857</a>

Reviewed by Ryosuke Niwa.

BitVector&apos;s out-of-line representation heap-allocates an OutOfLineBits
struct. Without move semantics, every copy of an out-of-line BitVector
triggers a new allocation + memcpy, even when the source is a temporary
or is being explicitly moved from via WTF::move().

Several call sites already use WTF:move() with BitVector (e.g.
BytecodeGenerator::addBitVector, LikelyDenseUnsignedIntegerSet,
UnlinkedCodeBlockGenerator), but these silently fall back to copying
since no move operations are defined. Storing BitVectors in Vector&lt;&gt;
and FixedVector&lt;&gt; also means copies during reallocation where moves
would suffice.

The implementation is trivial: steal the source&apos;s m_bitsOrPointer and
leave it as an empty inline vector via std::exchange. For inline
BitVectors (&lt;=63 bits) this is equivalent to a copy; for out-of-line
ones it avoids a heap allocation and deallocation entirely.

Test: Tools/TestWebKitAPI/Tests/WTF/BitVector.cpp

* Source/WTF/wtf/BitVector.h:
* Tools/TestWebKitAPI/Tests/WTF/BitVector.cpp:
(TestWebKitAPI::TEST(WTF_BitVector, MoveConstructInline)):
(TestWebKitAPI::TEST(WTF_BitVector, MoveConstructOutOfLine)):
(TestWebKitAPI::TEST(WTF_BitVector, MoveAssignInline)):
(TestWebKitAPI::TEST(WTF_BitVector, MoveAssignOutOfLine)):
(TestWebKitAPI::TEST(WTF_BitVector, MoveAssignOutOfLineToOutOfLine)):
(TestWebKitAPI::TEST(WTF_BitVector, MoveInVector)):
(TestWebKitAPI::TEST(WTF_BitVector, MoveAssignSelf)):

Canonical link: <a href="https://commits.webkit.org/310057@main">https://commits.webkit.org/310057@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c3bfa8c58c74ecf7374f0eb6a97636372be0e7c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152570 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25352 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18951 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161315 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dce6a7f1-483f-407a-81db-14df92fba34b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154444 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25880 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25658 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117895 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155530 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/20119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136972 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98608 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3873576e-6c8f-4b91-aeb4-df3cabbca130) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19194 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9149 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144582 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128844 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14846 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163786 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13373 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6925 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16440 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125951 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25150 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21171 "Found 1 new test failure: media/media-vp8-hiddenframes.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126112 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34215 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25152 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136642 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81754 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21086 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13421 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184202 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24768 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89054 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46972 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24460 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24619 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24520 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->