### PR TITLE
[JSC] DFG AI should set SpecStringResolved for StringAt

### DIFF
--- a/JSTests/microbenchmarks/string-at-char-code-at.js
+++ b/JSTests/microbenchmarks/string-at-char-code-at.js
@@ -1,0 +1,16 @@
+function test(str, n) {
+    var sum = 0;
+    for (var i = 0; i < n; ++i) {
+        var idx = (i * 0x9E3779B9 >>> 0) % str.length;
+        var c = str.at(idx);
+        sum += c.charCodeAt(0);
+    }
+    return sum;
+}
+noInline(test);
+
+var str = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+var result = test(str, 5000000);
+if (result !== 433632023)
+    throw "Error: bad result: " + result;

--- a/JSTests/stress/string-at-resolved-type.js
+++ b/JSTests/stress/string-at-resolved-type.js
@@ -1,0 +1,47 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+function testInBounds(string) {
+    var sum = 0;
+    for (var i = 0; i < string.length; ++i) {
+        var c = string.at(i);
+        sum += c.charCodeAt(0);
+    }
+    return sum;
+}
+noInline(testInBounds);
+
+function testNegative(string) {
+    var sum = 0;
+    for (var i = 1; i <= string.length; ++i) {
+        var c = string.at(-i);
+        sum += c.charCodeAt(0);
+    }
+    return sum;
+}
+noInline(testNegative);
+
+function testOutOfBounds(string) {
+    var sum = 0;
+    for (var i = 0; i < string.length * 2; ++i) {
+        var c = string.at(i);
+        if (c !== undefined)
+            sum += c.charCodeAt(0);
+    }
+    return sum;
+}
+noInline(testOutOfBounds);
+
+var str8bit = "Hello, World!";
+var str16bit = "こんにちは世界";
+
+for (var i = 0; i < testLoopCount; ++i) {
+    shouldBe(testInBounds(str8bit), 1129);
+    shouldBe(testNegative(str8bit), 1129);
+    shouldBe(testOutOfBounds(str8bit), 1129);
+    shouldBe(testInBounds(str16bit), 112003);
+    shouldBe(testNegative(str16bit), 112003);
+    shouldBe(testOutOfBounds(str16bit), 112003);
+}

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -2724,9 +2724,9 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
 
     case StringAt: {
         if (node->arrayMode().isOutOfBounds())
-            setTypeForNode(node, SpecString | SpecOther);
+            setTypeForNode(node, SpecStringResolved | SpecOther);
         else
-            setTypeForNode(node, SpecString);
+            setTypeForNode(node, SpecStringResolved);
         break;
     }
 


### PR DESCRIPTION
#### 1e7c2211fd71233af1fcc312a85dd608dacb1c65
<pre>
[JSC] DFG AI should set SpecStringResolved for StringAt
<a href="https://bugs.webkit.org/show_bug.cgi?id=310870">https://bugs.webkit.org/show_bug.cgi?id=310870</a>

Reviewed by Keith Miller.

StringAt always produces a single-character string from
vm.smallStrings.singleCharacterStrings() or jsSingleCharacterString(),
which is never a rope. However, DFG AbstractInterpreter was setting
SpecString instead of SpecStringResolved, causing unnecessary ResolveRope
nodes to be inserted when the result is consumed by subsequent string
operations. StringCharAt already correctly uses SpecStringResolved.

                               baseline                  patched

string-at-char-code-at     22.6820+-0.4127     ^     18.6003+-0.3451        ^ definitely 1.2194x faster

Tests: JSTests/microbenchmarks/string-at-char-code-at.js
       JSTests/stress/string-at-resolved-type.js

* JSTests/microbenchmarks/string-at-char-code-at.js: Added.
(test):
* JSTests/stress/string-at-resolved-type.js: Added.
(shouldBe):
(testInBounds):
(testNegative):
(testOutOfBounds):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):

Canonical link: <a href="https://commits.webkit.org/310077@main">https://commits.webkit.org/310077@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b54998515ed508139d2e0b5cb4cf887b7b126ef4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152600 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25382 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18981 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161345 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106057 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25910 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25688 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117917 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155560 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20142 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137000 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98630 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19217 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17160 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9179 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144612 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128867 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14874 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163816 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13405 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6955 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16468 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125973 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25180 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21199 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126134 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34229 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25182 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136670 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81785 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21109 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13449 "Too many flaky failures: http/tests/media/clearkey/clear-key-hls-aes128.html, http/tests/misc/referrer.html, http/tests/navigation/process-swap-on-client-side-redirect-private.html, http/tests/resourceLoadStatistics/log-delayed-client-side-redirects.html, http/tests/security/canvas-cors-with-two-hosts.html, http/tests/security/contentSecurityPolicy/1.1/stylehash-multiple-policies.html, http/tests/security/contentSecurityPolicy/navigate-self-to-data-url.html, http/tests/site-isolation/frame-index.html, http/tests/storageAccess/deny-storage-access-under-opener-ephemeral.html, http/tests/websocket/tests/hybi/fragmented-control-frame.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184232 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24798 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89084 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47030 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24490 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24649 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24550 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->