### PR TITLE
Crash in TreeScopeOrderedMap::add when adopting map element with id across documents

### DIFF
--- a/LayoutTests/fast/dom/map-element-move-to-new-document-crash-expected.txt
+++ b/LayoutTests/fast/dom/map-element-move-to-new-document-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/dom/map-element-move-to-new-document-crash.html
+++ b/LayoutTests/fast/dom/map-element-move-to-new-document-crash.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+let html = '<body><div><template shadowrootmode="open"><map id="testmap"></map></template></div></body>';
+let doc = Document.parseHTMLUnsafe(html);
+document.documentElement.prepend(doc.body);
+</script>
+This test passes if it does not crash.

--- a/Source/WebCore/html/HTMLMapElement.cpp
+++ b/Source/WebCore/html/HTMLMapElement.cpp
@@ -90,10 +90,6 @@ void HTMLMapElement::attributeChanged(const QualifiedName& name, const AtomStrin
 
     if (name == HTMLNames::idAttr || name == HTMLNames::nameAttr) {
         auto oldMapName = m_name;
-        auto oldId = name == HTMLNames::idAttr ? oldValue : getIdAttribute();
-
-        if (isInTreeScope())
-            treeScope().removeImageMap(*this, oldMapName, oldId);
 
         if (name == HTMLNames::nameAttr) {
             AtomString mapName = newValue;
@@ -102,8 +98,16 @@ void HTMLMapElement::attributeChanged(const QualifiedName& name, const AtomStrin
             m_name = WTF::move(mapName);
         }
 
-        if (isInTreeScope())
-            treeScope().addImageMap(*this, m_name, getIdAttribute());
+        auto newId = getIdAttribute();
+        if (oldMapName == m_name && m_registeredId == newId)
+            return;
+
+        if (isInTreeScope()) {
+            treeScope().removeImageMap(*this, oldMapName, m_registeredId);
+            m_registeredId = newId;
+            treeScope().addImageMap(*this, m_name, m_registeredId);
+        } else
+            m_registeredId = newId;
     }
 }
 
@@ -115,15 +119,17 @@ Ref<HTMLCollection> HTMLMapElement::areas()
 Node::NeedsPostConnectionSteps HTMLMapElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
     Node::NeedsPostConnectionSteps request = HTMLElement::insertionSteps(insertionType, parentOfInsertedTree);
-    if (insertionType.treeScopeChanged)
-        treeScope().addImageMap(*this, m_name, getIdAttribute());
+    if (insertionType.treeScopeChanged) {
+        m_registeredId = getIdAttribute();
+        treeScope().addImageMap(*this, m_name, m_registeredId);
+    }
     return request;
 }
 
 void HTMLMapElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
     if (removalType.treeScopeChanged)
-        oldParentOfRemovedTree.treeScope().removeImageMap(*this, m_name, getIdAttribute());
+        oldParentOfRemovedTree.treeScope().removeImageMap(*this, m_name, m_registeredId);
     HTMLElement::removingSteps(removalType, oldParentOfRemovedTree);
 }
 

--- a/Source/WebCore/html/HTMLMapElement.h
+++ b/Source/WebCore/html/HTMLMapElement.h
@@ -55,6 +55,7 @@ private:
     void removingSteps(RemovalType, ContainerNode&) final;
 
     AtomString m_name;
+    AtomString m_registeredId;
 };
 
 } // namespaces


### PR DESCRIPTION
#### cee1700b964c689189da24bf76591d16f3da0a24
<pre>
Crash in TreeScopeOrderedMap::add when adopting map element with id across documents
<a href="https://bugs.webkit.org/show_bug.cgi?id=310934">https://bugs.webkit.org/show_bug.cgi?id=310934</a>
<a href="https://rdar.apple.com/173358501">rdar://173358501</a>

Reviewed by Ryosuke Niwa.

When a map element inside a declarative shadow root is moved between
documents with different quirks modes (e.g., via Document.parseHTMLUnsafe),
Element::didMoveToNewDocument calls notifyAttributeChanged for the id
attribute with a fabricated null old value. This triggers
HTMLMapElement::attributeChanged which attempts to remove the old
registration with the wrong key (null instead of the actual id), then
re-add with the current id, hitting an assertion because the element is
already registered.

The fix adds m_registeredId to HTMLMapElement to track the id value
actually used for registration in the TreeScopeOrderedMap, analogous
to how m_name already tracks the registered name. Removal now always
uses the tracked registered values rather than relying on oldValue
from attributeChanged, which can be fabricated during document adoption.
An early return when the registration keys haven&apos;t changed prevents
unnecessary re-registration in the didMoveToNewDocument case.

* Source/WebCore/html/HTMLMapElement.cpp:
(WebCore::HTMLMapElement::attributeChanged):
(WebCore::HTMLMapElement::insertionSteps):
(WebCore::HTMLMapElement::removingSteps):
* Source/WebCore/html/HTMLMapElement.h:
* LayoutTests/fast/dom/map-element-move-to-new-document-crash-expected.txt: Added.
* LayoutTests/fast/dom/map-element-move-to-new-document-crash.html: Added.

Canonical link: <a href="https://commits.webkit.org/310360@main">https://commits.webkit.org/310360@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/264897816497fb387e494a440bc3529d6057e460

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153513 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26297 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19898 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162262 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106971 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/84608b9d-f05d-4beb-bbc4-206fa1699b20) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155386 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26824 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26617 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118691 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84001 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156472 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20938 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137822 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99402 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20017 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17959 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10096 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129663 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15692 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164734 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7868 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17286 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126752 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26094 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21995 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126917 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34442 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26096 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137488 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82763 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21846 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14268 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25713 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90000 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25404 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25563 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25464 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->