### PR TITLE
[JSC] Extract InlineCacheHandler to its own file and add subclass

### DIFF
--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -674,6 +674,7 @@
 		0FF8BDEB1AD4CF7100DFE884 /* InferredValue.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FF8BDE91AD4CF7100DFE884 /* InferredValue.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0FF922D414F46B410041A24E /* LLIntOffsetsExtractor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F4680A114BA7F8200BFE272 /* LLIntOffsetsExtractor.cpp */; };
 		0FF9CE741B9CD6D0004EDCA6 /* InlineCacheCompiler.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FF9CE721B9CD6D0004EDCA6 /* InlineCacheCompiler.h */; };
+		E3B1171B8D9863A965380963 /* InlineCacheHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = E3C902954CE7D697FE07FEE7 /* InlineCacheHandler.h */; };
 		0FFA549816B8835300B3A982 /* A64DOpcode.h in Headers */ = {isa = PBXBuildFile; fileRef = 652A3A231651C69700A80AFE /* A64DOpcode.h */; };
 		0FFB6C391AF48DDC00DB1BF7 /* TypeofType.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FFB6C371AF48DDC00DB1BF7 /* TypeofType.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0FFB921A16D02EC50055A5DB /* DFGBasicBlockInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FD5652216AB780A00197653 /* DFGBasicBlockInlines.h */; };
@@ -3748,6 +3749,8 @@
 		0FF922CF14F46B130041A24E /* JSCLLIntOffsetsExtractor */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = JSCLLIntOffsetsExtractor; sourceTree = BUILT_PRODUCTS_DIR; };
 		0FF9CE711B9CD6D0004EDCA6 /* InlineCacheCompiler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = InlineCacheCompiler.cpp; sourceTree = "<group>"; };
 		0FF9CE721B9CD6D0004EDCA6 /* InlineCacheCompiler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InlineCacheCompiler.h; sourceTree = "<group>"; };
+		E3C902954CE7D697FE07FEE7 /* InlineCacheHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InlineCacheHandler.h; sourceTree = "<group>"; };
+		E3C902954CE7D697FE07FEE8 /* InlineCacheHandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = InlineCacheHandler.cpp; sourceTree = "<group>"; };
 		0FFB6C361AF48DDC00DB1BF7 /* TypeofType.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TypeofType.cpp; sourceTree = "<group>"; };
 		0FFB6C371AF48DDC00DB1BF7 /* TypeofType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TypeofType.h; sourceTree = "<group>"; };
 		0FFC92151B94FB3E0071DD66 /* DFGPropertyTypeKey.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DFGPropertyTypeKey.h; path = dfg/DFGPropertyTypeKey.h; sourceTree = "<group>"; };
@@ -10113,6 +10116,8 @@
 				7905BB671D12050E0019FE57 /* InlineAccess.h */,
 				0FF9CE711B9CD6D0004EDCA6 /* InlineCacheCompiler.cpp */,
 				0FF9CE721B9CD6D0004EDCA6 /* InlineCacheCompiler.h */,
+				E3C902954CE7D697FE07FEE8 /* InlineCacheHandler.cpp */,
+				E3C902954CE7D697FE07FEE7 /* InlineCacheHandler.h */,
 				148A7BED1B82975A002D9157 /* InlineCallFrame.cpp */,
 				148A7BEE1B82975A002D9157 /* InlineCallFrame.h */,
 				0F24E55317F0B71C00ABB217 /* InlineCallFrameSet.cpp */,
@@ -11654,6 +11659,7 @@
 				7905BB691D12050E0019FE57 /* InlineAccess.h in Headers */,
 				E3D4FFE22AF21D96004ED359 /* InlineAttribute.h in Headers */,
 				0FF9CE741B9CD6D0004EDCA6 /* InlineCacheCompiler.h in Headers */,
+				E3B1171B8D9863A965380963 /* InlineCacheHandler.h in Headers */,
 				148A7BF01B82975A002D9157 /* InlineCallFrame.h in Headers */,
 				0F24E55617F0B71C00ABB217 /* InlineCallFrameSet.h in Headers */,
 				F395BE252A43C5920083DE3A /* InPlaceInterpreter.h in Headers */,

--- a/Source/JavaScriptCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -5,7 +5,7 @@ API/JSObjectRef.h
 API/JSRetainPtr.h
 API/tests/testapi.cpp
 BytecodeStructs.h
-bytecode/InlineCacheCompiler.h
+bytecode/InlineCacheHandler.h
 bytecode/SharedJITStubSet.h
 bytecode/PropertyInlineCacheClearingWatchpoint.h
 bytecompiler/BytecodeGenerator.h

--- a/Source/JavaScriptCore/SaferCPPExpectations/RefCntblBaseVirtualDtorExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/RefCntblBaseVirtualDtorExpectations
@@ -1,3 +1,4 @@
+bytecode/InlineCacheHandler.h
 bytecode/InstanceOfAccessCase.h
 bytecode/IntrinsicGetterAccessCase.h
 bytecode/ModuleNamespaceAccessCase.h

--- a/Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -26,6 +26,7 @@ bytecode/CodeBlockInlines.h
 bytecode/DirectEvalCodeCache.h
 bytecode/GetByStatus.cpp
 bytecode/InByStatus.cpp
+bytecode/InlineCacheHandler.cpp
 bytecode/InlineCacheCompiler.cpp
 bytecode/ObjectPropertyConditionSet.cpp
 bytecode/PolyProtoAccessChain.cpp

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -256,6 +256,7 @@ bytecode/InByStatus.cpp
 bytecode/InByVariant.cpp
 bytecode/InlineAccess.cpp
 bytecode/InlineCacheCompiler.cpp
+bytecode/InlineCacheHandler.cpp
 bytecode/InlineCallFrame.cpp
 bytecode/InlineCallFrameSet.cpp
 bytecode/InstanceOfAccessCase.cpp

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -113,12 +113,6 @@ void AccessGenerationResult::dump(PrintStream& out) const
         out.print(":", *m_handler);
 }
 
-void InlineCacheHandler::dump(PrintStream& out) const
-{
-    if (m_callTarget)
-        out.print(m_callTarget);
-}
-
 static TypedArrayType toTypedArrayType(AccessCase::AccessType accessType)
 {
     switch (accessType) {
@@ -1773,146 +1767,6 @@ MacroAssemblerCodeRef<JITThunkPtrTag> InlineCacheCompiler::generateSlowPathCode(
     RELEASE_ASSERT_NOT_REACHED();
     return { };
 }
-
-InlineCacheHandler::InlineCacheHandler(Ref<InlineCacheHandler>&& previous, Ref<PolymorphicAccessJITStubRoutine>&& stubRoutine, std::unique_ptr<PropertyInlineCacheClearingWatchpoint>&& watchpoint, unsigned callLinkInfoCount, CacheType cacheType)
-    : Base(callLinkInfoCount)
-    , m_callTarget(stubRoutine->code().code().template retagged<JITStubRoutinePtrTag>())
-    , m_jumpTarget(CodePtr<NoPtrTag> { m_callTarget.retagged<NoPtrTag>().dataLocation<uint8_t*>() + prologueSizeInBytesDataIC }.template retagged<JITStubRoutinePtrTag>())
-    , m_cacheType(cacheType)
-    , m_next(WTF::move(previous))
-    , m_stubRoutine(WTF::move(stubRoutine))
-    , m_watchpoint(WTF::move(watchpoint))
-{
-    disableThreadingChecks();
-}
-
-Ref<InlineCacheHandler> InlineCacheHandler::create(Ref<InlineCacheHandler>&& previous, CodeBlock* codeBlock, PropertyInlineCache& propertyCache, Ref<PolymorphicAccessJITStubRoutine>&& stubRoutine, std::unique_ptr<PropertyInlineCacheClearingWatchpoint>&& watchpoint, unsigned callLinkInfoCount)
-{
-    auto result = adoptRef(*new (NotNull, fastMalloc(Base::allocationSize(callLinkInfoCount))) InlineCacheHandler(WTF::move(previous), WTF::move(stubRoutine), WTF::move(watchpoint), callLinkInfoCount, CacheType::Unset));
-    VM& vm = codeBlock->vm();
-    for (auto& callLinkInfo : result->span())
-        callLinkInfo.initialize(vm, codeBlock, CallLinkInfo::CallType::Call, propertyCache.codeOrigin);
-    result->m_uid = propertyCache.identifier().uid();
-    return result;
-}
-
-Ref<InlineCacheHandler> InlineCacheHandler::createPreCompiled(Ref<InlineCacheHandler>&& previous, CodeBlock* codeBlock, PropertyInlineCache& propertyCache, Ref<PolymorphicAccessJITStubRoutine>&& stubRoutine, std::unique_ptr<PropertyInlineCacheClearingWatchpoint>&& watchpoint, AccessCase& accessCase, CacheType cacheType)
-{
-    unsigned callLinkInfoCount = JSC::doesJSCalls(accessCase.m_type) ? 1 : 0;
-    auto result = adoptRef(*new (NotNull, fastMalloc(Base::allocationSize(callLinkInfoCount))) InlineCacheHandler(WTF::move(previous), WTF::move(stubRoutine), WTF::move(watchpoint), callLinkInfoCount, cacheType));
-    VM& vm = codeBlock->vm();
-    for (auto& callLinkInfo : result->span())
-        callLinkInfo.initialize(vm, codeBlock, CallLinkInfo::CallType::Call, propertyCache.codeOrigin);
-
-    result->m_structureID = accessCase.structureID();
-    result->m_offset = accessCase.offset();
-    result->m_uid = propertyCache.identifier().uid();
-    if (!result->m_uid)
-        result->m_uid = accessCase.uid();
-    switch (accessCase.m_type) {
-    case AccessCase::Load:
-    case AccessCase::GetGetter:
-    case AccessCase::Getter:
-    case AccessCase::Setter: {
-        result->u.s1.m_holder = nullptr;
-        if (auto* holder = accessCase.tryGetAlternateBase())
-            result->u.s1.m_holder = holder;
-        break;
-    }
-    case AccessCase::ProxyObjectLoad: {
-        result->u.s1.m_holder = accessCase.identifier().cell();
-        break;
-    }
-    case AccessCase::Delete:
-    case AccessCase::SetPrivateBrand: {
-        result->u.s2.m_newStructureID = accessCase.newStructureID();
-        break;
-    }
-    case AccessCase::Transition: {
-        result->u.s2.m_newStructureID = accessCase.newStructureID();
-        result->u.s2.m_newSize = accessCase.newStructure()->outOfLineCapacity() * sizeof(JSValue);
-        result->u.s2.m_oldSize = accessCase.structure()->outOfLineCapacity() * sizeof(JSValue);
-        break;
-    }
-    case AccessCase::CustomAccessorGetter:
-    case AccessCase::CustomAccessorSetter:
-    case AccessCase::CustomValueGetter:
-    case AccessCase::CustomValueSetter: {
-        result->u.s1.m_holder = nullptr;
-        Structure* currStructure = accessCase.structure();
-        if (auto* holder = accessCase.tryGetAlternateBase()) {
-            currStructure = holder->structure();
-            result->u.s1.m_holder = holder;
-        }
-        result->u.s1.m_globalObject = currStructure->realm();
-        result->u.s1.m_customAccessor = accessCase.as<GetterSetterAccessCase>().customAccessor().taggedPtr();
-        break;
-    }
-    case AccessCase::InstanceOfHit:
-    case AccessCase::InstanceOfMiss: {
-        result->u.s1.m_holder = accessCase.as<InstanceOfAccessCase>().prototype();
-        break;
-    }
-    case AccessCase::ModuleNamespaceLoad: {
-        auto& derived = accessCase.as<ModuleNamespaceAccessCase>();
-        result->u.s3.m_moduleNamespaceObject = derived.moduleNamespaceObject();
-        result->u.s3.m_moduleVariableSlot = &derived.moduleEnvironment()->variableAt(derived.scopeOffset());
-        break;
-    }
-    case AccessCase::CheckPrivateBrand: {
-        break;
-    }
-    default:
-        break;
-    }
-
-    return result;
-}
-
-Ref<InlineCacheHandler> InlineCacheHandler::createNonHandlerSlowPath(CodePtr<JITStubRoutinePtrTag> slowPath)
-{
-    auto result = adoptRef(*new (NotNull, fastMalloc(Base::allocationSize(0))) InlineCacheHandler);
-    result->m_callTarget = slowPath;
-    result->m_jumpTarget = slowPath;
-    return result;
-}
-
-Ref<InlineCacheHandler> InlineCacheHandler::createSlowPath(VM& vm, AccessType accessType)
-{
-    auto result = adoptRef(*new (NotNull, fastMalloc(Base::allocationSize(0))) InlineCacheHandler);
-    auto codeRef = InlineCacheCompiler::generateSlowPathCode(vm, accessType);
-    result->m_callTarget = codeRef.code().template retagged<JITStubRoutinePtrTag>();
-    result->m_jumpTarget = CodePtr<NoPtrTag> { codeRef.retaggedCode<NoPtrTag>().dataLocation<uint8_t*>() + prologueSizeInBytesDataIC }.template retagged<JITStubRoutinePtrTag>();
-    return result;
-}
-
-Ref<InlineCacheHandler> InlineCacheCompiler::generateSlowPathHandler(VM& vm, AccessType accessType)
-{
-    ASSERT(!isCompilationThread());
-    if (auto handler = vm.m_sharedJITStubs->getSlowPathHandler(accessType))
-        return handler.releaseNonNull();
-    auto handler = InlineCacheHandler::createSlowPath(vm, accessType);
-    vm.m_sharedJITStubs->setSlowPathHandler(accessType, handler);
-    return handler;
-}
-
-template<typename Visitor>
-void InlineCacheHandler::propagateTransitions(Visitor& visitor) const
-{
-    if (m_accessCase)
-        m_accessCase->propagateTransitions(visitor);
-}
-
-template void InlineCacheHandler::propagateTransitions(AbstractSlotVisitor&) const;
-template void InlineCacheHandler::propagateTransitions(SlotVisitor&) const;
-
-template<typename Visitor>
-void InlineCacheHandler::visitAggregateImpl(Visitor& visitor)
-{
-    if (m_accessCase)
-        m_accessCase->visitAggregate(visitor);
-}
-DEFINE_VISIT_AGGREGATE(InlineCacheHandler);
 
 void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCase, CCallHelpers::JumpList& fallThrough)
 {
@@ -3601,10 +3455,10 @@ void InlineCacheCompiler::generateAccessCase(unsigned index, AccessCase& accessC
             // handlerGPR can be the same to BaselineJITRegisters::Call::calleeJSR.
             if constexpr (GPRInfo::handlerGPR == BaselineJITRegisters::Call::calleeJSR.payloadGPR()) {
                 jit.swap(scratchGPR, BaselineJITRegisters::Call::calleeJSR.payloadGPR());
-                jit.addPtr(CCallHelpers::TrustedImm32(InlineCacheHandler::offsetOfCallLinkInfos() + sizeof(DataOnlyCallLinkInfo) * index), scratchGPR, BaselineJITRegisters::Call::callLinkInfoGPR);
+                jit.addPtr(CCallHelpers::TrustedImm32(InlineCacheHandlerWithJSCall::offsetOfCallLinkInfo() + sizeof(DataOnlyCallLinkInfo) * index), scratchGPR, BaselineJITRegisters::Call::callLinkInfoGPR);
             } else {
                 jit.move(scratchGPR, BaselineJITRegisters::Call::calleeJSR.payloadGPR());
-                jit.addPtr(CCallHelpers::TrustedImm32(InlineCacheHandler::offsetOfCallLinkInfos() + sizeof(DataOnlyCallLinkInfo) * index), GPRInfo::handlerGPR, BaselineJITRegisters::Call::callLinkInfoGPR);
+                jit.addPtr(CCallHelpers::TrustedImm32(InlineCacheHandlerWithJSCall::offsetOfCallLinkInfo() + sizeof(DataOnlyCallLinkInfo) * index), GPRInfo::handlerGPR, BaselineJITRegisters::Call::callLinkInfoGPR);
             }
             // FIXME: Maybe this can tail call on ARM64
             CallLinkInfo::emitDataICFastPath(jit);
@@ -4341,10 +4195,10 @@ void InlineCacheCompiler::emitProxyObjectAccess(unsigned index, AccessCase& acce
         // handlerGPR can be the same to BaselineJITRegisters::Call::calleeJSR.
         if constexpr (GPRInfo::handlerGPR == BaselineJITRegisters::Call::calleeJSR.payloadGPR()) {
             jit.swap(scratchGPR, BaselineJITRegisters::Call::calleeJSR.payloadGPR());
-            jit.addPtr(CCallHelpers::TrustedImm32(InlineCacheHandler::offsetOfCallLinkInfos() + sizeof(DataOnlyCallLinkInfo) * index), scratchGPR, BaselineJITRegisters::Call::callLinkInfoGPR);
+            jit.addPtr(CCallHelpers::TrustedImm32(InlineCacheHandlerWithJSCall::offsetOfCallLinkInfo() + sizeof(DataOnlyCallLinkInfo) * index), scratchGPR, BaselineJITRegisters::Call::callLinkInfoGPR);
         } else {
             jit.move(scratchGPR, BaselineJITRegisters::Call::calleeJSR.payloadGPR());
-            jit.addPtr(CCallHelpers::TrustedImm32(InlineCacheHandler::offsetOfCallLinkInfos() + sizeof(DataOnlyCallLinkInfo) * index), GPRInfo::handlerGPR, BaselineJITRegisters::Call::callLinkInfoGPR);
+            jit.addPtr(CCallHelpers::TrustedImm32(InlineCacheHandlerWithJSCall::offsetOfCallLinkInfo() + sizeof(DataOnlyCallLinkInfo) * index), GPRInfo::handlerGPR, BaselineJITRegisters::Call::callLinkInfoGPR);
         }
 
         // FIXME: Maybe this can tail call on ARM64
@@ -5557,10 +5411,10 @@ static void getterHandlerImpl(VM&, CCallHelpers& jit, JSValueRegs baseJSR, [[may
     // handlerGPR can be the same to BaselineJITRegisters::Call::calleeJSR.
     if constexpr (GPRInfo::handlerGPR == BaselineJITRegisters::Call::calleeJSR.payloadGPR()) {
         jit.swap(scratch1GPR, BaselineJITRegisters::Call::calleeJSR.payloadGPR());
-        jit.addPtr(CCallHelpers::TrustedImm32(InlineCacheHandler::offsetOfCallLinkInfos()), scratch1GPR, BaselineJITRegisters::Call::callLinkInfoGPR);
+        jit.addPtr(CCallHelpers::TrustedImm32(InlineCacheHandlerWithJSCall::offsetOfCallLinkInfo()), scratch1GPR, BaselineJITRegisters::Call::callLinkInfoGPR);
     } else {
         jit.move(scratch1GPR, BaselineJITRegisters::Call::calleeJSR.payloadGPR());
-        jit.addPtr(CCallHelpers::TrustedImm32(InlineCacheHandler::offsetOfCallLinkInfos()), GPRInfo::handlerGPR, BaselineJITRegisters::Call::callLinkInfoGPR);
+        jit.addPtr(CCallHelpers::TrustedImm32(InlineCacheHandlerWithJSCall::offsetOfCallLinkInfo()), GPRInfo::handlerGPR, BaselineJITRegisters::Call::callLinkInfoGPR);
     }
     // FIXME: Maybe this can tail call on ARM64
     CallLinkInfo::emitDataICFastPath(jit);
@@ -5654,10 +5508,10 @@ MacroAssemblerCodeRef<JITThunkPtrTag> getByIdProxyObjectLoadHandler(VM&)
     // handlerGPR can be the same to BaselineJITRegisters::Call::calleeJSR.
     if constexpr (GPRInfo::handlerGPR == BaselineJITRegisters::Call::calleeJSR.payloadGPR()) {
         jit.swap(scratch1GPR, BaselineJITRegisters::Call::calleeJSR.payloadGPR());
-        jit.addPtr(CCallHelpers::TrustedImm32(InlineCacheHandler::offsetOfCallLinkInfos()), scratch1GPR, BaselineJITRegisters::Call::callLinkInfoGPR);
+        jit.addPtr(CCallHelpers::TrustedImm32(InlineCacheHandlerWithJSCall::offsetOfCallLinkInfo()), scratch1GPR, BaselineJITRegisters::Call::callLinkInfoGPR);
     } else {
         jit.move(scratch1GPR, BaselineJITRegisters::Call::calleeJSR.payloadGPR());
-        jit.addPtr(CCallHelpers::TrustedImm32(InlineCacheHandler::offsetOfCallLinkInfos()), GPRInfo::handlerGPR, BaselineJITRegisters::Call::callLinkInfoGPR);
+        jit.addPtr(CCallHelpers::TrustedImm32(InlineCacheHandlerWithJSCall::offsetOfCallLinkInfo()), GPRInfo::handlerGPR, BaselineJITRegisters::Call::callLinkInfoGPR);
     }
     // FIXME: Maybe this can tail call on ARM64
     CallLinkInfo::emitDataICFastPath(jit);
@@ -6043,10 +5897,10 @@ static void setterHandlerImpl(VM&, CCallHelpers& jit, JSValueRegs baseJSR, JSVal
     // handlerGPR can be the same to BaselineJITRegisters::Call::calleeJSR.
     if constexpr (GPRInfo::handlerGPR == BaselineJITRegisters::Call::calleeJSR.payloadGPR()) {
         jit.swap(scratch1GPR, BaselineJITRegisters::Call::calleeJSR.payloadGPR());
-        jit.addPtr(CCallHelpers::TrustedImm32(InlineCacheHandler::offsetOfCallLinkInfos()), scratch1GPR, BaselineJITRegisters::Call::callLinkInfoGPR);
+        jit.addPtr(CCallHelpers::TrustedImm32(InlineCacheHandlerWithJSCall::offsetOfCallLinkInfo()), scratch1GPR, BaselineJITRegisters::Call::callLinkInfoGPR);
     } else {
         jit.move(scratch1GPR, BaselineJITRegisters::Call::calleeJSR.payloadGPR());
-        jit.addPtr(CCallHelpers::TrustedImm32(InlineCacheHandler::offsetOfCallLinkInfos()), GPRInfo::handlerGPR, BaselineJITRegisters::Call::callLinkInfoGPR);
+        jit.addPtr(CCallHelpers::TrustedImm32(InlineCacheHandlerWithJSCall::offsetOfCallLinkInfo()), GPRInfo::handlerGPR, BaselineJITRegisters::Call::callLinkInfoGPR);
     }
     // FIXME: Maybe this can tail call on ARM64
     CallLinkInfo::emitDataICFastPath(jit);
@@ -8112,54 +7966,6 @@ void PolymorphicAccess::dump(PrintStream& out) const
     for (auto& entry : m_list)
         out.print(comma, entry.get());
     out.print("]"_s);
-}
-
-void InlineCacheHandler::aboutToDie()
-{
-    if (m_stubRoutine)
-        m_stubRoutine->aboutToDie();
-    // A reference to InlineCacheHandler may keep it alive later than the CodeBlock that "owns" this
-    // watchpoint but the watchpoint must not fire after the CodeBlock has finished destruction,
-    // so clear the watchpoint eagerly.
-    m_watchpoint.reset();
-}
-
-CallLinkInfo* InlineCacheHandler::callLinkInfoAt(const ConcurrentJSLocker& locker, unsigned index)
-{
-    if (index < Base::size())
-        return &span()[index];
-    if (!m_stubRoutine)
-        return nullptr;
-    return m_stubRoutine->callLinkInfoAt(locker, index);
-}
-
-bool InlineCacheHandler::visitWeak(VM& vm)
-{
-    bool isValid = true;
-    for (auto& callLinkInfo : Base::span())
-        callLinkInfo.visitWeak(vm);
-
-    if (m_accessCase)
-        isValid &= m_accessCase->visitWeak(vm);
-
-    if (m_stubRoutine)
-        isValid &= m_stubRoutine->visitWeak(vm);
-
-    return isValid;
-}
-
-void InlineCacheHandler::addOwner(CodeBlock* codeBlock)
-{
-    if (!m_stubRoutine)
-        return;
-    m_stubRoutine->addOwner(codeBlock);
-}
-
-void InlineCacheHandler::removeOwner(CodeBlock* codeBlock)
-{
-    if (!m_stubRoutine)
-        return;
-    m_stubRoutine->removeOwner(codeBlock);
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
@@ -28,6 +28,7 @@
 #if ENABLE(JIT)
 
 #include "AccessCase.h"
+#include "InlineCacheHandler.h"
 #include "JITStubRoutine.h"
 #include "JSFunctionInlines.h"
 #include "MacroAssembler.h"
@@ -45,20 +46,8 @@ class CCallHelpers;
 class CodeBlock;
 class PolymorphicAccess;
 class PropertyInlineCache;
-class InlineCacheHandler;
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(PolymorphicAccess);
-
-enum class CacheType : int8_t {
-    Unset,
-    GetByIdSelf,
-    GetByIdPrototype,
-    PutByIdReplace,
-    InByIdSelf,
-    Stub,
-    ArrayLength,
-    StringLength,
-};
 
 class AccessGenerationResult {
 public:
@@ -163,124 +152,6 @@ private:
     friend class InlineCacheCompiler;
 
     ListType m_list;
-};
-
-class InlineCacheHandler final : public RefCounted<InlineCacheHandler>, public TrailingArray<InlineCacheHandler, DataOnlyCallLinkInfo> {
-    WTF_MAKE_NONCOPYABLE(InlineCacheHandler);
-    friend class InlineCacheCompiler;
-public:
-    using Base = TrailingArray<InlineCacheHandler, DataOnlyCallLinkInfo>;
-
-    static Ref<InlineCacheHandler> create(Ref<InlineCacheHandler>&&, CodeBlock*, PropertyInlineCache&, Ref<PolymorphicAccessJITStubRoutine>&&, std::unique_ptr<PropertyInlineCacheClearingWatchpoint>&&, unsigned callLinkInfoCount);
-    static Ref<InlineCacheHandler> createPreCompiled(Ref<InlineCacheHandler>&&, CodeBlock*, PropertyInlineCache&, Ref<PolymorphicAccessJITStubRoutine>&&, std::unique_ptr<PropertyInlineCacheClearingWatchpoint>&&, AccessCase&, CacheType);
-
-    CodePtr<JITStubRoutinePtrTag> callTarget() const { return m_callTarget; }
-    CodePtr<JITStubRoutinePtrTag> jumpTarget() const { return m_jumpTarget; }
-
-    void aboutToDie();
-    bool containsPC(void* pc) const
-    {
-        if (!m_stubRoutine)
-            return false;
-
-        uintptr_t pcAsInt = std::bit_cast<uintptr_t>(pc);
-        return m_stubRoutine->startAddress() <= pcAsInt && pcAsInt <= m_stubRoutine->endAddress();
-    }
-
-    CallLinkInfo* callLinkInfoAt(const ConcurrentJSLocker&, unsigned index);
-
-    // If this returns false then we are requesting a reset of the owning PropertyInlineCache.
-    bool visitWeak(VM&);
-
-    void dump(PrintStream&) const;
-
-    static Ref<InlineCacheHandler> createNonHandlerSlowPath(CodePtr<JITStubRoutinePtrTag>);
-
-    void addOwner(CodeBlock*);
-    void removeOwner(CodeBlock*);
-
-    PolymorphicAccessJITStubRoutine* stubRoutine() { return m_stubRoutine.get(); }
-
-    InlineCacheHandler* next() const { return m_next.get(); }
-    void setNext(RefPtr<InlineCacheHandler>&& next)
-    {
-        m_next = WTF::move(next);
-    }
-
-    AccessCase* accessCase() const { return m_accessCase.get(); }
-    void setAccessCase(RefPtr<AccessCase>&& accessCase)
-    {
-        m_accessCase = WTF::move(accessCase);
-    }
-
-    static constexpr ptrdiff_t offsetOfCallTarget() { return OBJECT_OFFSETOF(InlineCacheHandler, m_callTarget); }
-    static constexpr ptrdiff_t offsetOfJumpTarget() { return OBJECT_OFFSETOF(InlineCacheHandler, m_jumpTarget); }
-    static constexpr ptrdiff_t offsetOfNext() { return OBJECT_OFFSETOF(InlineCacheHandler, m_next); }
-    static constexpr ptrdiff_t offsetOfUid() { return OBJECT_OFFSETOF(InlineCacheHandler, m_uid); }
-    static constexpr ptrdiff_t offsetOfStructureID() { return OBJECT_OFFSETOF(InlineCacheHandler, m_structureID); }
-    static constexpr ptrdiff_t offsetOfOffset() { return OBJECT_OFFSETOF(InlineCacheHandler, m_offset); }
-    static constexpr ptrdiff_t offsetOfNewStructureID() { return OBJECT_OFFSETOF(InlineCacheHandler, u.s2.m_newStructureID); }
-    static constexpr ptrdiff_t offsetOfNewSize() { return OBJECT_OFFSETOF(InlineCacheHandler, u.s2.m_newSize); }
-    static constexpr ptrdiff_t offsetOfOldSize() { return OBJECT_OFFSETOF(InlineCacheHandler, u.s2.m_oldSize); }
-    static constexpr ptrdiff_t offsetOfHolder() { return OBJECT_OFFSETOF(InlineCacheHandler, u.s1.m_holder); }
-    static constexpr ptrdiff_t offsetOfGlobalObject() { return OBJECT_OFFSETOF(InlineCacheHandler, u.s1.m_globalObject); }
-    static constexpr ptrdiff_t offsetOfCustomAccessor() { return OBJECT_OFFSETOF(InlineCacheHandler, u.s1.m_customAccessor); }
-    static constexpr ptrdiff_t offsetOfModuleNamespaceObject() { return OBJECT_OFFSETOF(InlineCacheHandler, u.s3.m_moduleNamespaceObject); }
-    static constexpr ptrdiff_t offsetOfModuleVariableSlot() { return OBJECT_OFFSETOF(InlineCacheHandler, u.s3.m_moduleVariableSlot); }
-    static constexpr ptrdiff_t offsetOfCallLinkInfos() { return Base::offsetOfData(); }
-
-    StructureID structureID() const { return m_structureID; }
-    PropertyOffset offset() const { return m_offset; }
-    JSCell* holder() const { return u.s1.m_holder; }
-    size_t newSize() const { return u.s2.m_newSize; }
-    size_t oldSize() const { return u.s2.m_oldSize; }
-    StructureID newStructureID() const { return u.s2.m_newStructureID; }
-
-    CacheType cacheType() const { return m_cacheType; }
-
-    DECLARE_VISIT_AGGREGATE;
-
-    // This returns true if it has marked everything it will ever marked. This can be used as an
-    // optimization to then avoid calling this method again during the fixpoint.
-    template<typename Visitor> void propagateTransitions(Visitor&) const;
-
-private:
-    InlineCacheHandler()
-        : Base(0)
-    {
-        disableThreadingChecks();
-    }
-
-    InlineCacheHandler(Ref<InlineCacheHandler>&&, Ref<PolymorphicAccessJITStubRoutine>&&, std::unique_ptr<PropertyInlineCacheClearingWatchpoint>&&, unsigned callLinkInfoCount, CacheType);
-
-    static Ref<InlineCacheHandler> createSlowPath(VM&, AccessType);
-
-    CodePtr<JITStubRoutinePtrTag> m_callTarget;
-    CodePtr<JITStubRoutinePtrTag> m_jumpTarget;
-    StructureID m_structureID { };
-    PropertyOffset m_offset { invalidOffset };
-    UniquedStringImpl* m_uid { nullptr };
-    union {
-        struct {
-            StructureID m_newStructureID { };
-            unsigned m_newSize { };
-            unsigned m_oldSize { };
-        } s2 { };
-        struct {
-            JSCell* m_holder;
-            JSGlobalObject* m_globalObject;
-            void* m_customAccessor;
-        } s1;
-        struct {
-            JSObject* m_moduleNamespaceObject;
-            WriteBarrierBase<Unknown>* m_moduleVariableSlot;
-        } s3;
-    } u;
-    CacheType m_cacheType { CacheType::Unset };
-    RefPtr<InlineCacheHandler> m_next;
-    RefPtr<PolymorphicAccessJITStubRoutine> m_stubRoutine;
-    RefPtr<AccessCase> m_accessCase;
-    std::unique_ptr<PropertyInlineCacheClearingWatchpoint> m_watchpoint;
 };
 
 ALWAYS_INLINE bool canUseMegamorphicGetByIdExcludingIndex(VM& vm, UniquedStringImpl* uid)

--- a/Source/JavaScriptCore/bytecode/InlineCacheHandler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheHandler.cpp
@@ -1,0 +1,265 @@
+/*
+ * Copyright (C) 2014-2022, 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "InlineCacheHandler.h"
+
+#if ENABLE(JIT)
+
+#include "CacheableIdentifierInlines.h"
+#include "CodeBlock.h"
+#include "GetterSetterAccessCase.h"
+#include "InlineCacheCompiler.h"
+#include "InstanceOfAccessCase.h"
+#include "JSModuleEnvironment.h"
+#include "ModuleNamespaceAccessCase.h"
+#include "PropertyInlineCache.h"
+#include "SharedJITStubSet.h"
+#include "StructureInlines.h"
+
+namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InlineCacheHandler);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InlineCacheHandlerWithJSCall);
+
+void InlineCacheHandler::dump(PrintStream& out) const
+{
+    if (m_callTarget)
+        out.print(m_callTarget);
+}
+
+
+InlineCacheHandler::InlineCacheHandler()
+{
+    disableThreadingChecks();
+}
+
+InlineCacheHandler::InlineCacheHandler(bool makesJSCalls, Ref<InlineCacheHandler>&& previous, Ref<PolymorphicAccessJITStubRoutine>&& stubRoutine, std::unique_ptr<PropertyInlineCacheClearingWatchpoint>&& watchpoint, CacheType cacheType)
+    : m_callTarget(stubRoutine->code().code().template retagged<JITStubRoutinePtrTag>())
+    , m_jumpTarget(CodePtr<NoPtrTag> { m_callTarget.retagged<NoPtrTag>().dataLocation<uint8_t*>() + prologueSizeInBytesDataIC }.template retagged<JITStubRoutinePtrTag>())
+    , m_cacheType(cacheType)
+    , m_makesJSCalls(makesJSCalls)
+    , m_next(WTF::move(previous))
+    , m_stubRoutine(WTF::move(stubRoutine))
+    , m_watchpoint(WTF::move(watchpoint))
+{
+    disableThreadingChecks();
+}
+
+InlineCacheHandlerWithJSCall::InlineCacheHandlerWithJSCall(Ref<InlineCacheHandler>&& previous, Ref<PolymorphicAccessJITStubRoutine>&& stubRoutine, std::unique_ptr<PropertyInlineCacheClearingWatchpoint>&& watchpoint, CacheType cacheType)
+    : InlineCacheHandler(true, WTF::move(previous), WTF::move(stubRoutine), WTF::move(watchpoint), cacheType)
+{
+}
+
+void InlineCacheHandler::operator delete(InlineCacheHandler* handler, std::destroying_delete_t)
+{
+    if (auto* withJSCall = dynamicDowncast<InlineCacheHandlerWithJSCall>(handler)) {
+        std::destroy_at(withJSCall);
+        InlineCacheHandlerWithJSCall::freeAfterDestruction(withJSCall);
+    } else {
+        std::destroy_at(handler);
+        InlineCacheHandler::freeAfterDestruction(handler);
+    }
+}
+
+Ref<InlineCacheHandler> InlineCacheHandler::create(Ref<InlineCacheHandler>&& previous, CodeBlock* codeBlock, PropertyInlineCache& propertyCache, Ref<PolymorphicAccessJITStubRoutine>&& stubRoutine, std::unique_ptr<PropertyInlineCacheClearingWatchpoint>&& watchpoint, unsigned callLinkInfoCount)
+{
+    VM& vm = codeBlock->vm();
+    if (callLinkInfoCount) {
+        auto result = adoptRef(*new InlineCacheHandlerWithJSCall(WTF::move(previous), WTF::move(stubRoutine), WTF::move(watchpoint), CacheType::Unset));
+        result->m_callLinkInfo.initialize(vm, codeBlock, CallLinkInfo::CallType::Call, propertyCache.codeOrigin);
+        result->m_uid = propertyCache.identifier().uid();
+        return result;
+    }
+    auto result = adoptRef(*new InlineCacheHandler(false, WTF::move(previous), WTF::move(stubRoutine), WTF::move(watchpoint), CacheType::Unset));
+    result->m_uid = propertyCache.identifier().uid();
+    return result;
+}
+
+Ref<InlineCacheHandler> InlineCacheHandler::createPreCompiled(Ref<InlineCacheHandler>&& previous, CodeBlock* codeBlock, PropertyInlineCache& propertyCache, Ref<PolymorphicAccessJITStubRoutine>&& stubRoutine, std::unique_ptr<PropertyInlineCacheClearingWatchpoint>&& watchpoint, AccessCase& accessCase, CacheType cacheType)
+{
+    bool makesJSCalls = JSC::doesJSCalls(accessCase.m_type);
+    VM& vm = codeBlock->vm();
+    Ref<InlineCacheHandler> result = [&]() -> Ref<InlineCacheHandler> {
+        if (makesJSCalls) {
+            auto handler = adoptRef(*new InlineCacheHandlerWithJSCall(WTF::move(previous), WTF::move(stubRoutine), WTF::move(watchpoint), cacheType));
+            handler->m_callLinkInfo.initialize(vm, codeBlock, CallLinkInfo::CallType::Call, propertyCache.codeOrigin);
+            return handler;
+        }
+        return adoptRef(*new InlineCacheHandler(false, WTF::move(previous), WTF::move(stubRoutine), WTF::move(watchpoint), cacheType));
+    }();
+
+    result->m_structureID = accessCase.structureID();
+    result->m_offset = accessCase.offset();
+    result->m_uid = propertyCache.identifier().uid();
+    if (!result->m_uid)
+        result->m_uid = accessCase.uid();
+    switch (accessCase.m_type) {
+    case AccessCase::Load:
+    case AccessCase::GetGetter:
+    case AccessCase::Getter:
+    case AccessCase::Setter: {
+        result->u.s1.m_holder = nullptr;
+        if (auto* holder = accessCase.tryGetAlternateBase())
+            result->u.s1.m_holder = holder;
+        break;
+    }
+    case AccessCase::ProxyObjectLoad: {
+        result->u.s1.m_holder = accessCase.identifier().cell();
+        break;
+    }
+    case AccessCase::Delete:
+    case AccessCase::SetPrivateBrand: {
+        result->u.s2.m_newStructureID = accessCase.newStructureID();
+        break;
+    }
+    case AccessCase::Transition: {
+        result->u.s2.m_newStructureID = accessCase.newStructureID();
+        result->u.s2.m_newSize = accessCase.newStructure()->outOfLineCapacity() * sizeof(JSValue);
+        result->u.s2.m_oldSize = accessCase.structure()->outOfLineCapacity() * sizeof(JSValue);
+        break;
+    }
+    case AccessCase::CustomAccessorGetter:
+    case AccessCase::CustomAccessorSetter:
+    case AccessCase::CustomValueGetter:
+    case AccessCase::CustomValueSetter: {
+        result->u.s1.m_holder = nullptr;
+        Structure* currStructure = accessCase.structure();
+        if (auto* holder = accessCase.tryGetAlternateBase()) {
+            currStructure = holder->structure();
+            result->u.s1.m_holder = holder;
+        }
+        result->u.s1.m_globalObject = currStructure->realm();
+        result->u.s1.m_customAccessor = accessCase.as<GetterSetterAccessCase>().customAccessor().taggedPtr();
+        break;
+    }
+    case AccessCase::InstanceOfHit:
+    case AccessCase::InstanceOfMiss: {
+        result->u.s1.m_holder = accessCase.as<InstanceOfAccessCase>().prototype();
+        break;
+    }
+    case AccessCase::ModuleNamespaceLoad: {
+        auto& derived = accessCase.as<ModuleNamespaceAccessCase>();
+        result->u.s3.m_moduleNamespaceObject = derived.moduleNamespaceObject();
+        result->u.s3.m_moduleVariableSlot = &derived.moduleEnvironment()->variableAt(derived.scopeOffset());
+        break;
+    }
+    case AccessCase::CheckPrivateBrand: {
+        break;
+    }
+    default:
+        break;
+    }
+
+    return result;
+}
+
+Ref<InlineCacheHandler> InlineCacheHandler::createNonHandlerSlowPath(CodePtr<JITStubRoutinePtrTag> slowPath)
+{
+    auto result = adoptRef(*new InlineCacheHandler);
+    result->m_callTarget = slowPath;
+    result->m_jumpTarget = slowPath;
+    return result;
+}
+
+Ref<InlineCacheHandler> InlineCacheHandler::createSlowPath(VM& vm, AccessType accessType)
+{
+    auto result = adoptRef(*new InlineCacheHandler);
+    auto codeRef = InlineCacheCompiler::generateSlowPathCode(vm, accessType);
+    result->m_callTarget = codeRef.code().template retagged<JITStubRoutinePtrTag>();
+    result->m_jumpTarget = CodePtr<NoPtrTag> { codeRef.retaggedCode<NoPtrTag>().dataLocation<uint8_t*>() + prologueSizeInBytesDataIC }.template retagged<JITStubRoutinePtrTag>();
+    return result;
+}
+
+Ref<InlineCacheHandler> InlineCacheCompiler::generateSlowPathHandler(VM& vm, AccessType accessType)
+{
+    ASSERT(!isCompilationThread());
+    if (auto handler = vm.m_sharedJITStubs->getSlowPathHandler(accessType))
+        return handler.releaseNonNull();
+    auto handler = InlineCacheHandler::createSlowPath(vm, accessType);
+    vm.m_sharedJITStubs->setSlowPathHandler(accessType, handler);
+    return handler;
+}
+
+template<typename Visitor>
+void InlineCacheHandler::propagateTransitions(Visitor& visitor) const
+{
+    if (m_accessCase)
+        m_accessCase->propagateTransitions(visitor);
+}
+
+template void InlineCacheHandler::propagateTransitions(AbstractSlotVisitor&) const;
+template void InlineCacheHandler::propagateTransitions(SlotVisitor&) const;
+
+template<typename Visitor>
+void InlineCacheHandler::visitAggregateImpl(Visitor& visitor)
+{
+    if (m_accessCase)
+        m_accessCase->visitAggregate(visitor);
+}
+DEFINE_VISIT_AGGREGATE(InlineCacheHandler);
+
+void InlineCacheHandler::aboutToDie()
+{
+    if (m_stubRoutine)
+        m_stubRoutine->aboutToDie();
+    // A reference to InlineCacheHandler may keep it alive later than the CodeBlock that "owns" this
+    // watchpoint but the watchpoint must not fire after the CodeBlock has finished destruction,
+    // so clear the watchpoint eagerly.
+    m_watchpoint.reset();
+}
+
+bool InlineCacheHandler::visitWeak(VM& vm)
+{
+    bool isValid = true;
+    if (auto* withJSCall = dynamicDowncast<InlineCacheHandlerWithJSCall>(*this))
+        withJSCall->m_callLinkInfo.visitWeak(vm);
+
+    if (m_accessCase)
+        isValid &= m_accessCase->visitWeak(vm);
+
+    if (m_stubRoutine)
+        isValid &= m_stubRoutine->visitWeak(vm);
+
+    return isValid;
+}
+
+void InlineCacheHandler::addOwner(CodeBlock* codeBlock)
+{
+    if (!m_stubRoutine)
+        return;
+    m_stubRoutine->addOwner(codeBlock);
+}
+
+void InlineCacheHandler::removeOwner(CodeBlock* codeBlock)
+{
+    if (!m_stubRoutine)
+        return;
+    m_stubRoutine->removeOwner(codeBlock);
+}
+
+} // namespace JSC
+
+#endif // ENABLE(JIT)

--- a/Source/JavaScriptCore/bytecode/InlineCacheHandler.h
+++ b/Source/JavaScriptCore/bytecode/InlineCacheHandler.h
@@ -1,0 +1,191 @@
+/*
+ * Copyright (C) 2014-2022, 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(JIT)
+
+#include "AccessCase.h"
+#include "CallLinkInfo.h"
+#include "JITStubRoutine.h"
+#include "PropertyInlineCacheClearingWatchpoint.h"
+#include <wtf/RefCounted.h>
+
+namespace JSC {
+
+class CodeBlock;
+class InlineCacheCompiler;
+class InlineCacheHandlerWithJSCall;
+class PolymorphicAccessJITStubRoutine;
+class PropertyInlineCache;
+
+enum class CacheType : int8_t {
+    Unset,
+    GetByIdSelf,
+    GetByIdPrototype,
+    PutByIdReplace,
+    InByIdSelf,
+    Stub,
+    ArrayLength,
+    StringLength,
+};
+
+class InlineCacheHandler : public RefCounted<InlineCacheHandler> {
+    WTF_MAKE_NONCOPYABLE(InlineCacheHandler);
+    WTF_MAKE_TZONE_ALLOCATED(InlineCacheHandler);
+    friend class InlineCacheCompiler;
+    friend class InlineCacheHandlerWithJSCall;
+public:
+    static Ref<InlineCacheHandler> create(Ref<InlineCacheHandler>&&, CodeBlock*, PropertyInlineCache&, Ref<PolymorphicAccessJITStubRoutine>&&, std::unique_ptr<PropertyInlineCacheClearingWatchpoint>&&, unsigned callLinkInfoCount);
+    static Ref<InlineCacheHandler> createPreCompiled(Ref<InlineCacheHandler>&&, CodeBlock*, PropertyInlineCache&, Ref<PolymorphicAccessJITStubRoutine>&&, std::unique_ptr<PropertyInlineCacheClearingWatchpoint>&&, AccessCase&, CacheType);
+
+    void operator delete(InlineCacheHandler*, std::destroying_delete_t);
+
+    CodePtr<JITStubRoutinePtrTag> callTarget() const { return m_callTarget; }
+    CodePtr<JITStubRoutinePtrTag> jumpTarget() const { return m_jumpTarget; }
+
+    void aboutToDie();
+    bool containsPC(void* pc) const
+    {
+        if (!m_stubRoutine)
+            return false;
+
+        uintptr_t pcAsInt = std::bit_cast<uintptr_t>(pc);
+        return m_stubRoutine->startAddress() <= pcAsInt && pcAsInt <= m_stubRoutine->endAddress();
+    }
+
+    // If this returns false then we are requesting a reset of the owning PropertyInlineCache.
+    bool visitWeak(VM&);
+
+    void dump(PrintStream&) const;
+
+    static Ref<InlineCacheHandler> createNonHandlerSlowPath(CodePtr<JITStubRoutinePtrTag>);
+
+    void addOwner(CodeBlock*);
+    void removeOwner(CodeBlock*);
+
+    PolymorphicAccessJITStubRoutine* stubRoutine() { return m_stubRoutine.get(); }
+
+    InlineCacheHandler* next() const { return m_next.get(); }
+    void setNext(RefPtr<InlineCacheHandler>&& next)
+    {
+        m_next = WTF::move(next);
+    }
+
+    AccessCase* accessCase() const { return m_accessCase.get(); }
+    void setAccessCase(RefPtr<AccessCase>&& accessCase)
+    {
+        m_accessCase = WTF::move(accessCase);
+    }
+
+    bool makesJSCalls() const { return m_makesJSCalls; }
+
+    static constexpr ptrdiff_t offsetOfCallTarget() { return OBJECT_OFFSETOF(InlineCacheHandler, m_callTarget); }
+    static constexpr ptrdiff_t offsetOfJumpTarget() { return OBJECT_OFFSETOF(InlineCacheHandler, m_jumpTarget); }
+    static constexpr ptrdiff_t offsetOfNext() { return OBJECT_OFFSETOF(InlineCacheHandler, m_next); }
+    static constexpr ptrdiff_t offsetOfUid() { return OBJECT_OFFSETOF(InlineCacheHandler, m_uid); }
+    static constexpr ptrdiff_t offsetOfStructureID() { return OBJECT_OFFSETOF(InlineCacheHandler, m_structureID); }
+    static constexpr ptrdiff_t offsetOfOffset() { return OBJECT_OFFSETOF(InlineCacheHandler, m_offset); }
+    static constexpr ptrdiff_t offsetOfNewStructureID() { return OBJECT_OFFSETOF(InlineCacheHandler, u.s2.m_newStructureID); }
+    static constexpr ptrdiff_t offsetOfNewSize() { return OBJECT_OFFSETOF(InlineCacheHandler, u.s2.m_newSize); }
+    static constexpr ptrdiff_t offsetOfOldSize() { return OBJECT_OFFSETOF(InlineCacheHandler, u.s2.m_oldSize); }
+    static constexpr ptrdiff_t offsetOfHolder() { return OBJECT_OFFSETOF(InlineCacheHandler, u.s1.m_holder); }
+    static constexpr ptrdiff_t offsetOfGlobalObject() { return OBJECT_OFFSETOF(InlineCacheHandler, u.s1.m_globalObject); }
+    static constexpr ptrdiff_t offsetOfCustomAccessor() { return OBJECT_OFFSETOF(InlineCacheHandler, u.s1.m_customAccessor); }
+    static constexpr ptrdiff_t offsetOfModuleNamespaceObject() { return OBJECT_OFFSETOF(InlineCacheHandler, u.s3.m_moduleNamespaceObject); }
+    static constexpr ptrdiff_t offsetOfModuleVariableSlot() { return OBJECT_OFFSETOF(InlineCacheHandler, u.s3.m_moduleVariableSlot); }
+
+    StructureID structureID() const { return m_structureID; }
+    PropertyOffset offset() const { return m_offset; }
+    JSCell* holder() const { return u.s1.m_holder; }
+    size_t newSize() const { return u.s2.m_newSize; }
+    size_t oldSize() const { return u.s2.m_oldSize; }
+    StructureID newStructureID() const { return u.s2.m_newStructureID; }
+
+    CacheType cacheType() const { return m_cacheType; }
+
+    DECLARE_VISIT_AGGREGATE;
+
+    // This returns true if it has marked everything it will ever marked. This can be used as an
+    // optimization to then avoid calling this method again during the fixpoint.
+    template<typename Visitor> void propagateTransitions(Visitor&) const;
+
+protected:
+    InlineCacheHandler();
+    InlineCacheHandler(bool makesJSCalls, Ref<InlineCacheHandler>&&, Ref<PolymorphicAccessJITStubRoutine>&&, std::unique_ptr<PropertyInlineCacheClearingWatchpoint>&&, CacheType);
+
+    static Ref<InlineCacheHandler> createSlowPath(VM&, AccessType);
+
+    CodePtr<JITStubRoutinePtrTag> m_callTarget;
+    CodePtr<JITStubRoutinePtrTag> m_jumpTarget;
+    StructureID m_structureID { };
+    PropertyOffset m_offset { invalidOffset };
+    UniquedStringImpl* m_uid { nullptr };
+    union {
+        struct {
+            StructureID m_newStructureID { };
+            unsigned m_newSize { };
+            unsigned m_oldSize { };
+        } s2 { };
+        struct {
+            JSCell* m_holder;
+            JSGlobalObject* m_globalObject;
+            void* m_customAccessor;
+        } s1;
+        struct {
+            JSObject* m_moduleNamespaceObject;
+            WriteBarrierBase<Unknown>* m_moduleVariableSlot;
+        } s3;
+    } u;
+    CacheType m_cacheType { CacheType::Unset };
+    bool m_makesJSCalls { false };
+    RefPtr<InlineCacheHandler> m_next;
+    RefPtr<PolymorphicAccessJITStubRoutine> m_stubRoutine;
+    RefPtr<AccessCase> m_accessCase;
+    std::unique_ptr<PropertyInlineCacheClearingWatchpoint> m_watchpoint;
+};
+
+class InlineCacheHandlerWithJSCall final : public InlineCacheHandler {
+    WTF_MAKE_TZONE_ALLOCATED(InlineCacheHandlerWithJSCall);
+    friend class InlineCacheHandler;
+    friend class InlineCacheCompiler;
+public:
+    CallLinkInfo* callLinkInfo(const ConcurrentJSLocker&) { return &m_callLinkInfo; }
+
+    static constexpr ptrdiff_t offsetOfCallLinkInfo() { return OBJECT_OFFSETOF(InlineCacheHandlerWithJSCall, m_callLinkInfo); }
+
+private:
+    InlineCacheHandlerWithJSCall(Ref<InlineCacheHandler>&&, Ref<PolymorphicAccessJITStubRoutine>&&, std::unique_ptr<PropertyInlineCacheClearingWatchpoint>&&, CacheType);
+
+    DataOnlyCallLinkInfo m_callLinkInfo;
+};
+
+} // namespace JSC
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(JSC::InlineCacheHandlerWithJSCall)
+    static bool isType(const JSC::InlineCacheHandler& handler) { return handler.makesJSCalls(); }
+SPECIALIZE_TYPE_TRAITS_END()
+
+#endif // ENABLE(JIT)

--- a/Source/JavaScriptCore/bytecode/PropertyInlineCache.cpp
+++ b/Source/JavaScriptCore/bytecode/PropertyInlineCache.cpp
@@ -497,23 +497,24 @@ CallLinkInfo* PropertyInlineCache::callLinkInfoAt(const ConcurrentJSLocker& lock
     if (auto* handlerIC = dynamicDowncast<HandlerPropertyInlineCache>(*this)) {
         if (handlerIC->m_inlinedHandler) {
             if (handlerIC->m_inlinedHandler->accessCase() == &accessCase)
-                return handlerIC->m_inlinedHandler->callLinkInfoAt(locker, 0);
+                return downcast<InlineCacheHandlerWithJSCall>(*handlerIC->m_inlinedHandler).callLinkInfo(locker);
         }
 
         if (auto* cursor = m_handler.get()) {
             while (cursor) {
                 if (cursor->accessCase() == &accessCase)
-                    return cursor->callLinkInfoAt(locker, 0);
+                    return downcast<InlineCacheHandlerWithJSCall>(*cursor).callLinkInfo(locker);
                 cursor = cursor->next();
             }
         }
         return nullptr;
     }
 
-    // Repatching IC path
     if (!m_handler)
         return nullptr;
-    return m_handler->callLinkInfoAt(locker, index);
+    if (!m_handler->stubRoutine())
+        return nullptr;
+    return m_handler->stubRoutine()->callLinkInfoAt(locker, index);
 }
 
 PropertyInlineCacheSummary PropertyInlineCache::summary(const ConcurrentJSLocker& locker, VM& vm) const


### PR DESCRIPTION
#### d5599ce3026f7826886d0466a516a254c8c901b9
<pre>
[JSC] Extract InlineCacheHandler to its own file and add subclass
<a href="https://bugs.webkit.org/show_bug.cgi?id=310886">https://bugs.webkit.org/show_bug.cgi?id=310886</a>
<a href="https://rdar.apple.com/173499272">rdar://173499272</a>

Reviewed by Yijia Huang.

Move InlineCacheHandler and CacheType out of InlineCacheCompiler.h/.cpp
into dedicated InlineCacheHandler.h/.cpp files. Replace the
`TrailingArray&lt;..., DataOnlyCallLinkInfo&gt; pattern with an
InlineCacheHandlerWithJSCall subclass that holds a single
DataOnlyCallLinkInfo member, since at most one CallLinkInfo is ever
needed per handler. This eliminates the variable-length allocation
overhead for the common case where no JS call is made, and uses
destroying delete with dynamicDowncast for correct polymorphic
destruction.

SaferCPPExpectations changes are carried over from prior code. Except
the non-virtual destructor but that&apos;s safe because we have an overloaded
destroying_delete_t delete operator.

No new tests, no behavior change.

Canonical link: <a href="https://commits.webkit.org/310116@main">https://commits.webkit.org/310116@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e490e0f791871f282f9b2c35d15b3844e489adb7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152758 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25539 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19138 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161502 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bac0fa74-e801-4917-969f-6dee333d15e4) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26067 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25845 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/118044 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155717 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/20268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137126 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98757 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b4f11c06-00ec-4993-a7ce-deb088315a66) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/19343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9338 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144770 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15000 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163974 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/13566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/7112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16594 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/126104 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/25337 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21328 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126262 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25339 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136796 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/81943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23402 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21222 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13575 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184390 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24955 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89242 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47070 "Passed tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/24647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/24806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/24707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->