### PR TITLE
[JSC] Fix testair and testb3 crashes under USE(PROTECTED_JIT) by adding ArenaLifetime to test threads

### DIFF
--- a/Source/JavaScriptCore/b3/air/testair.cpp
+++ b/Source/JavaScriptCore/b3/air/testair.cpp
@@ -3109,7 +3109,10 @@ void run(const char* filter)
                                 return;
                             task = tasks.takeFirst();
                         }
-
+#if USE(PROTECTED_JIT)
+                        // Must be constructed before we allocate anything using SequesteredArenaMalloc
+                        ArenaLifetime arenaLifetime;
+#endif
                         task->run();
                     }
                 }));

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -157,11 +157,21 @@ extern Lock crashLock;
             }));                                        \
     }
 
+#if USE(PROTECTED_JIT)
+// Must be constructed before we allocate anything using SequesteredArenaMalloc
+#define B3_TEST_ARENA_LIFETIME ArenaLifetime b3TestArenaLifetime;
+#else
+#define B3_TEST_ARENA_LIFETIME
+#endif
+
 #define RUN_NOW(test) do {                      \
         if (!shouldRun(config, #test))          \
             break;                              \
         dataLog(PREFIX #test "...\n");          \
-        test;                                   \
+        {                                       \
+            B3_TEST_ARENA_LIFETIME              \
+            test;                               \
+        }                                       \
         dataLog(PREFIX #test ": OK!\n");        \
     } while (false)
 

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -1201,6 +1201,7 @@ void run(const TestConfig* config)
                             task = tasks.takeFirst();
                         }
 
+                        B3_TEST_ARENA_LIFETIME
                         task->run();
                     }
                 }));

--- a/Source/WTF/wtf/SequesteredImmortalHeap.h
+++ b/Source/WTF/wtf/SequesteredImmortalHeap.h
@@ -78,7 +78,7 @@ public:
         }
     }
 
-    void decommit();
+    WTF_EXPORT_PRIVATE void decommit();
 private:
     GranuleList acquireExclusiveCopyOfGranuleList()
     {
@@ -198,7 +198,7 @@ private:
         return reinterpret_cast<void*>(allocation);
     }
 
-    GranuleHeader* addGranule(size_t minSize);
+    WTF_EXPORT_PRIVATE GranuleHeader* addGranule(size_t minSize);
 
     GranuleList m_granules { };
     uintptr_t m_allocHead { 0 };
@@ -356,7 +356,7 @@ public:
         ReturnNull
     };
 
-    static SequesteredImmortalHeap& instance();
+    WTF_EXPORT_PRIVATE static SequesteredImmortalHeap& instance();
 
     template <typename T> requires (sizeof(T) <= slotSize)
     T* allocateAndInstall()


### PR DESCRIPTION
#### db82cc210cb511fc769adb00b6e147727d0c1f31
<pre>
[JSC] Fix testair and testb3 crashes under USE(PROTECTED_JIT) by adding ArenaLifetime to test threads
<a href="https://bugs.webkit.org/show_bug.cgi?id=310911">https://bugs.webkit.org/show_bug.cgi?id=310911</a>
<a href="https://rdar.apple.com/173524423">rdar://173524423</a>

Reviewed by Dan Hecht.

testair and testb3 allocate B3::Procedure and related objects (CFG,
BasicBlock, Value, etc.) which are marked WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED.
When USE(PROTECTED_JIT) is enabled (internal SDK + macOS), these
types route through SequesteredArenaAllocator::malloc(), which hard-asserts
m_alive before every allocation. m_alive is set to true only by ArenaLifetime&apos;s
constructor (beginArenaLifetime()) and back to false by its destructor
(endArenaLifetime()).

Neither testair&apos;s worker thread loop nor testb3&apos;s worker thread loop nor
testb3&apos;s RUN_NOW main-thread path ever constructed an ArenaLifetime, so
every allocation crashed immediately with ASSERT(m_alive). This went
unnoticed because EWS bots build with the public SDK (USE(PROTECTED_JIT) = 0),
where WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED falls back to plain TZone malloc
with no arena lifetime requirement. This patch fixes the issue by constructing
ArenaLifetime scoped to each individual test task.

Canonical link: <a href="https://commits.webkit.org/310126@main">https://commits.webkit.org/310126@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6bb4ea96e1247b1320251c4008d2dd630429ff85

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152719 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25500 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19099 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161463 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26028 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25806 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118009 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/52688564-d5fa-4864-8d19-8cb3959e59e4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155678 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20236 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137110 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98722 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9ef35f00-27da-4b07-858c-1d874043a4a1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19311 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17256 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9299 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144731 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128963 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14984 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163935 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/13527 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7073 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16578 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126069 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25298 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21295 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126227 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25300 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136780 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81904 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23406 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21190 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13559 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184351 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24916 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89202 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47060 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24608 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24767 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24668 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->