### PR TITLE
SwiftBrowser should be able to show event region debug overlays

### DIFF
--- a/Tools/SwiftBrowser/Source/ViewModel/AppStorageKeys.swift
+++ b/Tools/SwiftBrowser/Source/ViewModel/AppStorageKeys.swift
@@ -30,4 +30,10 @@ enum AppStorageKeys {
     static let scrollBounceBehaviorBasedOnSize = "scrollBounceBehaviorBasedOnSize"
     static let backgroundHidden = "backgroundHidden"
     static let showColorInTabBar = "showColorInTabBar"
+
+    static let debugOverlayNonFastScrollableRegion = "debugOverlayNonFastScrollableRegion"
+    static let debugOverlayWheelEventHandlerRegion = "debugOverlayWheelEventHandlerRegion"
+    static let debugOverlayTouchActionRegion = "debugOverlayTouchActionRegion"
+    static let debugOverlayInteractionRegion = "debugOverlayInteractionRegion"
+    static let debugOverlayEnhancedSecurityRegion = "debugOverlayEnhancedSecurityRegion"
 }

--- a/Tools/SwiftBrowser/Source/ViewModel/BrowserViewModel.swift
+++ b/Tools/SwiftBrowser/Source/ViewModel/BrowserViewModel.swift
@@ -204,5 +204,23 @@ final class BrowserViewModel {
 
             preferences._setEnabled(value, for: feature)
         }
+
+        var overlayRegions: _WKDebugOverlayRegions = []
+        if UserDefaults.standard.bool(forKey: AppStorageKeys.debugOverlayNonFastScrollableRegion) {
+            overlayRegions.insert(.nonFastScrollableRegion)
+        }
+        if UserDefaults.standard.bool(forKey: AppStorageKeys.debugOverlayWheelEventHandlerRegion) {
+            overlayRegions.insert(.wheelEventHandlerRegion)
+        }
+        if UserDefaults.standard.bool(forKey: AppStorageKeys.debugOverlayTouchActionRegion) {
+            overlayRegions.insert(.touchActionRegion)
+        }
+        if UserDefaults.standard.bool(forKey: AppStorageKeys.debugOverlayInteractionRegion) {
+            overlayRegions.insert(.interactionRegion)
+        }
+        if UserDefaults.standard.bool(forKey: AppStorageKeys.debugOverlayEnhancedSecurityRegion) {
+            overlayRegions.insert(.enhancedSecurityRegion)
+        }
+        preferences._visibleDebugOverlayRegions = overlayRegions
     }
 }

--- a/Tools/SwiftBrowser/Source/Views/SettingsView.swift
+++ b/Tools/SwiftBrowser/Source/Views/SettingsView.swift
@@ -199,6 +199,35 @@ private struct FeatureFlagsView: View {
     }
 }
 
+private struct DebugOverlaysView: View {
+    @AppStorage(AppStorageKeys.debugOverlayNonFastScrollableRegion)
+    private var nonFastScrollableRegion = false
+
+    @AppStorage(AppStorageKeys.debugOverlayWheelEventHandlerRegion)
+    private var wheelEventHandlerRegion = false
+
+    @AppStorage(AppStorageKeys.debugOverlayTouchActionRegion)
+    private var touchActionRegion = false
+
+    @AppStorage(AppStorageKeys.debugOverlayInteractionRegion)
+    private var interactionRegion = false
+
+    @AppStorage(AppStorageKeys.debugOverlayEnhancedSecurityRegion)
+    private var enhancedSecurityRegion = false
+
+    var body: some View {
+        Form {
+            Section("Region Overlays") {
+                Toggle("Non-fast Scrollable Region", isOn: $nonFastScrollableRegion)
+                Toggle("Wheel Event Handler Region", isOn: $wheelEventHandlerRegion)
+                Toggle("Touch Action Region", isOn: $touchActionRegion)
+                Toggle("Interaction Region", isOn: $interactionRegion)
+                Toggle("Enhanced Security Region", isOn: $enhancedSecurityRegion)
+            }
+        }
+    }
+}
+
 struct SettingsView: View {
     let currentURL: URL?
 
@@ -211,6 +240,10 @@ struct SettingsView: View {
             Tab("Feature Flags", systemImage: "flag.filled.and.flag.crossed") {
                 FeatureFlagsView()
                     .environment(FeatureFlagsModel())
+            }
+
+            Tab("Debug Overlays", systemImage: "squareshape.split.2x2.dotted.inside.and.outside") {
+                DebugOverlaysView()
             }
         }
         .scenePadding()


### PR DESCRIPTION
#### f181e305b153be29ca1e8d167a01b6033fc815a4
<pre>
SwiftBrowser should be able to show event region debug overlays
<a href="https://bugs.webkit.org/show_bug.cgi?id=310919">https://bugs.webkit.org/show_bug.cgi?id=310919</a>
<a href="https://rdar.apple.com/173526691">rdar://173526691</a>

Reviewed by Richard Robinson.

It is often useful to look at debug overlays for the various event
regions we generate, and this is currently a mismatch with MiniBrowser.
Let&apos;s bring parity to SwiftBrowser with this patch.

* Tools/SwiftBrowser/Source/ViewModel/AppStorageKeys.swift:
* Tools/SwiftBrowser/Source/ViewModel/BrowserViewModel.swift:
(BrowserViewModel.updateWebPreferences):
* Tools/SwiftBrowser/Source/Views/SettingsView.swift:
(DebugOverlaysView.body):
(SettingsView.body):

Canonical link: <a href="https://commits.webkit.org/310097@main">https://commits.webkit.org/310097@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f41edf3c88d02fb9222194dfe3be7086f64f9d54

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152726 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/25507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19106 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/161470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/662fd7ba-78d8-4366-9c5a-919a5317d648) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154599 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26035 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25813 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/161470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155685 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/20240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/137099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/161470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/19315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/9306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/14973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163942 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16567 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/126076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/25305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/21299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126234 "Passed tests") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/25307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136769 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/81911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23396 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/25307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/13548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/24923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/24615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/24774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/24675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->