### PR TITLE
[WPE] Popups may fail to render after refactoring AcceleratedSurface SwapChain initialization in r310006@main

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
@@ -623,8 +623,9 @@ std::unique_ptr<AcceleratedSurface::RenderTarget> AcceleratedSurface::RenderTarg
 
 AcceleratedSurface::RenderTargetWPEBackend::RenderTargetWPEBackend(AcceleratedSurface& surface, const IntSize& initialSize, UnixFileDescriptor&& hostFD)
     : RenderTarget(surface)
-    , m_backend(wpe_renderer_backend_egl_target_create(hostFD.release()))
 {
+    ASSERT(hostFD, "RenderTargetWPEBackend created with invalid host FD");
+    m_backend = wpe_renderer_backend_egl_target_create(hostFD.release());
     static struct wpe_renderer_backend_egl_target_client s_client = {
         // frame_complete
         [](void* data) {
@@ -717,14 +718,13 @@ AcceleratedSurface::SwapChain::SwapChain(AcceleratedSurface& surface)
 #endif
 #endif // PLATFORM(GTK) || ENABLE(WPE_PLATFORM)
 #if USE(WPE_RENDERER)
-    case PlatformDisplay::Type::WPE: {
+    case PlatformDisplay::Type::WPE:
         m_type = Type::WPEBackend;
         Ref webPage { m_surface->m_webPage };
-        auto scaledSize = webPage->size();
-        scaledSize.scale(webPage->deviceScaleFactor());
-        m_lockedTargets.append(RenderTargetWPEBackend::create(m_surface.get(), scaledSize, webPage->hostFileDescriptor()));
+        m_initialSize = webPage->size();
+        m_initialSize.scale(webPage->deviceScaleFactor());
+        m_hostFD = webPage->hostFileDescriptor();
         break;
-    }
 #endif
 #if PLATFORM(GTK)
     case PlatformDisplay::Type::Default:
@@ -952,9 +952,11 @@ void AcceleratedSurface::SwapChain::releaseUnusedBuffers()
 }
 
 #if USE(WPE_RENDERER)
-uint64_t AcceleratedSurface::SwapChain::window() const
+uint64_t AcceleratedSurface::SwapChain::window()
 {
     ASSERT(m_type == Type::WPEBackend);
+    if (m_lockedTargets.isEmpty())
+        m_lockedTargets.append(RenderTargetWPEBackend::create(m_surface.get(), m_initialSize, WTF::move(m_hostFD)));
     return static_cast<RenderTargetWPEBackend*>(m_lockedTargets[0].get())->window();
 }
 #endif
@@ -1056,7 +1058,7 @@ void AcceleratedSurface::willDestroyGLContext()
     m_swapChain.reset();
 }
 
-uint64_t AcceleratedSurface::window() const
+uint64_t AcceleratedSurface::window()
 {
 #if USE(WPE_RENDERER)
     if (m_swapChain.type() == SwapChain::Type::WPEBackend)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
@@ -109,7 +109,7 @@ public:
     void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
 #endif
 
-    uint64_t window() const;
+    uint64_t window();
     uint64_t surfaceID() const { return m_id; }
     bool shouldPaintMirrored() const
     {
@@ -392,7 +392,7 @@ private:
 #endif
 
 #if USE(WPE_RENDERER)
-        uint64_t window() const;
+        uint64_t window();
 #endif
 
     private:
@@ -412,6 +412,10 @@ private:
         Lock m_bufferFormatLock;
         BufferFormat m_bufferFormat WTF_GUARDED_BY_LOCK(m_bufferFormatLock);
         bool m_bufferFormatChanged WTF_GUARDED_BY_LOCK(m_bufferFormatLock) { false };
+#endif
+#if USE(WPE_RENDERER)
+        UnixFileDescriptor m_hostFD;
+        WebCore::IntSize m_initialSize;
 #endif
     };
 


### PR DESCRIPTION
#### 8bab43a4d8f73157d14a5d8cb63823370cef0457
<pre>
[WPE] Popups may fail to render after refactoring AcceleratedSurface SwapChain initialization in r310006@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=310859">https://bugs.webkit.org/show_bug.cgi?id=310859</a>

Reviewed by Carlos Garcia Campos.

Since commit 310006@main, AcceleratedSurface::SwapChain calls wpe_renderer_backend_egl_target_create()
in its constructor using webPage-&gt;hostFileDescriptor(), but previously this was called when window()
was first called.

For popup pages created via window.open() the view backend may not be set up yet at that point,
resulting in wpe_renderer_backend_egl_target_create() being called with an empty host FD and
leaving the compositing pipeline broken.

Fix this by restoring the lazy initialization: store the FD and initial size in the constructor
and create the RenderTargetWPEBackend when window() is called.

* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp:
(WebKit::AcceleratedSurface::RenderTargetWPEBackend::RenderTargetWPEBackend):
(WebKit::AcceleratedSurface::SwapChain::SwapChain):
(WebKit::AcceleratedSurface::SwapChain::window):
(WebKit::AcceleratedSurface::window):
(WebKit::AcceleratedSurface::SwapChain::window const): Deleted.
(WebKit::AcceleratedSurface::window const): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h:

Canonical link: <a href="https://commits.webkit.org/310052@main">https://commits.webkit.org/310052@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5397dc017008a20ce9cb11d83c767fd98a6fe5b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152577 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25359 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18958 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161322 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25887 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25665 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117896 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155537 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/20122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136981 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98609 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/19197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9156 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163793 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6932 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16449 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125954 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25157 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21177 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126115 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25159 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136651 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81761 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23380 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21087 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13430 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24775 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89061 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24467 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24626 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/24527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->