### PR TITLE
Finish wiring model.entityTransform for the WebModelPlayer

### DIFF
--- a/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.cpp
@@ -243,7 +243,7 @@ void RemoteMeshProxy::sizeDidChange(unsigned width, unsigned height, CompletionH
 
 std::optional<WebModel::Float4x4> RemoteMeshProxy::entityTransform() const
 {
-    return m_transform;
+    return m_computedTransform;
 }
 #endif
 
@@ -370,7 +370,7 @@ void RemoteMeshProxy::computeTransform()
     }
 
     WebModel::Float4x4 result = matrix_identity_float4x4;
-    if (auto existingTransform = entityTransform())
+    if (auto existingTransform = m_transform)
         result = *existingTransform;
 
     result.column0 = scale * simd_normalize(result.column0);
@@ -384,6 +384,7 @@ void RemoteMeshProxy::computeTransform()
 
     setCameraDistance(viewportHeight / kVerticalFOVScale);
     setEntityTransformInternal(result);
+    m_computedTransform = result;
 }
 #endif
 

--- a/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.h
@@ -123,6 +123,7 @@ private:
     simd_float4 m_minCorner;
     simd_float4 m_maxCorner;
     std::optional<WebModel::Float4x4> m_transform;
+    std::optional<WebModel::Float4x4> m_computedTransform;
 #endif
 #if ENABLE(GPU_PROCESS_MODEL)
     float m_cameraDistance { 1.f };

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.h
@@ -128,7 +128,6 @@ private:
     mutable RefPtr<ModelDisplayBufferDisplayDelegate> m_contentsDisplayDelegate;
     uint32_t m_currentTexture { 0 };
     WebCore::StageModeOperation m_stageMode { WebCore::StageModeOperation::None };
-    float m_currentScale { 1.f };
     WebCore::IntSize m_currentPixelSize;
     bool m_didFinishLoading { false };
     enum class PauseState {

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
@@ -355,12 +355,7 @@ void WebModelPlayer::notifyEntityTransformUpdated()
     if (!model || !client || !model->entityTransform())
         return;
 
-    auto scaledTransform = *model->entityTransform();
-    auto scale = m_currentScale;
-    scaledTransform.column0 *= scale;
-    scaledTransform.column1 *= scale;
-    scaledTransform.column2 *= scale;
-    client->didUpdateEntityTransform(*this, WebCore::TransformationMatrix(static_cast<simd_float4x4>(scaledTransform)));
+    client->didUpdateEntityTransform(*this, WebCore::TransformationMatrix(static_cast<simd_float4x4>(*model->entityTransform())));
 }
 
 void WebModelPlayer::sizeDidChange(WebCore::LayoutSize size)
@@ -393,7 +388,6 @@ void WebModelPlayer::sizeDidChange(WebCore::LayoutSize size)
             RefPtr { protectedThis->m_contentsDisplayDelegate }->setDisplayBuffer(*protectedThis->displayBuffer());
     });
 
-    m_currentScale = static_cast<float>(size.minDimension());
     if (RefPtr model = m_currentModel)
         model->setViewportSize(size.width().toFloat(), size.height().toFloat());
     notifyEntityTransformUpdated();
@@ -426,8 +420,10 @@ void WebModelPlayer::handleMouseMove(const WebCore::LayoutPoint& currentPoint, M
         return;
 
     [orbitSimulator gestureDidUpdateWithDeltaX:totalDeltaX deltaY:totalDeltaY];
-    if (RefPtr model = m_currentModel)
+    if (RefPtr model = m_currentModel) {
         model->setRotation([orbitSimulator currentYaw], [orbitSimulator currentPitch]);
+        notifyEntityTransformUpdated();
+    }
 }
 
 bool WebModelPlayer::supportsMouseInteraction()
@@ -549,8 +545,10 @@ void WebModelPlayer::simulate(float elapsedTime)
     RetainPtr orbitSimulator = m_orbitSimulator;
     if (!orbitSimulator)
         return;
-    if ([orbitSimulator stepWithElapsedTime:elapsedTime])
+    if ([orbitSimulator stepWithElapsedTime:elapsedTime]) {
         model->setRotation([orbitSimulator currentYaw], [orbitSimulator currentPitch]);
+        notifyEntityTransformUpdated();
+    }
 }
 
 void WebModelPlayer::setPlaybackRate(double newRate, CompletionHandler<void(double effectivePlaybackRate)>&& completion)


### PR DESCRIPTION
#### dcf961e05925b368d924b430647ea50d9ec63fe8
<pre>
Finish wiring model.entityTransform for the WebModelPlayer
<a href="https://bugs.webkit.org/show_bug.cgi?id=310909">https://bugs.webkit.org/show_bug.cgi?id=310909</a>
&lt;<a href="https://rdar.apple.com/172649117">rdar://172649117</a>&gt;

Reviewed by Mike Wyrzykowski.

The object-fit and stagemode transforms should also be relayed to the
Model#entityTransform property.

* Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.cpp:
(WebKit::RemoteMeshProxy::entityTransform const):
(WebKit::RemoteMeshProxy::computeTransform):
* Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.h:
Store the final computed transform and use it to communicate back to the
client.

* Source/WebKit/WebProcess/Model/WebModelPlayer.h:
* Source/WebKit/WebProcess/Model/WebModelPlayer.mm:
(WebKit::WebModelPlayer::notifyEntityTransformUpdated):
(WebKit::WebModelPlayer::sizeDidChange):
(WebKit::WebModelPlayer::handleMouseMove):
(WebKit::WebModelPlayer::simulate):
Remote the unused `m_currentScale`.
Notify of entity transform updates during stagemode.

Canonical link: <a href="https://commits.webkit.org/310224@main">https://commits.webkit.org/310224@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0efefa80e899d796193e1705947db797fc0f873e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152715 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25496 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19095 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161459 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106171 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/452b4cee-6dc8-4477-a0b9-79b32028ee14) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26024 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25802 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118005 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83602 "7 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/95693615-99e2-414d-95d6-6b1349c76d56) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155674 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20235 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137097 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98718 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19310 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17252 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9295 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128962 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163931 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7069 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16565 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126066 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25294 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21291 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126224 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34343 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25296 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136767 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81900 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21194 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13546 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24912 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89198 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24604 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24763 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24664 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->