### PR TITLE
Optimize Vector::appendVector(&&) to use bulk move instead of per-element append

### DIFF
--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -170,6 +170,17 @@ struct VectorTypeOperations
         }
     }
 
+    template<typename U, std::size_t Extent>
+    static void uninitializedMove(std::span<U, Extent> source, std::span<T> destination)
+    {
+        if constexpr (std::same_as<T, U> && std::is_trivially_copyable_v<T>)
+            memcpySpan(destination, source);
+        else {
+            for (size_t i = 0; i < source.size(); ++i)
+                new (NotNull, std::addressof(destination[i])) T(WTF::move(source[i]));
+        }
+    }
+
     static void uninitializedFill(T* dst, T* dstEnd, const T& val)
     {
         if constexpr (VectorTraits<T>::canFillWithMemset) {
@@ -1568,20 +1579,23 @@ ALWAYS_INLINE void Vector<T, inlineCapacity, OverflowHandler, minCapacity, Mallo
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
 template<typename U, size_t otherCapacity, typename OtherOverflowHandler, size_t otherMinCapacity, typename OtherMalloc>
-inline void Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::appendVector(const Vector<U, otherCapacity, OtherOverflowHandler, otherMinCapacity, OtherMalloc>& val)
+inline void Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::appendVector(const Vector<U, otherCapacity, OtherOverflowHandler, otherMinCapacity, OtherMalloc>& other)
 {
-    append(val.span());
+    append(other.span());
 }
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
 template<typename U, size_t otherCapacity, typename OtherOverflowHandler, size_t otherMinCapacity, typename OtherMalloc>
-inline void Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::appendVector(Vector<U, otherCapacity, OtherOverflowHandler, otherMinCapacity, OtherMalloc>&& val)
+inline void Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::appendVector(Vector<U, otherCapacity, OtherOverflowHandler, otherMinCapacity, OtherMalloc>&& other)
 {
-    size_t newSize = m_size + val.size();
+    if (other.isEmpty())
+        return;
+    size_t newSize = m_size + other.size();
     if (newSize > capacity())
         expandCapacity<FailureAction::Crash>(newSize);
-    for (auto& item : val)
-        unsafeAppendWithoutCapacityCheck(WTF::move(item));
+    asanBufferSizeWillChangeTo(newSize);
+    TypeOperations::uninitializedMove(other.mutableSpan(), unsafeMakeSpan(end(), other.size()));
+    m_size = newSize;
 }
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>

--- a/Tools/TestWebKitAPI/Tests/WTF/Vector.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Vector.cpp
@@ -2383,4 +2383,282 @@ TEST(WTF_Vector, InsertFillAliasingElementBeforePosition)
     EXPECT_EQ("c"_s, v[4]);
 }
 
+TEST(WTF_Vector, AppendVectorCopyTrivial)
+{
+    Vector<int> dest = { 1, 2, 3 };
+    Vector<int> src = { 4, 5, 6 };
+    dest.appendVector(src);
+    EXPECT_EQ(6U, dest.size());
+    EXPECT_EQ(1, dest[0]);
+    EXPECT_EQ(2, dest[1]);
+    EXPECT_EQ(3, dest[2]);
+    EXPECT_EQ(4, dest[3]);
+    EXPECT_EQ(5, dest[4]);
+    EXPECT_EQ(6, dest[5]);
+    // Source unchanged.
+    EXPECT_EQ(3U, src.size());
+    EXPECT_EQ(4, src[0]);
+}
+
+TEST(WTF_Vector, AppendVectorCopyEmpty)
+{
+    Vector<int> dest = { 1, 2 };
+    Vector<int> empty;
+    dest.appendVector(empty);
+    EXPECT_EQ(2U, dest.size());
+    EXPECT_EQ(1, dest[0]);
+    EXPECT_EQ(2, dest[1]);
+}
+
+TEST(WTF_Vector, AppendVectorCopyToEmpty)
+{
+    Vector<int> dest;
+    Vector<int> src = { 1, 2, 3 };
+    dest.appendVector(src);
+    EXPECT_EQ(3U, dest.size());
+    EXPECT_EQ(1, dest[0]);
+    EXPECT_EQ(2, dest[1]);
+    EXPECT_EQ(3, dest[2]);
+}
+
+TEST(WTF_Vector, AppendVectorMoveTrivial)
+{
+    Vector<int> dest = { 1, 2, 3 };
+    Vector<int> src = { 4, 5, 6 };
+    dest.appendVector(WTF::move(src));
+    EXPECT_EQ(6U, dest.size());
+    EXPECT_EQ(1, dest[0]);
+    EXPECT_EQ(2, dest[1]);
+    EXPECT_EQ(3, dest[2]);
+    EXPECT_EQ(4, dest[3]);
+    EXPECT_EQ(5, dest[4]);
+    EXPECT_EQ(6, dest[5]);
+}
+
+TEST(WTF_Vector, AppendVectorMoveEmpty)
+{
+    Vector<int> dest = { 1, 2 };
+    Vector<int> empty;
+    dest.appendVector(WTF::move(empty));
+    EXPECT_EQ(2U, dest.size());
+    EXPECT_EQ(1, dest[0]);
+    EXPECT_EQ(2, dest[1]);
+}
+
+TEST(WTF_Vector, AppendVectorMoveToEmpty)
+{
+    Vector<int> dest;
+    Vector<int> src = { 1, 2, 3 };
+    dest.appendVector(WTF::move(src));
+    EXPECT_EQ(3U, dest.size());
+    EXPECT_EQ(1, dest[0]);
+    EXPECT_EQ(2, dest[1]);
+    EXPECT_EQ(3, dest[2]);
+}
+
+TEST(WTF_Vector, AppendVectorMoveTriggersExpansion)
+{
+    Vector<int> dest;
+    dest.reserveInitialCapacity(2);
+    dest.append(1);
+    dest.append(2);
+    EXPECT_EQ(2U, dest.capacity());
+
+    Vector<int> src = { 3, 4, 5 };
+    dest.appendVector(WTF::move(src));
+    EXPECT_EQ(5U, dest.size());
+    EXPECT_EQ(1, dest[0]);
+    EXPECT_EQ(2, dest[1]);
+    EXPECT_EQ(3, dest[2]);
+    EXPECT_EQ(4, dest[3]);
+    EXPECT_EQ(5, dest[4]);
+}
+
+TEST(WTF_Vector, AppendVectorMoveMoveOnly)
+{
+    Vector<MoveOnly> dest;
+    dest.append(MoveOnly(1));
+    dest.append(MoveOnly(2));
+
+    Vector<MoveOnly> src;
+    src.append(MoveOnly(3));
+    src.append(MoveOnly(4));
+    src.append(MoveOnly(5));
+
+    dest.appendVector(WTF::move(src));
+
+    EXPECT_EQ(5U, dest.size());
+    EXPECT_EQ(1U, dest[0].value());
+    EXPECT_EQ(2U, dest[1].value());
+    EXPECT_EQ(3U, dest[2].value());
+    EXPECT_EQ(4U, dest[3].value());
+    EXPECT_EQ(5U, dest[4].value());
+
+    // Source elements should be moved-from (zeroed by MoveOnly's move constructor).
+    EXPECT_EQ(3U, src.size());
+    EXPECT_EQ(0U, src[0].value());
+    EXPECT_EQ(0U, src[1].value());
+    EXPECT_EQ(0U, src[2].value());
+}
+
+TEST(WTF_Vector, AppendVectorMoveMoveOnlyEmpty)
+{
+    Vector<MoveOnly> dest;
+    dest.append(MoveOnly(1));
+
+    Vector<MoveOnly> empty;
+    dest.appendVector(WTF::move(empty));
+
+    EXPECT_EQ(1U, dest.size());
+    EXPECT_EQ(1U, dest[0].value());
+}
+
+TEST(WTF_Vector, AppendVectorMoveMoveOnlyToEmpty)
+{
+    Vector<MoveOnly> dest;
+
+    Vector<MoveOnly> src;
+    src.append(MoveOnly(10));
+    src.append(MoveOnly(20));
+
+    dest.appendVector(WTF::move(src));
+
+    EXPECT_EQ(2U, dest.size());
+    EXPECT_EQ(10U, dest[0].value());
+    EXPECT_EQ(20U, dest[1].value());
+}
+
+TEST(WTF_Vector, AppendVectorMoveMoveOnlyTriggersExpansion)
+{
+    Vector<MoveOnly> dest;
+    dest.reserveInitialCapacity(1);
+    dest.append(MoveOnly(1));
+    EXPECT_EQ(1U, dest.capacity());
+
+    Vector<MoveOnly> src;
+    src.append(MoveOnly(2));
+    src.append(MoveOnly(3));
+
+    dest.appendVector(WTF::move(src));
+
+    EXPECT_EQ(3U, dest.size());
+    EXPECT_EQ(1U, dest[0].value());
+    EXPECT_EQ(2U, dest[1].value());
+    EXPECT_EQ(3U, dest[2].value());
+}
+
+TEST(WTF_Vector, AppendVectorMoveInlineCapacity)
+{
+    Vector<int, 4> dest = { 1, 2 };
+    Vector<int, 4> src = { 3, 4 };
+    dest.appendVector(WTF::move(src));
+    EXPECT_EQ(4U, dest.size());
+    EXPECT_EQ(1, dest[0]);
+    EXPECT_EQ(2, dest[1]);
+    EXPECT_EQ(3, dest[2]);
+    EXPECT_EQ(4, dest[3]);
+}
+
+TEST(WTF_Vector, AppendVectorMoveInlineToHeap)
+{
+    Vector<int, 2> dest = { 1, 2 };
+    Vector<int, 2> src = { 3, 4, 5 };
+    dest.appendVector(WTF::move(src));
+    EXPECT_EQ(5U, dest.size());
+    EXPECT_EQ(1, dest[0]);
+    EXPECT_EQ(2, dest[1]);
+    EXPECT_EQ(3, dest[2]);
+    EXPECT_EQ(4, dest[3]);
+    EXPECT_EQ(5, dest[4]);
+}
+
+TEST(WTF_Vector, AppendVectorMoveLarge)
+{
+    Vector<int> dest;
+    Vector<int> src;
+    for (int i = 0; i < 1000; ++i)
+        dest.append(i);
+    for (int i = 1000; i < 2000; ++i)
+        src.append(i);
+
+    dest.appendVector(WTF::move(src));
+
+    EXPECT_EQ(2000U, dest.size());
+    for (int i = 0; i < 2000; ++i)
+        EXPECT_EQ(i, dest[i]);
+}
+
+TEST(WTF_Vector, AppendVectorMoveRefPtr)
+{
+    // RefPtr has canMoveWithMemcpy=true but is not trivially destructible.
+    // appendVector(&&) must use element-by-element move (not memcpy) so that
+    // ownership is properly transferred and the source vector's destructor
+    // doesn't over-release.
+    auto obj1 = RefCountedObject::create(10);
+    auto obj2 = RefCountedObject::create(20);
+    auto obj3 = RefCountedObject::create(30);
+
+    Vector<RefPtr<RefCountedObject>> dest;
+    dest.append(obj1.ptr());
+
+    Vector<RefPtr<RefCountedObject>> src;
+    src.append(obj2.ptr());
+    src.append(obj3.ptr());
+
+    dest.appendVector(WTF::move(src));
+
+    EXPECT_EQ(3U, dest.size());
+    EXPECT_EQ(10, dest[0]->value);
+    EXPECT_EQ(20, dest[1]->value);
+    EXPECT_EQ(30, dest[2]->value);
+
+    // Source elements should be null after move.
+    EXPECT_EQ(2U, src.size());
+    EXPECT_EQ(nullptr, src[0]);
+    EXPECT_EQ(nullptr, src[1]);
+}
+
+TEST(WTF_Vector, AppendVectorMoveRef)
+{
+    // Ref also has canMoveWithMemcpy=true but is not trivially destructible.
+    Vector<Ref<RefCountedObject>> dest;
+    dest.append(RefCountedObject::create(1));
+    dest.append(RefCountedObject::create(2));
+
+    Vector<Ref<RefCountedObject>> src;
+    src.append(RefCountedObject::create(3));
+    src.append(RefCountedObject::create(4));
+
+    dest.appendVector(WTF::move(src));
+
+    EXPECT_EQ(4U, dest.size());
+    EXPECT_EQ(1, dest[0]->value);
+    EXPECT_EQ(2, dest[1]->value);
+    EXPECT_EQ(3, dest[2]->value);
+    EXPECT_EQ(4, dest[3]->value);
+}
+
+TEST(WTF_Vector, AppendVectorMoveRefPtrTriggersExpansion)
+{
+    // Same as above but forces capacity expansion during appendVector.
+    Vector<RefPtr<RefCountedObject>> dest;
+    dest.reserveInitialCapacity(1);
+    dest.append(RefCountedObject::create(1).ptr());
+    EXPECT_EQ(1U, dest.capacity());
+
+    Vector<RefPtr<RefCountedObject>> src;
+    src.append(RefCountedObject::create(2).ptr());
+    src.append(RefCountedObject::create(3).ptr());
+
+    dest.appendVector(WTF::move(src));
+
+    EXPECT_EQ(3U, dest.size());
+    EXPECT_EQ(1, dest[0]->value);
+    EXPECT_EQ(2, dest[1]->value);
+    EXPECT_EQ(3, dest[2]->value);
+
+    EXPECT_EQ(nullptr, src[0]);
+    EXPECT_EQ(nullptr, src[1]);
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 9b1252efbbc4fba4423a37b453d91584fc59153e
<pre>
Optimize Vector::appendVector(&amp;&amp;) to use bulk move instead of per-element append
<a href="https://bugs.webkit.org/show_bug.cgi?id=310887">https://bugs.webkit.org/show_bug.cgi?id=310887</a>

Reviewed by Darin Adler.

The rvalue overload of `appendVector()` was appending elements one at a time
via `unsafeAppendWithoutCapacityCheck()`, which issues a separate ASan
annotation and m_size increment per element. For types with
canMoveWithMemcpy (e.g. int, pointers), this also prevents the compiler
from coalescing N individual copies into a single memcpy.

Replace with a bulk approach: a single ASan annotation, a single memcpy
for trivially-movable types (or a tight placement-new loop for non-trivial
types), and a single m_size update.

Also add comprehensive API tests for both appendVector overloads covering
trivial types (memcpy path), MoveOnly types (element-by-element path),
empty vectors, capacity expansion, inline buffers, and large vectors.

Test: Tools/TestWebKitAPI/Tests/WTF/Vector.cpp

* Source/WTF/wtf/Vector.h:
(WTF::VectorTypeOperations::uninitializedMove):
(WTF::Malloc&gt;::appendVector):
* Tools/TestWebKitAPI/Tests/WTF/Vector.cpp:
(TestWebKitAPI::TEST(WTF_Vector, AppendVectorCopyTrivial)):
(TestWebKitAPI::TEST(WTF_Vector, AppendVectorCopyEmpty)):
(TestWebKitAPI::TEST(WTF_Vector, AppendVectorCopyToEmpty)):
(TestWebKitAPI::TEST(WTF_Vector, AppendVectorMoveTrivial)):
(TestWebKitAPI::TEST(WTF_Vector, AppendVectorMoveEmpty)):
(TestWebKitAPI::TEST(WTF_Vector, AppendVectorMoveToEmpty)):
(TestWebKitAPI::TEST(WTF_Vector, AppendVectorMoveTriggersExpansion)):
(TestWebKitAPI::TEST(WTF_Vector, AppendVectorMoveMoveOnly)):
(TestWebKitAPI::TEST(WTF_Vector, AppendVectorMoveMoveOnlyEmpty)):
(TestWebKitAPI::TEST(WTF_Vector, AppendVectorMoveMoveOnlyToEmpty)):
(TestWebKitAPI::TEST(WTF_Vector, AppendVectorMoveMoveOnlyTriggersExpansion)):
(TestWebKitAPI::TEST(WTF_Vector, AppendVectorMoveInlineCapacity)):
(TestWebKitAPI::TEST(WTF_Vector, AppendVectorMoveInlineToHeap)):
(TestWebKitAPI::TEST(WTF_Vector, AppendVectorMoveLarge)):
(TestWebKitAPI::TEST(WTF_Vector, AppendVectorMoveRefPtr)):
(TestWebKitAPI::TEST(WTF_Vector, AppendVectorMoveRef)):
(TestWebKitAPI::TEST(WTF_Vector, AppendVectorMoveRefPtrTriggersExpansion)):

Canonical link: <a href="https://commits.webkit.org/310154@main">https://commits.webkit.org/310154@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a079a3231f064ff11052217585a410382ad27c4d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152881 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25663 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19261 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161625 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/661ef9e7-1a8b-45c9-8bbd-19101fe7b26f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154754 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26190 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25968 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118154 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155840 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20384 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137253 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98867 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3adf1424-c7e7-43c6-afee-2b6ede991217) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19458 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9461 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144893 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129110 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15127 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164099 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13690 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7235 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16721 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126216 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25460 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21437 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126374 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34285 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25462 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136923 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82066 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21331 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13702 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184514 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25078 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89365 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47103 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24770 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24929 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24830 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->