### PR TITLE
WebRTCVideoDecoderVTBVP9 should not need to override color space

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm
@@ -683,17 +683,8 @@ RetainPtr<CMVideoFormatDescriptionRef> createVP9FormatDescriptionFromRecord(cons
     ASSERT(record.frameWidth);
     ASSERT(record.frameHeight);
 
-    auto vpcc = vpcCFromVPCodecConfigurationRecord(record);
-    RetainPtr cfData = toCFData(vpcc.span());
-
-    auto configurationDict = @{ @"vpcC": (__bridge NSData *)cfData.get() };
-    auto extensions = @{ (__bridge NSString *)PAL::kCMFormatDescriptionExtension_SampleDescriptionExtensionAtoms: configurationDict };
-
-    CMVideoFormatDescriptionRef formatDescription = nullptr;
-    if (PAL::CMVideoFormatDescriptionCreate(kCFAllocatorDefault, kCMVideoCodecType_VP9, record.frameWidth, record.frameHeight, (__bridge CFDictionaryRef)extensions, &formatDescription) != noErr)
-        return { };
-
-    return adoptCF(formatDescription);
+    Ref videoInfo = createVideoInfoFromVPCodecConfigurationRecord(record, IntSize { record.frameWidth, record.frameHeight }, IntSize { record.frameWidth, record.frameHeight });
+    return createFormatDescriptionFromTrackInfo(videoInfo.get());
 }
 
 }

--- a/Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.cpp
@@ -267,6 +267,8 @@ void RealtimeOutgoingVideoSource::sendFrame(webrtc::scoped_refptr<webrtc::VideoF
     MonotonicTime timestamp = MonotonicTime::now();
     webrtc::VideoFrame frame(buffer, m_isApplyingRotation ? webrtc::kVideoRotation_0 : m_currentRotation, static_cast<int64_t>(timestamp.secondsSinceEpoch().microseconds()));
 
+    // FIXME: set color space based on VideoFrame.
+
 #if !RELEASE_LOG_DISABLED
     ++m_frameCount;
 

--- a/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTB.mm
+++ b/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTB.mm
@@ -36,7 +36,13 @@
 
 namespace WebCore {
 
-static RetainPtr<CFDictionaryRef> createPixelBufferAttributes()
+static bool shouldUseFullRange(CMVideoFormatDescriptionRef format)
+{
+    RetainPtr fullRange = dynamic_cf_cast<CFBooleanRef>(PAL::CMFormatDescriptionGetExtension(format, PAL::kCMFormatDescriptionExtension_FullRangeVideo));
+    return fullRange && CFBooleanGetValue(fullRange.get());
+}
+
+static RetainPtr<CFDictionaryRef> createPixelBufferAttributes(CMVideoFormatDescriptionRef format)
 {
     static size_t const attributesSize = 3;
     CFTypeRef keys[attributesSize] = {
@@ -50,7 +56,7 @@ static RetainPtr<CFDictionaryRef> createPixelBufferAttributes()
     };
 
     auto ioSurfaceValue = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, nullptr, nullptr, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
-    int64_t nv12type = kCVPixelFormatType_420YpCbCr8BiPlanarFullRange;
+    int64_t nv12type = shouldUseFullRange(format) ? kCVPixelFormatType_420YpCbCr8BiPlanarFullRange : kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange;
     auto pixelFormat = adoptCF(CFNumberCreate(nullptr, kCFNumberLongType, &nv12type));
     CFTypeRef values[attributesSize] = { kCFBooleanTrue, ioSurfaceValue.get(), pixelFormat.get() };
     return adoptCF(CFDictionaryCreate(kCFAllocatorDefault, keys, values, attributesSize, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
@@ -66,7 +72,7 @@ int32_t WebRTCVideoDecoderVTB::decodeFrameInternal(int64_t timeStamp, std::span<
         return -1;
 
     if (!m_decoder || !protect(m_decoder)->canAccept(m_format.get())) {
-        m_decoder = VideoDecoderVTB::create(m_format.get(), createPixelBufferAttributes().get());
+        m_decoder = VideoDecoderVTB::create(m_format.get(), createPixelBufferAttributes(m_format.get()).get());
         if (!m_decoder)
             return -1;
     }

--- a/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTBVP9.mm
+++ b/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTBVP9.mm
@@ -48,34 +48,17 @@ static RetainPtr<CMVideoFormatDescriptionRef> createVP9FormatDescriptionFromData
     if (height)
         parsedRecord->frameHeight = height;
 
+    if (parsedRecord->colorPrimaries == VPConfigurationColorPrimaries::Unspecified && parsedRecord->transferCharacteristics == VPConfigurationTransferCharacteristics::Unspecified && parsedRecord->matrixCoefficients == VPConfigurationMatrixCoefficients::Unspecified) {
+        parsedRecord->colorPrimaries = VPConfigurationColorPrimaries::BT_709_6;
+        parsedRecord->transferCharacteristics = VPConfigurationTransferCharacteristics::BT_709_6;
+        parsedRecord->matrixCoefficients = VPConfigurationMatrixCoefficients::BT_709_6;
+    }
+
     return createVP9FormatDescriptionFromRecord(*parsedRecord);
 }
 
-static void overrideVP9ColorSpaceAttachments(CVPixelBufferRef pixelBuffer)
-{
-    CVBufferSetAttachment(pixelBuffer, kCVImageBufferColorPrimariesKey, kCVImageBufferColorPrimaries_ITU_R_709_2, kCVAttachmentMode_ShouldPropagate);
-    CVBufferSetAttachment(pixelBuffer, kCVImageBufferTransferFunctionKey, kCVImageBufferTransferFunction_ITU_R_709_2, kCVAttachmentMode_ShouldPropagate);
-    CVBufferSetAttachment(pixelBuffer, kCVImageBufferYCbCrMatrixKey, kCVImageBufferYCbCrMatrix_ITU_R_709_2, kCVAttachmentMode_ShouldPropagate);
-    CVBufferSetAttachment(pixelBuffer, (CFStringRef)@"ColorInfoGuessedBy", (CFStringRef)@"WebRTCDecoderVTBVP9", kCVAttachmentMode_ShouldPropagate);
-}
-
-static BlockPtr<void(OSStatus, VTDecodeInfoFlags, CVImageBufferRef pixelBuffer, CMTaggedBufferGroupRef, CMTime presentationTime, CMTime)> createVP9Callback(WebRTCVideoDecoderCallback callback)
-{
-    return makeBlockPtr([callback = makeBlockPtr(callback)](OSStatus, VTDecodeInfoFlags, CVImageBufferRef pixelBuffer, CMTaggedBufferGroupRef, CMTime presentationTime, CMTime) mutable {
-        if (!pixelBuffer) {
-            callback(nil, 0, 0, false);
-            return;
-        }
-
-        // FIXME: We should remove this override once the encoder is properly setting color space info.
-        overrideVP9ColorSpaceAttachments(pixelBuffer);
-
-        callback((CVPixelBufferRef)pixelBuffer, presentationTime.value, 0, false);
-    });
-}
-
 WebRTCVideoDecoderVTBVP9::WebRTCVideoDecoderVTBVP9(WebRTCVideoDecoderCallback callback)
-    : WebRTCVideoDecoderVTB(createVP9Callback(WTF::move(callback)))
+    : WebRTCVideoDecoderVTB(createMultiImageCallback(WTF::move(callback)))
 {
 }
 


### PR DESCRIPTION
#### 28702dca01d9e4723014af2d724d6e95cb572923
<pre>
WebRTCVideoDecoderVTBVP9 should not need to override color space
<a href="https://rdar.apple.com/173491887">rdar://173491887</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=310879">https://bugs.webkit.org/show_bug.cgi?id=310879</a>

Reviewed by Eric Carlson.

We remove the override done in WebRTCVideoDecoderVTBVP9.
To do so, we correctly handle the format description color space creation by reusing createFormatDescriptionFromTrackInfo in createVP9FormatDescriptionFromRecord.
We also make sure to get the correct pixel buffer type wrt full range vs. video range.
We default to BT709 when no information is provided.
We add a fixme to provide the color space to WebRTC encoders, which should be done in a follow-up.

Covered by existing tests.

Canonical link: <a href="https://commits.webkit.org/310376@main">https://commits.webkit.org/310376@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39cb9ed99fefd44851994120951c391a067e796d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153666 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26450 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20067 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162416 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/107124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155539 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26978 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26772 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118809 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/107124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c5aef3ff-344a-4112-ab11-3189214c65f8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156625 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21062 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/137975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99520 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/72832dd1-fda2-492f-91b8-bb3fde68fa89) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20141 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/18092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10249 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/129790 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15834 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164887 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8021 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17428 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126884 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26247 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22124 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127050 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34452 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26249 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137629 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82927 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21962 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14411 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25866 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90154 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25557 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25717 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25617 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->