### PR TITLE
Fix aliasing bugs in Vector::fill() and Vector::insertFill()

### DIFF
--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -1158,6 +1158,10 @@ bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::removeFirs
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
 void Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::fill(const T& val, size_t newSize)
 {
+    // Copy val before mutating the vector, since val may reference an element
+    // within this vector that could be invalidated by shrink/clear/reallocation.
+    T valCopy(val);
+
     if (size() > newSize)
         shrink(newSize);
     else if (newSize > capacity()) {
@@ -1168,8 +1172,8 @@ void Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::fill(const
 
     asanBufferSizeWillChangeTo(newSize);
 
-    std::ranges::fill(*this, val);
-    TypeOperations::uninitializedFill(end(), begin() + newSize, val);
+    std::ranges::fill(*this, valCopy);
+    TypeOperations::uninitializedFill(end(), begin() + newSize, valCopy);
     m_size = newSize;
 }
 
@@ -1619,6 +1623,11 @@ inline void Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::ins
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
 void Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::insertFill(size_t position, const T& data, size_t dataSize)
 {
+    // Copy data before mutating the vector, since data may reference an element
+    // within this vector that could be invalidated by reallocation or the
+    // moveOverlapping shift.
+    T dataCopy(data);
+
     size_t newSize = m_size + dataSize;
     if (newSize > capacity()) {
         expandCapacity<FailureAction::Crash>(newSize);
@@ -1629,7 +1638,7 @@ void Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::insertFill
     asanBufferSizeWillChangeTo(newSize);
     T* spot = mutableSpan().subspan(position).data();
     TypeOperations::moveOverlapping(spot, end(), spot + dataSize);
-    TypeOperations::uninitializedFill(spot, spot + dataSize, data);
+    TypeOperations::uninitializedFill(spot, spot + dataSize, dataCopy);
     m_size = newSize;
 }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/Vector.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Vector.cpp
@@ -2253,4 +2253,134 @@ TEST(WTF_Vector, RangeToMoveOnly)
     EXPECT_EQ(7U, dest[2].value());
 }
 
+TEST(WTF_Vector, FillAliasingGrowth)
+{
+    // Test that fill() works correctly when val references an element in the
+    // vector and the fill triggers reallocation (clear + reserveCapacity).
+    Vector<String> v = { "a"_s, "b"_s, "c"_s };
+    v.fill(v[1], 10);
+    EXPECT_EQ(10U, v.size());
+    for (size_t i = 0; i < v.size(); ++i)
+        EXPECT_EQ("b"_s, v[i]);
+}
+
+TEST(WTF_Vector, FillAliasingShrink)
+{
+    // Test that fill() works correctly when val references an element that
+    // would be destroyed by shrink (index >= newSize).
+    Vector<String> v = { "a"_s, "b"_s, "c"_s, "d"_s, "e"_s };
+    v.fill(v[4], 3);
+    EXPECT_EQ(3U, v.size());
+    for (size_t i = 0; i < v.size(); ++i)
+        EXPECT_EQ("e"_s, v[i]);
+}
+
+TEST(WTF_Vector, FillAliasingNoReallocation)
+{
+    // Test that fill() works when val aliases an element and newSize fits
+    // within existing capacity.
+    Vector<String> v;
+    v.reserveCapacity(10);
+    v.append("a"_s);
+    v.append("b"_s);
+    v.append("c"_s);
+    v.fill(v[2], 5);
+    EXPECT_EQ(5U, v.size());
+    for (size_t i = 0; i < v.size(); ++i)
+        EXPECT_EQ("c"_s, v[i]);
+}
+
+TEST(WTF_Vector, FillAliasingSameSize)
+{
+    Vector<String> v = { "x"_s, "y"_s, "z"_s };
+    v.fill(v[0]);
+    EXPECT_EQ(3U, v.size());
+    for (size_t i = 0; i < v.size(); ++i)
+        EXPECT_EQ("x"_s, v[i]);
+}
+
+TEST(WTF_Vector, InsertFillAliasingWithReallocation)
+{
+    // Test that insertFill() works correctly when data references an element
+    // in the vector and the insertion triggers reallocation.
+    Vector<String> v;
+    v.reserveInitialCapacity(3);
+    v.append("a"_s);
+    v.append("b"_s);
+    v.append("c"_s);
+    EXPECT_EQ(3U, v.capacity());
+
+    // This must trigger reallocation since size + 2 > capacity.
+    v.insertFill(1, v[2], 2);
+    EXPECT_EQ(5U, v.size());
+    EXPECT_EQ("a"_s, v[0]);
+    EXPECT_EQ("c"_s, v[1]);
+    EXPECT_EQ("c"_s, v[2]);
+    EXPECT_EQ("b"_s, v[3]);
+    EXPECT_EQ("c"_s, v[4]);
+}
+
+TEST(WTF_Vector, InsertFillAliasingElementAfterPosition)
+{
+    // Test that insertFill() works correctly when data references an element
+    // at index >= position. Without the fix, moveOverlapping shifts the
+    // element and the reference reads the wrong value.
+    Vector<String> v;
+    v.reserveCapacity(10);
+    v.append("a"_s);
+    v.append("b"_s);
+    v.append("c"_s);
+    v.append("d"_s);
+
+    // Insert 2 copies of v[3]="d" at position 1. moveOverlapping shifts
+    // v[1..3] to v[3..5], which overwrites v[3].
+    v.insertFill(1, v[3], 2);
+    EXPECT_EQ(6U, v.size());
+    EXPECT_EQ("a"_s, v[0]);
+    EXPECT_EQ("d"_s, v[1]);
+    EXPECT_EQ("d"_s, v[2]);
+    EXPECT_EQ("b"_s, v[3]);
+    EXPECT_EQ("c"_s, v[4]);
+    EXPECT_EQ("d"_s, v[5]);
+}
+
+TEST(WTF_Vector, InsertFillAliasingElementAtPosition)
+{
+    // Test that insertFill() works when data references an element in the
+    // gap [position, position+dataSize) that gets moved/destructed.
+    Vector<String> v;
+    v.reserveCapacity(10);
+    v.append("a"_s);
+    v.append("b"_s);
+    v.append("c"_s);
+
+    // Insert 2 copies of v[1]="b" at position 1.
+    v.insertFill(1, v[1], 2);
+    EXPECT_EQ(5U, v.size());
+    EXPECT_EQ("a"_s, v[0]);
+    EXPECT_EQ("b"_s, v[1]);
+    EXPECT_EQ("b"_s, v[2]);
+    EXPECT_EQ("b"_s, v[3]);
+    EXPECT_EQ("c"_s, v[4]);
+}
+
+TEST(WTF_Vector, InsertFillAliasingElementBeforePosition)
+{
+    // Elements before position are not shifted, so aliasing should be safe
+    // even without the fix. Verify it still works.
+    Vector<String> v;
+    v.reserveCapacity(10);
+    v.append("a"_s);
+    v.append("b"_s);
+    v.append("c"_s);
+
+    v.insertFill(2, v[0], 2);
+    EXPECT_EQ(5U, v.size());
+    EXPECT_EQ("a"_s, v[0]);
+    EXPECT_EQ("b"_s, v[1]);
+    EXPECT_EQ("a"_s, v[2]);
+    EXPECT_EQ("a"_s, v[3]);
+    EXPECT_EQ("c"_s, v[4]);
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 80119b4639d5d97f8661d4917b4d0395c6a3a89a
<pre>
Fix aliasing bugs in Vector::fill() and Vector::insertFill()
<a href="https://bugs.webkit.org/show_bug.cgi?id=310889">https://bugs.webkit.org/show_bug.cgi?id=310889</a>

Reviewed by Darin Adler.

Both `fill()` and `insertFill()` take a `const T&amp;` parameter that may reference
an element within the vector itself. If the vector mutates (via shrink,
clear, reallocation, or element shifting), that reference becomes dangling
or points to the wrong value.

For `fill()`, `clear()` destroys all elements before reallocation, and `shrink()`
destroys elements past the new size -- either case invalidates a reference
to a vector element. For `insertFill()`, `expandCapacity()` may reallocate the
buffer, and even without reallocation, `moveOverlapping()` shifts elements
right, so a reference to an element at or after the insertion position
reads the wrong value (or a destructed object for non-trivial types).

Fix both by copying the value into a local before any mutation, matching
how std::vector is required to handle this case for `insert(pos, count, value)`
and `assign(count, value)`.

Test: Tools/TestWebKitAPI/Tests/WTF/Vector.cpp

* Source/WTF/wtf/Vector.h:
(WTF::Malloc&gt;::fill):
(WTF::Malloc&gt;::insertFill):
* Tools/TestWebKitAPI/Tests/WTF/Vector.cpp:
(TestWebKitAPI::TEST(WTF_Vector, FillAliasingGrowth)):
(TestWebKitAPI::TEST(WTF_Vector, FillAliasingShrink)):
(TestWebKitAPI::TEST(WTF_Vector, FillAliasingNoReallocation)):
(TestWebKitAPI::TEST(WTF_Vector, FillAliasingSameSize)):
(TestWebKitAPI::TEST(WTF_Vector, InsertFillAliasingWithReallocation)):
(TestWebKitAPI::TEST(WTF_Vector, InsertFillAliasingElementAfterPosition)):
(TestWebKitAPI::TEST(WTF_Vector, InsertFillAliasingElementAtPosition)):
(TestWebKitAPI::TEST(WTF_Vector, InsertFillAliasingElementBeforePosition)):

Canonical link: <a href="https://commits.webkit.org/310131@main">https://commits.webkit.org/310131@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18d0f43aa31b27adeb1a8d0bf61b68cb7eaaa1af

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152647 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25429 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19028 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161392 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106104 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8ab7cf7c-8069-41d2-ac6c-dca85eb3cb48) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154521 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25957 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25735 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117965 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83581 "9 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2dc27dba-7b46-48c5-aed3-e31ad080b72b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155607 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20176 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137039 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98677 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3712ff3d-6cc0-4aaa-80ab-e4336253e4af) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19251 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17197 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9226 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144659 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128901 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14913 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163863 "Built successfully") | | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13452 "Found unexpected failure with change (failure)") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7002 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16507 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126017 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25227 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21236 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126176 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34267 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25229 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136709 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81832 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21145 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13488 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184280 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24845 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89131 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47043 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24537 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24696 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24597 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->