### PR TITLE
Fix StaticRange::computeValidity() for collapsed and disconnected ranges

### DIFF
--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -1822,7 +1822,7 @@ static inline unsigned short compareDetachedElementsPosition(Node& firstNode, No
 bool connectedInSameTreeScope(const Node* a, const Node* b)
 {
     // Note that we avoid comparing Attr nodes here, since they return false from isConnected() all the time (which seems like a bug).
-    return a && b && a->isConnected() == b->isConnected() && &a->treeScope() == &b->treeScope();
+    return a && b && a->isConnected() && b->isConnected() && &a->treeScope() == &b->treeScope();
 }
 
 unsigned short Node::compareDocumentPosition(Node& otherNode)

--- a/Source/WebCore/dom/StaticRange.cpp
+++ b/Source/WebCore/dom/StaticRange.cpp
@@ -84,7 +84,7 @@ bool StaticRange::computeValidity() const
     if (endOffset() > endContainer->length())
         return false;
     if (startContainer.ptr() == endContainer.ptr())
-        return endOffset() > startOffset();
+        return endOffset() >= startOffset();
     if (!connectedInSameTreeScope(&startContainer->rootNode(), &endContainer->rootNode()))
         return false;
     return !is_gt(treeOrder<ComposedTree>(startContainer, endContainer));

--- a/Source/WebCore/dom/StaticRange.h
+++ b/Source/WebCore/dom/StaticRange.h
@@ -50,7 +50,7 @@ public:
 
     static ExceptionOr<Ref<StaticRange>> create(Init&&);
     WEBCORE_EXPORT static Ref<StaticRange> create(const SimpleRange&);
-    static Ref<StaticRange> create(SimpleRange&&);
+    WEBCORE_EXPORT static Ref<StaticRange> create(SimpleRange&&);
 
     Node& startContainer() const final { return SimpleRange::startContainer(); }
     unsigned startOffset() const final { return SimpleRange::startOffset(); }
@@ -59,7 +59,7 @@ public:
     bool collapsed() const final { return SimpleRange::collapsed(); }
 
     // https://dom.spec.whatwg.org/#staticrange-valid
-    bool computeValidity() const;
+    WEBCORE_EXPORT bool computeValidity() const;
 
     void visitNodesInGCThread(JSC::AbstractSlotVisitor&) const;
 

--- a/Tools/Scripts/webkitpy/api_tests/allowlist.txt
+++ b/Tools/Scripts/webkitpy/api_tests/allowlist.txt
@@ -395,6 +395,7 @@ TestWebKitAPI.Site
 TestWebKitAPI.SleepDisabler
 TestWebKitAPI.SnapshotStore
 TestWebKitAPI.SpellCheckerDocumentTag
+TestWebKitAPI.StaticRangeValidity
 TestWebKitAPI.StringWithDirection
 TestWebKitAPI.SwitchInputTests
 TestWebKitAPI.SynchronousTimeoutTests

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -675,6 +675,7 @@
 		933D631D1FCB76200032ECD6 /* Hasher.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 933D631B1FCB76180032ECD6 /* Hasher.cpp */; };
 		936E4AE42821BB6D00208654 /* SuspendableWorkQueueTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 936E4AE32821BB6D00208654 /* SuspendableWorkQueueTests.cpp */; };
 		93915A1724DB66C70019FF43 /* DocumentOrder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93915A1624DB66C70019FF43 /* DocumentOrder.cpp */; };
+		13A9FF1D120B98579E9E28F3 /* StaticRangeValidity.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 62C480C646AE2D4CB5936315 /* StaticRangeValidity.cpp */; };
 		93AF4ECE1506F064007FD57E /* NewFirstVisuallyNonEmptyLayoutForImages_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93AF4ECD1506F064007FD57E /* NewFirstVisuallyNonEmptyLayoutForImages_Bundle.cpp */; };
 		93C3647B2BDD8800006D8B55 /* UTF8Conversion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93C3647A2BDD8800006D8B55 /* UTF8Conversion.cpp */; };
 		93E2C5551FD3204100E1DF6A /* LineEnding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93E2C5541FD3204100E1DF6A /* LineEnding.cpp */; };
@@ -3615,6 +3616,7 @@
 		937A6C8824357BF300C3A6B0 /* KillWebProcessWithOpenConnection-1.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "KillWebProcessWithOpenConnection-1.html"; sourceTree = "<group>"; };
 		937A6C8924357BF300C3A6B0 /* KillWebProcessWithOpenConnection-2.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "KillWebProcessWithOpenConnection-2.html"; sourceTree = "<group>"; };
 		93915A1624DB66C70019FF43 /* DocumentOrder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DocumentOrder.cpp; sourceTree = "<group>"; };
+		62C480C646AE2D4CB5936315 /* StaticRangeValidity.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StaticRangeValidity.cpp; sourceTree = "<group>"; };
 		9399BA01237110AE008392BF /* IndexedDBInPageCache.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = IndexedDBInPageCache.mm; sourceTree = "<group>"; };
 		9399BA02237110BF008392BF /* IndexedDBInPageCache.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = IndexedDBInPageCache.html; sourceTree = "<group>"; };
 		9399BA03237110BF008392BF /* IndexedDBNotInPageCache.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = IndexedDBNotInPageCache.html; sourceTree = "<group>"; };
@@ -5480,6 +5482,7 @@
 				A17991891E1CA24100A505ED /* SharedBufferTest.cpp */,
 				A179918A1E1CA24100A505ED /* SharedBufferTest.h */,
 				7B84864B2ED4465C00E34DC1 /* SharedMemoryTests.cpp */,
+				62C480C646AE2D4CB5936315 /* StaticRangeValidity.cpp */,
 				ECA680CD1E68CC0900731D20 /* StringUtilities.mm */,
 				CE4D5DE51F6743BA0072CFC6 /* StringWithDirection.cpp */,
 				41E67A8425D16E83007B0A4C /* STUNMessageParsingTest.cpp */,
@@ -8258,6 +8261,7 @@
 				CDEEC7CD2DBC662A00F5B8EB /* SpatialAudioExperience.mm in Sources */,
 				F4CDF3D227E97C7E00191928 /* SpellCheckerDocumentTag.mm in Sources */,
 				83BC5AC020E6C0DF00F5879F /* StartLoadInDidFailProvisionalLoad.mm in Sources */,
+				13A9FF1D120B98579E9E28F3 /* StaticRangeValidity.cpp in Sources */,
 				51EB126524CA6B66000CB030 /* SteelSeriesNimbus.mm in Sources */,
 				7CCE7ECE1A411A7E00447C4C /* StopLoadingFromDidFinishLoading.mm in Sources */,
 				7CCE7ECF1A411A7E00447C4C /* StopLoadingFromDidReceiveResponse.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebCore/StaticRangeValidity.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/StaticRangeValidity.cpp
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <WebCore/CommonAtomStrings.h>
+#include <WebCore/DocumentInlines.h>
+#include <WebCore/HTMLBodyElement.h>
+#include <WebCore/HTMLDivElement.h>
+#include <WebCore/HTMLHtmlElement.h>
+#include <WebCore/ProcessWarming.h>
+#include <WebCore/Settings.h>
+#include <WebCore/StaticRange.h>
+
+// Tests for https://dom.spec.whatwg.org/#staticrange-valid
+
+namespace TestWebKitAPI {
+
+using namespace WebCore;
+
+static Ref<Document> createDocument()
+{
+    ProcessWarming::initializeNames();
+
+    auto settings = Settings::create(nullptr);
+    auto document = Document::create(settings.get(), aboutBlankURL());
+    auto documentElement = HTMLHtmlElement::create(document);
+    document->appendChild(documentElement);
+    auto body = HTMLBodyElement::create(document);
+    documentElement->appendChild(body);
+    return document;
+}
+
+static Ref<StaticRange> createStaticRange(Node& startContainer, unsigned startOffset, Node& endContainer, unsigned endOffset)
+{
+    return StaticRange::create(SimpleRange { { startContainer, startOffset }, { endContainer, endOffset } });
+}
+
+TEST(StaticRangeValidity, CollapsedSameNode)
+{
+    auto document = createDocument();
+    auto& body = *document->body();
+
+    // Collapsed on element with no children (length 0).
+    auto div = HTMLDivElement::create(document);
+    body.appendChild(div);
+    EXPECT_TRUE(createStaticRange(div, 0, div, 0)->computeValidity());
+
+    // Collapsed on element with children.
+    EXPECT_TRUE(createStaticRange(body, 0, body, 0)->computeValidity());
+    EXPECT_TRUE(createStaticRange(body, 1, body, 1)->computeValidity());
+}
+
+TEST(StaticRangeValidity, NonCollapsedSameNode)
+{
+    auto document = createDocument();
+    auto& body = *document->body();
+
+    auto div1 = HTMLDivElement::create(document);
+    body.appendChild(div1);
+    auto div2 = HTMLDivElement::create(document);
+    body.appendChild(div2);
+
+    // Forward range within element (body has 2 children).
+    EXPECT_TRUE(createStaticRange(body, 0, body, 2)->computeValidity());
+    EXPECT_TRUE(createStaticRange(body, 0, body, 1)->computeValidity());
+
+    // Backwards range within element (start after end).
+    EXPECT_FALSE(createStaticRange(body, 2, body, 0)->computeValidity());
+    EXPECT_FALSE(createStaticRange(body, 2, body, 1)->computeValidity());
+}
+
+TEST(StaticRangeValidity, OffsetBeyondLength)
+{
+    auto document = createDocument();
+    auto& body = *document->body();
+
+    auto div = HTMLDivElement::create(document);
+    body.appendChild(div);
+
+    // Offset beyond length on element with no children.
+    EXPECT_FALSE(createStaticRange(div, 1, div, 1)->computeValidity());
+    EXPECT_FALSE(createStaticRange(div, 0, div, 1)->computeValidity());
+
+    // body has 1 child, so length is 1.
+    EXPECT_TRUE(createStaticRange(body, 0, body, 1)->computeValidity());
+    EXPECT_FALSE(createStaticRange(body, 0, body, 2)->computeValidity());
+    EXPECT_FALSE(createStaticRange(body, 2, body, 2)->computeValidity());
+}
+
+TEST(StaticRangeValidity, DifferentNodesInSameTree)
+{
+    auto document = createDocument();
+    auto& body = *document->body();
+
+    auto div1 = HTMLDivElement::create(document);
+    body.appendChild(div1);
+    auto div2 = HTMLDivElement::create(document);
+    body.appendChild(div2);
+
+    // Start in earlier sibling, end in later sibling.
+    EXPECT_TRUE(createStaticRange(div1, 0, div2, 0)->computeValidity());
+
+    // Start in later sibling, end in earlier sibling.
+    EXPECT_FALSE(createStaticRange(div2, 0, div1, 0)->computeValidity());
+
+    // Start in ancestor, end in descendant.
+    EXPECT_TRUE(createStaticRange(body, 0, div1, 0)->computeValidity());
+
+    // Start in descendant, end in ancestor.
+    EXPECT_FALSE(createStaticRange(div1, 0, body, 0)->computeValidity());
+}
+
+TEST(StaticRangeValidity, DifferentTrees)
+{
+    auto document1 = createDocument();
+    auto& body1 = *document1->body();
+
+    auto document2 = createDocument();
+    auto& body2 = *document2->body();
+
+    // Nodes in different documents.
+    EXPECT_FALSE(createStaticRange(body1, 0, body2, 0)->computeValidity());
+}
+
+TEST(StaticRangeValidity, DisconnectedNode)
+{
+    auto document = createDocument();
+    auto& body = *document->body();
+
+    auto disconnected = HTMLDivElement::create(document);
+
+    // One node connected, one disconnected.
+    EXPECT_FALSE(createStaticRange(body, 0, disconnected, 0)->computeValidity());
+    EXPECT_FALSE(createStaticRange(disconnected, 0, body, 0)->computeValidity());
+
+    // Both disconnected but from the same document.
+    auto disconnected2 = HTMLDivElement::create(document);
+    EXPECT_FALSE(createStaticRange(disconnected, 0, disconnected2, 0)->computeValidity());
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### cf0468947fe56137cbb01541acb7c3ea6add7337
<pre>
Fix StaticRange::computeValidity() for collapsed and disconnected ranges
<a href="https://bugs.webkit.org/show_bug.cgi?id=310905">https://bugs.webkit.org/show_bug.cgi?id=310905</a>

Reviewed by Chris Dumez.

The only consumer (highlights) treats invalid and collapsed ranges the
same way so testing this with an API test.

The change to connectedInSameTreeScope() is correct for VisiblePosition
as well as it doesn&apos;t want disconnected nodes to count as connected
either.

Canonical link: <a href="https://commits.webkit.org/310159@main">https://commits.webkit.org/310159@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7c793d9ec754975893f0ae5ccc3aeba333ac1d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152857 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25639 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19237 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161601 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cc1b9343-5427-4f22-8573-e1e9b6fc5145) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154730 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26166 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25944 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118127 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155816 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20361 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137222 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98840 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8d215fcc-5d61-4585-8e01-a4b8bed1c3a1) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/152178 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19435 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17374 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9437 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129087 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15096 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164075 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7211 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16690 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126189 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25436 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21413 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126347 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25438 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136892 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82042 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23415 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21301 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13671 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25054 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89341 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24746 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24905 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24806 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->