### PR TITLE
[GStreamer] Pausing the pipeline at EOS is prone to resource exhaustion

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -174,7 +174,7 @@ MediaPlayerPrivateGStreamer::MediaPlayerPrivateGStreamer(MediaPlayer& player)
     , m_preload(player.preload())
     , m_maxTimeLoadedAtLastDidLoadingProgress(MediaTime::zeroTime())
     , m_drawTimer(RunLoop::mainSingleton(), "MediaPlayerPrivateGStreamer::DrawTimer"_s, this, &MediaPlayerPrivateGStreamer::repaint)
-    , m_pausedTimerHandler(RunLoop::mainSingleton(), "MediaPlayerPrivateGStreamer::PausedTimerHandler"_s, this, &MediaPlayerPrivateGStreamer::pausedTimerFired)
+    , m_eosTimerHandler(RunLoop::mainSingleton(), "MediaPlayerPrivateGStreamer::EOSTimer"_s, this, &MediaPlayerPrivateGStreamer::eosTimerFired)
 #if !RELEASE_LOG_DISABLED
     , m_logger(player.mediaPlayerLogger())
     , m_logIdentifier(player.mediaPlayerLogIdentifier())
@@ -193,7 +193,7 @@ MediaPlayerPrivateGStreamer::MediaPlayerPrivateGStreamer(MediaPlayer& player)
 #endif
 
 #if USE(GLIB)
-    m_pausedTimerHandler.setPriority(G_PRIORITY_DEFAULT_IDLE);
+    m_eosTimerHandler.setPriority(G_PRIORITY_DEFAULT_IDLE);
 #endif
     m_isPlayerShuttingDown.store(false);
 
@@ -238,8 +238,8 @@ void MediaPlayerPrivateGStreamer::tearDown(bool clearMediaPlayer)
     if (m_fillTimer.isActive())
         m_fillTimer.stop();
 
-    if (m_pausedTimerHandler.isActive())
-        m_pausedTimerHandler.stop();
+    if (m_eosTimerHandler.isActive())
+        m_eosTimerHandler.stop();
 
     if (m_videoSink) {
         GRefPtr<GstPad> videoSinkPad = adoptGRef(gst_element_get_static_pad(m_videoSink.get(), "sink"));
@@ -511,6 +511,7 @@ void MediaPlayerPrivateGStreamer::pause()
     if (currentState < GST_STATE_PAUSED && pendingState <= GST_STATE_PAUSED)
         return;
 
+    GST_DEBUG_OBJECT(pipeline(), "Pausing");
     auto result = changePipelineState(GST_STATE_PAUSED);
     if (result == ChangePipelineStateResult::Ok) {
         GST_INFO_OBJECT(pipeline(), "Pause");
@@ -1143,15 +1144,18 @@ MediaPlayerPrivateGStreamer::ChangePipelineStateResult MediaPlayerPrivateGStream
 
     m_isPipelinePlaying = newState == GST_STATE_PLAYING;
 
+    auto& quirksManager = GStreamerQuirksManager::singleton();
+    auto eosState = quirksManager.eosMediaPlayerState();
+
     // Create a timer when entering the READY state so that we can free resources if we stay for too long on READY.
     // Also lets remove the timer if we request a state change for any state other than READY. See also https://bugs.webkit.org/show_bug.cgi?id=117354
-    if (RefPtr player = m_player.get(); newState == GST_STATE_PAUSED && m_isEndReached && player && !player->isLooping()
-        && !isMediaSource() && !m_pausedTimerHandler.isActive()) {
-        // Max interval in seconds to stay in the PAUSED state after video finished on manual state change requests.
-        static const Seconds readyStateTimerDelay { 5_min };
-        m_pausedTimerHandler.startOneShot(readyStateTimerDelay);
-    } else if (newState != GST_STATE_PAUSED)
-        m_pausedTimerHandler.stop();
+    if (RefPtr player = m_player.get(); newState == eosState && m_isEndReached && player && !player->isLooping()
+        && !isMediaSource() && !m_eosTimerHandler.isActive()) {
+        // Max interval in seconds to stay in the eos state after video finished on manual state change requests.
+        static const Seconds delay { 5_min };
+        m_eosTimerHandler.startOneShot(delay);
+    } else if (newState != eosState)
+        m_eosTimerHandler.stop();
 
     return ChangePipelineStateResult::Ok;
 }
@@ -1545,7 +1549,7 @@ void MediaPlayerPrivateGStreamer::loadingFailed(MediaPlayer::NetworkState networ
     }
 
     // Loading failed, remove ready timer.
-    m_pausedTimerHandler.stop();
+    m_eosTimerHandler.stop();
 }
 
 GstElement* MediaPlayerPrivateGStreamer::createAudioSink()
@@ -3261,7 +3265,16 @@ void MediaPlayerPrivateGStreamer::didEnd()
 
     if (!player->isLooping() && !isMediaSource()) {
         m_isPaused = true;
-        changePipelineState(GST_STATE_PAUSED);
+
+        // Some platforms require the EOS'd pipeline to remain in PAUSED state. This was added in
+        // https://commits.webkit.org/270766@main. In https://bugs.webkit.org/show_bug.cgi?id=310895
+        // the behaviour was made tweakable using the Quirks system. All quirks excepted the
+        // Qualcomm quirk keep the behavior of pausing the pipeline at EOS.
+        auto& quirksManager = GStreamerQuirksManager::singleton();
+        auto eosState = quirksManager.eosMediaPlayerState();
+        GST_DEBUG_OBJECT(pipeline(), "Setting EOS state to %s", gst_state_get_name(eosState));
+        changePipelineState(eosState);
+
         m_didDownloadFinish = false;
         configureMediaStreamAudioTracks();
     }
@@ -3707,7 +3720,7 @@ bool MediaPlayerPrivateGStreamer::canSaveMediaData() const
     return false;
 }
 
-void MediaPlayerPrivateGStreamer::pausedTimerFired()
+void MediaPlayerPrivateGStreamer::eosTimerFired()
 {
     GST_DEBUG_OBJECT(pipeline(), "In PAUSED for too long. Releasing pipeline resources.");
     tearDown(true);

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -338,7 +338,7 @@ protected:
     static void volumeChangedCallback(MediaPlayerPrivateGStreamer*);
     static void muteChangedCallback(MediaPlayerPrivateGStreamer*);
 
-    void pausedTimerFired();
+    void eosTimerFired();
 
     template <typename TrackPrivateType> void notifyPlayerOfTrack();
 
@@ -601,7 +601,7 @@ private:
     Condition m_drawCondition;
     Lock m_drawLock;
     RunLoop::Timer m_drawTimer WTF_GUARDED_BY_LOCK(m_drawLock);
-    RunLoop::Timer m_pausedTimerHandler;
+    RunLoop::Timer m_eosTimerHandler;
 #if USE(COORDINATED_GRAPHICS)
     RefPtr<CoordinatedPlatformLayerBufferProxy> m_contentsBufferProxy;
 #endif

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkAmLogic.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkAmLogic.h
@@ -35,6 +35,7 @@ public:
     GstElement* createWebAudioSink() final;
     void configureElement(GstElement*, const OptionSet<ElementRuntimeCharacteristics>&) final;
     bool needsCustomInstantRateChange() const final { return true; }
+    std::optional<GstState> eosMediaPlayerState() const final { return GST_STATE_PAUSED; }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcomBase.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcomBase.h
@@ -38,6 +38,7 @@ public:
     int correctBufferingPercentage(MediaPlayerPrivateGStreamer*, int originalBufferingPercentage, GstBufferingMode) const;
     void resetBufferingPercentage(MediaPlayerPrivateGStreamer*, int bufferingPercentage) const;
     void setupBufferingPercentageCorrection(MediaPlayerPrivateGStreamer*, GstState currentState, GstState newState, GRefPtr<GstElement>&&) const;
+    std::optional<GstState> eosMediaPlayerState() const final { return GST_STATE_PAUSED; }
 
 protected:
     class MovingAverage {

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkOpenMAX.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkOpenMAX.h
@@ -34,6 +34,7 @@ public:
     unsigned getAdditionalPlaybinFlags() const final { return getGstPlayFlag("text") | getGstPlayFlag("native-video"); }
 
     bool processWebAudioSilentBuffer(GstBuffer*) const final;
+    std::optional<GstState> eosMediaPlayerState() const final { return GST_STATE_PAUSED; }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkQualcomm.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkQualcomm.h
@@ -37,6 +37,8 @@ public:
     std::optional<bool> isHardwareAccelerated(GstElementFactory*) final;
     unsigned getAdditionalPlaybinFlags() const final { return getGstPlayFlag("text") | getGstPlayFlag("native-video"); }
 
+    std::optional<GstState> eosMediaPlayerState() const final { return GST_STATE_READY; }
+
 private:
     mutable GRefPtr<GstCaps> m_glCaps;
 };

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.h
@@ -38,6 +38,7 @@ public:
     Vector<String> disallowedWebAudioDecoders() const final { return m_disallowedWebAudioDecoders; }
     bool shouldParseIncomingLibWebRTCBitStream() const final { return false; }
     bool needsCustomInstantRateChange() const final { return true; }
+    std::optional<GstState> eosMediaPlayerState() const final { return GST_STATE_PAUSED; }
 
 private:
     Vector<String> m_disallowedWebAudioDecoders;

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.h
@@ -44,6 +44,7 @@ public:
     bool shouldParseIncomingLibWebRTCBitStream() const final { return false; }
     unsigned getAdditionalPlaybinFlags() const { return getGstPlayFlag("text") | getGstPlayFlag("native-audio") | getGstPlayFlag("native-video"); }
     bool needsCustomInstantRateChange() const final { return true; }
+    std::optional<GstState> eosMediaPlayerState() const final { return GST_STATE_PAUSED; }
 
 private:
     GRefPtr<GstCaps> m_sinkCaps;

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp
@@ -335,6 +335,15 @@ bool GStreamerQuirksManager::isVideoCapsGLCompatible(const GRefPtr<GstCaps>& cap
     return true;
 }
 
+GstState GStreamerQuirksManager::eosMediaPlayerState() const
+{
+    for (auto& quirk : m_quirks) {
+        if (auto state = quirk->eosMediaPlayerState())
+            return *state;
+    }
+    return GST_STATE_READY;
+}
+
 bool GStreamerQuirksManager::needsBufferingPercentageCorrection() const
 {
     for (auto& quirk : m_quirks) {

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirks.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirks.h
@@ -108,6 +108,9 @@ public:
 
     [[nodiscard]] virtual GRefPtr<GstCaps> videoSinkGLCapsFormat() const { return nullptr; }
     virtual bool isVideoCapsGLCompatible(const GRefPtr<GstCaps>&) const { return true; }
+
+    virtual std::optional<GstState> eosMediaPlayerState() const { return { }; }
+
 };
 
 class GStreamerHolePunchQuirk : public GStreamerQuirkBase {
@@ -144,6 +147,8 @@ public:
 
     [[nodiscard]] GRefPtr<GstCaps> videoSinkGLCapsFormat() const;
     bool isVideoCapsGLCompatible(const GRefPtr<GstCaps>&) const;
+
+    GstState eosMediaPlayerState() const;
 
     bool supportsVideoHolePunchRendering() const;
     GstElement* createHolePunchVideoSink(bool isLegacyPlaybin, const MediaPlayer*);


### PR DESCRIPTION
#### 82ddc6a0bb6fe5ab04a9907cb4ffe7efbb271a69
<pre>
[GStreamer] Pausing the pipeline at EOS is prone to resource exhaustion
<a href="https://bugs.webkit.org/show_bug.cgi?id=310895">https://bugs.webkit.org/show_bug.cgi?id=310895</a>

Reviewed by Alicia Boya Garcia.

In 270766@main the pipeline EOS state was changed from READY to PAUSED due to some &quot;downstream
platforms&quot; having issues. The problem is that video and audio decoder resources are not released
anymore unless a 5 minutes timer is fired after EOS. On test bots where multiple web pages run
simultaneously this behavior can lead to file descriptors exhaustion.

The proposed solution is to keep this EOS PAUSED state for all quirks excepted the Qualcomm quirk
which is not affected. If no quirk is enabled, the EOS state is now READY, same as before
270766@main.

* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::MediaPlayerPrivateGStreamer):
(WebCore::MediaPlayerPrivateGStreamer::tearDown):
(WebCore::MediaPlayerPrivateGStreamer::pause):
(WebCore::MediaPlayerPrivateGStreamer::changePipelineState):
(WebCore::MediaPlayerPrivateGStreamer::loadingFailed):
(WebCore::MediaPlayerPrivateGStreamer::didEnd):
(WebCore::MediaPlayerPrivateGStreamer::eosTimerFired):
(WebCore::MediaPlayerPrivateGStreamer::pausedTimerFired): Deleted.
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:
* Source/WebCore/platform/gstreamer/GStreamerQuirkAmLogic.h:
* Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcomBase.h:
* Source/WebCore/platform/gstreamer/GStreamerQuirkOpenMAX.h:
* Source/WebCore/platform/gstreamer/GStreamerQuirkQualcomm.h:
* Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.h:
* Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.h:
* Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp:
(WebCore::GStreamerQuirksManager::eosMediaPlayerState const):
* Source/WebCore/platform/gstreamer/GStreamerQuirks.h:
(WebCore::GStreamerQuirk::eosMediaPlayerState const):

Canonical link: <a href="https://commits.webkit.org/310087@main">https://commits.webkit.org/310087@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22e3da5459a88dc1b10c97af797dff6bb47dd302

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152676 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25457 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19056 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161420 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154549 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25985 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25763 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117975 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155635 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/20197 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137056 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98687 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19272 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9256 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128923 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14930 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163891 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7030 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16524 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126032 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25255 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21257 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126192 "Found 1 new API test failure: WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/cache (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34237 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25257 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136726 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81861 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21161 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13505 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24873 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89159 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24565 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24724 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24625 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->