### PR TITLE
Setting <a rel> multiple times would not clear prior relations

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/links/links-created-by-a-and-area-elements/rel-attribute-clearing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/links/links-created-by-a-and-area-elements/rel-attribute-clearing-expected.txt
@@ -1,0 +1,6 @@
+
+PASS Anchor: changing rel from noopener to opener clears noopener
+PASS Anchor: changing rel from noreferrer to opener clears noreferrer
+PASS Anchor: changing rel from 'noopener noreferrer' to opener clears both
+PASS Area: changing rel from noopener to opener clears noopener
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/links/links-created-by-a-and-area-elements/rel-attribute-clearing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/links/links-created-by-a-and-area-elements/rel-attribute-clearing.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<meta name="timeout" content="long">
+<title>Changing rel attribute clears previous link relation state</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<body>
+<script>
+const supportURL = "support/target_blank_implicit_noopener.html";
+
+// Helper: click a link and get the opener status from the opened window.
+function clickAndGetOpener(element, channelName) {
+  return new Promise(resolve => {
+    const bc = new BroadcastChannel(channelName);
+    bc.addEventListener("message", e => {
+      bc.close();
+      resolve(e.data.hasOpener);
+    }, { once: true });
+    element.click();
+  });
+}
+
+// Unique channel names to avoid collisions.
+let counter = 0;
+function uid() {
+  return "rel-clearing-" + (++counter);
+}
+
+async_test(t => {
+  const a = document.createElement("a");
+  a.target = "_blank";
+  a.rel = "noopener";
+  document.body.appendChild(a);
+  t.add_cleanup(() => a.remove());
+
+  const id1 = uid();
+  a.href = supportURL + "?" + id1;
+
+  const bc1 = new BroadcastChannel(id1);
+  bc1.addEventListener("message", t.step_func(e => {
+    bc1.close();
+    assert_false(e.data.hasOpener, "First click with rel=noopener should not have opener");
+
+    // Now clear the rel attribute and click again.
+    a.rel = "";
+    // target=_blank with no rel implies noopener per spec, so use rel=opener.
+    a.rel = "opener";
+    const id2 = uid();
+    a.href = supportURL + "?" + id2;
+
+    const bc2 = new BroadcastChannel(id2);
+    bc2.addEventListener("message", t.step_func_done(e2 => {
+      bc2.close();
+      assert_true(e2.data.hasOpener, "After changing rel to opener, noopener should be cleared");
+    }), { once: true });
+    a.click();
+  }), { once: true });
+  a.click();
+}, "Anchor: changing rel from noopener to opener clears noopener");
+
+async_test(t => {
+  const a = document.createElement("a");
+  a.target = "_blank";
+  a.rel = "noreferrer";
+  document.body.appendChild(a);
+  t.add_cleanup(() => a.remove());
+
+  const id1 = uid();
+  a.href = supportURL + "?" + id1;
+
+  const bc1 = new BroadcastChannel(id1);
+  bc1.addEventListener("message", t.step_func(e => {
+    bc1.close();
+    assert_false(e.data.hasOpener, "First click with rel=noreferrer should not have opener");
+
+    // Change to opener only.
+    a.rel = "opener";
+    const id2 = uid();
+    a.href = supportURL + "?" + id2;
+
+    const bc2 = new BroadcastChannel(id2);
+    bc2.addEventListener("message", t.step_func_done(e2 => {
+      bc2.close();
+      assert_true(e2.data.hasOpener, "After changing rel to opener, noreferrer should be cleared");
+    }), { once: true });
+    a.click();
+  }), { once: true });
+  a.click();
+}, "Anchor: changing rel from noreferrer to opener clears noreferrer");
+
+async_test(t => {
+  const a = document.createElement("a");
+  a.target = "_blank";
+  a.rel = "noopener noreferrer";
+  document.body.appendChild(a);
+  t.add_cleanup(() => a.remove());
+
+  const id1 = uid();
+  a.href = supportURL + "?" + id1;
+
+  const bc1 = new BroadcastChannel(id1);
+  bc1.addEventListener("message", t.step_func(e => {
+    bc1.close();
+    assert_false(e.data.hasOpener, "First click with rel='noopener noreferrer' should not have opener");
+
+    // Clear all relations by setting to opener.
+    a.rel = "opener";
+    const id2 = uid();
+    a.href = supportURL + "?" + id2;
+
+    const bc2 = new BroadcastChannel(id2);
+    bc2.addEventListener("message", t.step_func_done(e2 => {
+      bc2.close();
+      assert_true(e2.data.hasOpener, "After changing rel to opener, both noopener and noreferrer should be cleared");
+    }), { once: true });
+    a.click();
+  }), { once: true });
+  a.click();
+}, "Anchor: changing rel from 'noopener noreferrer' to opener clears both");
+
+async_test(t => {
+  const area = document.createElement("area");
+  area.target = "_blank";
+  area.rel = "noopener";
+  area.shape = "default";
+  document.body.appendChild(area);
+  t.add_cleanup(() => area.remove());
+
+  const id1 = uid();
+  area.href = supportURL + "?" + id1;
+
+  const bc1 = new BroadcastChannel(id1);
+  bc1.addEventListener("message", t.step_func(e => {
+    bc1.close();
+    assert_false(e.data.hasOpener, "First click with rel=noopener should not have opener");
+
+    area.rel = "opener";
+    const id2 = uid();
+    area.href = supportURL + "?" + id2;
+
+    const bc2 = new BroadcastChannel(id2);
+    bc2.addEventListener("message", t.step_func_done(e2 => {
+      bc2.close();
+      assert_true(e2.data.hasOpener, "After changing rel to opener, noopener should be cleared");
+    }), { once: true });
+    area.click();
+  }), { once: true });
+  area.click();
+}, "Area: changing rel from noopener to opener clears noopener");
+</script>
+</body>

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -232,6 +232,7 @@ void HTMLAnchorElement::attributeChanged(const QualifiedName& name, const AtomSt
         static MainThreadNeverDestroyed<const AtomString> noReferrer("noreferrer"_s);
         static MainThreadNeverDestroyed<const AtomString> noOpener("noopener"_s);
         static MainThreadNeverDestroyed<const AtomString> opener("opener"_s);
+        m_linkRelations = { };
         SpaceSplitString relValue(newValue, SpaceSplitString::ShouldFoldCase::Yes);
         if (relValue.contains(noReferrer))
             m_linkRelations.add(Relation::NoReferrer);

--- a/Source/WebCore/svg/SVGAElement.cpp
+++ b/Source/WebCore/svg/SVGAElement.cpp
@@ -93,6 +93,7 @@ void SVGAElement::attributeChanged(const QualifiedName& name, const AtomString& 
         static MainThreadNeverDestroyed<const AtomString> noReferrer("noreferrer"_s);
         static MainThreadNeverDestroyed<const AtomString> noOpener("noopener"_s);
         static MainThreadNeverDestroyed<const AtomString> opener("opener"_s);
+        m_linkRelations = { };
         SpaceSplitString relValue(newValue, SpaceSplitString::ShouldFoldCase::Yes);
         if (relValue.contains(noReferrer))
             m_linkRelations.add(Relation::NoReferrer);


### PR DESCRIPTION
#### 07a132fe1f807c16a845b8c1e1069acaec557c61
<pre>
Setting &lt;a rel&gt; multiple times would not clear prior relations
<a href="https://bugs.webkit.org/show_bug.cgi?id=310907">https://bugs.webkit.org/show_bug.cgi?id=310907</a>

Reviewed by Chris Dumez.

Test: imported/w3c/web-platform-tests/html/semantics/links/links-created-by-a-and-area-elements/rel-attribute-clearing.html

Upstream:

    <a href="https://github.com/web-platform-tests/wpt/pull/58818">https://github.com/web-platform-tests/wpt/pull/58818</a>

Canonical link: <a href="https://commits.webkit.org/310144@main">https://commits.webkit.org/310144@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dfa1bf9b25ddddc6684f4db64a5cdcf46b273254

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152697 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25478 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19077 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161441 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106153 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/36c70768-f986-43d9-be3c-05bd8a6eb21c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154570 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26006 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25784 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117992 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83593 "5 flakes 2 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/38fb0a6b-9c53-4541-8dde-5262e6936e19) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155656 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20231 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137086 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98705 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19306 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17237 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9277 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128958 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14960 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163913 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7051 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16554 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126051 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25276 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21276 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126209 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25278 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136756 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81882 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23410 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21172 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13535 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24894 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89180 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24586 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24745 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24646 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->