### PR TITLE
[WPE][GTK] Internal error fired from WebLoaderStrategy.cpp(559) : internallyFailedLoadTimerFired

### DIFF
--- a/Source/WTF/wtf/linux/RealTimeThreads.cpp
+++ b/Source/WTF/wtf/linux/RealTimeThreads.cpp
@@ -29,12 +29,15 @@
 #include <sched.h>
 #include <signal.h>
 #include <string.h>
+#include <wtf/Logging.h>
 #include <wtf/MainThread.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/SafeStrerror.h>
 
 #if USE(GLIB)
 #include <gio/gio.h>
+#include <glib-unix.h>
+#include <sys/eventfd.h>
 #include <sys/resource.h>
 #include <sys/time.h>
 #include <wtf/Seconds.h>
@@ -69,19 +72,11 @@ RealTimeThreads::RealTimeThreads()
 {
 #if USE(GLIB)
     m_discardRealTimeKitProxyTimer.setPriority(RunLoopSourcePriority::ReleaseUnusedResourcesTimer);
-#endif
 
-    callOnMainThread([] {
-        struct sigaction action;
-        sigemptyset(&action.sa_mask);
-        action.sa_sigaction = +[](int, siginfo_t*, void*) {
-            // We don't know which thread caused the limit to be reached,
-            // so we demote all real time threads to avoid SIGKILL.
-            RealTimeThreads::singleton().demoteAllThreadsFromRealTime();
-        };
-        action.sa_flags = SA_SIGINFO;
-        sigaction(SIGXCPU, &action, nullptr);
+    callOnMainThread([this] {
+        setupSignalHandler();
     });
+#endif
 }
 
 void RealTimeThreads::registerThread(Thread& thread)
@@ -140,8 +135,20 @@ void RealTimeThreads::demoteThreadFromRealTime(const Thread& thread)
 {
     ASSERT(isMainThread());
 
+    int previousPolicy = sched_getscheduler(thread.id());
+    struct sched_param prevParam = { };
+    sched_getparam(thread.id(), &prevParam);
+    if (previousPolicy == SCHED_OTHER && !prevParam.sched_priority) {
+        // Skipping thread not running in real-time.
+        return;
+    }
+
     struct sched_param param = { };
-    sched_setscheduler(thread.id(), SCHED_OTHER | SCHED_RESET_ON_FORK, &param);
+    auto ret = sched_setscheduler(thread.id(), SCHED_OTHER | SCHED_RESET_ON_FORK, &param);
+    if (ret)
+        LOG_ERROR("Demote p%d, t%d: sched_setscheduler failed: %s", getpid(), thread.id(), safeStrerror(errno).data());
+    else
+        LOG(Process, "Demote p%d, t%d: sched_setscheduler suceeded", getpid(), thread.id());
 }
 
 void RealTimeThreads::demoteAllThreadsFromRealTime()
@@ -153,6 +160,60 @@ void RealTimeThreads::demoteAllThreadsFromRealTime()
 
 #if USE(GLIB)
 static const Seconds s_dbusCallTimeout = 20_ms;
+
+static int s_eventFd = -1;
+
+static void sigxcpuHandler(int)
+{
+    uint64_t value = 1;
+    auto ret = write(s_eventFd, &value, sizeof(value));
+    UNUSED_VARIABLE(ret);
+}
+
+void RealTimeThreads::setupSignalHandler()
+{
+    ASSERT(isMainThread());
+
+    if ((s_eventFd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC)) < 0) {
+        LOG_ERROR("Failed to create eventfd for SIGXCPU: %s", safeStrerror(errno).data());
+        return;
+    }
+
+    struct sigaction action;
+    sigemptyset(&action.sa_mask);
+    action.sa_handler = sigxcpuHandler;
+    action.sa_flags = SA_RESTART;
+
+    struct sigaction oldAction;
+    if (sigaction(SIGXCPU, &action, &oldAction))
+        LOG_ERROR("Failed to install SIGXCPU handler: %s", safeStrerror(errno).data());
+    else if (oldAction.sa_handler != SIG_DFL)
+        LOG_ERROR("Overriding existing handler for signal SIGXCPU");
+
+    g_unix_fd_add(s_eventFd, G_IO_IN, signalCallback, this);
+}
+
+gboolean RealTimeThreads::signalCallback(gint fd, GIOCondition condition, gpointer userData)
+{
+    ASSERT(s_eventFd == fd);
+
+    if (condition & (G_IO_ERR | G_IO_HUP)) {
+        LOG_ERROR("Removing event source as it has errored or disconnected. SIGXCPU is no longer handled.");
+        return G_SOURCE_REMOVE;
+    }
+
+    if (condition & G_IO_IN) {
+        uint64_t value;
+        while (read(fd, &value, sizeof(value)) == sizeof(value)) {
+        }
+
+        // We don't know which thread caused the limit to be reached,
+        // so we demote all real time threads to avoid SIGKILL.
+        static_cast<RealTimeThreads*>(userData)->demoteAllThreadsFromRealTime();
+    }
+
+    return G_SOURCE_CONTINUE;
+}
 
 #ifdef RLIMIT_RTTIME
 static int64_t realTimeKitGetProperty(GDBusProxy* proxy, const char* propertyName, GError** error)
@@ -214,7 +275,8 @@ void RealTimeThreads::realTimeKitMakeThreadRealTime(uint64_t processID, uint64_t
         }
 
         if (rl.rlim_max > static_cast<uint64_t>(rttimeMax)) {
-            rl.rlim_cur = rl.rlim_max = rttimeMax;
+            rl.rlim_cur = static_cast<uint64_t>(0.8 * rttimeMax);
+            rl.rlim_max = rttimeMax;
             setrlimit(RLIMIT_RTTIME, &rl);
         }
     }

--- a/Source/WTF/wtf/linux/RealTimeThreads.h
+++ b/Source/WTF/wtf/linux/RealTimeThreads.h
@@ -58,6 +58,8 @@ private:
     void realTimeKitMakeThreadRealTime(uint64_t processID, uint64_t threadID, uint32_t priority);
     void scheduleDiscardRealTimeKitProxy();
     void discardRealTimeKitProxyTimerFired();
+    void setupSignalHandler();
+    static gboolean signalCallback(gint, GIOCondition, gpointer);
 #endif
 
     Ref<ThreadGroup> m_threadGroup;


### PR DESCRIPTION
#### 0831c81f23e301efb4c38d4fc330746ab77b4160
<pre>
[WPE][GTK] Internal error fired from WebLoaderStrategy.cpp(559) : internallyFailedLoadTimerFired
<a href="https://bugs.webkit.org/show_bug.cgi?id=276312">https://bugs.webkit.org/show_bug.cgi?id=276312</a>

Reviewed by Adrian Perez de Castro.

It seems that under certain circumstances, NetworkProcess real-time
threads (promoted by RealtimeKit) will exceed their maximum 200ms hard
limit (rlim_max), getting killed by the kernel.

Although the code has provisions in place to demote the threads back
from real time, the fact the soft limit was set at the same value as the
hard limit meant it would never have a chance to run.

This commit adds two changes:
 - It sets the real time soft limit to 0.8 of the hard one, giving a
   chance to the SIGXCPU handler to run before the hard limit triggers a
   kill.
 - It makes the SIGXCPU signal handler async-signal-safe. The previous
   one needed to acquire a mutex and called sched_setscheduler, the
   current one uses eventfd.

The new implementation uses the handler installed by sigaction to write
to the event fd. This is bridged to the GLib main loop by g_unix_fd_add,
so that the callback can be queued and run safely, demoting all threads.

As the signal handler is installed, we query if a previous handler was
previously defined -- as done in ThreadingPOSIX --, logging it
unconditionally.

This bug can be reproduced consistently on debug builds under heavy load
(using e.g. stress-ng) without this fix. Commenting out setrlimit means
the process attempts to set an unlimited max, which RealtimeKit rejects:
in that case, the NetworkProcess runs normally and is not killed. After
this fix is applied, the demotion runs and NetworkProcess can survive.

* Source/WTF/wtf/linux/RealTimeThreads.cpp:
(WTF::RealTimeThreads::RealTimeThreads):
(WTF::RealTimeThreads::demoteThreadFromRealTime):
(WTF::sigxcpuHandler):
(WTF::RealTimeThreads::setupSignalHandler):
(WTF::RealTimeThreads::signalCallback):
(WTF::RealTimeThreads::realTimeKitMakeThreadRealTime):
* Source/WTF/wtf/linux/RealTimeThreads.h:

Canonical link: <a href="https://commits.webkit.org/310907@main">https://commits.webkit.org/310907@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1520430f344b7195f91de9c44a593c0d7e9ce243

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155175 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28435 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21594 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163935 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108774 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28575 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28283 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120065 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84811 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158134 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22318 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139348 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100760 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21404 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19456 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11761 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147225 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131067 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17188 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166413 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/16006 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/10832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18797 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128169 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27979 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23492 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128306 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34845 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27903 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138981 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84612 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23170 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15777 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/187060 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27596 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91700 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47975 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27174 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27404 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27247 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->