### PR TITLE
[grid-lanes] [Demo] Use CSS nesting for @media queries in grid3 demos

### DIFF
--- a/Websites/webkit.org/demos/grid3/megamenu/styles.css
+++ b/Websites/webkit.org/demos/grid3/megamenu/styles.css
@@ -45,9 +45,7 @@ nav section {
 
 main {
     padding-inline: calc(10vw + 1rem);
-}
-@media (max-width: 500px) {
-    main {
+    @media (width <= 500px) {
         padding-inline: calc(2vw + 0.5rem);
     }
 }
@@ -65,9 +63,7 @@ body:has(option[value="one"]:checked) main nav {
         break-inside: avoid;
         margin-trim: block;
     }
-}
-@media (max-width: 500px) {
-    body:has(option[value="one"]:checked) main nav {
+    @media (width <= 500px) {
         columns: 2;
     }
 }
@@ -79,9 +75,7 @@ body:has(option[value="two"]:checked) main nav {
     grid-template-rows: none; /* default value */
     column-gap: 1rem;
     justify-content: center;
-}
-@media (max-width: 500px) {
-    body:has(option[value="two"]:checked) main nav {
+    @media (width <= 500px) {
         grid-template-columns: repeat(2, 1fr);
     }
 }
@@ -92,9 +86,7 @@ body:has(option[value="three"]:checked) main nav {
     grid-template-columns: repeat(auto-fill, minmax(24ch, 1fr));
     column-gap: 2lh;
     justify-content: center;
-}
-@media (max-width: 500px) {
-    body:has(option[value="three"]:checked) main nav {
+    @media (width <= 500px) {
         grid-template-columns: repeat(2, 1fr);
     }
 }
@@ -105,9 +97,7 @@ body:has(option[value="four"]:checked) main nav {
     grid-template-columns: repeat(auto-fill, minmax(max-content, 24ch));
     column-gap: 4lh;
     justify-content: center;
-}
-@media (max-width: 500px) {
-    body:has(option[value="four"]:checked) main nav {
+    @media (width <= 500px) {
         grid-template-columns: repeat(2, 1fr);
         column-gap: 2lh;
     }

--- a/Websites/webkit.org/demos/grid3/museum/styles.css
+++ b/Websites/webkit.org/demos/grid3/museum/styles.css
@@ -134,17 +134,13 @@ body:has(option[value="twoandahalf"]:checked) main { /* before applying masonry 
   header {
     grid-column: -2 / -1; /* one columns wide */
   }
-}
-@media (max-width: 500px) {
-  body:has(option[value="twoandahalf"]:checked) main {
+  @media (width <= 500px) {
     grid-template-columns: repeat(2, 1fr);
     header {
       grid-column: 1 / -1;
     }
   }
-}
-@media (width > 1200px) {
-  body:has(option[value="twoandahalf"]:checked) main { /* before applying masonry */
+  @media (width > 1200px) {
     header {
       grid-column: -3 / -1; /* two column wide */
     }


### PR DESCRIPTION
#### 7230d8c501bff14d19f80442eafe5bc497aacb47
<pre>
[grid-lanes] [Demo] Use CSS nesting for @media queries in grid3 demos
<a href="https://bugs.webkit.org/show_bug.cgi?id=310891">https://bugs.webkit.org/show_bug.cgi?id=310891</a>
<a href="https://rdar.apple.com/173502742">rdar://173502742</a>

Reviewed by Tim Nguyen.

Nest @media queries inside their parent rules instead of repeating
selectors, as suggested in PR review.

* Websites/webkit.org/demos/grid3/megamenu/styles.css:
(main):
(body:has(option[value=&quot;two&quot;]:checked) main nav):
(body:has(option[value=&quot;three&quot;]:checked) main nav):
(body:has(option[value=&quot;four&quot;]:checked) main nav):
(@media (max-width: 500px) main): Deleted.
(@media (max-width: 500px) body:has(option[value=&quot;one&quot;]:checked) main nav): Deleted.
(@media (max-width: 500px) body:has(option[value=&quot;two&quot;]:checked) main nav): Deleted.
(@media (max-width: 500px) body:has(option[value=&quot;three&quot;]:checked) main nav): Deleted.
(@media (max-width: 500px) body:has(option[value=&quot;four&quot;]:checked) main nav): Deleted.
* Websites/webkit.org/demos/grid3/museum/styles.css:
(@media (max-width: 500px) body:has(option[value=&quot;twoandahalf&quot;]:checked) main): Deleted.
(@media (width &gt; 1200px) body:has(option[value=&quot;twoandahalf&quot;]:checked) main): Deleted.

Canonical link: <a href="https://commits.webkit.org/310080@main">https://commits.webkit.org/310080@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9118ef725d637ea6ed705c4593c005dc9f102fe6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152684 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25465 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/19064 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/161428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25993 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25771 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/161428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155643 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/20207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/137070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/161428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/19282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/9264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/163900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/16538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/163900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/25263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/21267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/163900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/25265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/136740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/81869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23389 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/25265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/13519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/24881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/24573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/24732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/24633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->