### PR TITLE
[JSC][WASM][Debugger] Implement WASM debugger memory write support

### DIFF
--- a/JSTests/wasm/debugger/tests/tests.py
+++ b/JSTests/wasm/debugger/tests/tests.py
@@ -17,6 +17,7 @@ class CWasmTestCase(BaseTestCase):
                 self.inspectionTest()
                 self.stepTest()
                 self.memoryTest()
+                self.memoryReadWriteTest()
                 self.detachTest()
                 self.quitTest()
 
@@ -249,6 +250,17 @@ class CWasmTestCase(BaseTestCase):
             patterns=["[0x0000000000000000-0x0000000001010000) rw- wasm_memory_0_0"],
         )
 
+    def memoryReadWriteTest(self):
+        self.send_lldb_command_or_raise("memory write 0x1000 0x42 0x43 0x44 0x45", patterns=[])
+        self.send_lldb_command_or_raise("memory read -c 4 0x1000", patterns=["0x00001000: 42 43 44 45"])
+
+        self.send_lldb_command_or_raise("memory write 0x0000000001000000 0x46", patterns=[])
+        self.send_lldb_command_or_raise("memory read -c 1 0x0000000001000000", patterns=["0x01000000: 46"])
+
+        self.send_lldb_command_or_raise("memory write 0x0000000001010000 0x00", patterns=["error:"])
+        self.send_lldb_command_or_raise("memory write 0x4000000000000000 0x00", patterns=["error:"])
+        self.send_lldb_command_or_raise("memory write 0x40000000000014e0 0x00", patterns=["error:"])
+
     def detachTest(self):
         self.send_lldb_command_or_raise(
             "detach",
@@ -276,6 +288,7 @@ class SwiftWasmTestCase(BaseTestCase):
                 self.inspectionTest()
                 self.stepTest()
                 self.memoryTest()
+                self.memoryReadWriteTest()
                 self.variableTest()
 
         except Exception as e:
@@ -497,6 +510,17 @@ class SwiftWasmTestCase(BaseTestCase):
             "mem reg 0x0000000000000000",
             patterns=["[0x0000000000000000-0x0000000000130000) rw- wasm_memory_0_0"],
         )
+
+    def memoryReadWriteTest(self):
+        self.send_lldb_command_or_raise("memory write 0x1000 0xde 0xad 0xbe 0xef", patterns=[])
+        self.send_lldb_command_or_raise("memory read -c 4 0x1000", patterns=["0x00001000: de ad be ef"])
+
+        self.send_lldb_command_or_raise("memory write 0x0000000000120000 0xab", patterns=[])
+        self.send_lldb_command_or_raise("memory read -c 1 0x0000000000120000", patterns=["0x00120000: ab"])
+
+        self.send_lldb_command_or_raise("memory write 0x0000000000130000 0x00", patterns=["error:"])
+        self.send_lldb_command_or_raise("memory write 0x4000000000000000 0x00", patterns=["error:"])
+        self.send_lldb_command_or_raise("memory write 0x40000000006b1239 0x00", patterns=["error:"])
 
     def variableTest(self):
         self.send_lldb_command_or_raise("b isEven")

--- a/Source/JavaScriptCore/wasm/debugger/WasmMemoryHandler.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmMemoryHandler.cpp
@@ -40,6 +40,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include "WasmVirtualAddress.h"
 #include <cstdlib>
 #include <cstring>
+#include <wtf/ASCIICType.h>
 #include <wtf/DataLog.h>
 #include <wtf/HexNumber.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -130,7 +131,7 @@ bool MemoryHandler::readMemoryData(VirtualAddress address, size_t length, String
         return false;
     }
 
-    // FIXME(wasm-multimemory): do any debuggers support multiple memories?
+    // FIXME(wasm-multimemory): Need to support WASM multiple memories once it's enabled.
     void* memoryBase = jsInstance->memory(0)->basePointer();
     size_t size = jsInstance->memory(0)->memory().size();
     if (!memoryBase || offset + length > size) {
@@ -189,7 +190,7 @@ void MemoryHandler::handleWasmMemoryRegionInfo(VirtualAddress address, uint32_t 
 {
     JSWebAssemblyInstance* instance = m_debugServer.m_moduleManager->jsInstance(instanceId);
     if (instance) {
-        // FIXME(wasm-multimemory): do any debuggers support multiple memories?
+        // FIXME(wasm-multimemory): Need to support WASM multiple memories once it's enabled.
         size_t memorySize = instance->memory(0)->memory().size();
         if (offset < memorySize) {
             // Address is within WASM memory - return the memory region
@@ -280,9 +281,71 @@ void MemoryHandler::sendUnmappedRegionReply(uint64_t start, uint64_t size)
     m_debugServer.sendReply(response);
 }
 
-NO_RETURN_DUE_TO_CRASH void MemoryHandler::write(StringView)
+void MemoryHandler::write(StringView packet)
 {
-    RELEASE_ASSERT_NOT_REACHED("Not supported yet.");
+    // Format: M<addr>,<length>:<hex-data>
+    // LLDB: Write memory at specified address and length
+    // Reference: [3] in wasm/debugger/README.md
+
+    // WebAssembly Context: Write to WASM linear memory only
+    // Module bytecode is read-only; only linear memory (Type::Memory) is writable
+    if (packet.isEmpty() || packet[0] != 'M') {
+        m_debugServer.sendErrorReply(ProtocolError::InvalidPacket);
+        return;
+    }
+
+    StringView params = packet.substring(1);
+    auto parts = splitWithDelimiters(params, ",:"_s);
+    if (parts.size() != 3) {
+        m_debugServer.sendErrorReply(ProtocolError::InvalidPacket);
+        return;
+    }
+
+    VirtualAddress address = VirtualAddress(parseHex(parts[0]));
+    size_t length = static_cast<size_t>(parseHex(parts[1]));
+    StringView hexData = parts[2];
+
+    // Validate hex data length (2 hex chars per byte)
+    if (hexData.length() != length * 2) {
+        m_debugServer.sendErrorReply(ProtocolError::InvalidPacket);
+        return;
+    }
+
+    VirtualAddress::Type addressType = address.type();
+
+    // Only allow writes to WASM linear memory for security; module bytecode is read-only
+    if (addressType != VirtualAddress::Type::Memory) {
+        dataLogLnIf(Options::verboseWasmDebugger(), "[MemoryHandler] Write rejected: only WASM linear memory is writable, address: ", address);
+        m_debugServer.sendErrorReply(ProtocolError::InvalidAddress);
+        return;
+    }
+
+    uint32_t instanceId = address.id();
+    uint32_t offset = address.offset();
+
+    JSWebAssemblyInstance* jsInstance = m_debugServer.m_moduleManager->jsInstance(instanceId);
+    if (!jsInstance) {
+        dataLogLnIf(Options::verboseWasmDebugger(), "[MemoryHandler] Write failed: instance not found for ID: ", instanceId);
+        m_debugServer.sendErrorReply(ProtocolError::InvalidAddress);
+        return;
+    }
+
+    // FIXME(wasm-multimemory): Need to support WASM multiple memories once it's enabled.
+    void* memoryBase = jsInstance->memory(0)->basePointer();
+    size_t memorySize = jsInstance->memory(0)->memory().size();
+    if (!memoryBase || offset + length > memorySize) {
+        dataLogLnIf(Options::verboseWasmDebugger(), "[MemoryHandler] Write out of bounds. Instance ID: ", instanceId, " offset: ", offset, " size: ", length, " memory size: ", memorySize);
+        m_debugServer.sendErrorReply(ProtocolError::MemoryError);
+        return;
+    }
+
+    // Decode hex data and write to WASM linear memory
+    uint8_t* memPtr = static_cast<uint8_t*>(memoryBase) + offset;
+    for (size_t i = 0; i < length; i++)
+        memPtr[i] = toASCIIHexValue(hexData[i * 2], hexData[i * 2 + 1]);
+
+    dataLogLnIf(Options::verboseWasmDebugger(), "[MemoryHandler] - wrote ", length, " bytes at offset: ", offset, " to instance ID: ", instanceId);
+    m_debugServer.sendReply("OK"_s);
 }
 
 } // namespace Wasm

--- a/Source/JavaScriptCore/wasm/debugger/WasmMemoryHandler.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmMemoryHandler.h
@@ -49,7 +49,7 @@ public:
     }
 
     void read(StringView packet);
-    NO_RETURN_DUE_TO_CRASH void write(StringView packet);
+    void write(StringView packet);
     void handleMemoryRegionInfo(StringView packet);
 
 private:


### PR DESCRIPTION
#### 91edef541d9d586895541354bfec78e7f93856c9
<pre>
[JSC][WASM][Debugger] Implement WASM debugger memory write support
<a href="https://bugs.webkit.org/show_bug.cgi?id=310929">https://bugs.webkit.org/show_bug.cgi?id=310929</a>
<a href="https://rdar.apple.com/173537872">rdar://173537872</a>

Reviewed by Yusuke Suzuki.

This patch implements MemoryHandler::write() for the M packet (M&lt;addr&gt;,&lt;len&gt;:&lt;hex-data&gt;).
Also, it adds memoryReadWriteTest() to CWasmTestCase and SwiftWasmTestCase covering
valid writes, read-back verification, out-of-bounds, and module write rejection.

Tests:
* JSTests/wasm/debugger/tests/tests.py:
(CWasmTestCase.memoryReadWriteTest):
(SwiftWasmTestCase.memoryReadWriteTest):

Canonical link: <a href="https://commits.webkit.org/310125@main">https://commits.webkit.org/310125@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fae8bfb1e5af0425ec709ad827f34d75979e38ff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152759 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25540 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19139 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161503 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/abf233a6-e3a6-49f3-b01e-95f13400e3a5) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26068 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25846 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118043 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9680a465-ac9d-43cc-abea-3e1a397dce9a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155718 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/20269 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137135 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98756 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/408f954c-e2ee-48f0-acee-c3b69ebcf589) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19344 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9339 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144771 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128996 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15009 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163975 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/13567 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7113 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16603 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126103 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25338 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21327 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126261 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25340 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136805 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81944 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23405 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21219 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13584 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184391 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24956 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89243 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47071 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24648 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24807 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24708 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->