### PR TITLE
[Skia] Fix GPU-backed NativeImage destruction to dispatch to the creating thread

### DIFF
--- a/Source/WebCore/platform/graphics/NativeImage.h
+++ b/Source/WebCore/platform/graphics/NativeImage.h
@@ -37,6 +37,8 @@
 
 #if USE(SKIA)
 class GrDirectContext;
+#include <wtf/RunLoop.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #endif
 
 namespace WebCore {
@@ -83,6 +85,7 @@ public:
 
 #if USE(SKIA)
     GrDirectContext* grContext() const { return m_grContext; }
+    ThreadSafeWeakPtr<SerialFunctionDispatcher> creationRunLoop() const { return m_creationRunLoop; }
 #endif
 
     void addObserver(WeakRef<RenderingResourceObserver>&& observer) const
@@ -110,6 +113,7 @@ protected:
     RenderingResourceIdentifier m_renderingResourceIdentifier { RenderingResourceIdentifier::generate() };
 #if USE(SKIA)
     GrDirectContext* m_grContext { nullptr };
+    ThreadSafeWeakPtr<SerialFunctionDispatcher> m_creationRunLoop { RunLoop::currentSingleton() };
 #endif
 };
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.cpp
@@ -31,7 +31,6 @@
 #include "CoordinatedPlatformLayerBufferRGB.h"
 #include "NativeImage.h"
 #include "TextureMapper.h"
-#include <wtf/MainThread.h>
 
 #if USE(CAIRO)
 #include <cairo.h>
@@ -92,13 +91,19 @@ CoordinatedPlatformLayerBufferNativeImage::CoordinatedPlatformLayerBufferNativeI
 CoordinatedPlatformLayerBufferNativeImage::~CoordinatedPlatformLayerBufferNativeImage()
 {
 #if USE(SKIA)
-    // GPU-backed NativeImages must be destroyed on the main thread where the
-    // Skia GrDirectContext was created, not on the compositor thread. Releasing
-    // GPU resources on the wrong thread corrupts Skia's GrResourceCache.
+    // GPU-backed NativeImages must be destroyed on the thread whose GrDirectContext
+    // created them. Releasing GPU resources on the wrong thread corrupts Skia's
+    // GrResourceCache. Dispatch to the creating thread's RunLoop if we're not on it.
     if (m_image && m_image->platformImage() && m_image->platformImage()->isTextureBacked()) {
-        callOnMainThread([image = WTF::move(m_image)]() mutable {
-            image = nullptr;
-        });
+        if (auto creationRunLoop = m_image->creationRunLoop().get()) {
+            if (creationRunLoop->isCurrent())
+                return;
+            creationRunLoop->dispatch([image = WTF::move(m_image)]() mutable {
+                image = nullptr;
+            });
+        }
+        // If the RunLoop is gone, the GrDirectContext is gone too,
+        // so no GPU cache to corrupt — safe to destroy in place.
     }
 #endif
 }


### PR DESCRIPTION
#### 6faffbff8d3a5a5ceeb75a4779718d5318244d3a
<pre>
[Skia] Fix GPU-backed NativeImage destruction to dispatch to the creating thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=310885">https://bugs.webkit.org/show_bug.cgi?id=310885</a>

Reviewed by NOBODY (OOPS!).

The destructor used callOnMainThread() unconditionally, but GPU-backed
NativeImages can be created on any thread (e.g. the scrolling thread for
scrollbar images). Destroying the SkImage on the wrong thread may corrupt
that thread&apos;s GrResourceCache. Store the creating thread&apos;s RunLoop in
NativeImage itself (captured at construction time via currentSingleton()),
and use it in the CoordinatedPlatformLayerBufferNativeImage destructor to
dispatch the release to the correct thread.

* Source/WebCore/platform/graphics/NativeImage.h:
(WebCore::NativeImage::creationRunLoop const):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.cpp:
(WebCore::CoordinatedPlatformLayerBufferNativeImage::~CoordinatedPlatformLayerBufferNativeImage):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6faffbff8d3a5a5ceeb75a4779718d5318244d3a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152637 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25419 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19018 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161382 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106094 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154511 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25947 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25725 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117950 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83892 "5 flakes 2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155597 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20174 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137033 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98662 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19249 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17188 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9216 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128899 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14907 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163853 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6992 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16501 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126007 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25217 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21227 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126168 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25219 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136703 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81822 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21134 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13482 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24835 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89121 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24527 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24686 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24587 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->