### PR TITLE
[ModelElement] stagemode=orbit does not allow user interaction after back/forward navigation

### DIFF
--- a/LayoutTests/model-element/model-element-determines-if-scroll-gesture-updates-position-information-after-bfcache-expected.txt
+++ b/LayoutTests/model-element/model-element-determines-if-scroll-gesture-updates-position-information-after-bfcache-expected.txt
@@ -1,0 +1,10 @@
+After restoring a page with a loaded model element from the back/forward cache, ensurePositionInformationIsUpToDate should still be called during scroll gestures.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS ensurePositionInformationIsUpToDate was called after back/forward cache restore
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/model-element/model-element-determines-if-scroll-gesture-updates-position-information-after-bfcache.html
+++ b/LayoutTests/model-element/model-element-determines-if-scroll-gesture-updates-position-information-after-bfcache.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true UsesBackForwardCache=true ModelElementEnabled=true ModelProcessEnabled=true allowTestOnlyIPC=true ] -->
+<html>
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="../resources/js-test.js"></script>
+    <script src="../resources/basic-gestures.js"></script>
+    <script src="../resources/ui-helper.js"></script>
+</head>
+<script>
+    jsTestIsAsync = true;
+    testRunner.dumpAsText();
+    internals.disableModelLoadDelaysForTesting();
+
+    async function scroll() {
+        var startX = 50;
+        var startY = 250;
+        await touchAndDragFromPointToPoint(startX, startY, startX, startY - 100);
+        await liftUpAtPoint(startX, startY - 100);
+    }
+
+    window.addEventListener("pageshow", async (event) => {
+        if (!event.persisted)
+            return;
+
+        await UIHelper.clearEnsurePositionInformationIsUpToDateTracking();
+        await scroll();
+        var didCall = await UIHelper.didCallEnsurePositionInformationIsUpToDateSinceLastCheck();
+        if (didCall)
+            testPassed("ensurePositionInformationIsUpToDate was called after back/forward cache restore");
+        else
+            testFailed("ensurePositionInformationIsUpToDate was not called after back/forward cache restore; model element count was not restored");
+        finishJSTest();
+    });
+
+    addEventListener("load", async () => {
+        if (!window.testRunner)
+            return;
+
+        description("After restoring a page with a loaded model element from the back/forward cache, " +
+            "ensurePositionInformationIsUpToDate should still be called during scroll gestures.");
+
+        await document.getElementById("model").ready;
+        window.location.href = "resources/go-back-on-load.html";
+    });
+</script>
+<body>
+    <div id="scroller" style="height: 300px; overflow: scroll;">
+        <div style="height: 600px;"></div>
+    </div>
+    <model id="model">
+        <source src="resources/cube.usdz" />
+    </model>
+    <div id="console"></div>
+</body>
+</html>

--- a/LayoutTests/model-element/model-element-determines-if-scroll-gesture-updates-position-information-frames.html
+++ b/LayoutTests/model-element/model-element-determines-if-scroll-gesture-updates-position-information-frames.html
@@ -112,9 +112,15 @@
             var secondFrame = newFrame.cloneNode(true);
             var thirdFrame = newFrame.cloneNode(true);
 
+            var frameLoads = [
+                new Promise(resolve => newFrame.addEventListener("load", resolve, { once: true })),
+                new Promise(resolve => secondFrame.addEventListener("load", resolve, { once: true })),
+                new Promise(resolve => thirdFrame.addEventListener("load", resolve, { once: true })),
+            ];
             modelContainer.appendChild(newFrame); // Page now has one model elements.
             modelContainer.appendChild(secondFrame); // Page now has two model elements.
             modelContainer.appendChild(thirdFrame); // Page now has three model elements.
+            await Promise.all(frameLoads);
             await scrollAndCheckIfPositionInformationUpdated(true);
 
             await clearModelsInFrame(newFrame); // Page now has two model elements.

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -328,11 +328,24 @@ RenderPtr<RenderElement> HTMLModelElement::createElementRenderer(RenderStyle&& s
 
 void HTMLModelElement::didAttachRenderers()
 {
+#if ENABLE(MODEL_PROCESS)
+    if (RefPtr page = document().page())
+        page->incrementModelElementCount();
+#endif
+
     if (!m_shouldCreateModelPlayerUponRendererAttachment)
         return;
 
     m_shouldCreateModelPlayerUponRendererAttachment = false;
     createModelPlayer();
+}
+
+void HTMLModelElement::willDetachRenderers()
+{
+#if ENABLE(MODEL_PROCESS)
+    if (RefPtr page = document().page())
+        page->decrementModelElementCount();
+#endif
 }
 
 // MARK: - CachedRawResourceClient overrides.
@@ -1706,9 +1719,6 @@ Node::NeedsPostConnectionSteps HTMLModelElement::insertionSteps(InsertionType in
     if (insertionType.connectedToDocument) {
         Ref document = this->document();
         document->registerForVisibilityStateChangedCallbacks(*this);
-#if ENABLE(MODEL_PROCESS)
-        document->incrementModelElementCount();
-#endif
         m_modelPlayerProvider = document->page()->modelPlayerProvider();
         LazyLoadModelObserver::observe(*this);
     }
@@ -1723,9 +1733,6 @@ void HTMLModelElement::removingSteps(RemovalType removalType, ContainerNode& old
     if (removalType.disconnectedFromDocument) {
         Ref document = this->document();
         document->unregisterForVisibilityStateChangedCallbacks(*this);
-#if ENABLE(MODEL_PROCESS)
-        document->decrementModelElementCount();
-#endif
         LazyLoadModelObserver::unobserve(*this, document);
 
         m_loadModelTimer = nullptr;

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -239,6 +239,7 @@ private:
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
     bool isReplaced(const RenderStyle* = nullptr) const final { return true; }
     void didAttachRenderers() final;
+    void willDetachRenderers() final;
 
     // CachedRawResourceClient overrides.
     void dataReceived(CachedResource&, const SharedBuffer&) final;

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3514,15 +3514,6 @@ void Document::destroyRenderTree()
     ASSERT(frame()->document() == this);
     ASSERT(page());
 
-#if ENABLE(MODEL_PROCESS)
-    if (m_modelElementCount) {
-        if (RefPtr page = this->page()) {
-            page->decrementModelElementCount(m_modelElementCount);
-            m_modelElementCount = 0;
-        }
-    }
-#endif
-
     // Prevent Widget tree changes from committing until the RenderView is dead and gone.
     WidgetHierarchyUpdatesSuspensionScope suspendWidgetHierarchyUpdates;
 
@@ -11495,35 +11486,6 @@ LazyLoadModelObserver& Document::lazyLoadModelObserver()
         m_lazyLoadModelObserver = makeUnique<LazyLoadModelObserver>();
     return *m_lazyLoadModelObserver;
 }
-#endif
-
-#if ENABLE(MODEL_PROCESS)
-
-void Document::incrementModelElementCount()
-{
-    RefPtr page = this->page();
-    if (!page)
-        return;
-
-    m_modelElementCount++;
-    page->incrementModelElementCount();
-}
-
-void Document::decrementModelElementCount()
-{
-    RefPtr page = this->page();
-    if (!page)
-        return;
-
-    if (!m_modelElementCount) [[unlikely]] {
-        ASSERT_NOT_REACHED();
-        return;
-    }
-
-    page->decrementModelElementCount(1);
-    m_modelElementCount--;
-}
-
 #endif
 
 CrossOriginOpenerPolicy Document::crossOriginOpenerPolicy() const

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1979,12 +1979,6 @@ public:
     LazyLoadModelObserver& lazyLoadModelObserver();
 #endif
 
-#if ENABLE(MODEL_PROCESS)
-    void incrementModelElementCount();
-    void decrementModelElementCount();
-    bool hasModelElement() const { return m_modelElementCount > 0; }
-#endif
-
     ContentVisibilityDocumentState& contentVisibilityDocumentState();
 
     void setHasVisuallyNonEmptyCustomContent() { m_hasVisuallyNonEmptyCustomContent = true; }
@@ -2359,10 +2353,6 @@ private:
     std::unique_ptr<LazyLoadImageObserver> m_lazyLoadImageObserver;
 #if ENABLE(MODEL_ELEMENT)
     std::unique_ptr<LazyLoadModelObserver> m_lazyLoadModelObserver;
-#endif
-
-#if ENABLE(MODEL_PROCESS)
-    unsigned m_modelElementCount { 0 };
 #endif
 
     std::unique_ptr<ContentVisibilityDocumentState> m_contentVisibilityDocumentState;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -3123,18 +3123,12 @@ void Page::incrementModelElementCount()
         chrome().client().setHasModelElement(true);
 }
 
-void Page::decrementModelElementCount(unsigned count)
+void Page::decrementModelElementCount()
 {
-    m_modelElementCount -= count;
-    if (!m_modelElementCount) {
+    ASSERT(m_modelElementCount > 0);
+    m_modelElementCount--;
+    if (!m_modelElementCount)
         chrome().client().setHasModelElement(false);
-        return;
-    }
-
-    if (m_modelElementCount < 0) [[unlikely]] {
-        m_modelElementCount = 0;
-        ASSERT_NOT_REACHED();
-    }
 }
 
 #endif

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1030,7 +1030,7 @@ public:
 
 #if ENABLE(MODEL_PROCESS)
     void incrementModelElementCount();
-    void decrementModelElementCount(unsigned);
+    void decrementModelElementCount();
 #endif
 
     std::optional<MediaSessionGroupIdentifier> NODELETE mediaSessionGroupIdentifier() const;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -3211,6 +3211,11 @@ static inline bool isSamePair(UIGestureRecognizer *a, UIGestureRecognizer *b, UI
     }
 #endif
 
+#if ENABLE(MODEL_PROCESS)
+    if (gestureRecognizer == _modelInteractionPanGestureRecognizer && otherGestureRecognizer == [_webView.get() scrollView].panGestureRecognizer)
+        return _page->hasModelElement();
+#endif
+
     if ([gestureRecognizer isKindOfClass:WKDeferringGestureRecognizer.class])
         return [(WKDeferringGestureRecognizer *)gestureRecognizer shouldDeferGestureRecognizer:otherGestureRecognizer];
 


### PR DESCRIPTION
#### 75bbb1a345f3ff296e72eaea48c86f668e26b9b8
<pre>
[ModelElement] stagemode=orbit does not allow user interaction after back/forward navigation
<a href="https://bugs.webkit.org/show_bug.cgi?id=310932">https://bugs.webkit.org/show_bug.cgi?id=310932</a>
<a href="https://rdar.apple.com/173267221">rdar://173267221</a>

Reviewed by Etienne Segonzac and Mike Wyrzykowski.

Model element counting was tied to DOM insertion/removal
(insertionSteps/removingSteps), which required special handling in
Document::destroyRenderTree and createRenderTree for BFCache since
DOM nodes stay connected while renderers are torn down. Move the
counting to didAttachRenderers/willDetachRenderers instead, which
naturally follows the renderer lifecycle and correctly handles BFCache
restore without extra bookkeeping. This removes the document-level
m_modelElementCount entirely — the page-level count is now maintained
directly by HTMLModelElement.

The WKScrollView&apos;s UIScrollViewPanGestureRecognizer can begin before
_modelInteractionPanGestureRecognizer reaches
gestureRecognizerShouldBegin:, causing UIKit to fail the model pan
gesture since the two do not allow simultaneous recognition. Add a
dynamic failure requirement in shouldBeRequiredToFailByGestureRecognizer:
so that when hasModelElement() is true, the scroll view pan waits for
the model pan to resolve first. When hasModelElement() is false, no
requirement is imposed, preserving zero-latency scrolling.

model-element-determines-if-scroll-gesture-updates-position-information-frames.html:
wait for iframe load events in the test before scrolling, so model
elements inside iframes are counted before the gesture is evaluated.

Test: model-element/model-element-determines-if-scroll-gesture-updates-position-information-after-bfcache.html

* LayoutTests/model-element/model-element-determines-if-scroll-gesture-updates-position-information-after-bfcache-expected.txt: Added.
* LayoutTests/model-element/model-element-determines-if-scroll-gesture-updates-position-information-after-bfcache.html: Added.
* LayoutTests/model-element/model-element-determines-if-scroll-gesture-updates-position-information-frames.html:
* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::didAttachRenderers):
(WebCore::HTMLModelElement::willDetachRenderers):
(WebCore::HTMLModelElement::insertionSteps):
(WebCore::HTMLModelElement::removingSteps):
* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::destroyRenderTree):
(WebCore::Document::incrementModelElementCount): Deleted.
(WebCore::Document::decrementModelElementCount): Deleted.
* Source/WebCore/dom/Document.h:
(WebCore::Document::hasModelElement const): Deleted.
* Source/WebCore/page/Page.cpp:
(WebCore::Page::decrementModelElementCount):
* Source/WebCore/page/Page.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView gestureRecognizer:shouldBeRequiredToFailByGestureRecognizer:]):

Canonical link: <a href="https://commits.webkit.org/310667@main">https://commits.webkit.org/310667@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/faa35232bf3725cd9078638daeae072cd4fdfdb0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154484 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27742 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20902 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163240 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107953 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156357 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27876 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27592 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119491 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84516 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157443 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21768 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138748 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100188 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4f23fb7d-916d-473c-9f20-5b3af99a4357) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20855 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18866 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11070 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130517 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16592 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165712 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8919 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18201 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127589 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27288 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22906 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127734 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34667 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27212 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138385 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83895 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22631 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15177 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26903 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91005 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26483 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26714 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26556 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->