### PR TITLE
[JSC] Reduce size of Wasm GC objects by dropping m_rtt

### DIFF
--- a/JSTests/stress/wasm-gc-structureid-cast-optimization.js
+++ b/JSTests/stress/wasm-gc-structureid-cast-optimization.js
@@ -1,0 +1,381 @@
+// Tests for WasmRefTypeCheckValue with StructureID-based type checking.
+// Exercises B3 ReduceStrength's replaceWithNullTrapping and ValueKey encoding
+// for 2-child WasmRefTypeCheckValue nodes.
+
+function uleb128(value) {
+    const result = [];
+    do {
+        let byte = value & 0x7f;
+        value >>>= 7;
+        if (value !== 0) byte |= 0x80;
+        result.push(byte);
+    } while (value !== 0);
+    return result;
+}
+
+function sleb128(value) {
+    const result = [];
+    let more = true;
+    while (more) {
+        let byte = value & 0x7f;
+        value >>= 7;
+        if ((value === 0 && (byte & 0x40) === 0) ||
+            (value === -1 && (byte & 0x40) !== 0)) {
+            more = false;
+        } else {
+            byte |= 0x80;
+        }
+        result.push(byte);
+    }
+    return result;
+}
+
+function encodeSection(id, contents) {
+    return [id, ...uleb128(contents.length), ...contents];
+}
+
+function encodeString(str) {
+    const bytes = [];
+    for (let i = 0; i < str.length; i++) bytes.push(str.charCodeAt(i));
+    return [...uleb128(bytes.length), ...bytes];
+}
+
+const WASM_MAGIC = [0x00, 0x61, 0x73, 0x6d];
+const WASM_VERSION = [0x01, 0x00, 0x00, 0x00];
+
+const SEC_TYPE = 1;
+const SEC_FUNCTION = 3;
+const SEC_EXPORT = 7;
+const SEC_CODE = 10;
+
+const TYPE_I32 = 0x7f;
+const TYPE_I64 = 0x7e;
+const TYPE_FUNCTYPE = 0x60;
+const TYPE_STRUCT = 0x5f;
+const TYPE_SUB = 0x50;
+const TYPE_SUB_FINAL = 0x4f;
+const TYPE_REC = 0x4e;
+const REF_NULL = 0x6c;
+const REF = 0x6b;
+const FIELD_MUTABLE = 0x01;
+
+const GC_PREFIX = 0xfb;
+const GC_STRUCT_NEW = 0x00;
+const GC_STRUCT_GET = 0x02;
+const GC_REF_TEST = 0x14;
+const GC_REF_TEST_NULL = 0x15;
+const GC_REF_CAST = 0x16;
+const GC_REF_CAST_NULL = 0x17;
+
+const OP_END = 0x0b;
+const OP_LOCAL_GET = 0x20;
+const OP_LOCAL_SET = 0x21;
+const OP_I32_CONST = 0x41;
+const OP_I64_CONST = 0x42;
+const OP_I32_ADD = 0x6a;
+const OP_IF = 0x04;
+const OP_ELSE = 0x05;
+const OP_BLOCK = 0x02;
+const OP_LOOP = 0x03;
+const OP_BR = 0x0c;
+const OP_BR_IF = 0x0d;
+const OP_I32_LT_S = 0x48;
+const OP_I32_EQZ = 0x45;
+const OP_REF_NULL = 0xd0;
+const OP_DROP = 0x1a;
+const OP_RETURN = 0x0f;
+const OP_REF_IS_NULL = 0xd1;
+const EXPORT_FUNC = 0x00;
+
+function buildModule() {
+    // Type hierarchy:
+    //   type 0: $Base = sub (open) struct { i32 }
+    //   type 1: $Mid  = sub $Base (open) struct { i32, i64 }
+    //   type 2: $Leaf = sub final $Mid struct { i32, i64, i32 }
+    //   type 3: $Final = sub final struct { i32 }  (unrelated final type)
+    //
+    // Function types:
+    //   type 4: (i32) -> (i32)
+    //   type 5: () -> (i32)
+    //   type 6: (i32) -> (i64)
+
+    const typeSectionBody = [
+        0x05,       // 5 entries: 1 rec group + 1 standalone struct + 3 func types
+
+        // Entry 1: rec group with 3 types
+        TYPE_REC,
+        0x03,       // 3 types in rec group
+
+        // Type 0: $Base = sub (open) struct { i32 mutable }
+        TYPE_SUB,
+        0x00,       // 0 supertypes
+        TYPE_STRUCT,
+        0x01,       // 1 field
+        TYPE_I32, FIELD_MUTABLE,
+
+        // Type 1: $Mid = sub $Base (open) struct { i32, i64 }
+        TYPE_SUB,
+        0x01,       // 1 supertype
+        ...uleb128(0),
+        TYPE_STRUCT,
+        0x02,       // 2 fields
+        TYPE_I32, FIELD_MUTABLE,
+        TYPE_I64, FIELD_MUTABLE,
+
+        // Type 2: $Leaf = sub final $Mid struct { i32, i64, i32 }
+        TYPE_SUB_FINAL,
+        0x01,       // 1 supertype
+        ...uleb128(1),
+        TYPE_STRUCT,
+        0x03,       // 3 fields
+        TYPE_I32, FIELD_MUTABLE,
+        TYPE_I64, FIELD_MUTABLE,
+        TYPE_I32, FIELD_MUTABLE,
+
+        // Entry 2: $Final = sub final struct { i32 } (standalone, unrelated final type)
+        TYPE_SUB_FINAL,
+        0x00,       // 0 supertypes
+        TYPE_STRUCT,
+        0x01,
+        TYPE_I32, FIELD_MUTABLE,
+
+        // Entry 3: (i32) -> (i32)
+        TYPE_FUNCTYPE, 0x01, TYPE_I32, 0x01, TYPE_I32,
+
+        // Entry 4: () -> (i32)
+        TYPE_FUNCTYPE, 0x00, 0x01, TYPE_I32,
+
+        // Entry 5: (i32) -> (i64)
+        TYPE_FUNCTYPE, 0x01, TYPE_I32, 0x01, TYPE_I64,
+    ];
+
+    const funcSectionBody = [
+        0x07,       // 7 functions
+        0x04,       // func 0: cast_to_final    type (i32)->i32
+        0x04,       // func 1: cast_to_mid      type (i32)->i32
+        0x04,       // func 2: test_final       type (i32)->i32
+        0x04,       // func 3: test_mid         type (i32)->i32
+        0x04,       // func 4: cast_to_parent   type (i32)->i32
+        0x06,       // func 5: null_cast_get    type (i32)->i64
+        0x05,       // func 6: loop_cast_final  type ()->i32
+    ];
+
+    const exportSectionBody = [
+        0x07,
+        ...encodeString("cast_to_final"),   EXPORT_FUNC, 0x00,
+        ...encodeString("cast_to_mid"),     EXPORT_FUNC, 0x01,
+        ...encodeString("test_final"),      EXPORT_FUNC, 0x02,
+        ...encodeString("test_mid"),        EXPORT_FUNC, 0x03,
+        ...encodeString("cast_to_parent"),  EXPORT_FUNC, 0x04,
+        ...encodeString("null_cast_get"),   EXPORT_FUNC, 0x05,
+        ...encodeString("loop_cast_final"), EXPORT_FUNC, 0x06,
+    ];
+
+    // func 0: cast_to_final(val: i32) -> i32
+    // Create $Leaf, cast to $Leaf (final type => StructureID compare), get field 0
+    const func0Body = [
+        0x00,
+        OP_LOCAL_GET, 0x00,
+        OP_I64_CONST, ...sleb128(100),
+        OP_LOCAL_GET, 0x00,
+        GC_PREFIX, GC_STRUCT_NEW, ...uleb128(2),    // struct.new $Leaf
+        GC_PREFIX, GC_REF_CAST, ...sleb128(2),      // ref.cast (ref $Leaf)
+        GC_PREFIX, GC_STRUCT_GET, ...uleb128(2), ...uleb128(0),  // struct.get $Leaf field 0
+        OP_END,
+    ];
+
+    // func 1: cast_to_mid(val: i32) -> i32
+    // Create $Leaf, cast to $Mid (non-final, shallow hierarchy), get field 0
+    const func1Body = [
+        0x00,
+        OP_LOCAL_GET, 0x00,
+        OP_I64_CONST, ...sleb128(200),
+        OP_LOCAL_GET, 0x00,
+        GC_PREFIX, GC_STRUCT_NEW, ...uleb128(2),    // struct.new $Leaf
+        GC_PREFIX, GC_REF_CAST, ...sleb128(1),      // ref.cast (ref $Mid)
+        GC_PREFIX, GC_STRUCT_GET, ...uleb128(1), ...uleb128(0),  // struct.get $Mid field 0
+        OP_END,
+    ];
+
+    // func 2: test_final(val: i32) -> i32
+    // Create $Leaf, ref.test for $Leaf (final type)
+    const func2Body = [
+        0x00,
+        OP_LOCAL_GET, 0x00,
+        OP_I64_CONST, ...sleb128(300),
+        OP_LOCAL_GET, 0x00,
+        GC_PREFIX, GC_STRUCT_NEW, ...uleb128(2),    // struct.new $Leaf
+        GC_PREFIX, GC_REF_TEST, ...sleb128(2),      // ref.test (ref $Leaf)
+        OP_END,
+    ];
+
+    // func 3: test_mid(val: i32) -> i32
+    // Create $Leaf, ref.test for $Mid (non-final)
+    const func3Body = [
+        0x00,
+        OP_LOCAL_GET, 0x00,
+        OP_I64_CONST, ...sleb128(400),
+        OP_LOCAL_GET, 0x00,
+        GC_PREFIX, GC_STRUCT_NEW, ...uleb128(2),    // struct.new $Leaf
+        GC_PREFIX, GC_REF_TEST, ...sleb128(1),      // ref.test (ref $Mid)
+        OP_END,
+    ];
+
+    // func 4: cast_to_parent(val: i32) -> i32
+    // Create $Leaf, cast to $Base (subtype hierarchy), get field 0
+    const func4Body = [
+        0x00,
+        OP_LOCAL_GET, 0x00,
+        OP_I64_CONST, ...sleb128(500),
+        OP_LOCAL_GET, 0x00,
+        GC_PREFIX, GC_STRUCT_NEW, ...uleb128(2),    // struct.new $Leaf
+        GC_PREFIX, GC_REF_CAST, ...sleb128(0),      // ref.cast (ref $Base)
+        GC_PREFIX, GC_STRUCT_GET, ...uleb128(0), ...uleb128(0),  // struct.get $Base field 0
+        OP_END,
+    ];
+
+    // func 5: null_cast_get(val: i32) -> i64
+    // ref.cast null $Leaf (allowNull) + struct.get => triggers replaceWithNullTrapping in ReduceStrength
+    // Always creates a valid $Leaf, but uses ref.cast null variant
+    const func5Body = [
+        0x00,                               // 0 local declarations
+        OP_LOCAL_GET, 0x00,                 // local.get 0 (val)
+        OP_I64_CONST, ...sleb128(777),
+        OP_I32_CONST, ...sleb128(888),
+        GC_PREFIX, GC_STRUCT_NEW, ...uleb128(2),  // struct.new $Leaf
+        GC_PREFIX, GC_REF_CAST_NULL, ...sleb128(2),  // ref.cast (ref null $Leaf) - allowNull
+        GC_PREFIX, GC_STRUCT_GET, ...uleb128(2), ...uleb128(1),  // struct.get $Leaf field 1
+        OP_END,
+    ];
+
+    // func 6: loop_cast_final() -> i32
+    // Loop doing ref.cast to final type to trigger OMG compilation
+    // 2 locals: i32 counter, i32 sum
+    const func6Body = [
+        0x02,                               // 2 local declarations
+        0x01, TYPE_I32,                     // 1 local of type i32 (counter)
+        0x01, TYPE_I32,                     // 1 local of type i32 (sum)
+        // counter = 0, sum = 0 (already zero-initialized)
+        OP_BLOCK, 0x40,                     // block (void)
+            OP_LOOP, 0x40,                  // loop (void)
+                // Create $Leaf, cast to $Leaf (final), get field 0, add to sum
+                OP_LOCAL_GET, 0x00,         // counter
+                OP_I64_CONST, ...sleb128(0),
+                OP_I32_CONST, ...sleb128(0),
+                GC_PREFIX, GC_STRUCT_NEW, ...uleb128(2),    // struct.new $Leaf
+                GC_PREFIX, GC_REF_CAST, ...sleb128(2),      // ref.cast (ref $Leaf)
+                GC_PREFIX, GC_STRUCT_GET, ...uleb128(2), ...uleb128(0),
+                OP_LOCAL_GET, 0x01,         // sum
+                OP_I32_ADD,
+                OP_LOCAL_SET, 0x01,         // sum += result
+                // counter++
+                OP_LOCAL_GET, 0x00,
+                OP_I32_CONST, ...sleb128(1),
+                OP_I32_ADD,
+                OP_LOCAL_SET, 0x00,
+                // if counter < 100000, continue loop
+                OP_LOCAL_GET, 0x00,
+                OP_I32_CONST, ...sleb128(100000),
+                OP_I32_LT_S,
+                OP_BR_IF, 0x00,             // br_if loop
+            OP_END,                         // end loop
+        OP_END,                             // end block
+        OP_LOCAL_GET, 0x01,                 // return sum
+        OP_END,
+    ];
+
+    function encodeBody(body) {
+        return [...uleb128(body.length), ...body];
+    }
+
+    const codeSectionBody = [
+        0x07,
+        ...encodeBody(func0Body),
+        ...encodeBody(func1Body),
+        ...encodeBody(func2Body),
+        ...encodeBody(func3Body),
+        ...encodeBody(func4Body),
+        ...encodeBody(func5Body),
+        ...encodeBody(func6Body),
+    ];
+
+    const module = [
+        ...WASM_MAGIC,
+        ...WASM_VERSION,
+        ...encodeSection(SEC_TYPE, typeSectionBody),
+        ...encodeSection(SEC_FUNCTION, funcSectionBody),
+        ...encodeSection(SEC_EXPORT, exportSectionBody),
+        ...encodeSection(SEC_CODE, codeSectionBody),
+    ];
+
+    return new Uint8Array(module);
+}
+
+function main() {
+    let bytes;
+    try {
+        bytes = buildModule();
+    } catch (e) {
+        throw new Error("Failed to build module: " + e);
+    }
+
+    let module, instance;
+    try {
+        module = new WebAssembly.Module(bytes);
+        instance = new WebAssembly.Instance(module);
+    } catch (e) {
+        throw new Error("Failed to instantiate module: " + e);
+    }
+
+    const exports = instance.exports;
+
+    // Case A: ref.cast to final type ($Leaf) — StructureID compare path
+    for (let i = 0; i < 200000; i++) {
+        let result = exports.cast_to_final(i);
+        if (result !== i)
+            throw new Error("cast_to_final(" + i + ") returned " + result + ", expected " + i);
+    }
+
+    // Case B: ref.cast to non-final type ($Mid) — inlined display path
+    for (let i = 0; i < 200000; i++) {
+        let result = exports.cast_to_mid(i);
+        if (result !== i)
+            throw new Error("cast_to_mid(" + i + ") returned " + result + ", expected " + i);
+    }
+
+    // Case C: ref.test for final type ($Leaf)
+    for (let i = 0; i < 200000; i++) {
+        let result = exports.test_final(i);
+        if (result !== 1)
+            throw new Error("test_final(" + i + ") returned " + result + ", expected 1");
+    }
+
+    // Case D: ref.test for non-final type ($Mid)
+    for (let i = 0; i < 200000; i++) {
+        let result = exports.test_mid(i);
+        if (result !== 1)
+            throw new Error("test_mid(" + i + ") returned " + result + ", expected 1");
+    }
+
+    // Case E: cast to parent type ($Base) from $Leaf
+    for (let i = 0; i < 200000; i++) {
+        let result = exports.cast_to_parent(i);
+        if (result !== i)
+            throw new Error("cast_to_parent(" + i + ") returned " + result + ", expected " + i);
+    }
+
+    // Case F: null handling — ref.cast null + struct.get triggers replaceWithNullTrapping
+    // The ReduceStrength optimization converts ref.cast(allowNull) + struct.get to ref.cast(!allowNull) + struct.get
+    for (let i = 0; i < 200000; i++) {
+        let result = exports.null_cast_get(i);
+        if (result !== 777n)
+            throw new Error("null_cast_get(" + i + ") returned " + result + ", expected 777n");
+    }
+
+    // Case G: loop with repeated casts to trigger OMG
+    for (let i = 0; i < 10; i++) {
+        exports.loop_cast_final();
+    }
+}
+
+main();

--- a/Source/JavaScriptCore/b3/B3AbstractHeapRepository.h
+++ b/Source/JavaScriptCore/b3/B3AbstractHeapRepository.h
@@ -204,7 +204,6 @@ namespace JSC::B3 {
     macro(WebAssemblyFunctionBase_entrypointLoadLocation, WebAssemblyFunctionBase::offsetOfEntrypointLoadLocation(), Mutability::Immutable) \
     macro(WebAssemblyFunctionBase_rtt, WebAssemblyFunctionBase::offsetOfRTT(), Mutability::Immutable) \
     macro(WebAssemblyFunctionBase_targetInstance, WebAssemblyFunctionBase::offsetOfTargetInstance(), Mutability::Immutable) \
-    macro(WebAssemblyGCObjectBase_rtt, WebAssemblyGCObjectBase::offsetOfRTT(), Mutability::Immutable) \
     macro(WebAssemblyGCStructure_rtt, WebAssemblyGCStructure::offsetOfRTT(), Mutability::Immutable) \
     macro(WebAssemblyModuleRecord_exportsObject, WebAssemblyModuleRecord::offsetOfExportsObject(), Mutability::Mutable) \
     macro(Symbol_symbolImpl, Symbol::offsetOfSymbolImpl(), Mutability::Immutable) \
@@ -230,6 +229,7 @@ namespace JSC::B3 {
     macro(HasOwnPropertyCache, 0, sizeof(HasOwnPropertyCache::Entry)) \
     macro(SmallIntCache, 0, sizeof(NumericStrings::StringWithJSString)) \
     macro(WasmRTT_data, Wasm::RTT::offsetOfData(), sizeof(RefPtr<const Wasm::RTT>)) \
+    macro(WebAssemblyGCStructure_inlinedDisplay, WebAssemblyGCStructure::offsetOfInlinedDisplay(), sizeof(WriteBarrierStructureID)) \
 
 #define FOR_EACH_NUMBERED_ABSTRACT_HEAP(macro) \
     macro(properties) \

--- a/Source/JavaScriptCore/b3/B3LowerMacros.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerMacros.cpp
@@ -836,7 +836,6 @@ private:
                     fastPathContinuation->appendNew<MemoryValue>(m_proc, Store, m_origin, structureID, cell, static_cast<int32_t>(JSCell::structureIDOffset()));
                     fastPathContinuation->appendNew<MemoryValue>(m_proc, Store, m_origin, typeInfo, cell, static_cast<int32_t>(JSCell::indexingTypeAndMiscOffset()));
                     fastPathContinuation->appendNew<MemoryValue>(m_proc, Store, m_origin, fastPathContinuation->appendIntConstant(m_proc, m_origin, pointerType(), 0), cell, static_cast<int32_t>(JSObject::butterflyOffset()));
-                    fastPathContinuation->appendNew<MemoryValue>(m_proc, Store, m_origin, fastPathContinuation->appendIntConstant(m_proc, m_origin, pointerType(), std::bit_cast<uintptr_t>(rtt.ptr())), cell, static_cast<int32_t>(WebAssemblyGCObjectBase::offsetOfRTT()));
 
                     fastUpsilon = fastPathContinuation->appendNew<UpsilonValue>(m_proc, m_origin, cell);
                     fastPathContinuation->appendNew<Value>(m_proc, Jump, m_origin);
@@ -1376,7 +1375,10 @@ private:
 
                     emitCheckOrBranchForCast(castKind, currentBlock->appendNew<Value>(m_proc, NotEqual, m_origin, jsType, constant(Int32, JSType::WebAssemblyGCObjectType)), castFailure, falseBlock);
                 }
-                Value* rtt = currentBlock->appendNew<MemoryValue>(m_proc, B3::Load, pointerType(), m_origin, value, safeCast<int32_t>(WebAssemblyGCObjectBase::offsetOfRTT()));
+                Value* structureID = currentBlock->appendNew<MemoryValue>(m_proc, Load, Int32, m_origin, value, safeCast<int32_t>(JSCell::structureIDOffset()));
+                Value* structure = currentBlock->appendNew<Value>(m_proc, ZExt32, m_origin, structureID);
+                structure = currentBlock->appendNew<Value>(m_proc, BitOr, m_origin, structure, currentBlock->appendIntConstant(m_proc, m_origin, Int64, structureIDBase()));
+                Value* rtt = currentBlock->appendNew<MemoryValue>(m_proc, B3::Load, pointerType(), m_origin, structure, safeCast<int32_t>(WebAssemblyGCStructure::offsetOfRTT()));
                 auto* kind = currentBlock->appendNew<MemoryValue>(m_proc, Load8Z, m_origin, rtt, safeCast<int32_t>(Wasm::RTT::offsetOfKind()));
                 kind->setControlDependent(false);
 
@@ -1402,7 +1404,34 @@ private:
                         emitCheckOrBranchForCast(castKind, currentBlock->appendNew<Value>(m_proc, NotEqual, m_origin, jsType, constant(Int32, JSType::WebAssemblyGCObjectType)), castFailure, falseBlock);
                     }
 
-                    rtt = currentBlock->appendNew<MemoryValue>(m_proc, B3::Load, pointerType(), m_origin, value, safeCast<int32_t>(WebAssemblyGCObjectBase::offsetOfRTT()));
+                    if (typeCheck->hasTargetStructureID()) {
+                        if (targetRTT->isFinalType()) {
+                            Value* objectStructureID = currentBlock->appendNew<MemoryValue>(m_proc, Load, Int32, m_origin, value, safeCast<int32_t>(JSCell::structureIDOffset()));
+                            Value* targetStructureID = typeCheck->targetStructureIDValue();
+                            emitCheckOrBranchForCast(castKind, currentBlock->appendNew<Value>(m_proc, NotEqual, m_origin, objectStructureID, targetStructureID), castFailure, falseBlock);
+                            return;
+                        }
+
+                        if (targetRTT->displaySizeExcludingThis() < WebAssemblyGCStructure::inlinedDisplaySize) {
+                            Value* objectStructureID = currentBlock->appendNew<MemoryValue>(m_proc, Load, Int32, m_origin, value, safeCast<int32_t>(JSCell::structureIDOffset()));
+                            Value* structure = currentBlock->appendNew<Value>(m_proc, ZExt32, m_origin, objectStructureID);
+                            structure = currentBlock->appendNew<Value>(m_proc, BitOr, m_origin, structure, currentBlock->appendIntConstant(m_proc, m_origin, Int64, structureIDBase()));
+                            auto* ancestorStructureID = currentBlock->appendNew<MemoryValue>(m_proc, B3::Load, Int32, m_origin, structure, safeCast<int32_t>(WebAssemblyGCStructure::offsetOfInlinedDisplay() + targetRTT->displaySizeExcludingThis() * sizeof(WriteBarrierStructureID)));
+                            ancestorStructureID->setReadsMutability(B3::Mutability::Immutable);
+                            ancestorStructureID->setControlDependent(false);
+
+                            Value* targetStructureID = typeCheck->targetStructureIDValue();
+                            emitCheckOrBranchForCast(castKind, currentBlock->appendNew<Value>(m_proc, NotEqual, m_origin, ancestorStructureID, targetStructureID), castFailure, falseBlock);
+                            return;
+                        }
+                    }
+
+                    {
+                        Value* structureID = currentBlock->appendNew<MemoryValue>(m_proc, Load, Int32, m_origin, value, safeCast<int32_t>(JSCell::structureIDOffset()));
+                        Value* structure = currentBlock->appendNew<Value>(m_proc, ZExt32, m_origin, structureID);
+                        structure = currentBlock->appendNew<Value>(m_proc, BitOr, m_origin, structure, currentBlock->appendIntConstant(m_proc, m_origin, Int64, structureIDBase()));
+                        rtt = currentBlock->appendNew<MemoryValue>(m_proc, B3::Load, pointerType(), m_origin, structure, safeCast<int32_t>(WebAssemblyGCStructure::offsetOfRTT()));
+                    }
                     if (targetRTT->isFinalType()) {
                         // If signature is final type and pointer equality failed, this value must not be a subtype.
                         emitCheckOrBranchForCast(castKind, currentBlock->appendNew<Value>(m_proc, NotEqual, m_origin, rtt, targetRTTPointer), castFailure, falseBlock);
@@ -1434,10 +1463,12 @@ private:
                     // If signature is final type and pointer equality failed, this value must not be a subtype.
                     emitCheckOrBranchForCast(castKind, constant(Int32, 1), castFailure, falseBlock);
                 } else {
-                    auto* displaySizeExcludingThis = currentBlock->appendNew<MemoryValue>(m_proc, B3::Load, Int32, m_origin, rtt, safeCast<int32_t>(Wasm::RTT::offsetOfDisplaySizeExcludingThis()));
-                    displaySizeExcludingThis->setControlDependent(false);
+                    if (targetRTT->displaySizeExcludingThis() >= Wasm::RTT::inlinedDisplaySize) {
+                        auto* displaySizeExcludingThis = currentBlock->appendNew<MemoryValue>(m_proc, B3::Load, Int32, m_origin, rtt, safeCast<int32_t>(Wasm::RTT::offsetOfDisplaySizeExcludingThis()));
+                        displaySizeExcludingThis->setControlDependent(false);
 
-                    emitCheckOrBranchForCast(castKind, currentBlock->appendNew<Value>(m_proc, BelowEqual, m_origin, displaySizeExcludingThis, constant(Int32, targetRTT->displaySizeExcludingThis())), castFailure, falseBlock);
+                        emitCheckOrBranchForCast(castKind, currentBlock->appendNew<Value>(m_proc, BelowEqual, m_origin, displaySizeExcludingThis, constant(Int32, targetRTT->displaySizeExcludingThis())), castFailure, falseBlock);
+                    }
 
                     auto* pointer = currentBlock->appendNew<MemoryValue>(m_proc, B3::Load, Int64, m_origin, rtt, safeCast<int32_t>(Wasm::RTT::offsetOfData() + targetRTT->displaySizeExcludingThis() * sizeof(RefPtr<const Wasm::RTT>)));
                     pointer->setReadsMutability(B3::Mutability::Immutable);

--- a/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
+++ b/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
@@ -3995,7 +3995,11 @@ private:
             auto replaceWithNullTrapping = [&] {
                 auto flags = cast->flags();
                 flags.remove(WasmRefTypeCheckFlag::AllowNull);
-                SUPPRESS_UNCOUNTED_ARG Value* newValue = m_insertionSet.insert<WasmRefTypeCheckValue>(m_index, trapping(WasmRefCast), Int64, cast->origin(), cast->targetHeapType(), flags, cast->targetRTT(), cast->child(0));
+                SUPPRESS_UNCOUNTED_ARG Value* newValue;
+                if (cast->hasTargetStructureID())
+                    newValue = m_insertionSet.insert<WasmRefTypeCheckValue>(m_index, trapping(WasmRefCast), Int64, cast->origin(), cast->targetHeapType(), flags, cast->targetRTT(), cast->child(0), cast->child(1));
+                else
+                    newValue = m_insertionSet.insert<WasmRefTypeCheckValue>(m_index, trapping(WasmRefCast), Int64, cast->origin(), cast->targetHeapType(), flags, cast->targetRTT(), cast->child(0));
                 replaceWithIdentity(newValue);
             };
 

--- a/Source/JavaScriptCore/b3/B3Validate.cpp
+++ b/Source/JavaScriptCore/b3/B3Validate.cpp
@@ -866,13 +866,13 @@ public:
                 VALIDATE(value->type() == Int64, ("At ", *value)); // returns struct pointer
                 break;
             case WasmRefCast:
-                VALIDATE(value->numChildren() == 1, ("At ", *value));
+                VALIDATE(value->numChildren() == 1 || value->numChildren() == 2, ("At ", *value));
                 VALIDATE(value->child(0)->type() == Int64, ("At ", *value)); // reference input
                 VALIDATE(value->type() == Int64, ("At ", *value)); // returns reference
                 break;
             case WasmRefTest:
                 VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));
-                VALIDATE(value->numChildren() == 1, ("At ", *value));
+                VALIDATE(value->numChildren() == 1 || value->numChildren() == 2, ("At ", *value));
                 VALIDATE(value->child(0)->type() == Int64, ("At ", *value)); // reference input
                 VALIDATE(value->type() == Int32, ("At ", *value)); // returns boolean
                 break;

--- a/Source/JavaScriptCore/b3/B3Value.cpp
+++ b/Source/JavaScriptCore/b3/B3Value.cpp
@@ -1121,15 +1121,16 @@ ValueKey Value::key() const
     case WasmRefTest: {
         auto* wasmValue = as<WasmRefTypeCheckValue>();
         OptionSet<WasmRefTypeCheckFlag> flags = wasmValue->flags();
+        Value* child2 = wasmValue->hasTargetStructureID() ? child(1) : nullptr;
 
         // Check if RTT is present and set HasRTT flag accordingly
         if (wasmValue->targetRTT()) {
             flags.add(WasmRefTypeCheckFlag::HasRTT);
-            return ValueKey(kind(), type(), child(0), flags.toRaw(), wasmValue->targetRTT());
+            return ValueKey(kind(), type(), child(0), child2, flags.toRaw(), wasmValue->targetRTT());
         }
 
         // Use targetHeapType when RTT is null (builtin types)
-        return ValueKey(kind(), type(), child(0), flags.toRaw(), wasmValue->targetHeapType());
+        return ValueKey(kind(), type(), child(0), child2, flags.toRaw(), wasmValue->targetHeapType());
     }
     case Nop:
     case Set:

--- a/Source/JavaScriptCore/b3/B3Value.h
+++ b/Source/JavaScriptCore/b3/B3Value.h
@@ -454,8 +454,6 @@ protected:
         case WasmAddress:
         case WasmBoundsCheck:
         case WasmStructGet:
-        case WasmRefCast:
-        case WasmRefTest:
         case VectorExtractLane:
         case VectorSplat:
         case VectorNot:
@@ -523,6 +521,8 @@ protected:
         case Store:
         case WasmStructSet:
         case WasmStructNew:
+        case WasmRefCast:
+        case WasmRefTest:
         case VectorReplaceLane:
         case VectorEqual:
         case VectorNotEqual:

--- a/Source/JavaScriptCore/b3/B3ValueKey.cpp
+++ b/Source/JavaScriptCore/b3/B3ValueKey.cpp
@@ -221,14 +221,15 @@ Value* ValueKey::materialize(Procedure& proc, Origin origin) const
         return proc.add<SIMDValue>(origin, kind(), type(), simdInfo(), child(proc, 0), child(proc, 1), child(proc, 2));
     case WasmRefTest:
     case WasmRefCast: {
-        OptionSet<WasmRefTypeCheckFlag> flags = OptionSet<WasmRefTypeCheckFlag>::fromRaw(u.indices[1]);
+        unsigned packedFlags = u.indices[3] >> 16;
+        OptionSet<WasmRefTypeCheckFlag> flags = OptionSet<WasmRefTypeCheckFlag>::fromRaw(packedFlags);
 
         int32_t targetHeapType = 0;
         RefPtr<const Wasm::RTT> targetRTT;
 
         if (flags.contains(WasmRefTypeCheckFlag::HasRTT)) {
-            // Reconstruct RTT pointer when HasRTT flag is set
-            uintptr_t rttPtr = static_cast<uintptr_t>(static_cast<uint64_t>(u.indices[2]) | (static_cast<uint64_t>(u.indices[3]) << 32));
+            // Reconstruct RTT pointer: lower 32 bits in indices[2], upper 16 bits in lower 16 bits of indices[3]
+            uintptr_t rttPtr = static_cast<uintptr_t>(static_cast<uint64_t>(u.indices[2]) | (static_cast<uint64_t>(u.indices[3] & 0xFFFF) << 32));
             targetRTT = reinterpret_cast<const Wasm::RTT*>(rttPtr);
         } else {
             // Use targetHeapType when HasRTT flag is not set (builtin types)
@@ -239,6 +240,9 @@ Value* ValueKey::materialize(Procedure& proc, Origin origin) const
         // Remove HasRTT from flags before passing to constructor (it's not stored in the value)
         flags.remove(WasmRefTypeCheckFlag::HasRTT);
 
+        bool hasChild2 = u.indices[1] != UINT_MAX;
+        if (hasChild2)
+            return proc.add<WasmRefTypeCheckValue>(kind(), type(), origin, targetHeapType, flags, WTF::move(targetRTT), child(proc, 0), child(proc, 1));
         return proc.add<WasmRefTypeCheckValue>(kind(), type(), origin, targetHeapType, flags, WTF::move(targetRTT), child(proc, 0));
     }
     case Nop:

--- a/Source/JavaScriptCore/b3/B3ValueKey.h
+++ b/Source/JavaScriptCore/b3/B3ValueKey.h
@@ -107,8 +107,8 @@ public:
     ValueKey(Kind, Type, SIMDInfo, Value*, uint8_t);
     ValueKey(Kind, Type, SIMDInfo, Value*, Value*, uint8_t);
 
-    ValueKey(Kind, Type, Value* child, unsigned packedFlags, const Wasm::RTT*);
-    ValueKey(Kind, Type, Value* child, unsigned packedFlags, int32_t targetHeapType);
+    ValueKey(Kind, Type, Value* child, Value* optionalChild2, unsigned packedFlags, const Wasm::RTT*);
+    ValueKey(Kind, Type, Value* child, Value* optionalChild2, unsigned packedFlags, int32_t targetHeapType);
 
     static ValueKey intConstant(Type type, int64_t value);
 

--- a/Source/JavaScriptCore/b3/B3ValueKeyInlines.h
+++ b/Source/JavaScriptCore/b3/B3ValueKeyInlines.h
@@ -115,27 +115,31 @@ inline ValueKey::ValueKey(Kind kind, Type type, SIMDInfo simdInfo, Value* a, Val
     u.indices[2] = immediate;
 }
 
-inline ValueKey::ValueKey(Kind kind, Type type, Value* child, unsigned packedFlags, const Wasm::RTT* rtt)
+inline ValueKey::ValueKey(Kind kind, Type type, Value* child, Value* optionalChild2, unsigned packedFlags, const Wasm::RTT* rtt)
     : m_kind(kind)
     , m_type(type)
 {
     u.indices[0] = child->index();
-    u.indices[1] = packedFlags;
+    u.indices[1] = optionalChild2 ? optionalChild2->index() : UINT_MAX;
+    static_assert(::allowCompactPointers<Wasm::RTT*>());
     if (rtt) {
         uint64_t rttPtr = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(rtt));
         u.indices[2] = static_cast<unsigned>(rttPtr);
-        u.indices[3] = static_cast<unsigned>(rttPtr >> 32);
+        u.indices[3] = static_cast<unsigned>(rttPtr >> 32) | (packedFlags << 16);
+    } else {
+        u.indices[2] = 0;
+        u.indices[3] = packedFlags << 16;
     }
 }
 
-inline ValueKey::ValueKey(Kind kind, Type type, Value* child, unsigned packedFlags, int32_t targetHeapType)
+inline ValueKey::ValueKey(Kind kind, Type type, Value* child, Value* optionalChild2, unsigned packedFlags, int32_t targetHeapType)
     : m_kind(kind)
     , m_type(type)
 {
     u.indices[0] = child->index();
-    u.indices[1] = packedFlags;
+    u.indices[1] = optionalChild2 ? optionalChild2->index() : UINT_MAX;
     u.indices[2] = static_cast<unsigned>(targetHeapType);
-    u.indices[3] = 0;
+    u.indices[3] = packedFlags << 16;
 }
 
 inline Value* ValueKey::child(Procedure& proc, unsigned index) const

--- a/Source/JavaScriptCore/b3/B3WasmRefTypeCheckValue.h
+++ b/Source/JavaScriptCore/b3/B3WasmRefTypeCheckValue.h
@@ -61,8 +61,10 @@ public:
     const Wasm::RTT* targetRTT() const { return m_targetRTT.get(); }
     OptionSet<WasmRefTypeCheckFlag> flags() const { return m_flags; }
 
-    B3_SPECIALIZE_VALUE_FOR_FIXED_CHILDREN(1)
-    B3_SPECIALIZE_VALUE_FOR_FINAL_SIZE_FIXED_CHILDREN
+    bool hasTargetStructureID() const { return numChildren() > 1; }
+    Value* targetStructureIDValue() const { ASSERT(hasTargetStructureID()); return child(1); }
+
+    B3_SPECIALIZE_VALUE_FOR_NON_VARARGS_CHILDREN
 
 private:
     void dumpMeta(CommaPrinter&, PrintStream&) const final;
@@ -73,11 +75,12 @@ protected:
 
     template<typename... Arguments>
     WasmRefTypeCheckValue(Kind kind, Type type, Origin origin, int32_t targetHeapType, OptionSet<WasmRefTypeCheckFlag> flags, RefPtr<const Wasm::RTT> targetRTT, Arguments... arguments)
-        : Value(CheckedOpcode, kind, type, One, origin, arguments...)
+        : Value(CheckedOpcode, kind, type, static_cast<NumChildren>(sizeof...(arguments)), origin, static_cast<Value*>(arguments)...)
         , m_targetHeapType(targetHeapType)
         , m_flags(flags)
         , m_targetRTT(WTF::move(targetRTT))
     {
+        static_assert(sizeof...(arguments) <= 2);
     }
 
     int32_t m_targetHeapType;

--- a/Source/JavaScriptCore/runtime/Structure.cpp
+++ b/Source/JavaScriptCore/runtime/Structure.cpp
@@ -1393,8 +1393,21 @@ void Structure::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     else if (thisObject->m_propertyTableUnsafe)
         thisObject->m_propertyTableUnsafe.clear();
 
-    if (thisObject->isBrandedStructure())
+    switch (thisObject->variant()) {
+    case StructureVariant::Normal:
+        break;
+    case StructureVariant::Branded:
         BrandedStructure::visitAdditionalChildren(cell, visitor);
+        break;
+    case StructureVariant::WebAssemblyGC:
+#if ENABLE(WEBASSEMBLY)
+        WebAssemblyGCStructure::visitAdditionalChildren(cell, visitor);
+        break;
+#endif
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+        break;
+    }
 
     // Mark only in non Full collection. In full collection, we handle it as a weak-link.
     if (!(visitor.heap()->collectionScope() == CollectionScope::Full)) {

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -63,6 +63,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include "WasmThunks.h"
 #include "WasmTypeDefinition.h"
 #include "WebAssemblyFunctionBase.h"
+#include "WebAssemblyGCStructure.h"
 #include <bit>
 #include <wtf/Assertions.h>
 #include <wtf/Compiler.h>
@@ -1451,7 +1452,6 @@ void BBQJIT::emitAllocateGCArrayUninitialized(GPRReg resultGPR, uint32_t typeInd
     RELEASE_ASSERT(m_info.hasGCObjectTypes());
     JumpList slowPath;
     const ArrayType* typeDefinition = m_info.typeSignatures[typeIndex]->expand().template as<ArrayType>();
-    Ref<const RTT> rtt = m_info.rtts[typeIndex];
     MacroAssembler::Address allocatorBufferBase(GPRInfo::wasmContextInstancePointer, JSWebAssemblyInstance::offsetOfAllocatorForGCObject(m_info, 0));
     MacroAssembler::Address structureIDAddress(GPRInfo::wasmContextInstancePointer, JSWebAssemblyInstance::offsetOfGCObjectStructureID(m_info, typeIndex));
     Location sizeLocation;
@@ -1469,7 +1469,6 @@ void BBQJIT::emitAllocateGCArrayUninitialized(GPRReg resultGPR, uint32_t typeInd
             static_assert(JSCell::structureIDOffset() + sizeof(int32_t) == JSCell::indexingTypeAndMiscOffset());
             m_jit.storePair32(scratchGPR, scratchGPR2, MacroAssembler::Address(resultGPR, JSCell::structureIDOffset()));
             m_jit.storePtr(TrustedImmPtr(nullptr), MacroAssembler::Address(resultGPR, JSObject::butterflyOffset()));
-            m_jit.storePtr(TrustedImmPtr(rtt.ptr()), MacroAssembler::Address(resultGPR, WebAssemblyGCObjectBase::offsetOfRTT()));
             m_jit.store32(TrustedImm32(size.asI32()), MacroAssembler::Address(resultGPR, JSWebAssemblyArray::offsetOfSize()));
         } else {
             // FIXME: emitCCall can't handle being passed a destination... which is why we just jump to the slow path here.
@@ -1492,7 +1491,6 @@ void BBQJIT::emitAllocateGCArrayUninitialized(GPRReg resultGPR, uint32_t typeInd
         static_assert(JSCell::structureIDOffset() + sizeof(int32_t) == JSCell::indexingTypeAndMiscOffset());
         m_jit.storePair32(scratchGPR, scratchGPR2, MacroAssembler::Address(resultGPR, JSCell::structureIDOffset()));
         m_jit.storePtr(TrustedImmPtr(nullptr), MacroAssembler::Address(resultGPR, JSObject::butterflyOffset()));
-        m_jit.storePtr(TrustedImmPtr(rtt.ptr()), MacroAssembler::Address(resultGPR, WebAssemblyGCObjectBase::offsetOfRTT()));
         m_jit.store32(sizeLocation.asGPR(), MacroAssembler::Address(resultGPR, JSWebAssemblyArray::offsetOfSize()));
     }
 
@@ -1993,7 +1991,6 @@ void BBQJIT::emitAllocateGCStructUninitialized(GPRReg resultGPR, uint32_t typeIn
     RELEASE_ASSERT(m_info.hasGCObjectTypes());
     JumpList slowPath;
     const StructType* typeDefinition = m_info.typeSignatures[typeIndex]->expand().template as<StructType>();
-    Ref<const RTT> rtt = m_info.rtts[typeIndex];
     MacroAssembler::Address allocatorBufferBase(GPRInfo::wasmContextInstancePointer, JSWebAssemblyInstance::offsetOfAllocatorForGCObject(m_info, 0));
     MacroAssembler::Address structureIDAddress(GPRInfo::wasmContextInstancePointer, JSWebAssemblyInstance::offsetOfGCObjectStructureID(m_info, typeIndex));
     Location sizeLocation;
@@ -2010,7 +2007,6 @@ void BBQJIT::emitAllocateGCStructUninitialized(GPRReg resultGPR, uint32_t typeIn
         static_assert(JSCell::structureIDOffset() + sizeof(int32_t) == JSCell::indexingTypeAndMiscOffset());
         m_jit.storePair32(scratchGPR, scratchGPR2, MacroAssembler::Address(resultGPR, JSCell::structureIDOffset()));
         m_jit.storePtr(TrustedImmPtr(nullptr), MacroAssembler::Address(resultGPR, JSObject::butterflyOffset()));
-        m_jit.storePtr(TrustedImmPtr(rtt.ptr()), MacroAssembler::Address(resultGPR, WebAssemblyGCObjectBase::offsetOfRTT()));
     } else {
         // FIXME: emitCCall can't handle being passed a destination... which is why we just jump to the slow path here.
         slowPath.append(m_jit.jump());
@@ -2243,8 +2239,8 @@ void BBQJIT::emitRefTestOrCast(CastKind castKind, const TypedExpression& typedVa
         if (typeIndexIsType(static_cast<Wasm::TypeIndex>(toHeapType)))
             return std::nullopt;
 
-        Wasm::TypeDefinition& signature = m_info.typeSignatures[toHeapType];
-        if (signature.expand().is<Wasm::FunctionSignature>())
+        Ref targetRTT = m_info.rtts[toHeapType];
+        if (targetRTT->kind() == Wasm::RTTKind::Function)
             return WebAssemblyFunctionBase::offsetOfRTT();
 
         if (!typedValue.type().definitelyIsCellOrNull())
@@ -2307,7 +2303,8 @@ void BBQJIT::emitRefTestOrCast(CastKind castKind, const TypedExpression& typedVa
                 failureCases.append(m_jit.branchIfNotCell(valueGPR, DoNotHaveTagRegisters));
             if (!typedValue.type().definitelyIsWasmGCObjectOrNull())
                 failureCases.append(m_jit.branchIfNotType(valueGPR, JSType::WebAssemblyGCObjectType));
-            m_jit.loadPtr(Address(valueGPR, WebAssemblyGCObjectBase::offsetOfRTT()), wasmScratchGPR);
+            m_jit.emitLoadStructure(valueGPR, wasmScratchGPR);
+            m_jit.loadPtr(Address(wasmScratchGPR, WebAssemblyGCStructure::offsetOfRTT()), wasmScratchGPR);
             failureCases.append(m_jit.branch8(CCallHelpers::NotEqual, Address(wasmScratchGPR, RTT::offsetOfKind()), TrustedImm32(static_cast<int32_t>(static_cast<TypeKind>(toHeapType) == Wasm::TypeKind::Arrayref ? RTTKind::Array : RTTKind::Struct))));
             break;
         }
@@ -2316,9 +2313,8 @@ void BBQJIT::emitRefTestOrCast(CastKind castKind, const TypedExpression& typedVa
         }
     } else {
         ([&] {
-            Wasm::TypeDefinition& signature = m_info.typeSignatures[toHeapType];
             Ref targetRTT = m_info.rtts[toHeapType];
-            if (signature.expand().is<Wasm::FunctionSignature>())
+            if (targetRTT->kind() == Wasm::RTTKind::Function)
                 m_jit.loadPtr(Address(valueGPR, WebAssemblyFunctionBase::offsetOfRTT()), wasmScratchGPR);
             else {
                 // The cell check is only needed for non-functions, as the typechecker does not allow non-Cell values for funcref casts.
@@ -2327,20 +2323,29 @@ void BBQJIT::emitRefTestOrCast(CastKind castKind, const TypedExpression& typedVa
                 if (!typedValue.type().definitelyIsWasmGCObjectOrNull())
                     failureCases.append(m_jit.branchIfNotType(valueGPR, JSType::WebAssemblyGCObjectType));
 
-                m_jit.loadPtr(Address(valueGPR, WebAssemblyGCObjectBase::offsetOfRTT()), wasmScratchGPR);
-                if (targetRTT->displaySizeExcludingThis() < RTT::inlinedDisplaySize) {
-                    m_jit.loadPtr(Address(wasmScratchGPR, RTT::offsetOfData() + targetRTT->displaySizeExcludingThis() * sizeof(RefPtr<const RTT>)), wasmScratchGPR);
-                    failureCases.append(m_jit.branchPtr(CCallHelpers::NotEqual, wasmScratchGPR, TrustedImmPtr(targetRTT.ptr())));
+                if (targetRTT->isFinalType()) {
+                    m_jit.load32(Address(valueGPR, JSCell::structureIDOffset()), wasmScratchGPR);
+                    failureCases.append(m_jit.branch32(CCallHelpers::NotEqual, wasmScratchGPR, Address(GPRInfo::wasmContextInstancePointer, JSWebAssemblyInstance::offsetOfGCObjectStructureID(m_info, toHeapType))));
                     return;
                 }
+
+                m_jit.emitLoadStructure(valueGPR, wasmScratchGPR);
+                if (targetRTT->displaySizeExcludingThis() < WebAssemblyGCStructure::inlinedDisplaySize) {
+                    m_jit.load32(Address(wasmScratchGPR, WebAssemblyGCStructure::offsetOfInlinedDisplay() + targetRTT->displaySizeExcludingThis() * sizeof(WriteBarrierStructureID)), wasmScratchGPR);
+                    failureCases.append(m_jit.branch32(CCallHelpers::NotEqual, wasmScratchGPR, Address(GPRInfo::wasmContextInstancePointer, JSWebAssemblyInstance::offsetOfGCObjectStructureID(m_info, toHeapType))));
+                    return;
+                }
+
+                m_jit.loadPtr(Address(wasmScratchGPR, WebAssemblyGCStructure::offsetOfRTT()), wasmScratchGPR);
             }
 
-            if (signature.isFinalType()) {
+            if (targetRTT->isFinalType()) {
                 // If signature is final type and pointer equality failed, this value must not be a subtype.
                 failureCases.append(m_jit.branchPtr(CCallHelpers::NotEqual, wasmScratchGPR, TrustedImmPtr(targetRTT.ptr())));
             } else {
                 doneCases.append(m_jit.branchPtr(CCallHelpers::Equal, wasmScratchGPR, TrustedImmPtr(targetRTT.ptr())));
-                failureCases.append(m_jit.branch32(CCallHelpers::BelowOrEqual, Address(wasmScratchGPR, RTT::offsetOfDisplaySizeExcludingThis()), TrustedImm32(targetRTT->displaySizeExcludingThis())));
+                if (targetRTT->displaySizeExcludingThis() >= RTT::inlinedDisplaySize)
+                    failureCases.append(m_jit.branch32(CCallHelpers::BelowOrEqual, Address(wasmScratchGPR, RTT::offsetOfDisplaySizeExcludingThis()), TrustedImm32(targetRTT->displaySizeExcludingThis())));
                 failureCases.append(m_jit.branchPtr(CCallHelpers::NotEqual, Address(wasmScratchGPR, (RTT::offsetOfData() + targetRTT->displaySizeExcludingThis() * sizeof(RefPtr<const RTT>))), TrustedImmPtr(targetRTT.ptr())));
             }
         }());

--- a/Source/JavaScriptCore/wasm/WasmFormat.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFormat.cpp
@@ -94,8 +94,8 @@ void validateWasmValue(uint64_t wasmValue, Type expectedType)
                 return;
             }
             auto objectPtr = jsCast<WebAssemblyGCObjectBase*>(value);
-            auto objectRTT = objectPtr->rtt();
-            ASSERT(objectRTT->isSubRTT(expectedRTT.get()));
+            auto& objectRTT = objectPtr->rtt();
+            ASSERT(objectRTT.isSubRTT(expectedRTT.get()));
         }
     }
 }

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -928,7 +928,7 @@ private:
 
     Value* allocatorForWasmGCHeapCellSize(Value* size, BasicBlock* slowPath);
     Value* allocateWasmGCHeapCell(Value* allocator, BasicBlock* slowPath);
-    Value* allocateWasmGCObject(const RTT*, Value* allocator, Value* structureID, Value* typeInfo, BasicBlock* slowPath);
+    Value* allocateWasmGCObject(Value* allocator, Value* structureID, Value* typeInfo, BasicBlock* slowPath);
     Value* allocateWasmGCArrayUninitialized(uint32_t typeIndex, Value* size);
 
     void mutatorFence();
@@ -4006,6 +4006,7 @@ void OMGIRGenerator::emitRefTestOrCast(CastKind castKind, TypedExpression refere
     Value* value = get(reference);
 
     RefPtr<const Wasm::RTT> targetRTT;
+    int32_t originalTypeIndex = toHeapType;
     if (!typeIndexIsType(static_cast<Wasm::TypeIndex>(toHeapType))) {
         targetRTT = m_info.rtts[toHeapType].ptr();
         toHeapType = 0;
@@ -4029,6 +4030,18 @@ void OMGIRGenerator::emitRefTestOrCast(CastKind castKind, TypedExpression refere
 
     auto type = castKind == CastKind::Cast ? Int64 : Int32;
     auto kind = castKind == CastKind::Cast ? trapping(WasmRefCast) : WasmRefTest;
+
+    if (targetRTT && targetRTT->kind() != Wasm::RTTKind::Function) {
+        auto* targetStructureID = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, Int32, origin(), instanceValue(), safeCast<int32_t>(JSWebAssemblyInstance::offsetOfGCObjectStructureID(m_info, originalTypeIndex)));
+        m_heaps.decorateMemory(&m_heaps.JSWebAssemblyInstance_gcObjectStructureIDs[originalTypeIndex], targetStructureID);
+        targetStructureID->setReadsMutability(B3::Mutability::Immutable);
+        targetStructureID->setControlDependent(false);
+
+        auto* castValue = m_currentBlock->appendNew<B3::WasmRefTypeCheckValue>(m_proc, kind, type, origin(), toHeapType, flags, WTF::move(targetRTT), value, targetStructureID);
+        result = push(castValue);
+        return;
+    }
+
     auto* castValue = m_currentBlock->appendNew<B3::WasmRefTypeCheckValue>(m_proc, kind, type, origin(), toHeapType, flags, WTF::move(targetRTT), value);
     result = push(castValue);
 }
@@ -4120,7 +4133,7 @@ Value* OMGIRGenerator::allocateWasmGCHeapCell(Value* allocator, BasicBlock* slow
     return patchpoint;
 }
 
-Value* OMGIRGenerator::allocateWasmGCObject(const RTT* rtt, Value* allocator, Value* structureID, Value* typeInfo, BasicBlock* slowPath)
+Value* OMGIRGenerator::allocateWasmGCObject(Value* allocator, Value* structureID, Value* typeInfo, BasicBlock* slowPath)
 {
     auto* cell = allocateWasmGCHeapCell(allocator, slowPath);
 
@@ -4132,9 +4145,6 @@ Value* OMGIRGenerator::allocateWasmGCObject(const RTT* rtt, Value* allocator, Va
 
     auto* storeButterfly = m_currentBlock->appendNew<B3::MemoryValue>(m_proc, B3::Store, origin(), constant(pointerType(), 0), cell, safeCast<int32_t>(JSObject::butterflyOffset()));
     m_heaps.decorateMemory(&m_heaps.JSObject_butterfly, storeButterfly);
-
-    auto* storeRTT = m_currentBlock->appendNew<B3::MemoryValue>(m_proc, B3::Store, origin(), constant(pointerType(), std::bit_cast<uintptr_t>(rtt)), cell, safeCast<int32_t>(WebAssemblyGCObjectBase::offsetOfRTT()));
-    m_heaps.decorateMemory(&m_heaps.WebAssemblyGCObjectBase_rtt, storeRTT);
 
     return cell;
 }
@@ -4150,14 +4160,13 @@ Value* OMGIRGenerator::allocateWasmGCArrayUninitialized(uint32_t typeIndex, Valu
     structureID->setControlDependent(false);
 
     const ArrayType* typeDefinition = m_info.typeSignatures[typeIndex]->expand().template as<ArrayType>();
-    Ref<const RTT> rtt = m_info.rtts[typeIndex];
     size_t elementSize = typeDefinition->elementType().type.elementSize();
     auto* extended = pointerOfInt32(size);
     auto* shifted = m_currentBlock->appendNew<Value>(m_proc, Shl, origin(), extended, constant(Int32, getLSBSet(elementSize)));
     auto* sizeInBytes = m_currentBlock->appendNew<Value>(m_proc, Add, pointerType(), origin(), shifted, constant(pointerType(), sizeof(JSWebAssemblyArray)));
     auto* allocator = allocatorForWasmGCHeapCellSize(sizeInBytes, slowPath);
     auto* typeInfo = constant(Int32, JSWebAssemblyArray::typeInfoBlob().blob());
-    auto* cell = allocateWasmGCObject(rtt.ptr(), allocator, structureID, typeInfo, slowPath);
+    auto* cell = allocateWasmGCObject(allocator, structureID, typeInfo, slowPath);
     auto* fastValue = m_currentBlock->appendNew<UpsilonValue>(m_proc, origin(), wasmRefOfCell(cell));
     m_currentBlock->appendNewControlValue(m_proc, Jump, origin(), continuation);
     continuation->addPredecessor(m_currentBlock);

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
@@ -1152,7 +1152,7 @@ bool TypeInformation::isReferenceValueAssignable(JSValue refValue, bool allowNul
         auto* object = jsDynamicCast<WebAssemblyGCObjectBase*>(refValue);
         if (!object)
             return false;
-        return object->rtt()->isSubRTT(*rtt);
+        return object->rtt().isSubRTT(*rtt);
     }
     }
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h
@@ -133,7 +133,7 @@ private:
 static_assert(std::is_final_v<JSWebAssemblyArray>, "JSWebAssemblyArray is a TrailingArray-like object so must know about all members");
 // We still have to check for PreciseAllocations since those are correctly aligned for v128 but this asserts our shifted offset will be correct.
 // FIXME: Fix this check for 32-bit.
-static_assert(isAddress32Bit() || !((JSWebAssemblyArray::offsetOfData()) % 16), "JSWebAssemblyArray storage needs to be aligned for v128_t");
+static_assert(isAddress32Bit() || !((JSWebAssemblyArray::offsetOfData() + JSWebAssemblyArray::v128AlignmentShift) % 16), "JSWebAssemblyArray storage needs to be aligned for v128_t");
 
 } // namespace JSC
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyGCObjectBase.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyGCObjectBase.cpp
@@ -38,7 +38,6 @@ const ClassInfo WebAssemblyGCObjectBase::s_info = { "WebAssemblyGCObjectBase"_s,
 
 WebAssemblyGCObjectBase::WebAssemblyGCObjectBase(VM& vm, WebAssemblyGCStructure* structure)
     : Base(vm, structure)
-    , m_rtt(&gcStructure()->rtt())
 {
 }
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyGCObjectBase.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyGCObjectBase.h
@@ -44,9 +44,7 @@ public:
     DECLARE_VISIT_CHILDREN;
 
     const WebAssemblyGCStructure* gcStructure() const { return uncheckedDowncast<WebAssemblyGCStructure>(structure()); }
-    Ref<const Wasm::RTT> rtt() const { return *m_rtt; }
-
-    static constexpr ptrdiff_t offsetOfRTT() { return OBJECT_OFFSETOF(WebAssemblyGCObjectBase, m_rtt); }
+    const Wasm::RTT& rtt() const { return gcStructure()->rtt(); }
 
 protected:
     WebAssemblyGCObjectBase(VM&, WebAssemblyGCStructure*);
@@ -66,8 +64,6 @@ protected:
     JS_EXPORT_PRIVATE static bool isExtensible(JSObject*, JSGlobalObject*);
     JS_EXPORT_PRIVATE static bool preventExtensions(JSObject*, JSGlobalObject*);
 
-    // It is held by structure. Keeping Wasm GC object trivially destructible is critical for performance.
-    SUPPRESS_UNCOUNTED_MEMBER const Wasm::RTT* m_rtt;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyGCStructure.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyGCStructure.cpp
@@ -26,10 +26,12 @@
 #include "config.h"
 #include "WebAssemblyGCStructure.h"
 
+#include "AbstractSlotVisitorInlines.h"
 #include "DeferGC.h"
 #include "JSCInlines.h"
 #include "JSWebAssemblyArray.h"
 #include "JSWebAssemblyStruct.h"
+#include "SlotVisitorInlines.h"
 #include "WasmFormat.h"
 
 #if ENABLE(WEBASSEMBLY)
@@ -106,6 +108,36 @@ WebAssemblyGCStructure* WebAssemblyGCStructure::create(VM& vm, const TypeInfo& t
         return newStructure;
     });
 }
+
+void WebAssemblyGCStructure::finishCreation(VM& vm)
+{
+    Structure::finishCreation(vm);
+
+    // The RTT display stores ancestors at indices 0..displaySize-1 and |this| at index displaySize.
+    // Mirror that layout in the inlined type display with StructureIDs.
+    unsigned displaySize = m_rtt->displaySizeExcludingThis();
+    unsigned actualDisplaySize = displaySize + 1; // +1 for |this|
+    unsigned count = std::min(actualDisplaySize, inlinedDisplaySize);
+    for (unsigned i = 0; i < count; ++i) {
+        RefPtr entryRTT = m_rtt->displayEntry(i);
+        auto* structure = this;
+        if (entryRTT != m_rtt.ptr())
+            structure = vm.wasmGCStructureMap.get(entryRTT);
+        RELEASE_ASSERT(structure);
+        m_inlinedDisplay[i].set(vm, this, structure);
+    }
+}
+
+template<typename Visitor>
+void WebAssemblyGCStructure::visitAdditionalChildren(JSCell* cell, Visitor& visitor)
+{
+    WebAssemblyGCStructure* thisObject = jsCast<WebAssemblyGCStructure*>(cell);
+    for (auto& slot : thisObject->m_inlinedDisplay)
+        visitor.append(slot);
+}
+
+template void WebAssemblyGCStructure::visitAdditionalChildren(JSCell*, AbstractSlotVisitor&);
+template void WebAssemblyGCStructure::visitAdditionalChildren(JSCell*, SlotVisitor&);
 
 } // namespace JSC
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyGCStructure.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyGCStructure.h
@@ -27,6 +27,7 @@
 
 #include <JavaScriptCore/Structure.h>
 #include <JavaScriptCore/WasmTypeDefinition.h>
+#include <JavaScriptCore/WriteBarrier.h>
 #include <wtf/Platform.h>
 #include <wtf/ReferenceWrapperVector.h>
 
@@ -80,12 +81,21 @@ public:
 
     static constexpr ptrdiff_t offsetOfRTT() { return OBJECT_OFFSETOF(WebAssemblyGCStructure, m_rtt); }
 
+    static constexpr unsigned inlinedDisplaySize = Wasm::RTT::inlinedDisplaySize;
+    static constexpr ptrdiff_t offsetOfInlinedDisplay() { return OBJECT_OFFSETOF(WebAssemblyGCStructure, m_inlinedDisplay); }
+
+    template<typename Visitor>
+    static void visitAdditionalChildren(JSCell*, Visitor&);
+
 private:
     WebAssemblyGCStructure(VM&, const TypeInfo&, const ClassInfo*, Ref<const Wasm::TypeDefinition>&& unexpandedType, Ref<const Wasm::TypeDefinition>&& expandedType, Ref<const Wasm::RTT>&&);
+
+    void finishCreation(VM&);
 
     const Ref<const Wasm::RTT> m_rtt;
     const Ref<const Wasm::TypeDefinition> m_type;
     WebAssemblyGCStructureTypeDependencies m_typeDependencies;
+    std::array<WriteBarrierStructureID, inlinedDisplaySize> m_inlinedDisplay { };
 };
 
 } // namespace JSC


### PR DESCRIPTION
#### e40eb8adbcd7183b6a5032e325dd57f28d72c490
<pre>
[JSC] Reduce size of Wasm GC objects by dropping m_rtt
<a href="https://bugs.webkit.org/show_bug.cgi?id=310881">https://bugs.webkit.org/show_bug.cgi?id=310881</a>
<a href="https://rdar.apple.com/173493466">rdar://173493466</a>

Reviewed by Keith Miller.

This patch reduces Wasm GC object size by removing m_rtt. The key is
that now these objects are realm-less: so Structure is unique to m_rtt.
We use StructureID for type checking instead of embedded m_rtt.

To keep the original m_rtt&apos;s faster checking,

1. We re-introduce cached type display in WebAssemblyGCStructure. But
   this time, we cache StructureID (4 bytes) instead of RTT* (8 bytes).
   And using StructureID comparison for most of type checks.
2. If the type depth is deeper than cached display size (6), then
   retrieving RTT* from Structure and uses the previous code.

* JSTests/stress/wasm-gc-structureid-cast-optimization.js: Added.
(uleb128):
(sleb128):
(encodeSection):
(encodeString):
(buildModule.encodeBody):
(buildModule):
(main):
* Source/JavaScriptCore/b3/B3AbstractHeapRepository.h:
* Source/JavaScriptCore/b3/B3LowerMacros.cpp:
* Source/JavaScriptCore/b3/B3ReduceStrength.cpp:
* Source/JavaScriptCore/b3/B3Validate.cpp:
* Source/JavaScriptCore/b3/B3Value.cpp:
(JSC::B3::Value::key const):
* Source/JavaScriptCore/b3/B3Value.h:
* Source/JavaScriptCore/b3/B3ValueKey.cpp:
(JSC::B3::ValueKey::materialize const):
* Source/JavaScriptCore/b3/B3ValueKey.h:
* Source/JavaScriptCore/b3/B3ValueKeyInlines.h:
(JSC::B3::ValueKey::ValueKey):
* Source/JavaScriptCore/b3/B3WasmRefTypeCheckValue.h:
* Source/JavaScriptCore/runtime/Structure.cpp:
(JSC::Structure::visitChildrenImpl):
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitAllocateGCArrayUninitialized):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitAllocateGCStructUninitialized):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitRefTestOrCast):
* Source/JavaScriptCore/wasm/WasmFormat.cpp:
(JSC::Wasm::validateWasmValue):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::emitRefTestOrCast):
(JSC::Wasm::OMGIRGenerator::allocateWasmGCObject):
(JSC::Wasm::OMGIRGenerator::allocateWasmGCArrayUninitialized):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp:
(JSC::Wasm::TypeInformation::isReferenceValueAssignable):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyGCObjectBase.cpp:
(JSC::WebAssemblyGCObjectBase::WebAssemblyGCObjectBase):
* Source/JavaScriptCore/wasm/js/WebAssemblyGCObjectBase.h:
(JSC::WebAssemblyGCObjectBase::rtt const):
(JSC::WebAssemblyGCObjectBase::offsetOfRTT): Deleted.
* Source/JavaScriptCore/wasm/js/WebAssemblyGCStructure.cpp:
(JSC::WebAssemblyGCStructure::finishCreation):
(JSC::WebAssemblyGCStructure::visitAdditionalChildren):
* Source/JavaScriptCore/wasm/js/WebAssemblyGCStructure.h:

Canonical link: <a href="https://commits.webkit.org/310119@main">https://commits.webkit.org/310119@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/329e26c993784e313db2f45fdd61042f02972770

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152747 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25528 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19127 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161491 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0763a7b9-fc5f-43a6-8939-be7c90bf2d27) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26056 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25834 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118035 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d757f6a0-d697-49a9-b14e-76a01b8bc4b8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155706 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20272 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137127 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98748 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d8ec61eb-c562-45eb-9390-2825b8553a64) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19347 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9327 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144759 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15001 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163963 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13555 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7101 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16595 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126094 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25326 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21319 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126252 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25328 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136797 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81932 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23404 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21214 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13576 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184379 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24944 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89230 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47068 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24636 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24795 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24696 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->