### PR TITLE
Unreviewed, reverting 309636@main (a80da14addae)

### DIFF
--- a/Tools/Scripts/webkitpy/api_tests/manager.py
+++ b/Tools/Scripts/webkitpy/api_tests/manager.py
@@ -25,11 +25,12 @@ import logging
 import os
 import re
 import time
-from typing import Optional
 
 from webkitpy.api_tests.runner import Runner
 from webkitpy.common.iteration_compatibility import iteritems
 from webkitpy.common.system.executive import ScriptError
+from webkitpy.results.upload import Upload
+from webkitpy.xcode.simulated_device import DeviceRequest, SimulatedDeviceManager
 
 _log = logging.getLogger(__name__)
 
@@ -99,54 +100,7 @@ class Manager(object):
                     continue
         return result
 
-    @classmethod
-    def _is_exact_test_name(cls, arg: str) -> bool:
-        """Returns True if arg looks like an exact fully-qualified test name (no globs)."""
-        if '*' in arg:
-            return False
-        parts = arg.split('.')
-        # Must be <Suite>.<Test> or <Binary>.<Suite>.<Test> (or with / for parameterized suites)
-        return len(parts) >= 2 and '' not in parts
-
-    def _try_collect_exact_tests(self, args: list[str]) -> Optional[list[str]]:
-        """Try to resolve test names without spawning the binary to list all tests.
-
-        Returns a list of fully-qualified test names (Binary.Suite.Test) if all args
-        can be resolved exactly, or None if we need to fall back to listing.
-        """
-        if not args:
-            return None
-
-        if not all(self._is_exact_test_name(arg) for arg in args):
-            return None
-
-        known_binaries: set[str] = set(self._port.path_to_api_test_binaries().keys())
-        result: list[str] = []
-
-        for arg in args:
-            parts = arg.split('.')
-            candidate_binary = parts[0]
-
-            if candidate_binary in known_binaries:
-                # First part is a binary name. Need at least 3 parts
-                # (Binary.Suite.Test) to be an exact test. With only 2 parts
-                # (Binary.Suite), it's a suite filter that requires listing.
-                if len(parts) < 3:
-                    return None
-                result.append(arg)
-            else:
-                # arg is <Suite>.<Test> — we don't know which binary contains it,
-                # so fall back to listing.
-                return None
-
-        return sorted(result) if result else None
-
-    def _collect_tests(self, args: list[str]) -> list[str]:
-        # Fast path: if all args are exact test names, skip listing
-        exact = self._try_collect_exact_tests(args)
-        if exact is not None:
-            return exact
-
+    def _collect_tests(self, args):
         available_tests = []
         specified_binaries = self._binaries_for_arguments(args)
         for canonicalized_binary, path in self._port.path_to_api_test_binaries().items():
@@ -227,6 +181,7 @@ class Manager(object):
             return False
 
         self._update_worker_count()
+        self._port.reset_preferences()
 
         # Set up devices for the test run
         if 'simulator' in self._port.port_name:
@@ -270,13 +225,14 @@ class Manager(object):
         start_time = time.time()
 
         self._stream.write_update('Checking build ...')
-        if self._options.build:
-            if not self._port.check_api_test_build(self._binaries_for_arguments(args)):
-                _log.error('Build check failed')
-                return Manager.FAILED_BUILD_CHECK
+        if not self._port.check_api_test_build(self._binaries_for_arguments(args)):
+            _log.error('Build check failed')
+            return Manager.FAILED_BUILD_CHECK
 
         if not self._set_up_run():
             return Manager.FAILED_BUILD_CHECK
+
+        configuration_for_upload = self._port.configuration_for_upload(self._port.target_host(0))
 
         self._stream.write_update('Collecting tests ...')
         try:
@@ -393,12 +349,8 @@ class Manager(object):
                 self.host.filesystem.write_text_file(json_output, json.dumps(result_dictionary, indent=4))
 
         if self._options.report_urls:
-            from webkitpy.results.upload import Upload
-
             self._stream.writeln('\n')
             self._stream.write_update('Preparing upload data ...')
-
-            configuration_for_upload = self._port.configuration_for_upload(self._port.target_host(0))
 
             status_to_test_result = {
                 runner.STATUS_PASSED: None,

--- a/Tools/Scripts/webkitpy/api_tests/manager_unittest.py
+++ b/Tools/Scripts/webkitpy/api_tests/manager_unittest.py
@@ -51,15 +51,3 @@ A.
         ]
         got_tests = Manager._test_list_from_output(gtest_list_tests_output)
         self.assertEqual(expected_tests, got_tests)
-
-    def test_is_exact_test_name(self):
-        self.assertTrue(Manager._is_exact_test_name('WebKit.MouseMoveOverElementWithClosedWebView'))
-        self.assertTrue(Manager._is_exact_test_name('TestWebKitAPI.WebKit.MouseMoveOverElementWithClosedWebView'))
-        self.assertTrue(Manager._is_exact_test_name('Misc/ValueParametrizedTest.ValueParametrizedTestsSupported/CatRed'))
-        self.assertFalse(Manager._is_exact_test_name('WebKit.*'))
-        self.assertFalse(Manager._is_exact_test_name('WebKit'))
-        self.assertFalse(Manager._is_exact_test_name('*'))
-        self.assertFalse(Manager._is_exact_test_name(''))
-        # Binary.Suite (only 2 parts) still passes _is_exact_test_name;
-        # _try_collect_exact_tests handles the binary prefix check separately
-        self.assertTrue(Manager._is_exact_test_name('TestWebKitAPI.SmartLists'))

--- a/Tools/Scripts/webkitpy/port/base.py
+++ b/Tools/Scripts/webkitpy/port/base.py
@@ -60,6 +60,7 @@ import time
 
 from collections import OrderedDict
 from webkitcorepy import string_utils, decorators
+from webkitscmpy import local
 
 from webkitpy.common.memoized import memoized
 from webkitpy.common.prettypatch import PrettyPatch
@@ -300,13 +301,12 @@ class Port(object):
         return True
 
     def check_api_test_build(self, canonicalized_binaries=None):
-        binaries = self.path_to_api_test_binaries()
         if not canonicalized_binaries:
-            canonicalized_binaries = binaries.keys()
+            canonicalized_binaries = self.path_to_api_test_binaries().keys()
         if not self._root_was_set and self.get_option('build') and not self._build_api_tests(wtf_only=(canonicalized_binaries == ['TestWTF'])):
             return False
 
-        for binary, path in binaries.items():
+        for binary, path in self.path_to_api_test_binaries().items():
             if binary not in canonicalized_binaries:
                 continue
             if not self._filesystem.exists(path):
@@ -1427,7 +1427,6 @@ class Port(object):
     @memoized
     def commits_for_upload(self):
         from webkitpy.results.upload import Upload
-        from webkitscmpy import local
 
         repos = {}
         if port_config.apple_additions() and getattr(port_config.apple_additions(), 'repos', False):

--- a/Tools/Scripts/webkitpy/port/embedded_device.py
+++ b/Tools/Scripts/webkitpy/port/embedded_device.py
@@ -51,7 +51,7 @@ class EmbeddedDevicePort(EmbeddedPort, metaclass=ABCMeta):
     @classmethod
     def determine_full_port_name(cls, host, options, port_name):
         if port_name == cls.port_name:
-            sdk_version = host.platform.xcode_sdk_version(cls._DEFAULT_SDK)
+            sdk_version = host.platform.xcode_sdk_version(cls.SDK)
             if not sdk_version:
                 raise Exception("Please install the {} SDK.".format(cls.DEVICE_TYPE.software_variant))
             port_name = port_name + '-' + str(sdk_version.major)

--- a/Tools/Scripts/webkitpy/port/factory.py
+++ b/Tools/Scripts/webkitpy/port/factory.py
@@ -35,6 +35,8 @@ import optparse
 import re
 
 from webkitpy.port import config
+from webkitpy.common.system import executive
+from webkitpy.common.system import filesystem
 
 
 def platform_options(use_globs=False):
@@ -76,7 +78,7 @@ def platform_options(use_globs=False):
 
 def configuration_options():
     return [
-        optparse.make_option("-t", "--target", default=None, dest="configuration", help="(DEPRECATED)"),
+        optparse.make_option("-t", "--target", default=config.Config(executive.Executive(), filesystem.FileSystem()).default_configuration(), dest="configuration", help="(DEPRECATED) (default: %default)"),
         optparse.make_option('--debug', action='store_const', const='Debug', dest="configuration",
             help='Set the configuration to Debug'),
         optparse.make_option('--release', action='store_const', const='Release', dest="configuration",
@@ -130,37 +132,28 @@ class PortFactory(object):
             return 'win'
         raise NotImplementedError('unknown platform: %s' % platform)
 
-    @staticmethod
-    def _load_port_class(port_class):
-        """Import and return the class object for a PORT_CLASSES entry."""
-        module_name, class_name = port_class.rsplit('.', 1)
-        module = __import__('webkitpy.port.{}'.format(module_name), globals(), locals(), [], 0)
-        return module.__dict__.get('port').__dict__.get(module_name).__dict__.get(class_name)
-
     def get(self, port_name=None, options=None, **kwargs):
         """Returns an object implementing the Port interface. If
         port_name is None, this routine attempts to guess at the most
         appropriate port on this platform."""
         port_name = port_name or self._default_port()
-
+        classes = []
         for port_class in self.PORT_CLASSES:
-            cls = self._load_port_class(port_class)
-            if cls and port_name.startswith(cls.port_name):
-                full_port_name = cls.determine_full_port_name(self._host, options, port_name)
+            module_name, class_name = port_class.rsplit('.', 1)
+            module = __import__('webkitpy.port.{}'.format(module_name), globals(), locals(), [], 0)
+            cls = module.__dict__.get('port').__dict__.get(module_name).__dict__.get(class_name)
+            if cls:
+                classes.append(cls)
+        if config.apple_additions() and hasattr(config.apple_additions(), 'ports'):
+            classes += config.apple_additions().ports()
+
+        for cls in classes:
+            if port_name.startswith(cls.port_name):
+                port_name = cls.determine_full_port_name(self._host, options, port_name)
                 try:
-                    return cls(self._host, full_port_name, options=options, **kwargs)
+                    return cls(self._host, port_name, options=options, **kwargs)
                 except ValueError:
                     continue
-
-        if config.apple_additions() and hasattr(config.apple_additions(), 'ports'):
-            for cls in config.apple_additions().ports():
-                if port_name.startswith(cls.port_name):
-                    full_port_name = cls.determine_full_port_name(self._host, options, port_name)
-                    try:
-                        return cls(self._host, full_port_name, options=options, **kwargs)
-                    except ValueError:
-                        continue
-
         raise NotImplementedError('unsupported platform: "%s"' % port_name)
 
     def all_port_names(self, platform=None):

--- a/Tools/Scripts/webkitpy/port/ios_device.py
+++ b/Tools/Scripts/webkitpy/port/ios_device.py
@@ -36,11 +36,7 @@ class IOSDevicePort(EmbeddedDevicePort, IOSPort):
     DEFAULT_ARCHITECTURE = 'arm64'
     VERSION_FALLBACK_ORDER = ['ios-7', 'ios-8', 'ios-9', 'ios-10']
 
-    _DEFAULT_SDK = 'iphoneos'
-
-    @property
-    def SDK(self):
-        return apple_additions().get_sdk(self._DEFAULT_SDK) if apple_additions() else self._DEFAULT_SDK
+    SDK = apple_additions().get_sdk('iphoneos') if apple_additions() else 'iphoneos'
 
     def _is_device_platform_match(self, device):
         return device.platform.is_ios()

--- a/Tools/Scripts/webkitpy/port/ios_simulator.py
+++ b/Tools/Scripts/webkitpy/port/ios_simulator.py
@@ -42,11 +42,7 @@ class IOSSimulatorPort(EmbeddedSimulatorPort, IOSPort):
         DeviceType(hardware_family='iPhone', hardware_type='12'),
         DeviceType(hardware_family='iPad', hardware_type='(9th generation)'),
     ]
-    _DEFAULT_SDK = 'iphonesimulator'
-
-    @property
-    def SDK(self):
-        return apple_additions().get_sdk(self._DEFAULT_SDK) if apple_additions() else self._DEFAULT_SDK
+    SDK = apple_additions().get_sdk('iphonesimulator') if apple_additions() else 'iphonesimulator'
 
     def architecture(self):
         result = self.get_option('architecture') or self.host.platform.architecture()

--- a/Tools/Scripts/webkitpy/port/port_testcase.py
+++ b/Tools/Scripts/webkitpy/port/port_testcase.py
@@ -86,10 +86,6 @@ def bind_mock_apple_additions():
     class MockAppleAdditions(object):
 
         @staticmethod
-        def get_sdk(sdk_name):
-            return sdk_name
-
-        @staticmethod
         def layout_tests_path():
             return '/additional_testing_path/'
 

--- a/Tools/Scripts/webkitpy/port/visionos_device.py
+++ b/Tools/Scripts/webkitpy/port/visionos_device.py
@@ -36,11 +36,7 @@ class VisionOSDevicePort(EmbeddedDevicePort, VisionOSPort):
     DEFAULT_ARCHITECTURE = 'arm64'
     VERSION_FALLBACK_ORDER = ['visionos-1', 'visionos-2']
 
-    _DEFAULT_SDK = 'xros'
-
-    @property
-    def SDK(self):
-        return apple_additions().get_sdk(self._DEFAULT_SDK) if apple_additions() else self._DEFAULT_SDK
+    SDK = apple_additions().get_sdk('xros') if apple_additions() else 'xros'
 
     def _is_device_platform_match(self, device):
         return device.platform.is_visionos()

--- a/Tools/Scripts/webkitpy/port/visionos_simulator.py
+++ b/Tools/Scripts/webkitpy/port/visionos_simulator.py
@@ -39,11 +39,7 @@ class VisionOSSimulatorPort(EmbeddedSimulatorPort, VisionOSPort):
     DEFAULT_DEVICE_TYPES = [
         DeviceType(software_variant='visionOS', hardware_family='Vision', hardware_type='Pro')
     ]
-    _DEFAULT_SDK = 'xrsimulator'
-
-    @property
-    def SDK(self):
-        return apple_additions().get_sdk(self._DEFAULT_SDK) if apple_additions() else self._DEFAULT_SDK
+    SDK = apple_additions().get_sdk('xrsimulator') if apple_additions() else 'xrsimulator'
 
     def architecture(self):
         result = self.get_option('architecture') or self.host.platform.architecture()

--- a/Tools/Scripts/webkitpy/port/watch_device.py
+++ b/Tools/Scripts/webkitpy/port/watch_device.py
@@ -35,11 +35,7 @@ class WatchDevicePort(EmbeddedDevicePort, WatchPort):
     ARCHITECTURES = ['armv7k', 'arm64e', 'arm64_32']
     DEFAULT_ARCHITECTURE = 'armv7k'
 
-    _DEFAULT_SDK = 'watchos'
-
-    @property
-    def SDK(self):
-        return apple_additions().get_sdk(self._DEFAULT_SDK) if apple_additions() else self._DEFAULT_SDK
+    SDK = apple_additions().get_sdk('watchos') if apple_additions() else 'watchos'
 
     def _is_device_platform_match(self, device):
         return device.platform.is_watchos()

--- a/Tools/Scripts/webkitpy/port/watch_simulator.py
+++ b/Tools/Scripts/webkitpy/port/watch_simulator.py
@@ -37,11 +37,7 @@ class WatchSimulatorPort(EmbeddedSimulatorPort, WatchPort):
     DEFAULT_ARCHITECTURE = 'i386'
 
     DEFAULT_DEVICE_TYPES = [DeviceType(hardware_family='Apple Watch', hardware_type='Series 9 - 45mm')]
-    _DEFAULT_SDK = 'watchsimulator'
-
-    @property
-    def SDK(self):
-        return apple_additions().get_sdk(self._DEFAULT_SDK) if apple_additions() else self._DEFAULT_SDK
+    SDK = apple_additions().get_sdk('watchsimulator') if apple_additions() else 'watchsimulator'
 
     def architecture(self):
         result = self.get_option('architecture') or self.host.platform.architecture()


### PR DESCRIPTION
#### 6cce7364331a14c39a8616b9a256314f26117504
<pre>
Unreviewed, reverting 309636@main (a80da14addae)
<a href="https://bugs.webkit.org/show_bug.cgi?id=310931">https://bugs.webkit.org/show_bug.cgi?id=310931</a>
<a href="https://rdar.apple.com/172887928">rdar://172887928</a>

[EWS]  New added test times out on run-api-tests-without-change step

Reverted change:

    [API Tests] Reduce run-api-tests startup overhead when running specific tests
    <a href="https://bugs.webkit.org/show_bug.cgi?id=310247">https://bugs.webkit.org/show_bug.cgi?id=310247</a>
    <a href="https://rdar.apple.com/172887928">rdar://172887928</a>
    309636@main (a80da14addae)

Canonical link: <a href="https://commits.webkit.org/310110@main">https://commits.webkit.org/310110@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb3d28974d59bb6225f4cbf0a17f0b41bbcd7bf6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152764 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/25545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/19144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/161508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154637 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/26073 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/25851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/161508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/155723 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/26073 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/19144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/161508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/152085 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/26073 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/25851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/9344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/26073 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/19144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/163980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/19144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/163980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/25343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/25851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/163980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/25345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/19144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/81949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23400 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/25345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/19144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/24961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/24653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/24812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/24713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->