### PR TITLE
Fix logic errors with cloning XML documents

### DIFF
--- a/LayoutTests/fast/dom/Document/clone-node-document-types-expected.txt
+++ b/LayoutTests/fast/dom/Document/clone-node-document-types-expected.txt
@@ -1,0 +1,18 @@
+Tests that cloneNode produces the correct document type for XML, XHTML, and SVG documents.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS xmlClone.contentType is "application/xml"
+PASS xmlClone.__proto__ is XMLDocument.prototype
+PASS xmlClone.documentElement.localName is "root"
+PASS xhtmlClone.contentType is "application/xhtml+xml"
+PASS xhtmlClone.__proto__ is XMLDocument.prototype
+PASS xhtmlClone.documentElement.localName is "html"
+PASS svgClone.contentType is "image/svg+xml"
+PASS svgClone.__proto__ is XMLDocument.prototype
+PASS svgClone.documentElement.localName is "svg"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/Document/clone-node-document-types.html
+++ b/LayoutTests/fast/dom/Document/clone-node-document-types.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../../resources/js-test.js"></script>
+<script>
+description('Tests that cloneNode produces the correct document type for XML, XHTML, and SVG documents.');
+
+// Plain XML document should clone as XMLDocument.
+var xmlDoc = document.implementation.createDocument(null, 'root', null);
+var xmlClone = xmlDoc.cloneNode(true);
+shouldBeEqualToString('xmlClone.contentType', 'application/xml');
+shouldBe('xmlClone.__proto__', 'XMLDocument.prototype');
+shouldBeEqualToString('xmlClone.documentElement.localName', 'root');
+
+// XHTML document should clone as XMLDocument (XHTML flavor).
+var xhtmlDoc = document.implementation.createDocument('http://www.w3.org/1999/xhtml', 'html', null);
+var xhtmlClone = xhtmlDoc.cloneNode(true);
+shouldBeEqualToString('xhtmlClone.contentType', 'application/xhtml+xml');
+shouldBe('xhtmlClone.__proto__', 'XMLDocument.prototype');
+shouldBeEqualToString('xhtmlClone.documentElement.localName', 'html');
+
+// SVG document should clone as XMLDocument (SVG flavor).
+var svgDoc = document.implementation.createDocument('http://www.w3.org/2000/svg', 'svg', null);
+var svgClone = svgDoc.cloneNode(true);
+shouldBeEqualToString('svgClone.contentType', 'image/svg+xml');
+shouldBe('svgClone.__proto__', 'XMLDocument.prototype');
+shouldBeEqualToString('svgClone.documentElement.localName', 'svg');
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -5676,10 +5676,10 @@ ClonedDocumentType Document::clonedDocumentType() const
     if (isXMLDocument()) {
         if (isXHTMLDocument())
             return ClonedDocumentType::XHTMLDocument;
+        if (isSVGDocument())
+            return ClonedDocumentType::SVGDocument;
         return ClonedDocumentType::XMLDocument;
     }
-    if (isSVGDocument())
-        return ClonedDocumentType::SVGDocument;
     if (isHTMLDocument())
         return ClonedDocumentType::HTMLDocument;
     return ClonedDocumentType::Document;
@@ -5727,9 +5727,9 @@ Ref<Document> Document::createCloned(ClonedDocumentType clonedDocumentType, cons
     Ref clone = [&] -> Ref<Document> {
         switch (clonedDocumentType) {
         case ClonedDocumentType::XMLDocument:
-            return XMLDocument::createXHTML(nullptr, settings, url);
-        case ClonedDocumentType::XHTMLDocument:
             return XMLDocument::create(nullptr, settings, url);
+        case ClonedDocumentType::XHTMLDocument:
+            return XMLDocument::createXHTML(nullptr, settings, url);
         case ClonedDocumentType::HTMLDocument:
             return HTMLDocument::create(nullptr, settings, url);
         case ClonedDocumentType::SVGDocument:


### PR DESCRIPTION
#### 641d4a902767366138f100aeb2d21b6ed6e3e134
<pre>
Fix logic errors with cloning XML documents
<a href="https://bugs.webkit.org/show_bug.cgi?id=310902">https://bugs.webkit.org/show_bug.cgi?id=310902</a>

Reviewed by David Kilzer.

isSVGDocument() is a subset of isXMLDocument() so was never reached.
And the second bug is that we had XML and XHTML swapped.

Canonical link: <a href="https://commits.webkit.org/310106@main">https://commits.webkit.org/310106@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af960b9008bdfe4e9e39aa5af663676b7324bd47

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152683 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25464 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19063 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161427 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154556 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25992 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25770 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117983 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155642 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20211 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137069 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98696 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19286 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17225 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9263 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128937 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14943 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163899 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7037 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16537 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126042 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25262 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21264 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126200 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25264 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136739 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81868 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23398 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21167 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13518 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24880 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89166 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24572 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24731 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24632 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->