### PR TITLE
macOS: Wheel events with no backing platform event can't start a swipe

### DIFF
--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -636,6 +636,7 @@ UIProcess/mac/DisplayLinkMac.cpp
 UIProcess/mac/PageClientImplMac.mm @nonARC
 UIProcess/mac/SecItemShimProxy.cpp
 UIProcess/mac/ServicesController.mm @nonARC
+UIProcess/mac/SwipeProgressTrackerMac.mm @nonARC
 UIProcess/mac/TextCheckerMac.mm @nonARC
 UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.mm @nonARC
 UIProcess/mac/ViewGestureControllerMac.mm @nonARC

--- a/Source/WebKit/UIProcess/ViewGestureController.cpp
+++ b/Source/WebKit/UIProcess/ViewGestureController.cpp
@@ -53,6 +53,10 @@
 #include "ViewGestureGeometryCollectorMessages.h"
 #endif
 
+#if PLATFORM(MAC)
+#include "SwipeProgressTrackerMac.h"
+#endif
+
 // FIXME: https://bugs.webkit.org/show_bug.cgi?id=306415
 #include "WebKit-Swift.h"
 
@@ -98,6 +102,8 @@ ViewGestureController::ViewGestureController(WebPageProxy& webPageProxy)
 {
     if (webPageProxy.hasRunningProcess())
         connectToProcess();
+
+    platformInitialize();
 
     viewGestureControllersForAllPages().add(m_webPageProxyIdentifier, *this);
 }
@@ -146,6 +152,14 @@ ViewGestureController* ViewGestureController::controllerForGesture(WebPageProxyI
     if (gestureControllerIter->value->m_currentGestureID != gestureID)
         return nullptr;
     return gestureControllerIter->value.ptr();
+}
+
+ViewGestureController* ViewGestureController::controllerForPage(WebPageProxyIdentifier pageID)
+{
+    auto it = viewGestureControllersForAllPages().find(pageID);
+    if (it == viewGestureControllersForAllPages().end())
+        return nullptr;
+    return it->value.ptr();
 }
 
 #if PLATFORM(COCOA)
@@ -496,7 +510,10 @@ bool ViewGestureController::PendingSwipeTracker::scrollEventCanBecomeSwipe(Platf
 
     FloatSize size = scrollEventGetScrollingDeltas(event);
 
-    if (deltaShouldCancelSwipe(size))
+    if (auto shouldCancel = protect(m_viewGestureController)->platformEventShouldCancelSwipe(event, size)) {
+        if (*shouldCancel)
+            return false;
+    } else if (deltaShouldCancelSwipe(size))
         return false;
 
     Ref page = m_webPageProxy.get();
@@ -859,5 +876,14 @@ double ViewGestureController::magnification() const
 }
 
 #endif // !PLATFORM(IOS_FAMILY)
+
+#if !PLATFORM(COCOA)
+
+std::optional<bool> ViewGestureController::platformEventShouldCancelSwipe(PlatformScrollEvent, FloatSize)
+{
+    return std::nullopt;
+}
+
+#endif
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/ViewGestureController.h
+++ b/Source/WebKit/UIProcess/ViewGestureController.h
@@ -98,6 +98,7 @@ typedef void* PlatformScrollEvent;
 
 namespace WebKit {
 
+class SwipeProgressTracker;
 class ViewSnapshot;
 class WebBackForwardList;
 #if ENABLE(BACK_FORWARD_LIST_SWIFT)
@@ -117,11 +118,13 @@ public:
     static constexpr double defaultMaxMagnification { 3 };
 
     static Ref<ViewGestureController> create(WebPageProxy&);
+    static ViewGestureController* NODELETE controllerForPage(WebPageProxyIdentifier);
     ~ViewGestureController();
 
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
+    void platformInitialize();
     void platformTeardown();
 
     void disconnectFromProcess();
@@ -167,10 +170,14 @@ public:
     void gestureEventWasNotHandledByWebCore(PlatformMagnificationEvent, WebCore::FloatPoint origin);
 
     void setCustomSwipeViews(Vector<RetainPtr<NSView>> views) { m_customSwipeViews = WTF::move(views); }
+    bool hasCustomSwipeViews() const { return !m_customSwipeViews.isEmpty(); }
+    float customSwipeViewsWidth() const { return m_currentSwipeCustomViewBounds.width(); }
     const WebCore::FloatBoxExtent& customSwipeViewsObscuredContentInsets() const LIFETIME_BOUND { return m_customSwipeViewsObscuredContentInsets; }
     void setCustomSwipeViewsObscuredContentInsets(WebCore::FloatBoxExtent&& insets) { m_customSwipeViewsObscuredContentInsets = WTF::move(insets); }
     WebCore::FloatRect windowRelativeBoundsForCustomSwipeViews() const;
     void setDidMoveSwipeSnapshotCallback(BlockPtr<void (CGRect)>&& callback) { m_didMoveSwipeSnapshotCallback = WTF::move(callback); }
+
+    SwipeProgressTracker* swipeProgressTracker() const { return m_swipeProgressTracker.get(); }
 #elif PLATFORM(IOS_FAMILY)
     bool isNavigationSwipeGestureRecognizer(UIGestureRecognizer *) const;
     void installSwipeHandler(UIView *gestureRecognizerView, UIView *swipingView);
@@ -315,6 +322,8 @@ private:
 
     WebCore::FloatPoint NODELETE scaledMagnificationOrigin(WebCore::FloatPoint origin, double scale);
 
+    std::optional<bool> platformEventShouldCancelSwipe(PlatformScrollEvent, WebCore::FloatSize);
+
     void startSwipeGesture(PlatformScrollEvent, SwipeDirection);
     void trackSwipeGesture(PlatformScrollEvent, SwipeDirection, RefPtr<WebBackForwardListItem>);
 
@@ -442,6 +451,9 @@ private:
     WebCore::FloatRect m_currentSwipeCustomViewBounds;
 
     BlockPtr<void (CGRect)> m_didMoveSwipeSnapshotCallback;
+
+    friend class SwipeProgressTracker;
+    std::unique_ptr<SwipeProgressTracker> m_swipeProgressTracker;
 #elif PLATFORM(IOS_FAMILY)
     WeakObjCPtr<UIView> m_liveSwipeView;
     RetainPtr<UIView> m_liveSwipeViewClippingView;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1478,6 +1478,7 @@ public:
 
     bool NODELETE isProcessingWheelEvents() const;
     void handleNativeWheelEvent(const NativeWebWheelEvent&);
+    void interruptSyntheticMomentumScrolling();
     void continueWheelEventHandling(const WebWheelEvent&, const WebCore::WheelEventHandlingResult&, std::optional<bool> willStartSwipe);
     void wheelEventHandlingCompleted(bool wasHandled);
 

--- a/Source/WebKit/UIProcess/gtk/ViewGestureControllerGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/ViewGestureControllerGtk.cpp
@@ -74,6 +74,10 @@ static bool isEventStop(PlatformGtkScrollData* event)
     return event->isEnd;
 }
 
+void ViewGestureController::platformInitialize()
+{
+}
+
 void ViewGestureController::platformTeardown()
 {
     cancelSwipe();

--- a/Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm
@@ -176,6 +176,10 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 
 namespace WebKit {
 
+void ViewGestureController::platformInitialize()
+{
+}
+
 void ViewGestureController::platformTeardown()
 {
     [m_swipeTransitionContext _setTransitionIsInFlight:NO];

--- a/Source/WebKit/UIProcess/mac/SwipeProgressTrackerMac.h
+++ b/Source/WebKit/UIProcess/mac/SwipeProgressTrackerMac.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(MAC)
+
+#include "DisplayLink.h"
+#include "DisplayLinkObserverID.h"
+#include "ViewGestureController.h"
+#include <WebCore/VelocityData.h>
+
+namespace WebKit {
+
+class WebBackForwardListItem;
+
+class SwipeProgressTracker final : public DisplayLink::Client {
+    WTF_MAKE_TZONE_ALLOCATED(SwipeProgressTracker);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SwipeProgressTracker);
+public:
+    SwipeProgressTracker(WebPageProxy&, ViewGestureController&);
+    ~SwipeProgressTracker();
+
+    void startTracking(RefPtr<WebBackForwardListItem>&&, ViewGestureController::SwipeDirection);
+    void reset();
+    bool handleEvent(PlatformScrollEvent);
+    void animationTimerFired();
+
+private:
+    void displayLinkFired(WebCore::PlatformDisplayID, WebCore::DisplayUpdate, bool, bool) override;
+
+    enum class State : uint8_t {
+        None,
+        Pending,
+        Swiping,
+        Animating,
+        Done
+    };
+
+    double totalSwipeDistance() const;
+    bool shouldCancel();
+    void startAnimation(bool forceCancelled = false);
+    void endAnimation();
+
+    void startDisplayLinkObserver();
+    void stopDisplayLinkObserver();
+
+    State m_state { State::None };
+    ViewGestureController::SwipeDirection m_direction { ViewGestureController::SwipeDirection::Back };
+    RefPtr<WebBackForwardListItem> m_targetItem;
+
+    double m_progress { 0 };
+    double m_averageVelocity { 0 };
+
+    WebCore::HistoricalVelocityData m_velocityData;
+
+    double m_animationStartProgress { 0 };
+    double m_animationEndProgress { 0 };
+    MonotonicTime m_animationStartTime;
+    MonotonicTime m_animationEndTime;
+
+    bool m_cancelled { false };
+
+    std::optional<DisplayLinkObserverID> m_displayLinkObserverID;
+
+    WeakRef<ViewGestureController> m_viewGestureController;
+    WeakRef<WebPageProxy> m_webPageProxy;
+};
+
+} // namespace WebKit
+
+#endif // PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/mac/SwipeProgressTrackerMac.mm
+++ b/Source/WebKit/UIProcess/mac/SwipeProgressTrackerMac.mm
@@ -1,0 +1,269 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "SwipeProgressTrackerMac.h"
+
+#if PLATFORM(MAC)
+
+#import "DisplayLink.h"
+#import "DrawingAreaProxy.h"
+#import "ViewGestureController.h"
+#import "WebBackForwardListItem.h"
+#import "WebPageProxy.h"
+#import "WebProcessPool.h"
+#import <WebCore/AnimationFrameRate.h>
+#import <wtf/TZoneMallocInlines.h>
+
+namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SwipeProgressTracker);
+
+static constexpr Seconds kineticProjectionDuration = 300_ms;
+static constexpr double completionThresholdPoints = 187.5;
+static constexpr double maximumCompletionThresholdRatio = 0.5;
+static constexpr double minimumAnimationVelocity = 3.0;
+static constexpr Seconds minimumAnimationDuration = 100_ms;
+static constexpr Seconds maximumAnimationDuration = 400_ms;
+
+static double easeOutCubic(double t)
+{
+    double p = t - 1;
+    return p * p * p + 1;
+}
+
+SwipeProgressTracker::SwipeProgressTracker(WebPageProxy& webPageProxy, ViewGestureController& viewGestureController)
+    : m_viewGestureController(viewGestureController)
+    , m_webPageProxy(webPageProxy)
+{
+}
+
+SwipeProgressTracker::~SwipeProgressTracker()
+{
+    stopDisplayLinkObserver();
+}
+
+void SwipeProgressTracker::startTracking(RefPtr<WebBackForwardListItem>&& targetItem, ViewGestureController::SwipeDirection direction)
+{
+    if (m_state != State::None)
+        return;
+
+    m_targetItem = WTF::move(targetItem);
+    m_direction = direction;
+    m_state = State::Pending;
+}
+
+void SwipeProgressTracker::reset()
+{
+    stopDisplayLinkObserver();
+
+    m_targetItem = nullptr;
+    m_state = State::None;
+    m_direction = ViewGestureController::SwipeDirection::Back;
+
+    m_progress = 0;
+    m_averageVelocity = 0;
+
+    m_velocityData.clear();
+
+    m_animationStartProgress = 0;
+    m_animationEndProgress = 0;
+    m_animationStartTime = MonotonicTime();
+    m_animationEndTime = MonotonicTime();
+
+    m_cancelled = false;
+}
+
+double SwipeProgressTracker::totalSwipeDistance() const
+{
+    if (m_viewGestureController->hasCustomSwipeViews())
+        return m_viewGestureController->customSwipeViewsWidth();
+
+    RefPtr page = m_webPageProxy.get();
+    if (!page || !page->drawingArea())
+        return 0;
+
+    return page->drawingArea()->size().width();
+}
+
+bool SwipeProgressTracker::handleEvent(PlatformScrollEvent event)
+{
+    Ref viewGestureController = m_viewGestureController.get();
+
+    switch (m_state) {
+    case State::None:
+        return false;
+
+    case State::Pending:
+        viewGestureController->beginSwipeGesture(m_targetItem.get(), m_direction);
+        m_state = State::Swiping;
+        break;
+
+    case State::Swiping:
+        break;
+
+    case State::Animating:
+        stopDisplayLinkObserver();
+        m_cancelled = false;
+        m_state = State::Swiping;
+        break;
+
+    case State::Done:
+        return true;
+    }
+
+    auto phase = event.phase();
+    if (phase == WebWheelEvent::Phase::Ended || phase == WebWheelEvent::Phase::Cancelled) {
+        startAnimation(phase == WebWheelEvent::Phase::Cancelled);
+        return true;
+    }
+
+    double totalDistance = totalSwipeDistance();
+    if (totalDistance <= 0)
+        return true;
+
+    double progressDelta = event.delta().width() / totalDistance;
+    m_progress += progressDelta;
+
+    auto velocityData = m_velocityData.velocityForNewData(WebCore::FloatPoint(m_progress, 0), 1.0, MonotonicTime::now());
+    m_averageVelocity = velocityData.horizontalVelocity;
+
+    bool swipingLeft = viewGestureController->isPhysicallySwipingLeft(m_direction);
+    double maxProgress = swipingLeft ? 1 : 0;
+    double minProgress = !swipingLeft ? -1 : 0;
+    m_progress = std::clamp(m_progress, minProgress, maxProgress);
+
+    viewGestureController->handleSwipeGesture(m_targetItem.get(), m_progress, m_direction);
+    return true;
+}
+
+bool SwipeProgressTracker::shouldCancel()
+{
+    double totalDistance = totalSwipeDistance();
+    if (totalDistance <= 0)
+        return true;
+
+    bool swipingLeft = protect(m_viewGestureController)->isPhysicallySwipingLeft(m_direction);
+    double effectiveVelocity = m_averageVelocity * (swipingLeft ? 1 : -1);
+    double projectedProgress = std::abs(m_progress) + effectiveVelocity * kineticProjectionDuration.seconds();
+    double threshold = std::min(completionThresholdPoints / totalDistance, maximumCompletionThresholdRatio);
+    return projectedProgress < threshold;
+}
+
+void SwipeProgressTracker::startAnimation(bool forceCancelled)
+{
+    Ref viewGestureController = m_viewGestureController.get();
+
+    m_cancelled = forceCancelled || shouldCancel();
+
+    m_state = State::Animating;
+    viewGestureController->willEndSwipeGesture(*protect(m_targetItem), m_cancelled);
+
+    m_animationStartProgress = m_progress;
+    if (m_cancelled)
+        m_animationEndProgress = 0;
+    else
+        m_animationEndProgress = viewGestureController->isPhysicallySwipingLeft(m_direction) ? 1 : -1;
+
+    double animationVelocity = minimumAnimationVelocity;
+    if ((m_animationEndProgress - m_animationStartProgress) * m_averageVelocity > 0)
+        animationVelocity = std::max(std::abs(m_averageVelocity), minimumAnimationVelocity);
+
+    double distance = std::abs(m_animationEndProgress - m_animationStartProgress);
+    Seconds duration = std::clamp(Seconds(distance / animationVelocity), minimumAnimationDuration, maximumAnimationDuration);
+
+    m_animationStartTime = MonotonicTime::now();
+    m_animationEndTime = m_animationStartTime + duration;
+
+    startDisplayLinkObserver();
+}
+
+void SwipeProgressTracker::animationTimerFired()
+{
+    if (m_state != State::Animating)
+        return;
+    ASSERT(m_animationEndTime > m_animationStartTime);
+
+    auto now = MonotonicTime::now();
+    double animationProgress = std::min((now - m_animationStartTime) / (m_animationEndTime - m_animationStartTime), 1.0);
+
+    m_progress = m_animationStartProgress + (m_animationEndProgress - m_animationStartProgress) * easeOutCubic(animationProgress);
+
+    protect(m_viewGestureController)->handleSwipeGesture(m_targetItem.get(), m_progress, m_direction);
+
+    if (now >= m_animationEndTime)
+        endAnimation();
+}
+
+void SwipeProgressTracker::endAnimation()
+{
+    stopDisplayLinkObserver();
+    m_state = State::Done;
+    protect(m_viewGestureController)->endSwipeGesture(m_targetItem.get(), m_cancelled);
+}
+
+void SwipeProgressTracker::displayLinkFired(WebCore::PlatformDisplayID, WebCore::DisplayUpdate, bool, bool)
+{
+    RefPtr page = m_webPageProxy.get();
+    if (!page)
+        return;
+
+    RunLoop::mainSingleton().dispatch([pageID = page->identifier()]() {
+        RefPtr controller = ViewGestureController::controllerForPage(pageID);
+        if (controller && controller->swipeProgressTracker())
+            protect(*controller->swipeProgressTracker())->animationTimerFired();
+    });
+}
+
+void SwipeProgressTracker::startDisplayLinkObserver()
+{
+    RefPtr page = m_webPageProxy.get();
+    if (!page)
+        return;
+
+    m_displayLinkObserverID = DisplayLinkObserverID::generate();
+    auto displayID = page->displayID().value_or(0);
+    page->configuration().processPool().displayLinks().startDisplayLink(*this, *m_displayLinkObserverID, displayID, WebCore::FullSpeedFramesPerSecond);
+}
+
+void SwipeProgressTracker::stopDisplayLinkObserver()
+{
+    if (!m_displayLinkObserverID)
+        return;
+
+    RefPtr page = m_webPageProxy.get();
+    if (!page) {
+        m_displayLinkObserverID = std::nullopt;
+        return;
+    }
+
+    auto displayID = page->displayID().value_or(0);
+    page->configuration().processPool().displayLinks().stopDisplayLink(*this, *m_displayLinkObserverID, displayID);
+    m_displayLinkObserverID = std::nullopt;
+}
+
+} // namespace WebKit
+
+#endif // PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
+++ b/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
@@ -40,6 +40,7 @@
 #import "Logging.h"
 #import "NativeWebWheelEvent.h"
 #import "ProvisionalPageProxy.h"
+#import "SwipeProgressTrackerMac.h"
 #import "ViewGestureControllerMessages.h"
 #import "ViewGestureGeometryCollectorMessages.h"
 #import "ViewSnapshotStore.h"
@@ -83,8 +84,18 @@ static const CGFloat swipeOverlayShadowWidth = 81;
 namespace WebKit {
 using namespace WebCore;
 
+void ViewGestureController::platformInitialize()
+{
+    RefPtr page = m_webPageProxy.get();
+    if (page)
+        m_swipeProgressTracker = makeUnique<SwipeProgressTracker>(*page, *this);
+}
+
 void ViewGestureController::platformTeardown()
 {
+    if (m_swipeProgressTracker)
+        protect(*m_swipeProgressTracker)->reset();
+
     if (m_swipeCancellationTracker)
         [m_swipeCancellationTracker setIsCancelled:YES];
 
@@ -256,7 +267,7 @@ void ViewGestureController::didCollectGeometryForSmartMagnificationGesture(Float
 
 bool ViewGestureController::PendingSwipeTracker::scrollEventCanStartSwipe(NativeWebWheelEvent event)
 {
-    return event.phase() == WebWheelEvent::Phase::Began && event.nativeEvent();
+    return event.phase() == WebWheelEvent::Phase::Began;
 }
 
 bool ViewGestureController::PendingSwipeTracker::scrollEventCanEndSwipe(NativeWebWheelEvent event)
@@ -276,6 +287,8 @@ FloatSize ViewGestureController::PendingSwipeTracker::scrollEventGetScrollingDel
 
 bool ViewGestureController::handleScrollWheelEvent(NativeWebWheelEvent event)
 {
+    if (m_swipeProgressTracker && protect(*m_swipeProgressTracker)->handleEvent(event))
+        return true;
     if (m_activeGestureType != ViewGestureType::None)
         return false;
     return m_pendingSwipeTracker.handleEvent(event);
@@ -283,34 +296,40 @@ bool ViewGestureController::handleScrollWheelEvent(NativeWebWheelEvent event)
 
 void ViewGestureController::trackSwipeGesture(PlatformScrollEvent event, SwipeDirection direction, RefPtr<WebBackForwardListItem> targetItem)
 {
-    BOOL swipingLeft = isPhysicallySwipingLeft(direction);
-    CGFloat maxProgress = swipingLeft ? 1 : 0;
-    CGFloat minProgress = !swipingLeft ? -1 : 0;
-
-    __block bool swipeCancelled = false;
-
     ASSERT(!m_swipeCancellationTracker);
     RetainPtr<WKSwipeCancellationTracker> swipeCancellationTracker = adoptNS([[WKSwipeCancellationTracker alloc] init]);
     m_swipeCancellationTracker = swipeCancellationTracker;
 
-    BEGIN_BLOCK_OBJC_EXCEPTIONS
-    [protect(event.nativeEvent()) trackSwipeEventWithOptions:NSEventSwipeTrackingConsumeMouseEvents dampenAmountThresholdMin:minProgress max:maxProgress usingHandler:^(CGFloat progress, NSEventPhase phase, BOOL isComplete, BOOL *stop) {
-        if ([swipeCancellationTracker isCancelled]) {
-            *stop = YES;
-            return;
-        }
-        if (phase == NSEventPhaseBegan)
-            this->beginSwipeGesture(targetItem.get(), direction);
-        CGFloat clampedProgress = std::min(std::max(progress, minProgress), maxProgress);
-        this->handleSwipeGesture(targetItem.get(), clampedProgress, direction);
-        if (phase == NSEventPhaseCancelled)
-            swipeCancelled = true;
-        if (phase == NSEventPhaseEnded || phase == NSEventPhaseCancelled)
-            this->willEndSwipeGesture(*targetItem, swipeCancelled);
-        if (isComplete)
-            this->endSwipeGesture(targetItem.get(), swipeCancelled);
-    }];
-    END_BLOCK_OBJC_EXCEPTIONS
+    if (event.nativeEvent()) {
+        BOOL swipingLeft = isPhysicallySwipingLeft(direction);
+        CGFloat maxProgress = swipingLeft ? 1 : 0;
+        CGFloat minProgress = !swipingLeft ? -1 : 0;
+
+        __block bool swipeCancelled = false;
+
+        BEGIN_BLOCK_OBJC_EXCEPTIONS
+        [protect(event.nativeEvent()) trackSwipeEventWithOptions:NSEventSwipeTrackingConsumeMouseEvents dampenAmountThresholdMin:minProgress max:maxProgress usingHandler:^(CGFloat progress, NSEventPhase phase, BOOL isComplete, BOOL *stop) {
+            if ([swipeCancellationTracker isCancelled]) {
+                *stop = YES;
+                return;
+            }
+            if (phase == NSEventPhaseBegan)
+                this->beginSwipeGesture(targetItem.get(), direction);
+            CGFloat clampedProgress = std::min(std::max(progress, minProgress), maxProgress);
+            this->handleSwipeGesture(targetItem.get(), clampedProgress, direction);
+            if (phase == NSEventPhaseCancelled)
+                swipeCancelled = true;
+            if (phase == NSEventPhaseEnded || phase == NSEventPhaseCancelled)
+                this->willEndSwipeGesture(*targetItem, swipeCancelled);
+            if (isComplete)
+                this->endSwipeGesture(targetItem.get(), swipeCancelled);
+        }];
+        END_BLOCK_OBJC_EXCEPTIONS
+    } else {
+        CheckedRef tracker = *m_swipeProgressTracker;
+        tracker->startTracking(WTF::move(targetItem), direction);
+        tracker->handleEvent(event);
+    }
 }
 
 FloatRect ViewGestureController::windowRelativeBoundsForCustomSwipeViews() const
@@ -398,6 +417,21 @@ void ViewGestureController::applyDebuggingPropertiesToSwipeViews()
     [m_swipeSnapshotLayer setBackgroundColor:RetainPtr { [NSColor greenColor].CGColor }.get()];
     [m_swipeSnapshotLayer setBorderColor:RetainPtr { [NSColor redColor].CGColor }.get()];
     [m_swipeSnapshotLayer setBorderWidth:2];
+}
+
+std::optional<bool> ViewGestureController::platformEventShouldCancelSwipe(PlatformScrollEvent event, FloatSize delta)
+{
+    static constexpr float minimumHorizontalSwipeDistance = 50;
+    static constexpr float minVerticalSwipeHysteresis = 10;
+    static constexpr float maxVerticalSwipeHysteresis = 25;
+
+    if (!event.nativeEvent()) {
+        static constexpr float verticalSwipeTolerance = (minimumHorizontalSwipeDistance - minVerticalSwipeHysteresis) / maxVerticalSwipeHysteresis;
+        float yBoundary = std::min(maxVerticalSwipeHysteresis, std::abs(verticalSwipeTolerance * delta.width()) + minVerticalSwipeHysteresis);
+        return std::abs(delta.height()) >= yBoundary;
+    }
+
+    return std::nullopt;
 }
 
 void ViewGestureController::beginSwipeGesture(WebBackForwardListItem* targetItem, SwipeDirection direction)
@@ -628,6 +662,14 @@ void ViewGestureController::removeSwipeSnapshot()
 
 void ViewGestureController::resetState()
 {
+    if (m_activeGestureType == ViewGestureType::Swipe) {
+        if (RefPtr page = m_webPageProxy.get())
+            page->interruptSyntheticMomentumScrolling();
+    }
+
+    if (m_swipeProgressTracker)
+        protect(*m_swipeProgressTracker)->reset();
+
     if (RefPtr currentSwipeSnapshot = m_currentSwipeSnapshot)
         currentSwipeSnapshot->setVolatile(true);
     m_currentSwipeSnapshot = nullptr;

--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
@@ -806,27 +806,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     if (!page)
         return;
 
-    auto timestamp = MonotonicTime::now();
-
-    WebKit::WebWheelEvent cancelEvent {
-        { WebKit::WebEventType::Wheel, { }, timestamp, WTF::UUID::createVersion4() },
-        WebCore::IntPoint { },
-        WebCore::IntPoint { },
-        WebCore::FloatSize { },
-        WebCore::FloatSize { },
-        WebKit::WebWheelEvent::Granularity::ScrollByPixelWheelEvent,
-        false,
-        WebKit::WebWheelEvent::Phase::Cancelled,
-        WebKit::WebWheelEvent::Phase::None,
-        true,
-        1,
-        WebCore::FloatSize { },
-        timestamp,
-        std::nullopt,
-        WebKit::WebWheelEvent::MomentumEndType::Interrupted
-    };
-
-    page->handleNativeWheelEvent(WebKit::NativeWebWheelEvent { cancelEvent });
+    page->interruptSyntheticMomentumScrolling();
     WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(page->logIdentifier(), "Interrupted momentum scrolling");
 }
 

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -38,6 +38,7 @@
 #import "MenuUtilities.h"
 #import "MessageSenderInlines.h"
 #import "NativeWebKeyboardEvent.h"
+#import "NativeWebWheelEvent.h"
 #import "NetworkProcessMessages.h"
 #import "PDFContextMenu.h"
 #import "PageClient.h"
@@ -80,6 +81,7 @@
 #import <wtf/FileHandle.h>
 #import <wtf/FileSystem.h>
 #import <wtf/ProcessPrivilege.h>
+#import <wtf/UUID.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #import <wtf/cocoa/SpanCocoa.h>
 #import <wtf/text/cf/StringConcatenateCF.h>
@@ -1146,6 +1148,29 @@ void WebPageProxy::platformUnlockPointer()
 }
 
 #endif
+
+void WebPageProxy::interruptSyntheticMomentumScrolling()
+{
+    auto timestamp = MonotonicTime::now();
+    WebWheelEvent cancelEvent {
+        { WebEventType::Wheel, { }, timestamp, WTF::UUID::createVersion4() },
+        WebCore::IntPoint { },
+        WebCore::IntPoint { },
+        WebCore::FloatSize { },
+        WebCore::FloatSize { },
+        WebWheelEvent::Granularity::ScrollByPixelWheelEvent,
+        false,
+        WebWheelEvent::Phase::Cancelled,
+        WebWheelEvent::Phase::None,
+        true,
+        1,
+        WebCore::FloatSize { },
+        timestamp,
+        std::nullopt,
+        WebWheelEvent::MomentumEndType::Interrupted
+    };
+    handleNativeWheelEvent(NativeWebWheelEvent { cancelEvent });
+}
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -673,6 +673,7 @@
 		2BBCCE242EB2B3F500FE7E5A /* RemotePageScreenOrientationManagerProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 2BBCCE232EB2B3F500FE7E5A /* RemotePageScreenOrientationManagerProxy.h */; };
 		2D0C56FD229F1DEA00BD33E7 /* DeviceManagementSoftLink.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D0C56FB229F1DEA00BD33E7 /* DeviceManagementSoftLink.h */; };
 		2D0C56FE229F1DEA00BD33E7 /* DeviceManagementSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2D0C56FC229F1DEA00BD33E7 /* DeviceManagementSoftLink.mm */; };
+		2D0FD45E2F75127900B1A53C /* SwipeProgressTrackerMac.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D0FD45C2F75126800B1A53C /* SwipeProgressTrackerMac.h */; };
 		2D1087611D2C573E00B85F82 /* LoadParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D10875F1D2C573E00B85F82 /* LoadParameters.h */; };
 		2D11B7512126A282006F8878 /* UnifiedSource1-nonARC.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2D7DEC9421269E4C00B9F73C /* UnifiedSource1-nonARC.mm */; };
 		2D11B7532126A282006F8878 /* UnifiedSource2-nonARC.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2D7DEC0321269E4B00B9F73C /* UnifiedSource2-nonARC.mm */; };
@@ -4848,6 +4849,8 @@
 		2D0C56FC229F1DEA00BD33E7 /* DeviceManagementSoftLink.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = DeviceManagementSoftLink.mm; sourceTree = "<group>"; };
 		2D0CF64B21F2A80300787566 /* TextCheckingController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TextCheckingController.mm; sourceTree = "<group>"; };
 		2D0CF64C21F2A80300787566 /* TextCheckingController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TextCheckingController.h; sourceTree = "<group>"; };
+		2D0FD45C2F75126800B1A53C /* SwipeProgressTrackerMac.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SwipeProgressTrackerMac.h; sourceTree = "<group>"; };
+		2D0FD45D2F75126800B1A53C /* SwipeProgressTrackerMac.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SwipeProgressTrackerMac.mm; sourceTree = "<group>"; };
 		2D10875F1D2C573E00B85F82 /* LoadParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LoadParameters.h; sourceTree = "<group>"; };
 		2D1087621D2C641B00B85F82 /* LoadParametersCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = LoadParametersCocoa.mm; sourceTree = "<group>"; };
 		2D125C5C1857EA05003BA3CB /* ViewGestureController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ViewGestureController.h; sourceTree = "<group>"; };
@@ -16881,6 +16884,8 @@
 				E18E690D169B57DF009B6670 /* SecItemShimProxy.messages.in */,
 				514D9F5519119D35000063A7 /* ServicesController.h */,
 				514D9F5619119D35000063A7 /* ServicesController.mm */,
+				2D0FD45C2F75126800B1A53C /* SwipeProgressTrackerMac.h */,
+				2D0FD45D2F75126800B1A53C /* SwipeProgressTrackerMac.mm */,
 				1AA417ED12C00D87002BE67B /* TextCheckerMac.mm */,
 				1AF05D8514688348008B1E81 /* TiledCoreAnimationDrawingAreaProxy.h */,
 				1AF05D8414688348008B1E81 /* TiledCoreAnimationDrawingAreaProxy.mm */,
@@ -18661,6 +18666,7 @@
 				296BD85D15019BC30071F424 /* StringUtilities.h in Headers */,
 				57FD318622B3516C008D0E8B /* SubFrameSOAuthorizationSession.h in Headers */,
 				5C7E075A2DF0596B00C61A6C /* SwiftDemoLogoConfirmation.h in Headers */,
+				2D0FD45E2F75127900B1A53C /* SwipeProgressTrackerMac.h in Headers */,
 				448AC24E267135A700B28921 /* SynapseSPI.h in Headers */,
 				4459984222833E8700E61373 /* SyntheticEditingCommandType.h in Headers */,
 				3157135F2040A9B20084F9CF /* SystemPreviewController.h in Headers */,


### PR DESCRIPTION
#### fd843afddf6f891ee6c2d287b7c6a6b4ab44762d
<pre>
macOS: Wheel events with no backing platform event can&apos;t start a swipe
<a href="https://bugs.webkit.org/show_bug.cgi?id=310869">https://bugs.webkit.org/show_bug.cgi?id=310869</a>
<a href="https://rdar.apple.com/171300135">rdar://171300135</a>

Reviewed by Richard Robinson, Aditya Keerthi, and Abrar Rahman Protyasha.

Wheel events that have no backing platform event can&apos;t make use of AppKit&apos;s
&quot;trackSwipeWithEvent&quot; method, and thus need a different path to make swiping work.
Take matters into our own hands with a custom (and async) swipe tracker and animator.

* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/ViewGestureController.cpp:
(WebKit::ViewGestureController::ViewGestureController):
(WebKit::ViewGestureController::controllerForPage):
(WebKit::ViewGestureController::PendingSwipeTracker::scrollEventCanBecomeSwipe):
(WebKit::ViewGestureController::platformEventShouldCancelSwipe):
Allow the platform implementations to override `deltaShouldCancelSwipe` with richer
information from the platform event. If they decide not to, fall back to the existing behavior.

* Source/WebKit/UIProcess/ViewGestureController.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/gtk/ViewGestureControllerGtk.cpp:
(WebKit::ViewGestureController::platformInitialize):
* Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm:
(WebKit::ViewGestureController::platformInitialize):
* Source/WebKit/UIProcess/mac/SwipeProgressTrackerMac.h: Added.
* Source/WebKit/UIProcess/mac/SwipeProgressTrackerMac.mm: Added.
Emulate &quot;trackSwipeWithEvent&quot; behavior.

(WebKit::easeOutCubic):
(WebKit::SwipeProgressTracker::SwipeProgressTracker):
(WebKit::SwipeProgressTracker::~SwipeProgressTracker):
(WebKit::SwipeProgressTracker::startTracking):
(WebKit::SwipeProgressTracker::reset):
(WebKit::SwipeProgressTracker::totalSwipeDistance const):
(WebKit::SwipeProgressTracker::handleEvent):
As events come in, progress through the m_state state machine. &quot;Swiping&quot; is the
fingers-down phase, and may result in either cancellation or completion of the swipe,
both of which usually (unless swiped all the way in one direction or the other)
progress to a snap animation (in either direction).

(WebKit::SwipeProgressTracker::shouldCancel):
Decide whether or not the swipe should be cancelled based on the current velocity
estimation and some thresholding.

(WebKit::SwipeProgressTracker::startAnimation):
(WebKit::SwipeProgressTracker::animationTimerFired):
(WebKit::SwipeProgressTracker::endAnimation):
(WebKit::SwipeProgressTracker::displayLinkFired):
(WebKit::SwipeProgressTracker::startDisplayLinkObserver):
(WebKit::SwipeProgressTracker::stopDisplayLinkObserver):
Implement the snap animation with a custom display link at full display framerate.

* Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm:
(WebKit::ViewGestureController::platformInitialize):
(WebKit::ViewGestureController::platformTeardown):
(WebKit::ViewGestureController::PendingSwipeTracker::scrollEventCanStartSwipe):
(WebKit::ViewGestureController::handleScrollWheelEvent):
(WebKit::ViewGestureController::trackSwipeGesture):
For now, decide whether to use the existing implementation or not based on the existence
of an underlying platform event.

(WebKit::ViewGestureController::platformEventShouldCancelSwipe):
(WebKit::ViewGestureController::resetState):
Interrupt any ongoing MomentumEventDispatcher-driven momentum scrolling when cancelling a swipe,
so that a hard swipe doesn&apos;t result in the page scrolling from synthetic momentum events
after the swipe completes. trackSwipeWithEvent handles this for us normally, but
not in the new path.

* Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm:
(-[WKAppKitGestureController interruptMomentumIfNeeded]):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::interruptSyntheticMomentumScrolling):
Factor this interruption code out of one existing caller.

* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/310189@main">https://commits.webkit.org/310189@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4cc9612277386ddcf066aba02fc345690107414

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153071 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25853 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19451 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161815 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106529 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f33309d4-3096-4d7c-aae9-05c0db0826ab) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26380 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26158 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118314 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7453f4fa-9a50-4acf-9178-9f6361af68e4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156030 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20551 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137417 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99027 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/14b3ab4a-9dad-44e1-a4e5-9111a0c1b93d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19625 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17565 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9651 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129278 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164289 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7425 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16884 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126377 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25650 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21604 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126535 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34316 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25652 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137086 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82294 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21486 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13865 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25268 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89555 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24961 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25119 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25020 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->