### PR TITLE
[BFCache]

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -8826,6 +8826,20 @@ UseMicrophoneMuteStatusAPI:
     WebCore:
       default: false
 
+UseMultiProcessBackForwardCache:
+  type: bool
+  status: unstable
+  category: security
+  humanReadableName: "Multi-Process Back/Forward Cache"
+  humanReadableDescription: "Enable back/forward cache when site isolation is active"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 UsePreHTML5ParserQuirks:
   type: bool
   status: embedder

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1423,6 +1423,7 @@ public:
 
     bool processingLoadEvent() const { return m_processingLoadEvent; }
     bool loadEventFinished() const { return m_loadEventFinished; }
+    void resetLoadEventFinished() { m_loadEventFinished = false; }
 
     bool isContextThread() const final;
     bool isSecureContext() const final;

--- a/Source/WebCore/history/BackForwardCache.cpp
+++ b/Source/WebCore/history/BackForwardCache.cpp
@@ -574,7 +574,6 @@ std::unique_ptr<CachedPage> BackForwardCache::take(HistoryItem& item, Page* page
 
     m_items.remove(item.frameItemID());
     auto cachedPage = std::get<UniqueRef<CachedPage>>(m_cachedPageMap.take(it));
-    item.notifyChanged();
 
     if (page && &cachedPage->page() != page) {
         auto ptr = cachedPage.moveToUniquePtr();
@@ -582,6 +581,8 @@ std::unique_ptr<CachedPage> BackForwardCache::take(HistoryItem& item, Page* page
         m_items.add(item.frameItemID());
         return nullptr;
     }
+
+    item.notifyChanged();
 
     RELEASE_LOG(BackForwardCache, "BackForwardCache::take item: %s, frameItem: %s, size: %u / %u", item.itemID().toString().utf8().data(), item.frameItemID().toString().utf8().data(), pageCount(), maxSize());
 

--- a/Source/WebCore/history/BackForwardCache.cpp
+++ b/Source/WebCore/history/BackForwardCache.cpp
@@ -49,6 +49,7 @@
 #include "LocalFrameView.h"
 #include "Logging.h"
 #include "Page.h"
+#include "RemoteFrame.h"
 #include "ScriptDisallowedScope.h"
 #include "SecurityOriginHash.h"
 #include "Settings.h"
@@ -79,6 +80,24 @@ static inline void logBackForwardCacheFailureDiagnosticMessage(Page* page, const
         return;
 
     logBackForwardCacheFailureDiagnosticMessage(protect(page->diagnosticLoggingClient()), reason);
+}
+
+static bool canCacheFrame(LocalFrame&, DiagnosticLoggingClient&, unsigned indentLevel);
+
+// Recurse through RemoteFrame bridges to check cacheability of LocalFrame descendants.
+// This handles A→B→A nesting patterns where LocalFrames exist behind RemoteFrame boundaries.
+static bool canCacheFrameDescendants(Frame& frame, DiagnosticLoggingClient& diagnosticLoggingClient, unsigned indentLevel)
+{
+    for (RefPtr child = frame.tree().firstChild(); child; child = child->tree().nextSibling()) {
+        if (auto* localChild = dynamicDowncast<LocalFrame>(child.get())) {
+            if (!canCacheFrame(*localChild, diagnosticLoggingClient, indentLevel + 1))
+                return false;
+        } else if (is<RemoteFrame>(*child)) {
+            if (!canCacheFrameDescendants(*child, diagnosticLoggingClient, indentLevel + 1))
+                return false;
+        }
+    }
+    return true;
 }
 
 static bool canCacheFrame(LocalFrame& frame, DiagnosticLoggingClient& diagnosticLoggingClient, unsigned indentLevel)
@@ -182,11 +201,13 @@ static bool canCacheFrame(LocalFrame& frame, DiagnosticLoggingClient& diagnostic
     }
 
     for (RefPtr child = frame.tree().firstChild(); child; child = child->tree().nextSibling()) {
-        auto* localChild = dynamicDowncast<LocalFrame>(child.get());
-        if (!localChild)
-            continue;
-        if (!canCacheFrame(*localChild, diagnosticLoggingClient, indentLevel + 1))
-            isCacheable = false;
+        if (auto* localChild = dynamicDowncast<LocalFrame>(child.get())) {
+            if (!canCacheFrame(*localChild, diagnosticLoggingClient, indentLevel + 1))
+                isCacheable = false;
+        } else if (is<RemoteFrame>(*child)) {
+            if (!canCacheFrameDescendants(*child, diagnosticLoggingClient, indentLevel + 1))
+                isCacheable = false;
+        }
     }
     
     PCLOG(isCacheable ? " Frame CAN be cached"_s : " Frame CANNOT be cached"_s);
@@ -204,11 +225,24 @@ static bool canCachePage(Page& page)
 
     CheckedRef diagnosticLoggingClient = page.diagnosticLoggingClient();
     RefPtr localMainFrame = page.localMainFrame();
-    if (!localMainFrame)
-        return false;
-    bool isCacheable = canCacheFrame(*localMainFrame, diagnosticLoggingClient, indentLevel + 1);
 
-    if (!page.settings().usesBackForwardCache() || page.isResourceCachingDisabledByWebInspector() || page.settings().siteIsolationEnabled()) {
+    // In iframe processes with Site Isolation, the main frame is a RemoteFrame,
+    // so localMainFrame() returns null. Find the topmost LocalFrame as the
+    // representative frame for cacheability checks.
+    RefPtr<LocalFrame> representativeFrame = localMainFrame;
+    if (!representativeFrame) {
+        for (RefPtr frame = page.mainFrame().tree().firstChild(); frame; frame = frame->tree().traverseNext()) {
+            if (auto* localFrame = dynamicDowncast<LocalFrame>(frame.get())) {
+                representativeFrame = localFrame;
+                break;
+            }
+        }
+        if (!representativeFrame)
+            return false;
+    }
+    bool isCacheable = canCacheFrame(*representativeFrame, diagnosticLoggingClient, indentLevel + 1);
+
+    if (!page.settings().usesBackForwardCache() || page.isResourceCachingDisabledByWebInspector()) {
         PCLOG("   -Page settings says b/f cache disabled"_s);
         logBackForwardCacheFailureDiagnosticMessage(diagnosticLoggingClient, DiagnosticLoggingKeys::isDisabledKey());
         isCacheable = false;
@@ -226,7 +260,7 @@ static bool canCachePage(Page& page)
     }
 #endif
 
-    FrameLoadType loadType = localMainFrame->loader().loadType();
+    FrameLoadType loadType = representativeFrame->loader().loadType();
     switch (loadType) {
     case FrameLoadType::Reload:
         // No point writing to the cache on a reload, since we will just write over it again when we leave that page.
@@ -282,9 +316,9 @@ static bool canCachePage(Page& page)
 
     // If this is a same-origin navigation and the navigated-to main resource serves the
     // `Clear-Site-Data: "cache"` HTTP header, then we shouldn't cache the current page.
-    if (RefPtr provisionalDocumentLoader = localMainFrame->loader().provisionalDocumentLoader()) {
+    if (RefPtr provisionalDocumentLoader = representativeFrame->loader().provisionalDocumentLoader()) {
         if (provisionalDocumentLoader->responseClearSiteDataValues().contains(ClearSiteDataValue::Cache)) {
-            if (RefPtr topDocument = localMainFrame->document()) {
+            if (RefPtr topDocument = representativeFrame->document()) {
                 if (protect(topDocument->securityOrigin())->isSameOriginAs(SecurityOrigin::create(provisionalDocumentLoader->response().url()))) {
                     PCLOG("   -`Clear-Site-Data: cache` HTTP header is present"_s);
                     isCacheable = false;

--- a/Source/WebCore/history/BackForwardCache.cpp
+++ b/Source/WebCore/history/BackForwardCache.cpp
@@ -576,6 +576,13 @@ std::unique_ptr<CachedPage> BackForwardCache::take(HistoryItem& item, Page* page
     auto cachedPage = std::get<UniqueRef<CachedPage>>(m_cachedPageMap.take(it));
     item.notifyChanged();
 
+    if (page && &cachedPage->page() != page) {
+        auto ptr = cachedPage.moveToUniquePtr();
+        m_cachedPageMap.set(item.frameItemID(), makeUniqueRefFromNonNullUniquePtr(WTF::move(ptr)));
+        m_items.add(item.frameItemID());
+        return nullptr;
+    }
+
     RELEASE_LOG(BackForwardCache, "BackForwardCache::take item: %s, frameItem: %s, size: %u / %u", item.itemID().toString().utf8().data(), item.frameItemID().toString().utf8().data(), pageCount(), maxSize());
 
     if (cachedPage->hasExpired() || (page && page->isResourceCachingDisabledByWebInspector())) {
@@ -583,6 +590,32 @@ std::unique_ptr<CachedPage> BackForwardCache::take(HistoryItem& item, Page* page
         logBackForwardCacheFailureDiagnosticMessage(page, DiagnosticLoggingKeys::expiredKey());
         return nullptr;
     }
+
+    return cachedPage.moveToUniquePtr();
+}
+
+std::unique_ptr<CachedPage> BackForwardCache::takeByFrameItemID(BackForwardFrameItemIdentifier frameItemID, Page* page)
+{
+    auto it = m_cachedPageMap.find(frameItemID);
+    if (it == m_cachedPageMap.end())
+        return nullptr;
+    if (std::get_if<PruningReason>(&it->value))
+        return nullptr;
+
+    m_items.remove(frameItemID);
+    auto cachedPage = std::get<UniqueRef<CachedPage>>(m_cachedPageMap.take(it));
+
+    if (page && &cachedPage->page() != page) {
+        auto ptr = cachedPage.moveToUniquePtr();
+        m_cachedPageMap.set(frameItemID, makeUniqueRefFromNonNullUniquePtr(WTF::move(ptr)));
+        m_items.add(frameItemID);
+        return nullptr;
+    }
+
+    RELEASE_LOG(BackForwardCache, "BackForwardCache::takeByFrameItemID frameItem: %s, size: %u / %u", frameItemID.toString().utf8().data(), pageCount(), maxSize());
+
+    if (cachedPage->hasExpired() || (page && page->isResourceCachingDisabledByWebInspector()))
+        return nullptr;
 
     return cachedPage.moveToUniquePtr();
 }
@@ -618,6 +651,8 @@ CachedPage* BackForwardCache::get(HistoryItem& item, Page* page)
             logBackForwardCacheFailureDiagnosticMessage(page, pruningReasonToDiagnosticLoggingKey(pruningReason));
         return nullptr;
     }, [&](UniqueRef<CachedPage>& cachedPage) -> CachedPage* {
+        if (page && &cachedPage->page() != page)
+            return nullptr;
         if (cachedPage->hasExpired() || (page && page->isResourceCachingDisabledByWebInspector())) {
             LOG(BackForwardCache, "Not restoring page for %s from back/forward cache because cache entry has expired", item.url().string().ascii().data());
             logBackForwardCacheFailureDiagnosticMessage(page, DiagnosticLoggingKeys::expiredKey());

--- a/Source/WebCore/history/BackForwardCache.h
+++ b/Source/WebCore/history/BackForwardCache.h
@@ -61,6 +61,7 @@ public:
     WEBCORE_EXPORT void remove(HistoryItem&);
     CachedPage* get(HistoryItem&, Page*);
     std::unique_ptr<CachedPage> take(HistoryItem&, Page*);
+    WEBCORE_EXPORT std::unique_ptr<CachedPage> takeByFrameItemID(BackForwardFrameItemIdentifier, Page*);
 
     void removeAllItemsForPage(Page&);
 

--- a/Source/WebCore/history/CachedFrame.cpp
+++ b/Source/WebCore/history/CachedFrame.cpp
@@ -249,6 +249,12 @@ void CachedFrame::open()
 
     if (RefPtr localFrameView = dynamicDowncast<LocalFrameView>(m_view.get()))
         localFrameView->frame().loader().open(*this);
+    else {
+        // RemoteFrame main frame in iframe process.
+        // Open child CachedFrames directly to restore LocalFrame content.
+        for (auto& childFrame : m_childFrames)
+            childFrame->open();
+    }
 }
 
 void CachedFrame::clear()

--- a/Source/WebCore/history/CachedFrame.cpp
+++ b/Source/WebCore/history/CachedFrame.cpp
@@ -129,13 +129,12 @@ void CachedFrameBase::restore()
 
         // Reconstruct the FrameTree. And open the child CachedFrames in their respective FrameLoaders.
         for (auto& childFrame : m_childFrames) {
-            // Skip RemoteFrame children — they have no document and are reconnected
-            // by the UIProcess separately after main frame restoration completes.
-            // Clear the stale content frame reference so the iframe element triggers
-            // fresh frame creation and loading after restoration.
+            // RemoteFrame children have no document. Re-add them to the frame
+            // tree so the iframe element stays connected, but skip open() —
+            // the iframe process restores its content independently via
+            // SetIsSuspendedWithFrameItem IPC.
             if (!childFrame->document()) {
-                if (auto* ownerElement = childFrame->view()->frame().ownerElement())
-                    ownerElement->clearContentFrame();
+                frame->tree().appendChild(protect(protect(childFrame->view())->frame()));
                 continue;
             }
             ASSERT(childFrame->view()->frame().page());

--- a/Source/WebCore/history/CachedFrame.cpp
+++ b/Source/WebCore/history/CachedFrame.cpp
@@ -30,9 +30,11 @@
 #include "CachedFramePlatformData.h"
 #include "CachedPage.h"
 #include "DocumentLoader.h"
+#include "HTMLFrameOwnerElement.h"
 #include "DocumentPage.h"
 #include "DocumentView.h"
 #include "DocumentWindow.h"
+#include "FrameInlines.h"
 #include "FrameLoader.h"
 #include "LocalDOMWindow.h"
 #include "LocalFrame.h"
@@ -127,6 +129,15 @@ void CachedFrameBase::restore()
 
         // Reconstruct the FrameTree. And open the child CachedFrames in their respective FrameLoaders.
         for (auto& childFrame : m_childFrames) {
+            // Skip RemoteFrame children — they have no document and are reconnected
+            // by the UIProcess separately after main frame restoration completes.
+            // Clear the stale content frame reference so the iframe element triggers
+            // fresh frame creation and loading after restoration.
+            if (!childFrame->document()) {
+                if (auto* ownerElement = childFrame->view()->frame().ownerElement())
+                    ownerElement->clearContentFrame();
+                continue;
+            }
             ASSERT(childFrame->view()->frame().page());
             frame->tree().appendChild(protect(protect(childFrame->view())->frame()));
             childFrame->open();

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -2757,6 +2757,7 @@ void FrameLoader::open(CachedFrameBase& cachedFrame)
     m_needsClear = true;
     m_isComplete = false;
     m_didCallImplicitClose = false;
+    document->resetLoadEventFinished();
     setOutgoingReferrer(url);
 
     RefPtr view = cachedFrame.view();

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
@@ -259,6 +259,12 @@ void BrowsingContextGroup::forEachRemotePage(const WebPageProxy& page, Function<
         function(remotePage);
 }
 
+void BrowsingContextGroup::closeRemotePagesForPage(WebPageProxy& page)
+{
+    for (auto& remotePage : m_remotePages.take(page))
+        remotePage->disconnect();
+}
+
 RefPtr<RemotePageProxy> BrowsingContextGroup::remotePageInProcess(const WebPageProxy& page, const WebProcessProxy& process)
 {
     auto it = m_remotePages.find(page);

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.h
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.h
@@ -75,6 +75,7 @@ public:
     void addRemotePage(WebPageProxy&, Ref<RemotePageProxy>&&);
     void removePage(WebPageProxy&);
     void forEachRemotePage(const WebPageProxy&, Function<void(RemotePageProxy&)>&&);
+    void closeRemotePagesForPage(WebPageProxy&);
 
     RefPtr<RemotePageProxy> remotePageInProcess(const WebPageProxy&, const WebProcessProxy&);
 

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -490,7 +490,7 @@ void ProvisionalPageProxy::didCommitLoadForFrame(IPC::Connection& connection, Fr
         Site pageMainFrameSite { pageMainFrame->url() };
 
         bool frameProcessChanged = m_frameProcess.ptr() != pageMainFrameProcess.ptr();
-        if (frameProcessChanged)
+        if (frameProcessChanged && pageMainFrame == m_mainFrame)
             pageMainFrame->setProcess(m_frameProcess);
 
         // If the originating FrameProcess still has local frames and is still in the same

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -124,6 +124,7 @@ ProvisionalPageProxy::ProvisionalPageProxy(WebPageProxy& page, Ref<FrameProcess>
     // already exists and already has a main frame.
     if (suspendedPage) {
         ASSERT(&suspendedPage->process() == process.ptr());
+        m_suspendedPageBrowsingContextGroup = &suspendedPage->browsingContextGroup();
         suspendedPage->unsuspend(navigation.targetItem());
         m_mainFrame = suspendedPage->mainFrame();
         m_mainFrame->updateReferrerPolicy(ReferrerPolicy::EmptyString);
@@ -260,7 +261,7 @@ void ProvisionalPageProxy::initializeWebPage(RefPtr<API::WebsitePolicies>&& webs
     if (websitePolicies)
         m_mainFrameWebsitePolicies = websitePolicies->copy();
 
-    if (preferences->siteIsolationEnabled()) {
+    if (preferences->siteIsolationEnabled() && !m_suspendedPageBrowsingContextGroup) {
         if (RefPtr existingRemotePageProxy = m_browsingContextGroup->takeRemotePageInProcessForProvisionalPage(page, process)) {
             if (m_shouldReuseMainFrame) {
                 m_webPageID = existingRemotePageProxy->pageID();
@@ -282,7 +283,7 @@ void ProvisionalPageProxy::initializeWebPage(RefPtr<API::WebsitePolicies>&& webs
 
     RefPtr mainFrame = m_mainFrame;
     auto creationParameters = page->creationParametersForProvisionalPage(process, *drawingArea, mainFrame->frameID());
-    if (preferences->siteIsolationEnabled()) {
+    if (preferences->siteIsolationEnabled() && !m_suspendedPageBrowsingContextGroup) {
         creationParameters.remotePageParameters = RemotePageParameters {
             m_request.url(),
             mainFrame->frameTreeCreationParameters(),

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -124,7 +124,7 @@ ProvisionalPageProxy::ProvisionalPageProxy(WebPageProxy& page, Ref<FrameProcess>
     // already exists and already has a main frame.
     if (suspendedPage) {
         ASSERT(&suspendedPage->process() == process.ptr());
-        suspendedPage->unsuspend();
+        suspendedPage->unsuspend(navigation.targetItem());
         m_mainFrame = suspendedPage->mainFrame();
         m_mainFrame->updateReferrerPolicy(ReferrerPolicy::EmptyString);
         m_needsMainFrameObserver = true;

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "BrowsingContextGroup.h"
 #include "MessageReceiver.h"
 #include "MessageSender.h"
 #include "NetworkResourceLoadIdentifier.h"
@@ -105,6 +106,7 @@ public:
     WebCore::PageIdentifier webPageID() const { return m_webPageID; }
     WebFrameProxy* mainFrame() const { return m_mainFrame.get(); }
     BrowsingContextGroup& browsingContextGroup() const { return m_browsingContextGroup.get(); }
+    RefPtr<BrowsingContextGroup> suspendedPageBrowsingContextGroup() const { return m_suspendedPageBrowsingContextGroup; }
     WebProcessProxy& NODELETE process();
     ProcessSwapRequestedByClient processSwapRequestedByClient() const { return m_processSwapRequestedByClient; }
     WebCore::NavigationIdentifier navigationID() const { return m_navigationID; }
@@ -211,6 +213,7 @@ private:
     WebCore::PageIdentifier m_webPageID;
     Ref<FrameProcess> m_frameProcess;
     const Ref<BrowsingContextGroup> m_browsingContextGroup;
+    RefPtr<BrowsingContextGroup> m_suspendedPageBrowsingContextGroup;
     RefPtr<RemotePageProxy> m_takenRemotePage;
 
     // Keep WebsiteDataStore alive for provisional page load.

--- a/Source/WebKit/UIProcess/RemotePageProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageProxy.cpp
@@ -183,6 +183,36 @@ void RemotePageProxy::injectPageIntoNewProcess()
     );
 }
 
+void RemotePageProxy::setupSubsystemsForBFCacheRestoration()
+{
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+    if (!page->mainFrame())
+        return;
+
+    Ref drawingArea = *page->drawingArea();
+    m_drawingArea = RemotePageDrawingAreaProxy::create(drawingArea.get(), m_process);
+#if ENABLE(FULLSCREEN_API)
+    m_fullscreenManager = RemotePageFullscreenManagerProxy::create(pageID(), protect(page->fullScreenManager()), m_process);
+#endif
+#if ENABLE(VIDEO_PRESENTATION_MODE)
+    m_videoPresentationManager = RemotePageVideoPresentationManagerProxy::create(pageID(), m_process, protect(page->videoPresentationManager()));
+#endif
+#if PLATFORM(IOS_FAMILY) && ENABLE(DEVICE_ORIENTATION)
+    m_webDeviceOrientationUpdateProvider = RemotePageWebDeviceOrientationUpdateProviderProxy::create(pageID(), m_process, page->webDeviceOrientationUpdateProviderProxy());
+#endif
+#if PLATFORM(IOS_FAMILY) || (PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE))
+    m_playbackSessionManager = RemotePagePlaybackSessionManagerProxy::create(pageID(), protect(page->playbackSessionManager()), m_process);
+#endif
+
+    if (RefPtr screenOrientationManager = page->screenOrientationManager())
+        m_screenOrientationManager = RemotePageScreenOrientationManagerProxy::create(m_webPageID, screenOrientationManager.get(), m_process);
+
+    m_visitedLinkStoreRegistration = makeUnique<RemotePageVisitedLinkStoreRegistration>(*page, m_process);
+    // No CreateWebPage IPC — the WebPage already exists in this process.
+}
+
 void RemotePageProxy::processDidTerminate(WebProcessProxy& process, ProcessTerminationReason reason)
 {
     RefPtr page = m_page.get();

--- a/Source/WebKit/UIProcess/RemotePageProxy.h
+++ b/Source/WebKit/UIProcess/RemotePageProxy.h
@@ -100,6 +100,7 @@ public:
     WebPageProxy* NODELETE page() const;
 
     void injectPageIntoNewProcess();
+    void setupSubsystemsForBFCacheRestoration();
     void processDidTerminate(WebProcessProxy&, ProcessTerminationReason);
 
     WebPageProxyMessageReceiverRegistration& messageReceiverRegistration() LIFETIME_BOUND { return m_messageReceiverRegistration; }

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
@@ -168,10 +168,20 @@ SuspendedPageProxy::~SuspendedPageProxy()
         });
     }
 
+    if (RefPtr page = m_page.get())
+        m_browsingContextGroup->closeRemotePagesForPage(*page);
+
     if (m_suspensionState != SuspensionState::Resumed) {
         // If the suspended page was not consumed before getting destroyed, then close the corresponding page
         // on the WebProcess side.
         close();
+    }
+
+    for (RefPtr frame = m_mainFrame->traverseNext().frame;
+         frame; frame = frame->traverseNext().frame) {
+        Ref frameProcess = frame->process();
+        if (&frameProcess.get() != &m_process.get())
+            frameProcess->removeSuspendedPageProxy(*this);
     }
 
     m_process->removeSuspendedPageProxy(*this);

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
@@ -171,12 +171,11 @@ SuspendedPageProxy::~SuspendedPageProxy()
         });
     }
 
-    if (RefPtr page = m_page.get())
-        m_browsingContextGroup->closeRemotePagesForPage(*page);
-
     if (m_suspensionState != SuspensionState::Resumed) {
         // If the suspended page was not consumed before getting destroyed, then close the corresponding page
         // on the WebProcess side.
+        if (RefPtr page = m_page.get())
+            m_browsingContextGroup->closeRemotePagesForPage(*page);
         close();
     }
 

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
@@ -33,8 +33,11 @@
 #include "HandleMessage.h"
 #include "Logging.h"
 #include "MessageSenderInlines.h"
+#include "RemotePageProxy.h"
 #include "WebBackForwardCache.h"
 #include "WebBackForwardList.h"
+#include "WebBackForwardListFrameItem.h"
+#include "WebBackForwardListItem.h"
 #include "WebBackForwardListMessages.h"
 #include "WebFrameProxy.h"
 #include "WebPageMessages.h"
@@ -218,7 +221,7 @@ void SuspendedPageProxy::waitUntilReadyToUnsuspend(CompletionHandler<void(Suspen
     }
 }
 
-void SuspendedPageProxy::unsuspend()
+void SuspendedPageProxy::unsuspend(WebBackForwardListItem* targetItem)
 {
     ASSERT(m_suspensionState == SuspensionState::Suspended);
 
@@ -226,6 +229,35 @@ void SuspendedPageProxy::unsuspend()
     sendWithAsyncReply(Messages::WebPage::SetIsSuspended(false), [](std::optional<bool> didSuspend) {
         ASSERT(!didSuspend.has_value());
     });
+
+    RefPtr page = m_page.get();
+    if (!targetItem || !page || !page->preferences().useMultiProcessBackForwardCache())
+        return;
+
+    auto& rootFrameItem = targetItem->mainFrameItem();
+    m_browsingContextGroup->forEachRemotePage(*page,
+        [&](RemotePageProxy& remotePage) {
+            RefPtr<WebFrameProxy> frameInProcess;
+            for (RefPtr f = m_mainFrame->traverseNext().frame;
+                 f; f = f->traverseNext().frame) {
+                if (&f->process() == &remotePage.siteIsolatedProcess()) {
+                    frameInProcess = f;
+                    break;
+                }
+            }
+            if (!frameInProcess)
+                return;
+
+            RefPtr frameItem = rootFrameItem.childItemForFrameID(frameInProcess->frameID());
+            if (!frameItem)
+                return;
+
+            remotePage.siteIsolatedProcess().sendWithAsyncReply(
+                Messages::WebPage::SetIsSuspendedWithFrameItem(false, frameItem->identifier()),
+                [](std::optional<bool>) { },
+                remotePage.identifierInSiteIsolatedProcess()
+            );
+        });
 }
 
 void SuspendedPageProxy::close()

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.h
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.h
@@ -73,7 +73,8 @@ public:
     WebCore::PageIdentifier webPageID() const { return m_webPageID; }
     WebProcessProxy& process() const { return m_process.get(); }
     WebFrameProxy& mainFrame() { return m_mainFrame.get(); }
-    const BrowsingContextGroup& browsingContextGroup() { return m_browsingContextGroup.get(); }
+    const BrowsingContextGroup& browsingContextGroup() const { return m_browsingContextGroup.get(); }
+    BrowsingContextGroup& browsingContextGroup() { return m_browsingContextGroup.get(); }
 
     WebBackForwardCache& NODELETE backForwardCache() const;
 

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.h
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.h
@@ -83,7 +83,7 @@ public:
     bool NODELETE pageIsClosedOrClosing() const;
 
     void waitUntilReadyToUnsuspend(CompletionHandler<void(SuspendedPageProxy*)>&&);
-    void unsuspend();
+    void unsuspend(WebBackForwardListItem* targetItem = nullptr);
 
     void pageDidFirstLayerFlush();
     void closeWithoutFlashing();

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5700,7 +5700,22 @@ void WebPageProxy::commitProvisionalPage(IPC::Connection& connection, FrameIdent
 #endif
 
     const auto oldWebPageID = m_webPageID;
+    RefPtr suspendedPageBCG = provisionalPage->suspendedPageBrowsingContextGroup();
     swapToProvisionalPage(provisionalPage.releaseNonNull());
+
+    // Reconnect iframe processes to the new BCG after BFCache restoration.
+    if (suspendedPageBCG) {
+        suspendedPageBCG->forEachRemotePage(*this, [&](RemotePageProxy& oldRP) {
+            Ref process = oldRP.siteIsolatedProcess();
+            auto site = oldRP.site();
+            auto pageID = oldRP.identifierInSiteIsolatedProcess();
+
+            m_browsingContextGroup->ensureProcessForSite(site, Site { mainFrame()->url() }, process, preferences, LoadedWebArchive::No, BrowsingContextGroupUpdate::AddProcess);
+            Ref newRP = RemotePageProxy::create(*this, process, site, nullptr, pageID);
+            newRP->setupSubsystemsForBFCacheRestoration();
+            m_browsingContextGroup->addRemotePage(*this, WTF::move(newRP));
+        });
+    }
 
     didCommitLoadForFrame(connection, frameID, WTF::move(frameInfo), WTF::move(request), navigationID, WTF::move(mimeType), frameHasCustomContentProvider, frameLoadType, certificateInfo, usedLegacyTLS, privateRelayed, WTF::move(proxyName), source, containsPluginDocument, hasInsecureContent, mouseEventPolicy, WTF::move(documentSecurityPolicy), userData);
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1512,9 +1512,11 @@ WebBackForwardCache& WebPageProxy::backForwardCache() const
 bool WebPageProxy::shouldUseBackForwardCache() const
 {
     Ref preferences = m_preferences;
-    return preferences->usesBackForwardCache()
-        && backForwardCache().capacity() > 0
-        && !preferences->siteIsolationEnabled();
+    if (!preferences->usesBackForwardCache() || backForwardCache().capacity() == 0)
+        return false;
+    if (preferences->siteIsolationEnabled())
+        return preferences->useMultiProcessBackForwardCache();
+    return true;
 }
 
 void WebPageProxy::setBrowsingContextGroup(BrowsingContextGroup& browsingContextGroup)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2780,8 +2780,14 @@ RefPtr<API::Navigation> WebPageProxy::goToBackForwardItem(WebBackForwardListFram
 WebProcessProxy& WebPageProxy::processForTheFrameItem(WebBackForwardListFrameItem& frameItem) const
 {
     if (protect(preferences())->siteIsolationEnabled()) {
-        if (RefPtr frame = WebFrameProxy::webFrame(frameItem.frameID()); frame && frame->page() == this)
-            return frame->process();
+        if (RefPtr frame = WebFrameProxy::webFrame(frameItem.frameID()); frame && frame->page() == this) {
+            // Only use this frame's process if it's in the live tree,
+            // not surviving in a SuspendedPageProxy.
+            for (RefPtr f = m_mainFrame.get(); f; f = f->traverseNext().frame) {
+                if (f.get() == frame.get())
+                    return frame->process();
+            }
+        }
     }
 
     return m_legacyMainFrameProcess;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2797,8 +2797,14 @@ Ref<FrameState> WebPageProxy::copyFrameStateForBackForwardNavigation(WebBackForw
 {
     auto frameItemForNavigation = [&]() -> Ref<WebBackForwardListFrameItem> {
         if (protect(preferences())->siteIsolationEnabled()) {
-            if (RefPtr frame = WebFrameProxy::webFrame(frameItem.frameID()); frame && frame->page() == this)
-                return frameItem;
+            if (RefPtr frame = WebFrameProxy::webFrame(frameItem.frameID()); frame && frame->page() == this) {
+                // Only use this frame's item if it's in the live tree,
+                // not surviving in a SuspendedPageProxy.
+                for (RefPtr f = m_mainFrame.get(); f; f = f->traverseNext().frame) {
+                    if (f.get() == frame.get())
+                        return frameItem;
+                }
+            }
         }
         return frameItem.backForwardListItem()->mainFrameItem();
     };

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1502,6 +1502,33 @@ bool WebPageProxy::suspendCurrentPageIfPossible(API::Navigation& navigation, Ref
             frameProcess->addSuspendedPageProxy(suspendedPage);
     }
 
+    if (fromItem && preferences().useMultiProcessBackForwardCache()) {
+        auto& rootFrameItem = fromItem->mainFrameItem();
+        suspendedPage->browsingContextGroup().forEachRemotePage(*this,
+            [&](RemotePageProxy& remotePage) {
+                RefPtr<WebFrameProxy> frameInProcess;
+                for (RefPtr f = suspendedPage->mainFrame().traverseNext().frame;
+                     f; f = f->traverseNext().frame) {
+                    if (&f->process() == &remotePage.siteIsolatedProcess()) {
+                        frameInProcess = f;
+                        break;
+                    }
+                }
+                if (!frameInProcess)
+                    return;
+
+                RefPtr frameItem = rootFrameItem.childItemForFrameID(frameInProcess->frameID());
+                if (!frameItem)
+                    return;
+
+                remotePage.siteIsolatedProcess().sendWithAsyncReply(
+                    Messages::WebPage::SetIsSuspendedWithFrameItem(true, frameItem->identifier()),
+                    [](std::optional<bool>) { },
+                    remotePage.identifierInSiteIsolatedProcess()
+                );
+            });
+    }
+
     LOG(ProcessSwapping, "WebPageProxy %" PRIu64 " created suspended page %s for process pid %i, back/forward item %s" PRIu64, identifier().toUInt64(), suspendedPage->loggingString().utf8().data(), m_legacyMainFrameProcess->processID(), fromItem ? fromItem->identifier().toString().utf8().data() : "0"_s);
 
     m_lastSuspendedPage = suspendedPage.get();

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1462,6 +1462,11 @@ bool WebPageProxy::suspendCurrentPageIfPossible(API::Navigation& navigation, Ref
         return false;
     }
 
+    if (openedByDOM() || hasPageOpenedByMainFrame()) {
+        WEBPAGEPROXY_RELEASE_LOG(ProcessSwapping, "suspendCurrentPageIfPossible: Not suspending current page for process pid %i because it has opener relationships", m_legacyMainFrameProcess->processID());
+        return false;
+    }
+
     RefPtr fromItem = navigation.fromItem();
 
     // If the source and the destination back / forward list items are the same, then this is a client-side redirect. In this case,
@@ -1489,6 +1494,13 @@ bool WebPageProxy::suspendCurrentPageIfPossible(API::Navigation& navigation, Ref
     mainFrame->frameLoadState().didSuspend();
 
     Ref suspendedPage = SuspendedPageProxy::create(*this, protect(legacyMainFrameProcess()), mainFrame.releaseNonNull(), std::exchange(m_browsingContextGroup, BrowsingContextGroup::create()), shouldDelayClosingUntilFirstLayerFlush);
+
+    for (RefPtr frame = suspendedPage->mainFrame().traverseNext().frame;
+         frame; frame = frame->traverseNext().frame) {
+        Ref frameProcess = frame->process();
+        if (&frameProcess.get() != &suspendedPage->process())
+            frameProcess->addSuspendedPageProxy(suspendedPage);
+    }
 
     LOG(ProcessSwapping, "WebPageProxy %" PRIu64 " created suspended page %s for process pid %i, back/forward item %s" PRIu64, identifier().toUInt64(), suspendedPage->loggingString().utf8().data(), m_legacyMainFrameProcess->processID(), fromItem ? fromItem->identifier().toString().utf8().data() : "0"_s);
 
@@ -5608,7 +5620,6 @@ void WebPageProxy::commitProvisionalPage(IPC::Connection& connection, FrameIdent
         // handles the update).
         if (mainFrameInPreviousProcess->frameID() != frameID)
             backForwardList().updateFrameIdentifier(mainFrameInPreviousProcess->frameID(), frameID);
-        mainFrameInPreviousProcess->removeChildFrames();
     }
 
     ASSERT(m_legacyMainFrameProcess.ptr() != &provisionalPage->process() || preferences->siteIsolationEnabled());
@@ -5629,6 +5640,10 @@ void WebPageProxy::commitProvisionalPage(IPC::Connection& connection, FrameIdent
     removeAllMessageReceivers();
     RefPtr navigation = m_navigationState->navigation(provisionalPage->navigationID());
     bool didSuspendPreviousPage = navigation ? suspendCurrentPageIfPossible(*navigation, WTF::move(mainFrameInPreviousProcess), shouldDelayClosingUntilFirstLayerFlush) : false;
+
+    if (!didSuspendPreviousPage && mainFrameInPreviousProcess && preferences->siteIsolationEnabled())
+        mainFrameInPreviousProcess->removeChildFrames();
+
     // Defer shutting down old process as it might lead WebPageProxy to be closed and removeWebPage to be invoked again.
     auto preventProcessShutdownScope = protect(legacyMainFrameProcess())->shutdownPreventingScope();
     protect(legacyMainFrameProcess())->removeWebPage(*this, m_websiteDataStore.ptr() == provisionalPage->process().websiteDataStore() ? WebProcessProxy::EndsUsingDataStore::No : WebProcessProxy::EndsUsingDataStore::Yes);

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -2318,7 +2318,7 @@ std::tuple<Ref<WebProcessProxy>, RefPtr<SuspendedPageProxy>, ASCIILiteral> WebPr
         && !(isRequestFromClientOrUserInput || siteIsolationEnabled))
         return { WTF::move(sourceProcess), nullptr, "Browsing context has opened other windows"_s };
 
-    if (RefPtr targetItem = navigation.targetItem(); targetItem && !siteIsolationEnabled) {
+    if (RefPtr targetItem = navigation.targetItem(); targetItem && (!siteIsolationEnabled || protect(page.preferences())->useMultiProcessBackForwardCache())) {
         if (CheckedPtr suspendedPage = targetItem->suspendedPage()) {
             if (suspendedPage->process().state() != AuxiliaryProcessProxy::State::Terminated)
                 return { suspendedPage->process(), suspendedPage.get(), "Using target back/forward item's process and suspended page"_s };

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -8527,6 +8527,52 @@ void WebPage::setIsSuspended(bool suspended, CompletionHandler<void(std::optiona
     suspendForProcessSwap(WTF::move(completionHandler));
 }
 
+RefPtr<HistoryItem> WebPage::findHistoryItemByFrameItemID(BackForwardFrameItemIdentifier frameItemID)
+{
+    for (auto* frame = &corePage()->mainFrame(); frame; frame = frame->tree().traverseNext()) {
+        auto* localFrame = dynamicDowncast<LocalFrame>(frame);
+        if (!localFrame)
+            continue;
+        if (RefPtr item = localFrame->loader().history().currentItem()) {
+            if (item->frameItemID() == frameItemID)
+                return item;
+        }
+    }
+    return nullptr;
+}
+
+void WebPage::suspendForProcessSwapWithFrameItem(BackForwardFrameItemIdentifier frameItemID, CompletionHandler<void(std::optional<bool>)>&& completionHandler)
+{
+    flushDeferredDidReceiveMouseEvent();
+    RefPtr historyItem = findHistoryItemByFrameItemID(frameItemID);
+    if (!historyItem)
+        return completionHandler(false);
+    if (!BackForwardCache::singleton().addIfCacheable(*historyItem, protect(corePage()).get()))
+        return completionHandler(false);
+    completionHandler(true);
+}
+
+void WebPage::setIsSuspendedWithFrameItem(bool suspended, BackForwardFrameItemIdentifier frameItemID, CompletionHandler<void(std::optional<bool>)>&& completionHandler)
+{
+    if (m_isSuspended == suspended)
+        return completionHandler({ });
+    m_isSuspended = suspended;
+
+    if (!suspended) {
+        // Phase 4 restore path.
+        unfreezeLayerTree(LayerTreeFreezeReason::PageSuspended);
+        auto cachedPage = BackForwardCache::singleton().takeByFrameItemID(frameItemID, corePage());
+        if (!cachedPage)
+            return completionHandler(false);
+        cachedPage->restore(*corePage());
+        return completionHandler(true);
+    }
+
+    freezeLayerTree(LayerTreeFreezeReason::PageSuspended);
+    unfreezeLayerTree(LayerTreeFreezeReason::BackgroundApplication);
+    suspendForProcessSwapWithFrameItem(frameItemID, WTF::move(completionHandler));
+}
+
 void WebPage::hasStorageAccess(RegistrableDomain&& subFrameDomain, RegistrableDomain&& topFrameDomain, WebFrame& frame, CompletionHandler<void(bool)>&& completionHandler)
 {
     if (hasPageLevelStorageAccess(topFrameDomain, subFrameDomain)) {

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2633,6 +2633,9 @@ private:
     void setNeedsDOMWindowResizeEvent();
 
     void setIsSuspended(bool, CompletionHandler<void(std::optional<bool>)>&&);
+    void setIsSuspendedWithFrameItem(bool suspended, WebCore::BackForwardFrameItemIdentifier, CompletionHandler<void(std::optional<bool>)>&&);
+    void suspendForProcessSwapWithFrameItem(WebCore::BackForwardFrameItemIdentifier, CompletionHandler<void(std::optional<bool>)>&&);
+    RefPtr<WebCore::HistoryItem> findHistoryItemByFrameItemID(WebCore::BackForwardFrameItemIdentifier);
 
     RefPtr<WebImage> snapshotAtSize(const WebCore::IntRect&, const WebCore::IntSize& bitmapSize, SnapshotOptions, WebCore::LocalFrame&, WebCore::LocalFrameView&);
     RefPtr<WebImage> snapshotNode(WebCore::Node&, SnapshotOptions, unsigned maximumPixelCount = std::numeric_limits<unsigned>::max());

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -718,6 +718,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
     URLSchemeTaskDidComplete(WebKit::WebURLSchemeHandlerIdentifier handlerIdentifier, WebCore::ResourceLoaderIdentifier taskIdentifier, WebCore::ResourceError error)
 
     SetIsSuspended(bool suspended) -> (std::optional<bool> didSuspend)
+    SetIsSuspendedWithFrameItem(bool suspended, WebCore::BackForwardFrameItemIdentifier frameItemID) -> (std::optional<bool> didSuspend)
 
 #if ENABLE(ATTACHMENT_ELEMENT)
     InsertAttachment(String identifier, std::optional<uint64_t> fileSize, String fileName, String contentType) -> ()

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
@@ -68,6 +68,8 @@
 #import <wtf/BlockPtr.h>
 #import <wtf/text/MakeString.h>
 
+#include <signal.h>
+
 #if ENABLE(IMAGE_ANALYSIS)
 #import "ImageAnalysisTestingUtilities.h"
 #import <pal/spi/cocoa/VisionKitCoreSPI.h>
@@ -8415,6 +8417,95 @@ TEST(SiteIsolation, ProcessActivityGroup)
     [webView setHidden:YES];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
     Util::run(&finishedLoading);
+}
+
+TEST(SiteIsolation, MultiProcessBFCacheIframeProcessSurvival)
+{
+    HTTPServer server({
+        { "/a"_s, { "<iframe src='https://b.com/frame'></iframe>"_s } },
+        { "/frame"_s, { "iframe content"_s } },
+        { "/c"_s, { "page c"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto *configuration = server.httpsProxyConfiguration();
+    enableFeature(configuration, @"UseMultiProcessBackForwardCache");
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    checkFrameTreesInProcesses(webView.get(), {
+        { "https://a.com"_s, { { RemoteFrame } } },
+        { RemoteFrame, { { "https://b.com"_s } } },
+    });
+
+    // Record iframe process PID.
+    pid_t iframePID = 0;
+    auto trees = frameTrees(webView.get());
+    for (_WKFrameTreeNode *tree in trees.get()) {
+        if (!tree.info._isLocalFrame && tree.childFrames.count)
+            iframePID = tree.childFrames[0].info._processIdentifier;
+    }
+    EXPECT_NE(iframePID, 0);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://c.com/c"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // Iframe process must survive. Without Phase 2, removeChildFrames()
+    // sends WebPage::Close() and kills it.
+    EXPECT_EQ(kill(iframePID, 0), 0);
+}
+
+TEST(SiteIsolation, MultiProcessBFCacheOpenerSkipsBFCache)
+{
+    HTTPServer server({
+        { "/a"_s, { "<script>window.open('https://a.com/child');</script>"_s } },
+        { "/child"_s, { "child page"_s } },
+        { "/b"_s, { "page b"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto *configuration = server.httpsProxyConfiguration();
+    enableFeature(configuration, @"UseMultiProcessBackForwardCache");
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
+
+    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    [webView setUIDelegate:uiDelegate.get()];
+
+    __block RetainPtr<WKWebView> openedWebView;
+    uiDelegate.get().createWebViewWithConfiguration = ^WKWebView *(WKWebViewConfiguration *config, WKNavigationAction *action, WKWindowFeatures *windowFeatures) {
+        openedWebView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:config]);
+        return openedWebView.get();
+    };
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    while (!openedWebView)
+        Util::spinRunLoop();
+
+    // Set a BFCache marker on the opener page.
+    __block bool done = false;
+    [webView evaluateJavaScript:@"window.__bfcacheMarker = true" completionHandler:^(id, NSError *) {
+        done = true;
+    }];
+    Util::run(&done);
+
+    // Navigate to a different site to trigger PSON.
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://b.com/b"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // Go back.
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // Verify the marker is gone (full reload, not BFCache restore).
+    done = false;
+    __block bool markerGone = false;
+    [webView evaluateJavaScript:@"window.__bfcacheMarker ? 'yes' : 'no'" completionHandler:^(NSString *result, NSError *) {
+        markerGone = [result isEqualToString:@"no"];
+        done = true;
+    }];
+    Util::run(&done);
+    EXPECT_TRUE(markerGone);
 }
 
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
@@ -8548,7 +8548,7 @@ TEST(SiteIsolation, MultiProcessBFCacheSuspensionDoesNotCrash)
 TEST(SiteIsolation, MultiProcessBFCacheSimpleGoBack)
 {
     HTTPServer server({
-        { "/a"_s, { "page a"_s } },
+        { "/a"_s, { "<script>window.__bfcacheMarker = true;</script>page a"_s } },
         { "/b"_s, { "page b"_s } }
     }, HTTPServer::Protocol::HttpsProxy);
 
@@ -8559,11 +8559,27 @@ TEST(SiteIsolation, MultiProcessBFCacheSimpleGoBack)
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
     [navigationDelegate waitForDidFinishNavigation];
 
+    // Verify marker is set.
+    __block bool done = false;
+    [webView evaluateJavaScript:@"window.__bfcacheMarker ? 'yes' : 'no'" completionHandler:^(NSString *result, NSError *) {
+        EXPECT_WK_STREQ(result, "yes");
+        done = true;
+    }];
+    Util::run(&done);
+
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://b.com/b"]]];
     [navigationDelegate waitForDidFinishNavigation];
 
     [webView goBack];
     [navigationDelegate waitForDidFinishNavigation];
+
+    // Verify JS state was preserved (BFCache used, not full reload).
+    done = false;
+    [webView evaluateJavaScript:@"window.__bfcacheMarker ? 'yes' : 'no'" completionHandler:^(NSString *result, NSError *) {
+        EXPECT_WK_STREQ(result, "yes");
+        done = true;
+    }];
+    Util::run(&done);
 }
 
 TEST(SiteIsolation, MultiProcessBFCacheNavigationCompletesAfterRestore)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
@@ -8605,4 +8605,38 @@ TEST(SiteIsolation, MultiProcessBFCacheNavigationCompletesAfterRestore)
     [navigationDelegate waitForDidFinishNavigation];
 }
 
+TEST(SiteIsolation, MultiProcessBFCacheIframeRestoration)
+{
+    HTTPServer server({
+        { "/a"_s, { "<iframe src='https://b.com/frame'></iframe>"_s } },
+        { "/frame"_s, { "<script>window.__iframeMarker = true;</script>iframe content"_s } },
+        { "/c"_s, { "page c"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto *configuration = server.httpsProxyConfiguration();
+    enableFeature(configuration, @"UseMultiProcessBackForwardCache");
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    checkFrameTreesInProcesses(webView.get(), {
+        { "https://a.com"_s, { { RemoteFrame } } },
+        { RemoteFrame, { { "https://b.com"_s } } },
+    });
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://c.com/c"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // TODO: Add frame tree verification after CachedFrameBase::restore()
+    // correctly re-adds RemoteFrame children to the frame tree.
+    // checkFrameTreesInProcesses(webView.get(), {
+    //     { "https://a.com"_s, { { RemoteFrame } } },
+    //     { RemoteFrame, { { "https://b.com"_s } } },
+    // });
+}
+
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
@@ -8508,4 +8508,41 @@ TEST(SiteIsolation, MultiProcessBFCacheOpenerSkipsBFCache)
     EXPECT_TRUE(markerGone);
 }
 
+TEST(SiteIsolation, MultiProcessBFCacheSuspensionDoesNotCrash)
+{
+    HTTPServer server({
+        { "/a"_s, { "<iframe src='https://b.com/frame'></iframe>"_s } },
+        { "/frame"_s, { "iframe content"_s } },
+        { "/c"_s, { "page c"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto *configuration = server.httpsProxyConfiguration();
+    enableFeature(configuration, @"UseMultiProcessBackForwardCache");
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    checkFrameTreesInProcesses(webView.get(), {
+        { "https://a.com"_s, { { RemoteFrame } } },
+        { RemoteFrame, { { "https://b.com"_s } } },
+    });
+
+    // Record iframe process PID.
+    pid_t iframePID = 0;
+    auto trees = frameTrees(webView.get());
+    for (_WKFrameTreeNode *tree in trees.get()) {
+        if (!tree.info._isLocalFrame && tree.childFrames.count)
+            iframePID = tree.childFrames[0].info._processIdentifier;
+    }
+    EXPECT_NE(iframePID, 0);
+
+    // Navigate away — triggers multi-process suspension.
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://c.com/c"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // No crash, iframe process still alive.
+    EXPECT_EQ(kill(iframePID, 0), 0);
+}
+
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
@@ -8545,4 +8545,48 @@ TEST(SiteIsolation, MultiProcessBFCacheSuspensionDoesNotCrash)
     EXPECT_EQ(kill(iframePID, 0), 0);
 }
 
+TEST(SiteIsolation, MultiProcessBFCacheSimpleGoBack)
+{
+    HTTPServer server({
+        { "/a"_s, { "page a"_s } },
+        { "/b"_s, { "page b"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto *configuration = server.httpsProxyConfiguration();
+    enableFeature(configuration, @"UseMultiProcessBackForwardCache");
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://b.com/b"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigation];
+}
+
+TEST(SiteIsolation, MultiProcessBFCacheNavigationCompletesAfterRestore)
+{
+    HTTPServer server({
+        { "/a"_s, { "<iframe src='https://b.com/frame'></iframe>"_s } },
+        { "/frame"_s, { "iframe content"_s } },
+        { "/c"_s, { "page c"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto *configuration = server.httpsProxyConfiguration();
+    enableFeature(configuration, @"UseMultiProcessBackForwardCache");
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://c.com/c"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // goBack must complete without hanging.
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigation];
+}
+
 }


### PR DESCRIPTION
#### 8d7be19e456ac1b7584852ac0ef2a12156f154ca
<pre>
[BFCache] Phase 4c: BCG reconnection after BFCache restoration

Reconnect iframe processes to the new BrowsingContextGroup after
BFCache restoration so frame tree queries can reach iframe processes.

Changes:
- Fix ~SuspendedPageProxy: only call closeRemotePagesForPage() when
  evicted (not Resumed), preserving iframe RemotePageProxies for
  consumed suspended pages
- Save suspended page&apos;s BCG in ProvisionalPageProxy for use during
  commitProvisionalPage
- Add RemotePageProxy::setupSubsystemsForBFCacheRestoration() — same
  subsystem setup as injectPageIntoNewProcess() without CreateWebPage
- In commitProvisionalPage, after swapToProvisionalPage, create new
  RemotePageProxy objects in the new BCG using data from the old BCG
- Skip SI-specific frame tree setup in initializeWebPage() for BFCache
  restore (remotePageParameters, provisionalFrameCreationParameters,
  addFrameProcessAndInjectPageContextIf) to avoid overwriting the
  BFCache-restored frame tree
- CachedFrameBase::restore(): re-add RemoteFrame children to frame
  tree via appendChild (skip open) instead of clearContentFrame

Known limitation: frame tree verification (checkFrameTreesInProcesses)
after BFCache restore does not yet show the correct cross-process
structure. The WebProcess-side frame tree reconstruction needs further
investigation. Test includes goBack completion check only.

Co-Authored-By: Claude Opus 4.6 &lt;noreply@anthropic.com&gt;
</pre>
----------------------------------------------------------------------
#### fb0f73203aa0b36e0b5ae449b0723c7978c2d37e
<pre>
[BFCache] Address review feedback for Phase 2-4a

1. BackForwardCache::take(): Move notifyChanged() after page ownership
   check to avoid spurious UI notifications when a wrong Page takes
   and puts back a CachedPage.

2. copyFrameStateForBackForwardNavigation(): Add live-tree guard
   matching processForTheFrameItem() to prevent suspended frames from
   being used for frame state lookup.

3. MultiProcessBFCacheSimpleGoBack: Add JS state preservation check
   (window.__bfcacheMarker) to verify actual BFCache usage, not just
   navigation completion.

Co-Authored-By: Claude Opus 4.6 &lt;noreply@anthropic.com&gt;
</pre>
----------------------------------------------------------------------
#### 50dce5fe19748346af724aa88fc2186db1a01cc1
<pre>
[BFCache] Phase 4b: Send restore IPC to iframe processes during unsuspend

When restoring a page from BFCache, send SetIsSuspendedWithFrameItem(false)
to each iframe process so they restore their own CachedPages.

Changes:
- Update unsuspend() to accept WebBackForwardListItem* parameter
- After sending SetIsSuspended(false) to main process, iterate iframe
  processes via the old BCG&apos;s RemotePageProxy objects and send
  SetIsSuspendedWithFrameItem(false, frameItemID) to each
- Pass navigation.targetItem() from ProvisionalPageProxy constructor

Note: Full iframe restoration verification (e.g., pageshow event from
iframe reaching UIProcess) requires Phase 4c BCG reconnection.

Co-Authored-By: Claude Opus 4.6 &lt;noreply@anthropic.com&gt;
</pre>
----------------------------------------------------------------------
#### 6c05af3af8dc04c2645f5b9cb976445f3b622531
<pre>
[BFCache] Phase 4a: WebProcess restoration for multi-process BFCache

Enable goBack to restore pages from BFCache with Site Isolation.

Changes:
- CachedFrame::open(): Handle RemoteFrameView main CachedFrame by
  recursing into child CachedFrames for iframe process restoration
- processForTheFrameItem(): Limit WebFrameProxy lookup to the live
  frame tree to avoid routing GoToBackForwardItem to suspended frames
- ProvisionalPageProxy::didCommitLoadForFrame(): Guard setProcess()
  with pageMainFrame == m_mainFrame check to prevent corrupting
  suspended WebFrameProxy&apos;s FrameProcess. Without this guard,
  updateFrameProcess() overwrites the ProvisionalPageProxy&apos;s
  m_frameProcess via the stale suspended frame reference.

The goBack flow uses a two-hop approach: GoToBackForwardItem goes to
the current process (BFCache miss), triggers policy check, UIProcess
finds the suspended page via processForNavigationInternal, PSON creates
ProvisionalPageProxy which sends GoToBackForwardItem to the restored
process (BFCache hit).

Tests: MultiProcessBFCacheSimpleGoBack,
       MultiProcessBFCacheNavigationCompletesAfterRestore

Co-Authored-By: Claude Opus 4.6 &lt;noreply@anthropic.com&gt;
</pre>
----------------------------------------------------------------------
#### bbc208c9b913e80c13829bdf19cc7e50a4faf909
<pre>
[BFCache] Phase 3: Multi-process suspension for BFCache with Site Isolation

When suspending a page with cross-origin iframes, send
SetIsSuspendedWithFrameItem IPC to each iframe process so it creates
its own CachedPage.

Changes:
- Add SetIsSuspendedWithFrameItem IPC message
- Implement WebPage::setIsSuspendedWithFrameItem(),
  suspendForProcessSwapWithFrameItem(), findHistoryItemByFrameItemID()
- Send suspension IPC to iframe processes via RemotePageProxy in
  suspendCurrentPageIfPossible()
- Add page ownership guards to BackForwardCache::get() and take()
  to prevent cross-Page CachedPage theft in shared processes
- Add BackForwardCache::takeByFrameItemID() for Phase 4 restore path
- Add non-const browsingContextGroup() overload to SuspendedPageProxy

Test: MultiProcessBFCacheSuspensionDoesNotCrash

Co-Authored-By: Claude Opus 4.6 &lt;noreply@anthropic.com&gt;
</pre>
----------------------------------------------------------------------
#### 4bd6ab99f9da310b8cd7d0f068307140fcfabad5
<pre>
[BFCache] Phase 2: WebFrameProxy tree survival for multi-process BFCache

When BFCache suspension succeeds with Site Isolation, skip
removeChildFrames() so the UIProcess-side frame tree survives in
SuspendedPageProxy. This is the foundation for multi-process BFCache.

Changes:
- Add opener relationship guard in suspendCurrentPageIfPossible()
- Register iframe processes with addSuspendedPageProxy() for lifetime
  management after SuspendedPageProxy creation
- Move removeChildFrames() to after suspendCurrentPageIfPossible(),
  only called when suspension fails
- Add cleanup in ~SuspendedPageProxy: closeRemotePagesForPage() and
  removeSuspendedPageProxy() on all iframe processes
- Add BrowsingContextGroup::closeRemotePagesForPage() method

Tests: MultiProcessBFCacheIframeProcessSurvival,
       MultiProcessBFCacheOpenerSkipsBFCache

Co-Authored-By: Claude Opus 4.6 &lt;noreply@anthropic.com&gt;
</pre>
----------------------------------------------------------------------
#### 808340755ffebc4f265d10510fa74e72f2281aad
<pre>
[BFCache] Phase 3: Allow BFCache with Site Isolation behind feature flag

UIProcess guard changes gated by UseMultiProcessBackForwardCache flag:

WebPageProxy::shouldUseBackForwardCache():
- When Site Isolation is enabled, allow BFCache if
  UseMultiProcessBackForwardCache is true (instead of
  unconditionally disabling).

WebProcessPool::processForNavigationInternal():
- Allow BFCache process reuse for back/forward items when
  UseMultiProcessBackForwardCache is enabled, even with
  Site Isolation active.

Co-Authored-By: Claude Opus 4.6 (1M context) &lt;noreply@anthropic.com&gt;
</pre>
----------------------------------------------------------------------
#### 860b3049a36133f4199278e88739e0362d33df22
<pre>
[BFCache] Phase 2a: WebCore changes for BFCache with Site Isolation

WebCore-only changes that make BFCache compatible with RemoteFrame
children. These are upstreamable and do not require the feature flag.

BackForwardCache.cpp:
- canCacheFrameDescendants(): New helper to recurse through RemoteFrame
  bridges for cacheability checks (handles A→B→A nesting patterns).
- canCacheFrame(): Check RemoteFrame children via canCacheFrameDescendants.
- canCachePage(): Representative frame concept for iframe processes where
  localMainFrame() returns null. Remove siteIsolationEnabled() guard.

CachedFrame.cpp:
- CachedFrameBase::restore(): Skip RemoteFrame children during frame tree
  reconstruction. Clear stale content frame reference on the iframe&apos;s
  owner element so fresh frame creation works after restoration.

Document.h:
- Add resetLoadEventFinished() method.

FrameLoader.cpp:
- FrameLoader::open(): Reset loadEventFinished on restored document.
  Needed for UseUIProcessForBackForwardItemLoading delegation path
  which checks \!loadEventFinished() in loadURLIntoChildFrame().

Co-Authored-By: Claude Opus 4.6 (1M context) &lt;noreply@anthropic.com&gt;
</pre>
----------------------------------------------------------------------
#### 99f72895706e6f83bf63d2242a271a81498773ef
<pre>
[BFCache] Phase 1: Add UseMultiProcessBackForwardCache feature flag

Add a new feature flag to gate BFCache enablement when Site Isolation
is active. Default: false. Category: security (matching SiteIsolationEnabled).

Co-Authored-By: Claude Opus 4.6 (1M context) &lt;noreply@anthropic.com&gt;
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d7be19e456ac1b7584852ac0ef2a12156f154ca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152586 "Failed to checkout and rebase branch from PR 61469") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25368 "Failed to checkout and rebase branch from PR 61469") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18967 "Failed to checkout and rebase branch from PR 61469") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161331 "Failed to checkout and rebase branch from PR 61469") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106043 "Failed to checkout and rebase branch from PR 61469") | ⏳ 🛠 ios-apple 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154460 "Failed to checkout and rebase branch from PR 61469") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25896 "Failed to checkout and rebase branch from PR 61469") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25674 "Failed to checkout and rebase branch from PR 61469") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/161331 "Failed to checkout and rebase branch from PR 61469") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/106043 "Failed to checkout and rebase branch from PR 61469") | ⏳ 🛠 mac-apple 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155546 "Failed to checkout and rebase branch from PR 61469") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/25896 "Failed to checkout and rebase branch from PR 61469") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/18967 "Failed to checkout and rebase branch from PR 61469") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/161331 "Failed to checkout and rebase branch from PR 61469") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/25896 "Failed to checkout and rebase branch from PR 61469") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/25674 "Failed to checkout and rebase branch from PR 61469") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9165 "Failed to checkout and rebase branch from PR 61469") | | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144598 "Failed to checkout and rebase branch from PR 61469") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/25896 "Failed to checkout and rebase branch from PR 61469") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/18967 "Failed to checkout and rebase branch from PR 61469") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163802 "Failed to checkout and rebase branch from PR 61469") | | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13389 "Failed to checkout and rebase branch from PR 61469") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6941 "Failed to checkout and rebase branch from PR 61469") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/18967 "Failed to checkout and rebase branch from PR 61469") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/163802 "Failed to checkout and rebase branch from PR 61469") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25166 "Failed to checkout and rebase branch from PR 61469") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/25674 "Failed to checkout and rebase branch from PR 61469") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/163802 "Failed to checkout and rebase branch from PR 61469") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25168 "Failed to checkout and rebase branch from PR 61469") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/18967 "Failed to checkout and rebase branch from PR 61469") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81770 "Failed to checkout and rebase branch from PR 61469") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/25168 "Failed to checkout and rebase branch from PR 61469") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/18967 "Failed to checkout and rebase branch from PR 61469") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184218 "Failed to checkout and rebase branch from PR 61469") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24784 "Failed to checkout and rebase branch from PR 61469") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89070 "Failed to checkout and rebase branch from PR 61469") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/184218 "Failed to checkout and rebase branch from PR 61469") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24476 "Failed to checkout and rebase branch from PR 61469") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24635 "Failed to checkout and rebase branch from PR 61469") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24536 "Failed to checkout and rebase branch from PR 61469") | | | | 
<!--EWS-Status-Bubble-End-->