### PR TITLE
[threaded-animations] REGRESSION: animating to an implicit value for individual transform properties fails to animate

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/rotate-explicit-and-implicit-keyframes-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/rotate-explicit-and-implicit-keyframes-expected.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+div {
+    width: 100px;
+    height: 100px;
+    margin: 10px;
+    background-color: black;
+    rotate: 90deg;
+}
+
+div:after {
+    position: absolute;
+    content: "";
+    width: 50px;
+    height: 50px;
+    background-color: gray;
+}
+
+#unspecifed-to {
+    rotate: 270deg;
+}
+
+</style>
+</head>
+<body>
+
+<div id="explicit-from-and-to"></div>
+<div id="unspecifed-from"></div>
+<div id="base-value-from"></div>
+<div id="unspecifed-to"></div>
+<div id="base-value-to"></div>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/rotate-explicit-and-implicit-keyframes-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/rotate-explicit-and-implicit-keyframes-ref.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+div {
+    width: 100px;
+    height: 100px;
+    margin: 10px;
+    background-color: black;
+    rotate: 90deg;
+}
+
+div:after {
+    position: absolute;
+    content: "";
+    width: 50px;
+    height: 50px;
+    background-color: gray;
+}
+
+#unspecifed-to {
+    rotate: 270deg;
+}
+
+</style>
+</head>
+<body>
+
+<div id="explicit-from-and-to"></div>
+<div id="unspecifed-from"></div>
+<div id="base-value-from"></div>
+<div id="unspecifed-to"></div>
+<div id="base-value-to"></div>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/rotate-explicit-and-implicit-keyframes.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/rotate-explicit-and-implicit-keyframes.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<title>Animating the "rotate" property with explicit and implicit keyframes</title>
+<link rel="help" href="https://drafts.csswg.org/css-transforms/">
+<link rel="match" href="rotate-explicit-and-implicit-keyframes-ref.html">
+<script src="../../../common/reftest-wait.js"></script>
+<style>
+
+div {
+    width: 100px;
+    height: 100px;
+    margin: 10px;
+    background-color: black;
+    animation: none 100000s -25000s linear forwards;
+}
+
+div:after {
+    position: absolute;
+    content: "";
+    width: 50px;
+    height: 50px;
+    background-color: gray;
+}
+
+@keyframes explicit-from-and-to {
+    from { rotate: 80deg }
+    to   { rotate: 120deg}
+}
+
+@keyframes unspecified-from {
+    to { rotate: 360deg }
+}
+
+@keyframes base-value-from {
+    to { rotate: 120deg }
+}
+
+@keyframes unspecified-to {
+    from { rotate: 360deg }
+}
+
+@keyframes base-value-to {
+    from { rotate: 80deg }
+}
+
+#explicit-from-and-to {
+    animation-name: explicit-from-and-to;
+}
+
+#unspecifed-from {
+    animation-name: unspecified-from;
+}
+
+#base-value-from {
+    rotate: 80deg;
+    animation-name: base-value-from;
+}
+
+#unspecifed-to {
+    animation-name: unspecified-to;
+}
+
+#base-value-to {
+    rotate: 120deg;
+    animation-name: base-value-to;
+}
+
+</style>
+</head>
+<body>
+
+<div id="explicit-from-and-to"></div>
+<div id="unspecifed-from"></div>
+<div id="base-value-from"></div>
+<div id="unspecifed-to"></div>
+<div id="base-value-to"></div>
+
+<script>
+(async function() {
+    await Promise.all(document.getAnimations().map(animation => animation.ready));
+    await new Promise(requestAnimationFrame);
+    await new Promise(requestAnimationFrame);
+    takeScreenshot();
+})();
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/scale-explicit-and-implicit-keyframes-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/scale-explicit-and-implicit-keyframes-expected.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+div {
+    width: 100px;
+    height: 100px;
+    margin: 10px;
+    background-color: black;
+}
+
+#explicit-from-and-to {
+    scale: 0.3;
+}
+
+#unspecifed-from {
+    scale: 0.8;
+}
+
+#base-value-from {
+    scale: 0.5;
+}
+
+#unspecifed-to {
+    scale: 0.4;
+}
+
+#base-value-to {
+    scale: 0.3;
+}
+
+</style>
+</head>
+<body>
+
+<div id="explicit-from-and-to"></div>
+<div id="unspecifed-from"></div>
+<div id="base-value-from"></div>
+<div id="unspecifed-to"></div>
+<div id="base-value-to"></div>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/scale-explicit-and-implicit-keyframes-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/scale-explicit-and-implicit-keyframes-ref.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+div {
+    width: 100px;
+    height: 100px;
+    margin: 10px;
+    background-color: black;
+}
+
+#explicit-from-and-to {
+    scale: 0.3;
+}
+
+#unspecifed-from {
+    scale: 0.8;
+}
+
+#base-value-from {
+    scale: 0.5;
+}
+
+#unspecifed-to {
+    scale: 0.4;
+}
+
+#base-value-to {
+    scale: 0.3;
+}
+
+</style>
+</head>
+<body>
+
+<div id="explicit-from-and-to"></div>
+<div id="unspecifed-from"></div>
+<div id="base-value-from"></div>
+<div id="unspecifed-to"></div>
+<div id="base-value-to"></div>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/scale-explicit-and-implicit-keyframes.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/scale-explicit-and-implicit-keyframes.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<title>Animating the "scale" property with explicit and implicit keyframes</title>
+<link rel="help" href="https://drafts.csswg.org/css-transforms/">
+<link rel="match" href="scale-explicit-and-implicit-keyframes-ref.html">
+<script src="../../../common/reftest-wait.js"></script>
+<style>
+
+div {
+    width: 100px;
+    height: 100px;
+    margin: 10px;
+    background-color: black;
+    animation: none 100000s -25000s linear forwards;
+}
+
+@keyframes explicit-from-and-to {
+    from { scale: 0.1 }
+    to   { scale: 0.9 }
+}
+
+@keyframes implicit-from {
+    to { scale: 0.2 }
+}
+
+@keyframes implicit-to {
+    from { scale: 0.2 }
+}
+
+#explicit-from-and-to {
+    animation-name: explicit-from-and-to;
+}
+
+#unspecifed-from {
+    animation-name: implicit-from;
+}
+
+#base-value-from {
+    scale: 0.6;
+    animation-name: implicit-from;
+}
+
+#unspecifed-to {
+    animation-name: implicit-to;
+}
+
+#base-value-to {
+    scale: 0.6;
+    animation-name: implicit-to;
+}
+
+</style>
+</head>
+<body>
+
+<div id="explicit-from-and-to"></div>
+<div id="unspecifed-from"></div>
+<div id="base-value-from"></div>
+<div id="unspecifed-to"></div>
+<div id="base-value-to"></div>
+
+<script>
+(async function() {
+    await Promise.all(document.getAnimations().map(animation => animation.ready));
+    await new Promise(requestAnimationFrame);
+    await new Promise(requestAnimationFrame);
+    takeScreenshot();
+})();
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/translate-explicit-and-implicit-keyframes-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/translate-explicit-and-implicit-keyframes-expected.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+div {
+    width: 100px;
+    height: 100px;
+    margin: 10px;
+    background-color: black;
+}
+
+#explicit-from-and-to {
+    translate: 125px;
+}
+
+#unspecifed-from {
+    translate: 50px;
+}
+
+#base-value-from {
+    translate: 125px;
+}
+
+#unspecifed-to {
+    translate: 150px;
+}
+
+#base-value-to {
+    translate: 175px;
+}
+
+</style>
+</head>
+<body>
+
+<div id="explicit-from-and-to"></div>
+<div id="unspecifed-from"></div>
+<div id="base-value-from"></div>
+<div id="unspecifed-to"></div>
+<div id="base-value-to"></div>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/translate-explicit-and-implicit-keyframes-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/translate-explicit-and-implicit-keyframes-ref.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+div {
+    width: 100px;
+    height: 100px;
+    margin: 10px;
+    background-color: black;
+}
+
+#explicit-from-and-to {
+    translate: 125px;
+}
+
+#unspecifed-from {
+    translate: 50px;
+}
+
+#base-value-from {
+    translate: 125px;
+}
+
+#unspecifed-to {
+    translate: 150px;
+}
+
+#base-value-to {
+    translate: 175px;
+}
+
+</style>
+</head>
+<body>
+
+<div id="explicit-from-and-to"></div>
+<div id="unspecifed-from"></div>
+<div id="base-value-from"></div>
+<div id="unspecifed-to"></div>
+<div id="base-value-to"></div>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/translate-explicit-and-implicit-keyframes.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/translate-explicit-and-implicit-keyframes.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<title>Animating the "translate" property with explicit and implicit keyframes</title>
+<link rel="help" href="https://drafts.csswg.org/css-transforms/">
+<link rel="match" href="translate-explicit-and-implicit-keyframes-ref.html">
+<script src="../../../common/reftest-wait.js"></script>
+<style>
+
+div {
+    width: 100px;
+    height: 100px;
+    margin: 10px;
+    background-color: black;
+    animation: none 100000s -25000s linear forwards;
+}
+
+@keyframes explicit-from-and-to {
+    from { translate: 100px }
+    to   { translate: 200px }
+}
+
+@keyframes implicit-from {
+    to { translate: 200px }
+}
+
+@keyframes implicit-to {
+    from { translate: 200px }
+}
+
+#explicit-from-and-to {
+    animation-name: explicit-from-and-to;
+}
+
+#unspecifed-from {
+    animation-name: implicit-from;
+}
+
+#base-value-from {
+    translate: 100px;
+    animation-name: implicit-from;
+}
+
+#unspecifed-to {
+    animation-name: implicit-to;
+}
+
+#base-value-to {
+    translate: 100px;
+    animation-name: implicit-to;
+}
+
+</style>
+</head>
+<body>
+
+<div id="explicit-from-and-to"></div>
+<div id="unspecifed-from"></div>
+<div id="base-value-from"></div>
+<div id="unspecifed-to"></div>
+<div id="base-value-to"></div>
+
+<script>
+(async function() {
+    await Promise.all(document.getAnimations().map(animation => animation.ready));
+    await new Promise(requestAnimationFrame);
+    await new Promise(requestAnimationFrame);
+    takeScreenshot();
+})();
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1331,6 +1331,8 @@ webkit.org/b/264579 imported/w3c/web-platform-tests/css/css-transforms/animation
 webkit.org/b/264579 imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-rotate.html [ ImageOnlyFailure ]
 webkit.org/b/264579 imported/w3c/web-platform-tests/css/css-transforms/transform-3d-rotateY-stair-above-001.xht [ ImageOnlyFailure ]
 
+imported/w3c/web-platform-tests/css/css-transforms/animation/rotate-explicit-and-implicit-keyframes.html [ ImageOnlyFailure ]
+
 imported/w3c/web-platform-tests/css/css-images/gradient/conic-gradient-001.html [ ImageOnlyFailure ]
 
 webkit.org/b/215799 imported/w3c/web-platform-tests/css/css-content/quotes-018.html [ ImageOnlyFailure ]

--- a/Source/WebCore/platform/animation/AcceleratedEffect.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.cpp
@@ -334,6 +334,23 @@ AcceleratedEffect::AcceleratedEffect(const AcceleratedEffect& source, OptionSet<
     }
 }
 
+static RefPtr<TransformOperation> blend(const RefPtr<TransformOperation>& base, const RefPtr<TransformOperation>& from, const RefPtr<TransformOperation>& to, const BlendingContext& blendingContext, NOESCAPE const Function<Ref<TransformOperation>(const TransformOperation&)>& identity)
+{
+    if (to) {
+        // Explicit "from" and "to" values.
+        if (from)
+            return to->blend(from.get(), blendingContext);
+        // Implicit "from" value.
+        return to->blend(base.get(), blendingContext);
+    }
+
+    // Implicit "to" value.
+    ASSERT(from);
+    if (base)
+        return base->blend(from.get(), blendingContext);
+    return identity(*from)->blend(from.get(), blendingContext);
+}
+
 static void blend(AcceleratedEffectProperty property, AcceleratedEffectValues& output, const AcceleratedEffectValues& from, const AcceleratedEffectValues& to, BlendingContext& blendingContext)
 {
     switch (property) {
@@ -344,16 +361,19 @@ static void blend(AcceleratedEffectProperty property, AcceleratedEffectValues& o
         output.transform = blend(from.transform, to.transform, blendingContext);
         break;
     case AcceleratedEffectProperty::Translate:
-        if (auto& toTranslate = to.translate)
-            output.translate = toTranslate->blend(from.translate.get(), blendingContext);
+        output.translate = blend(output.translate, from.translate, to.translate, blendingContext, [](auto& translate) {
+            return TranslateTransformOperation::create(0.0f, 0.0f, 0.0f, translate.type());
+        });
         break;
     case AcceleratedEffectProperty::Rotate:
-        if (auto& toRotate = to.rotate)
-            output.rotate = toRotate->blend(from.rotate.get(), blendingContext);
+        output.rotate = blend(output.rotate, from.rotate, to.rotate, blendingContext, [](auto& rotate) {
+            return RotateTransformOperation::create(0, rotate.type());
+        });
         break;
     case AcceleratedEffectProperty::Scale:
-        if (auto& toScale = to.scale)
-            output.scale = toScale->blend(from.scale.get(), blendingContext);
+        output.scale = blend(output.scale, from.scale, to.scale, blendingContext, [](auto& scale) {
+            return ScaleTransformOperation::create(1, 1, 1, scale.type());
+        });
         break;
     case AcceleratedEffectProperty::OffsetAnchor:
         if (!canBlend(from.offsetAnchor, to.offsetAnchor)) {

--- a/Source/WebCore/platform/graphics/transforms/TransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/TransformOperation.h
@@ -61,7 +61,7 @@ enum class TransformOperationType : uint8_t {
     None
 };
 
-class TransformOperation : public RefCounted<TransformOperation> {
+class TransformOperation : public ThreadSafeRefCounted<TransformOperation> {
 public:
     using Type = TransformOperationType;
 


### PR DESCRIPTION
#### 8f4c548a8aaf7ea0d57c6ab7a69c73339b67bcc7
<pre>
[threaded-animations] REGRESSION: animating to an implicit value for individual transform properties fails to animate
<a href="https://bugs.webkit.org/show_bug.cgi?id=310874">https://bugs.webkit.org/show_bug.cgi?id=310874</a>
<a href="https://rdar.apple.com/173487467">rdar://173487467</a>

Reviewed by Simon Fraser.

The `AcceleratedEffect` blending code would only work if we had an explicit &quot;to&quot; value for a given keyframe interval,
but animations may omit those so that they would work with the underlying value. We now account for all three cases:

1. explicit &quot;from&quot; and &quot;to&quot; values,
2. implicit &quot;from&quot; value,
3. implicit &quot;to&quot; value.

For the cases where we have implicit values, we also account for the case where the &quot;to&quot; value can&apos;t be read from
an absent base value and we fall back to the identity transform for the given property.

Running those new tests in repetition also brought to light an issue where we hit the &quot;Unsafe to ref/deref from
different threads&quot; assertion, so we make `TransformOperation` use `ThreadSafeRefCounted`.

Tests: imported/w3c/web-platform-tests/css/css-transforms/animation/rotate-explicit-and-implicit-keyframes.html
       imported/w3c/web-platform-tests/css/css-transforms/animation/scale-explicit-and-implicit-keyframes.html
       imported/w3c/web-platform-tests/css/css-transforms/animation/translate-explicit-and-implicit-keyframes.html

* LayoutTests/webanimations/threaded-animations/blending/blending-test.js: Added.
* LayoutTests/webanimations/threaded-animations/blending/rotate-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/blending/rotate.html: Added.
* LayoutTests/webanimations/threaded-animations/blending/scale-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/blending/scale.html: Added.
* LayoutTests/webanimations/threaded-animations/blending/translate-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/blending/translate.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
(WebCore::blend):
* Source/WebCore/platform/graphics/transforms/TransformOperation.h:

Canonical link: <a href="https://commits.webkit.org/310146@main">https://commits.webkit.org/310146@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/442a77df2fe2bedcc70087a49cc21ec2d3edd4a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152754 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25535 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19134 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161498 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106210 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bc515737-c589-4a3a-aa84-c0ba7afc98c9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154627 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26063 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25841 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118040 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83607 "4 flakes 2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155713 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20278 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137136 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98753 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b3a72249-5159-410f-a5b1-9ec4b4b687cf) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19353 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17287 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9334 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129005 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15010 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163970 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7108 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16604 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126102 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25333 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21326 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126260 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25335 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136806 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Running apply-patch; Checked out pull request; Passed layout tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81939 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23412 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21217 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13585 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24951 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89238 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24643 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24802 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24703 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->