### PR TITLE
Simplify / Optimize HTMLInputElement::isDevolvableWidget()

### DIFF
--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -2081,20 +2081,25 @@ bool HTMLInputElement::isEmptyValue() const
 
 bool HTMLInputElement::isDevolvableWidget() const
 {
-    return m_inputType->isColorControl()
-        || m_inputType->isDateField()
-        || m_inputType->isDateTimeLocalField()
-        || m_inputType->isEmailField()
-        || m_inputType->isMonthField()
-        || m_inputType->isNumberField()
-        || m_inputType->isPasswordField()
-        || m_inputType->isSearchField()
-        || m_inputType->isTelephoneField()
-        || m_inputType->isTextButton()
-        || m_inputType->isTextType()
-        || m_inputType->isTimeField()
-        || m_inputType->isURLField()
-        || m_inputType->isWeekField();
+    static constexpr OptionSet<InputType::Type> devolvableTypes = {
+        InputType::Type::Button,
+        InputType::Type::Color,
+        InputType::Type::Date,
+        InputType::Type::DateTimeLocal,
+        InputType::Type::Email,
+        InputType::Type::Month,
+        InputType::Type::Number,
+        InputType::Type::Password,
+        InputType::Type::Reset,
+        InputType::Type::Search,
+        InputType::Type::Submit,
+        InputType::Type::Telephone,
+        InputType::Type::Text,
+        InputType::Type::Time,
+        InputType::Type::URL,
+        InputType::Type::Week,
+    };
+    return devolvableTypes.contains(m_inputType->type());
 }
 
 void HTMLInputElement::maxLengthAttributeChanged(const AtomString& newValue)


### PR DESCRIPTION
#### 357f0423e8b4c2209de2c65e1911b10e2561e8ee
<pre>
Simplify / Optimize HTMLInputElement::isDevolvableWidget()
<a href="https://bugs.webkit.org/show_bug.cgi?id=310894">https://bugs.webkit.org/show_bug.cgi?id=310894</a>

Reviewed by Anne van Kesteren.

Replace 14 individual type-check calls with a single OptionSet check
listing the 16 devolvable input types, matching the HTML spec [1].
The new code is a single bitmask AND operation instead of up to 14
sequential OptionSet::contains checks with short-circuit evaluation.

The old code had two additional problems:
- isEmailField(), isPasswordField(), isSearchField(),
  isTelephoneField(), and isURLField() were redundant with the
  isTextType() call, which already covers all of them.
- isURLField() after isTextType() was dead code: URL is in textTypes,
  so if isTextType() returned false, isURLField() would also return
  false.

[1] <a href="https://html.spec.whatwg.org/multipage/rendering.html#the-input-element-as-a-text-entry-widget">https://html.spec.whatwg.org/multipage/rendering.html#the-input-element-as-a-text-entry-widget</a>

* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::isDevolvableWidget const):

Canonical link: <a href="https://commits.webkit.org/310140@main">https://commits.webkit.org/310140@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94be982308382bed30dd23b776ac783e4bb5f2b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152658 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25440 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19039 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161403 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106115 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a1523d68-3f24-430b-9fb9-14b92b43358f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154532 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25968 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25746 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117966 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83584 "7 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8f2cdb9a-ac8d-4e20-ab98-01cd84713c37) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155618 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20184 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137051 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98678 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ee86e1ef-88a2-4038-aa14-5d0f1dcedac9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19259 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17204 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9238 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128909 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14925 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163874 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7013 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16519 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126023 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25238 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21243 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126183 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34277 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25240 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136721 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81843 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21147 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13500 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24856 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89142 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24548 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24707 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24608 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->