### PR TITLE
[JSC] Improve the removal logic in InlineMap

### DIFF
--- a/Source/WTF/wtf/InlineMap.h
+++ b/Source/WTF/wtf/InlineMap.h
@@ -79,8 +79,8 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
             for (unsigned i = 0; i < m_size; ++i)
                 std::construct_at(&inlineStorage()[i], WTF::move(other.inlineStorage()[i]));
         } else {
-            m_storage.heapEntries = other.m_storage.heapEntries;
-            other.m_storage.heapEntries = nullptr;
+            m_storage.hashedData.entries = std::exchange(other.m_storage.hashedData.entries, nullptr);
+            m_storage.hashedData.deletedCount = std::exchange(other.m_storage.hashedData.deletedCount, 0);
         }
         other.m_size = 0;
         other.m_capacity = InlineCapacity;
@@ -96,9 +96,10 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
             return;
         }
 
-        m_storage.heapEntries = allocateAndInitializeStorage(m_capacity);
-        Entry* srcEntries = other.m_storage.heapEntries;
-        Entry* destEntries = m_storage.heapEntries;
+        m_storage.hashedData.entries = allocateAndInitializeStorage(m_capacity);
+        m_storage.hashedData.deletedCount = other.m_storage.hashedData.deletedCount;
+        Entry* srcEntries = other.m_storage.hashedData.entries;
+        Entry* destEntries = m_storage.hashedData.entries;
 
         for (unsigned i = 0; i < m_capacity; ++i) {
             if (isEmptyEntry(srcEntries[i]))
@@ -132,14 +133,14 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
     ~InlineMap()
     {
-        if (isInline()) {
+        if (isInline())
             std::destroy_n(inlineStorage(), m_size);
-        } else if (m_storage.heapEntries) {
+        else {
             for (unsigned i = 0; i < m_capacity; ++i) {
-                if (!isEmptyOrDeletedEntry(m_storage.heapEntries[i]))
-                    std::destroy_at(&m_storage.heapEntries[i]);
+                if (!isEmptyOrDeletedEntry(m_storage.hashedData.entries[i]))
+                    std::destroy_at(&m_storage.hashedData.entries[i]);
             }
-            FastMalloc::free(m_storage.heapEntries);
+            FastMalloc::free(m_storage.hashedData.entries);
         }
     }
 
@@ -242,8 +243,8 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
             transitionToHashed();
         }
 
-        if (m_size * loadFactorDenominator >= m_capacity * loadFactorNumerator) [[unlikely]]
-            grow();
+        if ((m_size + deletedCount()) * loadFactorDenominator >= m_capacity * loadFactorNumerator) [[unlikely]]
+            expand();
 
         Entry* end = entriesEnd();
         Entry* slot = findKeyOrEmptyOrDeleted(key);
@@ -251,6 +252,8 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
             return { iterator { slot, end }, false };
 
         // Slot is either empty or deleted - we can insert here
+        if (isDeletedEntry(*slot))
+            decrementDeletedCount();
         std::construct_at(slot, std::forward<K>(key), std::forward<V>(value));
         ++m_size;
         return { iterator { slot, end }, true };
@@ -291,7 +294,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         }
 
         Entry* slot = findKeyOrEmpty(key);
-        Entry* end = m_storage.heapEntries + m_capacity;
+        Entry* end = m_storage.hashedData.entries + m_capacity;
         if (isEmptyOrDeletedEntry(*slot))
             return iterator { end, end };
         return iterator { slot, end };
@@ -335,7 +338,12 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
         std::destroy_at(slot);
         constructDeletedEntry(*slot);
+        incrementDeletedCount();
         --m_size;
+
+        if (shouldShrink())
+            shrink();
+
         return true;
     }
 
@@ -384,26 +392,23 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
     void clear()
     {
-        if (!m_size)
-            return;
-
-        Entry* entryStorage = entries();
-        if (isInline())
-            std::destroy_n(entryStorage, m_size);
-        else {
-            for (unsigned i = 0; i < m_capacity; ++i) {
-                if (isEmptyEntry(entryStorage[i]))
-                    continue;
-                if constexpr (EntryTraits::emptyValueIsZero) {
-                    // If emptyValueIsZero, deleted entries don't have live values and shouldn't be destroyed
-                    if (!isDeletedEntry(entryStorage[i]))
-                        std::destroy_at(&entryStorage[i]);
-                } else
-                    std::destroy_at(&entryStorage[i]);
-                constructEmptyEntry(entryStorage[i]);
+        if (isInline()) {
+            if (m_size) {
+                std::destroy_n(inlineStorage(), m_size);
+                m_size = 0;
             }
+            return;
         }
+
+        // Hashed mode: destroy live entries, free heap, transition to inline
+        Entry* entryStorage = m_storage.hashedData.entries;
+        for (unsigned i = 0; i < m_capacity; ++i) {
+            if (!isEmptyOrDeletedEntry(entryStorage[i]))
+                std::destroy_at(&entryStorage[i]);
+        }
+        FastMalloc::free(entryStorage);
         m_size = 0;
+        m_capacity = InlineCapacity;
     }
 
     ALWAYS_INLINE void swap(InlineMap& other)
@@ -423,7 +428,8 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
         unsigned capacity = roundUpToPowerOfTwo(keyCount * loadFactorDenominator / loadFactorNumerator + 1);
         m_capacity = capacity;
-        m_storage.heapEntries = allocateAndInitializeStorage(capacity);
+        m_storage.hashedData.entries = allocateAndInitializeStorage(capacity);
+        m_storage.hashedData.deletedCount = 0;
     }
 
 private:
@@ -443,12 +449,12 @@ private:
 
     ALWAYS_INLINE Entry* entries()
     {
-        return isInline() ? inlineStorage() : m_storage.heapEntries;
+        return isInline() ? inlineStorage() : m_storage.hashedData.entries;
     }
 
     ALWAYS_INLINE const Entry* entries() const
     {
-        return isInline() ? inlineStorage() : m_storage.heapEntries;
+        return isInline() ? inlineStorage() : m_storage.hashedData.entries;
     }
 
     ALWAYS_INLINE Entry* entriesEnd()
@@ -519,6 +525,38 @@ private:
 
     static constexpr unsigned loadFactorNumerator = 3;
     static constexpr unsigned loadFactorDenominator = 4;
+    static constexpr unsigned minLoadInverse = 6;
+
+    ALWAYS_INLINE unsigned deletedCount() const
+    {
+        ASSERT(!isInline());
+        return m_storage.hashedData.deletedCount;
+    }
+
+    ALWAYS_INLINE void incrementDeletedCount()
+    {
+        ASSERT(!isInline());
+        ++m_storage.hashedData.deletedCount;
+    }
+
+    ALWAYS_INLINE void decrementDeletedCount()
+    {
+        ASSERT(!isInline());
+        ASSERT(m_storage.hashedData.deletedCount);
+        --m_storage.hashedData.deletedCount;
+    }
+
+    bool shouldShrink() const
+    {
+        ASSERT(!isInline());
+        return m_size * minLoadInverse < m_capacity;
+    }
+
+    bool shouldCompactOnly() const
+    {
+        ASSERT(!isInline());
+        return m_size * minLoadInverse < m_capacity * 2;
+    }
 
     ALWAYS_INLINE static Entry* allocateAndInitializeStorage(unsigned capacity)
     {
@@ -549,7 +587,8 @@ private:
 
         Entry* toFree = wasInline ? nullptr : oldEntries;
         m_capacity = newCapacity;
-        m_storage.heapEntries = newEntries;
+        m_storage.hashedData.entries = newEntries;
+        m_storage.hashedData.deletedCount = 0;
         if (toFree)
             FastMalloc::free(toFree);
     }
@@ -560,10 +599,45 @@ private:
         rehashTo(roundUpToPowerOfTwo(m_size * 2 * loadFactorDenominator / loadFactorNumerator));
     }
 
-    void grow()
+    void expand()
     {
         ASSERT(!isInline());
-        rehashTo(m_capacity * 2);
+        if (shouldCompactOnly())
+            rehashTo(m_capacity);
+        else
+            rehashTo(m_capacity * 2);
+    }
+
+    void shrink()
+    {
+        ASSERT(!isInline());
+        if (m_size <= InlineCapacity) {
+            transitionToInline();
+            return;
+        }
+        rehashTo(m_capacity / 2);
+    }
+
+    void transitionToInline()
+    {
+        ASSERT(!isInline());
+        ASSERT(m_size <= InlineCapacity);
+
+        Entry* oldEntries = m_storage.hashedData.entries;
+        unsigned oldCapacity = m_capacity;
+
+        m_capacity = InlineCapacity;
+
+        unsigned insertIndex = 0;
+        for (unsigned i = 0; i < oldCapacity; ++i) {
+            if (!isEmptyOrDeletedEntry(oldEntries[i])) {
+                std::construct_at(&inlineStorage()[insertIndex], WTF::move(oldEntries[i]));
+                ++insertIndex;
+            }
+        }
+        ASSERT(insertIndex == m_size);
+
+        FastMalloc::free(oldEntries);
     }
 
     template<typename K>
@@ -593,7 +667,7 @@ private:
     Entry* findKeyOrEmpty(const K& key) const
     {
         ASSERT(!isInline());
-        return findKeyOrEmptyInStorage(key, m_storage.heapEntries, m_capacity);
+        return findKeyOrEmptyInStorage(key, m_storage.hashedData.entries, m_capacity);
     }
 
     Entry* findKeyOrEmptyOrDeleted(const KeyType& key) const
@@ -601,7 +675,7 @@ private:
         ASSERT(!isInline());
         ASSERT(isPowerOfTwo(m_capacity));
 
-        Entry* data = m_storage.heapEntries;
+        Entry* data = m_storage.hashedData.entries;
         unsigned hash = HashArg::hash(key);
         unsigned mask = m_capacity - 1;
         unsigned bucket = hash & mask;
@@ -630,8 +704,12 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         struct alignas(Entry) EntryBytes {
             std::byte data[sizeof(Entry)];
         };
+        struct HashedModeData {
+            Entry* entries;
+            unsigned deletedCount;
+        };
         std::array<EntryBytes, InlineCapacity> inlineEntries;
-        Entry* heapEntries;
+        HashedModeData hashedData;
     } m_storage;
 };
 
@@ -647,6 +725,12 @@ public:
     static unsigned capacity(InlineMap<KeyArg, ValueArg, InlineCapacity, HashArg, KeyTraitsArg, MappedTraitsArg>& map)
     {
         return map.m_capacity;
+    }
+
+    template<typename KeyArg, typename ValueArg, unsigned InlineCapacity, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg>
+    static unsigned deletedCount(InlineMap<KeyArg, ValueArg, InlineCapacity, HashArg, KeyTraitsArg, MappedTraitsArg>& map)
+    {
+        return map.deletedCount();
     }
 };
 

--- a/Tools/TestWebKitAPI/Tests/WTF/InlineMap.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/InlineMap.cpp
@@ -101,7 +101,7 @@ TEST(WTF_InlineMap, StorageModeTransitions)
     // New map starts empty
     EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
 
-    // First add transitions to linear mode
+    // First add stays in linear mode
     map.add(1, 10);
     EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
 
@@ -1120,7 +1120,7 @@ TEST(WTF_InlineMap, ClearLinearMode)
 
 TEST(WTF_InlineMap, ClearHashedMode)
 {
-    // Clearing in hashed mode removes entries but preserves hashed storage.
+    // Clearing in hashed mode frees heap storage and transitions back to inline.
     InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
 
     for (unsigned i = 1; i <= 20; ++i)
@@ -1131,19 +1131,24 @@ TEST(WTF_InlineMap, ClearHashedMode)
 
     map.clear();
 
-    // Storage is preserved, just cleared
-    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+    // Should transition back to inline
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
     EXPECT_TRUE(map.isEmpty());
     EXPECT_EQ(map.size(), 0u);
 
     // Should be able to add entries again after clear
-    for (unsigned i = 100; i <= 105; ++i)
+    for (unsigned i = 100; i <= 104; ++i)
         map.add(i, i);
 
-    EXPECT_EQ(map.size(), 6u);
-    for (unsigned i = 100; i <= 105; ++i)
+    EXPECT_EQ(map.size(), 5u);
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+    for (unsigned i = 100; i <= 104; ++i)
         EXPECT_TRUE(map.contains(i));
     EXPECT_FALSE(map.contains(1));
+
+    // Adding one more should transition to hashed
+    map.add(105, 105);
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
 }
 
 TEST(WTF_InlineMap, ClearWithStrings)
@@ -1785,26 +1790,25 @@ TEST(WTF_InlineMap, SwapInlineAndHashed)
 
 TEST(WTF_InlineMap, ClearThenGrow)
 {
-    // A cleared map can grow beyond its original capacity.
+    // A cleared map transitions to inline and can grow back to hashed.
     InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
 
     for (unsigned i = 1; i <= 20; ++i)
         map.add(i, i * 10);
 
     EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
-    unsigned capacityAfterFirstGrowth = WTF::InlineMapAccessForTesting::capacity(map);
 
     map.clear();
 
     EXPECT_TRUE(map.isEmpty());
-    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map)); // Storage preserved
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
 
-    // Add enough entries to trigger growth beyond the cleared capacity
+    // Add enough entries to trigger growth back to hashed
     for (unsigned i = 1; i <= 100; ++i)
         map.add(i, i + 100);
 
     EXPECT_EQ(map.size(), 100u);
-    EXPECT_GT(WTF::InlineMapAccessForTesting::capacity(map), capacityAfterFirstGrowth);
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
 
     for (unsigned i = 1; i <= 100; ++i) {
         EXPECT_TRUE(map.contains(i));
@@ -1814,7 +1818,7 @@ TEST(WTF_InlineMap, ClearThenGrow)
 
 TEST(WTF_InlineMap, CopyWithDeletedEntries)
 {
-    // Copying a map with deleted tombstones produces a clean copy without them.
+    // Copying a map with deleted tombstones preserves them in the copy.
     InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map1;
 
     for (unsigned i = 1; i <= 20; ++i)
@@ -1870,6 +1874,705 @@ TEST(WTF_InlineMap, RemoveLastInlineEntry)
     EXPECT_EQ(map.size(), 1u);
     EXPECT_TRUE(map.contains(99));
     EXPECT_EQ(map.find(99)->value, 990u);
+}
+
+// --- Shrink / deleted-count / transition-back-to-inline tests ---
+
+TEST(WTF_InlineMap, ShrinkAfterRemovalTransitionsToInline)
+{
+    // Removing enough entries from hashed mode triggers shrink back to inline.
+    // With InlineCapacity=5, adding 20 entries gives capacity=32.
+    // Shrink triggers when m_size * 6 < capacity. At capacity=32, that's m_size < 5.33.
+    // Since m_size=5 <= InlineCapacity=5, we transition to inline.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    for (unsigned i = 1; i <= 20; ++i)
+        map.add(i, i * 10);
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+    EXPECT_EQ(map.size(), 20u);
+
+    // Remove entries 6 through 20, leaving keys 1-5
+    for (unsigned i = 6; i <= 20; ++i)
+        EXPECT_TRUE(map.remove(i));
+
+    EXPECT_EQ(map.size(), 5u);
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    // All remaining entries should be accessible
+    for (unsigned i = 1; i <= 5; ++i) {
+        EXPECT_TRUE(map.contains(i));
+        EXPECT_EQ(map.find(i)->value, i * 10);
+    }
+    for (unsigned i = 6; i <= 20; ++i)
+        EXPECT_FALSE(map.contains(i));
+}
+
+TEST(WTF_InlineMap, ShrinkAfterRemovalReducesCapacity)
+{
+    // Removing entries reduces capacity but stays hashed when size > InlineCapacity.
+    // With InlineCapacity=3, adding 100 entries gives capacity=256.
+    // Remove down to 10 entries: should shrink but remain hashed since 10 > 3.
+    InlineMap<unsigned, unsigned, 3, IntHash<unsigned>> map;
+
+    for (unsigned i = 1; i <= 100; ++i)
+        map.add(i, i * 10);
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+    unsigned originalCapacity = WTF::InlineMapAccessForTesting::capacity(map);
+
+    // Remove entries, keeping 1-10
+    for (unsigned i = 11; i <= 100; ++i)
+        EXPECT_TRUE(map.remove(i));
+
+    EXPECT_EQ(map.size(), 10u);
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+    EXPECT_LT(WTF::InlineMapAccessForTesting::capacity(map), originalCapacity);
+
+    for (unsigned i = 1; i <= 10; ++i) {
+        EXPECT_TRUE(map.contains(i));
+        EXPECT_EQ(map.find(i)->value, i * 10);
+    }
+}
+
+TEST(WTF_InlineMap, DeletedCountTracking)
+{
+    // Deleted count is incremented on remove and decremented when a deleted slot is reused.
+    InlineMap<unsigned, unsigned, 3, IntHash<unsigned>> map;
+
+    // Go to hashed mode
+    for (unsigned i = 1; i <= 10; ++i)
+        map.add(i, i * 10);
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+    EXPECT_EQ(WTF::InlineMapAccessForTesting::deletedCount(map), 0u);
+
+    // Remove 2 entries (these won't trigger shrink since 8*6=48 is not < 16)
+    EXPECT_TRUE(map.remove(1));
+    EXPECT_TRUE(map.remove(2));
+    EXPECT_EQ(map.size(), 8u);
+    EXPECT_EQ(WTF::InlineMapAccessForTesting::deletedCount(map), 2u);
+
+    // Re-add one of the removed keys — should reuse a deleted slot
+    auto result = map.add(1, 100);
+    EXPECT_TRUE(result.isNewEntry);
+    EXPECT_EQ(WTF::InlineMapAccessForTesting::deletedCount(map), 1u);
+    EXPECT_EQ(map.size(), 9u);
+}
+
+TEST(WTF_InlineMap, DeletedCountResetAfterRehash)
+{
+    // Deleted count resets to 0 after a rehash triggered by expansion.
+    InlineMap<unsigned, unsigned, 3, IntHash<unsigned>> map;
+
+    for (unsigned i = 1; i <= 10; ++i)
+        map.add(i, i * 10);
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    // Remove a couple entries to build up deleted count
+    map.remove(1);
+    map.remove(2);
+    EXPECT_EQ(WTF::InlineMapAccessForTesting::deletedCount(map), 2u);
+
+    // Add enough new entries to trigger expansion
+    // Current: m_size=8, deletedCount=2, capacity=16
+    // Expansion triggers when (8+2)*4 >= 16*3 -> 40 >= 48 -> false
+    // After adding 4 more: m_size=12, deletedCount=2 -> (12+2)*4 = 56 >= 48 -> true
+    for (unsigned i = 11; i <= 14; ++i)
+        map.add(i, i * 10);
+
+    // After expansion, deleted count should be 0
+    EXPECT_EQ(WTF::InlineMapAccessForTesting::deletedCount(map), 0u);
+
+    // All live entries should be accessible
+    EXPECT_FALSE(map.contains(1));
+    EXPECT_FALSE(map.contains(2));
+    for (unsigned i = 3; i <= 14; ++i) {
+        EXPECT_TRUE(map.contains(i));
+        EXPECT_EQ(map.find(i)->value, i * 10);
+    }
+}
+
+TEST(WTF_InlineMap, CompactOnlyWhenManyDeleted)
+{
+    // When many entries are deleted and new (non-reusable) keys are added,
+    // the expansion check triggers. If shouldCompactOnly is true, the table
+    // rehashes at the same capacity rather than doubling.
+    InlineMap<unsigned, unsigned, 3, IntHash<unsigned>> map;
+
+    // Build a larger table: add 24 entries to get capacity=32
+    // (transitions: 4→cap8, 6→cap16, 12→cap32)
+    for (unsigned i = 1; i <= 24; ++i)
+        map.add(i, i * 10);
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+    EXPECT_EQ(WTF::InlineMapAccessForTesting::capacity(map), 32u);
+
+    // Remove 20 entries, keeping only 4 live entries (keys 21-24).
+    // shouldShrink: 4*6=24 < 32? Yes — but shrink happens one removal at a time.
+    // At m_size=5: 5*6=30 < 32 → shrink to 16. deletedCount resets to 0.
+    // Then at m_size=4 in cap=16: 4*6=24 not < 16 → no further shrink.
+    for (unsigned i = 1; i <= 20; ++i)
+        map.remove(i);
+
+    // After shrinks, we should be at capacity=16 with 4 live entries.
+    EXPECT_EQ(map.size(), 4u);
+
+    // Now create deleted entries without triggering shrink.
+    // Add 8 more entries (keys 25-32) to get m_size=12 at some capacity,
+    // then remove 6 of them.
+    for (unsigned i = 25; i <= 32; ++i)
+        map.add(i, i * 10);
+
+    // Remove 6 entries without hitting shrink threshold
+    for (unsigned i = 25; i <= 30; ++i)
+        map.remove(i);
+
+    // Now we have 6 live entries and 6 deleted entries.
+    EXPECT_EQ(map.size(), 6u);
+    unsigned currentCapacity = WTF::InlineMapAccessForTesting::capacity(map);
+
+    // Add new keys (that won't match any deleted slot's key) until expansion triggers.
+    // Expansion triggers when (m_size + deletedCount) * 4 >= capacity * 3.
+    // Each add of a new key into an empty slot: m_size++, deletedCount unchanged, sum increases.
+    // Each add into a deleted slot: m_size++, deletedCount--, sum unchanged.
+    // We keep adding until expansion happens.
+    unsigned nextKey = 100;
+    while (WTF::InlineMapAccessForTesting::capacity(map) == currentCapacity) {
+        map.add(nextKey, nextKey * 10);
+        ++nextKey;
+    }
+
+    // After expansion, deletedCount should be 0
+    EXPECT_EQ(WTF::InlineMapAccessForTesting::deletedCount(map), 0u);
+
+    // All live entries should be accessible
+    for (unsigned i = 21; i <= 24; ++i)
+        EXPECT_TRUE(map.contains(i));
+    for (unsigned i = 31; i <= 32; ++i)
+        EXPECT_TRUE(map.contains(i));
+}
+
+TEST(WTF_InlineMap, ClearTransitionsToInline)
+{
+    // Clearing a hashed-mode map transitions back to inline mode.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    for (unsigned i = 1; i <= 20; ++i)
+        map.add(i, i * 10);
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    map.clear();
+
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+    EXPECT_TRUE(map.isEmpty());
+    EXPECT_EQ(map.size(), 0u);
+
+    // Re-adding entries should work with normal inline→hashed lifecycle
+    for (unsigned i = 1; i <= 5; ++i) {
+        map.add(i, i);
+        EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+    }
+
+    map.add(6, 6);
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+}
+
+TEST(WTF_InlineMap, ClearEmptyHashedTransitionsToInline)
+{
+    // Clearing an empty hashed-mode map (from reserveInitialCapacity) transitions to inline.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    map.reserveInitialCapacity(20);
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+    EXPECT_TRUE(map.isEmpty());
+
+    map.clear();
+
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+    EXPECT_TRUE(map.isEmpty());
+
+    // Should be usable as a fresh map
+    map.add(1, 10);
+    EXPECT_EQ(map.size(), 1u);
+    EXPECT_TRUE(map.contains(1));
+}
+
+TEST(WTF_InlineMap, ShrinkToInlineWithStrings)
+{
+    // Shrink-to-inline transition works with String keys.
+    InlineMap<String, unsigned, 5, StringHash> map;
+
+    for (unsigned i = 1; i <= 20; ++i)
+        map.add(makeString("key"_s, i), i);
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    // Remove entries, keeping only 5
+    for (unsigned i = 6; i <= 20; ++i)
+        EXPECT_TRUE(map.remove(makeString("key"_s, i)));
+
+    EXPECT_EQ(map.size(), 5u);
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    // Verify remaining entries
+    for (unsigned i = 1; i <= 5; ++i) {
+        auto key = makeString("key"_s, i);
+        EXPECT_TRUE(map.contains(key));
+        EXPECT_EQ(map.find(key)->value, i);
+    }
+}
+
+TEST(WTF_InlineMap, ShrinkPreservesDataIntegrity)
+{
+    // Exact key-value pairs survive the hashed→inline transition, and the map
+    // can grow back to hashed afterwards.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    for (unsigned i = 1; i <= 50; ++i)
+        map.add(i, i * 100);
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    // Remove all but keys 10, 20, 30, 40, 50
+    for (unsigned i = 1; i <= 50; ++i) {
+        if (i % 10)
+            map.remove(i);
+    }
+
+    EXPECT_EQ(map.size(), 5u);
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    // Verify exact key-value pairs
+    EXPECT_EQ(map.find(10)->value, 1000u);
+    EXPECT_EQ(map.find(20)->value, 2000u);
+    EXPECT_EQ(map.find(30)->value, 3000u);
+    EXPECT_EQ(map.find(40)->value, 4000u);
+    EXPECT_EQ(map.find(50)->value, 5000u);
+
+    // Grow back to hashed
+    for (unsigned i = 51; i <= 60; ++i)
+        map.add(i, i * 100);
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+    EXPECT_EQ(map.size(), 15u);
+
+    // Original entries still accessible
+    EXPECT_EQ(map.find(10)->value, 1000u);
+    EXPECT_EQ(map.find(50)->value, 5000u);
+}
+
+TEST(WTF_InlineMap, RepeatedGrowShrinkCycles)
+{
+    // Multiple cycles of grow-to-hashed then shrink-to-inline work correctly.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+    unsigned nextKey = 1;
+
+    for (int cycle = 0; cycle < 3; ++cycle) {
+        // Add 20 entries to go hashed
+        unsigned firstKey = nextKey;
+        for (unsigned i = 0; i < 20; ++i) {
+            map.add(nextKey, nextKey * 10);
+            ++nextKey;
+        }
+
+        EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+
+        // Remove all but 2 entries from this batch
+        for (unsigned i = firstKey; i < firstKey + 18; ++i)
+            map.remove(i);
+
+        // Verify the map is inline if small enough, and the remaining entries are correct
+        if (map.size() <= 5)
+            EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+        unsigned remaining1 = firstKey + 18;
+        unsigned remaining2 = firstKey + 19;
+        EXPECT_TRUE(map.contains(remaining1));
+        EXPECT_TRUE(map.contains(remaining2));
+    }
+
+    // After 3 cycles, we have 6 entries (2 per cycle)
+    EXPECT_EQ(map.size(), 6u);
+}
+
+TEST(WTF_InlineMap, RemoveAllOneByOneTriggersShrink)
+{
+    // Removing all entries one by one eventually transitions back to inline.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    for (unsigned i = 1; i <= 20; ++i)
+        map.add(i, i * 10);
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    bool becameInline = false;
+    for (unsigned i = 1; i <= 20; ++i) {
+        EXPECT_TRUE(map.remove(i));
+        if (!becameInline && WTF::InlineMapAccessForTesting::isInline(map))
+            becameInline = true;
+    }
+
+    EXPECT_TRUE(becameInline);
+    EXPECT_TRUE(map.isEmpty());
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+}
+
+TEST(WTF_InlineMap, DeletedCountWithCollisions)
+{
+    // Deleted count tracking works correctly under hash collisions.
+    InlineMap<unsigned, unsigned, 5, ZeroHash<unsigned>> map;
+
+    // All entries hash to bucket 0
+    for (unsigned i = 1; i <= 10; ++i)
+        map.add(i, i * 10);
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+    EXPECT_EQ(WTF::InlineMapAccessForTesting::deletedCount(map), 0u);
+
+    // Remove 3 entries
+    map.remove(3);
+    map.remove(5);
+    map.remove(7);
+    EXPECT_EQ(WTF::InlineMapAccessForTesting::deletedCount(map), 3u);
+    EXPECT_EQ(map.size(), 7u);
+
+    // Re-add one of them — should reuse a deleted slot and decrement deletedCount
+    map.add(3, 300);
+    EXPECT_EQ(WTF::InlineMapAccessForTesting::deletedCount(map), 2u);
+    EXPECT_EQ(map.size(), 8u);
+    EXPECT_EQ(map.find(3)->value, 300u);
+
+    // All remaining entries accessible
+    for (unsigned i = 1; i <= 10; ++i) {
+        if (i == 5 || i == 7)
+            EXPECT_FALSE(map.contains(i));
+        else
+            EXPECT_TRUE(map.contains(i));
+    }
+}
+
+TEST(WTF_InlineMap, ExpandWithDeletedEntriesPreservesData)
+{
+    // Expansion triggered by deleted entries filling the table preserves all live data.
+    // We add entries until expansion triggers, then verify everything is intact.
+    InlineMap<unsigned, unsigned, 3, IntHash<unsigned>> map;
+
+    // Build up a table then create deleted entries
+    for (unsigned i = 1; i <= 10; ++i)
+        map.add(i, i * 10);
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    // Remove entries but stay above shrink threshold
+    map.remove(1);
+    map.remove(2);
+    map.remove(3);
+    map.remove(4);
+    // m_size=6, some deletedCount, some capacity
+    EXPECT_EQ(map.size(), 6u);
+
+    unsigned capacityBefore = WTF::InlineMapAccessForTesting::capacity(map);
+
+    // Add new keys until expansion triggers (capacity changes)
+    unsigned nextKey = 100;
+    while (WTF::InlineMapAccessForTesting::capacity(map) == capacityBefore) {
+        map.add(nextKey, nextKey * 10);
+        ++nextKey;
+    }
+
+    // After expansion, deleted count should be 0
+    EXPECT_EQ(WTF::InlineMapAccessForTesting::deletedCount(map), 0u);
+
+    // All live entries preserved
+    for (unsigned i = 5; i <= 10; ++i) {
+        EXPECT_TRUE(map.contains(i));
+        EXPECT_EQ(map.find(i)->value, i * 10);
+    }
+    for (unsigned i = 100; i < nextKey; ++i) {
+        EXPECT_TRUE(map.contains(i));
+        EXPECT_EQ(map.find(i)->value, i * 10);
+    }
+    for (unsigned i = 1; i <= 4; ++i)
+        EXPECT_FALSE(map.contains(i));
+}
+
+TEST(WTF_InlineMap, MoveConstructionPreservesDeletedCount)
+{
+    // Move-constructing from a hashed map with deleted entries transfers deletedCount.
+    InlineMap<unsigned, unsigned, 3, IntHash<unsigned>> map1;
+
+    for (unsigned i = 1; i <= 10; ++i)
+        map1.add(i, i * 10);
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map1));
+
+    // Remove entries without triggering shrink
+    map1.remove(1);
+    map1.remove(2);
+    EXPECT_EQ(WTF::InlineMapAccessForTesting::deletedCount(map1), 2u);
+
+    InlineMap<unsigned, unsigned, 3, IntHash<unsigned>> map2(WTF::move(map1));
+
+    EXPECT_TRUE(map1.isEmpty());
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map1));
+
+    EXPECT_EQ(map2.size(), 8u);
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map2));
+    EXPECT_EQ(WTF::InlineMapAccessForTesting::deletedCount(map2), 2u);
+
+    for (unsigned i = 3; i <= 10; ++i) {
+        EXPECT_TRUE(map2.contains(i));
+        EXPECT_EQ(map2.find(i)->value, i * 10);
+    }
+}
+
+TEST(WTF_InlineMap, CopyConstructionPreservesDeletedCount)
+{
+    // Copy-constructing from a hashed map with deleted entries preserves deletedCount.
+    InlineMap<unsigned, unsigned, 3, IntHash<unsigned>> map1;
+
+    for (unsigned i = 1; i <= 10; ++i)
+        map1.add(i, i * 10);
+
+    map1.remove(1);
+    map1.remove(2);
+    EXPECT_EQ(WTF::InlineMapAccessForTesting::deletedCount(map1), 2u);
+
+    InlineMap<unsigned, unsigned, 3, IntHash<unsigned>> map2(map1);
+
+    // Both maps should have same state
+    EXPECT_EQ(map1.size(), 8u);
+    EXPECT_EQ(map2.size(), 8u);
+    EXPECT_EQ(WTF::InlineMapAccessForTesting::deletedCount(map1), 2u);
+    EXPECT_EQ(WTF::InlineMapAccessForTesting::deletedCount(map2), 2u);
+
+    // Both maps should have the same entries
+    for (unsigned i = 3; i <= 10; ++i) {
+        EXPECT_TRUE(map1.contains(i));
+        EXPECT_TRUE(map2.contains(i));
+        EXPECT_EQ(map1.find(i)->value, i * 10);
+        EXPECT_EQ(map2.find(i)->value, i * 10);
+    }
+    EXPECT_FALSE(map1.contains(1));
+    EXPECT_FALSE(map2.contains(1));
+}
+
+TEST(WTF_InlineMap, ShrinkWithMoveOnlyValues)
+{
+    // Move-only values survive the hashed→inline transition.
+    InlineMap<unsigned, MoveOnly, 5, IntHash<unsigned>> map;
+
+    for (unsigned i = 1; i <= 20; ++i)
+        map.add(i, MoveOnly(i));
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    // Remove entries, keeping 1-4
+    for (unsigned i = 5; i <= 20; ++i)
+        map.remove(i);
+
+    EXPECT_EQ(map.size(), 4u);
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    for (unsigned i = 1; i <= 4; ++i) {
+        auto it = map.find(i);
+        ASSERT_FALSE(it == map.end());
+        EXPECT_EQ(it->value.value(), i);
+    }
+}
+
+TEST(WTF_InlineMap, ShrinkDoesNotHappenAboveThreshold)
+{
+    // Removing entries that keep the load above 1/6 does not trigger shrink.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    for (unsigned i = 1; i <= 20; ++i)
+        map.add(i, i * 10);
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+    unsigned capacityBefore = WTF::InlineMapAccessForTesting::capacity(map);
+
+    // With capacity=32, shrink triggers when m_size * 6 < 32, i.e., m_size < 5.33
+    // Removing down to m_size=6 should NOT trigger shrink (6*6=36 >= 32)
+    for (unsigned i = 7; i <= 20; ++i)
+        EXPECT_TRUE(map.remove(i));
+
+    EXPECT_EQ(map.size(), 6u);
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+    EXPECT_EQ(WTF::InlineMapAccessForTesting::capacity(map), capacityBefore);
+    EXPECT_EQ(WTF::InlineMapAccessForTesting::deletedCount(map), 14u);
+
+    // All remaining entries accessible
+    for (unsigned i = 1; i <= 6; ++i) {
+        EXPECT_TRUE(map.contains(i));
+        EXPECT_EQ(map.find(i)->value, i * 10);
+    }
+}
+
+TEST(WTF_InlineMap, ClearHashedMapWithDeletedEntries)
+{
+    // clear() on a hashed map with nonzero deletedCount transitions to inline.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    for (unsigned i = 1; i <= 20; ++i)
+        map.add(i, i * 10);
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    // Remove some entries to build up deletedCount
+    map.remove(3);
+    map.remove(7);
+    map.remove(11);
+    EXPECT_EQ(WTF::InlineMapAccessForTesting::deletedCount(map), 3u);
+    EXPECT_EQ(map.size(), 17u);
+
+    map.clear();
+    EXPECT_TRUE(map.isEmpty());
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    // Re-adding entries works normally
+    for (unsigned i = 1; i <= 10; ++i)
+        map.add(i, i * 100);
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+    EXPECT_EQ(map.size(), 10u);
+    for (unsigned i = 1; i <= 10; ++i)
+        EXPECT_EQ(map.find(i)->value, i * 100);
+}
+
+TEST(WTF_InlineMap, CopyAfterShrinkToInline)
+{
+    // Copy and move construction work correctly after a hashed→inline shrink.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    for (unsigned i = 1; i <= 20; ++i)
+        map.add(i, i * 10);
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    // Remove down to 5 entries, triggering shrink to inline
+    for (unsigned i = 6; i <= 20; ++i)
+        map.remove(i);
+
+    EXPECT_EQ(map.size(), 5u);
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    // Copy-construct from the shrunk inline map
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> mapCopy(map);
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(mapCopy));
+    EXPECT_EQ(mapCopy.size(), 5u);
+    for (unsigned i = 1; i <= 5; ++i) {
+        EXPECT_TRUE(mapCopy.contains(i));
+        EXPECT_EQ(mapCopy.find(i)->value, i * 10);
+    }
+
+    // Original still intact
+    for (unsigned i = 1; i <= 5; ++i) {
+        EXPECT_TRUE(map.contains(i));
+        EXPECT_EQ(map.find(i)->value, i * 10);
+    }
+
+    // Move-construct from the shrunk inline map
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> mapMoved(WTF::move(map));
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(mapMoved));
+    EXPECT_EQ(mapMoved.size(), 5u);
+    for (unsigned i = 1; i <= 5; ++i) {
+        EXPECT_TRUE(mapMoved.contains(i));
+        EXPECT_EQ(mapMoved.find(i)->value, i * 10);
+    }
+
+    EXPECT_TRUE(map.isEmpty());
+}
+
+TEST(WTF_InlineMap, IterationAfterShrinkToInline)
+{
+    // Range-for iteration works correctly after hashed→inline shrink.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    for (unsigned i = 1; i <= 20; ++i)
+        map.add(i, i * 10);
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    // Remove down to 4 entries (keys 1-4 survive)
+    for (unsigned i = 5; i <= 20; ++i)
+        map.remove(i);
+
+    EXPECT_EQ(map.size(), 4u);
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    // Iterate and collect all entries
+    HashSet<unsigned> seenKeys;
+    unsigned total = 0;
+    for (auto& entry : map) {
+        EXPECT_TRUE(entry.key >= 1 && entry.key <= 4);
+        EXPECT_EQ(entry.value, entry.key * 10);
+        seenKeys.add(entry.key);
+        ++total;
+    }
+
+    EXPECT_EQ(total, 4u);
+    for (unsigned i = 1; i <= 4; ++i)
+        EXPECT_TRUE(seenKeys.contains(i));
+}
+
+TEST(WTF_InlineMap, MustRehashInPlacePathDirect)
+{
+    // Directly tests the mustRehashInPlace() path: many deleted entries cause
+    // expand() to rehash in place (same capacity) rather than doubling.
+    InlineMap<unsigned, unsigned, 3, IntHash<unsigned>> map;
+
+    // Add enough entries to get a known capacity
+    for (unsigned i = 1; i <= 20; ++i)
+        map.add(i, i * 10);
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+    unsigned initialCapacity = WTF::InlineMapAccessForTesting::capacity(map);
+
+    // Remove entries to create many deleted slots.
+    // Keep enough live entries that shouldShrink() is false but mustRehashInPlace() is true.
+    // shouldShrink: m_size * 6 < capacity  => false when m_size >= capacity/6
+    // mustRehashInPlace: m_size * 6 < capacity * 2  => true when m_size < capacity/3
+    // So we need capacity/6 <= m_size < capacity/3.
+    // With capacity=32: we need 6 <= m_size < 11.
+    unsigned targetSize = initialCapacity / 4; // safely between capacity/6 and capacity/3
+    if (targetSize < initialCapacity / 6 + 1)
+        targetSize = initialCapacity / 6 + 1;
+
+    for (unsigned i = targetSize + 1; i <= 20; ++i)
+        map.remove(i);
+
+    EXPECT_EQ(map.size(), targetSize);
+    unsigned capacityAfterRemoves = WTF::InlineMapAccessForTesting::capacity(map);
+    unsigned deletedAfterRemoves = WTF::InlineMapAccessForTesting::deletedCount(map);
+    EXPECT_GT(deletedAfterRemoves, 0u);
+
+    // Now add new unique keys until expansion triggers.
+    // Because (m_size + deletedCount) * 4 >= capacity * 3, the expansion check fires.
+    // Since mustRehashInPlace() is true, it should rehash to the same capacity.
+    unsigned nextKey = 1000;
+    while (WTF::InlineMapAccessForTesting::capacity(map) == capacityAfterRemoves
+        && WTF::InlineMapAccessForTesting::deletedCount(map) > 0) {
+        map.add(nextKey, nextKey * 10);
+        ++nextKey;
+    }
+
+    // Either capacity stayed the same (rehash in place reclaimed deleted slots)
+    // or if all deleted slots were reused before expansion, deletedCount hit 0.
+    // In either case, deletedCount should be 0 after rehash.
+    EXPECT_EQ(WTF::InlineMapAccessForTesting::deletedCount(map), 0u);
+
+    // Verify all live entries are accessible
+    for (unsigned i = 1; i <= targetSize; ++i) {
+        EXPECT_TRUE(map.contains(i));
+        EXPECT_EQ(map.find(i)->value, i * 10);
+    }
+    for (unsigned i = 1000; i < nextKey; ++i) {
+        EXPECT_TRUE(map.contains(i));
+        EXPECT_EQ(map.find(i)->value, i * 10);
+    }
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 82c4913a2116d0321bed425dfae637f402000fa0
<pre>
[JSC] Improve the removal logic in InlineMap
<a href="https://bugs.webkit.org/show_bug.cgi?id=310928">https://bugs.webkit.org/show_bug.cgi?id=310928</a>
<a href="https://rdar.apple.com/173536817">rdar://173536817</a>

Reviewed by Yusuke Suzuki.

The original implementation of InlineMap comes with very simple removal logic which does
nothing to compact deleted entries as they accumulate, or to shrink the map. This is not
an immediate problem because in VariableEnvironments where InlineMap is used removal never
happens. But as it&apos;s a library class we might start using in other places, let&apos;s improve
the existing implementation.

This patch changes the implementation to track the number of deleted entries and compact
the map or shrink it to a smaller size as needed, including switching back to linear mode
if the map becomes small enough. The compaction/shrinking policy and logic mirror what
happens in HashTable.

Tests: Tools/TestWebKitAPI/Tests/WTF/InlineMap.cpp - added new tests
Canonical link: <a href="https://commits.webkit.org/310162@main">https://commits.webkit.org/310162@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64297f6edf0d547be96c340a7a6c3d1e3cf9f5c9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152911 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25693 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19291 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161655 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2d25526a-e366-4d7a-82f0-dfca50223ba9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154784 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26220 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25998 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118177 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0ad216e3-4b5e-4211-bfec-a54308b57fa9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155870 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20412 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137276 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/98890 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d4799c5f-a9b0-4c7a-a040-120429897120) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19486 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9491 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144923 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129139 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15150 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164129 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13721 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7265 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16744 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126238 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25490 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21463 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126396 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34291 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25492 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136946 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82101 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21353 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13725 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184544 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25108 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89395 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47115 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24800 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24959 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24860 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->