### PR TITLE
WebKit BinCompat: Missing C-API WKPageIsPlayingVideoInEnhancedFullscreen()

### DIFF
--- a/Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.h
+++ b/Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.h
@@ -27,6 +27,7 @@
 #define WKPagePrivateMac_h
 
 #include <WebKit/WKBase.h>
+#include <WebKit/WKDeprecated.h>
 #include <sys/types.h>
 
 #ifdef __cplusplus
@@ -78,6 +79,7 @@ WK_EXPORT bool WKPageIsURLKnownHSTSHost(WKPageRef page, WKURLRef url);
 
 #if !TARGET_OS_IPHONE
 WK_EXPORT bool WKPageIsPlayingVideoInPictureInPicture(WKPageRef page);
+WK_EXPORT bool WKPageIsPlayingVideoInEnhancedFullscreen(WKPageRef page) WK_C_API_DEPRECATED_WITH_REPLACEMENT(WKPageIsPlayingVideoInPictureInPicture);
 #endif
 
 #ifdef __cplusplus

--- a/Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm
+++ b/Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm
@@ -156,6 +156,11 @@ bool WKPageIsPlayingVideoInPictureInPicture(WKPageRef pageRef)
 {
     return protect(WebKit::toImpl(pageRef))->isPlayingVideoInPictureInPicture();
 }
+
+bool WKPageIsPlayingVideoInEnhancedFullscreen(WKPageRef pageRef)
+{
+    return WKPageIsPlayingVideoInPictureInPicture(pageRef);
+}
 #endif
 
 void WKPageSetFullscreenDelegate(WKPageRef page, id <_WKFullscreenDelegate> delegate)


### PR DESCRIPTION
#### afa0a083488daa43be4290335e421544aad999a4
<pre>
WebKit BinCompat: Missing C-API WKPageIsPlayingVideoInEnhancedFullscreen()
<a href="https://bugs.webkit.org/show_bug.cgi?id=310900">https://bugs.webkit.org/show_bug.cgi?id=310900</a>
<a href="https://rdar.apple.com/173462235">rdar://173462235</a>

Reviewed by Jer Noble.

Add WKPageIsPlayingVideoInEnhancedFullscreen() back in as a deprecated
synonym of WKPageIsPlayingVideoInPictureInPicture().

No new tests.

* Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.h:
* Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm:
(WKPageIsPlayingVideoInEnhancedFullscreen):

Canonical link: <a href="https://commits.webkit.org/310095@main">https://commits.webkit.org/310095@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0393cd2720149898416df1b320d44369bb42855

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152675 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25456 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19055 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161419 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ea30a9dd-6886-4a14-8948-448ff767a7e8) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25984 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25762 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117974 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155634 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20196 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137054 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98686 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f8bbc2fc-1af6-4843-8688-5c6f03d14fa3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19271 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9255 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128922 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163890 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7029 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16522 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126037 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25254 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21256 "Found 1 new test failure: http/tests/webgpu/webgpu/api/validation/gpu_external_texture_expiration.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126191 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34240 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25256 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136724 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81860 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21160 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13503 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24872 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89158 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24564 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24723 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24624 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->