### PR TITLE
Rubberband animation restoration sometimes appears incorrect

### DIFF
--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm
@@ -146,6 +146,14 @@ WheelEventHandlingResult ScrollingTreeFrameScrollingNodeMac::handleWheelEvent(co
     if (!canHandleWheelEvent(wheelEvent, eventTargeting))
         return WheelEventHandlingResult::unhandled();
 
+#if HAVE(RUBBER_BANDING)
+    // FIXME: <https://webkit.org/b/310912> Stale momentum events from scroll gestures continue
+    // to dispatch across page reloads. Until this problem is solved, absorb wheel events during
+    // rubberband restoration to prevent interference.
+    if (restoredRubberbandingInProgress())
+        return WheelEventHandlingResult::handled();
+#endif
+
     bool handled = delegate().handleWheelEvent(wheelEvent);
     delegate().updateSnapScrollState();
     return WheelEventHandlingResult::result(handled);

--- a/Source/WebCore/platform/RubberbandingState.h
+++ b/Source/WebCore/platform/RubberbandingState.h
@@ -42,9 +42,6 @@ struct RubberbandingState {
     MonotonicTime captureTime;
 
     RectEdges<bool> rubberbandingEdges;
-
-    FloatSize stretchScrollForce;
-    FloatSize momentumVelocity;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mac/ScrollingEffectsController.mm
+++ b/Source/WebCore/platform/mac/ScrollingEffectsController.mm
@@ -867,14 +867,12 @@ std::optional<RubberbandingState> ScrollingEffectsController::captureRubberbandi
     auto stretchAmount = m_client.stretchAmount();
     LOG_WITH_STREAM(ScrollAnimations, stream << "ScrollingEffectsController::captureRubberbandingState: m_isRubberBanding=" << m_isRubberBanding << " m_isAnimatingRubberBand=" << m_isAnimatingRubberBand << " stretchAmount=" << stretchAmount);
 
-    if (stretchAmount.isZero() || (!m_isRubberBanding && !m_isAnimatingRubberBand))
+    if (stretchAmount.isZero())
         return std::nullopt;
 
     RubberbandingState state;
     state.captureTime = MonotonicTime::now();
     state.rubberbandingEdges = m_rubberBandingEdges;
-    state.stretchScrollForce = m_stretchScrollForce;
-    state.momentumVelocity = m_momentumVelocity;
 
     if (CheckedPtr rubberBandAnimation = dynamicDowncast<ScrollAnimationRubberBand>(m_currentAnimation.get())) {
         if (rubberBandAnimation->isActive()) {
@@ -887,13 +885,12 @@ std::optional<RubberbandingState> ScrollingEffectsController::captureRubberbandi
         }
     }
 
-    // User is still dragging past the edge (not yet in bounce-back animation).
-    state.initialVelocity = m_momentumVelocity;
+    state.initialVelocity = { };
     state.initialOverscroll = stretchAmount;
     state.targetOverscroll = m_client.rubberBandTargetOffset();
     state.animationStartTime = MonotonicTime::now();
 
-    LOG_WITH_STREAM(ScrollAnimations, stream << "ScrollingEffectsController::captureRubberbandingState - captured from stretch: initialOverscroll=" << state.initialOverscroll << " targetOverscroll=" << state.targetOverscroll << " initialVelocity=" << state.initialVelocity);
+    LOG_WITH_STREAM(ScrollAnimations, stream << "ScrollingEffectsController::captureRubberbandingState - captured outside of animation: initialOverscroll=" << state.initialOverscroll << " targetOverscroll=" << state.targetOverscroll << " initialVelocity=" << state.initialVelocity);
     return state;
 }
 
@@ -909,8 +906,6 @@ bool ScrollingEffectsController::restoreRubberbandingState(const RubberbandingSt
     LOG_WITH_STREAM(ScrollAnimations, stream << "ScrollingEffectsController::restoreRubberbandingState - restoring with initialOverscroll=" << state.initialOverscroll << " targetOverscroll=" << state.targetOverscroll << " totalElapsed=" << totalElapsed.seconds() << "s");
 
     m_rubberBandingEdges = state.rubberbandingEdges;
-    m_stretchScrollForce = state.stretchScrollForce;
-    m_momentumVelocity = state.momentumVelocity;
     m_isRubberBanding = true;
 
     bool started = startRubberBandAnimationWithElapsedTime(state.initialVelocity, state.initialOverscroll, totalElapsed, state.targetOverscroll);


### PR DESCRIPTION
#### b3caa50f3bdc9a117cb22a736568813c3cf3350e
<pre>
Rubberband animation restoration sometimes appears incorrect
<a href="https://bugs.webkit.org/show_bug.cgi?id=310913">https://bugs.webkit.org/show_bug.cgi?id=310913</a>
<a href="https://rdar.apple.com/173029226">rdar://173029226</a>

Reviewed by Abrar Rahman Protyasha.

Fix two bugs with rubberband restoration.

Bug one: If the page fully rubberbands to a non-zero overscroll location,
the page reloads, rubberbanding restoration is triggered, and the overscroll
location returns to 0, no animation plays.
Fix by not gating restoration behind whether or not an animation is
already playing. Even if one is not playing at restoration time, if the
overscroll is greater than 0 and then becomes 0 after page load, we still need
to rubberband.

Bug two: After a rubberband animation is restored, scroll stretch may increase
unexpectedly with no user interaction, causing it to appear to &quot;jump&quot; before
rubberbanding back. This is caused by stale wheel events continuing to dispatch
after the page reloads.
Fix by absorbing wheel events during rubberband restoration, and by not
restoring scroll force and momentum velocity since these are related to active
gestures rather than rubberbanding animations.

Tests will be added in a later patch.

* Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm:
(WebCore::ScrollingTreeFrameScrollingNodeMac::handleWheelEvent):
* Source/WebCore/platform/RubberbandingState.h:
* Source/WebCore/platform/mac/ScrollingEffectsController.mm:
(WebCore::ScrollingEffectsController::captureRubberbandingState const):
(WebCore::ScrollingEffectsController::restoreRubberbandingState):

Canonical link: <a href="https://commits.webkit.org/310114@main">https://commits.webkit.org/310114@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8d3f9b4f1f6a2aac27aace3d84766f50a154bd1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152724 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25505 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19104 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161468 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b9e47fc7-8417-49e9-872a-8263b05959f6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154597 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26033 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25811 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118014 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155683 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/20239 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137102 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98727 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/05743ddd-94f0-4bbd-914f-5a7291182f60) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/19314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9304 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128966 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14976 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163940 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7078 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16570 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126072 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25303 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21298 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126230 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34254 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25305 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136772 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/81909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21193 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13551 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24921 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89207 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24613 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24772 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24673 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->