### PR TITLE
[BFCache]

### DIFF
--- a/Source/WebCore/history/BackForwardCache.cpp
+++ b/Source/WebCore/history/BackForwardCache.cpp
@@ -571,9 +571,9 @@ std::unique_ptr<CachedPage> BackForwardCache::suspendPage(Page& page)
     return trySuspendPage(page, ForceSuspension::Yes);
 }
 
-std::unique_ptr<CachedPage> BackForwardCache::take(HistoryItem& item, Page* page)
+std::unique_ptr<CachedPage> BackForwardCache::take(BackForwardFrameItemIdentifier frameItemID, Page* page)
 {
-    auto it = m_cachedPageMap.find(item.frameItemID());
+    auto it = m_cachedPageMap.find(frameItemID);
     if (it == m_cachedPageMap.end())
         return nullptr;
     if (auto* pruningReason = std::get_if<PruningReason>(&it->value)) {
@@ -583,19 +583,32 @@ std::unique_ptr<CachedPage> BackForwardCache::take(HistoryItem& item, Page* page
         return nullptr;
     }
 
-    m_items.remove(item.frameItemID());
+    m_items.remove(frameItemID);
     auto cachedPage = std::get<UniqueRef<CachedPage>>(m_cachedPageMap.take(it));
-    item.notifyChanged();
 
-    RELEASE_LOG(BackForwardCache, "BackForwardCache::take item: %s, frameItem: %s, size: %u / %u", item.itemID().toString().utf8().data(), item.frameItemID().toString().utf8().data(), pageCount(), maxSize());
+    if (page && &cachedPage->page() != page) {
+        auto ptr = cachedPage.moveToUniquePtr();
+        m_cachedPageMap.set(frameItemID, makeUniqueRefFromNonNullUniquePtr(WTF::move(ptr)));
+        m_items.add(frameItemID);
+        return nullptr;
+    }
+
+    RELEASE_LOG(BackForwardCache, "BackForwardCache::take frameItem: %s, size: %u / %u", frameItemID.toString().utf8().data(), pageCount(), maxSize());
 
     if (cachedPage->hasExpired() || (page && page->isResourceCachingDisabledByWebInspector())) {
-        LOG(BackForwardCache, "Not restoring page for %s from back/forward cache because cache entry has expired", item.url().string().ascii().data());
         logBackForwardCacheFailureDiagnosticMessage(page, DiagnosticLoggingKeys::expiredKey());
         return nullptr;
     }
 
     return cachedPage.moveToUniquePtr();
+}
+
+std::unique_ptr<CachedPage> BackForwardCache::take(HistoryItem& item, Page* page)
+{
+    auto cachedPage = take(item.frameItemID(), page);
+    if (cachedPage)
+        item.notifyChanged();
+    return cachedPage;
 }
 
 void BackForwardCache::removeAllItemsForPage(Page& page)
@@ -629,6 +642,8 @@ CachedPage* BackForwardCache::get(HistoryItem& item, Page* page)
             logBackForwardCacheFailureDiagnosticMessage(page, pruningReasonToDiagnosticLoggingKey(pruningReason));
         return nullptr;
     }, [&](UniqueRef<CachedPage>& cachedPage) -> CachedPage* {
+        if (page && &cachedPage->page() != page)
+            return nullptr;
         if (cachedPage->hasExpired() || (page && page->isResourceCachingDisabledByWebInspector())) {
             LOG(BackForwardCache, "Not restoring page for %s from back/forward cache because cache entry has expired", item.url().string().ascii().data());
             logBackForwardCacheFailureDiagnosticMessage(page, DiagnosticLoggingKeys::expiredKey());

--- a/Source/WebCore/history/BackForwardCache.h
+++ b/Source/WebCore/history/BackForwardCache.h
@@ -60,6 +60,7 @@ public:
     WEBCORE_EXPORT void remove(BackForwardFrameItemIdentifier);
     WEBCORE_EXPORT void remove(HistoryItem&);
     CachedPage* get(HistoryItem&, Page*);
+    WEBCORE_EXPORT std::unique_ptr<CachedPage> take(BackForwardFrameItemIdentifier, Page*);
     std::unique_ptr<CachedPage> take(HistoryItem&, Page*);
 
     void removeAllItemsForPage(Page&);

--- a/Source/WebCore/history/CachedFrame.cpp
+++ b/Source/WebCore/history/CachedFrame.cpp
@@ -30,9 +30,11 @@
 #include "CachedFramePlatformData.h"
 #include "CachedPage.h"
 #include "DocumentLoader.h"
+#include "HTMLFrameOwnerElement.h"
 #include "DocumentPage.h"
 #include "DocumentView.h"
 #include "DocumentWindow.h"
+#include "FrameInlines.h"
 #include "FrameLoader.h"
 #include "LocalDOMWindow.h"
 #include "LocalFrame.h"
@@ -127,6 +129,14 @@ void CachedFrameBase::restore()
 
         // Reconstruct the FrameTree. And open the child CachedFrames in their respective FrameLoaders.
         for (auto& childFrame : m_childFrames) {
+            // RemoteFrame children have no document. Re-add them to the frame
+            // tree so the iframe element stays connected, but skip open() —
+            // the iframe process restores its content independently via
+            // SetIsSuspendedWithFrameItem IPC.
+            if (!childFrame->document()) {
+                frame->tree().appendChild(protect(protect(childFrame->view())->frame()));
+                continue;
+            }
             ASSERT(childFrame->view()->frame().page());
             frame->tree().appendChild(protect(protect(childFrame->view())->frame()));
             childFrame->open();
@@ -238,6 +248,18 @@ void CachedFrame::open()
 
     if (RefPtr localFrameView = dynamicDowncast<LocalFrameView>(m_view.get()))
         localFrameView->frame().loader().open(*this);
+    else {
+        // RemoteFrame main frame in iframe process.
+        // Re-attach child frames to the frame tree and open them to restore
+        // LocalFrame content. This mirrors what CachedFrameBase::restore()
+        // does for LocalFrame parents, but RemoteFrames have no FrameLoader
+        // so we handle the appendChild + open() directly here.
+        Ref frame = m_view->frame();
+        for (auto& childFrame : m_childFrames) {
+            frame->tree().appendChild(protect(childFrame->view()->frame()));
+            childFrame->open();
+        }
+    }
 }
 
 void CachedFrame::clear()

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
@@ -206,6 +206,8 @@ typedef NSVisualEffectView _WKPlatformVisualEffectView;
 
 - (void)_lastPageLoadNetworkActivityCompletionCodeForTesting:(void(^)(NSNumber * _Nullable completionCode))completionHandler;
 
+- (void)_preventBackForwardCacheInSubframesForTesting;
+
 @end
 
 typedef NS_ENUM(NSInteger, _WKMediaSessionReadyState) {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -1325,6 +1325,11 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 #endif
 }
 
+- (void)_preventBackForwardCacheInSubframesForTesting
+{
+    _page->preventBackForwardCacheForTestingInSubframes();
+}
+
 @end
 
 #if ENABLE(MEDIA_SESSION_COORDINATOR)

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
@@ -216,6 +216,12 @@ void BrowsingContextGroup::detachPageForSuspension(WebPageProxy& page, Suspended
     m_pages.remove(page);
 }
 
+void BrowsingContextGroup::removeProcessMapEntryForSite(const Site& site)
+{
+    m_processMap.remove(site);
+}
+}
+
 void BrowsingContextGroup::addPage(WebPageProxy& page)
 {
     ASSERT(!m_pages.contains(page));
@@ -282,6 +288,12 @@ void BrowsingContextGroup::cleanupSuspendedPage(WebPageProxy& page, SuspendedPag
     });
     if (closeRemotePages == CloseRemotePages::Yes)
         closeRemotePagesForPage(page);
+}
+
+HashSet<Ref<RemotePageProxy>> BrowsingContextGroup::takeRemotePagesForPage(WebPageProxy& page)
+{
+    return m_remotePages.take(page);
+}
 }
 
 RefPtr<RemotePageProxy> BrowsingContextGroup::remotePageInProcess(const WebPageProxy& page, const WebProcessProxy& process)

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
@@ -33,6 +33,7 @@
 #include "PageLoadState.h"
 #include "ProvisionalPageProxy.h"
 #include "RemotePageProxy.h"
+#include "SuspendedPageProxy.h"
 #include "WebFrameProxy.h"
 #include "WebPageProxy.h"
 #include "WebProcessPool.h"
@@ -205,6 +206,16 @@ void BrowsingContextGroup::removeFrameProcess(FrameProcess& process)
     });
 }
 
+void BrowsingContextGroup::detachPageForSuspension(WebPageProxy& page, SuspendedPageProxy& suspendedPage)
+{
+    forEachRemotePage(page, [&](auto& remotePage) {
+        remotePage.siteIsolatedProcess().addSuspendedPageProxy(suspendedPage);
+        m_processMap.remove(remotePage.site());
+    });
+    m_processMap.remove(Site { suspendedPage.mainFrame().url() });
+    m_pages.remove(page);
+}
+
 void BrowsingContextGroup::addPage(WebPageProxy& page)
 {
     ASSERT(!m_pages.contains(page));
@@ -246,8 +257,7 @@ void BrowsingContextGroup::addRemotePage(WebPageProxy& page, Ref<RemotePageProxy
 void BrowsingContextGroup::removePage(WebPageProxy& page)
 {
     m_pages.remove(page);
-    for (auto& remotePage : m_remotePages.take(page))
-        remotePage->disconnect();
+    closeRemotePagesForPage(page);
 }
 
 void BrowsingContextGroup::forEachRemotePage(const WebPageProxy& page, Function<void(RemotePageProxy&)>&& function)
@@ -257,6 +267,21 @@ void BrowsingContextGroup::forEachRemotePage(const WebPageProxy& page, Function<
         return;
     for (Ref remotePage : it->value)
         function(remotePage);
+}
+
+void BrowsingContextGroup::closeRemotePagesForPage(WebPageProxy& page)
+{
+    for (auto& remotePage : m_remotePages.take(page))
+        remotePage->disconnect();
+}
+
+void BrowsingContextGroup::cleanupSuspendedPage(WebPageProxy& page, SuspendedPageProxy& suspendedPage, CloseRemotePages closeRemotePages)
+{
+    forEachRemotePage(page, [&](auto& remotePage) {
+        remotePage.siteIsolatedProcess().removeSuspendedPageProxy(suspendedPage);
+    });
+    if (closeRemotePages == CloseRemotePages::Yes)
+        closeRemotePagesForPage(page);
 }
 
 RefPtr<RemotePageProxy> BrowsingContextGroup::remotePageInProcess(const WebPageProxy& page, const WebProcessProxy& process)

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.h
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.h
@@ -49,6 +49,7 @@ namespace WebKit {
 class FrameProcess;
 class ProvisionalPageProxy;
 class RemotePageProxy;
+class SuspendedPageProxy;
 class WebPageProxy;
 class WebPreferences;
 class WebProcessPool;
@@ -56,6 +57,8 @@ class WebProcessPool;
 enum class IsMainFrame : bool;
 
 enum class BrowsingContextGroupUpdate : uint8_t { None, AddProcess, AddProcessAndInjectBrowsingContext };
+
+enum class CloseRemotePages : bool { No, Yes };
 
 class BrowsingContextGroup : public RefCountedAndCanMakeWeakPtr<BrowsingContextGroup> {
 public:
@@ -75,6 +78,9 @@ public:
     void addRemotePage(WebPageProxy&, Ref<RemotePageProxy>&&);
     void removePage(WebPageProxy&);
     void forEachRemotePage(const WebPageProxy&, Function<void(RemotePageProxy&)>&&);
+    void closeRemotePagesForPage(WebPageProxy&);
+    void detachPageForSuspension(WebPageProxy&, SuspendedPageProxy&);
+    void cleanupSuspendedPage(WebPageProxy&, SuspendedPageProxy&, CloseRemotePages);
 
     RefPtr<RemotePageProxy> remotePageInProcess(const WebPageProxy&, const WebProcessProxy&);
 

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.h
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.h
@@ -72,6 +72,7 @@ public:
     void addFrameProcessAndInjectPageContextIf(FrameProcess&, Function<bool(WebPageProxy&)>);
     bool addFrameProcessWithoutInjectingPageContext(FrameProcess&);
     void removeFrameProcess(FrameProcess&);
+    void removeProcessMapEntryForSite(const WebCore::Site&);
     void processDidTerminate(WebPageProxy&, WebProcessProxy&);
 
     void addPage(WebPageProxy&);
@@ -81,6 +82,7 @@ public:
     void closeRemotePagesForPage(WebPageProxy&);
     void detachPageForSuspension(WebPageProxy&, SuspendedPageProxy&);
     void cleanupSuspendedPage(WebPageProxy&, SuspendedPageProxy&, CloseRemotePages);
+    HashSet<Ref<RemotePageProxy>> takeRemotePagesForPage(WebPageProxy&);
 
     RefPtr<RemotePageProxy> remotePageInProcess(const WebPageProxy&, const WebProcessProxy&);
 

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -124,7 +124,8 @@ ProvisionalPageProxy::ProvisionalPageProxy(WebPageProxy& page, Ref<FrameProcess>
     // already exists and already has a main frame.
     if (suspendedPage) {
         ASSERT(&suspendedPage->process() == process.ptr());
-        suspendedPage->unsuspend();
+        m_suspendedPageBrowsingContextGroup = &suspendedPage->browsingContextGroup();
+        suspendedPage->unsuspend(navigation.targetItem());
         m_mainFrame = suspendedPage->mainFrame();
         m_mainFrame->updateReferrerPolicy(ReferrerPolicy::EmptyString);
         m_needsMainFrameObserver = true;
@@ -265,7 +266,7 @@ void ProvisionalPageProxy::initializeWebPage(RefPtr<API::WebsitePolicies>&& webs
     if (websitePolicies)
         m_mainFrameWebsitePolicies = websitePolicies->copy();
 
-    if (preferences->siteIsolationEnabled()) {
+    if (preferences->siteIsolationEnabled() && !m_suspendedPageBrowsingContextGroup) {
         if (RefPtr existingRemotePageProxy = m_browsingContextGroup->takeRemotePageInProcessForProvisionalPage(page, process)) {
             if (m_shouldReuseMainFrame) {
                 m_webPageID = existingRemotePageProxy->pageID();
@@ -287,7 +288,7 @@ void ProvisionalPageProxy::initializeWebPage(RefPtr<API::WebsitePolicies>&& webs
 
     RefPtr mainFrame = m_mainFrame;
     auto creationParameters = page->creationParametersForProvisionalPage(process, *drawingArea, mainFrame->frameID());
-    if (preferences->siteIsolationEnabled()) {
+    if (preferences->siteIsolationEnabled() && !m_suspendedPageBrowsingContextGroup) {
         creationParameters.remotePageParameters = RemotePageParameters {
             m_request.url(),
             mainFrame->frameTreeCreationParameters(),
@@ -495,7 +496,7 @@ void ProvisionalPageProxy::didCommitLoadForFrame(IPC::Connection& connection, Fr
         Site pageMainFrameSite { pageMainFrame->url() };
 
         bool frameProcessChanged = m_frameProcess.ptr() != pageMainFrameProcess.ptr();
-        if (frameProcessChanged)
+        if (frameProcessChanged && pageMainFrame == m_mainFrame)
             pageMainFrame->setProcess(m_frameProcess);
 
         // If the originating FrameProcess still has local frames and is still in the same

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "BrowsingContextGroup.h"
 #include "MessageReceiver.h"
 #include "MessageSender.h"
 #include "NetworkResourceLoadIdentifier.h"
@@ -105,6 +106,7 @@ public:
     WebCore::PageIdentifier webPageID() const { return m_webPageID; }
     WebFrameProxy* mainFrame() const { return m_mainFrame.get(); }
     BrowsingContextGroup& browsingContextGroup() const { return m_browsingContextGroup.get(); }
+    RefPtr<BrowsingContextGroup> suspendedPageBrowsingContextGroup() const { return m_suspendedPageBrowsingContextGroup; }
     WebProcessProxy& NODELETE process();
     ProcessSwapRequestedByClient processSwapRequestedByClient() const { return m_processSwapRequestedByClient; }
     WebCore::NavigationIdentifier navigationID() const { return m_navigationID; }
@@ -212,6 +214,7 @@ private:
     WebCore::PageIdentifier m_webPageID;
     Ref<FrameProcess> m_frameProcess;
     const Ref<BrowsingContextGroup> m_browsingContextGroup;
+    RefPtr<BrowsingContextGroup> m_suspendedPageBrowsingContextGroup;
     RefPtr<RemotePageProxy> m_takenRemotePage;
 
     // Keep WebsiteDataStore alive for provisional page load.

--- a/Source/WebKit/UIProcess/RemotePageProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageProxy.cpp
@@ -109,14 +109,8 @@ RemotePageProxy::RemotePageProxy(WebPageProxy& page, WebProcessProxy& process, c
     protectedPage->didCreateRemotePage(*this);
 }
 
-void RemotePageProxy::disconnect()
+void RemotePageProxy::cleanupSubsystems()
 {
-    if (RefPtr page = m_page.get())
-        page->isNoLongerAssociatedWithRemotePage(*this);
-    if (m_drawingArea)
-        m_process->send(Messages::WebPage::Close(), m_webPageID);
-    m_process->removeRemotePageProxy(*this);
-
     m_drawingArea = nullptr;
 #if ENABLE(FULLSCREEN_API)
     m_fullscreenManager = nullptr;
@@ -138,17 +132,32 @@ void RemotePageProxy::disconnect()
 #endif
 }
 
-void RemotePageProxy::injectPageIntoNewProcess()
+void RemotePageProxy::disconnect()
+{
+    if (RefPtr page = m_page.get())
+        page->isNoLongerAssociatedWithRemotePage(*this);
+    if (m_drawingArea)
+        m_process->send(Messages::WebPage::Close(), m_webPageID);
+    m_process->removeRemotePageProxy(*this);
+    cleanupSubsystems();
+}
+
+void RemotePageProxy::disconnectWithoutClosingWebPage()
+{
+    if (RefPtr page = m_page.get())
+        page->isNoLongerAssociatedWithRemotePage(*this);
+    // No WebPage::Close IPC — the iframe WebPage is preserved in BFCache.
+    m_process->removeRemotePageProxy(*this);
+    cleanupSubsystems();
+}
+
+void RemotePageProxy::setupSubsystems()
 {
     RefPtr page = m_page.get();
-    if (!page) {
-        ASSERT_NOT_REACHED();
+    if (!page)
         return;
-    }
-    if (!page->mainFrame()) {
-        ASSERT_NOT_REACHED();
+    if (!page->mainFrame())
         return;
-    }
 
     Ref drawingArea = *page->drawingArea();
     m_drawingArea = RemotePageDrawingAreaProxy::create(drawingArea.get(), m_process);
@@ -169,7 +178,23 @@ void RemotePageProxy::injectPageIntoNewProcess()
         m_screenOrientationManager = RemotePageScreenOrientationManagerProxy::create(m_webPageID, screenOrientationManager.get(), m_process);
 
     m_visitedLinkStoreRegistration = makeUnique<RemotePageVisitedLinkStoreRegistration>(*page, m_process);
+}
 
+void RemotePageProxy::injectPageIntoNewProcess()
+{
+    RefPtr page = m_page.get();
+    if (!page) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+    if (!page->mainFrame()) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    setupSubsystems();
+
+    Ref drawingArea = *page->drawingArea();
     RefPtr websitePolicies = page->mainFrameWebsitePolicies();
     m_process->send(
         Messages::WebProcess::CreateWebPage(
@@ -181,6 +206,12 @@ void RemotePageProxy::injectPageIntoNewProcess()
             })
         ), 0
     );
+}
+
+void RemotePageProxy::setupSubsystemsForBFCacheRestoration()
+{
+    setupSubsystems();
+    // No CreateWebPage IPC — the WebPage already exists in this process.
 }
 
 void RemotePageProxy::processDidTerminate(WebProcessProxy& process, ProcessTerminationReason reason)

--- a/Source/WebKit/UIProcess/RemotePageProxy.h
+++ b/Source/WebKit/UIProcess/RemotePageProxy.h
@@ -100,6 +100,7 @@ public:
     WebPageProxy* NODELETE page() const;
 
     void injectPageIntoNewProcess();
+    void setupSubsystemsForBFCacheRestoration();
     void processDidTerminate(WebProcessProxy&, ProcessTerminationReason);
 
     WebPageProxyMessageReceiverRegistration& messageReceiverRegistration() LIFETIME_BOUND { return m_messageReceiverRegistration; }
@@ -120,6 +121,7 @@ public:
     bool hasNetworkRequestsInProgress() const { return m_hasNetworkRequestsInProgress; }
 
     void disconnect();
+    void disconnectWithoutClosingWebPage();
 
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)
     void didCreateContextInWebProcessForVisibilityPropagation(LayerHostingContextID);
@@ -128,6 +130,10 @@ public:
 
 private:
     RemotePageProxy(WebPageProxy&, WebProcessProxy&, const WebCore::Site&, WebPageProxyMessageReceiverRegistration*, std::optional<WebCore::PageIdentifier>);
+
+    void setupSubsystems();
+    void cleanupSubsystems();
+
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
     void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
     void isPlayingMediaDidChange(WebCore::MediaProducerMediaStateFlags);

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
@@ -219,14 +219,44 @@ void SuspendedPageProxy::waitUntilReadyToUnsuspend(CompletionHandler<void(Suspen
     }
 }
 
-void SuspendedPageProxy::unsuspend(WebBackForwardListItem*)
+void SuspendedPageProxy::unsuspend(WebBackForwardListItem* targetItem)
 {
     ASSERT(m_suspensionState == SuspensionState::Suspended);
-    // FIXME: Use targetItem to restore iframe processes in the follow-up patch.
     m_suspensionState = SuspensionState::Resumed;
     sendWithAsyncReply(Messages::WebPage::SetIsSuspended(false), [](std::optional<bool> didSuspend) {
         ASSERT(!didSuspend.has_value());
     });
+
+    RefPtr page = m_page.get();
+    if (!targetItem || !page || !page->preferences().multiProcessBackForwardCacheEnabled())
+        return;
+
+    auto& rootFrameItem = targetItem->mainFrameItem();
+    m_browsingContextGroup->forEachRemotePage(*page,
+        [&](RemotePageProxy& remotePage) {
+            RefPtr<WebFrameProxy> frameInProcess;
+            for (RefPtr f = m_mainFrame->traverseNext().frame;
+                 f; f = f->traverseNext().frame) {
+                if (&f->process() == &remotePage.siteIsolatedProcess()) {
+                    frameInProcess = f;
+                    break;
+                }
+            }
+            if (!frameInProcess)
+                return;
+
+            RefPtr frameItem = rootFrameItem.childItemForFrameID(frameInProcess->frameID());
+            if (!frameItem)
+                return;
+
+            RELEASE_LOG(ProcessSwapping, "%p - SuspendedPageProxy::unsuspend: Sending restore IPC to iframe process pid %i for frameItem %s", this, remotePage.siteIsolatedProcess().processID(), frameItem->identifier().toString().utf8().data());
+
+            remotePage.siteIsolatedProcess().sendWithAsyncReply(
+                Messages::WebPage::SetIsSuspendedWithFrameItem(false, frameItem->identifier()),
+                [](std::optional<bool>) { },
+                remotePage.identifierInSiteIsolatedProcess()
+            );
+        });
 }
 
 void SuspendedPageProxy::close()

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
@@ -33,8 +33,11 @@
 #include "HandleMessage.h"
 #include "Logging.h"
 #include "MessageSenderInlines.h"
+#include "RemotePageProxy.h"
 #include "WebBackForwardCache.h"
 #include "WebBackForwardList.h"
+#include "WebBackForwardListFrameItem.h"
+#include "WebBackForwardListItem.h"
 #include "WebBackForwardListMessages.h"
 #include "WebFrameProxy.h"
 #include "WebPageMessages.h"
@@ -168,11 +171,13 @@ SuspendedPageProxy::~SuspendedPageProxy()
         });
     }
 
-    if (m_suspensionState != SuspensionState::Resumed) {
-        // If the suspended page was not consumed before getting destroyed, then close the corresponding page
-        // on the WebProcess side.
+    if (RefPtr page = m_page.get())
+        m_browsingContextGroup->cleanupSuspendedPage(*page, *this, m_suspensionState != SuspensionState::Resumed ? CloseRemotePages::Yes : CloseRemotePages::No);
+
+    // If the suspended page was not consumed before getting destroyed, then close the corresponding page
+    // on the WebProcess side.
+    if (m_suspensionState != SuspensionState::Resumed)
         close();
-    }
 
     m_process->removeSuspendedPageProxy(*this);
 }
@@ -198,8 +203,14 @@ void SuspendedPageProxy::waitUntilReadyToUnsuspend(CompletionHandler<void(Suspen
         m_readyToUnsuspendHandler = WTF::move(completionHandler);
         break;
     case SuspensionState::FailedToSuspend:
-    case SuspensionState::Suspended:
         completionHandler(this);
+        break;
+    case SuspensionState::Suspended:
+        // Store the handler and let maybeFireReadyToUnsuspendHandler() decide
+        // whether to fire it or invalidate the BFCache entry (if an iframe
+        // suspension failed).
+        m_readyToUnsuspendHandler = WTF::move(completionHandler);
+        maybeFireReadyToUnsuspendHandler();
         break;
     case SuspensionState::Resumed:
         ASSERT_NOT_REACHED();
@@ -208,10 +219,10 @@ void SuspendedPageProxy::waitUntilReadyToUnsuspend(CompletionHandler<void(Suspen
     }
 }
 
-void SuspendedPageProxy::unsuspend()
+void SuspendedPageProxy::unsuspend(WebBackForwardListItem*)
 {
     ASSERT(m_suspensionState == SuspensionState::Suspended);
-
+    // FIXME: Use targetItem to restore iframe processes in the follow-up patch.
     m_suspensionState = SuspensionState::Resumed;
     sendWithAsyncReply(Messages::WebPage::SetIsSuspended(false), [](std::optional<bool> didSuspend) {
         ASSERT(!didSuspend.has_value());
@@ -276,14 +287,104 @@ void SuspendedPageProxy::didProcessRequestToSuspend(SuspensionState newSuspensio
     if (m_suspensionState == SuspensionState::FailedToSuspend)
         closeWithoutFlashing();
 
-    if (m_readyToUnsuspendHandler)
-        m_readyToUnsuspendHandler(this);
+    maybeFireReadyToUnsuspendHandler();
 }
 
 void SuspendedPageProxy::suspensionTimedOut()
 {
     RELEASE_LOG_ERROR(ProcessSwapping, "%p - SuspendedPageProxy::suspensionTimedOut() destroying the suspended page because it failed to suspend in time", this);
     protect(backForwardCache())->removeEntry(*this); // Will destroy |this|.
+}
+
+void SuspendedPageProxy::suspendIframeProcesses(WebBackForwardListItem& fromItem)
+{
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
+    Ref rootFrameItem = fromItem.mainFrameItem();
+
+    m_browsingContextGroup->forEachRemotePage(*page, [&](auto& remotePage) {
+        // FIXME: Add WebFrameProxy::forEachDescendant() to avoid manual traverseNext() loops.
+        for (RefPtr f = m_mainFrame->traverseNext().frame; f; f = f->traverseNext().frame) {
+            Ref process = remotePage.siteIsolatedProcess();
+            if (&f->process() != process.ptr())
+                continue;
+
+            RefPtr frameItem = rootFrameItem->childItemForFrameID(f->frameID());
+            if (!frameItem)
+                continue;
+
+            RELEASE_LOG(ProcessSwapping, "%p - SuspendedPageProxy::suspendIframeProcesses: Sending SetIsSuspendedWithFrameItem to iframe process pid %i for frameItem %s", this, process->processID(), frameItem->identifier().toString().utf8().data());
+            ++m_expectedIframeSuspensions;
+
+            process->sendWithAsyncReply(Messages::WebPage::SetIsSuspendedWithFrameItem(true, frameItem->identifier()), [weakThis = WeakPtr { *this }](std::optional<bool> didSuspend) {
+                RefPtr protectedThis = weakThis.get();
+                if (protectedThis)
+                    protectedThis->didIframeSuspensionComplete(didSuspend.value_or(false));
+            }, remotePage.identifierInSiteIsolatedProcess());
+        }
+    });
+}
+
+bool SuspendedPageProxy::hasIframeInProcess(WebCore::ProcessIdentifier processIdentifier) const
+{
+    // FIXME: Add WebFrameProxy::forEachDescendant() to avoid manual traverseNext() loops.
+    for (RefPtr frame = m_mainFrame->traverseNext().frame; frame; frame = frame->traverseNext().frame) {
+        if (frame->process().coreProcessIdentifier() == processIdentifier)
+            return true;
+    }
+    return false;
+}
+
+void SuspendedPageProxy::didIframeSuspensionComplete(bool success)
+{
+    if (m_suspensionState == SuspensionState::Resumed)
+        return;
+
+    ++m_completedIframeSuspensions;
+    if (!success)
+        m_anyIframeSuspensionFailed = true;
+
+    if (m_completedIframeSuspensions < m_expectedIframeSuspensions)
+        return;
+
+    RELEASE_LOG(ProcessSwapping, "%p - SuspendedPageProxy::didIframeSuspensionComplete: All %u iframe suspensions completed (anyFailed: %d)", this, m_expectedIframeSuspensions, m_anyIframeSuspensionFailed);
+
+    maybeFireReadyToUnsuspendHandler();
+}
+
+void SuspendedPageProxy::maybeFireReadyToUnsuspendHandler()
+{
+    // Don't fire until the main page suspension has completed.
+    if (m_suspensionState == SuspensionState::Suspending)
+        return;
+
+    // If the main page failed to suspend, fire immediately — iframe results
+    // are irrelevant since the entry is already being closed.
+    if (m_suspensionState == SuspensionState::FailedToSuspend) {
+        if (m_readyToUnsuspendHandler)
+            m_readyToUnsuspendHandler(nullptr);
+        return;
+    }
+
+    // Main page suspended successfully. Wait for all iframe suspensions to
+    // complete before allowing restoration (if any are expected).
+    if (m_expectedIframeSuspensions && m_completedIframeSuspensions < m_expectedIframeSuspensions)
+        return;
+
+    // If any iframe suspension failed, invalidate the BFCache entry instead of
+    // allowing restoration. This must run even when there is no handler
+    // waiting, because the iframe failure can be reported before the
+    // navigation calls waitUntilReadyToUnsuspend().
+    if (m_anyIframeSuspensionFailed) {
+        RELEASE_LOG_ERROR(ProcessSwapping, "%p - SuspendedPageProxy::maybeFireReadyToUnsuspendHandler: iframe suspension failed, invalidating cache entry", this);
+        protect(backForwardCache())->removeEntry(*this); // Will destroy |this|.
+        return;
+    }
+
+    if (m_readyToUnsuspendHandler)
+        m_readyToUnsuspendHandler(this);
 }
 
 WebPageProxy* SuspendedPageProxy::page() const

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.h
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.h
@@ -73,7 +73,8 @@ public:
     WebCore::PageIdentifier webPageID() const { return m_webPageID; }
     WebProcessProxy& process() const { return m_process.get(); }
     WebFrameProxy& mainFrame() { return m_mainFrame.get(); }
-    const BrowsingContextGroup& browsingContextGroup() { return m_browsingContextGroup.get(); }
+    const BrowsingContextGroup& browsingContextGroup() const { return m_browsingContextGroup.get(); }
+    BrowsingContextGroup& browsingContextGroup() { return m_browsingContextGroup.get(); }
 
     WebBackForwardCache& NODELETE backForwardCache() const;
 
@@ -82,7 +83,10 @@ public:
     bool NODELETE pageIsClosedOrClosing() const;
 
     void waitUntilReadyToUnsuspend(CompletionHandler<void(SuspendedPageProxy*)>&&);
-    void unsuspend();
+    void unsuspend(WebBackForwardListItem* targetItem = nullptr);
+
+    void suspendIframeProcesses(WebBackForwardListItem&);
+    bool hasIframeInProcess(WebCore::ProcessIdentifier) const;
 
     void pageDidFirstLayerFlush();
     void closeWithoutFlashing();
@@ -104,6 +108,8 @@ private:
     enum class SuspensionState : uint8_t { Suspending, FailedToSuspend, Suspended, Resumed };
     void didProcessRequestToSuspend(SuspensionState);
     void suspensionTimedOut();
+    void maybeFireReadyToUnsuspendHandler();
+    void didIframeSuspensionComplete(bool success);
 
     void close();
     void didDestroyNavigation(WebCore::NavigationIdentifier);
@@ -128,6 +134,9 @@ private:
     SuspensionState m_suspensionState { SuspensionState::Suspending };
     CompletionHandler<void(SuspendedPageProxy*)> m_readyToUnsuspendHandler;
     RunLoop::Timer m_suspensionTimeoutTimer;
+    unsigned m_expectedIframeSuspensions { 0 };
+    unsigned m_completedIframeSuspensions { 0 };
+    bool m_anyIframeSuspensionFailed { false };
 #if USE(RUNNINGBOARD)
     RefPtr<ProcessThrottler::BackgroundActivity> m_suspensionActivity;
 #endif

--- a/Source/WebKit/UIProcess/WebBackForwardCache.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardCache.cpp
@@ -143,9 +143,22 @@ Ref<SuspendedPageProxy> WebBackForwardCache::takeSuspendedPage(WebBackForwardLis
 
 void WebBackForwardCache::removeEntriesForProcess(WebProcessProxy& process)
 {
-    removeEntriesMatching([processIdentifier = process.coreProcessIdentifier()](auto& entry) {
+    auto processIdentifier = process.coreProcessIdentifier();
+    removeEntriesMatching([&](auto& entry) {
         ASSERT(entry.backForwardCacheEntry());
-        return entry.backForwardCacheEntry()->processIdentifier() == processIdentifier;
+
+        // Check main process (existing behavior).
+        if (entry.backForwardCacheEntry()->processIdentifier() == processIdentifier)
+            return true;
+
+        // Check iframe processes (multi-process BFCache).
+        if (RefPtr suspendedPage = entry.suspendedPage()) {
+            if (suspendedPage->hasIframeInProcess(processIdentifier)) {
+                RELEASE_LOG(ProcessSwapping, "WebBackForwardCache::removeEntriesForProcess: iframe process terminated while in BFCache, invalidating cache entry");
+                return true;
+            }
+        }
+        return false;
     });
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1467,6 +1467,11 @@ bool WebPageProxy::suspendCurrentPageIfPossible(API::Navigation& navigation, Ref
         return false;
     }
 
+    if (mainFrame->opener() || hasPageOpenedByMainFrame(*mainFrame)) {
+        WEBPAGEPROXY_RELEASE_LOG(ProcessSwapping, "suspendCurrentPageIfPossible: Not suspending current page for process pid %i because it has opener relationships", m_legacyMainFrameProcess->processID());
+        return false;
+    }
+
     RefPtr fromItem = navigation.fromItem();
 
     // If the source and the destination back / forward list items are the same, then this is a client-side redirect. In this case,
@@ -1494,6 +1499,13 @@ bool WebPageProxy::suspendCurrentPageIfPossible(API::Navigation& navigation, Ref
     mainFrame->frameLoadState().didSuspend();
 
     Ref suspendedPage = SuspendedPageProxy::create(*this, protect(legacyMainFrameProcess()), mainFrame.releaseNonNull(), std::exchange(m_browsingContextGroup, BrowsingContextGroup::create()), shouldDelayClosingUntilFirstLayerFlush);
+
+    if (protect(preferences())->multiProcessBackForwardCacheEnabled()) {
+        protect(suspendedPage->browsingContextGroup())->detachPageForSuspension(*this, suspendedPage);
+
+        if (fromItem)
+            suspendedPage->suspendIframeProcesses(*fromItem);
+    }
 
     LOG(ProcessSwapping, "WebPageProxy %" PRIu64 " created suspended page %s for process pid %i, back/forward item %s" PRIu64, identifier().toUInt64(), suspendedPage->loggingString().utf8().data(), m_legacyMainFrameProcess->processID(), fromItem ? fromItem->identifier().toString().utf8().data() : "0"_s);
 
@@ -5623,7 +5635,6 @@ void WebPageProxy::commitProvisionalPage(IPC::Connection& connection, FrameIdent
         // handles the update).
         if (*oldMainFrameID != frameID)
             backForwardList().updateFrameIdentifier(*oldMainFrameID, frameID);
-        mainFrameInPreviousProcess->removeChildFrames();
     }
 
     ASSERT(m_legacyMainFrameProcess.ptr() != &provisionalPage->process() || preferences->siteIsolationEnabled());
@@ -5644,6 +5655,10 @@ void WebPageProxy::commitProvisionalPage(IPC::Connection& connection, FrameIdent
     removeAllMessageReceivers();
     RefPtr navigation = m_navigationState->navigation(provisionalPage->navigationID());
     bool didSuspendPreviousPage = navigation ? suspendCurrentPageIfPossible(*navigation, WTF::move(mainFrameInPreviousProcess), shouldDelayClosingUntilFirstLayerFlush) : false;
+
+    if (!didSuspendPreviousPage && mainFrameInPreviousProcess && preferences->siteIsolationEnabled())
+        mainFrameInPreviousProcess->removeChildFrames();
+
     // Defer shutting down old process as it might lead WebPageProxy to be closed and removeWebPage to be invoked again.
     auto preventProcessShutdownScope = protect(legacyMainFrameProcess())->shutdownPreventingScope();
     protect(legacyMainFrameProcess())->removeWebPage(*this, m_websiteDataStore.ptr() == provisionalPage->process().websiteDataStore() ? WebProcessProxy::EndsUsingDataStore::No : WebProcessProxy::EndsUsingDataStore::Yes);
@@ -9708,12 +9723,18 @@ bool WebPageProxy::hasOpenedPage() const
 bool WebPageProxy::hasPageOpenedByMainFrame() const
 {
     ASSERT(mainFrame());
+    if (!mainFrame())
+        return false;
+    return hasPageOpenedByMainFrame(protect(*mainFrame()));
+}
 
+bool WebPageProxy::hasPageOpenedByMainFrame(const WebFrameProxy& frameToCheck) const
+{
     for (Ref page : internals().m_openedPages) {
         auto* openedFrame = page->mainFrame();
         if (!openedFrame)
             continue;
-        if (openedFrame->opener() == mainFrame())
+        if (openedFrame->opener() == &frameToCheck)
             return true;
     }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2758,8 +2758,10 @@ RefPtr<API::Navigation> WebPageProxy::goToBackForwardItem(WebBackForwardListFram
 WebProcessProxy& WebPageProxy::processForTheFrameItem(WebBackForwardListFrameItem& frameItem) const
 {
     if (protect(preferences())->siteIsolationEnabled()) {
-        if (RefPtr frame = WebFrameProxy::webFrame(frameItem.frameID()); frame && frame->page() == this)
-            return frame->process();
+        if (RefPtr frame = WebFrameProxy::webFrame(frameItem.frameID()); frame && frame->page() == this) {
+            if (isFrameInLiveTree(*frame))
+                return frame->process();
+        }
     }
 
     return m_legacyMainFrameProcess;
@@ -2769,8 +2771,10 @@ Ref<FrameState> WebPageProxy::copyFrameStateForBackForwardNavigation(WebBackForw
 {
     auto frameItemForNavigation = [&]() -> Ref<WebBackForwardListFrameItem> {
         if (protect(preferences())->siteIsolationEnabled()) {
-            if (RefPtr frame = WebFrameProxy::webFrame(frameItem.frameID()); frame && frame->page() == this)
-                return frameItem;
+            if (RefPtr frame = WebFrameProxy::webFrame(frameItem.frameID()); frame && frame->page() == this) {
+                if (isFrameInLiveTree(*frame))
+                    return frameItem;
+            }
         }
         return frameItem.backForwardListItem()->mainFrameItem();
     };
@@ -5677,7 +5681,32 @@ void WebPageProxy::commitProvisionalPage(IPC::Connection& connection, FrameIdent
 
     const auto oldProcessID = siteIsolatedProcess().coreProcessIdentifier();
     const auto oldWebPageID = m_webPageID;
+    RefPtr suspendedPageBCG = provisionalPage->suspendedPageBrowsingContextGroup();
     swapToProvisionalPage(provisionalPage.releaseNonNull());
+
+    // Reconnect iframe processes to the new BCG after BFCache restoration.
+    // Collect old RemotePageProxy entries before iterating to avoid iterator
+    // invalidation when suspendedPageBCG == m_browsingContextGroup (which is
+    // always true during goBack — both reference the old BCG from the
+    // back/forward item).
+    if (suspendedPageBCG) {
+        Vector<Ref<RemotePageProxy>> oldRemotePages;
+        suspendedPageBCG->forEachRemotePage(*this, [&](RemotePageProxy& oldRP) {
+            oldRemotePages.append(oldRP);
+        });
+
+        for (auto& oldRP : oldRemotePages) {
+            Ref process = oldRP->siteIsolatedProcess();
+            auto preventProcessShutdown = process->shutdownPreventingScope();
+            auto site = oldRP->site();
+            auto pageID = oldRP->identifierInSiteIsolatedProcess();
+
+            m_browsingContextGroup->ensureProcessForSite(site, Site { mainFrame()->url() }, process, preferences, LoadedWebArchive::No, BrowsingContextGroupUpdate::AddProcess);
+            Ref newRP = RemotePageProxy::create(*this, process, site, nullptr, pageID);
+            newRP->setupSubsystemsForBFCacheRestoration();
+            m_browsingContextGroup->addRemotePage(*this, WTF::move(newRP));
+        }
+    }
 
     didCommitLoadForFrame(connection, frameID, WTF::move(frameInfo), WTF::move(request), navigationID, WTF::move(mimeType), frameHasCustomContentProvider, frameLoadType, certificateInfo, usedLegacyTLS, privateRelayed, WTF::move(proxyName), source, containsPluginDocument, hasInsecureContent, mouseEventPolicy, WTF::move(documentSecurityPolicy), userData);
 
@@ -9718,6 +9747,15 @@ void WebPageProxy::showPage()
 bool WebPageProxy::hasOpenedPage() const
 {
     return !internals().m_openedPages.isEmptyIgnoringNullReferences();
+}
+
+bool WebPageProxy::isFrameInLiveTree(const WebFrameProxy& frame) const
+{
+    for (RefPtr f = m_mainFrame.get(); f; f = f->traverseNext().frame) {
+        if (f.get() == &frame)
+            return true;
+    }
+    return false;
 }
 
 bool WebPageProxy::hasPageOpenedByMainFrame() const
@@ -17620,6 +17658,16 @@ void WebPageProxy::frameTextForTesting(WebCore::FrameIdentifier frameID, Complet
 
     auto [result] = sendResult.takeReply();
     completionHandler(WTF::move(result));
+}
+
+void WebPageProxy::preventBackForwardCacheForTestingInSubframes()
+{
+    protect(browsingContextGroup())->forEachRemotePage(*this, [](RemotePageProxy& remotePage) {
+        remotePage.siteIsolatedProcess().send(
+            Messages::WebPage::PreventBackForwardCacheForTesting(),
+            remotePage.identifierInSiteIsolatedProcess()
+        );
+    });
 }
 
 void WebPageProxy::requestAllTextAndRects(CompletionHandler<void(Vector<Ref<API::TextRun>>&&)>&& completion)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2626,6 +2626,7 @@ public:
     bool NODELETE hasOpenedPage() const;
     bool hasPageOpenedByMainFrame() const;
     bool hasPageOpenedByMainFrame(const WebFrameProxy&) const;
+    bool isFrameInLiveTree(const WebFrameProxy&) const;
 
     void requestImageBitmap(const WebCore::ElementContext&, CompletionHandler<void(std::optional<WebCore::ShareableBitmapHandle>&&, const String& sourceMIMEType)>&&);
 
@@ -2970,6 +2971,8 @@ public:
 #endif
 
     bool shouldUseBackForwardCache() const;
+
+    void preventBackForwardCacheForTestingInSubframes();
 
 private:
     WebPageProxy(PageClient&, WebProcessProxy&, Ref<API::PageConfiguration>&&);

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2625,6 +2625,7 @@ public:
     void addOpenedPage(WebPageProxy&);
     bool NODELETE hasOpenedPage() const;
     bool hasPageOpenedByMainFrame() const;
+    bool hasPageOpenedByMainFrame(const WebFrameProxy&) const;
 
     void requestImageBitmap(const WebCore::ElementContext&, CompletionHandler<void(std::optional<WebCore::ShareableBitmapHandle>&&, const String& sourceMIMEType)>&&);
 

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -2150,20 +2150,32 @@ void WebProcessPool::processForNavigation(WebPageProxy& page, WebFrameProxy& fra
     }
 
     if (siteIsolationEnabled && !site.isEmpty()) {
-        ASSERT(frameInfo.isMainFrame ? site == mainFrameSite : Site(URL(protect(page.pageLoadState())->activeURL())) == mainFrameSite);
-        if (!frame.isMainFrame() && site == mainFrameSite) {
-            Ref mainFrameProcess = Ref { page.mainFrame()->process() };
-            if (!mainFrameProcess->isInProcessCache())
-                return completionHandler(mainFrameProcess.copyRef(), nullptr, "Found process for the same site as main frame"_s);
-        }
-        RefPtr<WebProcessProxy> process;
-        if (RefPtr frameProcess = browsingContextGroup.processForSite(site))
-            process = &frameProcess->process();
-        if (process && process->websiteDataStore() == dataStore.ptr() && process->websiteDataStore() == &page.websiteDataStore() && !process->isInProcessCache() && process->lockdownMode() == lockdownMode && enhancedSecurityStatesAreConsistent(process->enhancedSecurity(), enhancedSecurity)) {
-            protect(dataStore->networkProcess())->addAllowedFirstPartyForCookies(*process, mainFrameSite.domain(), LoadedWebArchive::No, [completionHandler = WTF::move(completionHandler), process] () mutable {
-                completionHandler(process.releaseNonNull(), nullptr, "Found process for the same site"_s);
-            });
-            return;
+        // For back/forward navigations with a suspended page, skip the BCG
+        // process lookup and fall through to processForNavigationInternal()
+        // which handles BFCache restoration properly.
+        bool hasSuspendedPageForTarget = false;
+        if (RefPtr targetItem = navigation.targetItem())
+            hasSuspendedPageForTarget = !!targetItem->suspendedPage();
+
+        if (hasSuspendedPageForTarget)
+            WEBPROCESSPOOL_RELEASE_LOG(ProcessSwapping, "processForNavigation: Bypassing BCG process lookup because target back/forward item has a suspended page");
+
+        if (!hasSuspendedPageForTarget) {
+            ASSERT(frameInfo.isMainFrame ? site == mainFrameSite : Site(URL(protect(page.pageLoadState())->activeURL())) == mainFrameSite);
+            if (!frame.isMainFrame() && site == mainFrameSite) {
+                Ref mainFrameProcess = Ref { page.mainFrame()->process() };
+                if (!mainFrameProcess->isInProcessCache())
+                    return completionHandler(mainFrameProcess.copyRef(), nullptr, "Found process for the same site as main frame"_s);
+            }
+            RefPtr<WebProcessProxy> process;
+            if (RefPtr frameProcess = browsingContextGroup.processForSite(site))
+                process = &frameProcess->process();
+            if (process && process->websiteDataStore() == dataStore.ptr() && process->websiteDataStore() == &page.websiteDataStore() && !process->isInProcessCache() && process->lockdownMode() == lockdownMode && enhancedSecurityStatesAreConsistent(process->enhancedSecurity(), enhancedSecurity)) {
+                protect(dataStore->networkProcess())->addAllowedFirstPartyForCookies(*process, mainFrameSite.domain(), LoadedWebArchive::No, [completionHandler = WTF::move(completionHandler), process] () mutable {
+                    completionHandler(process.releaseNonNull(), nullptr, "Found process for the same site"_s);
+                });
+                return;
+            }
         }
     }
 
@@ -2297,7 +2309,7 @@ std::tuple<Ref<WebProcessProxy>, RefPtr<SuspendedPageProxy>, ASCIILiteral> WebPr
         && !(isRequestFromClientOrUserInput || siteIsolationEnabled))
         return { WTF::move(sourceProcess), nullptr, "Browsing context has opened other windows"_s };
 
-    if (RefPtr targetItem = navigation.targetItem(); targetItem && !siteIsolationEnabled) {
+    if (RefPtr targetItem = navigation.targetItem(); targetItem && (!siteIsolationEnabled || protect(page.preferences())->multiProcessBackForwardCacheEnabled())) {
         if (CheckedPtr suspendedPage = targetItem->suspendedPage()) {
             if (suspendedPage->process().state() != AuxiliaryProcessProxy::State::Terminated)
                 return { suspendedPage->process(), suspendedPage.get(), "Using target back/forward item's process and suspended page"_s };

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -8591,8 +8591,16 @@ void WebPage::setIsSuspendedWithFrameItem(bool suspended, BackForwardFrameItemId
     m_isSuspended = suspended;
 
     if (!suspended) {
-        // FIXME: Restore path (implemented in a follow-up patch).
-        return completionHandler({ });
+        // Phase 4 restore path.
+        unfreezeLayerTree(LayerTreeFreezeReason::PageSuspended);
+        auto cachedPage = BackForwardCache::singleton().take(frameItemID, corePage());
+        if (!cachedPage) {
+            WEBPAGE_RELEASE_LOG_ERROR(ProcessSwapping, "setIsSuspendedWithFrameItem: Failed to take cached page for frameItemID %s", frameItemID.toString().utf8().data());
+            return completionHandler(false);
+        }
+        cachedPage->restore(*corePage());
+        WEBPAGE_RELEASE_LOG(ProcessSwapping, "setIsSuspendedWithFrameItem: Successfully restored cached page for frameItemID %s", frameItemID.toString().utf8().data());
+        return completionHandler(true);
     }
 
     freezeLayerTree(LayerTreeFreezeReason::PageSuspended);
@@ -10004,6 +10012,15 @@ void WebPage::frameTextForTesting(WebCore::FrameIdentifier frameID, CompletionHa
     }
     constexpr bool includeSubframes { true };
     completionHandler(webFrame->frameTextForTesting(includeSubframes));
+}
+
+void WebPage::preventBackForwardCacheForTesting()
+{
+    if (RefPtr page = corePage()) {
+        page->forEachDocument([](Document& document) {
+            document.preventEnteringBackForwardCacheForTesting();
+        });
+    }
 }
 
 void WebPage::requestAllTextAndRects(CompletionHandler<void(Vector<std::pair<String, WebCore::FloatRect>>&&)>&& completion)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -8554,6 +8554,54 @@ void WebPage::setIsSuspended(bool suspended, CompletionHandler<void(std::optiona
     suspendForProcessSwap(WTF::move(completionHandler));
 }
 
+RefPtr<HistoryItem> WebPage::findHistoryItemByFrameItemID(BackForwardFrameItemIdentifier frameItemID)
+{
+    for (RefPtr frame = &corePage()->mainFrame(); frame; frame = frame->tree().traverseNext()) {
+        RefPtr localFrame = dynamicDowncast<LocalFrame>(frame);
+        if (!localFrame)
+            continue;
+        if (RefPtr item = localFrame->loader().history().currentItem()) {
+            if (item->frameItemID() == frameItemID)
+                return item;
+        }
+    }
+    return nullptr;
+}
+
+void WebPage::suspendForProcessSwapWithFrameItem(BackForwardFrameItemIdentifier frameItemID, CompletionHandler<void(std::optional<bool>)>&& completionHandler)
+{
+    flushDeferredDidReceiveMouseEvent();
+    RefPtr historyItem = findHistoryItemByFrameItemID(frameItemID);
+    if (!historyItem) {
+        WEBPAGE_RELEASE_LOG_ERROR(ProcessSwapping, "suspendForProcessSwapWithFrameItem: Failed to find history item for frameItemID %s", frameItemID.toString().utf8().data());
+        return completionHandler(false);
+    }
+    if (!BackForwardCache::singleton().addIfCacheable(*historyItem, protect(corePage()).get())) {
+        WEBPAGE_RELEASE_LOG_ERROR(ProcessSwapping, "suspendForProcessSwapWithFrameItem: BackForwardCache::addIfCacheable failed for frameItemID %s", frameItemID.toString().utf8().data());
+        return completionHandler(false);
+    }
+    WEBPAGE_RELEASE_LOG(ProcessSwapping, "suspendForProcessSwapWithFrameItem: Successfully cached page for frameItemID %s", frameItemID.toString().utf8().data());
+    completionHandler(true);
+}
+
+void WebPage::setIsSuspendedWithFrameItem(bool suspended, BackForwardFrameItemIdentifier frameItemID, CompletionHandler<void(std::optional<bool>)>&& completionHandler)
+{
+    if (m_isSuspended == suspended)
+        return completionHandler({ });
+    m_isSuspended = suspended;
+
+    if (!suspended) {
+        // FIXME: Restore path (implemented in a follow-up patch).
+        return completionHandler({ });
+    }
+
+    freezeLayerTree(LayerTreeFreezeReason::PageSuspended);
+    // Unlike the main-frame path in setIsSuspended, sendPrewarmInformation is
+    // intentionally omitted here because prewarming is a main-frame optimization.
+    unfreezeLayerTree(LayerTreeFreezeReason::BackgroundApplication);
+    suspendForProcessSwapWithFrameItem(frameItemID, WTF::move(completionHandler));
+}
+
 void WebPage::hasStorageAccess(RegistrableDomain&& subFrameDomain, RegistrableDomain&& topFrameDomain, WebFrame& frame, CompletionHandler<void(bool)>&& completionHandler)
 {
     if (hasPageLevelStorageAccess(topFrameDomain, subFrameDomain)) {

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2721,6 +2721,7 @@ private:
     void renderTreeAsTextForTesting(WebCore::FrameIdentifier, uint64_t baseIndent, OptionSet<WebCore::RenderAsTextFlag>, CompletionHandler<void(String&&)>&&);
     void layerTreeAsTextForTesting(WebCore::FrameIdentifier, uint64_t baseIndent, OptionSet<WebCore::LayerTreeAsTextOptions>, CompletionHandler<void(String&&)>&&);
     void frameTextForTesting(WebCore::FrameIdentifier, CompletionHandler<void(String&&)>&&);
+    void preventBackForwardCacheForTesting();
     void bindRemoteAccessibilityFrames(int processIdentifier, WebCore::FrameIdentifier, WebCore::AccessibilityRemoteToken, CompletionHandler<void(WebCore::AccessibilityRemoteToken, int)>&&);
     void updateRemotePageAccessibilityOffset(WebCore::FrameIdentifier, WebCore::IntPoint);
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2632,6 +2632,9 @@ private:
     void setNeedsDOMWindowResizeEvent();
 
     void setIsSuspended(bool, CompletionHandler<void(std::optional<bool>)>&&);
+    void setIsSuspendedWithFrameItem(bool suspended, WebCore::BackForwardFrameItemIdentifier, CompletionHandler<void(std::optional<bool>)>&&);
+    void suspendForProcessSwapWithFrameItem(WebCore::BackForwardFrameItemIdentifier, CompletionHandler<void(std::optional<bool>)>&&);
+    RefPtr<WebCore::HistoryItem> findHistoryItemByFrameItemID(WebCore::BackForwardFrameItemIdentifier);
 
     RefPtr<WebImage> snapshotAtSize(const WebCore::IntRect&, const WebCore::IntSize& bitmapSize, SnapshotOptions, WebCore::LocalFrame&, WebCore::LocalFrameView&);
     RefPtr<WebImage> snapshotNode(WebCore::Node&, SnapshotOptions, unsigned maximumPixelCount = std::numeric_limits<unsigned>::max());

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -718,6 +718,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
     URLSchemeTaskDidComplete(WebKit::WebURLSchemeHandlerIdentifier handlerIdentifier, WebCore::ResourceLoaderIdentifier taskIdentifier, WebCore::ResourceError error)
 
     SetIsSuspended(bool suspended) -> (std::optional<bool> didSuspend)
+    SetIsSuspendedWithFrameItem(bool suspended, WebCore::BackForwardFrameItemIdentifier frameItemID) -> (std::optional<bool> didSuspend)
 
 #if ENABLE(ATTACHMENT_ELEMENT)
     InsertAttachment(String identifier, std::optional<uint64_t> fileSize, String fileName, String contentType) -> ()

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -852,6 +852,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
     RenderTreeAsTextForTesting(WebCore::FrameIdentifier frameID, uint64_t baseIndent, OptionSet<WebCore::RenderAsTextFlag> behavior) -> (String renderTreeDump) Synchronous
     LayerTreeAsTextForTesting(WebCore::FrameIdentifier frameID, uint64_t baseIndent, OptionSet<WebCore::LayerTreeAsTextOptions> options) -> (String layerTreeDump) Synchronous
     FrameTextForTesting(WebCore::FrameIdentifier frameID) -> (String text) Synchronous
+    PreventBackForwardCacheForTesting()
 
     RequestAllTextAndRects() -> (Vector<std::pair<String, WebCore::FloatRect>> textAndRects)
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -438,6 +438,20 @@ void checkFrameTreesInProcesses(WKWebView *webView, Vector<ExpectedFrameTree>&& 
     checkFrameTreesInProcesses(frameTrees(webView).get(), WTF::move(expectedFrameTrees));
 }
 
+static void waitForFrameTreesInProcesses(WKWebView *webView, Vector<ExpectedFrameTree>&& expectedFrameTrees)
+{
+    // BFCache restoration in iframe processes is asynchronous. Poll until
+    // the frame trees match or a generous timeout expires.
+    bool matched = false;
+    for (int attempt = 0; attempt < 500 && !matched; ++attempt) {
+        matched = frameTreesMatch(frameTrees(webView).get(), Vector<ExpectedFrameTree> { expectedFrameTrees });
+        if (!matched)
+            Util::spinRunLoop();
+    }
+    if (!matched)
+        checkFrameTreesInProcesses(frameTrees(webView).get(), expectedFrameTrees);
+}
+
 static unsigned countWebPages(const RetainPtr<WKWebView>& webView)
 {
     __block bool done { false };
@@ -8570,6 +8584,715 @@ TEST(SiteIsolation, MultiProcessBFCacheOpenerSkipsBFCache)
 
     // Verify the marker is gone (full reload, not BFCache restore).
     EXPECT_FALSE([[webView objectByEvaluatingJavaScript:@"window.__bfcacheMarker ? true : false"] boolValue]);
+}
+
+TEST(SiteIsolation, MultiProcessBFCacheSimpleGoBack)
+{
+    HTTPServer server({
+        { "/a"_s, { "<script>window.__bfcacheMarker = true;</script>page a"_s } },
+        { "/b"_s, { "page b"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto *configuration = server.httpsProxyConfiguration();
+    enableFeature(configuration, @"MultiProcessBackForwardCacheEnabled");
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // Verify marker is set.
+    __block bool done = false;
+    [webView evaluateJavaScript:@"window.__bfcacheMarker ? 'yes' : 'no'" completionHandler:^(NSString *result, NSError *) {
+        EXPECT_WK_STREQ(result, "yes");
+        done = true;
+    }];
+    Util::run(&done);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://b.com/b"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // Verify JS state was preserved (BFCache used, not full reload).
+    done = false;
+    [webView evaluateJavaScript:@"window.__bfcacheMarker ? 'yes' : 'no'" completionHandler:^(NSString *result, NSError *) {
+        EXPECT_WK_STREQ(result, "yes");
+        done = true;
+    }];
+    Util::run(&done);
+}
+
+TEST(SiteIsolation, MultiProcessBFCacheNavigationCompletesAfterRestore)
+{
+    HTTPServer server({
+        { "/a"_s, { "<iframe src='https://b.com/frame'></iframe>"_s } },
+        { "/frame"_s, { "iframe content"_s } },
+        { "/c"_s, { "page c"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto *configuration = server.httpsProxyConfiguration();
+    enableFeature(configuration, @"MultiProcessBackForwardCacheEnabled");
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://c.com/c"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // goBack must complete without hanging.
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigation];
+}
+
+TEST(SiteIsolation, MultiProcessBFCacheIframeRestoration)
+{
+    HTTPServer server({
+        { "/a"_s, { "<script>window.addEventListener('pageshow', function(e) { if (e.persisted) window.__bfcacheRestored = true; });</script><iframe src='https://b.com/frame'></iframe>"_s } },
+        { "/frame"_s, { "<script>window.__iframeMarker = true;</script>iframe content"_s } },
+        { "/c"_s, { "page c"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto *configuration = server.httpsProxyConfiguration();
+    enableFeature(configuration, @"MultiProcessBackForwardCacheEnabled");
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    checkFrameTreesInProcesses(webView.get(), {
+        { "https://a.com"_s, { { RemoteFrame } } },
+        { RemoteFrame, { { "https://b.com"_s } } },
+    });
+
+    // Record iframe process PID.
+    pid_t iframePID = 0;
+    auto trees = frameTrees(webView.get());
+    for (_WKFrameTreeNode *tree in trees.get()) {
+        if (!tree.info._isLocalFrame && tree.childFrames.count)
+            iframePID = tree.childFrames[0].info._processIdentifier;
+    }
+    EXPECT_NE(iframePID, 0);
+
+    // Navigate away — triggers multi-process suspension.
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://c.com/c"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // Verify BFCache was actually used (pageshow event.persisted was true).
+    __block bool done = false;
+    [webView evaluateJavaScript:@"window.__bfcacheRestored ? 'yes' : 'no'" completionHandler:^(NSString *result, NSError *) {
+        EXPECT_WK_STREQ(result, "yes");
+        done = true;
+    }];
+    Util::run(&done);
+
+    // Verify the frame tree is correct after BFCache restoration.
+    checkFrameTreesInProcesses(webView.get(), {
+        { "https://a.com"_s, { { RemoteFrame } } },
+        { RemoteFrame, { { "https://b.com"_s } } },
+    });
+
+    // Verify iframe process survived (same PID as before suspension).
+    pid_t restoredIframePID = 0;
+    auto restoredTrees = frameTrees(webView.get());
+    for (_WKFrameTreeNode *tree in restoredTrees.get()) {
+        if (!tree.info._isLocalFrame && tree.childFrames.count)
+            restoredIframePID = tree.childFrames[0].info._processIdentifier;
+    }
+    EXPECT_EQ(restoredIframePID, iframePID);
+}
+
+TEST(SiteIsolation, MultiProcessBFCacheScriptNavigation)
+{
+    HTTPServer server({
+        { "/a"_s, { "<script>window.addEventListener('pageshow', function(e) { if (e.persisted) window.__bfcacheRestored = true; });</script><iframe src='https://b.com/frame'></iframe>"_s } },
+        { "/frame"_s, { "iframe content"_s } },
+        { "/c"_s, { "page c"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto *configuration = server.httpsProxyConfiguration();
+    enableFeature(configuration, @"MultiProcessBackForwardCacheEnabled");
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // Navigate away — triggers multi-process suspension. The processMap
+    // cleanup in suspendCurrentPageIfPossible() prevents duplicate
+    // CreateWebPage messages when addPage() later iterates the old BCG's
+    // processMap entries. Without this cleanup, stale iframe FrameProcess
+    // entries cause spurious injectPageIntoNewProcess() calls.
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://c.com/c"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // goBack triggers BFCache restoration and Phase 4c BCG reconnection.
+    // The reconnection code collects RemotePageProxy entries into a Vector
+    // before processing them, avoiding iterator invalidation when the
+    // suspended page's BCG is the same object as the current BCG (which is
+    // always true during goBack).
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // Verify BFCache was used.
+    __block bool done = false;
+    [webView evaluateJavaScript:@"window.__bfcacheRestored ? 'yes' : 'no'" completionHandler:^(NSString *result, NSError *) {
+        EXPECT_WK_STREQ(result, "yes");
+        done = true;
+    }];
+    Util::run(&done);
+}
+
+TEST(SiteIsolation, MultiProcessBFCacheIframeProcessDeath)
+{
+    HTTPServer server({
+        { "/a"_s, { "<script>window.__bfcacheMarker = true; window.addEventListener('pageshow', function(e) { if (e.persisted) window.__bfcacheRestored = true; });</script><iframe src='https://b.com/frame'></iframe>"_s } },
+        { "/frame"_s, { "iframe content"_s } },
+        { "/c"_s, { "page c"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto *configuration = server.httpsProxyConfiguration();
+    enableFeature(configuration, @"MultiProcessBackForwardCacheEnabled");
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
+
+    // 1. Load a.com with b.com iframe.
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // Record iframe process PID.
+    pid_t iframePID = 0;
+    auto trees = frameTrees(webView.get());
+    for (_WKFrameTreeNode *tree in trees.get()) {
+        if (!tree.info._isLocalFrame && tree.childFrames.count)
+            iframePID = tree.childFrames[0].info._processIdentifier;
+    }
+    EXPECT_NE(iframePID, 0);
+
+    // 2. Navigate to c.com (triggers multi-process BFCache suspension).
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://c.com/c"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // 3. Kill the b.com iframe process and wait for it to be reaped.
+    kill(iframePID, SIGKILL);
+    // Wait until the process is actually gone.
+    for (int i = 0; i < 100; i++) {
+        if (kill(iframePID, 0) != 0)
+            break;
+        Util::runFor(0.01_s);
+    }
+    // Give the run loop time to process the XPC connection close notification.
+    Util::runFor(0.5_s);
+
+    // 4. goBack — should do full page reload, NOT BFCache restore.
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigation];
+    [navigationDelegate waitForDidFinishLoadInSubframe];
+
+    // 5. Verify: BFCache was NOT used (full reload).
+    __block bool done = false;
+    [webView evaluateJavaScript:@"window.__bfcacheRestored ? 'yes' : 'no'" completionHandler:^(NSString *result, NSError *) {
+        EXPECT_WK_STREQ(result, "no");
+        done = true;
+    }];
+    Util::run(&done);
+
+    // 6. Verify: page loads correctly with iframe (fresh load).
+    checkFrameTreesInProcesses(webView.get(), {
+        { "https://a.com"_s, { { RemoteFrame } } },
+        { RemoteFrame, { { "https://b.com"_s } } },
+    });
+}
+
+TEST(SiteIsolation, MultiProcessBFCacheSuspensionFailure)
+{
+    HTTPServer server({
+        { "/a"_s, { "<iframe src='https://b.com/frame'></iframe>"_s } },
+        { "/frame"_s, { "iframe content"_s } },
+        { "/c"_s, { "page c"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto *configuration = server.httpsProxyConfiguration();
+    enableFeature(configuration, @"MultiProcessBackForwardCacheEnabled");
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
+
+    // 1. Load a.com with cross-origin b.com iframe.
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    checkFrameTreesInProcesses(webView.get(), {
+        { "https://a.com"_s, { { RemoteFrame } } },
+        { RemoteFrame, { { "https://b.com"_s } } },
+    });
+
+    // 2. Set a JS marker in the main frame to detect BFCache vs full reload.
+    __block bool done = false;
+    [webView evaluateJavaScript:@"window.__marker = true" completionHandler:^(id, NSError *) {
+        done = true;
+    }];
+    Util::run(&done);
+
+    // 3. Mark iframe documents as uncacheable.
+    [webView _preventBackForwardCacheInSubframesForTesting];
+
+    // 4. Navigate to c.com — triggers multi-process BFCache suspension.
+    //    The iframe process will fail to cache (preventEnteringBackForwardCacheForTesting),
+    //    causing the BFCache entry to be invalidated.
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://c.com/c"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // 5. goBack — should do a full page reload, NOT BFCache restore.
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigation];
+    [navigationDelegate waitForDidFinishLoadInSubframe];
+
+    // 6. Verify: frame tree is correct after full reload.
+    checkFrameTreesInProcesses(webView.get(), {
+        { "https://a.com"_s, { { RemoteFrame } } },
+        { RemoteFrame, { { "https://b.com"_s } } },
+    });
+
+    // 7. Verify: BFCache was NOT used. The marker should be absent after full reload.
+    done = false;
+    [webView evaluateJavaScript:@"window.__marker ? 'yes' : 'no'" completionHandler:^(NSString *result, NSError *) {
+        EXPECT_WK_STREQ(result, "no");
+        done = true;
+    }];
+    Util::run(&done);
+}
+
+TEST(SiteIsolation, MultiProcessBFCacheMainProcessDeath)
+{
+    HTTPServer server({
+        { "/a"_s, { "<script>window.__bfcacheMarker = true; window.addEventListener('pageshow', function(e) { if (e.persisted) window.__bfcacheRestored = true; });</script><iframe src='https://b.com/frame'></iframe>"_s } },
+        { "/frame"_s, { "iframe content"_s } },
+        { "/c"_s, { "page c"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto *configuration = server.httpsProxyConfiguration();
+    enableFeature(configuration, @"MultiProcessBackForwardCacheEnabled");
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
+
+    // 1. Load a.com with b.com iframe.
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // Record the a.com main process PID.
+    pid_t mainPID = [webView _webProcessIdentifier];
+    EXPECT_NE(mainPID, 0);
+
+    // 2. Navigate to c.com (triggers multi-process BFCache suspension).
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://c.com/c"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // The main PID should now be different (PSON to c.com).
+    EXPECT_NE([webView _webProcessIdentifier], mainPID);
+
+    // 3. Kill the suspended a.com main process.
+    kill(mainPID, SIGKILL);
+    // Wait until the process is actually gone.
+    for (int i = 0; i < 100; i++) {
+        if (kill(mainPID, 0) != 0)
+            break;
+        Util::runFor(0.01_s);
+    }
+    // Give the run loop time to process the XPC connection close notification.
+    Util::runFor(0.5_s);
+
+    // 4. goBack — should do full page reload, NOT BFCache restore.
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigation];
+    [navigationDelegate waitForDidFinishLoadInSubframe];
+
+    // 5. Verify: BFCache was NOT used (full reload, no crash).
+    __block bool done = false;
+    [webView evaluateJavaScript:@"window.__bfcacheRestored ? 'yes' : 'no'" completionHandler:^(NSString *result, NSError *) {
+        EXPECT_WK_STREQ(result, "no");
+        done = true;
+    }];
+    Util::run(&done);
+
+    // 6. Verify: page loads correctly with iframe (fresh load).
+    checkFrameTreesInProcesses(webView.get(), {
+        { "https://a.com"_s, { { RemoteFrame } } },
+        { RemoteFrame, { { "https://b.com"_s } } },
+    });
+}
+
+TEST(SiteIsolation, MultiProcessBFCacheMultipleIframes)
+{
+    HTTPServer server({
+        { "/a"_s, { "<script>window.addEventListener('pageshow', function(e) { if (e.persisted) window.__bfcacheRestored = true; });</script><iframe src='https://b.com/frame1'></iframe><iframe src='https://c.com/frame2'></iframe>"_s } },
+        { "/frame1"_s, { "<script>window.__iframeMarkerB = true;</script>iframe b content"_s } },
+        { "/frame2"_s, { "<script>window.__iframeMarkerC = true;</script>iframe c content"_s } },
+        { "/d"_s, { "page d"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto *configuration = server.httpsProxyConfiguration();
+    enableFeature(configuration, @"MultiProcessBackForwardCacheEnabled");
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
+
+    // 1. Load a.com with iframes from b.com AND c.com.
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    checkFrameTreesInProcesses(webView.get(), {
+        { "https://a.com"_s, { { RemoteFrame }, { RemoteFrame } } },
+        { RemoteFrame, { { "https://b.com"_s }, { RemoteFrame } } },
+        { RemoteFrame, { { RemoteFrame }, { "https://c.com"_s } } },
+    });
+
+    // 2. Record both iframe PIDs.
+    pid_t bPID = 0, cPID = 0;
+    auto trees = frameTrees(webView.get());
+    for (_WKFrameTreeNode *tree in trees.get()) {
+        for (_WKFrameTreeNode *child in tree.childFrames) {
+            if (child.info._isLocalFrame) {
+                NSString *url = child.info.request.URL.absoluteString;
+                if ([url containsString:@"frame1"])
+                    bPID = child.info._processIdentifier;
+                else if ([url containsString:@"frame2"])
+                    cPID = child.info._processIdentifier;
+            }
+        }
+    }
+    EXPECT_NE(bPID, 0);
+    EXPECT_NE(cPID, 0);
+    EXPECT_NE(bPID, cPID);
+
+    // 3. Navigate to d.com -- triggers multi-process suspension of BOTH iframes.
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://d.com/d"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // 4. goBack -- triggers BFCache restoration.
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // 5. Verify BFCache was used.
+    __block bool done = false;
+    [webView evaluateJavaScript:@"window.__bfcacheRestored ? 'yes' : 'no'" completionHandler:^(NSString *result, NSError *) {
+        EXPECT_WK_STREQ(result, "yes");
+        done = true;
+    }];
+    Util::run(&done);
+
+    // 6. Verify the frame tree is correct after restoration (main + 2 remote frames).
+    checkFrameTreesInProcesses(webView.get(), {
+        { "https://a.com"_s, { { RemoteFrame }, { RemoteFrame } } },
+        { RemoteFrame, { { "https://b.com"_s }, { RemoteFrame } } },
+        { RemoteFrame, { { RemoteFrame }, { "https://c.com"_s } } },
+    });
+
+    // 7. Verify both iframe PIDs survived.
+    pid_t restoredBPID = 0, restoredCPID = 0;
+    auto restoredTrees = frameTrees(webView.get());
+    for (_WKFrameTreeNode *tree in restoredTrees.get()) {
+        for (_WKFrameTreeNode *child in tree.childFrames) {
+            if (child.info._isLocalFrame) {
+                NSString *url = child.info.request.URL.absoluteString;
+                if ([url containsString:@"frame1"])
+                    restoredBPID = child.info._processIdentifier;
+                else if ([url containsString:@"frame2"])
+                    restoredCPID = child.info._processIdentifier;
+            }
+        }
+    }
+    EXPECT_EQ(restoredBPID, bPID);
+    EXPECT_EQ(restoredCPID, cPID);
+}
+
+TEST(SiteIsolation, MultiProcessBFCacheGoForward)
+{
+    HTTPServer server({
+        { "/a"_s, { "<script>window.__marker = true; window.addEventListener('pageshow', function(e) { if (e.persisted) window.__bfcacheRestored = true; });</script><iframe src='https://b.com/frame'></iframe>"_s } },
+        { "/frame"_s, { "iframe content"_s } },
+        { "/c"_s, { "<script>window.addEventListener('pageshow', function(e) { if (e.persisted) window.__bfcacheRestoredC = true; });</script>page c"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto *configuration = server.httpsProxyConfiguration();
+    enableFeature(configuration, @"MultiProcessBackForwardCacheEnabled");
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
+
+    // 1. Load a.com with b.com iframe.
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // 2. Navigate to c.com (a.com + b.com cached).
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://c.com/c"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // 3. goBack (restore a.com + b.com).
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // 4. Verify BFCache was used (marker present).
+    __block bool done = false;
+    [webView evaluateJavaScript:@"window.__bfcacheRestored ? 'yes' : 'no'" completionHandler:^(NSString *result, NSError *) {
+        EXPECT_WK_STREQ(result, "yes");
+        done = true;
+    }];
+    Util::run(&done);
+
+    // 5. goForward (restore c.com).
+    [webView goForward];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // 6. Verify on c.com.
+    done = false;
+    [webView evaluateJavaScript:@"window.location.hostname" completionHandler:^(NSString *result, NSError *) {
+        EXPECT_WK_STREQ(result, "c.com");
+        done = true;
+    }];
+    Util::run(&done);
+
+    // 7. goBack again (restore a.com + b.com again).
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // 8. Verify BFCache was used (marker still present from original load).
+    done = false;
+    [webView evaluateJavaScript:@"window.__marker ? 'yes' : 'no'" completionHandler:^(NSString *result, NSError *) {
+        EXPECT_WK_STREQ(result, "yes");
+        done = true;
+    }];
+    Util::run(&done);
+
+    checkFrameTreesInProcesses(webView.get(), {
+        { "https://a.com"_s, { { RemoteFrame } } },
+        { RemoteFrame, { { "https://b.com"_s } } },
+    });
+}
+
+TEST(SiteIsolation, MultiProcessBFCacheRapidNavigation)
+{
+    HTTPServer server({
+        { "/a"_s, { "<script>window.__marker = true; window.addEventListener('pageshow', function(e) { if (e.persisted) window.__bfcacheRestored = true; });</script><iframe src='https://b.com/frame'></iframe>"_s } },
+        { "/frame"_s, { "iframe content"_s } },
+        { "/c"_s, { "page c"_s } },
+        { "/d"_s, { "page d"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto *configuration = server.httpsProxyConfiguration();
+    enableFeature(configuration, @"MultiProcessBackForwardCacheEnabled");
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
+
+    // 1. Load a.com with b.com iframe.
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    checkFrameTreesInProcesses(webView.get(), {
+        { "https://a.com"_s, { { RemoteFrame } } },
+        { RemoteFrame, { { "https://b.com"_s } } },
+    });
+
+    // 2. Navigate to c.com (a.com cached).
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://c.com/c"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // 3. Navigate to d.com (c.com cached).
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://d.com/d"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // 4. goBack (restore c.com -- no iframe).
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    __block bool done = false;
+    [webView evaluateJavaScript:@"window.location.hostname" completionHandler:^(NSString *result, NSError *) {
+        EXPECT_WK_STREQ(result, "c.com");
+        done = true;
+    }];
+    Util::run(&done);
+
+    // 5. goBack (restore a.com with b.com iframe).
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // 6. Verify BFCache was used (marker present).
+    done = false;
+    [webView evaluateJavaScript:@"window.__bfcacheRestored ? 'yes' : 'no'" completionHandler:^(NSString *result, NSError *) {
+        EXPECT_WK_STREQ(result, "yes");
+        done = true;
+    }];
+    Util::run(&done);
+
+    // 7. Verify frame tree correct. Use waitFor variant because the iframe
+    // process CachedPage restoration is asynchronous after multiple goBack hops.
+    waitForFrameTreesInProcesses(webView.get(), {
+        { "https://a.com"_s, { { RemoteFrame } } },
+        { RemoteFrame, { { "https://b.com"_s } } },
+    });
+}
+
+TEST(SiteIsolation, MultiProcessBFCacheNestedIframes)
+{
+    // A→B→A nesting: a.com main → b.com iframe → a.com nested iframe.
+    // Tests canCacheFrame() RemoteFrame traversal and CachedFrame tree reconstruction with nesting.
+    HTTPServer server({
+        { "/a"_s, { "<script>window.__marker = true; window.addEventListener('pageshow', function(e) { if (e.persisted) window.__bfcacheRestored = true; });</script><iframe src='https://b.com/frame'></iframe>"_s } },
+        { "/frame"_s, { "<iframe src='https://a.com/nested'></iframe>"_s } },
+        { "/nested"_s, { "<script>window.__nestedMarker = true; alert('nested-loaded');</script>nested content"_s } },
+        { "/c"_s, { "page c"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto *configuration = server.httpsProxyConfiguration();
+    enableFeature(configuration, @"MultiProcessBackForwardCacheEnabled");
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
+
+    // 1. Load a.com with b.com iframe containing nested a.com iframe.
+    //    Wait for nested iframe alert to ensure all frames are loaded.
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "nested-loaded");
+
+    // 2. Record b.com iframe PID.
+    pid_t iframePID = 0;
+    auto trees = frameTrees(webView.get());
+    for (_WKFrameTreeNode *tree in trees.get()) {
+        for (_WKFrameTreeNode *child in tree.childFrames) {
+            if (child.info._isLocalFrame) {
+                NSString *url = child.info.request.URL.absoluteString;
+                if ([url containsString:@"frame"])
+                    iframePID = child.info._processIdentifier;
+            }
+        }
+    }
+    EXPECT_NE(iframePID, 0);
+
+    // 3. Verify nested iframe marker is set via JS evaluation.
+    __block bool done = false;
+    RetainPtr<WKFrameInfo> nestedFrame = [webView mainFrame].childFrames.firstObject.childFrames.firstObject.info;
+    EXPECT_NOT_NULL(nestedFrame.get());
+    [webView evaluateJavaScript:@"window.__nestedMarker ? 'yes' : 'no'" inFrame:nestedFrame.get() completionHandler:^(NSString *result, NSError *) {
+        EXPECT_WK_STREQ(result, "yes");
+        done = true;
+    }];
+    Util::run(&done);
+
+    // 4. Navigate to c.com — triggers multi-process suspension.
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://c.com/c"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // 5. goBack — triggers BFCache restoration.
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // 6. Verify BFCache was used.
+    done = false;
+    [webView evaluateJavaScript:@"window.__bfcacheRestored ? 'yes' : 'no'" completionHandler:^(NSString *result, NSError *) {
+        EXPECT_WK_STREQ(result, "yes");
+        done = true;
+    }];
+    Util::run(&done);
+
+    // 7. Verify b.com iframe PID survived.
+    pid_t restoredIframePID = 0;
+    auto restoredTrees = frameTrees(webView.get());
+    for (_WKFrameTreeNode *tree in restoredTrees.get()) {
+        for (_WKFrameTreeNode *child in tree.childFrames) {
+            if (child.info._isLocalFrame) {
+                NSString *url = child.info.request.URL.absoluteString;
+                if ([url containsString:@"frame"])
+                    restoredIframePID = child.info._processIdentifier;
+            }
+        }
+    }
+    EXPECT_EQ(restoredIframePID, iframePID);
+
+    // 8. Verify nested iframe marker survived BFCache (not a fresh load).
+    done = false;
+    RetainPtr<WKFrameInfo> restoredNestedFrame = [webView mainFrame].childFrames.firstObject.childFrames.firstObject.info;
+    EXPECT_NOT_NULL(restoredNestedFrame.get());
+    [webView evaluateJavaScript:@"window.__nestedMarker ? 'yes' : 'no'" inFrame:restoredNestedFrame.get() completionHandler:^(NSString *result, NSError *) {
+        EXPECT_WK_STREQ(result, "yes");
+        done = true;
+    }];
+    Util::run(&done);
+}
+
+TEST(SiteIsolation, MultiProcessBFCacheNavigateIframeBeforeGoBack)
+{
+    // Navigate iframe to a different origin, then navigate main frame (BFCache),
+    // then goBack. Verifies the post-navigation iframe state (c.com) is cached and restored.
+    HTTPServer server({
+        { "/a"_s, { "<script>window.addEventListener('pageshow', function(e) { if (e.persisted) window.__bfcacheRestored = true; });</script><iframe src='https://b.com/frame'></iframe>"_s } },
+        { "/frame"_s, { "original b.com content"_s } },
+        { "/frame2"_s, { "<script>window.__cMarker = true; alert('c-loaded');</script>c.com content"_s } },
+        { "/d"_s, { "page d"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto *configuration = server.httpsProxyConfiguration();
+    enableFeature(configuration, @"MultiProcessBackForwardCacheEnabled");
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
+
+    // 1. Load a.com with b.com iframe.
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // 2. Verify initial frame tree.
+    checkFrameTreesInProcesses(webView.get(), {
+        { "https://a.com"_s, { { RemoteFrame } } },
+        { RemoteFrame, { { "https://b.com"_s } } },
+    });
+
+    // 3. Navigate iframe from b.com to c.com.
+    [webView evaluateJavaScript:@"location.href = 'https://c.com/frame2'" inFrame:[webView firstChildFrame] completionHandler:nil];
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "c-loaded");
+
+    // 4. Verify frame tree now shows c.com (not b.com).
+    checkFrameTreesInProcesses(webView.get(), {
+        { "https://a.com"_s, { { RemoteFrame } } },
+        { RemoteFrame, { { "https://c.com"_s } } },
+    });
+
+    // 5. Record c.com iframe PID.
+    pid_t cPID = 0;
+    auto trees = frameTrees(webView.get());
+    for (_WKFrameTreeNode *tree in trees.get()) {
+        if (!tree.info._isLocalFrame && tree.childFrames.count)
+            cPID = tree.childFrames[0].info._processIdentifier;
+    }
+    EXPECT_NE(cPID, 0);
+
+    // 6. Navigate to d.com — triggers BFCache suspension with c.com iframe state.
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://d.com/d"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // 7. goBack — restores a.com + c.com iframe from BFCache.
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // 8. Verify BFCache was used.
+    __block bool done = false;
+    [webView evaluateJavaScript:@"window.__bfcacheRestored ? 'yes' : 'no'" completionHandler:^(NSString *result, NSError *) {
+        EXPECT_WK_STREQ(result, "yes");
+        done = true;
+    }];
+    Util::run(&done);
+
+    // 9. Verify frame tree shows c.com (NOT b.com) — the post-navigation state was cached.
+    checkFrameTreesInProcesses(webView.get(), {
+        { "https://a.com"_s, { { RemoteFrame } } },
+        { RemoteFrame, { { "https://c.com"_s } } },
+    });
+
+    // 10. Verify c.com iframe PID survived.
+    pid_t restoredCPID = 0;
+    auto restoredTrees = frameTrees(webView.get());
+    for (_WKFrameTreeNode *tree in restoredTrees.get()) {
+        if (!tree.info._isLocalFrame && tree.childFrames.count)
+            restoredCPID = tree.childFrames[0].info._processIdentifier;
+    }
+    EXPECT_EQ(restoredCPID, cPID);
+
+    // 11. Verify c.com iframe marker survived BFCache (not a fresh reload).
+    done = false;
+    [webView evaluateJavaScript:@"window.__cMarker ? 'yes' : 'no'" inFrame:[webView firstChildFrame] completionHandler:^(NSString *result, NSError *) {
+        EXPECT_WK_STREQ(result, "yes");
+        done = true;
+    }];
+    Util::run(&done);
 }
 
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -8501,4 +8501,75 @@ TEST(SiteIsolation, OpenEmptySiteFromProcessWithNonEmptySite)
     Util::run(&openedFinishedLoading);
 }
 
+TEST(SiteIsolation, MultiProcessBFCacheIframeProcessSurvival)
+{
+    HTTPServer server({
+        { "/a"_s, { "<iframe src='https://b.com/frame'></iframe>"_s } },
+        { "/frame"_s, { "iframe content"_s } },
+        { "/c"_s, { "page c"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto *configuration = server.httpsProxyConfiguration();
+    enableFeature(configuration, @"MultiProcessBackForwardCacheEnabled");
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    checkFrameTreesInProcesses(webView.get(), {
+        { "https://a.com"_s, { { RemoteFrame } } },
+        { RemoteFrame, { { "https://b.com"_s } } },
+    });
+
+    pid_t iframePID = findFramePID(frameTrees(webView.get()).get(), FrameType::Remote);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://c.com/c"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // Iframe process must survive. Without multi-process suspension,
+    // removeChildFrames() sends WebPage::Close() and kills it.
+    EXPECT_TRUE(processStillRunning(iframePID));
+}
+
+// FIXME: Use openerAndOpenedViews() once MultiProcessBackForwardCacheEnabled is on by default.
+TEST(SiteIsolation, MultiProcessBFCacheOpenerSkipsBFCache)
+{
+    HTTPServer server({
+        { "/a"_s, { "<script>window.open('https://a.com/child');</script>"_s } },
+        { "/child"_s, { "child page"_s } },
+        { "/b"_s, { "page b"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto *configuration = server.httpsProxyConfiguration();
+    enableFeature(configuration, @"MultiProcessBackForwardCacheEnabled");
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
+
+    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    [webView setUIDelegate:uiDelegate.get()];
+    webView.get().configuration.preferences.javaScriptCanOpenWindowsAutomatically = YES;
+
+    __block RetainPtr<WKWebView> openedWebView;
+    uiDelegate.get().createWebViewWithConfiguration = ^WKWebView *(WKWebViewConfiguration *config, WKNavigationAction *action, WKWindowFeatures *windowFeatures) {
+        openedWebView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:config]);
+        return openedWebView.get();
+    };
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // Set a BFCache marker on the opener page.
+    [webView objectByEvaluatingJavaScript:@"window.__bfcacheMarker = true"];
+
+    // Navigate to a different site to trigger PSON.
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://b.com/b"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // Go back.
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // Verify the marker is gone (full reload, not BFCache restore).
+    EXPECT_FALSE([[webView objectByEvaluatingJavaScript:@"window.__bfcacheMarker ? true : false"] boolValue]);
+}
+
 }


### PR DESCRIPTION
#### 3145e666450ad3ee557aeb8e47f357f4cbb0756a
<pre>
[BFCache] Phase 4c: BCG reconnection after BFCache restoration

Reconnect iframe processes to the new BrowsingContextGroup after
BFCache restoration so frame tree queries can reach iframe processes.

Changes:
- Fix ~SuspendedPageProxy: only call closeRemotePagesForPage() when
  evicted (not Resumed), preserving iframe RemotePageProxies for
  consumed suspended pages
- Save suspended page&apos;s BCG in ProvisionalPageProxy for use during
  commitProvisionalPage
- Add RemotePageProxy::setupSubsystemsForBFCacheRestoration() — same
  subsystem setup as injectPageIntoNewProcess() without CreateWebPage
- In commitProvisionalPage, after swapToProvisionalPage, create new
  RemotePageProxy objects in the new BCG using data from the old BCG
- Skip SI-specific frame tree setup in initializeWebPage() for BFCache
  restore (remotePageParameters, provisionalFrameCreationParameters,
  addFrameProcessAndInjectPageContextIf) to avoid overwriting the
  BFCache-restored frame tree
- CachedFrameBase::restore(): re-add RemoteFrame children to frame
  tree via appendChild (skip open) instead of clearContentFrame

Known limitation: frame tree verification (checkFrameTreesInProcesses)
after BFCache restore does not yet show the correct cross-process
structure. The WebProcess-side frame tree reconstruction needs further
investigation. Test includes goBack completion check only.

Co-Authored-By: Claude Opus 4.6 &lt;noreply@anthropic.com&gt;
</pre>
----------------------------------------------------------------------
#### b638f57eb4906d4bf551ce14ef892907c93b9b03
<pre>
[BFCache] Address review feedback for Phase 2-4a

1. BackForwardCache::take(): Move notifyChanged() after page ownership
   check to avoid spurious UI notifications when a wrong Page takes
   and puts back a CachedPage.

2. copyFrameStateForBackForwardNavigation(): Add live-tree guard
   matching processForTheFrameItem() to prevent suspended frames from
   being used for frame state lookup.

3. MultiProcessBFCacheSimpleGoBack: Add JS state preservation check
   (window.__bfcacheMarker) to verify actual BFCache usage, not just
   navigation completion.

Co-Authored-By: Claude Opus 4.6 &lt;noreply@anthropic.com&gt;
</pre>
----------------------------------------------------------------------
#### 6c86b16f411eff50fa3f55c802d27190f9f0a143
<pre>
[BFCache] Phase 4b: Send restore IPC to iframe processes during unsuspend

When restoring a page from BFCache, send SetIsSuspendedWithFrameItem(false)
to each iframe process so they restore their own CachedPages.

Changes:
- Update unsuspend() to accept WebBackForwardListItem* parameter
- After sending SetIsSuspended(false) to main process, iterate iframe
  processes via the old BCG&apos;s RemotePageProxy objects and send
  SetIsSuspendedWithFrameItem(false, frameItemID) to each
- Pass navigation.targetItem() from ProvisionalPageProxy constructor

Note: Full iframe restoration verification (e.g., pageshow event from
iframe reaching UIProcess) requires Phase 4c BCG reconnection.

Co-Authored-By: Claude Opus 4.6 &lt;noreply@anthropic.com&gt;
</pre>
----------------------------------------------------------------------
#### 6c5bc7eb8543b3a2871b2025573998f4c2ce855d
<pre>
[BFCache] Phase 4a: WebProcess restoration for multi-process BFCache

Enable goBack to restore pages from BFCache with Site Isolation.

Changes:
- CachedFrame::open(): Handle RemoteFrameView main CachedFrame by
  recursing into child CachedFrames for iframe process restoration
- processForTheFrameItem(): Limit WebFrameProxy lookup to the live
  frame tree to avoid routing GoToBackForwardItem to suspended frames
- ProvisionalPageProxy::didCommitLoadForFrame(): Guard setProcess()
  with pageMainFrame == m_mainFrame check to prevent corrupting
  suspended WebFrameProxy&apos;s FrameProcess. Without this guard,
  updateFrameProcess() overwrites the ProvisionalPageProxy&apos;s
  m_frameProcess via the stale suspended frame reference.

The goBack flow uses a two-hop approach: GoToBackForwardItem goes to
the current process (BFCache miss), triggers policy check, UIProcess
finds the suspended page via processForNavigationInternal, PSON creates
ProvisionalPageProxy which sends GoToBackForwardItem to the restored
process (BFCache hit).

Tests: MultiProcessBFCacheSimpleGoBack,
       MultiProcessBFCacheNavigationCompletesAfterRestore

Co-Authored-By: Claude Opus 4.6 &lt;noreply@anthropic.com&gt;
</pre>
----------------------------------------------------------------------
#### 3857cb1c72166c03a90751d545c1b61caefc4dd4
<pre>
[BFCache] Phase 3: Multi-process suspension for BFCache with Site Isolation

When suspending a page with cross-origin iframes, send
SetIsSuspendedWithFrameItem IPC to each iframe process so it creates
its own CachedPage.

Changes:
- Add SetIsSuspendedWithFrameItem IPC message
- Implement WebPage::setIsSuspendedWithFrameItem(),
  suspendForProcessSwapWithFrameItem(), findHistoryItemByFrameItemID()
- Send suspension IPC to iframe processes via RemotePageProxy in
  suspendCurrentPageIfPossible()
- Add page ownership guards to BackForwardCache::get() and take()
  to prevent cross-Page CachedPage theft in shared processes
- Add BackForwardCache::takeByFrameItemID() for Phase 4 restore path
- Add non-const browsingContextGroup() overload to SuspendedPageProxy

Test: MultiProcessBFCacheSuspensionDoesNotCrash

Co-Authored-By: Claude Opus 4.6 &lt;noreply@anthropic.com&gt;
</pre>
----------------------------------------------------------------------
#### a04d7da88f4b06b8b276dd9876344588e4d48498
<pre>
[BFCache] Phase 2: WebFrameProxy tree survival for multi-process BFCache

When BFCache suspension succeeds with Site Isolation, skip
removeChildFrames() so the UIProcess-side frame tree survives in
SuspendedPageProxy. This is the foundation for multi-process BFCache.

Changes:
- Add opener relationship guard in suspendCurrentPageIfPossible()
- Register iframe processes with addSuspendedPageProxy() for lifetime
  management after SuspendedPageProxy creation
- Move removeChildFrames() to after suspendCurrentPageIfPossible(),
  only called when suspension fails
- Add cleanup in ~SuspendedPageProxy: closeRemotePagesForPage() and
  removeSuspendedPageProxy() on all iframe processes
- Add BrowsingContextGroup::closeRemotePagesForPage() method

Tests: MultiProcessBFCacheIframeProcessSurvival,
       MultiProcessBFCacheOpenerSkipsBFCache

Co-Authored-By: Claude Opus 4.6 &lt;noreply@anthropic.com&gt;
</pre>
----------------------------------------------------------------------
#### 7682fb09c61ed39afedc8ee3c2889667118002a9
<pre>
[BFCache] Phase 3: Allow BFCache with Site Isolation behind feature flag

UIProcess guard changes gated by UseMultiProcessBackForwardCache flag:

WebPageProxy::shouldUseBackForwardCache():
- When Site Isolation is enabled, allow BFCache if
  UseMultiProcessBackForwardCache is true (instead of
  unconditionally disabling).

WebProcessPool::processForNavigationInternal():
- Allow BFCache process reuse for back/forward items when
  UseMultiProcessBackForwardCache is enabled, even with
  Site Isolation active.

Co-Authored-By: Claude Opus 4.6 (1M context) &lt;noreply@anthropic.com&gt;
</pre>
----------------------------------------------------------------------
#### a9474ff64c458359b14587c6970c037358e82e05
<pre>
[BFCache] Phase 2a: WebCore changes for BFCache with Site Isolation

WebCore-only changes that make BFCache compatible with RemoteFrame
children. These are upstreamable and do not require the feature flag.

BackForwardCache.cpp:
- canCacheFrameDescendants(): New helper to recurse through RemoteFrame
  bridges for cacheability checks (handles A→B→A nesting patterns).
- canCacheFrame(): Check RemoteFrame children via canCacheFrameDescendants.
- canCachePage(): Representative frame concept for iframe processes where
  localMainFrame() returns null. Remove siteIsolationEnabled() guard.

CachedFrame.cpp:
- CachedFrameBase::restore(): Skip RemoteFrame children during frame tree
  reconstruction. Clear stale content frame reference on the iframe&apos;s
  owner element so fresh frame creation works after restoration.

Document.h:
- Add resetLoadEventFinished() method.

FrameLoader.cpp:
- FrameLoader::open(): Reset loadEventFinished on restored document.
  Needed for UseUIProcessForBackForwardItemLoading delegation path
  which checks \!loadEventFinished() in loadURLIntoChildFrame().

Co-Authored-By: Claude Opus 4.6 (1M context) &lt;noreply@anthropic.com&gt;
</pre>
----------------------------------------------------------------------
#### bea1b55b652498f736fea1685e12849e793a490f
<pre>
[BFCache] Phase 1: Add UseMultiProcessBackForwardCache feature flag

Add a new feature flag to gate BFCache enablement when Site Isolation
is active. Default: false. Category: security (matching SiteIsolationEnabled).

Co-Authored-By: Claude Opus 4.6 (1M context) &lt;noreply@anthropic.com&gt;
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e61a7c9a3a13d039cef2296ff606481efd11d03

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155255 "5 style errors") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28515 "Hash 9e61a7c9 for PR 61498 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21674 "Hash 9e61a7c9 for PR 61498 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164015 "Hash 9e61a7c9 for PR 61498 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109060 "Hash 9e61a7c9 for PR 61498 does not build (failure)") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/45c93c02-7ac0-45f1-9945-e4986bf34967) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157128 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28655 "Hash 9e61a7c9 for PR 61498 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28363 "Hash 9e61a7c9 for PR 61498 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/164015 "Hash 9e61a7c9 for PR 61498 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/109060 "Hash 9e61a7c9 for PR 61498 does not build (failure)") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/10cb8e40-71d4-42e1-94cf-c713d03828e9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158214 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/28655 "Hash 9e61a7c9 for PR 61498 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/21674 "Hash 9e61a7c9 for PR 61498 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/164015 "Hash 9e61a7c9 for PR 61498 does not build (failure)") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a4ac6c0c-b5f8-4610-96dd-ef2889813f99) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/28655 "Hash 9e61a7c9 for PR 61498 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/28363 "Hash 9e61a7c9 for PR 61498 does not build (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11841 "Hash 9e61a7c9 for PR 61498 does not build (failure)") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/28655 "Hash 9e61a7c9 for PR 61498 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/21674 "Hash 9e61a7c9 for PR 61498 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166494 "Hash 9e61a7c9 for PR 61498 does not build (failure)") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/10652 "Failed to build and analyze WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/21674 "Hash 9e61a7c9 for PR 61498 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/166494 "Hash 9e61a7c9 for PR 61498 does not build (failure)") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28059 "Hash 9e61a7c9 for PR 61498 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/28363 "Hash 9e61a7c9 for PR 61498 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/166494 "Hash 9e61a7c9 for PR 61498 does not build (failure)") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27983 "Hash 9e61a7c9 for PR 61498 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/21674 "Hash 9e61a7c9 for PR 61498 does not build (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84692 "Hash 9e61a7c9 for PR 61498 does not build (failure)") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/27983 "Hash 9e61a7c9 for PR 61498 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/21674 "Hash 9e61a7c9 for PR 61498 does not build (failure)") | | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27683 "Hash 9e61a7c9 for PR 61498 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91780 "Failed to build and analyze WebKit") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27254 "Hash 9e61a7c9 for PR 61498 does not build (failure)") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27484 "Hash 9e61a7c9 for PR 61498 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27327 "Hash 9e61a7c9 for PR 61498 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->