### PR TITLE
[MSE][GStreamer] Move WebCore log message handler from SourceBufferPrivate to MediaSourcePrivate

### DIFF
--- a/Source/WebCore/platform/graphics/TrackBuffer.cpp
+++ b/Source/WebCore/platform/graphics/TrackBuffer.cpp
@@ -146,7 +146,7 @@ RefPtr<MediaSample> TrackBuffer::nextSample()
     Ref sample = decodeQueue().begin()->second;
 
     if (sample->decodeTime() > enqueueDiscontinuityBoundary()) {
-        DEBUG_LOG(LOGIDENTIFIER, "bailing early because of unbuffered gap, new sample: ", sample->decodeTime(), " >= the current discontinuity boundary: ", enqueueDiscontinuityBoundary());
+        WARNING_LOG(LOGIDENTIFIER, "bailing early because of unbuffered gap, new sample DTS: ", sample->decodeTime(), " >= the current discontinuity boundary: ", enqueueDiscontinuityBoundary());
         return { };
     }
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -456,6 +456,7 @@ std::tuple<GRefPtr<GstCaps>, StreamType, FloatSize> AppendPipeline::parseDemuxer
 void AppendPipeline::appsinkCapsChanged(Track& track)
 {
     ASSERT(isMainThread());
+    GST_TRACE_OBJECT(pipeline(), "Processing caps-changed notification");
 
     // Consume any pending samples with the previous caps.
     consumeAppsinksAvailableSamples();
@@ -463,6 +464,7 @@ void AppendPipeline::appsinkCapsChanged(Track& track)
     GRefPtr<GstPad> pad = adoptGRef(gst_element_get_static_pad(track.appsink.get(), "sink"));
     GRefPtr<GstCaps> caps = adoptGRef(gst_pad_get_current_caps(pad.get()));
 
+    GST_DEBUG_OBJECT(pipeline(), "Caps changed to %" GST_PTR_FORMAT, caps.get());
     if (!caps)
         return;
 
@@ -489,7 +491,7 @@ void AppendPipeline::appsinkCapsChanged(Track& track)
         track.ongoingChangeType = false;
     }
 
-    if (track.caps != caps)
+    if (!gst_caps_is_equal(track.caps.get(), caps.get()))
         track.caps = WTF::move(caps);
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
@@ -49,6 +49,7 @@
 #include <wtf/NativePromise.h>
 #include <wtf/RefPtr.h>
 #include <wtf/glib/GRefPtr.h>
+#include <wtf/text/StringToIntegerConversion.h>
 
 GST_DEBUG_CATEGORY_STATIC(webkit_mse_private_debug);
 #define GST_CAT_DEFAULT webkit_mse_private_debug
@@ -74,12 +75,77 @@ MediaSourcePrivateGStreamer::MediaSourcePrivateGStreamer(MediaSourcePrivateClien
     std::call_once(debugRegisteredFlag, [] {
         GST_DEBUG_CATEGORY_INIT(webkit_mse_private_debug, "webkitmseprivate", 0, "WebKit MSE Private");
     });
+#if !RELEASE_LOG_DISABLED && !defined(GST_DISABLE_GST_DEBUG)
+    m_logger->addMessageHandlerObserver(*this);
+#endif
 }
 
 MediaSourcePrivateGStreamer::~MediaSourcePrivateGStreamer()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
+#if !RELEASE_LOG_DISABLED && GST_CHECK_VERSION(1, 22, 0) && !defined(GST_DISABLE_GST_DEBUG)
+    m_logger->removeMessageHandlerObserver(*this);
+#endif
 }
+
+#if !RELEASE_LOG_DISABLED && !defined(GST_DISABLE_GST_DEBUG)
+void MediaSourcePrivateGStreamer::handleLogMessage(const WTFLogChannel& channel, WTFLogLevel level, std::optional<WTFLogLocation> location, const Vector<JSONLogValue>& values)
+{
+    auto gstDebugLevel = gstDebugLevelFromWTFLogLevel(level);
+    if (gstDebugLevel > gst_debug_category_get_threshold(GST_CAT_DEFAULT))
+        return;
+
+    auto name = StringView::fromLatin1(channel.name);
+    if (name != "MediaSource"_s)
+        return;
+
+    // Ignore logs containing only the call site information.
+    if (values.size() < 2)
+        return;
+
+    // Parse "foo::bar(hexidentifier) "
+    auto& signature = values[0].value;
+    auto leftParenthesisIndex = signature.reverseFind('(');
+    if (leftParenthesisIndex == notFound)
+        return;
+
+    auto rightParenthesisIndex = signature.reverseFind(')');
+    if (rightParenthesisIndex == notFound)
+        return;
+
+    auto identifierString = signature.substring(leftParenthesisIndex + 1, rightParenthesisIndex - leftParenthesisIndex - 1);
+    auto identifier = WTF::parseInteger<uint64_t>(identifierString, 16);
+    if (!identifier)
+        return;
+
+    // Filter out logs not related with our log identifier.
+    if (!LoggerHelper::isChildLogIdentifier(*identifier, m_logIdentifier))
+        return;
+
+    StringBuilder builder;
+    for (auto& value : values.subvector(1))
+        builder.append(value.value);
+
+    // Find the C++ method name, foo::bar() -> bar.
+    auto methodName = emptyString();
+    if (location)
+        methodName = String::fromUTF8(location->function);
+    else {
+        auto methodNameSeparatorIndex = signature.reverseFind(':');
+        if (methodNameSeparatorIndex != notFound)
+            methodName = signature.substring(methodNameSeparatorIndex + 1, leftParenthesisIndex - methodNameSeparatorIndex - 1);
+    }
+
+    auto message = builder.toString();
+    const char* file = location ? location->file : __FILE__;
+    int line = location ? location->line : __LINE__;
+#if GST_CHECK_VERSION(1, 22, 0)
+    gst_debug_log_id_literal(GST_CAT_DEFAULT, gstDebugLevel, file, methodName.utf8().data(), line, identifierString.utf8().data(), message.utf8().data());
+#else
+    gst_debug_log(GST_CAT_DEFAULT, gstDebugLevel, file, methodName.utf8().data(), line, nullptr, "%s: %s", identifierString.utf8().data(), message.utf8().data());
+#endif
+}
+#endif // !RELEASE_LOG_DISABLED && !defined(GST_DISABLE_GST_DEBUG)
 
 MediaSourcePrivateGStreamer::AddStatus MediaSourcePrivateGStreamer::addSourceBuffer(const ContentType& contentType, const MediaSourceConfiguration&, RefPtr<SourceBufferPrivate>& sourceBufferPrivate)
 {

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h
@@ -50,6 +50,9 @@ class PlatformTimeRanges;
 class MediaSourcePrivateGStreamer final : public MediaSourcePrivate
 #if !RELEASE_LOG_DISABLED
     , private LoggerHelper
+#ifndef GST_DISABLE_GST_DEBUG
+    , public Logger::MessageHandlerObserver
+#endif
 #endif
 {
 public:
@@ -111,6 +114,9 @@ public:
     WTFLogChannel& logChannel() const final;
 
     uint64_t nextSourceBufferLogIdentifier() { return childLogIdentifier(m_logIdentifier, ++m_nextSourceBufferID); }
+#ifndef GST_DISABLE_GST_DEBUG
+    void handleLogMessage(const WTFLogChannel&, WTFLogLevel, std::optional<WTFLogLocation>, const Vector<JSONLogValue>&) final;
+#endif
 #endif
 
 private:

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
@@ -83,79 +83,17 @@ SourceBufferPrivateGStreamer::SourceBufferPrivateGStreamer(MediaSourcePrivateGSt
         GST_DEBUG_CATEGORY_INIT(webkit_mse_sourcebuffer_debug, "webkitmsesourcebuffer", 0, "WebKit MSE SourceBuffer");
     });
 
-#if !RELEASE_LOG_DISABLED && !defined(GST_DISABLE_GST_DEBUG)
-    m_logger->addMessageHandlerObserver(*this);
-#endif
+    GST_DEBUG_OBJECT(m_appendPipeline ? m_appendPipeline->pipeline() : nullptr, "SourceBufferPrivate created");
 }
 
 SourceBufferPrivateGStreamer::~SourceBufferPrivateGStreamer()
 {
-#if !RELEASE_LOG_DISABLED && !defined(GST_DISABLE_GST_DEBUG)
-    m_logger->removeMessageHandlerObserver(*this);
-#endif
-
     if (!m_appendPromise)
         return;
 
     m_appendPromise->reject(PlatformMediaError::BufferRemoved);
     m_appendPromise.reset();
 }
-
-#if !RELEASE_LOG_DISABLED && !defined(GST_DISABLE_GST_DEBUG)
-void SourceBufferPrivateGStreamer::handleLogMessage(const WTFLogChannel& channel, WTFLogLevel level, std::optional<WTFLogLocation> location, const Vector<JSONLogValue>& values)
-{
-    auto gstDebugLevel = gstDebugLevelFromWTFLogLevel(level);
-    if (gstDebugLevel > gst_debug_category_get_threshold(GST_CAT_DEFAULT))
-        return;
-
-    auto name = StringView::fromLatin1(channel.name);
-    if (name != "MediaSource"_s)
-        return;
-
-    // Ignore logs containing only the call site information.
-    if (values.size() < 2)
-        return;
-
-    // Parse "foo::bar(hexidentifier) "
-    auto& signature = values[0].value;
-    auto leftParenthesisIndex = signature.reverseFind('(');
-    if (leftParenthesisIndex == notFound)
-        return;
-
-    auto rightParenthesisIndex = signature.reverseFind(')');
-    if (rightParenthesisIndex == notFound)
-        return;
-
-    auto identifierString = signature.substring(leftParenthesisIndex + 1, rightParenthesisIndex - leftParenthesisIndex - 1);
-    auto identifier = WTF::parseInteger<uint64_t>(identifierString, 16);
-    if (!identifier)
-        return;
-
-    // Filter out logs not related with our log identifier.
-    if (!LoggerHelper::isChildLogIdentifier(*identifier, sourceBufferLogIdentifier()))
-        return;
-
-    StringBuilder builder;
-    for (auto& value : values.subvector(1))
-        builder.append(WTF::makeStringByReplacingAll(value.value, '\"', '\''));
-
-    // Find the C++ method name, foo::bar() -> bar.
-    auto methodName = emptyString();
-    if (location)
-        methodName = String::fromUTF8(location->function);
-    else {
-        auto methodNameSeparatorIndex = signature.reverseFind(':');
-        if (methodNameSeparatorIndex != notFound)
-            methodName = signature.substring(methodNameSeparatorIndex + 1, leftParenthesisIndex - methodNameSeparatorIndex - 1);
-    }
-
-    auto message = builder.toString();
-    auto pipeline = m_appendPipeline ? m_appendPipeline->pipeline() : nullptr;
-    const char* file = location ? location->file : __FILE__;
-    int line = location ? location->line : __LINE__;
-    gst_debug_log(GST_CAT_DEFAULT, gstDebugLevel, file, methodName.utf8().data(), line, G_OBJECT(pipeline), "%s", message.utf8().data());
-}
-#endif // !RELEASE_LOG_DISABLED && !defined(GST_DISABLE_GST_DEBUG)
 
 Ref<MediaPromise> SourceBufferPrivateGStreamer::appendInternal(Ref<SharedBuffer>&& data)
 {

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
@@ -57,9 +57,6 @@ class AppendPipeline;
 class MediaSourcePrivateGStreamer;
 
 class SourceBufferPrivateGStreamer final : public SourceBufferPrivate, public CanMakeWeakPtr<SourceBufferPrivateGStreamer>
-#if !RELEASE_LOG_DISABLED && !defined(GST_DISABLE_GST_DEBUG)
-    , public Logger::MessageHandlerObserver
-#endif
 {
 public:
     static bool isContentTypeSupported(const ContentType&);
@@ -100,9 +97,6 @@ public:
     WTFLogChannel& logChannel() const final;
     const Logger& sourceBufferLogger() const final { return m_logger; }
     uint64_t sourceBufferLogIdentifier() final { return logIdentifier(); }
-#ifndef GST_DISABLE_GST_DEBUG
-    void handleLogMessage(const WTFLogChannel&, WTFLogLevel, std::optional<WTFLogLocation>, const Vector<JSONLogValue>&) final;
-#endif
 #endif
 
     size_t platformMaximumBufferSize() const override;


### PR DESCRIPTION
#### 29c4212dc11a5265d5aa01d8fd484dc74a4b7e8b
<pre>
[MSE][GStreamer] Move WebCore log message handler from SourceBufferPrivate to MediaSourcePrivate
<a href="https://bugs.webkit.org/show_bug.cgi?id=310884">https://bugs.webkit.org/show_bug.cgi?id=310884</a>

Reviewed by Alicia Boya Garcia.

On a typical MSE video where the MediaSource handles one SourceBuffer for video and one for audio,
the previous approach of generating logs at the SourceBuffer level would result in duplicate log
messages because both SourceBuffer would have registered as observers for the same MediaSource
object. To fix this, move the logging one level up, directly in the MediaSource.

Driving-by, convert a debug message in TrackBuffer to a warning, bailing out early due to gaps seems
like a bad thing that deserves a more noticeable logging level.

* Source/WebCore/platform/graphics/TrackBuffer.cpp:
(WebCore::TrackBuffer::nextSample):
* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp:
(WebCore::AppendPipeline::appsinkCapsChanged):
* Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp:
(WebCore::MediaSourcePrivateGStreamer::MediaSourcePrivateGStreamer):
(WebCore::MediaSourcePrivateGStreamer::~MediaSourcePrivateGStreamer):
(WebCore::MediaSourcePrivateGStreamer::handleLogMessage):
* Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp:
(WebCore::SourceBufferPrivateGStreamer::SourceBufferPrivateGStreamer):
(WebCore::SourceBufferPrivateGStreamer::~SourceBufferPrivateGStreamer):
(WebCore::SourceBufferPrivateGStreamer::handleLogMessage): Deleted.
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/310089@main">https://commits.webkit.org/310089@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/918a4a9c92bc12797df9ac32a2e93798bb277e11

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152674 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25455 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19054 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161418 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154547 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25983 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25761 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117973 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155633 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/20199 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137052 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98685 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19274 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9254 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128925 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14926 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163889 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7028 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16520 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126030 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25253 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21255 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126190 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34238 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25255 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136722 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81859 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21159 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13501 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24871 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89157 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24563 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24722 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24623 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->