### PR TITLE
[JSC][WASM][Debugger] Make the WASM debugger stop at unreachable traps

### DIFF
--- a/JSTests/wasm/debugger/resources/swift-wasm/build.sh
+++ b/JSTests/wasm/debugger/resources/swift-wasm/build.sh
@@ -33,11 +33,11 @@ if [ -d "$SCRIPT_DIR/$FOLDER" ]; then
     # Build Swift WASM with Swiftly https://www.swift.org/documentation/articles/wasm-getting-started.html
     echo "Building Swift WebAssembly $FOLDER..."
     cd "$SCRIPT_DIR/$FOLDER"
-    "$SWIFT" build --swift-sdk "$SDK"
+    "$SWIFT" build --swift-sdk "$SDK" --configuration release
 
     # Move compiled WASM beside main.js
     echo "Moving $FOLDER.wasm..."
-    mv ".build/wasm32-unknown-wasip1/debug/$FOLDER.wasm" "./$FOLDER.wasm"
+    mv ".build/wasm32-unknown-wasip1/release/$FOLDER.wasm" "./$FOLDER.wasm"
 
     # Clean up build artifacts
     echo "Cleaning up..."

--- a/JSTests/wasm/debugger/resources/swift-wasm/crash-test/Package.swift
+++ b/JSTests/wasm/debugger/resources/swift-wasm/crash-test/Package.swift
@@ -1,0 +1,15 @@
+// swift-tools-version: 6.2
+import PackageDescription
+
+let package = Package(
+    name: "crash-test",
+    targets: [
+        .executableTarget(
+            name: "crash-test",
+            path: "Sources/crash-test",
+            linkerSettings: [
+                .unsafeFlags(["-Xlinker", "--export=crash_on_zero"])
+            ]
+        )
+    ]
+)

--- a/JSTests/wasm/debugger/resources/swift-wasm/crash-test/Sources/crash-test/main.swift
+++ b/JSTests/wasm/debugger/resources/swift-wasm/crash-test/Sources/crash-test/main.swift
@@ -1,0 +1,17 @@
+@inline(never)
+private func _overflowTrap(_ x: Int32) -> Int32 { return x + 1 }
+
+@_cdecl("crash_on_zero")
+public func crashOnZero(_ value: Int32) -> Int32 {
+    if value == 0 {
+        let _ = _overflowTrap(Int32.max)
+    }
+    return value * 2
+}
+
+@main
+struct CrashTest {
+    static func main() {
+        _ = crashOnZero
+    }
+}

--- a/JSTests/wasm/debugger/resources/swift-wasm/crash-test/main.js
+++ b/JSTests/wasm/debugger/resources/swift-wasm/crash-test/main.js
@@ -1,0 +1,45 @@
+var wasm_code = read('crash-test.wasm', 'binary');
+var wasm_module = new WebAssembly.Module(wasm_code);
+var imports = {
+    wasi_snapshot_preview1: {
+        proc_exit: function (code) {
+            print("Program exited with code:", code);
+        },
+        args_get: function () { return 0; },
+        args_sizes_get: function () { return 0; },
+        environ_get: function () { return 0; },
+        environ_sizes_get: function () { return 0; },
+        fd_write: function () { return 0; },
+        fd_read: function () { return 0; },
+        fd_close: function () { return 0; },
+        fd_seek: function () { return 0; },
+        fd_fdstat_get: function () { return 0; },
+        fd_prestat_get: function () { return 8; },
+        fd_prestat_dir_name: function () { return 8; },
+        path_open: function () { return 8; },
+        random_get: function () { return 0; },
+        clock_time_get: function () { return 0; }
+    }
+};
+
+var instance = new WebAssembly.Instance(wasm_module, imports);
+
+print("Available exports:", Object.keys(instance.exports));
+
+let crashOnZero = instance.exports.crash_on_zero;
+
+let iteration = 0;
+for (;;) {
+    try {
+        crashOnZero(0);
+    } catch (e) {
+        // When the debugger is not yet connected the Swift fatalError propagates as a
+        // JS exception. Catch and retry so the process stays alive until LLDB connects.
+        //
+        // When the debugger IS connected, hitFault() blocks the VM before the exception
+        // reaches here, so this catch is never taken on a debugger-intercepted fault.
+    }
+    iteration += 1;
+    if (iteration % 1e5 == 0)
+        print("iteration=", iteration);
+}

--- a/JSTests/wasm/debugger/resources/wasm/unreachable.js
+++ b/JSTests/wasm/debugger/resources/wasm/unreachable.js
@@ -1,0 +1,39 @@
+var wasm = new Uint8Array([
+    // [0x00] WASM header
+    0x00, 0x61, 0x73, 0x6d, // magic: \0asm
+    0x01, 0x00, 0x00, 0x00, // version: 1
+
+    // [0x08] Type section: 1 type, func () -> ()
+    0x01, 0x04, 0x01, 0x60, 0x00, 0x00,
+
+    // [0x0e] Function section: 1 function, type index 0
+    0x03, 0x02, 0x01, 0x00,
+
+    // [0x12] Export section: export function 0 as "crasher"
+    0x07, 0x0b, 0x01, 0x07, 0x63, 0x72, 0x61, 0x73, 0x68, 0x65, 0x72, 0x00, 0x00,
+
+    // [0x1f] Code section
+    0x0a,       // section id = 10
+    0x05,       // section size = 5
+    0x01,       // 1 function body
+    0x03,       // body size = 3
+    0x00,       // 0 local declarations
+    0x00,       // [0x24] unreachable
+    0x0b        // [0x25] end
+]);
+
+var module = new WebAssembly.Module(wasm);
+var instance = new WebAssembly.Instance(module);
+let crasher = instance.exports.crasher;
+
+let iteration = 0;
+for (; ;) {
+    try {
+        crasher();
+    } catch (e) {
+
+    }
+    iteration += 1;
+    if (iteration % 1e5 == 0)
+        print("iteration=", iteration);
+}

--- a/JSTests/wasm/debugger/tests/tests.py
+++ b/JSTests/wasm/debugger/tests/tests.py
@@ -1766,3 +1766,64 @@ class WasmJsWasmJsWasmCallStackTestCase(BaseTestCase):
                 "frame #5: 0xc000000000000000",  # JS main loop
             ],
         )
+
+
+class SwiftWasmCrashTestCase(BaseTestCase):
+
+    def __init__(self, build_config: str = None, port: int = None):
+        super().__init__(build_config, port)
+
+    def execute(self):
+        self.setup_debugging_session_or_raise("resources/swift-wasm/crash-test/main.js")
+
+        try:
+            for _ in range(1):
+                self.faultTest()
+
+        except Exception as e:
+            raise Exception(f"Test failed: {e}")
+
+    def faultTest(self):
+        for _ in range(10):
+            self.send_lldb_command_or_raise("c", patterns=["Process 1 stopped"])
+            self.send_lldb_command_or_raise("dis", patterns=["->  0x4000000000010a43 <+1>: unreachable"]);
+
+        self.send_lldb_command_or_raise(
+            "bt",
+            patterns=[
+                "frame #0: 0x4000000000010a43",
+                "frame #1: 0x4000000000010a43",
+                "frame #2: 0x4000000000010a6a",
+                "frame #3: 0x4000000000010a46",
+                "frame #4: 0xc000000000000000",
+            ]
+        )
+
+
+class WasmUnreachableFaultTestCase(BaseTestCase):
+
+    def __init__(self, build_config: str = None, port: int = None):
+        super().__init__(build_config, port)
+
+    def execute(self):
+        self.setup_debugging_session_or_raise("resources/wasm/unreachable.js")
+
+        try:
+            for _ in range(1):
+                self.faultTest()
+
+        except Exception as e:
+            raise Exception(f"Test failed: {e}")
+
+    def faultTest(self):
+        for _ in range(10):
+            self.send_lldb_command_or_raise("c", patterns=["Process 1 stopped"])
+            self.send_lldb_command_or_raise("dis", patterns=["->  0x4000000000000024: unreachable"]);
+
+        self.send_lldb_command_or_raise(
+            "bt",
+            patterns=[
+                "frame #0: 0x4000000000000024",
+                "frame #1: 0xc000000000000000",
+            ]
+        )

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -243,7 +243,7 @@ ipintOp(_unreachable, macro()
 
     move cfr, a1
     move sp, a2
-    operationCall(macro() cCall3(_ipint_extern_unreachable_breakpoint_handler) end)
+    operationCall(macro() cCall3(_ipint_extern_unreachable_handler) end)
 
     # Remove pushed values
     addq 4 * SlotSize, sp

--- a/Source/JavaScriptCore/runtime/StopTheWorldCallback.h
+++ b/Source/JavaScriptCore/runtime/StopTheWorldCallback.h
@@ -49,6 +49,7 @@ enum class StopTheWorldEvent : uint8_t {
     VMActivated,
     VMStopped,
     BreakpointHit,
+    TrapHit,
     StepIntoSiteReached,
 };
 

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -1327,14 +1327,13 @@ static UNUSED_FUNCTION void displayWasmDebugState(JSWebAssemblyInstance* instanc
 }
 #endif
 
-WASM_IPINT_EXTERN_CPP_DECL(unreachable_breakpoint_handler, CallFrame* callFrame, Register* sp)
+WASM_IPINT_EXTERN_CPP_DECL(unreachable_handler, CallFrame* callFrame, Register* sp)
 {
-    dataLogLnIf(Options::verboseWasmDebugger(), "[Code][unreachable] Start");
     bool breakpointHandled = false;
 #if ENABLE(WEBASSEMBLY_DEBUGGER)
     if (Options::enableWasmDebugger()) [[unlikely]] {
         Wasm::DebugServer& debugServer = Wasm::DebugServer::singleton();
-        if (debugServer.needToHandleBreakpoints()) {
+        if (debugServer.shouldHandleUnreachable()) {
             uint8_t* pc = static_cast<uint8_t*>(sp[2].pointer());
             uint8_t* mc = static_cast<uint8_t*>(sp[3].pointer());
             IPIntLocal* pl = static_cast<IPIntLocal*>(sp[0].pointer());
@@ -1343,7 +1342,8 @@ WASM_IPINT_EXTERN_CPP_DECL(unreachable_breakpoint_handler, CallFrame* callFrame,
             IPIntStackEntry* stackPointer = std::bit_cast<IPIntStackEntry*>(sp + 4);
             if (Options::verboseWasmDebugger())
                 displayWasmDebugState(instance, callee, stackPointer, pl);
-            breakpointHandled = debugServer.execution().hitBreakpoint(callFrame, instance, callee, pc, mc, pl, stackPointer);
+
+            breakpointHandled = debugServer.execution().handleUnreachable(callFrame, instance, callee, pc, mc, pl, stackPointer);
         }
     }
 #else
@@ -1351,7 +1351,6 @@ WASM_IPINT_EXTERN_CPP_DECL(unreachable_breakpoint_handler, CallFrame* callFrame,
     UNUSED_PARAM(callFrame);
     UNUSED_PARAM(sp);
 #endif
-    dataLogLnIf(Options::verboseWasmDebugger(), "[Code][unreachable] Done with breakpointHandled=", breakpointHandled);
     IPINT_RETURN(static_cast<EncodedJSValue>(static_cast<int32_t>(breakpointHandled)));
 }
 

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h
@@ -141,7 +141,7 @@ WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_atomic_wait64, uint64_t, uint64_t, uint
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_atomic_notify, unsigned, unsigned, int32_t);
 
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(check_stack_and_vm_traps, void* candidateNewStackPointer, Wasm::IPIntCallee*);
-WASM_IPINT_EXTERN_CPP_DECL(unreachable_breakpoint_handler, CallFrame*, Register*);
+WASM_IPINT_EXTERN_CPP_DECL(unreachable_handler, CallFrame*, Register*);
 
 } } // namespace JSC::IPInt
 

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.cpp
@@ -203,11 +203,6 @@ void DebugServer::resetAll()
 #endif
 }
 
-bool DebugServer::needToHandleBreakpoints() const
-{
-    return isConnected() && execution().hasBreakpoints();
-}
-
 union SocketAddress {
     sockaddr_in in;
     sockaddr generic;
@@ -411,8 +406,21 @@ void DebugServer::handlePacket(StringView packet)
         dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Routing continue packet to ExecutionHandler");
         m_executionHandler->resume();
         break;
+    case 'C':
+        // ContinueWithSignal: LLDB sends C<sig> instead of 'c' when resuming from a signal
+        // stop (e.g. T05/SIGTRAP). Signal re-delivery is a ptrace concept; we have no OS-level
+        // signal injection so the signal number is irrelevant — just resume.
+        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Routing ContinueWithSignal packet to ExecutionHandler (signal ignored)");
+        m_executionHandler->resume();
+        break;
     case 's':
         dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Routing legacy step packet to ExecutionHandler");
+        m_executionHandler->step();
+        break;
+    case 'S':
+        // StepWithSignal: same reasoning as 'C' above — signal re-delivery does not apply
+        // to our WASM VM, so ignore the signal number and treat it as a plain step.
+        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Routing StepWithSignal packet to ExecutionHandler (signal ignored)");
         m_executionHandler->step();
         break;
     case 'Z':
@@ -430,6 +438,10 @@ void DebugServer::handlePacket(StringView packet)
     case '?':
         dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Routing halt reason query to ExecutionHandler");
         m_executionHandler->interrupt();
+        // After the initial interrupt is handled and the stop reply is sent, the debugger has
+        // established a known VM state. Any unreachable trap encountered in future execution
+        // (after the user sends 'c') will be properly intercepted.
+        m_executionHandler->setUnreachableHandlingEnabled(true);
         break;
     case 'k':
         dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Kill request");
@@ -561,6 +573,11 @@ bool DebugServer::isConnected() const
         return true;
 #endif
     return isSocketValid(m_clientSocket);
+}
+
+bool DebugServer::shouldHandleUnreachable() const
+{
+    return isConnected() && m_executionHandler->isUnreachableHandlingEnabled();
 }
 
 }

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.h
@@ -115,9 +115,9 @@ public:
     void untrackModule(Module&);
 
     void setPort(uint64_t port) { m_port = port; }
-    bool needToHandleBreakpoints() const;
 
     JS_EXPORT_PRIVATE bool isConnected() const;
+    bool shouldHandleUnreachable() const;
 
     JS_EXPORT_PRIVATE void handlePacket(StringView packet);
 

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.cpp
@@ -348,8 +348,9 @@ StopData::StopData(IPIntCallee* callee, JSWebAssemblyInstance* instance)
 {
 }
 
-StopData::StopData(Breakpoint::Type type, VirtualAddress address, uint8_t originalBytecode, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal* locals, IPInt::IPIntStackEntry* stack, IPIntCallee* callee, JSWebAssemblyInstance* instance, CallFrame* callFrame)
-    : location(Location::Breakpoint)
+StopData::StopData(Location location, Code code, VirtualAddress address, uint8_t originalBytecode, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal* locals, IPInt::IPIntStackEntry* stack, IPIntCallee* callee, JSWebAssemblyInstance* instance, CallFrame* callFrame)
+    : code(code)
+    , location(location)
     , address(address)
     , originalBytecode(originalBytecode)
     , pc(pc)
@@ -360,27 +361,33 @@ StopData::StopData(Breakpoint::Type type, VirtualAddress address, uint8_t origin
     , instance(instance)
     , callFrame(callFrame)
 {
-    setCode(type);
 }
 
-StopData::~StopData() = default;
-
-void StopData::setCode(Breakpoint::Type type)
+static StopData::Code codeForBreakpointType(Breakpoint::Type type)
 {
     switch (type) {
     case Breakpoint::Type::Interrupt:
-        code = Code::Stop;
-        break;
+        return StopData::Code::Stop;
     case Breakpoint::Type::Step:
-        code = Code::Trace;
-        break;
+        return StopData::Code::Trace;
     case Breakpoint::Type::Regular:
-        code = Code::Breakpoint;
-        break;
+        return StopData::Code::Breakpoint;
     default:
-        break;
+        return StopData::Code::Unknown;
     }
 }
+
+StopData::StopData(Breakpoint::Type type, VirtualAddress address, uint8_t originalBytecode, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal* locals, IPInt::IPIntStackEntry* stack, IPIntCallee* callee, JSWebAssemblyInstance* instance, CallFrame* callFrame)
+    : StopData(Location::Breakpoint, codeForBreakpointType(type), address, originalBytecode, pc, mc, locals, stack, callee, instance, callFrame)
+{
+}
+
+StopData::StopData(IPIntCallee* callee, JSWebAssemblyInstance* instance, CallFrame* callFrame, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal* locals, IPInt::IPIntStackEntry* stack)
+    : StopData(Location::Trap, Code::Trap, VirtualAddress::toVirtual(instance, callee->functionIndex(), pc), 0, pc, mc, locals, stack, callee, instance, callFrame)
+{
+}
+
+StopData::~StopData() = default;
 
 void StopData::dump(PrintStream& out) const
 {

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.h
@@ -143,21 +143,24 @@ struct StopData {
         Unknown = 0,
         Stop, // SIGSTOP - Debugger interrupt (uncatchable stop) - reason:signal
         Trace, // SIGTRAP - Single step/trace completion - reason:trace
-        Breakpoint // SIGTRAP - Breakpoint hit - reason:breakpoint (distinct from trace)
+        Breakpoint, // SIGTRAP - Breakpoint hit - reason:breakpoint (distinct from trace)
+        Trap, // SIGTRAP - Wasm trap (unreachable instruction) - reason:signal
     };
 
     enum class Location : uint8_t {
         Prologue = 0,
-        Breakpoint
+        Breakpoint,
+        Trap, // Stopped at a Wasm unreachable trap
     };
 
     StopData(Breakpoint::Type, VirtualAddress, uint8_t originalBytecode, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal*, IPInt::IPIntStackEntry*, IPIntCallee*, JSWebAssemblyInstance*, CallFrame*);
 
     StopData(IPIntCallee*, JSWebAssemblyInstance*);
 
+    StopData(IPIntCallee*, JSWebAssemblyInstance*, CallFrame*, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal*, IPInt::IPIntStackEntry*);
+
     ~StopData();
 
-    void setCode(Breakpoint::Type);
     void dump(PrintStream&) const;
 
     Code code { Code::Unknown };
@@ -171,6 +174,9 @@ struct StopData {
     RefPtr<IPIntCallee> callee;
     JSWebAssemblyInstance* instance { nullptr };
     CallFrame* callFrame { nullptr };
+
+private:
+    StopData(Location, Code, VirtualAddress, uint8_t originalBytecode, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal*, IPInt::IPIntStackEntry*, IPIntCallee*, JSWebAssemblyInstance*, CallFrame*);
 };
 
 // Per-VM debugging state machine (Running/Stopped) with current stop information.
@@ -196,9 +202,16 @@ struct DebugState {
         stopData = makeUnique<StopData>(type, address, originalBytecode, pc, mc, locals, stack, callee, instance, callFrame);
     }
 
+    void setTrapStopData(IPIntCallee* callee, JSWebAssemblyInstance* instance, CallFrame* callFrame, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal* locals, IPInt::IPIntStackEntry* stack)
+    {
+        stopData = makeUnique<StopData>(callee, instance, callFrame, pc, mc, locals, stack);
+    }
+
     bool atSystemCall() const { return !stopData; }
     bool atPrologue() const { return !!stopData && stopData->location == StopData::Location::Prologue; }
     bool atBreakpoint() const { return !!stopData && stopData->location == StopData::Location::Breakpoint; }
+    bool atTrap() const { return !!stopData && stopData->location == StopData::Location::Trap; }
+    bool atBreakpointOrTrap() const { return atBreakpoint() || atTrap(); }
 
     void clearStop()
     {

--- a/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.cpp
@@ -69,21 +69,25 @@ struct StopReasonInfo {
     StringView reasonSuffix;
 };
 
+// GDB RSP stop reply: T<AA> where AA is the POSIX signal number in two-digit hex.
+// "reason:<suffix>" is an LLDB extension (not in the GDB RSP spec).
+// Reference: https://sourceware.org/gdb/current/onlinedocs/gdb/Stop-Reply-Packets.html
+static String signalStopString(int signo)
+{
+    return makeString('T', hex(signo, 2, WTF::Uppercase));
+}
+
 static inline StopReasonInfo stopReasonCodeToInfo(StopData::Code code)
 {
     switch (code) {
     case StopData::Code::Stop:
-#if OS(DARWIN)
-        return { "T11"_s, "signal"_s }; // SIGSTOP on macOS (17 decimal = 0x11 hex)
-#elif OS(LINUX)
-        return { "T13"_s, "signal"_s }; // SIGSTOP on Linux (19 decimal = 0x13 hex)
-#else
-        return { "T11"_s, "signal"_s }; // Default: SIGSTOP (most common value)
-#endif
+        return { signalStopString(SIGSTOP), "signal"_s };
     case StopData::Code::Trace:
-        return { "T05"_s, "trace"_s }; // SIGTRAP - Trace/single step
+        return { signalStopString(SIGTRAP), "trace"_s };
     case StopData::Code::Breakpoint:
-        return { "T05"_s, "breakpoint"_s }; // SIGTRAP - Breakpoint hit
+        return { signalStopString(SIGTRAP), "breakpoint"_s };
+    case StopData::Code::Trap:
+        return { signalStopString(SIGTRAP), "exception"_s };
     default:
         RELEASE_ASSERT_NOT_REACHED();
         return { String(), "trace"_s };
@@ -111,6 +115,7 @@ void ExecutionHandler::stopTheWorld(VM& debuggee, StopTheWorldEvent event)
             RELEASE_ASSERT(m_debuggee == info.targetVM && info.worldMode == VMManager::Mode::RunOne);
             break;
         case StopTheWorldEvent::BreakpointHit:
+        case StopTheWorldEvent::TrapHit:
             RELEASE_ASSERT(info.worldMode != VMManager::Mode::Stopped);
             break;
         default:
@@ -128,16 +133,22 @@ void ExecutionHandler::stopTheWorld(VM& debuggee, StopTheWorldEvent event)
     VMManager::singleton().notifyVMStop(debuggee, event);
 }
 
-bool ExecutionHandler::hitBreakpoint(CallFrame* callFrame, JSWebAssemblyInstance* instance, IPIntCallee* callee, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal* locals, IPInt::IPIntStackEntry* stack)
+bool ExecutionHandler::handleUnreachable(CallFrame* callFrame, JSWebAssemblyInstance* instance, IPIntCallee* callee, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal* locals, IPInt::IPIntStackEntry* stack)
 {
-    VirtualAddress address = VirtualAddress::toVirtual(instance, callee->functionIndex(), pc);
-    if (auto* breakpoint = m_breakpointManager->findBreakpoint(address)) {
-        VM& debuggee = instance->vm();
-        debuggee.debugState()->setBreakpointStopData(breakpoint->type, address, breakpoint->originalBytecode, pc, mc, locals, stack, callee, instance, callFrame);
-        dataLogLnIf(Options::verboseWasmDebugger(), "[Code][hitBreakpoint] Going to stop at ", *breakpoint, " with ", *debuggee.debugState()->stopData);
-        stopTheWorld(debuggee, StopTheWorldEvent::BreakpointHit);
-        return true;
+    if (hasBreakpoints()) {
+        VirtualAddress address = VirtualAddress::toVirtual(instance, callee->functionIndex(), pc);
+        if (auto* breakpoint = m_breakpointManager->findBreakpoint(address)) {
+            VM& debuggee = instance->vm();
+            debuggee.debugState()->setBreakpointStopData(breakpoint->type, address, breakpoint->originalBytecode, pc, mc, locals, stack, callee, instance, callFrame);
+            dataLogLnIf(Options::verboseWasmDebugger(), "[Code][handleUnreachable] Breakpoint at ", *breakpoint, " with ", *debuggee.debugState()->stopData);
+            stopTheWorld(debuggee, StopTheWorldEvent::BreakpointHit);
+            return true;
+        }
     }
+    VM& debuggee = instance->vm();
+    debuggee.debugState()->setTrapStopData(callee, instance, callFrame, pc, mc, locals, stack);
+    dataLogLnIf(Options::verboseWasmDebugger(), "[Code][handleUnreachable] Wasm unreachable trap at ", *debuggee.debugState()->stopData);
+    stopTheWorld(debuggee, StopTheWorldEvent::TrapHit);
     return false;
 }
 
@@ -166,6 +177,7 @@ ExecutionHandler::ResumeMode ExecutionHandler::stopCode(Locker<Lock>& locker, St
         notifyDebuggerOfStop();
         break;
     case StopTheWorldEvent::BreakpointHit:
+    case StopTheWorldEvent::TrapHit:
         RELEASE_ASSERT(m_debuggerState == DebuggerState::StepRequested || m_debuggerState == DebuggerState::ContinueRequested || m_debuggerState == DebuggerState::SwitchRequested);
         m_breakpointManager->clearAllOneTimeBreakpoints();
         notifyDebuggerOfStop();
@@ -379,8 +391,12 @@ void ExecutionHandler::step()
     RELEASE_ASSERT(m_debuggerState == DebuggerState::Replied && state->isStopped());
 
     bool resumeAll = false;
-    if (state->atSystemCall())
+    if (state->atSystemCall() || state->atTrap()) {
+        // There is no valid next WASM instruction to step to in either case.
+        // For traps, unreachable throws a WebAssembly.RuntimeError back to JS — equivalent
+        // to returning from WASM — so resuming all is the right behavior.
         resumeAll = true;
+    }
     else if (state->atBreakpoint())
         resumeAll = stepAtBreakpoint(locker, state);
     else {
@@ -689,7 +705,7 @@ void ExecutionHandler::handleThreadStopInfo(StringView packet)
 
 static uint64_t getStopPC(const DebugState& state)
 {
-    if (state.atBreakpoint() || state.atPrologue())
+    if (state.atBreakpointOrTrap() || state.atPrologue())
         return state.stopData->address;
     return VirtualAddress(VirtualAddress::INVALID_BASE).value();
 }
@@ -697,7 +713,7 @@ static uint64_t getStopPC(const DebugState& state)
 static String getThreadName(const DebugState& state, uint64_t threadId)
 {
     StringView stateName;
-    if (state.atBreakpoint())
+    if (state.atBreakpointOrTrap())
         stateName = "wasm-call"_s;
     else if (state.atPrologue())
         stateName = "wasm-prologue"_s;
@@ -753,7 +769,7 @@ void ExecutionHandler::sendStopReplyForThread(AbstractLocker& locker, uint64_t t
     Vector<ThreadInfo> allThreads = collectAllStoppedThreads();
 
     // FIXME: Report different stop reasons for active vs passive threads (currently all use same code).
-    StopData::Code code = state->atBreakpoint() ? state->stopData->code : StopData::Code::Stop;
+    StopData::Code code = state->atBreakpointOrTrap() ? state->stopData->code : StopData::Code::Stop;
     auto stopInfo = stopReasonCodeToInfo(code);
 
     // Build packet with target thread
@@ -782,6 +798,15 @@ void ExecutionHandler::sendStopReplyForThread(AbstractLocker& locker, uint64_t t
 
     reply.append("00:"_s, toNativeEndianHex(getStopPC(*state)), ';');
     reply.append("reason:"_s, stopInfo.reasonSuffix, ';');
+
+    // For trap stops, include a hex-encoded description of the exception message
+    // matching WAMR convention so LLDB can display it to the user.
+    if (code == StopData::Code::Trap) {
+        reply.append("description:"_s);
+        for (UChar c : StringView("unreachable hit"_s).codeUnits())
+            reply.append(hex(static_cast<uint8_t>(c), 2, Lowercase));
+        reply.append(';');
+    }
 
     dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Sending stop reply: target thread="_s, hex(threadId), ", total threads="_s, allThreads.size(), ", packet="_s, reply.toString());
     sendReplyImpl(locker, reply.toString());
@@ -833,6 +858,7 @@ void ExecutionHandler::reset()
 
     m_breakpointManager->clearAllBreakpoints();
     m_debuggerState = DebuggerState::Replied;
+    setUnreachableHandlingEnabled(false);
     takeAwaitingResumeNotification();
     m_debuggee = nullptr;
 }
@@ -877,8 +903,8 @@ String ExecutionHandler::callStackStringFor(uint64_t threadId)
     auto* state = targetVM->debugState();
     RELEASE_ASSERT(state->isStopped());
 
-    // For threads stopped at breakpoint with full call stack, walk the stack
-    if (state->atBreakpoint()) {
+    // For threads stopped at breakpoint or trap with full call stack, walk the stack
+    if (state->atBreakpointOrTrap()) {
         auto& stopData = *state->stopData;
         RELEASE_ASSERT(stopData.callFrame);
 

--- a/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.h
@@ -77,7 +77,7 @@ public:
     };
 
     ResumeMode stopCode(Locker<Lock>&, StopTheWorldEvent) WTF_REQUIRES_LOCK(m_lock);
-    bool hitBreakpoint(CallFrame*, JSWebAssemblyInstance*, IPIntCallee*, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal* = nullptr, IPInt::IPIntStackEntry* = nullptr);
+    bool handleUnreachable(CallFrame*, JSWebAssemblyInstance*, IPIntCallee*, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal* = nullptr, IPInt::IPIntStackEntry* = nullptr);
 
     JS_EXPORT_PRIVATE void resume();
     JS_EXPORT_PRIVATE void step();
@@ -126,6 +126,8 @@ public:
     StopTheWorldStatus handleStopTheWorld(VM&, StopTheWorldEvent);
     void handlePostResume();
     bool takeAwaitingResumeNotification() WTF_REQUIRES_LOCK(m_lock) { return std::exchange(m_awaitingResumeNotification, false); }
+    void setUnreachableHandlingEnabled(bool enabled) { m_unreachableHandlingEnabled.store(enabled, std::memory_order_release); }
+    bool isUnreachableHandlingEnabled() const { return m_unreachableHandlingEnabled.load(std::memory_order_acquire); }
 
 private:
     friend class DebugServer;
@@ -168,6 +170,7 @@ private:
     Condition m_debuggeeContinue;
     DebuggerState m_debuggerState WTF_GUARDED_BY_LOCK(m_lock) { DebuggerState::Replied };
     bool m_awaitingResumeNotification WTF_GUARDED_BY_LOCK(m_lock) { false };
+    std::atomic<bool> m_unreachableHandlingEnabled { false };
     VM* m_debuggee WTF_GUARDED_BY_LOCK(m_lock) { nullptr };
     std::optional<uint64_t> m_debugServerThreadId;
 };

--- a/Source/JavaScriptCore/wasm/debugger/WasmQueryHandler.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmQueryHandler.cpp
@@ -213,8 +213,8 @@ bool QueryHandler::handleChunkedLibrariesResponse(size_t offset, size_t maxSize,
 String QueryHandler::buildWasmCallStackResponse()
 {
     auto* state = m_debugServer.execution().debuggeeStateSafe();
-    if (!state->atBreakpoint()) {
-        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] buildWasmCallStackResponse: not stopped at breakpoint, returning empty");
+    if (!state->atBreakpointOrTrap()) {
+        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] buildWasmCallStackResponse: not stopped at breakpoint or trap, returning empty");
         return String();
     }
 
@@ -378,7 +378,7 @@ void QueryHandler::handleWasmLocal(StringView packet)
     dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] qWasmLocal frame=", frameIndex, ", variable=", localIndex);
 
     auto* state = m_debugServer.execution().debuggeeStateSafe();
-    if (!state->atBreakpoint()) {
+    if (!state->atBreakpointOrTrap()) {
         m_debugServer.sendErrorReply(ProtocolError::UnknownCommand);
         return;
     }
@@ -460,7 +460,7 @@ void QueryHandler::handleWasmGlobal(StringView packet)
     dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] qWasmGlobal frame=", frameIndex, ", global=", globalIndex);
 
     auto* state = m_debugServer.execution().debuggeeStateSafe();
-    if (!state->atBreakpoint()) {
+    if (!state->atBreakpointOrTrap()) {
         m_debugServer.sendErrorReply(ProtocolError::UnknownCommand);
         return;
     }

--- a/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTest.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTest.cpp
@@ -379,6 +379,7 @@ static void cleanupAfterScript(const TestScript& script, RefPtr<Thread>& workerT
     doneTesting = true;
     workerThread->waitForCompletion();
     executionHandler->reset();
+    executionHandler->setUnreachableHandlingEnabled(true);
     doneTesting = false;
 }
 

--- a/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTestSupport.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTestSupport.cpp
@@ -276,6 +276,7 @@ void setupTestEnvironment(DebugServer*& debugServer, ExecutionHandler*& executio
 
     executionHandler = &debugServer->execution();
     executionHandler->setDebugServerThreadId(Thread::currentSingleton().uid());
+    executionHandler->setUnreachableHandlingEnabled(true);
 
     dataLogLnIf(verboseLogging, "DebugServer setup complete in RWI mode");
 }


### PR DESCRIPTION
#### 2f3246a7a730c64cb82705521cf54298ce02c5da
<pre>
[JSC][WASM][Debugger] Make the WASM debugger stop at unreachable traps
<a href="https://bugs.webkit.org/show_bug.cgi?id=310858">https://bugs.webkit.org/show_bug.cgi?id=310858</a>
<a href="https://rdar.apple.com/173465318">rdar://173465318</a>

Reviewed by Keith Miller.

The WASM debugger did not intercept unreachable traps — they
propagated as JS exceptions with no debugger notification, making it
impossible to catch crash-style faults in WASM programs from LLDB.

This patch teaches the WASM debugger to intercept unreachable traps
and report them as debugger stops, allowing LLDB to inspect the call
stack and locals at the point of the fault. A Swift WASM test package
and a minimal hand-crafted WASM test are added to cover the feature.

Tests:
* JSTests/wasm/debugger/tests/tests.py:
(SwiftWasmCrashTestCase):
(WasmUnreachableFaultTestCase):

Canonical link: <a href="https://commits.webkit.org/310104@main">https://commits.webkit.org/310104@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8544db31fdfe1e6003ae071719df865c158a2792

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152700 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25481 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19080 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161444 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a950f854-2257-4b70-aabf-884a5a652cdd) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26009 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25787 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117994 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0d6d05f6-4281-405d-a77a-b34b23526838) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155659 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/20221 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137089 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98707 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3f440e04-9e90-48b7-b8d9-3ad9ad8cae25) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/19296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9280 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144711 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128948 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14963 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163916 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/13507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7054 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16557 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126054 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25279 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21280 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126212 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34248 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25281 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136759 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81885 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21179 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13538 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184332 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24897 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89183 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47056 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24589 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24748 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24649 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->