### PR TITLE
[IndexedDB API] Support IDBGetAllOptions in IDBIndex::getAll()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAll-options.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAll-options.any-expected.txt
@@ -1,28 +1,28 @@
 
-FAIL Single item get Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Empty object store Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get all Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get all with generated keys Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get all with large values Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL maxCount=10 Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get bound range Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get bound range with maxCount Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get upper excluded Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get lower excluded Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get bound range (generated) with maxCount Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Non existent key Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL maxCount=0 Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Max value count Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Query with empty range where  first key < upperBound Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Query with empty range where lowerBound < last key Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Retrieve multiEntry key Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Retrieve one key multiple values Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction: next Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction: prev Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction: nextunique Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction: prevunique Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction and query Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction, query and count Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get all values with both options and count Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+PASS Single item get
+PASS Empty object store
+PASS Get all
+PASS Get all with generated keys
+PASS Get all with large values
+PASS maxCount=10
+PASS Get bound range
+PASS Get bound range with maxCount
+PASS Get upper excluded
+PASS Get lower excluded
+PASS Get bound range (generated) with maxCount
+PASS Non existent key
+PASS maxCount=0
+PASS Max value count
+PASS Query with empty range where  first key < upperBound
+PASS Query with empty range where lowerBound < last key
+PASS Retrieve multiEntry key
+PASS Retrieve one key multiple values
+PASS Direction: next
+PASS Direction: prev
+PASS Direction: nextunique
+PASS Direction: prevunique
+PASS Direction and query
+PASS Direction, query and count
+PASS Get all values with both options and count
 PASS Get all values with invalid query keys
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAll-options.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAll-options.any.serviceworker-expected.txt
@@ -1,28 +1,28 @@
 
-FAIL Single item get Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Empty object store Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get all Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get all with generated keys Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get all with large values Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL maxCount=10 Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get bound range Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get bound range with maxCount Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get upper excluded Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get lower excluded Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get bound range (generated) with maxCount Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Non existent key Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL maxCount=0 Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Max value count Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Query with empty range where  first key < upperBound Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Query with empty range where lowerBound < last key Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Retrieve multiEntry key Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Retrieve one key multiple values Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction: next Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction: prev Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction: nextunique Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction: prevunique Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction and query Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction, query and count Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get all values with both options and count Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+PASS Single item get
+PASS Empty object store
+PASS Get all
+PASS Get all with generated keys
+PASS Get all with large values
+PASS maxCount=10
+PASS Get bound range
+PASS Get bound range with maxCount
+PASS Get upper excluded
+PASS Get lower excluded
+PASS Get bound range (generated) with maxCount
+PASS Non existent key
+PASS maxCount=0
+PASS Max value count
+PASS Query with empty range where  first key < upperBound
+PASS Query with empty range where lowerBound < last key
+PASS Retrieve multiEntry key
+PASS Retrieve one key multiple values
+PASS Direction: next
+PASS Direction: prev
+PASS Direction: nextunique
+PASS Direction: prevunique
+PASS Direction and query
+PASS Direction, query and count
+PASS Get all values with both options and count
 PASS Get all values with invalid query keys
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAll-options.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAll-options.any.sharedworker-expected.txt
@@ -1,28 +1,28 @@
 
-FAIL Single item get Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Empty object store Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get all Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get all with generated keys Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get all with large values Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL maxCount=10 Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get bound range Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get bound range with maxCount Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get upper excluded Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get lower excluded Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get bound range (generated) with maxCount Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Non existent key Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL maxCount=0 Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Max value count Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Query with empty range where  first key < upperBound Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Query with empty range where lowerBound < last key Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Retrieve multiEntry key Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Retrieve one key multiple values Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction: next Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction: prev Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction: nextunique Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction: prevunique Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction and query Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction, query and count Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get all values with both options and count Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+PASS Single item get
+PASS Empty object store
+PASS Get all
+PASS Get all with generated keys
+PASS Get all with large values
+PASS maxCount=10
+PASS Get bound range
+PASS Get bound range with maxCount
+PASS Get upper excluded
+PASS Get lower excluded
+PASS Get bound range (generated) with maxCount
+PASS Non existent key
+PASS maxCount=0
+PASS Max value count
+PASS Query with empty range where  first key < upperBound
+PASS Query with empty range where lowerBound < last key
+PASS Retrieve multiEntry key
+PASS Retrieve one key multiple values
+PASS Direction: next
+PASS Direction: prev
+PASS Direction: nextunique
+PASS Direction: prevunique
+PASS Direction and query
+PASS Direction, query and count
+PASS Get all values with both options and count
 PASS Get all values with invalid query keys
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAll-options.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAll-options.any.worker-expected.txt
@@ -1,28 +1,28 @@
 
-FAIL Single item get Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Empty object store Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get all Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get all with generated keys Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get all with large values Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL maxCount=10 Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get bound range Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get bound range with maxCount Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get upper excluded Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get lower excluded Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get bound range (generated) with maxCount Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Non existent key Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL maxCount=0 Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Max value count Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Query with empty range where  first key < upperBound Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Query with empty range where lowerBound < last key Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Retrieve multiEntry key Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Retrieve one key multiple values Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction: next Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction: prev Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction: nextunique Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction: prevunique Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction and query Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Direction, query and count Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
-FAIL Get all values with both options and count Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key.
+PASS Single item get
+PASS Empty object store
+PASS Get all
+PASS Get all with generated keys
+PASS Get all with large values
+PASS maxCount=10
+PASS Get bound range
+PASS Get bound range with maxCount
+PASS Get upper excluded
+PASS Get lower excluded
+PASS Get bound range (generated) with maxCount
+PASS Non existent key
+PASS maxCount=0
+PASS Max value count
+PASS Query with empty range where  first key < upperBound
+PASS Query with empty range where lowerBound < last key
+PASS Retrieve multiEntry key
+PASS Retrieve one key multiple values
+PASS Direction: next
+PASS Direction: prev
+PASS Direction: nextunique
+PASS Direction: prevunique
+PASS Direction and query
+PASS Direction, query and count
+PASS Get all values with both options and count
 PASS Get all values with invalid query keys
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any-expected.txt
@@ -29,9 +29,7 @@ FAIL IDBObjectStore getAllKeys() method with throwing/invalid keys assert_throws
 FAIL IDBObjectStore getAllRecords() method with throwing/invalid keys assert_throws_dom: options query key conversion with invalid key should throw DataError function "() => {
     receiver[method]({query: invalid_key});
   }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0
-FAIL IDBIndex getAll() method with throwing/invalid keys assert_throws_exactly: options query key conversion with throwing getter should rethrow function "() => {
-    receiver[method]({query: key});
-  }" threw object "DataError: Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key." but we expected it to throw object "getter: throwing from getter"
+PASS IDBIndex getAll() method with throwing/invalid keys
 PASS IDBIndex getAllKeys() method with throwing/invalid keys
 FAIL IDBIndex getAllRecords() method with throwing/invalid keys assert_throws_dom: options query key conversion with invalid key should throw DataError function "() => {
     receiver[method]({query: invalid_key});

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.serviceworker-expected.txt
@@ -29,9 +29,7 @@ FAIL IDBObjectStore getAllKeys() method with throwing/invalid keys assert_throws
 FAIL IDBObjectStore getAllRecords() method with throwing/invalid keys assert_throws_dom: options query key conversion with invalid key should throw DataError function "() => {
     receiver[method]({query: invalid_key});
   }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0
-FAIL IDBIndex getAll() method with throwing/invalid keys assert_throws_exactly: options query key conversion with throwing getter should rethrow function "() => {
-    receiver[method]({query: key});
-  }" threw object "DataError: Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key." but we expected it to throw object "getter: throwing from getter"
+PASS IDBIndex getAll() method with throwing/invalid keys
 PASS IDBIndex getAllKeys() method with throwing/invalid keys
 FAIL IDBIndex getAllRecords() method with throwing/invalid keys assert_throws_dom: options query key conversion with invalid key should throw DataError function "() => {
     receiver[method]({query: invalid_key});

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.sharedworker-expected.txt
@@ -29,9 +29,7 @@ FAIL IDBObjectStore getAllKeys() method with throwing/invalid keys assert_throws
 FAIL IDBObjectStore getAllRecords() method with throwing/invalid keys assert_throws_dom: options query key conversion with invalid key should throw DataError function "() => {
     receiver[method]({query: invalid_key});
   }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0
-FAIL IDBIndex getAll() method with throwing/invalid keys assert_throws_exactly: options query key conversion with throwing getter should rethrow function "() => {
-    receiver[method]({query: key});
-  }" threw object "DataError: Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key." but we expected it to throw object "getter: throwing from getter"
+PASS IDBIndex getAll() method with throwing/invalid keys
 PASS IDBIndex getAllKeys() method with throwing/invalid keys
 FAIL IDBIndex getAllRecords() method with throwing/invalid keys assert_throws_dom: options query key conversion with invalid key should throw DataError function "() => {
     receiver[method]({query: invalid_key});

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.worker-expected.txt
@@ -29,9 +29,7 @@ FAIL IDBObjectStore getAllKeys() method with throwing/invalid keys assert_throws
 FAIL IDBObjectStore getAllRecords() method with throwing/invalid keys assert_throws_dom: options query key conversion with invalid key should throw DataError function "() => {
     receiver[method]({query: invalid_key});
   }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0
-FAIL IDBIndex getAll() method with throwing/invalid keys assert_throws_exactly: options query key conversion with throwing getter should rethrow function "() => {
-    receiver[method]({query: key});
-  }" threw object "DataError: Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key." but we expected it to throw object "getter: throwing from getter"
+PASS IDBIndex getAll() method with throwing/invalid keys
 PASS IDBIndex getAllKeys() method with throwing/invalid keys
 FAIL IDBIndex getAllRecords() method with throwing/invalid keys assert_throws_dom: options query key conversion with invalid key should throw DataError function "() => {
     receiver[method]({query: invalid_key});

--- a/Source/WebCore/Modules/indexeddb/IDBGetAllOptions.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBGetAllOptions.cpp
@@ -1,0 +1,60 @@
+/*
+* Copyright (C) 2026 Apple Inc. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+* THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+* PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+* BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+* THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "config.h"
+#include "IDBGetAllOptions.h"
+
+#include "IDBKeyRange.h"
+#include "JSIDBGetAllOptions.h"
+#include "JSIDBKeyRange.h"
+#include <JavaScriptCore/JSGlobalObject.h>
+
+namespace WebCore {
+
+// https://w3c.github.io/IndexedDB/#create-a-request-to-retrieve-multiple-items (Step 9).
+ExceptionOr<ParsedGetAllQueryOrOptions> parseGetAllOptions(JSC::JSGlobalObject& execState, JSC::JSValue keyOrOptions)
+{
+    auto throwScope = DECLARE_THROW_SCOPE(execState.vm());
+    auto optionsResult = convertDictionary<IDBGetAllOptions>(execState, keyOrOptions);
+    if (throwScope.exception())
+        return Exception { ExceptionCode::DataError, "The parameter is not a valid options object."_s };
+
+    auto options = optionsResult.releaseReturnValue();
+    auto query = options.query;
+
+    if (query.isUndefinedOrNull())
+        return ParsedGetAllQueryOrOptions { nullptr, options.count, options.direction };
+
+    if (RefPtr keyRange = JSIDBKeyRange::toWrapped(execState.vm(), query))
+        return ParsedGetAllQueryOrOptions { WTF::move(keyRange), options.count, options.direction };
+
+    auto onlyResultFromQuery = IDBKeyRange::only(execState, query);
+    if (onlyResultFromQuery.hasException())
+        return Exception(ExceptionCode::DataError, "The query specified in options is not a valid key."_s);
+
+    return ParsedGetAllQueryOrOptions { onlyResultFromQuery.releaseReturnValue(), options.count, options.direction };
+}
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/indexeddb/IDBGetAllOptions.h
+++ b/Source/WebCore/Modules/indexeddb/IDBGetAllOptions.h
@@ -25,16 +25,31 @@
 
 #pragma once
 
+#include "ExceptionOr.h"
 #include "IDBCursorDirection.h"
 #include <JavaScriptCore/JSCJSValue.h>
 #include <optional>
 
+namespace JSC {
+class JSGlobalObject;
+}
+
 namespace WebCore {
+
+class IDBKeyRange;
 
 struct IDBGetAllOptions {
     JSC::JSValue query;
     std::optional<uint32_t> count;
     IDBCursorDirection direction { IDBCursorDirection::Next };
 };
+
+struct ParsedGetAllQueryOrOptions {
+    RefPtr<IDBKeyRange> keyRange;
+    std::optional<uint32_t> count { std::nullopt };
+    IDBCursorDirection cursorDirection { IDBCursorDirection::Next };
+};
+
+ExceptionOr<ParsedGetAllQueryOrOptions> parseGetAllOptions(JSC::JSGlobalObject& execState, JSC::JSValue keyOrOptions);
 
 }

--- a/Source/WebCore/Modules/indexeddb/IDBIndex.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBIndex.cpp
@@ -37,8 +37,6 @@
 #include "IDBObjectStore.h"
 #include "IDBRequest.h"
 #include "IDBTransaction.h"
-#include "JSIDBGetAllOptions.h"
-#include "JSIDBKeyRange.h"
 #include "Logging.h"
 #include "Settings.h"
 #include "WebCoreOpaqueRoot.h"
@@ -349,104 +347,88 @@ ExceptionOr<Ref<IDBRequest>> IDBIndex::doGetKey(ExceptionOr<IDBKeyRangeData> ran
     return transaction->requestGetKey(*this, keyRange);
 }
 
-ExceptionOr<Ref<IDBRequest>> IDBIndex::doGetAll(std::optional<uint32_t> count, Function<ExceptionOr<RefPtr<IDBKeyRange>>()>&& function)
+// https://w3c.github.io/IndexedDB/#create-a-request-to-retrieve-multiple-items
+ExceptionOr<Ref<IDBRequest>> IDBIndex::doGetAllShared(IndexedDB::GetAllType getAllType, std::optional<uint32_t> count, Function<ExceptionOr<ParsedGetAllQueryOrOptions>()>&& function)
 {
-    LOG(IndexedDB, "IDBIndex::getAll");
+    String callingFunctionExceptionMessagePrefix;
+    switch (getAllType) {
+    case IndexedDB::GetAllType::Values:
+        callingFunctionExceptionMessagePrefix = "Failed to execute 'getAll' on IDBIdex': "_s;
+        break;
+    case IndexedDB::GetAllType::Keys:
+        callingFunctionExceptionMessagePrefix = "Failed to execute 'getAllValues' on IDBIdex': "_s;
+        break;
+    }
+
     Ref transaction = m_objectStore->transaction();
     ASSERT(canCurrentThreadAccessThreadLocalData(transaction->database().originThread()));
 
     if (m_deleted || m_objectStore->isDeleted())
-        return Exception { ExceptionCode::InvalidStateError, "Failed to execute 'getAll' on 'IDBIndex': The index or its object store has been deleted."_s };
+        return Exception { ExceptionCode::InvalidStateError, makeString(callingFunctionExceptionMessagePrefix, "The index or its object store has been deleted."_s) };
 
     if (!transaction->isActive())
-        return Exception { ExceptionCode::TransactionInactiveError, "Failed to execute 'getAll' on 'IDBIndex': The transaction is inactive or finished."_s };
-
-    auto keyRange = function();
-    if (keyRange.hasException())
-        return keyRange.releaseException();
-
-    RefPtr keyRangePointer = keyRange.returnValue().get();
-    return transaction->requestGetAllIndexRecords(*this, keyRangePointer.get(), IndexedDB::GetAllType::Values, count, IDBCursorDirection::Next);
-}
-
-ExceptionOr<Ref<IDBRequest>> IDBIndex::getAll(RefPtr<IDBKeyRange>&& range, std::optional<uint32_t> count)
-{
-    return doGetAll(count, [range = WTF::move(range)]() {
-        return range;
-    });
-}
-
-ExceptionOr<Ref<IDBRequest>> IDBIndex::getAll(JSGlobalObject& execState, JSValue key, std::optional<uint32_t> count)
-{
-    return doGetAll(count, [state = &execState, key]() {
-        auto onlyResult = IDBKeyRange::only(*state, key);
-        if (onlyResult.hasException())
-            return ExceptionOr<RefPtr<IDBKeyRange>> { Exception(ExceptionCode::DataError, "Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key."_s) };
-
-        return ExceptionOr<RefPtr<IDBKeyRange>> { onlyResult.releaseReturnValue() };
-    });
-}
-
-ExceptionOr<Ref<IDBRequest>> IDBIndex::doGetAllKeys(std::optional<uint32_t> count, Function<ExceptionOr<ParsedGetAllQueryOrOptions>()>&& function)
-{
-    LOG(IndexedDB, "IDBIndex::getAllKeys");
-    Ref transaction = m_objectStore->transaction();
-    ASSERT(canCurrentThreadAccessThreadLocalData(transaction->database().originThread()));
-
-    if (m_deleted || m_objectStore->isDeleted())
-        return Exception { ExceptionCode::InvalidStateError, "Failed to execute 'getAllKeys' on 'IDBIndex': The index or its object store has been deleted."_s };
-
-    if (!transaction->isActive())
-        return Exception { ExceptionCode::TransactionInactiveError, "Failed to execute 'getAllKeys' on 'IDBIndex': The transaction is inactive or finished."_s };
+        return Exception { ExceptionCode::TransactionInactiveError, makeString(callingFunctionExceptionMessagePrefix, "The transaction is inactive or finished."_s) };
 
     auto exceptionOrParsedGetAllQueryOrOptions = function();
-    if (exceptionOrParsedGetAllQueryOrOptions.hasException())
-        return exceptionOrParsedGetAllQueryOrOptions.releaseException();
+    if (exceptionOrParsedGetAllQueryOrOptions.hasException()) {
+        auto exception = exceptionOrParsedGetAllQueryOrOptions.releaseException();
+        return Exception { exception.code(), makeString(callingFunctionExceptionMessagePrefix, exception.releaseMessage()) };
+    }
 
     auto parsedGetAllQueryOrOptions = exceptionOrParsedGetAllQueryOrOptions.releaseReturnValue();
     if (parsedGetAllQueryOrOptions.count)
         count = parsedGetAllQueryOrOptions.count;
 
-    return transaction->requestGetAllIndexRecords(*this, parsedGetAllQueryOrOptions.keyRange.get(), IndexedDB::GetAllType::Keys, count, parsedGetAllQueryOrOptions.cursorDirection);
+    return transaction->requestGetAllIndexRecords(*this, parsedGetAllQueryOrOptions.keyRange.get(), getAllType, count, parsedGetAllQueryOrOptions.cursorDirection);
 }
 
-ExceptionOr<Ref<IDBRequest>> IDBIndex::getAllKeys(RefPtr<IDBKeyRange>&& range, std::optional<uint32_t> count)
+ExceptionOr<Ref<IDBRequest>> IDBIndex::getAll(RefPtr<IDBKeyRange>&& range, std::optional<uint32_t> count)
 {
-    return doGetAllKeys(count, [range = WTF::move(range)]() {
+    LOG(IndexedDB, "IDBIndex::getAll");
+
+    return doGetAllShared(IndexedDB::GetAllType::Values, count, [range = WTF::move(range)]() {
         return ParsedGetAllQueryOrOptions { range };
     });
 }
 
-// https://w3c.github.io/IndexedDB/#create-a-request-to-retrieve-multiple-items
-ExceptionOr<Ref<IDBRequest>> IDBIndex::getAllKeys(JSGlobalObject& execState, JSValue keyOrOptions, std::optional<uint32_t> count)
+ExceptionOr<Ref<IDBRequest>> IDBIndex::getAll(JSGlobalObject& execState, JSValue keyOrOptions, std::optional<uint32_t> count)
 {
-    return doGetAllKeys(count, [context = RefPtr { scriptExecutionContext() }, execState = &execState, keyOrOptions]() -> ExceptionOr<ParsedGetAllQueryOrOptions> {
+    LOG(IndexedDB, "IDBIndex::getAll");
+
+    return doGetAllShared(IndexedDB::GetAllType::Values, count, [context = RefPtr { scriptExecutionContext() }, execState = &execState, keyOrOptions, count]() -> ExceptionOr<ParsedGetAllQueryOrOptions> {
         auto onlyResult = IDBKeyRange::only(*execState, keyOrOptions);
         if (!onlyResult.hasException())
-            return ParsedGetAllQueryOrOptions { onlyResult.releaseReturnValue() };
+            return ParsedGetAllQueryOrOptions { onlyResult.releaseReturnValue(), count };
+
+        if (!context || !context->settingsValues().indexedDBGetAllRecordsEnabled)
+            return Exception(ExceptionCode::DataError, "Failed to execute 'getAll' on 'IDBIndex': The parameter is not a valid key."_s);
+
+        return parseGetAllOptions(*execState, keyOrOptions);
+    });
+}
+
+ExceptionOr<Ref<IDBRequest>> IDBIndex::getAllKeys(RefPtr<IDBKeyRange>&& range, std::optional<uint32_t> count)
+{
+    LOG(IndexedDB, "IDBIndex::getAllKeys");
+
+    return doGetAllShared(IndexedDB::GetAllType::Keys, count, [range = WTF::move(range)]() {
+        return ParsedGetAllQueryOrOptions { range };
+    });
+}
+
+ExceptionOr<Ref<IDBRequest>> IDBIndex::getAllKeys(JSGlobalObject& execState, JSValue keyOrOptions, std::optional<uint32_t> count)
+{
+    LOG(IndexedDB, "IDBIndex::getAllKeys");
+
+    return doGetAllShared(IndexedDB::GetAllType::Keys, count, [context = RefPtr { scriptExecutionContext() }, execState = &execState, keyOrOptions, count]() -> ExceptionOr<ParsedGetAllQueryOrOptions> {
+        auto onlyResult = IDBKeyRange::only(*execState, keyOrOptions);
+        if (!onlyResult.hasException())
+            return ParsedGetAllQueryOrOptions { onlyResult.releaseReturnValue(), count };
 
         if (!context || !context->settingsValues().indexedDBGetAllRecordsEnabled)
             return Exception(ExceptionCode::DataError, "Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid key."_s);
 
-        auto throwScope = DECLARE_THROW_SCOPE(execState->vm());
-        auto optionsResult = convertDictionary<IDBGetAllOptions>(*execState, keyOrOptions);
-        if (throwScope.exception())
-            return Exception { ExceptionCode::DataError, "Failed to execute 'getAllKeys' on 'IDBIndex': The parameter is not a valid options object."_s };
-
-        auto options = optionsResult.releaseReturnValue();
-        auto query = options.query;
-
-        if (query.isUndefinedOrNull())
-            return ParsedGetAllQueryOrOptions { nullptr, options.count, options.direction };
-
-        if (RefPtr keyRange = JSIDBKeyRange::toWrapped(execState->vm(), query))
-            return ParsedGetAllQueryOrOptions { WTF::move(keyRange), options.count, options.direction };
-
-        auto onlyResultFromQuery = IDBKeyRange::only(*execState, query);
-        if (onlyResultFromQuery.hasException())
-            return Exception(ExceptionCode::DataError, "Failed to execute 'getAllKeys' on 'IDBIndex': The query specified in options is not a valid key."_s);
-
-        return ParsedGetAllQueryOrOptions { onlyResultFromQuery.releaseReturnValue(), options.count, options.direction };
+        return parseGetAllOptions(*execState, keyOrOptions);
     });
 }
 

--- a/Source/WebCore/Modules/indexeddb/IDBIndex.h
+++ b/Source/WebCore/Modules/indexeddb/IDBIndex.h
@@ -26,8 +26,7 @@
 #pragma once
 
 #include "IDBCursor.h"
-#include <WebCore/IDBIndexInfo.h>
-#include <WebCore/IDBRequest.h>
+#include "IDBIndexInfo.h"
 #include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 
@@ -38,16 +37,12 @@ class CallFrame;
 namespace WebCore {
 
 class IDBKeyRange;
+class IDBRequest;
 class WebCoreOpaqueRoot;
 
 struct IDBGetAllOptions;
 struct IDBKeyRangeData;
-
-struct ParsedGetAllQueryOrOptions {
-    RefPtr<IDBKeyRange> keyRange;
-    std::optional<uint32_t> count { std::nullopt };
-    IDBCursorDirection cursorDirection { IDBCursorDirection::Next };
-};
+struct ParsedGetAllQueryOrOptions;
 
 class IDBIndex final : public ActiveDOMObject {
     WTF_MAKE_TZONE_ALLOCATED(IDBIndex);
@@ -79,7 +74,7 @@ public:
     ExceptionOr<Ref<IDBRequest>> getKey(JSC::JSGlobalObject&, JSC::JSValue key);
 
     ExceptionOr<Ref<IDBRequest>> getAll(RefPtr<IDBKeyRange>&&, std::optional<uint32_t> count);
-    ExceptionOr<Ref<IDBRequest>> getAll(JSC::JSGlobalObject&, JSC::JSValue key, std::optional<uint32_t> count);
+    ExceptionOr<Ref<IDBRequest>> getAll(JSC::JSGlobalObject&, JSC::JSValue keyOrOptions, std::optional<uint32_t> count);
     ExceptionOr<Ref<IDBRequest>> getAllKeys(RefPtr<IDBKeyRange>&&, std::optional<uint32_t> count);
     ExceptionOr<Ref<IDBRequest>> getAllKeys(JSC::JSGlobalObject&, JSC::JSValue keyOrOptions, std::optional<uint32_t> count);
     ExceptionOr<Ref<IDBRequest>> getAllRecords(JSC::JSGlobalObject&, IDBGetAllOptions&&);
@@ -103,8 +98,7 @@ private:
     ExceptionOr<Ref<IDBRequest>> doGetKey(ExceptionOr<IDBKeyRangeData>);
     ExceptionOr<Ref<IDBRequest>> doOpenCursor(IDBCursorDirection, Function<ExceptionOr<RefPtr<IDBKeyRange>>()> &&);
     ExceptionOr<Ref<IDBRequest>> doOpenKeyCursor(IDBCursorDirection, Function<ExceptionOr<RefPtr<IDBKeyRange>>()> &&);
-    ExceptionOr<Ref<IDBRequest>> doGetAll(std::optional<uint32_t> count, Function<ExceptionOr<RefPtr<IDBKeyRange>>()> &&);
-    ExceptionOr<Ref<IDBRequest>> doGetAllKeys(std::optional<uint32_t> count, Function<ExceptionOr<ParsedGetAllQueryOrOptions>()> &&);
+    ExceptionOr<Ref<IDBRequest>> doGetAllShared(IndexedDB::GetAllType, std::optional<uint32_t> count, Function<ExceptionOr<ParsedGetAllQueryOrOptions>()>&&);
 
     // ActiveDOMObject.
     bool virtualHasPendingActivity() const final;

--- a/Source/WebCore/Modules/indexeddb/IDBIndex.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBIndex.idl
@@ -48,7 +48,7 @@ typedef (DOMString or sequence<DOMString>) IDBKeyPath;
     [NewObject, CallWith=CurrentGlobalObject] IDBRequest getKey(any key);
 
     [NewObject] IDBRequest getAll(optional IDBKeyRange? range = null, optional [EnforceRange] unsigned long count);
-    [NewObject, CallWith=CurrentGlobalObject] IDBRequest getAll(any key, optional [EnforceRange] unsigned long count);
+    [NewObject, CallWith=CurrentGlobalObject] IDBRequest getAll(any keyOrOptions, optional [EnforceRange] unsigned long count);
 
     [NewObject] IDBRequest getAllKeys(optional IDBKeyRange? range = null, optional [EnforceRange] unsigned long count);
     [NewObject, CallWith=CurrentGlobalObject] IDBRequest getAllKeys(any keyOrOptions, optional [EnforceRange] unsigned long count);

--- a/Source/WebCore/Modules/mediastream/VideoTrackGenerator.cpp
+++ b/Source/WebCore/Modules/mediastream/VideoTrackGenerator.cpp
@@ -29,6 +29,7 @@
 
 #include "Exception.h"
 #include "ExceptionCode.h"
+#include "JSDOMPromiseDeferred.h"
 #include "JSWebCodecsVideoFrame.h"
 #include "MediaStreamTrack.h"
 #include "VideoFrame.h"

--- a/Source/WebCore/Modules/mediastream/VideoTrackGenerator.h
+++ b/Source/WebCore/Modules/mediastream/VideoTrackGenerator.h
@@ -27,6 +27,7 @@
 #if ENABLE(MEDIA_STREAM) && ENABLE(WEB_CODECS)
 
 #include "RealtimeMediaSource.h"
+#include "ScriptExecutionContextIdentifier.h"
 #include "WritableStreamSink.h"
 #include <wtf/RefCounted.h>
 

--- a/Source/WebCore/Modules/streams/ReadableByteStreamController.cpp
+++ b/Source/WebCore/Modules/streams/ReadableByteStreamController.cpp
@@ -1021,6 +1021,9 @@ void ReadableByteStreamController::visitDirectChildrenInGCThread(Visitor& visito
         SUPPRESS_UNCOUNTED_ARG m_cancelAlgorithm->visitJSFunctionInGCThread(visitor);
 }
 
+template void ReadableByteStreamController::visitDirectChildrenInGCThread(JSC::AbstractSlotVisitor&);
+template void ReadableByteStreamController::visitDirectChildrenInGCThread(JSC::SlotVisitor&);
+
 template<typename Visitor>
 void ReadableByteStreamController::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {

--- a/Source/WebCore/Modules/streams/ReadableStream.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStream.cpp
@@ -29,6 +29,8 @@
 #include "ContextDestructionObserverInlines.h"
 #include "DOMAsyncIterator.h"
 #include "InternalWritableStreamWriter.h"
+#include "JSDOMConvertBufferSource.h"
+#include "JSDOMConvertNullable.h"
 #include "JSDOMPromise.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSReadableStream.h"

--- a/Source/WebCore/Modules/streams/StreamTransferUtilities.cpp
+++ b/Source/WebCore/Modules/streams/StreamTransferUtilities.cpp
@@ -28,6 +28,7 @@
 #include "StreamTransferUtilities.h"
 
 #include "JSDOMException.h"
+#include "JSDOMPromiseDeferred.h"
 #include "MessagePort.h"
 #include "ReadableStream.h"
 #include "ReadableStreamSource.h"

--- a/Source/WebCore/Modules/webtransport/DatagramSink.cpp
+++ b/Source/WebCore/Modules/webtransport/DatagramSink.cpp
@@ -29,6 +29,7 @@
 #include "Exception.h"
 #include "JSDOMConvertBufferSource.h"
 #include "JSDOMConvertUnion.h"
+#include "JSDOMPromiseDeferred.h"
 #include "ScriptExecutionContextInlines.h"
 #include "WebTransport.h"
 #include "WebTransportDatagramsWritable.h"

--- a/Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.cpp
@@ -39,6 +39,8 @@ namespace WebCore {
 
 using GL = GraphicsContextGL;
 
+WebXRWebGLSwapchain::~WebXRWebGLSwapchain() = default;
+
 WebXRWebGLSwapchain::WebXRWebGLSwapchain(WebGLRenderingContextBase& context, SwapchainTargets targets, bool clearOnAccess)
     : WebXRSwapchain(targets, clearOnAccess)
     , m_context(context)
@@ -91,6 +93,11 @@ void WebXRWebGLSwapchain::clearCurrentTexture(GraphicsContextGL& gl)
     gl.bindFramebuffer(GL::FRAMEBUFFER, m_framebufferForClearing->object());
     gl.framebufferTexture2D(GL::FRAMEBUFFER, computeAttachment(m_targetFlags), GL::TEXTURE_2D, texture, 0);
     gl.clear(clearMask);
+}
+
+RefPtr<WebGLRenderingContextBase> WebXRWebGLSwapchain::context()
+{
+    return m_context;
 }
 
 std::unique_ptr<WebXRWebGLSharedImageSwapchain> WebXRWebGLSharedImageSwapchain::create(WebGLRenderingContextBase& context, SwapchainTargets targets, GCGLenum format, bool clearOnAccess)

--- a/Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.h
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.h
@@ -78,9 +78,9 @@ using WebXRExternalImages = WebXRImageSet<WebXRExternalImage>;
 
 class WebXRWebGLSwapchain : public WebXRSwapchain {
 public:
-    ~WebXRWebGLSwapchain() override = default;
+    ~WebXRWebGLSwapchain() override;
 
-    RefPtr<WebGLRenderingContextBase> context() { return m_context; }
+    RefPtr<WebGLRenderingContextBase> context();
 
     IntSize size() const { return m_texSize; }
 

--- a/Source/WebCore/Modules/webxr/XRWebGLLayerBacking.h
+++ b/Source/WebCore/Modules/webxr/XRWebGLLayerBacking.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(WEBXR_LAYERS)
 
+#include "GraphicsTypesGL.h"
 #include "XRLayerBacking.h"
 #include <wtf/TZoneMalloc.h>
 

--- a/Source/WebCore/Modules/webxr/XRWebGLProjectionLayerBacking.cpp
+++ b/Source/WebCore/Modules/webxr/XRWebGLProjectionLayerBacking.cpp
@@ -31,6 +31,7 @@
 #include "WebXRSession.h"
 #include "WebXRWebGLLayer.h"
 #include "WebXRWebGLSwapchain.h"
+#include "XRProjectionLayerInit.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -164,6 +164,7 @@ Modules/indexeddb/IDBDatabase.cpp
 Modules/indexeddb/IDBDatabaseIdentifier.cpp
 Modules/indexeddb/IDBDatabaseNameAndVersionRequest.cpp
 Modules/indexeddb/IDBFactory.cpp
+Modules/indexeddb/IDBGetAllOptions.cpp
 Modules/indexeddb/IDBGetAllResult.cpp
 Modules/indexeddb/IDBGetResult.cpp
 Modules/indexeddb/IDBIndex.cpp


### PR DESCRIPTION
#### f93fe13c4e39cd71963a90e66272433242eb7d7a
<pre>
[IndexedDB API] Support IDBGetAllOptions in IDBIndex::getAll()
<a href="https://bugs.webkit.org/show_bug.cgi?id=310862">https://bugs.webkit.org/show_bug.cgi?id=310862</a>
<a href="https://rdar.apple.com/173478298">rdar://173478298</a>

Reviewed by Brady Eidson.

In <a href="https://commits.webkit.org/310051@main">https://commits.webkit.org/310051@main</a> we added support for IDBGetAllOptions
in IDBIndex::getAllKeys(). Here we reuse the logic added there to add support in
IDBIndex::getAll() as well.

That commit added logic to getAllKeys() to parse the input in case its an
IDBGetAllOptions object. We factor out that logic into it&apos;s own function called
parseGetAllOptions() so that getAll() can use it as well. We put it in
IDBGetAllOptions.cpp because IDBObjectStore will need it later as well.

With that, we can use the parsed cursor direction instead of hardcoding &quot;next&quot;.
The previous patch already introduced the logic to plumb this direction down from
IDBTransaction::requestGetAllIndexRecords to SQLiteIDBBackingStore::getAllIndexRecords.

Since doGetAll() and doGetAllKeys() are identical, we remove the duplicated code
by combining them into one function doGetAllShared().

Also fix unified source build issues.

* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAll-options.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAll-options.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAll-options.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAll-options.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.worker-expected.txt:
* Source/WebCore/Modules/indexeddb/IDBGetAllOptions.cpp: Added.
(WebCore::parseGetAllOptions):

Put the logic for parsing IDBGetAllOptions here.
<a href="https://w3c.github.io/IndexedDB/#create-a-request-to-retrieve-multiple-items">https://w3c.github.io/IndexedDB/#create-a-request-to-retrieve-multiple-items</a> (Step 9).

* Source/WebCore/Modules/indexeddb/IDBGetAllOptions.h:
* Source/WebCore/Modules/indexeddb/IDBIndex.cpp:
(WebCore::IDBIndex::doGetAllShared):

The implementation of doGetAll() and doGetAllKeys() is now shared here.

(WebCore::IDBIndex::getAll):
(WebCore::IDBIndex::getAllKeys):
(WebCore::IDBIndex::doGetAll): Deleted.
(WebCore::IDBIndex::doGetAllKeys): Deleted.

Use parseGetAllOptions() if we support IDBGetAllOptions.

* Source/WebCore/Modules/indexeddb/IDBIndex.h:
* Source/WebCore/Modules/indexeddb/IDBIndex.idl:
* Source/WebCore/Modules/mediastream/VideoTrackGenerator.cpp:
* Source/WebCore/Modules/mediastream/VideoTrackGenerator.h:
* Source/WebCore/Modules/streams/ReadableByteStreamController.cpp:
* Source/WebCore/Modules/streams/ReadableStream.cpp:
* Source/WebCore/Modules/streams/StreamTransferUtilities.cpp:
* Source/WebCore/Modules/webtransport/DatagramSink.cpp:
* Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.cpp:
(WebCore::WebXRWebGLStaticImageSwapchain::context):
* Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.h:
(WebCore::WebXRWebGLSwapchain::context): Deleted.
* Source/WebCore/Modules/webxr/XRWebGLLayerBacking.h:
* Source/WebCore/Modules/webxr/XRWebGLProjectionLayerBacking.cpp:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/310164@main">https://commits.webkit.org/310164@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/586c343594ef9af8581e9f637c34b750cdb96970

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152851 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25633 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19231 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161595 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106307 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154724 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26160 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25938 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118121 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83645 "8 flakes 5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/101294ae-2757-435e-98ac-f356aee01938) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155810 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20353 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137226 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98834 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19427 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17368 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9431 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129079 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15100 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164069 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7205 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16694 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126183 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25430 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21407 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126341 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25432 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136896 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82036 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23418 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21294 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13675 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25048 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89335 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24740 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24899 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24800 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->