### PR TITLE
Optimize Deque::takeFirst(predicate) and takeLast(predicate)

### DIFF
--- a/Source/WTF/wtf/Deque.h
+++ b/Source/WTF/wtf/Deque.h
@@ -613,38 +613,26 @@ template<typename T, size_t inlineCapacity>
 template<std::predicate<T&> Predicate>
 inline T Deque<T, inlineCapacity>::takeFirst(NOESCAPE const Predicate& predicate)
 {
-    size_t count = 0;
-    size_t size = this->size();
-    while (count < size) {
-        T candidate = takeFirst();
-        if (predicate(candidate)) {
-            while (count--)
-                prepend(takeLast());
-            return candidate;
-        }
-        ++count;
-        append(WTF::move(candidate));
-    }
-    return T();
+    auto it = findIf(predicate);
+    if (it == end())
+        return T();
+    T result = WTF::move(*it);
+    remove(it);
+    return result;
 }
 
 template<typename T, size_t inlineCapacity>
 template<std::predicate<T&> Predicate>
 inline T Deque<T, inlineCapacity>::takeLast(NOESCAPE const Predicate& predicate)
 {
-    size_t count = 0;
-    size_t size = this->size();
-    while (count < size) {
-        T candidate = takeLast();
-        if (predicate(candidate)) {
-            while (count--)
-                append(takeFirst());
-            return candidate;
-        }
-        ++count;
-        prepend(WTF::move(candidate));
-    }
-    return T();
+    auto reverseIt = std::find_if(rbegin(), rend(), predicate);
+    if (reverseIt == rend())
+        return T();
+    T result = WTF::move(*reverseIt);
+    // Convert reverse iterator to forward iterator pointing to the same element.
+    auto it = std::prev(reverseIt.base());
+    remove(it);
+    return result;
 }
 
 #ifdef NDEBUG

--- a/Tools/TestWebKitAPI/Tests/WTF/Deque.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Deque.cpp
@@ -368,4 +368,182 @@ TEST(WTF_Deque, RemoveFirstMatching)
     EXPECT_EQ(4u, deque.size());
 }
 
+TEST(WTF_Deque, TakeFirstWithPredicate)
+{
+    Deque<int> deque = { 1, 2, 3, 4, 5 };
+
+    // Take the first even number.
+    int result = deque.takeFirst([](int value) { return !(value % 2); });
+    EXPECT_EQ(2, result);
+    EXPECT_EQ(4u, deque.size());
+
+    // Verify remaining elements and order.
+    auto it = deque.begin();
+    EXPECT_EQ(1, *it); ++it;
+    EXPECT_EQ(3, *it); ++it;
+    EXPECT_EQ(4, *it); ++it;
+    EXPECT_EQ(5, *it); ++it;
+    EXPECT_TRUE(it == deque.end());
+}
+
+TEST(WTF_Deque, TakeFirstWithPredicateNoMatch)
+{
+    Deque<int> deque = { 1, 3, 5 };
+
+    int result = deque.takeFirst([](int value) { return !(value % 2); });
+    EXPECT_EQ(0, result);
+    EXPECT_EQ(3u, deque.size());
+
+    // Verify elements are unchanged.
+    auto it = deque.begin();
+    EXPECT_EQ(1, *it); ++it;
+    EXPECT_EQ(3, *it); ++it;
+    EXPECT_EQ(5, *it); ++it;
+    EXPECT_TRUE(it == deque.end());
+}
+
+TEST(WTF_Deque, TakeFirstWithPredicateFirstElement)
+{
+    Deque<int> deque = { 10, 1, 2, 3 };
+
+    int result = deque.takeFirst([](int value) { return value == 10; });
+    EXPECT_EQ(10, result);
+    EXPECT_EQ(3u, deque.size());
+    EXPECT_EQ(1, deque.first());
+}
+
+TEST(WTF_Deque, TakeFirstWithPredicateLastElement)
+{
+    Deque<int> deque = { 1, 2, 3, 10 };
+
+    int result = deque.takeFirst([](int value) { return value == 10; });
+    EXPECT_EQ(10, result);
+    EXPECT_EQ(3u, deque.size());
+    EXPECT_EQ(3, deque.last());
+}
+
+TEST(WTF_Deque, TakeFirstWithPredicateSingleElement)
+{
+    Deque<int> deque = { 42 };
+
+    int result = deque.takeFirst([](int value) { return value == 42; });
+    EXPECT_EQ(42, result);
+    EXPECT_TRUE(deque.isEmpty());
+}
+
+TEST(WTF_Deque, TakeLastWithPredicate)
+{
+    Deque<int> deque = { 1, 2, 3, 4, 5 };
+
+    // Take the last even number (should be 4, not 2).
+    int result = deque.takeLast([](int value) { return !(value % 2); });
+    EXPECT_EQ(4, result);
+    EXPECT_EQ(4u, deque.size());
+
+    // Verify remaining elements and order.
+    auto it = deque.begin();
+    EXPECT_EQ(1, *it); ++it;
+    EXPECT_EQ(2, *it); ++it;
+    EXPECT_EQ(3, *it); ++it;
+    EXPECT_EQ(5, *it); ++it;
+    EXPECT_TRUE(it == deque.end());
+}
+
+TEST(WTF_Deque, TakeLastWithPredicateNoMatch)
+{
+    Deque<int> deque = { 1, 3, 5 };
+
+    int result = deque.takeLast([](int value) { return !(value % 2); });
+    EXPECT_EQ(0, result);
+    EXPECT_EQ(3u, deque.size());
+
+    // Verify elements are unchanged.
+    auto it = deque.begin();
+    EXPECT_EQ(1, *it); ++it;
+    EXPECT_EQ(3, *it); ++it;
+    EXPECT_EQ(5, *it); ++it;
+    EXPECT_TRUE(it == deque.end());
+}
+
+TEST(WTF_Deque, TakeLastWithPredicateLastElement)
+{
+    Deque<int> deque = { 1, 2, 3, 10 };
+
+    int result = deque.takeLast([](int value) { return value == 10; });
+    EXPECT_EQ(10, result);
+    EXPECT_EQ(3u, deque.size());
+    EXPECT_EQ(3, deque.last());
+}
+
+TEST(WTF_Deque, TakeLastWithPredicateFirstElement)
+{
+    Deque<int> deque = { 10, 1, 2, 3 };
+
+    int result = deque.takeLast([](int value) { return value == 10; });
+    EXPECT_EQ(10, result);
+    EXPECT_EQ(3u, deque.size());
+    EXPECT_EQ(1, deque.first());
+}
+
+TEST(WTF_Deque, TakeFirstWithPredicateWrappedBuffer)
+{
+    Deque<int> deque;
+
+    // Force wrap-around: append then remove from front to advance m_start.
+    for (int i = 0; i < 14; ++i)
+        deque.append(i);
+    for (int i = 0; i < 12; ++i)
+        deque.removeFirst();
+    // Now m_start is advanced. Add more so elements wrap around.
+    for (int i = 14; i < 26; ++i)
+        deque.append(i);
+
+    // Deque contains [12, 13, 14, ..., 25] = 14 elements, wrapping around.
+    EXPECT_EQ(14u, deque.size());
+
+    // Take the first element matching > 20 (should be 21, not 12).
+    int result = deque.takeFirst([](int value) { return value == 21; });
+    EXPECT_EQ(21, result);
+    EXPECT_EQ(13u, deque.size());
+
+    // Verify order is preserved.
+    int expected = 12;
+    for (auto& element : deque) {
+        EXPECT_EQ(expected, element);
+        expected++;
+        if (expected == 21)
+            expected = 22; // 21 was removed
+    }
+}
+
+TEST(WTF_Deque, TakeLastWithPredicateWrappedBuffer)
+{
+    Deque<int> deque;
+
+    // Force wrap-around.
+    for (int i = 0; i < 14; ++i)
+        deque.append(i);
+    for (int i = 0; i < 12; ++i)
+        deque.removeFirst();
+    for (int i = 14; i < 26; ++i)
+        deque.append(i);
+
+    // Deque contains [12, 13, 14, ..., 25] = 14 elements, wrapping around.
+    EXPECT_EQ(14u, deque.size());
+
+    // Take the last even number (should be 24).
+    int result = deque.takeLast([](int value) { return !(value % 2); });
+    EXPECT_EQ(24, result);
+    EXPECT_EQ(13u, deque.size());
+
+    // Verify order is preserved.
+    int expected = 12;
+    for (auto& element : deque) {
+        EXPECT_EQ(expected, element);
+        expected++;
+        if (expected == 24)
+            expected = 25; // 24 was removed
+    }
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### b24e9a4a55b5f96f91532375e98c36d7f879794a
<pre>
Optimize Deque::takeFirst(predicate) and takeLast(predicate)
<a href="https://bugs.webkit.org/show_bug.cgi?id=310877">https://bugs.webkit.org/show_bug.cgi?id=310877</a>

Reviewed by Darin Adler.

The old implementation cycled elements through the deque: it would
`takeFirst/takeLast` each element, check the predicate, and `append/prepend`
non-matching elements to the opposite end. When a match was found at
position k, this required 2k+1 move-constructions (k to cycle past
non-matching elements, plus k more to unwind them back to their original
positions).

Replace this with `findIf` (or `std::find_if` with reverse iterators for
takeLast) to locate the matching element with zero moves, then a single
move to extract the result, followed by `remove(iterator)` to close the
gap. This reduces the total moves from O(2k) to O(min(k, n-k)), the cost
of `remove(iterator)` shifting the shorter side of the buffer.

Test: Tools/TestWebKitAPI/Tests/WTF/Deque.cpp

* Source/WTF/wtf/Deque.h:
* Tools/TestWebKitAPI/Tests/WTF/Deque.cpp:
(TestWebKitAPI::TEST(WTF_Deque, TakeFirstWithPredicate)):
(TestWebKitAPI::TEST(WTF_Deque, TakeFirstWithPredicateNoMatch)):
(TestWebKitAPI::TEST(WTF_Deque, TakeFirstWithPredicateFirstElement)):
(TestWebKitAPI::TEST(WTF_Deque, TakeFirstWithPredicateLastElement)):
(TestWebKitAPI::TEST(WTF_Deque, TakeFirstWithPredicateSingleElement)):
(TestWebKitAPI::TEST(WTF_Deque, TakeLastWithPredicate)):
(TestWebKitAPI::TEST(WTF_Deque, TakeLastWithPredicateNoMatch)):
(TestWebKitAPI::TEST(WTF_Deque, TakeLastWithPredicateLastElement)):
(TestWebKitAPI::TEST(WTF_Deque, TakeLastWithPredicateFirstElement)):
(TestWebKitAPI::TEST(WTF_Deque, TakeFirstWithPredicateWrappedBuffer)):
(TestWebKitAPI::TEST(WTF_Deque, TakeLastWithPredicateWrappedBuffer)):

Canonical link: <a href="https://commits.webkit.org/310141@main">https://commits.webkit.org/310141@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f3c2aeef9445e2435f66c15cac8eb2fe4b6256d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152803 "25 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25584 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19183 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161547 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/65ac2e8a-c4b1-4d61-8cc0-97da844299a8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154676 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26112 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25890 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118084 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155762 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20313 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137177 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98797 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19388 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9383 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144815 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129040 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15051 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164020 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13612 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7157 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16645 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126154 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25382 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21366 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126312 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34275 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25384 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136847 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81988 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21258 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13626 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184435 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25000 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89287 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47081 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24692 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24851 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24752 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->