### PR TITLE
Simplify the RemoteMesh update IPC messages and types

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift
@@ -272,7 +272,6 @@ extension WKBridgeRemovals {
 @implementation
 extension WKBridgeUpdateMesh {
     let identifier: WKBridgeTypedResourceId
-    let updateType: WKBridgeDataUpdateType
     let descriptor: WKBridgeMeshDescriptor?
     let parts: [WKBridgeMeshPart]
     let indexData: Data?
@@ -284,7 +283,6 @@ extension WKBridgeUpdateMesh {
 
     init(
         identifier: WKBridgeTypedResourceId,
-        updateType: WKBridgeDataUpdateType,
         descriptor: WKBridgeMeshDescriptor?,
         parts: [WKBridgeMeshPart],
         indexData: Data?,
@@ -295,7 +293,6 @@ extension WKBridgeUpdateMesh {
         deformationData: WKBridgeDeformationData?
     ) {
         self.identifier = identifier
-        self.updateType = updateType
         self.descriptor = descriptor
         self.parts = parts
         self.indexData = indexData

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h
@@ -55,11 +55,6 @@ typedef struct __IOSurface *IOSurfaceRef;
 
 NS_HEADER_AUDIT_BEGIN(nullability, sendability)
 
-typedef NS_ENUM(uint8_t, WKBridgeDataUpdateType) {
-    WKBridgeDataUpdateTypeInitial,
-    WKBridgeDataUpdateTypeDelta
-};
-
 typedef NS_ENUM(uint8_t, WKBridgeVertexSemantic) {
     WKBridgeVertexSemanticPosition,
     WKBridgeVertexSemanticColor,
@@ -406,7 +401,6 @@ NS_SWIFT_SENDABLE
 @interface WKBridgeUpdateMesh : NSObject
 
 @property (nonatomic, readonly) WKBridgeTypedResourceId *identifier;
-@property (nonatomic, readonly) WKBridgeDataUpdateType updateType;
 @property (nonatomic, strong, readonly, nullable) WKBridgeMeshDescriptor *descriptor;
 @property (nonatomic, strong, readonly) NSArray<WKBridgeMeshPart*> *parts;
 @property (nonatomic, strong, readonly, nullable) NSData *indexData;
@@ -418,7 +412,6 @@ NS_SWIFT_SENDABLE
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithIdentifier:(WKBridgeTypedResourceId *)identifier
-    updateType:(WKBridgeDataUpdateType)updateType
     descriptor:(nullable WKBridgeMeshDescriptor *)descriptor
     parts:(NSArray<WKBridgeMeshPart*> *)parts
     indexData:(nullable NSData *)indexData
@@ -824,12 +817,10 @@ struct DeformationData {
 
 struct UpdateMeshDescriptor {
     TypedResourceId identifier;
-    uint8_t updateType;
-    MeshDescriptor descriptor;
+    std::optional<MeshDescriptor> descriptor;
     Vector<MeshPart> parts;
     Vector<uint8_t> indexData;
     Vector<Vector<uint8_t>> vertexData;
-    Float4x4 transform;
     Vector<Float4x4> instanceTransforms;
     Vector<TypedResourceId> assignedMaterials;
     std::optional<DeformationData> deformationData;

--- a/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.cpp
+++ b/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.cpp
@@ -80,10 +80,9 @@ void RemoteMesh::setLabel(String&& label)
     m_backing->setLabel(WTF::move(label));
 }
 
-void RemoteMesh::update(Vector<WebModel::UpdateMeshDescriptor>&& descriptor, CompletionHandler<void(bool)>&& completionHandler)
+void RemoteMesh::update(Vector<WebModel::UpdateMeshDescriptor>&& descriptor)
 {
     m_backing->update(WTF::move(descriptor));
-    completionHandler(true);
 }
 
 void RemoteMesh::render(uint32_t textureIndex, CompletionHandler<void(bool)>&& completionHandler)
@@ -96,16 +95,14 @@ void RemoteMesh::render(uint32_t textureIndex, CompletionHandler<void(bool)>&& c
     });
 }
 
-void RemoteMesh::updateTexture(Vector<WebModel::UpdateTextureDescriptor>&& descriptor, CompletionHandler<void(bool)>&& completionHandler)
+void RemoteMesh::updateTexture(Vector<WebModel::UpdateTextureDescriptor>&& descriptor)
 {
     m_backing->updateTexture(WTF::move(descriptor));
-    completionHandler(true);
 }
 
-void RemoteMesh::updateMaterial(Vector<WebModel::UpdateMaterialDescriptor>&& descriptor, CompletionHandler<void(bool)>&& completionHandler)
+void RemoteMesh::updateMaterial(Vector<WebModel::UpdateMaterialDescriptor>&& descriptor)
 {
     m_backing->updateMaterial(WTF::move(descriptor));
-    completionHandler(true);
 }
 
 void RemoteMesh::updateTransform(const WebModel::Float4x4& transform)

--- a/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.h
+++ b/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.h
@@ -91,9 +91,9 @@ private:
     void destruct();
 
     void setLabel(String&&);
-    void update(Vector<WebModel::UpdateMeshDescriptor>&&, CompletionHandler<void(bool)>&&);
-    void updateTexture(Vector<WebModel::UpdateTextureDescriptor>&&, CompletionHandler<void(bool)>&&);
-    void updateMaterial(Vector<WebModel::UpdateMaterialDescriptor>&&, CompletionHandler<void(bool)>&&);
+    void update(Vector<WebModel::UpdateMeshDescriptor>&&);
+    void updateTexture(Vector<WebModel::UpdateTextureDescriptor>&&);
+    void updateMaterial(Vector<WebModel::UpdateMaterialDescriptor>&&);
     void updateTransform(const WebModel::Float4x4& transform);
     void setFOV(float fovY);
     void play(bool);

--- a/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.messages.in
@@ -31,11 +31,11 @@
 messages -> RemoteMesh Stream {
     void SetLabel(String label)
     void Destruct()
-    void Update(struct Vector<WebModel::UpdateMeshDescriptor> descriptor) -> (bool success)
+    void Update(struct Vector<WebModel::UpdateMeshDescriptor> descriptor)
     void Render(uint32_t textureIndex) -> (bool success)
     void ProcessRemovals(struct Vector<WebModel::TypedResourceId> meshRemovals, struct Vector<WebModel::TypedResourceId> materialRemovals, struct Vector<WebModel::TypedResourceId> textureRemovals) -> (bool success)
-    void UpdateTexture(struct Vector<WebModel::UpdateTextureDescriptor> descriptor) -> (bool success) NotStreamEncodable
-    void UpdateMaterial(struct Vector<WebModel::UpdateMaterialDescriptor> descriptor) -> (bool success)
+    void UpdateTexture(struct Vector<WebModel::UpdateTextureDescriptor> descriptor) NotStreamEncodable
+    void UpdateMaterial(struct Vector<WebModel::UpdateMaterialDescriptor> descriptor)
     void UpdateTransform(struct WebModel::Float4x4 transform)
     void SetFOV(float fovY)
     void Play(bool playing)

--- a/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
@@ -931,10 +931,7 @@ extension WKBridgeReceiver {
                 let identifier = meshData.identifier
 
                 let meshResource: LowLevelMeshResource
-                if meshData.updateType == .initial || meshData.descriptor != nil {
-                    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
-                    // swift-format-ignore: NeverForceUnwrap
-                    let meshDescriptor = meshData.descriptor!
+                if let meshDescriptor = meshData.descriptor {
                     let descriptor = LowLevelMeshResource.Descriptor.fromLlmDescriptor(meshDescriptor)
                     if let cachedMeshResource = meshResources[identifier] {
                         meshResource = cachedMeshResource
@@ -1283,7 +1280,6 @@ private func webMeshFromMeshData(
             path: meshData.primPath,
             hashValue: meshData.id.hashValue
         ),
-        updateType: .initial,
         descriptor: .init(request: meshData.descriptor),
         parts: webPartsFromParts(meshData.parts),
         indexData: meshData.indexData,
@@ -1312,7 +1308,6 @@ private func webMeshFromMeshUpdate(
             path: primPath,
             hashValue: update.id.hashValue
         ),
-        updateType: .delta,
         descriptor: nil,
         parts: webPartsFromParts(update.parts ?? []),
         indexData: update.indexData,
@@ -1345,7 +1340,6 @@ private func webMeshDeformationDelta(
             path: primPath,
             hashValue: meshId.hashValue
         ),
-        updateType: .delta,
         descriptor: nil,
         parts: [],
         indexData: nil,

--- a/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm
+++ b/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm
@@ -626,11 +626,12 @@ static NSArray<WKBridgeVertexLayout *> *convert(const Vector<VertexLayout>& layo
     return result;
 }
 
-static WKBridgeMeshDescriptor *convert(const MeshDescriptor& descriptor)
+static WKBridgeMeshDescriptor *convert(const std::optional<MeshDescriptor>& optionalDescriptor)
 {
-    if (!descriptor.vertexBufferCount)
+    if (!optionalDescriptor)
         return nil;
 
+    auto& descriptor = *optionalDescriptor;
     return [WebKit::allocWKBridgeMeshDescriptorInstance() initWithVertexBufferCount:descriptor.vertexBufferCount
         vertexCapacity:descriptor.vertexCapacity
         vertexAttributes:convert(descriptor.vertexAttributes)
@@ -974,7 +975,6 @@ void WebMesh::render(uint32_t textureIndex, Function<void(bool)>&& completionHan
 static WKBridgeUpdateMesh *convert(const WebModel::UpdateMeshDescriptor& input)
 {
     return [WebKit::allocWKBridgeUpdateMeshInstance() initWithIdentifier:convert(input.identifier)
-        updateType:static_cast<WKBridgeDataUpdateType>(input.updateType)
         descriptor:WebModel::convert(input.descriptor)
         parts:WebModel::convert(input.parts)
         indexData:WebModel::convert(input.indexData)

--- a/Source/WebKit/Shared/Model.serialization.in
+++ b/Source/WebKit/Shared/Model.serialization.in
@@ -131,12 +131,10 @@ header: <WebKit/ModelTypes.h>
 header: <WebKit/ModelTypes.h>
 [AdditionalEncoder=StreamConnectionEncoder, CustomHeader] struct WebModel::UpdateMeshDescriptor {
     WebModel::TypedResourceId identifier;
-    uint8_t updateType;
-    WebModel::MeshDescriptor descriptor;
+    std::optional<WebModel::MeshDescriptor> descriptor;
     Vector<WebModel::MeshPart> parts;
     Vector<uint8_t> indexData;
     Vector<Vector<uint8_t>> vertexData;
-    WebModel::Float4x4 transform;
     Vector<WebModel::Float4x4> instanceTransforms;
     Vector<WebModel::TypedResourceId> assignedMaterials;
     std::optional<WebModel::DeformationData> deformationData;

--- a/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.cpp
@@ -155,8 +155,7 @@ void RemoteMeshProxy::update(Vector<WebModel::UpdateMeshDescriptor>&& descriptor
         }
     }
 
-    auto sendResult = sendWithAsyncReply(Messages::RemoteMesh::Update(WTF::move(descriptorArray)), [](auto) mutable {
-    });
+    auto sendResult = send(Messages::RemoteMesh::Update(WTF::move(descriptorArray)));
     UNUSED_VARIABLE(sendResult);
 
     if (needBoundingBoxUpdate)
@@ -189,8 +188,7 @@ void RemoteMeshProxy::setLabelInternal(const String& label)
 void RemoteMeshProxy::updateTexture(Vector<WebModel::UpdateTextureDescriptor>&& descriptor)
 {
 #if ENABLE(GPU_PROCESS_MODEL)
-    auto sendResult = sendWithAsyncReply(Messages::RemoteMesh::UpdateTexture(WTF::move(descriptor)), [](auto) mutable {
-    });
+    auto sendResult = send(Messages::RemoteMesh::UpdateTexture(WTF::move(descriptor)));
     UNUSED_VARIABLE(sendResult);
 #else
     UNUSED_PARAM(descriptor);
@@ -200,8 +198,7 @@ void RemoteMeshProxy::updateTexture(Vector<WebModel::UpdateTextureDescriptor>&& 
 void RemoteMeshProxy::updateMaterial(Vector<WebModel::UpdateMaterialDescriptor>&& descriptor)
 {
 #if ENABLE(GPU_PROCESS_MODEL)
-    auto sendResult = sendWithAsyncReply(Messages::RemoteMesh::UpdateMaterial(WTF::move(descriptor)), [](auto) mutable {
-    });
+    auto sendResult = send(Messages::RemoteMesh::UpdateMaterial(WTF::move(descriptor)));
     UNUSED_VARIABLE(sendResult);
 #else
     UNUSED_PARAM(descriptor);

--- a/Source/WebKit/WebProcess/Model/ModelInlineConverters.h
+++ b/Source/WebKit/WebProcess/Model/ModelInlineConverters.h
@@ -504,8 +504,11 @@ static Vector<WebModel::MeshPart> convert(NSArray<WKBridgeMeshPart *> *parts)
     return result;
 }
 
-static WebModel::MeshDescriptor convert(WKBridgeMeshDescriptor *descriptor)
+static std::optional<WebModel::MeshDescriptor> convert(WKBridgeMeshDescriptor *descriptor)
 {
+    if (!descriptor)
+        return std::nullopt;
+
     return WebModel::MeshDescriptor {
         .vertexBufferCount = descriptor.vertexBufferCount,
         .vertexCapacity = descriptor.vertexCapacity,
@@ -875,7 +878,6 @@ static WebModel::UpdateMeshDescriptor convert(WKBridgeUpdateMesh *update)
 {
     return WebModel::UpdateMeshDescriptor {
         .identifier = convert(update.identifier),
-        .updateType = static_cast<uint8_t>(update.updateType),
         .descriptor = convert(update.descriptor),
         .parts = convert(update.parts),
         .indexData = makeVector(update.indexData),


### PR DESCRIPTION
#### 2b018dd1e2c9a62d752236db85f207cee3e32d6e
<pre>
Simplify the RemoteMesh update IPC messages and types
<a href="https://bugs.webkit.org/show_bug.cgi?id=310921">https://bugs.webkit.org/show_bug.cgi?id=310921</a>
<a href="https://rdar.apple.com/173502283">rdar://173502283</a>

Reviewed by NOBODY (OOPS!).

The mesh update message carried state that was dead or redundant, which let the
WebContent and GPU processes disagree about what an update meant.

- transform was never read or written, so remove it.

- updateType said whether an update was initial or a delta, but the GPU process
  already decided that from whether a descriptor was present, and would crash if
  the two disagreed. Make the descriptor optional and drop the tag, so the data
  answers the question on its own.

- Update, UpdateTexture and UpdateMaterial replied with a bool that was always
  true and always discarded, so remove their replies. RemoteMesh is a stream
  receiver, so Render is still dispatched after them and its reply continues to
  confirm the updates were applied.

* Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift:
* Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h:
* Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.cpp:
(WebKit::RemoteMesh::update):
(WebKit::RemoteMesh::updateTexture):
(WebKit::RemoteMesh::updateMaterial):
* Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.h:
* Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.messages.in:
* Source/WebKit/GPUProcess/graphics/Model/USDModel.swift:
(updateMesh(_:)):
* Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm:
(WebModel::convert):
(WebKit::convert):
* Source/WebKit/Shared/Model.serialization.in:
* Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.cpp:
(WebKit::RemoteMeshProxy::update):
(WebKit::RemoteMeshProxy::updateTexture):
(WebKit::RemoteMeshProxy::updateMaterial):
* Source/WebKit/WebProcess/Model/ModelInlineConverters.h:
(WebKit::convert):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b018dd1e2c9a62d752236db85f207cee3e32d6e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181969 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55916 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49720 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192194 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146298 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/324189c0-69e3-42c8-9f1c-94d94eae7b68) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57230 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55639 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142073 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98638 "3 flakes 17 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3af0bc49-f377-4c67-870b-d4b69eec52fe) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184924 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45752 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162807 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122508 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/04469e7d-d969-44de-9050-13eedd94cbd9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44437 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42701 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154835 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42332 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3359 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48547 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46957 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194122 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55587 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151485 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56278 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38957 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151189 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45761 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128560 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124355 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54789 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17327 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54170 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54409 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54237 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->