### PR TITLE
[Swift in WebKit] Non-PAL targets should not access the internal PAL Swift bridging header (part 6)

### DIFF
--- a/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
+++ b/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		070190F02F75F24B006A4130 /* CryptoAlgorithmHKDFCocoaBridging.h in Headers */ = {isa = PBXBuildFile; fileRef = 070190EF2F75F24B006A4130 /* CryptoAlgorithmHKDFCocoaBridging.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		070190F52F75F2D6006A4130 /* CryptoAlgorithmHKDFCocoaBridging.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 070190F42F75F2D6006A4130 /* CryptoAlgorithmHKDFCocoaBridging.cpp */; };
 		070BEE2D2F0381BF00392FEA /* module.modulemap in Headers */ = {isa = PBXBuildFile; fileRef = 94C759022B990D31000CC511 /* module.modulemap */; settings = {ATTRIBUTES = (Private, ); }; };
 		071CFF4F2F0614FB00E07A47 /* pal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 071CFF4E2F0614FB00E07A47 /* pal.swift */; };
 		0721D3202F7082570069239A /* CryptoAlgorithmAESGCMCocoa.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0721D31F2F7082570069239A /* CryptoAlgorithmAESGCMCocoa.cpp */; };
@@ -19,6 +21,8 @@
 		0737C2732F7351B300372185 /* CryptoAlgorithmX25519CocoaBridging.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0737C2712F7351B300372185 /* CryptoAlgorithmX25519CocoaBridging.cpp */; };
 		0737C27A2F7360D000372185 /* CryptoAlgorithmEd25519CocoaBridging.h in Headers */ = {isa = PBXBuildFile; fileRef = 0737C2792F7360D000372185 /* CryptoAlgorithmEd25519CocoaBridging.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0737C27F2F7361D500372185 /* CryptoAlgorithmEd25519CocoaBridging.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0737C27E2F7361D500372185 /* CryptoAlgorithmEd25519CocoaBridging.cpp */; };
+		073A17A42F769BC200630B55 /* CryptoAlgorithmHMACCocoaBridging.h in Headers */ = {isa = PBXBuildFile; fileRef = 073A17A32F769BC200630B55 /* CryptoAlgorithmHMACCocoaBridging.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		073A17A92F769C0500630B55 /* CryptoAlgorithmHMACCocoaBridging.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 073A17A82F769C0500630B55 /* CryptoAlgorithmHMACCocoaBridging.cpp */; };
 		07611DB7243FA5BF00D80704 /* UsageTrackingSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 07611DB5243FA5BF00D80704 /* UsageTrackingSoftLink.mm */; };
 		076E34C42F725D9D006A65D9 /* CryptoKit+UnsafeOverlays.swift in Sources */ = {isa = PBXBuildFile; fileRef = 076E34C32F725D9D006A65D9 /* CryptoKit+UnsafeOverlays.swift */; };
 		076E34C92F725DD9006A65D9 /* CryptoTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 076E34C82F725DD9006A65D9 /* CryptoTypes.swift */; };
@@ -30,6 +34,8 @@
 		078D1F422F74FB5D00B6BFA9 /* PlatformECKey.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 078D1F412F74FB5D00B6BFA9 /* PlatformECKey.cpp */; };
 		079D1D9826950DD700883577 /* SystemStatusSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 079D1D9626950DD700883577 /* SystemStatusSoftLink.mm */; };
 		07C9C8DC2EDAAABD007B579A /* CryptoTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 07C9C8DB2EDAAABD007B579A /* CryptoTypes.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		07ED41282F771BC200C91401 /* CryptoEDKeyBridging.h in Headers */ = {isa = PBXBuildFile; fileRef = 07ED41272F771BC200C91401 /* CryptoEDKeyBridging.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		07ED412D2F771D5100C91401 /* CryptoEDKeyBridging.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 07ED412C2F771D5100C91401 /* CryptoEDKeyBridging.cpp */; };
 		07ED41382F7736C400C91401 /* NSTextFieldCellSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 72BA2A872951462500678507 /* NSTextFieldCellSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		07ED41392F77370D00C91401 /* NSSearchFieldCellSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 72C9483A2959517C006ECB96 /* NSSearchFieldCellSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0CF99CA41F736375007EE793 /* MediaTimeAVFoundation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0C00CFD11F68CE4600AAC26D /* MediaTimeAVFoundation.cpp */; };
@@ -470,6 +476,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		070190EF2F75F24B006A4130 /* CryptoAlgorithmHKDFCocoaBridging.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CryptoAlgorithmHKDFCocoaBridging.h; sourceTree = "<group>"; };
+		070190F42F75F2D6006A4130 /* CryptoAlgorithmHKDFCocoaBridging.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CryptoAlgorithmHKDFCocoaBridging.cpp; sourceTree = "<group>"; };
 		071CFF4E2F0614FB00E07A47 /* pal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = pal.swift; sourceTree = "<group>"; };
 		0721D31E2F7082570069239A /* CryptoAlgorithmAESGCMCocoa.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CryptoAlgorithmAESGCMCocoa.h; sourceTree = "<group>"; };
 		0721D31F2F7082570069239A /* CryptoAlgorithmAESGCMCocoa.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CryptoAlgorithmAESGCMCocoa.cpp; sourceTree = "<group>"; };
@@ -481,6 +489,8 @@
 		0737C2712F7351B300372185 /* CryptoAlgorithmX25519CocoaBridging.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CryptoAlgorithmX25519CocoaBridging.cpp; sourceTree = "<group>"; };
 		0737C2792F7360D000372185 /* CryptoAlgorithmEd25519CocoaBridging.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CryptoAlgorithmEd25519CocoaBridging.h; sourceTree = "<group>"; };
 		0737C27E2F7361D500372185 /* CryptoAlgorithmEd25519CocoaBridging.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CryptoAlgorithmEd25519CocoaBridging.cpp; sourceTree = "<group>"; };
+		073A17A32F769BC200630B55 /* CryptoAlgorithmHMACCocoaBridging.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CryptoAlgorithmHMACCocoaBridging.h; sourceTree = "<group>"; };
+		073A17A82F769C0500630B55 /* CryptoAlgorithmHMACCocoaBridging.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CryptoAlgorithmHMACCocoaBridging.cpp; sourceTree = "<group>"; };
 		07611DB4243FA5BE00D80704 /* UsageTrackingSoftLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UsageTrackingSoftLink.h; sourceTree = "<group>"; };
 		07611DB5243FA5BF00D80704 /* UsageTrackingSoftLink.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = UsageTrackingSoftLink.mm; sourceTree = "<group>"; };
 		076E34C32F725D9D006A65D9 /* CryptoKit+UnsafeOverlays.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CryptoKit+UnsafeOverlays.swift"; sourceTree = "<group>"; };
@@ -496,6 +506,8 @@
 		079D1D9526950DD700883577 /* SystemStatusSoftLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SystemStatusSoftLink.h; sourceTree = "<group>"; };
 		079D1D9626950DD700883577 /* SystemStatusSoftLink.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = SystemStatusSoftLink.mm; sourceTree = "<group>"; };
 		07C9C8DB2EDAAABD007B579A /* CryptoTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CryptoTypes.h; sourceTree = "<group>"; };
+		07ED41272F771BC200C91401 /* CryptoEDKeyBridging.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CryptoEDKeyBridging.h; sourceTree = "<group>"; };
+		07ED412C2F771D5100C91401 /* CryptoEDKeyBridging.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CryptoEDKeyBridging.cpp; sourceTree = "<group>"; };
 		0C00CFD11F68CE4600AAC26D /* MediaTimeAVFoundation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MediaTimeAVFoundation.cpp; sourceTree = "<group>"; };
 		0C00CFD21F68CE4600AAC26D /* MediaTimeAVFoundation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MediaTimeAVFoundation.h; sourceTree = "<group>"; };
 		0C2D9E721EEF5AF600DBC317 /* ExportMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ExportMacros.h; sourceTree = "<group>"; };
@@ -1123,9 +1135,15 @@
 				0737C2652F7349EB00372185 /* CryptoAlgorithmAESKWCocoaBridging.h */,
 				0737C27E2F7361D500372185 /* CryptoAlgorithmEd25519CocoaBridging.cpp */,
 				0737C2792F7360D000372185 /* CryptoAlgorithmEd25519CocoaBridging.h */,
+				070190F42F75F2D6006A4130 /* CryptoAlgorithmHKDFCocoaBridging.cpp */,
+				070190EF2F75F24B006A4130 /* CryptoAlgorithmHKDFCocoaBridging.h */,
+				073A17A82F769C0500630B55 /* CryptoAlgorithmHMACCocoaBridging.cpp */,
+				073A17A32F769BC200630B55 /* CryptoAlgorithmHMACCocoaBridging.h */,
 				0737C2712F7351B300372185 /* CryptoAlgorithmX25519CocoaBridging.cpp */,
 				0737C2702F7351B300372185 /* CryptoAlgorithmX25519CocoaBridging.h */,
 				1C09D0521E31C44100725F18 /* CryptoDigest.h */,
+				07ED412C2F771D5100C91401 /* CryptoEDKeyBridging.cpp */,
+				07ED41272F771BC200C91401 /* CryptoEDKeyBridging.h */,
 				076E34C32F725D9D006A65D9 /* CryptoKit+UnsafeOverlays.swift */,
 				07C9C8DB2EDAAABD007B579A /* CryptoTypes.h */,
 				076E34C82F725DD9006A65D9 /* CryptoTypes.swift */,
@@ -1492,8 +1510,11 @@
 				0721D3212F7082570069239A /* CryptoAlgorithmAESGCMCocoa.h in Headers */,
 				0737C2672F7349EB00372185 /* CryptoAlgorithmAESKWCocoaBridging.h in Headers */,
 				0737C27A2F7360D000372185 /* CryptoAlgorithmEd25519CocoaBridging.h in Headers */,
+				070190F02F75F24B006A4130 /* CryptoAlgorithmHKDFCocoaBridging.h in Headers */,
+				073A17A42F769BC200630B55 /* CryptoAlgorithmHMACCocoaBridging.h in Headers */,
 				0737C2722F7351B300372185 /* CryptoAlgorithmX25519CocoaBridging.h in Headers */,
 				DD20DD2727BC90D60093D175 /* CryptoDigest.h in Headers */,
+				07ED41282F771BC200C91401 /* CryptoEDKeyBridging.h in Headers */,
 				DD20DD1D27BC90D60093D175 /* CryptoKitPrivateSoftLink.h in Headers */,
 				DD20DDE327BC90D70093D175 /* CryptoKitPrivateSPI.h in Headers */,
 				07C9C8DC2EDAAABD007B579A /* CryptoTypes.h in Headers */,
@@ -1853,8 +1874,11 @@
 				0721D3202F7082570069239A /* CryptoAlgorithmAESGCMCocoa.cpp in Sources */,
 				0737C2682F7349EB00372185 /* CryptoAlgorithmAESKWCocoaBridging.cpp in Sources */,
 				0737C27F2F7361D500372185 /* CryptoAlgorithmEd25519CocoaBridging.cpp in Sources */,
+				070190F52F75F2D6006A4130 /* CryptoAlgorithmHKDFCocoaBridging.cpp in Sources */,
+				073A17A92F769C0500630B55 /* CryptoAlgorithmHMACCocoaBridging.cpp in Sources */,
 				0737C2732F7351B300372185 /* CryptoAlgorithmX25519CocoaBridging.cpp in Sources */,
 				1C09D0561E31C46500725F18 /* CryptoDigestCommonCrypto.cpp in Sources */,
+				07ED412D2F771D5100C91401 /* CryptoEDKeyBridging.cpp in Sources */,
 				076E34C42F725D9D006A65D9 /* CryptoKit+UnsafeOverlays.swift in Sources */,
 				57F1C90A25DCF0CF00E8F6EA /* CryptoKitPrivateSoftLink.mm in Sources */,
 				94F4AA022B730D2C006DFFDE /* CryptoKitShim.swift in Sources */,

--- a/Source/WebCore/PAL/pal/PALSwift/CryptoKitShim.swift
+++ b/Source/WebCore/PAL/pal/PALSwift/CryptoKitShim.swift
@@ -530,61 +530,53 @@ public struct ECKey {
 
 // FIXME: PALSwift should have no public symbols.
 // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-public enum EdSigningAlgorithm {
-    case ed25519
-    case ed448
-}
-
-// FIXME: PALSwift should have no public symbols.
-// swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-public enum EdKeyAgreementAlgorithm {
-    case x25519
-    case x448
-}
-
-// FIXME: PALSwift should have no public symbols.
-// swift-format-ignore: AllPublicDeclarationsHaveDocumentation
 public class EdKey {
     // FIXME: PALSwift should have no public symbols.
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-    public static func generatePrivateKey(algo: EdSigningAlgorithm) -> VectorUInt8 {
+    public static func generatePrivateKey(algo: PAL.Crypto.EdSigningAlgorithm) -> VectorUInt8 {
         switch algo {
-        case .ed25519:
-            return Curve25519.Signing.PrivateKey().rawRepresentation.copyToVectorUInt8()
-        case .ed448:
-            return Data(count: 0).copyToVectorUInt8()
+        case .ED25519:
+            Curve25519.Signing.PrivateKey().rawRepresentation.copyToVectorUInt8()
+        case .ED448:
+            Data(count: 0).copyToVectorUInt8()
+        @unknown default:
+            fatalError()
         }
     }
 
     // FIXME: PALSwift should have no public symbols.
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-    public static func generatePrivateKeyKeyAgreement(algo: EdKeyAgreementAlgorithm) -> VectorUInt8 {
+    public static func generatePrivateKeyKeyAgreement(algo: PAL.Crypto.EdKeyAgreementAlgorithm) -> VectorUInt8 {
         switch algo {
-        case .x25519:
-            return Curve25519.KeyAgreement.PrivateKey().rawRepresentation.copyToVectorUInt8()
-        case .x448:
-            return Data(count: 0).copyToVectorUInt8()
+        case .X25519:
+            Curve25519.KeyAgreement.PrivateKey().rawRepresentation.copyToVectorUInt8()
+        case .X448:
+            Data(count: 0).copyToVectorUInt8()
+        @unknown default:
+            fatalError()
         }
     }
 
     // FIXME: PALSwift should have no public symbols.
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-    public static func privateToPublic(algo: EdSigningAlgorithm, privateKey: SpanConstUInt8) -> CryptoOperationReturnValue {
+    public static func privateToPublic(algo: PAL.Crypto.EdSigningAlgorithm, privateKey: SpanConstUInt8) -> CryptoOperationReturnValue {
         var returnValue = CryptoOperationReturnValue()
         do {
             if unsafe privateKey.size() != 32 {
                 throw LocalErrors.invalidArgument
             }
             switch algo {
-            case .ed25519:
+            case .ED25519:
                 returnValue.result = try unsafe Curve25519.Signing.PrivateKey(span: privateKey).publicKey
                     .rawRepresentation.copyToVectorUInt8()
                 if returnValue.result.size() != 32 {
                     throw LocalErrors.invalidArgument
                 }
                 returnValue.errorCode = .Success
-            case .ed448:
+            case .ED448:
                 returnValue.errorCode = .UnsupportedAlgorithm
+            @unknown default:
+                fatalError()
             }
         } catch {
             returnValue.errorCode = .FailedToImport
@@ -595,7 +587,7 @@ public class EdKey {
     // FIXME: PALSwift should have no public symbols.
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public static func privateToPublicKeyAgreement(
-        algo: EdKeyAgreementAlgorithm,
+        algo: PAL.Crypto.EdKeyAgreementAlgorithm,
         privateKey: SpanConstUInt8
     ) -> CryptoOperationReturnValue {
         var returnValue = CryptoOperationReturnValue()
@@ -604,15 +596,17 @@ public class EdKey {
                 throw LocalErrors.invalidArgument
             }
             switch algo {
-            case .x25519:
+            case .X25519:
                 returnValue.result = try unsafe Curve25519.KeyAgreement.PrivateKey(span: privateKey).publicKey
                     .rawRepresentation.copyToVectorUInt8()
                 if returnValue.result.size() != 32 {
                     throw LocalErrors.invalidArgument
                 }
                 returnValue.errorCode = .Success
-            case .x448:
+            case .X448:
                 returnValue.errorCode = .UnsupportedAlgorithm
+            @unknown default:
+                fatalError()
             }
         } catch {
             returnValue.errorCode = .FailedToImport
@@ -622,18 +616,20 @@ public class EdKey {
 
     // FIXME: PALSwift should have no public symbols.
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-    public static func validateKeyPair(algo: EdSigningAlgorithm, privateKey: SpanConstUInt8, publicKey: SpanConstUInt8) -> Bool {
+    public static func validateKeyPair(algo: PAL.Crypto.EdSigningAlgorithm, privateKey: SpanConstUInt8, publicKey: SpanConstUInt8) -> Bool {
         do {
             if unsafe (privateKey.size() != 32 || publicKey.size() != 32) {
                 throw LocalErrors.invalidArgument
             }
             switch algo {
-            case .ed25519:
+            case .ED25519:
                 let derivedPublicKey = try unsafe Curve25519.Signing.PrivateKey(span: privateKey).publicKey.rawRepresentation
                 let importedPublicKey = try unsafe Curve25519.Signing.PublicKey(span: publicKey).rawRepresentation
                 return derivedPublicKey == importedPublicKey
-            case .ed448:
+            case .ED448:
                 return false
+            @unknown default:
+                fatalError()
             }
         } catch {
             return false
@@ -643,7 +639,7 @@ public class EdKey {
     // FIXME: PALSwift should have no public symbols.
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public static func validateKeyPairKeyAgreement(
-        algo: EdKeyAgreementAlgorithm,
+        algo: PAL.Crypto.EdKeyAgreementAlgorithm,
         privateKey: SpanConstUInt8,
         publicKey: SpanConstUInt8
     ) -> Bool {
@@ -652,12 +648,14 @@ public class EdKey {
                 throw LocalErrors.invalidArgument
             }
             switch algo {
-            case .x25519:
+            case .X25519:
                 let derivedPublicKey = try unsafe Curve25519.KeyAgreement.PrivateKey(span: privateKey).publicKey.rawRepresentation
                 let importedPublicKey = try unsafe Curve25519.KeyAgreement.PublicKey(span: publicKey).rawRepresentation
                 return derivedPublicKey == importedPublicKey
-            case .x448:
+            case .X448:
                 return false
+            @unknown default:
+                fatalError()
             }
         } catch {
             return false
@@ -666,16 +664,22 @@ public class EdKey {
 
     // FIXME: PALSwift should have no public symbols.
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-    public static func sign(algo: EdSigningAlgorithm, privateKey: SpanConstUInt8, data: SpanConstUInt8) -> CryptoOperationReturnValue {
+    public static func sign(
+        algo: PAL.Crypto.EdSigningAlgorithm,
+        privateKey: SpanConstUInt8,
+        data: SpanConstUInt8
+    ) -> CryptoOperationReturnValue {
         var returnValue = CryptoOperationReturnValue()
         do {
             switch algo {
-            case .ed25519:
+            case .ED25519:
                 let privateKeyImported = try unsafe Curve25519.Signing.PrivateKey(span: privateKey)
                 returnValue.result = try unsafe privateKeyImported.signature(span: data)
                 returnValue.errorCode = .Success
-            case .ed448:
+            case .ED448:
                 returnValue.errorCode = .UnsupportedAlgorithm
+            @unknown default:
+                fatalError()
             }
         } catch {
             returnValue.errorCode = .FailedToSign
@@ -686,7 +690,7 @@ public class EdKey {
     // FIXME: PALSwift should have no public symbols.
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public static func verify(
-        algo: EdSigningAlgorithm,
+        algo: PAL.Crypto.EdSigningAlgorithm,
         publicKey: SpanConstUInt8,
         signature: SpanConstUInt8,
         data: SpanConstUInt8
@@ -694,13 +698,15 @@ public class EdKey {
         var returnValue = CryptoOperationReturnValue()
         do {
             switch algo {
-            case .ed25519:
+            case .ED25519:
                 let publicKeyImported = try unsafe Curve25519.Signing.PublicKey(span: publicKey)
                 returnValue.errorCode =
                     unsafe publicKeyImported.isValidSignature(signature: signature, data: data)
                     ? .Success : .FailedToVerify
-            case .ed448:
+            case .ED448:
                 returnValue.errorCode = .UnsupportedAlgorithm
+            @unknown default:
+                fatalError()
             }
         } catch {
             returnValue.errorCode = .FailedToSign
@@ -711,19 +717,21 @@ public class EdKey {
     // FIXME: PALSwift should have no public symbols.
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public static func deriveBits(
-        algo: EdKeyAgreementAlgorithm,
+        algo: PAL.Crypto.EdKeyAgreementAlgorithm,
         privateKey: SpanConstUInt8,
         publicKey: SpanConstUInt8
     ) -> CryptoOperationReturnValue {
         var returnValue = CryptoOperationReturnValue()
         do {
             switch algo {
-            case .x25519:
+            case .X25519:
                 let privateKeyImported = try unsafe Curve25519.KeyAgreement.PrivateKey(span: privateKey)
                 returnValue.result = try unsafe privateKeyImported.sharedSecretFromKeyAgreement(pubSpan: publicKey)
                 returnValue.errorCode = .Success
-            case .x448:
+            case .X448:
                 returnValue.errorCode = .UnsupportedAlgorithm
+            @unknown default:
+                fatalError()
             }
         } catch {
             returnValue.errorCode = .FailedToDerive

--- a/Source/WebCore/PAL/pal/crypto/CryptoAlgorithmAESGCMCocoa.h
+++ b/Source/WebCore/PAL/pal/crypto/CryptoAlgorithmAESGCMCocoa.h
@@ -27,7 +27,6 @@
 
 #include <pal/crypto/CryptoTypes.h>
 #include <wtf/Expected.h>
-#include <wtf/Unexpected.h>
 
 namespace PAL::Crypto {
 

--- a/Source/WebCore/PAL/pal/crypto/CryptoAlgorithmAESKWCocoaBridging.h
+++ b/Source/WebCore/PAL/pal/crypto/CryptoAlgorithmAESKWCocoaBridging.h
@@ -27,7 +27,6 @@
 
 #include <pal/crypto/CryptoTypes.h>
 #include <wtf/Expected.h>
-#include <wtf/Unexpected.h>
 
 namespace PAL::Crypto {
 

--- a/Source/WebCore/PAL/pal/crypto/CryptoAlgorithmEd25519CocoaBridging.cpp
+++ b/Source/WebCore/PAL/pal/crypto/CryptoAlgorithmEd25519CocoaBridging.cpp
@@ -26,9 +26,7 @@
 #include "config.h"
 #include "CryptoAlgorithmEd25519CocoaBridging.h"
 
-#include "CommonCryptoSPI.h"
 #include "PALSwift-Generated.h"
-#include <wtf/CryptographicUtilities.h>
 
 namespace PAL::Crypto {
 
@@ -36,7 +34,7 @@ Expected<VectorUInt8, Error> signEd25519CryptoKit(const VectorUInt8 &sk, const V
 {
     if (sk.size() != ed25519KeySize)
         return makeUnexpected(Error::FailedToSign);
-    auto rv = pal::EdKey::sign(pal::EdSigningAlgorithm::ed25519(), sk.span(), data.span());
+    auto rv = pal::EdKey::sign(PAL::Crypto::EdSigningAlgorithm::ED25519, sk.span(), data.span());
     if (rv.errorCode != PAL::Crypto::Error::Success)
         return makeUnexpected(rv.errorCode);
     return WTF::move(rv.result);
@@ -46,7 +44,7 @@ Expected<bool, Error> verifyEd25519CryptoKit(const VectorUInt8& pubKey, const Ve
 {
     if (pubKey.size() != ed25519KeySize || signature.size() != ed25519SignatureSize)
         return false;
-    auto rv = pal::EdKey::verify(pal::EdSigningAlgorithm::ed25519(), pubKey.span(), signature.span(), data.span());
+    auto rv = pal::EdKey::verify(PAL::Crypto::EdSigningAlgorithm::ED25519, pubKey.span(), signature.span(), data.span());
     return rv.errorCode == PAL::Crypto::Error::Success;
 }
 

--- a/Source/WebCore/PAL/pal/crypto/CryptoAlgorithmEd25519CocoaBridging.h
+++ b/Source/WebCore/PAL/pal/crypto/CryptoAlgorithmEd25519CocoaBridging.h
@@ -27,7 +27,6 @@
 
 #include <pal/crypto/CryptoTypes.h>
 #include <wtf/Expected.h>
-#include <wtf/Unexpected.h>
 
 namespace PAL::Crypto {
 

--- a/Source/WebCore/PAL/pal/crypto/CryptoAlgorithmHKDFCocoaBridging.cpp
+++ b/Source/WebCore/PAL/pal/crypto/CryptoAlgorithmHKDFCocoaBridging.cpp
@@ -23,68 +23,19 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include "config.h"
+#include "CryptoAlgorithmHKDFCocoaBridging.h"
 
-#include <cstdint>
-#include <span>
-#include <wtf/Vector.h>
+#include "PALSwift-Generated.h"
 
 namespace PAL::Crypto {
 
-using VectorUInt8 = WTF::Vector<uint8_t>;
+Expected<VectorUInt8, Error> deriveBitsHKDFCryptoKit(const VectorUInt8& key, const VectorUInt8& salt, const VectorUInt8& info, size_t length, CryptoDigestHashFunction hashFunction)
+{
+    auto rv = pal::HKDF::deriveBits(key.span(), salt.span(), info.span(), length, hashFunction);
+    if (rv.errorCode != PAL::Crypto::Error::Success)
+        return makeUnexpected(rv.errorCode);
+    return WTF::move(rv.result);
+}
 
-using SpanConstUInt8 = std::span<const uint8_t>;
-
-enum class CryptoDigestHashFunction: int {
-    SHA_1,
-    DEPRECATED_SHA_224,
-    SHA_256,
-    SHA_384,
-    SHA_512,
-};
-
-enum class Error: int {
-    Success = 0,
-    WrongTagSize,
-    EncryptionFailed,
-    EncryptionResultNil,
-    InvalidArgument,
-    TooBigArguments,
-    DecryptionFailed,
-    HashingFailed,
-    PublicKeyProvidedToSign,
-    FailedToSign,
-    FailedToVerify,
-    PrivateKeyProvidedForVerification,
-    FailedToImport,
-    FailedToDerive,
-    FailedToExport,
-    DefaultValue,
-    UnsupportedAlgorithm,
-};
-
-struct CryptoOperationReturnValue {
-    Error errorCode = Error::DefaultValue;
-    VectorUInt8 result;
-};
-
-enum class ECNamedCurve : uint8_t {
-    P256,
-    P384,
-    P521,
-};
-
-enum class EdSigningAlgorithm : uint8_t {
-    ED25519,
-    ED448,
-};
-
-enum class EdKeyAgreementAlgorithm : uint8_t {
-    X25519,
-    X448,
-};
-
-constexpr auto ed25519KeySize = 32;
-constexpr auto ed25519SignatureSize = ed25519KeySize * 2;
-
-} // namespace PAL::Crypto
+}

--- a/Source/WebCore/PAL/pal/crypto/CryptoAlgorithmHKDFCocoaBridging.h
+++ b/Source/WebCore/PAL/pal/crypto/CryptoAlgorithmHKDFCocoaBridging.h
@@ -25,66 +25,11 @@
 
 #pragma once
 
-#include <cstdint>
-#include <span>
-#include <wtf/Vector.h>
+#include <pal/crypto/CryptoTypes.h>
+#include <wtf/Expected.h>
 
 namespace PAL::Crypto {
 
-using VectorUInt8 = WTF::Vector<uint8_t>;
-
-using SpanConstUInt8 = std::span<const uint8_t>;
-
-enum class CryptoDigestHashFunction: int {
-    SHA_1,
-    DEPRECATED_SHA_224,
-    SHA_256,
-    SHA_384,
-    SHA_512,
-};
-
-enum class Error: int {
-    Success = 0,
-    WrongTagSize,
-    EncryptionFailed,
-    EncryptionResultNil,
-    InvalidArgument,
-    TooBigArguments,
-    DecryptionFailed,
-    HashingFailed,
-    PublicKeyProvidedToSign,
-    FailedToSign,
-    FailedToVerify,
-    PrivateKeyProvidedForVerification,
-    FailedToImport,
-    FailedToDerive,
-    FailedToExport,
-    DefaultValue,
-    UnsupportedAlgorithm,
-};
-
-struct CryptoOperationReturnValue {
-    Error errorCode = Error::DefaultValue;
-    VectorUInt8 result;
-};
-
-enum class ECNamedCurve : uint8_t {
-    P256,
-    P384,
-    P521,
-};
-
-enum class EdSigningAlgorithm : uint8_t {
-    ED25519,
-    ED448,
-};
-
-enum class EdKeyAgreementAlgorithm : uint8_t {
-    X25519,
-    X448,
-};
-
-constexpr auto ed25519KeySize = 32;
-constexpr auto ed25519SignatureSize = ed25519KeySize * 2;
+Expected<VectorUInt8, Error> deriveBitsHKDFCryptoKit(const VectorUInt8& key, const VectorUInt8& salt, const VectorUInt8& info, size_t length, CryptoDigestHashFunction);
 
 } // namespace PAL::Crypto

--- a/Source/WebCore/PAL/pal/crypto/CryptoAlgorithmHMACCocoaBridging.cpp
+++ b/Source/WebCore/PAL/pal/crypto/CryptoAlgorithmHMACCocoaBridging.cpp
@@ -23,68 +23,21 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include "config.h"
+#include "CryptoAlgorithmHMACCocoaBridging.h"
 
-#include <cstdint>
-#include <span>
-#include <wtf/Vector.h>
+#include "PALSwift-Generated.h"
 
 namespace PAL::Crypto {
 
-using VectorUInt8 = WTF::Vector<uint8_t>;
+Expected<VectorUInt8, Error> signHMACCryptoKit(const VectorUInt8& key, const VectorUInt8& data, CryptoDigestHashFunction hashFunction)
+{
+    return pal::HMAC::sign(key.span(), data.span(), hashFunction);
+}
 
-using SpanConstUInt8 = std::span<const uint8_t>;
+Expected<bool, Error> verifyHMACCryptoKit(const VectorUInt8& signature, const VectorUInt8& key, const VectorUInt8& data, CryptoDigestHashFunction hashFunction)
+{
+    return pal::HMAC::verify(signature.span(), key.span(), data.span(), hashFunction);
+}
 
-enum class CryptoDigestHashFunction: int {
-    SHA_1,
-    DEPRECATED_SHA_224,
-    SHA_256,
-    SHA_384,
-    SHA_512,
-};
-
-enum class Error: int {
-    Success = 0,
-    WrongTagSize,
-    EncryptionFailed,
-    EncryptionResultNil,
-    InvalidArgument,
-    TooBigArguments,
-    DecryptionFailed,
-    HashingFailed,
-    PublicKeyProvidedToSign,
-    FailedToSign,
-    FailedToVerify,
-    PrivateKeyProvidedForVerification,
-    FailedToImport,
-    FailedToDerive,
-    FailedToExport,
-    DefaultValue,
-    UnsupportedAlgorithm,
-};
-
-struct CryptoOperationReturnValue {
-    Error errorCode = Error::DefaultValue;
-    VectorUInt8 result;
-};
-
-enum class ECNamedCurve : uint8_t {
-    P256,
-    P384,
-    P521,
-};
-
-enum class EdSigningAlgorithm : uint8_t {
-    ED25519,
-    ED448,
-};
-
-enum class EdKeyAgreementAlgorithm : uint8_t {
-    X25519,
-    X448,
-};
-
-constexpr auto ed25519KeySize = 32;
-constexpr auto ed25519SignatureSize = ed25519KeySize * 2;
-
-} // namespace PAL::Crypto
+}

--- a/Source/WebCore/PAL/pal/crypto/CryptoAlgorithmHMACCocoaBridging.h
+++ b/Source/WebCore/PAL/pal/crypto/CryptoAlgorithmHMACCocoaBridging.h
@@ -25,66 +25,13 @@
 
 #pragma once
 
-#include <cstdint>
-#include <span>
-#include <wtf/Vector.h>
+#include <pal/crypto/CryptoTypes.h>
+#include <wtf/Expected.h>
 
 namespace PAL::Crypto {
 
-using VectorUInt8 = WTF::Vector<uint8_t>;
+Expected<VectorUInt8, Error> signHMACCryptoKit(const VectorUInt8& key, const VectorUInt8& data, CryptoDigestHashFunction);
 
-using SpanConstUInt8 = std::span<const uint8_t>;
-
-enum class CryptoDigestHashFunction: int {
-    SHA_1,
-    DEPRECATED_SHA_224,
-    SHA_256,
-    SHA_384,
-    SHA_512,
-};
-
-enum class Error: int {
-    Success = 0,
-    WrongTagSize,
-    EncryptionFailed,
-    EncryptionResultNil,
-    InvalidArgument,
-    TooBigArguments,
-    DecryptionFailed,
-    HashingFailed,
-    PublicKeyProvidedToSign,
-    FailedToSign,
-    FailedToVerify,
-    PrivateKeyProvidedForVerification,
-    FailedToImport,
-    FailedToDerive,
-    FailedToExport,
-    DefaultValue,
-    UnsupportedAlgorithm,
-};
-
-struct CryptoOperationReturnValue {
-    Error errorCode = Error::DefaultValue;
-    VectorUInt8 result;
-};
-
-enum class ECNamedCurve : uint8_t {
-    P256,
-    P384,
-    P521,
-};
-
-enum class EdSigningAlgorithm : uint8_t {
-    ED25519,
-    ED448,
-};
-
-enum class EdKeyAgreementAlgorithm : uint8_t {
-    X25519,
-    X448,
-};
-
-constexpr auto ed25519KeySize = 32;
-constexpr auto ed25519SignatureSize = ed25519KeySize * 2;
+Expected<bool, Error> verifyHMACCryptoKit(const VectorUInt8& signature, const VectorUInt8& key, const VectorUInt8& data, CryptoDigestHashFunction);
 
 } // namespace PAL::Crypto

--- a/Source/WebCore/PAL/pal/crypto/CryptoAlgorithmX25519CocoaBridging.cpp
+++ b/Source/WebCore/PAL/pal/crypto/CryptoAlgorithmX25519CocoaBridging.cpp
@@ -26,17 +26,15 @@
 #include "config.h"
 #include "CryptoAlgorithmX25519CocoaBridging.h"
 
-#include "CommonCryptoSPI.h"
 #include "PALSwift-Generated.h"
-#include <wtf/CryptographicUtilities.h>
 
 namespace PAL::Crypto {
 
-std::optional<VectorUInt8> deriveBitsCryptoKit(const VectorUInt8& baseKey, const VectorUInt8& publicKey)
+std::optional<VectorUInt8> deriveBitsX25519CryptoKit(const VectorUInt8& baseKey, const VectorUInt8& publicKey)
 {
     if (baseKey.size() != ed25519KeySize || publicKey.size() != ed25519KeySize)
         return std::nullopt;
-    auto rv = pal::EdKey::deriveBits(pal::EdKeyAgreementAlgorithm::x25519(), baseKey.span(), publicKey.span());
+    auto rv = pal::EdKey::deriveBits(PAL::Crypto::EdKeyAgreementAlgorithm::X25519, baseKey.span(), publicKey.span());
     if (rv.errorCode != PAL::Crypto::Error::Success)
         return std::nullopt;
     return WTF::move(rv.result);

--- a/Source/WebCore/PAL/pal/crypto/CryptoAlgorithmX25519CocoaBridging.h
+++ b/Source/WebCore/PAL/pal/crypto/CryptoAlgorithmX25519CocoaBridging.h
@@ -27,10 +27,9 @@
 
 #include <pal/crypto/CryptoTypes.h>
 #include <wtf/Expected.h>
-#include <wtf/Unexpected.h>
 
 namespace PAL::Crypto {
 
-std::optional<VectorUInt8> deriveBitsCryptoKit(const VectorUInt8& baseKey, const VectorUInt8& publicKey);
+std::optional<VectorUInt8> deriveBitsX25519CryptoKit(const VectorUInt8& baseKey, const VectorUInt8& publicKey);
 
 } // namespace PAL::Crypto

--- a/Source/WebCore/PAL/pal/crypto/CryptoEDKeyBridging.cpp
+++ b/Source/WebCore/PAL/pal/crypto/CryptoEDKeyBridging.cpp
@@ -23,68 +23,41 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include "config.h"
+#include "CryptoEDKeyBridging.h"
 
-#include <cstdint>
-#include <span>
-#include <wtf/Vector.h>
+#include "PALSwift-Generated.h"
 
-namespace PAL::Crypto {
+namespace PAL::Crypto::EdKey {
 
-using VectorUInt8 = WTF::Vector<uint8_t>;
+VectorUInt8 generatePrivateKey(EdSigningAlgorithm algorithm)
+{
+    return pal::EdKey::generatePrivateKey(algorithm);
+}
 
-using SpanConstUInt8 = std::span<const uint8_t>;
+VectorUInt8 generatePrivateKeyKeyAgreement(EdKeyAgreementAlgorithm algorithm)
+{
+    return pal::EdKey::generatePrivateKeyKeyAgreement(algorithm);
+}
 
-enum class CryptoDigestHashFunction: int {
-    SHA_1,
-    DEPRECATED_SHA_224,
-    SHA_256,
-    SHA_384,
-    SHA_512,
-};
+CryptoOperationReturnValue privateToPublic(EdSigningAlgorithm algorithm, SpanConstUInt8 privateKey)
+{
+    return pal::EdKey::privateToPublic(algorithm, privateKey);
+}
 
-enum class Error: int {
-    Success = 0,
-    WrongTagSize,
-    EncryptionFailed,
-    EncryptionResultNil,
-    InvalidArgument,
-    TooBigArguments,
-    DecryptionFailed,
-    HashingFailed,
-    PublicKeyProvidedToSign,
-    FailedToSign,
-    FailedToVerify,
-    PrivateKeyProvidedForVerification,
-    FailedToImport,
-    FailedToDerive,
-    FailedToExport,
-    DefaultValue,
-    UnsupportedAlgorithm,
-};
+CryptoOperationReturnValue privateToPublicKeyAgreement(EdKeyAgreementAlgorithm algorithm, SpanConstUInt8 privateKey)
+{
+    return pal::EdKey::privateToPublicKeyAgreement(algorithm, privateKey);
+}
 
-struct CryptoOperationReturnValue {
-    Error errorCode = Error::DefaultValue;
-    VectorUInt8 result;
-};
+bool validateKeyPair(EdSigningAlgorithm algorithm, SpanConstUInt8 privateKey, SpanConstUInt8 publicKey)
+{
+    return pal::EdKey::validateKeyPair(algorithm, privateKey, publicKey);
+}
 
-enum class ECNamedCurve : uint8_t {
-    P256,
-    P384,
-    P521,
-};
+bool validateKeyPairKeyAgreement(EdKeyAgreementAlgorithm algorithm, SpanConstUInt8 privateKey, SpanConstUInt8 publicKey)
+{
+    return pal::EdKey::validateKeyPairKeyAgreement(algorithm, privateKey, publicKey);
+}
 
-enum class EdSigningAlgorithm : uint8_t {
-    ED25519,
-    ED448,
-};
-
-enum class EdKeyAgreementAlgorithm : uint8_t {
-    X25519,
-    X448,
-};
-
-constexpr auto ed25519KeySize = 32;
-constexpr auto ed25519SignatureSize = ed25519KeySize * 2;
-
-} // namespace PAL::Crypto
+} // namespace PAL::Crypto::EdKey

--- a/Source/WebCore/PAL/pal/crypto/CryptoEDKeyBridging.h
+++ b/Source/WebCore/PAL/pal/crypto/CryptoEDKeyBridging.h
@@ -25,66 +25,20 @@
 
 #pragma once
 
-#include <cstdint>
-#include <span>
-#include <wtf/Vector.h>
+#include <pal/crypto/CryptoTypes.h>
 
-namespace PAL::Crypto {
+namespace PAL::Crypto::EdKey {
 
-using VectorUInt8 = WTF::Vector<uint8_t>;
+VectorUInt8 generatePrivateKey(EdSigningAlgorithm);
 
-using SpanConstUInt8 = std::span<const uint8_t>;
+VectorUInt8 generatePrivateKeyKeyAgreement(EdKeyAgreementAlgorithm);
 
-enum class CryptoDigestHashFunction: int {
-    SHA_1,
-    DEPRECATED_SHA_224,
-    SHA_256,
-    SHA_384,
-    SHA_512,
-};
+CryptoOperationReturnValue privateToPublic(EdSigningAlgorithm, SpanConstUInt8 privateKey);
 
-enum class Error: int {
-    Success = 0,
-    WrongTagSize,
-    EncryptionFailed,
-    EncryptionResultNil,
-    InvalidArgument,
-    TooBigArguments,
-    DecryptionFailed,
-    HashingFailed,
-    PublicKeyProvidedToSign,
-    FailedToSign,
-    FailedToVerify,
-    PrivateKeyProvidedForVerification,
-    FailedToImport,
-    FailedToDerive,
-    FailedToExport,
-    DefaultValue,
-    UnsupportedAlgorithm,
-};
+CryptoOperationReturnValue privateToPublicKeyAgreement(EdKeyAgreementAlgorithm, SpanConstUInt8 privateKey);
 
-struct CryptoOperationReturnValue {
-    Error errorCode = Error::DefaultValue;
-    VectorUInt8 result;
-};
+bool validateKeyPair(EdSigningAlgorithm, SpanConstUInt8 privateKey, SpanConstUInt8 publicKey);
 
-enum class ECNamedCurve : uint8_t {
-    P256,
-    P384,
-    P521,
-};
+bool validateKeyPairKeyAgreement(EdKeyAgreementAlgorithm, SpanConstUInt8 privateKey, SpanConstUInt8 publicKey);
 
-enum class EdSigningAlgorithm : uint8_t {
-    ED25519,
-    ED448,
-};
-
-enum class EdKeyAgreementAlgorithm : uint8_t {
-    X25519,
-    X448,
-};
-
-constexpr auto ed25519KeySize = 32;
-constexpr auto ed25519SignatureSize = ed25519KeySize * 2;
-
-} // namespace PAL::Crypto
+} // namespace PAL::Crypto::EdKey

--- a/Source/WebCore/PAL/pal/module.modulemap
+++ b/Source/WebCore/PAL/pal/module.modulemap
@@ -29,4 +29,4 @@ module pal [system] {
     export *
 }
 
-// (v5) This comment ensures an incremental build causes this module to rebuild (rdar://170129992)
+// (v7) This comment ensures an incremental build causes this module to rebuild (rdar://170129992)

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmHKDFCocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmHKDFCocoa.cpp
@@ -31,27 +31,17 @@
 #include "CryptoKeyRaw.h"
 #include "CryptoTypesBridging.h"
 #include "CryptoUtilitiesCocoa.h"
+#include <pal/crypto/CryptoAlgorithmHKDFCocoaBridging.h>
 #include <pal/crypto/CryptoTypes.h>
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
-#include "PALSwift-Generated.h"
-#pragma clang diagnostic pop
 
 namespace WebCore {
 
-static ExceptionOr<Vector<uint8_t>> platformDeriveBitsCryptoKit(const CryptoAlgorithmHkdfParams& parameters, const CryptoKeyRaw& key, size_t length)
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHKDF::platformDeriveBits(const CryptoAlgorithmHkdfParams& parameters, const CryptoKeyRaw& key, size_t length)
 {
     if (!isValidHashParameter(parameters.hashIdentifier))
         return Exception { ExceptionCode::OperationError };
-    auto rv = pal::HKDF::deriveBits(key.key().span(), parameters.saltVector().span(), parameters.infoVector().span(), length, toCKHashFunction(parameters.hashIdentifier));
-    if (rv.errorCode != PAL::Crypto::Error::Success)
-        return Exception { ExceptionCode::OperationError };
-    return WTF::move(rv.result);
+
+    return toException(PAL::Crypto::deriveBitsHKDFCryptoKit(key.key(), parameters.saltVector(), parameters.infoVector(), length, toCKHashFunction(parameters.hashIdentifier)));
 }
 
-ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHKDF::platformDeriveBits(const CryptoAlgorithmHkdfParams& parameters, const CryptoKeyRaw& key, size_t length)
-{
-    return platformDeriveBitsCryptoKit(parameters, key, length);
-}
 } // namespace WebCore

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmHMACCocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmHMACCocoa.cpp
@@ -29,33 +29,25 @@
 #include "CryptoKeyHMAC.h"
 #include "CryptoTypesBridging.h"
 #include "CryptoUtilitiesCocoa.h"
-#include <CommonCrypto/CommonHMAC.h>
+#include <pal/crypto/CryptoAlgorithmHMACCocoaBridging.h>
 #include <pal/crypto/CryptoTypes.h>
-#include <wtf/CryptographicUtilities.h>
 
 namespace WebCore {
 
-static ExceptionOr<Vector<uint8_t>> platformSignCryptoKit(const CryptoKeyHMAC& key, const Vector<uint8_t>& data)
-{
-    if (!isValidHashParameter(key.hashAlgorithmIdentifier()))
-        return Exception { ExceptionCode::OperationError };
-    return pal::HMAC::sign(key.key().span(), data.span(), toCKHashFunction(key.hashAlgorithmIdentifier()));
-}
-
-static ExceptionOr<bool> platformVerifyCryptoKit(const CryptoKeyHMAC& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data)
-{
-    if (!isValidHashParameter(key.hashAlgorithmIdentifier()))
-        return Exception { ExceptionCode::OperationError };
-    return pal::HMAC::verify(signature.span(), key.key().span(), data.span(), toCKHashFunction(key.hashAlgorithmIdentifier()));
-}
-
 ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHMAC::platformSign(const CryptoKeyHMAC& key, const Vector<uint8_t>& data)
 {
-    return platformSignCryptoKit(key, data);
+    if (!isValidHashParameter(key.hashAlgorithmIdentifier()))
+        return Exception { ExceptionCode::OperationError };
+
+    return toException(PAL::Crypto::signHMACCryptoKit(key.key(), data, toCKHashFunction(key.hashAlgorithmIdentifier())));
 }
 
 ExceptionOr<bool> CryptoAlgorithmHMAC::platformVerify(const CryptoKeyHMAC& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data)
 {
-    return platformVerifyCryptoKit(key, signature, data);
+    if (!isValidHashParameter(key.hashAlgorithmIdentifier()))
+        return Exception { ExceptionCode::OperationError };
+
+    return toException(PAL::Crypto::verifyHMACCryptoKit(signature, key.key(), data, toCKHashFunction(key.hashAlgorithmIdentifier())));
 }
+
 } // namespace WebCore

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmX25519Cocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmX25519Cocoa.cpp
@@ -29,7 +29,7 @@ namespace WebCore {
 
 std::optional<Vector<uint8_t>> CryptoAlgorithmX25519::platformDeriveBits(const CryptoKeyOKP& baseKey, const CryptoKeyOKP& publicKey)
 {
-    return PAL::Crypto::deriveBitsCryptoKit(baseKey.platformKey(), publicKey.platformKey());
+    return PAL::Crypto::deriveBitsX25519CryptoKit(baseKey.platformKey(), publicKey.platformKey());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/crypto/cocoa/CryptoKeyOKPCocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoKeyOKPCocoa.cpp
@@ -30,10 +30,7 @@
 #include "ExceptionOr.h"
 #include "JsonWebKey.h"
 #include "Logging.h"
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
-#include "PALSwift-Generated.h"
-#pragma clang diagnostic pop
+#include <pal/crypto/CryptoEDKeyBridging.h>
 #include <pal/crypto/CryptoTypes.h>
 #include <pal/spi/cocoa/CoreCryptoSPI.h>
 #include <wtf/StdLibExtras.h>
@@ -53,9 +50,9 @@ std::optional<CryptoKeyPair> CryptoKeyOKP::platformGeneratePair(CryptoAlgorithmI
 
     switch (identifier) {
     case CryptoAlgorithmIdentifier::Ed25519: {
-        auto privateKeyPlatform = pal::EdKey::generatePrivateKey(pal::EdSigningAlgorithm::ed25519());
+        auto privateKeyPlatform = PAL::Crypto::EdKey::generatePrivateKey(PAL::Crypto::EdSigningAlgorithm::ED25519);
         RELEASE_ASSERT(privateKeyPlatform.size() == 32);
-        auto publicKeyPlatformRv = pal::EdKey::privateToPublic(pal::EdSigningAlgorithm::ed25519(), privateKeyPlatform.span());
+        auto publicKeyPlatformRv = PAL::Crypto::EdKey::privateToPublic(PAL::Crypto::EdSigningAlgorithm::ED25519, privateKeyPlatform.span());
         if (publicKeyPlatformRv.errorCode != PAL::Crypto::Error::Success)
             return std::nullopt;
         bool isPublicKeyExtractable = true;
@@ -66,9 +63,9 @@ std::optional<CryptoKeyPair> CryptoKeyOKP::platformGeneratePair(CryptoAlgorithmI
         return CryptoKeyPair { WTF::move(publicKey), WTF::move(privateKey) };
     }
     case CryptoAlgorithmIdentifier::X25519: {
-        auto privateKeyPlatform = pal::EdKey::generatePrivateKeyKeyAgreement(pal::EdKeyAgreementAlgorithm::x25519());
+        auto privateKeyPlatform = PAL::Crypto::EdKey::generatePrivateKeyKeyAgreement(PAL::Crypto::EdKeyAgreementAlgorithm::X25519);
         RELEASE_ASSERT(privateKeyPlatform.size() == 32);
-        auto publicKeyPlatformRv = pal::EdKey::privateToPublicKeyAgreement(pal::EdKeyAgreementAlgorithm::x25519(), privateKeyPlatform.span());
+        auto publicKeyPlatformRv = PAL::Crypto::EdKey::privateToPublicKeyAgreement(PAL::Crypto::EdKeyAgreementAlgorithm::X25519, privateKeyPlatform.span());
         if (publicKeyPlatformRv.errorCode != PAL::Crypto::Error::Success)
             return std::nullopt;
         bool isPublicKeyExtractable = true;
@@ -94,9 +91,9 @@ bool CryptoKeyOKP::platformCheckPairedKeys(CryptoAlgorithmIdentifier identifier,
 
     switch (identifier) {
     case CryptoAlgorithmIdentifier::Ed25519:
-        return pal::EdKey::validateKeyPair(pal::EdSigningAlgorithm::ed25519(), privateKey.span(), publicKey.span());
+        return PAL::Crypto::EdKey::validateKeyPair(PAL::Crypto::EdSigningAlgorithm::ED25519, privateKey.span(), publicKey.span());
     case CryptoAlgorithmIdentifier::X25519:
-        return pal::EdKey::validateKeyPairKeyAgreement(pal::EdKeyAgreementAlgorithm::x25519(), privateKey.span(), publicKey.span());
+        return PAL::Crypto::EdKey::validateKeyPairKeyAgreement(PAL::Crypto::EdKeyAgreementAlgorithm::X25519, privateKey.span(), publicKey.span());
     default:
         RELEASE_ASSERT_NOT_REACHED();
         return false;
@@ -360,12 +357,12 @@ String CryptoKeyOKP::generateJwkX() const
     ASSERT(type() == CryptoKeyType::Private);
     switch (namedCurve()) {
     case NamedCurve::Ed25519: {
-        auto publicKeyPlatformRv = pal::EdKey::privateToPublic(pal::EdSigningAlgorithm::ed25519(), platformKey().span());
+        auto publicKeyPlatformRv = PAL::Crypto::EdKey::privateToPublic(PAL::Crypto::EdSigningAlgorithm::ED25519, platformKey().span());
         RELEASE_ASSERT(publicKeyPlatformRv.errorCode == PAL::Crypto::Error::Success);
         return base64URLEncodeToString(publicKeyPlatformRv.result.span());
     }
     case NamedCurve::X25519: {
-        auto publicKeyPlatformRv = pal::EdKey::privateToPublicKeyAgreement(pal::EdKeyAgreementAlgorithm::x25519(), platformKey().span());
+        auto publicKeyPlatformRv = PAL::Crypto::EdKey::privateToPublicKeyAgreement(PAL::Crypto::EdKeyAgreementAlgorithm::X25519, platformKey().span());
         RELEASE_ASSERT(publicKeyPlatformRv.errorCode == PAL::Crypto::Error::Success);
         return base64URLEncodeToString(publicKeyPlatformRv.result.span());
     }


### PR DESCRIPTION
#### a5807ce0c94366e2ae2beea700326110e275a131
<pre>
[Swift in WebKit] Non-PAL targets should not access the internal PAL Swift bridging header (part 6)
<a href="https://bugs.webkit.org/show_bug.cgi?id=310930">https://bugs.webkit.org/show_bug.cgi?id=310930</a>
<a href="https://rdar.apple.com/173538464">rdar://173538464</a>

Reviewed by Abrar Rahman Protyasha.

Remove the final usages of the internal PAL generated swift header from WebCore.

* Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj:
* Source/WebCore/PAL/pal/PALSwift/CryptoKitShim.swift:
(EdKey.generatePrivateKey(_:)):
(EdKey.generatePrivateKeyKeyAgreement(_:)):
(EdKey.privateToPublic(_:privateKey:)):
(EdKey.validateKeyPair(_:privateKey:publicKey:)):
(EdKey.sign(_:privateKey:data:)):

- Move EdSigningAlgorithm and EdKeyAgreementAlgorithm to be agnostic C++ enums

* Source/WebCore/PAL/pal/crypto/CryptoAlgorithmEd25519CocoaBridging.cpp:
(PAL::Crypto::signEd25519CryptoKit):
(PAL::Crypto::verifyEd25519CryptoKit):
* Source/WebCore/PAL/pal/crypto/CryptoAlgorithmHKDFCocoaBridging.cpp: Copied from Source/WebCore/PAL/pal/crypto/CryptoAlgorithmX25519CocoaBridging.cpp.
(PAL::Crypto::deriveBitsHKDFCryptoKit):
* Source/WebCore/PAL/pal/crypto/CryptoAlgorithmHKDFCocoaBridging.h: Copied from Source/WebCore/PAL/pal/crypto/CryptoAlgorithmX25519CocoaBridging.h.
* Source/WebCore/PAL/pal/crypto/CryptoAlgorithmHMACCocoaBridging.cpp: Copied from Source/WebCore/PAL/pal/crypto/CryptoAlgorithmX25519CocoaBridging.cpp.
(PAL::Crypto::signHMACCryptoKit):
(PAL::Crypto::verifyHMACCryptoKit):
* Source/WebCore/PAL/pal/crypto/CryptoAlgorithmHMACCocoaBridging.h: Copied from Source/WebCore/PAL/pal/crypto/CryptoAlgorithmX25519CocoaBridging.h.
* Source/WebCore/PAL/pal/crypto/CryptoAlgorithmX25519CocoaBridging.cpp:
(PAL::Crypto::deriveBitsEd25519CryptoKit):
(PAL::Crypto::deriveBitsCryptoKit): Deleted.
* Source/WebCore/PAL/pal/crypto/CryptoAlgorithmX25519CocoaBridging.h:
* Source/WebCore/PAL/pal/crypto/CryptoEDKeyBridging.cpp: Copied from Source/WebCore/PAL/pal/crypto/CryptoAlgorithmEd25519CocoaBridging.cpp.
(PAL::Crypto::EdKey::generatePrivateKey):
(PAL::Crypto::EdKey::generatePrivateKeyKeyAgreement):
(PAL::Crypto::EdKey::privateToPublic):
(PAL::Crypto::EdKey::privateToPublicKeyAgreement):
(PAL::Crypto::EdKey::validateKeyPair):
(PAL::Crypto::EdKey::validateKeyPairKeyAgreement):
* Source/WebCore/PAL/pal/crypto/CryptoEDKeyBridging.h: Copied from Source/WebCore/PAL/pal/crypto/CryptoAlgorithmX25519CocoaBridging.h.
* Source/WebCore/PAL/pal/crypto/CryptoTypes.h:
* Source/WebCore/PAL/pal/module.modulemap:
* Source/WebCore/crypto/cocoa/CryptoAlgorithmHKDFCocoa.cpp:
(WebCore::CryptoAlgorithmHKDF::platformDeriveBits):
(WebCore::platformDeriveBitsCryptoKit): Deleted.
* Source/WebCore/crypto/cocoa/CryptoAlgorithmHMACCocoa.cpp:
(WebCore::CryptoAlgorithmHMAC::platformSign):
(WebCore::CryptoAlgorithmHMAC::platformVerify):
(WebCore::platformSignCryptoKit): Deleted.
(WebCore::platformVerifyCryptoKit): Deleted.
* Source/WebCore/crypto/cocoa/CryptoAlgorithmX25519Cocoa.cpp:
(WebCore::CryptoAlgorithmX25519::platformDeriveBits):
* Source/WebCore/crypto/cocoa/CryptoKeyOKPCocoa.cpp:
(WebCore::CryptoKeyOKP::platformGeneratePair):
(WebCore::CryptoKeyOKP::platformCheckPairedKeys):
(WebCore::CryptoKeyOKP::generateJwkX const):

Sink all these functions into PAL.

Canonical link: <a href="https://commits.webkit.org/310148@main">https://commits.webkit.org/310148@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/293439e21733b776bac515d76c2eaa9c0af9f975

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152855 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25637 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19235 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161599 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154728 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26164 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25942 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118126 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e6927af2-ac1e-40b4-9c3e-f1023dbda264) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155814 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/20363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137225 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98839 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eecad143-de68-4f68-aa55-103e9a747a96) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/19437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9435 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/129089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15099 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164073 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7209 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16693 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126188 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25434 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21411 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126346 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34278 "Found 1 new test failure: fast/block/transparent-outline-with-and-without-border-radius.html (failure)") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25436 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136895 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/82040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23413 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21299 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13674 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25052 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89339 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/24744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24903 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/24804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->