### PR TITLE
Remove more convertToASCIILowercase() string allocations

### DIFF
--- a/Source/WebCore/css/MediaList.cpp
+++ b/Source/WebCore/css/MediaList.cpp
@@ -119,10 +119,9 @@ String MediaList::item(unsigned index) const
 
 ExceptionOr<void> MediaList::deleteMedium(const String& value)
 {
-    auto valueToRemove = value.convertToASCIILowercase();
     auto queries = mediaQueries();
     for (unsigned i = 0; i < queries.size(); ++i) {
-        if (item(i) == valueToRemove) {
+        if (equalIgnoringASCIICase(item(i), value)) {
             queries.removeAt(i);
             setMediaQueries(WTF::move(queries));
             return { };

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -385,11 +385,11 @@ bool Element::isNonceable() const
 
         for (auto& attribute : attributes()) {
             auto name = attribute.localNameLowercase();
-            auto value = attribute.value().convertToASCIILowercase();
+            auto value = attribute.value();
             if (name.contains(scriptString)
                 || name.contains(styleString)
-                || value.contains(scriptString)
-                || value.contains(styleString))
+                || value.containsIgnoringASCIICase(scriptString)
+                || value.containsIgnoringASCIICase(styleString))
                 return false;
         }
     }

--- a/Source/WebCore/platform/audio/cocoa/AudioDecoderCocoa.cpp
+++ b/Source/WebCore/platform/audio/cocoa/AudioDecoderCocoa.cpp
@@ -173,16 +173,16 @@ Expected<std::pair<FourCharCode, std::optional<AudioStreamDescription::PCMFormat
     auto components = codecName.toString().split('-');
     if (components.size() != 2)
         return makeUnexpected(makeString("Invalid LPCM codec string:"_s, codecName));
-    auto pcmFormat = components[1].convertToASCIILowercase();
-    if (pcmFormat == "u8"_s)
+    auto& pcmFormat = components[1];
+    if (equalLettersIgnoringASCIICase(pcmFormat, "u8"_s))
         format = AudioStreamDescription::Uint8;
-    else if (pcmFormat == "s16"_s)
+    else if (equalLettersIgnoringASCIICase(pcmFormat, "s16"_s))
         format = AudioStreamDescription::Int16;
-    else if (pcmFormat == "s24"_s)
+    else if (equalLettersIgnoringASCIICase(pcmFormat, "s24"_s))
         format = AudioStreamDescription::Int24;
-    else if (pcmFormat == "s32"_s)
+    else if (equalLettersIgnoringASCIICase(pcmFormat, "s32"_s))
         format = AudioStreamDescription::Int32;
-    else if (pcmFormat == "f32"_s)
+    else if (equalLettersIgnoringASCIICase(pcmFormat, "f32"_s))
         format = AudioStreamDescription::Float32;
     else
         return makeUnexpected(makeString("Invalid LPCM codec format:"_s, pcmFormat));

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -690,13 +690,13 @@ static void registerFontsInFamilyIfNeeded(const String& family)
 {
     Locker locker(userInstalledFontMapLock());
     if (!userInstalledFontMap().isEmpty()) {
-        auto fontFamily = family.convertToASCIILowercase();
-
-        if (fontFamily == "helvetica"_s) {
+        if (equalLettersIgnoringASCIICase(family, "helvetica"_s)) {
             // Helvetica is a system font with several variants, so we choose not to register additional fonts in this family.
             // This is because it can affect font matching. See rdar://172261885.
             return;
         }
+
+        auto fontFamily = family.convertToASCIILowercase();
 
         registerFontIfNeeded(fontFamily);
         auto fontNames = userInstalledFontFamilyMap().find(fontFamily);


### PR DESCRIPTION
#### 581f74e56eb3d3a1d0102c23a5444965710a238d
<pre>
Remove more convertToASCIILowercase() string allocations
<a href="https://bugs.webkit.org/show_bug.cgi?id=310892">https://bugs.webkit.org/show_bug.cgi?id=310892</a>

Reviewed by Chris Dumez.

Canonical link: <a href="https://commits.webkit.org/310092@main">https://commits.webkit.org/310092@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/781bb7543d6d1ea64c4635b139931abdc1910d0f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152655 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25437 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19036 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161400 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dd726038-b314-4f52-a0db-82c86a030902) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154529 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25965 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25743 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117961 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c6620eff-7910-4743-bf9e-6357744f57b7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155615 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20187 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137045 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98673 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/759ae125-5e44-42c0-81a2-c4e5edd4d06b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19262 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17200 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9235 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128913 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14919 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163871 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7010 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16513 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126018 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25235 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21239 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126178 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25237 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136715 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81840 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23393 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21149 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13494 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24853 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89139 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24545 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24704 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24605 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->