### PR TITLE
Avoid using convertToASCIILowercase() for comparisons

### DIFF
--- a/Source/WebCore/accessibility/AXLiveRegionManager.cpp
+++ b/Source/WebCore/accessibility/AXLiveRegionManager.cpp
@@ -136,10 +136,9 @@ void AXLiveRegionManager::registerLiveRegion(AccessibilityObject& object, bool s
 
 static LiveRegionStatus stringToLiveRegionStatus(const String& string)
 {
-    String lowercaseString = string.convertToASCIILowercase();
-    if (lowercaseString == "assertive")
+    if (equalLettersIgnoringASCIICase(string, "assertive"_s))
         return LiveRegionStatus::Assertive;
-    if (lowercaseString == "polite")
+    if (equalLettersIgnoringASCIICase(string, "polite"_s))
         return LiveRegionStatus::Polite;
 
     return LiveRegionStatus::Off;
@@ -147,16 +146,15 @@ static LiveRegionStatus stringToLiveRegionStatus(const String& string)
 
 static OptionSet<LiveRegionRelevant> stringToLiveRegionRelevant(const String& string)
 {
-    Vector<String> strings = string.convertToASCIILowercase().split(" "_s);
     OptionSet<LiveRegionRelevant> result;
-    for (const auto& attribute : strings) {
-        if (attribute == "additions")
+    for (auto attribute : StringView(string).split(' ')) {
+        if (equalLettersIgnoringASCIICase(attribute, "additions"_s))
             result.add(LiveRegionRelevant::Additions);
-        else if (attribute == "all")
+        else if (equalLettersIgnoringASCIICase(attribute, "all"_s))
             result.add(LiveRegionRelevant::All);
-        else if (attribute == "removals")
+        else if (equalLettersIgnoringASCIICase(attribute, "removals"_s))
             result.add(LiveRegionRelevant::Removals);
-        else if (attribute == "text")
+        else if (equalLettersIgnoringASCIICase(attribute, "text"_s))
             result.add(LiveRegionRelevant::Text);
     }
     return result;

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -75,7 +75,7 @@ static bool matchesActiveViewTransitionTypePseudoClass(const Element& element, c
         for (const auto& type : types) {
             // https://github.com/w3c/csswg-drafts/issues/9534#issuecomment-1802364085
             // RESOLVED: type can accept any idents, except 'none' or '-ua-' prefixes
-            if (type.convertToASCIILowercase() == "none"_s || type.convertToASCIILowercase().startsWith("-ua-"_s))
+            if (equalLettersIgnoringASCIICase(type, "none"_s) || startsWithLettersIgnoringASCIICase(type, "-ua-"_s))
                 continue;
 
             if (activeTypes.hasType(type))

--- a/Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.cpp
@@ -186,17 +186,17 @@ GStreamerInternalAudioDecoder::GStreamerInternalAudioDecoder(const String& codec
         m_inputCaps = adoptGRef(gst_caps_new_empty_simple("application/ogg"));
     } else if (codecName.startsWith("pcm-"_s)) {
         auto components = codecName.split('-');
-        auto pcmFormat = components[1].convertToASCIILowercase();
+        auto& pcmFormat = components[1];
         GstAudioFormat gstPcmFormat = GST_AUDIO_FORMAT_UNKNOWN;
-        if (pcmFormat == "u8"_s)
+        if (equalLettersIgnoringASCIICase(pcmFormat, "u8"_s))
             gstPcmFormat = GST_AUDIO_FORMAT_U8;
-        else if (pcmFormat == "s16"_s)
+        else if (equalLettersIgnoringASCIICase(pcmFormat, "s16"_s))
             gstPcmFormat = GST_AUDIO_FORMAT_S16;
-        else if (pcmFormat == "s24"_s)
+        else if (equalLettersIgnoringASCIICase(pcmFormat, "s24"_s))
             gstPcmFormat = GST_AUDIO_FORMAT_S24;
-        else if (pcmFormat == "s32"_s)
+        else if (equalLettersIgnoringASCIICase(pcmFormat, "s32"_s))
             gstPcmFormat = GST_AUDIO_FORMAT_S32;
-        else if (pcmFormat == "f32"_s)
+        else if (equalLettersIgnoringASCIICase(pcmFormat, "f32"_s))
             gstPcmFormat = GST_AUDIO_FORMAT_F32;
         else {
             GST_WARNING("Invalid LPCM codec format: %s", pcmFormat.ascii().data());

--- a/Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp
@@ -319,17 +319,17 @@ String GStreamerInternalAudioEncoder::initialize(const String& codecName, const 
             g_object_set(m_encoder.get(), "bitrate", static_cast<int>(config.bitRate), nullptr);
     } else if (codecName.startsWith("pcm-"_s)) {
         auto components = codecName.split('-');
-        auto pcmFormat = components[1].convertToASCIILowercase();
+        auto& pcmFormat = components[1];
         GstAudioFormat gstPcmFormat = GST_AUDIO_FORMAT_UNKNOWN;
-        if (pcmFormat == "u8"_s)
+        if (equalLettersIgnoringASCIICase(pcmFormat, "u8"_s))
             gstPcmFormat = GST_AUDIO_FORMAT_U8;
-        else if (pcmFormat == "s16"_s)
+        else if (equalLettersIgnoringASCIICase(pcmFormat, "s16"_s))
             gstPcmFormat = GST_AUDIO_FORMAT_S16;
-        else if (pcmFormat == "s24"_s)
+        else if (equalLettersIgnoringASCIICase(pcmFormat, "s24"_s))
             gstPcmFormat = GST_AUDIO_FORMAT_S24;
-        else if (pcmFormat == "s32"_s)
+        else if (equalLettersIgnoringASCIICase(pcmFormat, "s32"_s))
             gstPcmFormat = GST_AUDIO_FORMAT_S32;
-        else if (pcmFormat == "f32"_s)
+        else if (equalLettersIgnoringASCIICase(pcmFormat, "f32"_s))
             gstPcmFormat = GST_AUDIO_FORMAT_F32;
         else
             return makeString("Invalid LPCM codec format: "_s, pcmFormat);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AVAssetMIMETypeCache.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AVAssetMIMETypeCache.mm
@@ -131,16 +131,13 @@ bool AVAssetMIMETypeCache::isUnsupportedContainerType(const String& type)
     if (type.isEmpty())
         return false;
 
-    String lowerCaseType = type.convertToASCIILowercase();
-
     // AVFoundation will return non-video MIME types which it claims to support, but which we
     // do not support in the <video> element. Reject all non video/, audio/, and application/ types.
-    if (!lowerCaseType.startsWith("video/"_s) && !lowerCaseType.startsWith("audio/"_s) && !lowerCaseType.startsWith("application/"_s))
+    if (!startsWithLettersIgnoringASCIICase(type, "video/"_s) && !startsWithLettersIgnoringASCIICase(type, "audio/"_s) && !startsWithLettersIgnoringASCIICase(type, "application/"_s))
         return true;
 
     // Reject types we know AVFoundation does not support that sites commonly ask about.
-    static constexpr SortedArraySet unsupportedTypesSet { std::to_array<ComparableASCIILiteral>({ "video/h264"_s, "video/x-flv"_s }) };
-    return unsupportedTypesSet.contains(lowerCaseType);
+    return equalLettersIgnoringASCIICase(type, "video/h264"_s) || equalLettersIgnoringASCIICase(type, "video/x-flv"_s);
 }
 
 bool AVAssetMIMETypeCache::isStaticContainerType(StringView type)

--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -178,30 +178,30 @@ inline SessionFeature sessionFeatureFromReferenceSpaceType(ReferenceSpaceType re
 
 inline std::optional<SessionFeature> parseSessionFeatureDescriptor(StringView string)
 {
-    auto feature = string.trim(isUnicodeCompatibleASCIIWhitespace<char16_t>).convertToASCIILowercase();
+    auto feature = string.trim(isUnicodeCompatibleASCIIWhitespace<char16_t>);
 
-    if (feature == "viewer"_s)
+    if (equalLettersIgnoringASCIICase(feature, "viewer"_s))
         return SessionFeature::ReferenceSpaceTypeViewer;
-    if (feature == "local"_s)
+    if (equalLettersIgnoringASCIICase(feature, "local"_s))
         return SessionFeature::ReferenceSpaceTypeLocal;
-    if (feature == "local-floor"_s)
+    if (equalLettersIgnoringASCIICase(feature, "local-floor"_s))
         return SessionFeature::ReferenceSpaceTypeLocalFloor;
-    if (feature == "bounded-floor"_s)
+    if (equalLettersIgnoringASCIICase(feature, "bounded-floor"_s))
         return SessionFeature::ReferenceSpaceTypeBoundedFloor;
-    if (feature == "unbounded"_s)
+    if (equalLettersIgnoringASCIICase(feature, "unbounded"_s))
         return SessionFeature::ReferenceSpaceTypeUnbounded;
 #if ENABLE(WEBXR_HANDS)
-    if (feature == "hand-tracking"_s)
+    if (equalLettersIgnoringASCIICase(feature, "hand-tracking"_s))
         return SessionFeature::HandTracking;
 #endif
 #if ENABLE(WEBXR_HIT_TEST)
-    if (feature == "hit-test"_s)
+    if (equalLettersIgnoringASCIICase(feature, "hit-test"_s))
         return SessionFeature::HitTest;
 #endif
-    if (feature == "webgpu"_s)
+    if (equalLettersIgnoringASCIICase(feature, "webgpu"_s))
         return SessionFeature::WebGPU;
 #if ENABLE(WEBXR_LAYERS)
-    if (feature == "layers"_s)
+    if (equalLettersIgnoringASCIICase(feature, "layers"_s))
         return SessionFeature::Layers;
 #endif
     return std::nullopt;


### PR DESCRIPTION
#### dd36b8911103d63389820e9459f8329ca1eeb9ed
<pre>
Avoid using convertToASCIILowercase() for comparisons
<a href="https://bugs.webkit.org/show_bug.cgi?id=310865">https://bugs.webkit.org/show_bug.cgi?id=310865</a>

Reviewed by Philippe Normand.

Avoid needless string allocations.

Canonical link: <a href="https://commits.webkit.org/310067@main">https://commits.webkit.org/310067@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee94ae9e424060ca0d96423d1b180d256512b4a6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152594 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25376 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18975 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161339 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106051 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dcdd8089-fbbc-4475-b01b-c642042518a4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154468 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25904 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25682 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117914 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bffe188d-1724-4f39-8259-b732b2334ad9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155554 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20139 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136995 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98627 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ef056747-c79f-4f5d-a898-e500a755c407) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19214 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17154 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9173 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128864 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14869 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163810 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6949 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16463 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125972 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25174 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21193 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126133 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25176 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136665 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81778 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23385 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21105 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13444 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24792 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89078 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24484 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24643 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24544 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->