### PR TITLE
Deque's implementation truncates `size_t` to `unsigned` in a few places

### DIFF
--- a/Source/WTF/wtf/Deque.h
+++ b/Source/WTF/wtf/Deque.h
@@ -214,7 +214,7 @@ public:
     Iterator& operator--() { Base::decrement(); return *this; }
     // postfix -- intentionally omitted
 
-    // Only forwarding + unsigned is supported.
+    // Only forwarding + size_t is supported.
     Iterator& operator+=(size_t count) { Base::increment(count); return *this; }
     Iterator operator+(size_t count) const { Iterator result(*this); result += count; return result; }
 };
@@ -252,7 +252,7 @@ public:
     Iterator& operator--() { Base::decrement(); return *this; }
     // postfix -- intentionally omitted
 
-    // Only forwarding + unsigned is supported.
+    // Only forwarding + size_t is supported.
     Iterator& operator+=(size_t count) { Base::increment(count); return *this; }
     Iterator operator+(size_t count) const { Iterator result(*this); result += count; return result; }
 };
@@ -612,8 +612,8 @@ template<typename T, size_t inlineCapacity>
 template<std::predicate<T&> Predicate>
 inline T Deque<T, inlineCapacity>::takeFirst(NOESCAPE const Predicate& predicate)
 {
-    unsigned count = 0;
-    unsigned size = this->size();
+    size_t count = 0;
+    size_t size = this->size();
     while (count < size) {
         T candidate = takeFirst();
         if (predicate(candidate)) {
@@ -621,7 +621,7 @@ inline T Deque<T, inlineCapacity>::takeFirst(NOESCAPE const Predicate& predicate
                 prepend(takeLast());
             return candidate;
         }
-        count++;
+        ++count;
         append(WTF::move(candidate));
     }
     return T();
@@ -631,8 +631,8 @@ template<typename T, size_t inlineCapacity>
 template<std::predicate<T&> Predicate>
 inline T Deque<T, inlineCapacity>::takeLast(NOESCAPE const Predicate& predicate)
 {
-    unsigned count = 0;
-    unsigned size = this->size();
+    size_t count = 0;
+    size_t size = this->size();
     while (count < size) {
         T candidate = takeLast();
         if (predicate(candidate)) {
@@ -640,7 +640,7 @@ inline T Deque<T, inlineCapacity>::takeLast(NOESCAPE const Predicate& predicate)
                 append(takeFirst());
             return candidate;
         }
-        count++;
+        ++count;
         prepend(WTF::move(candidate));
     }
     return T();


### PR DESCRIPTION
#### 7e3461d081151a5b9b6fa8c019e65939bcd95a47
<pre>
Deque&apos;s implementation truncates `size_t` to `unsigned` in a few places
<a href="https://bugs.webkit.org/show_bug.cgi?id=310873">https://bugs.webkit.org/show_bug.cgi?id=310873</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/Deque.h:

Canonical link: <a href="https://commits.webkit.org/310082@main">https://commits.webkit.org/310082@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b181c0636ba94e22c319fb5ad0e3be1425476580

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152608 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25390 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18989 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161353 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106065 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f167a78a-bc2f-4abb-988c-5a11ccb4b2ef) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25918 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25696 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117924 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/38df331b-f6f3-4096-a403-d393d2748add) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155568 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20153 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137007 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98637 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e1566b06-5a97-45b2-9778-f29107f97c1b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19228 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17166 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9187 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144620 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128878 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14881 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163824 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13413 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6963 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16475 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125984 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25188 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21205 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126145 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34235 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25190 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136677 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81793 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21117 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13456 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184241 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24806 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89092 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47034 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24498 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24657 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24558 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->