### PR TITLE
Text effect continually reapplied unnecessarily.

### DIFF
--- a/Source/WebCore/dom/DocumentMarkerController.cpp
+++ b/Source/WebCore/dom/DocumentMarkerController.cpp
@@ -79,6 +79,9 @@ void DocumentMarkerController::detach()
     m_possiblyExistingMarkerTypes = { };
     m_fadeAnimationTimer.stop();
     m_writingToolsTextSuggestionAnimationTimer.stop();
+#if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+    m_appliedGrammarTextEffectRanges.clear();
+#endif
 }
 
 auto DocumentMarkerController::collectTextRanges(const SimpleRange& range) -> Vector<TextRange>
@@ -97,7 +100,24 @@ bool DocumentMarkerController::addMarker(const SimpleRange& range, DocumentMarke
 
 #if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
     RefPtr page = m_document->page();
-    bool needsTextEffect = type == DocumentMarkerType::Grammar && page && page->settings().textEffectsEnabled();
+    bool isGrammar = type == DocumentMarkerType::Grammar;
+    bool textEffectsEnabled = page && page->settings().textEffectsEnabled();
+    bool needsTextEffect = false;
+    if (isGrammar && textEffectsEnabled) {
+        needsTextEffect = true;
+        auto textRanges = collectTextRanges(range);
+        for (auto& textPiece : textRanges) {
+            SimpleRange pieceRange { BoundaryPoint { textPiece.node.copyRef(), textPiece.range.start }, BoundaryPoint { textPiece.node.copyRef(), textPiece.range.end } };
+            for (auto& applied : m_appliedGrammarTextEffectRanges) {
+                if (applied == pieceRange) {
+                    needsTextEffect = false;
+                    break;
+                }
+            }
+            if (!needsTextEffect)
+                break;
+        }
+    }
     RefPtr<TextIndicator> textIndicator;
     if (needsTextEffect)
         textIndicator = page->textEffectController().createTextIndicatorForRange(range);
@@ -112,6 +132,8 @@ bool DocumentMarkerController::addMarker(const SimpleRange& range, DocumentMarke
     if (needsTextEffect) {
         RefPtr decorationIndicator = page->textEffectController().createTextIndicatorForRange(range);
         page->textEffectController().addTextEffect(range, WTF::move(textIndicator), WTF::move(decorationIndicator));
+        for (auto& textPiece : collectTextRanges(range))
+            m_appliedGrammarTextEffectRanges.append(SimpleRange { BoundaryPoint { textPiece.node.copyRef(), textPiece.range.start }, BoundaryPoint { textPiece.node.copyRef(), textPiece.range.end } });
     }
 #endif
     return added;

--- a/Source/WebCore/dom/DocumentMarkerController.h
+++ b/Source/WebCore/dom/DocumentMarkerController.h
@@ -140,6 +140,10 @@ private:
 
     Timer m_fadeAnimationTimer;
     Timer m_writingToolsTextSuggestionAnimationTimer;
+
+#if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+    Vector<SimpleRange> m_appliedGrammarTextEffectRanges;
+#endif
 };
 
 


### PR DESCRIPTION
#### 476f7053d6287342360ee4c6356b8011ab5addc2
<pre>
Text effect continually reapplied unnecessarily.
<a href="https://bugs.webkit.org/show_bug.cgi?id=310917">https://bugs.webkit.org/show_bug.cgi?id=310917</a>
<a href="https://rdar.apple.com/173526354">rdar://173526354</a>

Reviewed by Lily Spiniolas.

Since grammar suggestions are continuously generated
and the document markers are continually removed and
reapplied, the effect is also continuously applied,
when it should only be applied once. We need to keep
a separate list of applied effects so that they are
only applied the first time. I really would have liked
to use the presence of a document marker as a signal
that the effect does not need to be applied, but since
they are removed before reapplication, there is no way
to used their presence as a signal.

* Source/WebCore/dom/DocumentMarkerController.cpp:
(WebCore::DocumentMarkerController::detach):
(WebCore::DocumentMarkerController::addMarker):
* Source/WebCore/dom/DocumentMarkerController.h:

Canonical link: <a href="https://commits.webkit.org/310132@main">https://commits.webkit.org/310132@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b63b9d7955d5aade7b86d0fb4d9a8903f67b50d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152725 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25506 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19105 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161469 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5dd0a385-c674-4feb-a4a8-79f17c5751cf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154598 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26034 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25812 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118015 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155684 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20241 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137113 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98728 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2a1f7fec-f9f8-4171-8a26-27478e03ea55) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19316 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17261 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9305 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128968 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14987 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163941 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7079 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16581 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126074 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25304 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21300 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126232 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34269 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25306 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136783 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81910 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21197 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13562 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24922 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89208 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24614 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24773 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24674 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->