### PR TITLE
[JSC] Introduce butterfly-less objects

### DIFF
--- a/Source/JavaScriptCore/b3/B3LowerMacros.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerMacros.cpp
@@ -835,7 +835,6 @@ private:
                     Value* typeInfo = fastPathContinuation->appendNew<Const32Value>(m_proc, m_origin, JSWebAssemblyStruct::typeInfoBlob().blob());
                     fastPathContinuation->appendNew<MemoryValue>(m_proc, Store, m_origin, structureID, cell, static_cast<int32_t>(JSCell::structureIDOffset()));
                     fastPathContinuation->appendNew<MemoryValue>(m_proc, Store, m_origin, typeInfo, cell, static_cast<int32_t>(JSCell::indexingTypeAndMiscOffset()));
-                    fastPathContinuation->appendNew<MemoryValue>(m_proc, Store, m_origin, fastPathContinuation->appendIntConstant(m_proc, m_origin, pointerType(), 0), cell, static_cast<int32_t>(JSObject::butterflyOffset()));
 
                     fastUpsilon = fastPathContinuation->appendNew<UpsilonValue>(m_proc, m_origin, cell);
                     fastPathContinuation->appendNew<Value>(m_proc, Jump, m_origin);

--- a/Source/JavaScriptCore/heap/PreciseAllocation.cpp
+++ b/Source/JavaScriptCore/heap/PreciseAllocation.cpp
@@ -49,9 +49,9 @@ constexpr size_t dataCacheLineSize()
 static_assert(PreciseAllocation::cacheLineAdjustment == 2 * PreciseAllocation::halfAlignment);
 
 // The purpose of cacheLineAdjustment is to ensure that the JSObject header word and its butterfly
-// are both in the same cache line. Therefore, cacheLineAdjustment must be greater than sizeof(JSObject)
+// are both in the same cache line. Therefore, cacheLineAdjustment must be greater than sizeof(JSObjectWithButterfly)
 // in order for the adjustment to adequately push the start of the object into the next cache line.
-static_assert(PreciseAllocation::cacheLineAdjustment >= sizeof(JSObject));
+static_assert(PreciseAllocation::cacheLineAdjustment >= sizeof(JSObjectWithButterfly));
 
 // Also, by definition, cacheLineAdjustment must be smaller than dataCacheLineSize. Otherwise, there's
 // not way to fit the JSObject header word and its butterfly in a cache line.

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
@@ -452,7 +452,7 @@ void AssemblyHelpers::loadProperty(GPRReg object, GPRReg offset, JSValueRegs res
     isInline.link(this);
     addPtr(
         TrustedImm32(
-            static_cast<int32_t>(sizeof(JSObject)) -
+            static_cast<int32_t>(JSObject::offsetOfInlineStorage()) -
             (static_cast<int32_t>(firstOutOfLineOffset) - 2) * static_cast<int32_t>(sizeof(EncodedJSValue))),
         object, result.payloadGPR());
 
@@ -479,7 +479,7 @@ void AssemblyHelpers::storeProperty(JSValueRegs value, GPRReg object, GPRReg off
     isInline.link(this);
     addPtr(
         TrustedImm32(
-            static_cast<int32_t>(sizeof(JSObject)) -
+            static_cast<int32_t>(JSObject::offsetOfInlineStorage()) -
             (static_cast<int32_t>(firstOutOfLineOffset) - 2) * static_cast<int32_t>(sizeof(EncodedJSValue))),
         object, scratch);
 

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm
@@ -1409,18 +1409,18 @@ end)
 macro loadPropertyAtVariableOffsetKnownNotInline(propertyOffset, objectAndStorage, tag, payload)
     assert(macro (ok) bigteq propertyOffset, firstOutOfLineOffset, ok end)
     negi propertyOffset
-    loadp JSObject::m_butterfly[objectAndStorage], objectAndStorage
+    loadp JSObjectWithButterfly::m_butterfly[objectAndStorage], objectAndStorage
     loadi TagOffset + (firstOutOfLineOffset - 2) * 8[objectAndStorage, propertyOffset, 8], tag
     loadi PayloadOffset + (firstOutOfLineOffset - 2) * 8[objectAndStorage, propertyOffset, 8], payload
 end
 
 macro loadPropertyAtVariableOffset(propertyOffset, objectAndStorage, tag, payload)
     bilt propertyOffset, firstOutOfLineOffset, .isInline
-    loadp JSObject::m_butterfly[objectAndStorage], objectAndStorage
+    loadp JSObjectWithButterfly::m_butterfly[objectAndStorage], objectAndStorage
     negi propertyOffset
     jmp .ready
 .isInline:
-    addp sizeof JSObject - (firstOutOfLineOffset - 2) * 8, objectAndStorage
+    addp sizeof JSObjectWithButterfly - (firstOutOfLineOffset - 2) * 8, objectAndStorage
 .ready:
     loadi TagOffset + (firstOutOfLineOffset - 2) * 8[objectAndStorage, propertyOffset, 8], tag
     loadi PayloadOffset + (firstOutOfLineOffset - 2) * 8[objectAndStorage, propertyOffset, 8], payload
@@ -1428,11 +1428,11 @@ end
 
 macro storePropertyAtVariableOffset(propertyOffsetAsInt, objectAndStorage, tag, payload)
     bilt propertyOffsetAsInt, firstOutOfLineOffset, .isInline
-    loadp JSObject::m_butterfly[objectAndStorage], objectAndStorage
+    loadp JSObjectWithButterfly::m_butterfly[objectAndStorage], objectAndStorage
     negi propertyOffsetAsInt
     jmp .ready
 .isInline:
-    addp sizeof JSObject - (firstOutOfLineOffset - 2) * 8, objectAndStorage
+    addp sizeof JSObjectWithButterfly - (firstOutOfLineOffset - 2) * 8, objectAndStorage
 .ready:
     storeJSValueConcurrent(
         macro(val, offset)
@@ -1521,7 +1521,7 @@ macro performGetByIDHelper(opcodeStruct, modeMetadataName, valueProfileName, slo
     loadb JSCell::m_indexingTypeAndMisc[t3], t0
     btiz t0, IsArray, slowLabel
     btiz t0, IndexingShapeMask, slowLabel
-    loadp JSObject::m_butterfly[t3], t0
+    loadp JSObjectWithButterfly::m_butterfly[t3], t0
     loadi -sizeof IndexingHeader + IndexingHeader::u.lengths.publicLength[t0], t0
     bilt t0, 0, slowLabel
     valueProfile(size, opcodeStruct, valueProfileName, Int32Tag, t0, t2)
@@ -1558,7 +1558,7 @@ llintOpWithMetadata(op_get_by_id, OpGetById, macro (size, get, dispatch, metadat
     loadb JSCell::m_indexingTypeAndMisc[t3], t2
     btiz t2, IsArray, .opGetByIdSlow
     btiz t2, IndexingShapeMask, .opGetByIdSlow
-    loadp JSObject::m_butterfly[t3], t0
+    loadp JSObjectWithButterfly::m_butterfly[t3], t0
     loadi -sizeof IndexingHeader + IndexingHeader::u.lengths.publicLength[t0], t0
     bilt t0, 0, .opGetByIdSlow
     valueProfile(size, OpGetById, m_valueProfile, Int32Tag, t0, t5)
@@ -1613,7 +1613,7 @@ llintOpWithMetadata(op_get_length, OpGetLength, macro (size, get, dispatch, meta
     loadb JSCell::m_indexingTypeAndMisc[t3], t2
     btiz t2, IsArray, .opGetLengthSlow
     btiz t2, IndexingShapeMask, .opGetLengthSlow
-    loadp JSObject::m_butterfly[t3], t0
+    loadp JSObjectWithButterfly::m_butterfly[t3], t0
     loadi -sizeof IndexingHeader + IndexingHeader::u.lengths.publicLength[t0], t0
     bilt t0, 0, .opGetLengthSlow
     valueProfile(size, OpGetLength, m_valueProfile, Int32Tag, t0, t5)
@@ -1740,7 +1740,7 @@ llintOpWithMetadata(op_get_by_val, OpGetByVal, macro (size, get, dispatch, metad
     loadb JSCell::m_indexingTypeAndMisc[t2], t2
     get(m_property, t3)
     loadConstantOrVariablePayload(size, t3, Int32Tag, t1, .opGetByValSlow)
-    loadp JSObject::m_butterfly[t0], t3
+    loadp JSObjectWithButterfly::m_butterfly[t0], t3
     andi IndexingShapeMask, t2
     bieq t2, Int32Shape, .opGetByValIsContiguous
     bineq t2, ContiguousShape, .opGetByValNotContiguous
@@ -1885,7 +1885,7 @@ macro putByValOp(opcodeName, opcodeStruct, osrExitPoint)
         loadb JSCell::m_indexingTypeAndMisc[t2], t2
         get(m_property, t0)
         loadConstantOrVariablePayload(size, t0, Int32Tag, t3, .opPutByValSlow)
-        loadp JSObject::m_butterfly[t1], t0
+        loadp JSObjectWithButterfly::m_butterfly[t1], t0
         btinz t2, CopyOnWrite, .opPutByValSlow
         andi IndexingShapeMask, t2
         bineq t2, Int32Shape, .opPutByValNotInt32

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
@@ -1559,19 +1559,19 @@ end)
 
 
 macro loadInlineOffset(propertyOffsetAsInt, objectAndStorage, value)
-    addp sizeof JSObject - (firstOutOfLineOffset - 2) * 8, objectAndStorage
+    addp sizeof JSObjectWithButterfly - (firstOutOfLineOffset - 2) * 8, objectAndStorage
     loadq (firstOutOfLineOffset - 2) * 8[objectAndStorage, propertyOffsetAsInt, 8], value
 end
 
 
 macro loadPropertyAtVariableOffset(propertyOffsetAsInt, objectAndStorage, value)
     bilt propertyOffsetAsInt, firstOutOfLineOffset, .isInline
-    loadp JSObject::m_butterfly[objectAndStorage], objectAndStorage
+    loadp JSObjectWithButterfly::m_butterfly[objectAndStorage], objectAndStorage
     negi propertyOffsetAsInt
     sxi2q propertyOffsetAsInt, propertyOffsetAsInt
     jmp .ready
 .isInline:
-    addp sizeof JSObject - (firstOutOfLineOffset - 2) * 8, objectAndStorage
+    addp sizeof JSObjectWithButterfly - (firstOutOfLineOffset - 2) * 8, objectAndStorage
 .ready:
     loadq (firstOutOfLineOffset - 2) * 8[objectAndStorage, propertyOffsetAsInt, 8], value
 end
@@ -1579,12 +1579,12 @@ end
 
 macro storePropertyAtVariableOffset(propertyOffsetAsInt, objectAndStorage, value)
     bilt propertyOffsetAsInt, firstOutOfLineOffset, .isInline
-    loadp JSObject::m_butterfly[objectAndStorage], objectAndStorage
+    loadp JSObjectWithButterfly::m_butterfly[objectAndStorage], objectAndStorage
     negi propertyOffsetAsInt
     sxi2q propertyOffsetAsInt, propertyOffsetAsInt
     jmp .ready
 .isInline:
-    addp sizeof JSObject - (firstOutOfLineOffset - 2) * 8, objectAndStorage
+    addp sizeof JSObjectWithButterfly - (firstOutOfLineOffset - 2) * 8, objectAndStorage
 .ready:
     storeq value, (firstOutOfLineOffset - 2) * 8[objectAndStorage, propertyOffsetAsInt, 8]
 end
@@ -1660,7 +1660,7 @@ macro performGetByIDHelper(opcodeStruct, modeMetadataName, valueProfileName, slo
     loadb JSCell::m_indexingTypeAndMisc[t3], t0
     btiz t0, IsArray, slowLabel
     btiz t0, IndexingShapeMask, slowLabel
-    loadCagedJSValue(JSObject::m_butterfly[t3], t0, t1)
+    loadCagedJSValue(JSObjectWithButterfly::m_butterfly[t3], t0, t1)
     loadi -sizeof IndexingHeader + IndexingHeader::u.lengths.publicLength[t0], t0
     bilt t0, 0, slowLabel
     orq numberTag, t0
@@ -1847,7 +1847,7 @@ llintOpWithMetadata(op_get_by_val, OpGetByVal, macro (size, get, dispatch, metad
     # This sign-extension makes the bounds-checking in getByValTypedArray work even on 4GB TypedArray.
     sxi2q t1, t1
 
-    loadCagedJSValue(JSObject::m_butterfly[t0], t3, numberTag)
+    loadCagedJSValue(JSObjectWithButterfly::m_butterfly[t0], t3, numberTag)
     move TagNumber, numberTag
 
     andi IndexingShapeMask, t2
@@ -2034,7 +2034,7 @@ macro putByValOp(opcodeName, opcodeStruct, osrExitPoint)
         get(m_property, t0)
         loadConstantOrVariableInt32(size, t0, t3, .opPutByValSlow)
         sxi2q t3, t3
-        loadCagedJSValue(JSObject::m_butterfly[t1], t0, numberTag)
+        loadCagedJSValue(JSObjectWithButterfly::m_butterfly[t1], t0, numberTag)
         move TagNumber, numberTag
         btinz t2, CopyOnWrite, .opPutByValSlow
         andi IndexingShapeMask, t2
@@ -3497,11 +3497,11 @@ llintOpWithMetadata(op_enumerator_get_by_val, OpEnumeratorGetByVal, macro (size,
     biaeq t2, t1, .outOfLine
 
     zxi2q t2, t2
-    loadq sizeof JSObject[t0, t2, 8], t2
+    loadq sizeof JSObjectWithButterfly[t0, t2, 8], t2
     jmp .done
 
 .outOfLine:
-    loadp JSObject::m_butterfly[t0], t0
+    loadp JSObjectWithButterfly::m_butterfly[t0], t0
     subi t1, t2
     negi t2
     sxi2q t2, t2
@@ -3550,12 +3550,12 @@ llintOpWithMetadata(op_enumerator_put_by_val, OpEnumeratorPutByVal, macro (size,
     biaeq t2, t1, .outOfLine
 
     zxi2q t2, t2
-    storeq t3, sizeof JSObject[t0, t2, 8]
+    storeq t3, sizeof JSObjectWithButterfly[t0, t2, 8]
     jmp .done
 
 .outOfLine:
     subi t1, t2
-    loadp JSObject::m_butterfly[t0], t1
+    loadp JSObjectWithButterfly::m_butterfly[t0], t1
     negi t2
     sxi2q t2, t2
     storeq t3, constexpr ((offsetInButterfly(firstOutOfLineOffset)) * sizeof(EncodedJSValue))[t1, t2, 8]

--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -59,6 +59,7 @@ namespace JSC {
 static unsigned lastArraySize = 0;
 
 STATIC_ASSERT_IS_TRIVIALLY_DESTRUCTIBLE(JSObject);
+STATIC_ASSERT_IS_TRIVIALLY_DESTRUCTIBLE(JSObjectWithButterfly);
 STATIC_ASSERT_IS_TRIVIALLY_DESTRUCTIBLE(JSFinalObject);
 
 const ASCIILiteral NonExtensibleObjectPropertyDefineError { "Attempting to define property on object that is not extensible."_s };
@@ -73,10 +74,12 @@ const ASCIILiteral PrototypeValueCanOnlyBeAnObjectOrNullTypeError { "Prototype v
 
 const ClassInfo JSObject::s_info = { "Object"_s, nullptr, nullptr, nullptr, CREATE_METHOD_TABLE(JSObject) };
 
+const ClassInfo JSObjectWithButterfly::s_info = { "Object"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSObjectWithButterfly) };
+
 const ClassInfo JSFinalObject::s_info = { "Object"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSFinalObject) };
 
 template<typename Visitor>
-ALWAYS_INLINE void JSObject::markAuxiliaryAndVisitOutOfLineProperties(Visitor& visitor, Butterfly* butterfly, Structure* structure, PropertyOffset maxOffset)
+ALWAYS_INLINE void JSObjectWithButterfly::markAuxiliaryAndVisitOutOfLineProperties(Visitor& visitor, Butterfly* butterfly, Structure* structure, PropertyOffset maxOffset)
 {
     // We call this when we found everything without races.
     ASSERT(structure);
@@ -108,9 +111,9 @@ ALWAYS_INLINE void JSObject::markAuxiliaryAndVisitOutOfLineProperties(Visitor& v
 }
 
 template<typename Visitor>
-ALWAYS_INLINE Structure* JSObject::visitButterfly(Visitor& visitor)
+ALWAYS_INLINE Structure* JSObjectWithButterfly::visitButterfly(Visitor& visitor)
 {
-    static const char* const raceReason = "JSObject::visitButterfly";
+    static const char* const raceReason = "JSObjectWithButterfly::visitButterfly";
     Structure* result = visitButterflyImpl(visitor);
     if (!result)
         visitor.didRace(this, raceReason);
@@ -118,7 +121,7 @@ ALWAYS_INLINE Structure* JSObject::visitButterfly(Visitor& visitor)
 }
 
 template<typename Visitor>
-ALWAYS_INLINE Structure* JSObject::visitButterflyImpl(Visitor& visitor)
+ALWAYS_INLINE Structure* JSObjectWithButterfly::visitButterflyImpl(Visitor& visitor)
 {
     Butterfly* butterfly;
     Structure* structure;
@@ -411,7 +414,7 @@ ALWAYS_INLINE Structure* JSObject::visitButterflyImpl(Visitor& visitor)
 size_t JSObject::estimatedSize(JSCell* cell, VM& vm)
 {
     JSObject* thisObject = jsCast<JSObject*>(cell);
-    size_t butterflyOutOfLineSize = thisObject->m_butterfly ? thisObject->structure()->outOfLineSize() : 0;
+    size_t butterflyOutOfLineSize = thisObject->butterfly() ? thisObject->structure()->outOfLineSize() : 0;
     return Base::estimatedSize(cell, vm) + butterflyOutOfLineSize;
 }
 
@@ -423,11 +426,23 @@ void JSObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     typename Visitor::DefaultMarkingViolationAssertionScope assertionScope(visitor);
 
     JSCell::visitChildren(thisObject, visitor);
+}
+
+DEFINE_VISIT_CHILDREN_WITH_MODIFIER(JS_EXPORT_PRIVATE, JSObject);
+
+template<typename Visitor>
+void JSObjectWithButterfly::visitChildrenImpl(JSCell* cell, Visitor& visitor)
+{
+    JSObjectWithButterfly* thisObject = jsCast<JSObjectWithButterfly*>(cell);
+    ASSERT_GC_OBJECT_INHERITS(thisObject, info());
+    typename Visitor::DefaultMarkingViolationAssertionScope assertionScope(visitor);
+
+    JSCell::visitChildren(thisObject, visitor);
 
     thisObject->visitButterfly(visitor);
 }
 
-DEFINE_VISIT_CHILDREN_WITH_MODIFIER(JS_EXPORT_PRIVATE, JSObject);
+DEFINE_VISIT_CHILDREN_WITH_MODIFIER(JS_EXPORT_PRIVATE, JSObjectWithButterfly);
 
 void JSObject::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
 {
@@ -475,7 +490,7 @@ void JSFinalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     typename Visitor::DefaultMarkingViolationAssertionScope assertionScope(visitor);
     
     JSCell::visitChildren(thisObject, visitor);
-    
+
     if (Structure* structure = thisObject->visitButterfly(visitor)) {
         if (unsigned storageSize = structure->inlineSize())
             visitor.appendValuesHidden(thisObject->inlineStorage(), storageSize);
@@ -614,7 +629,7 @@ bool JSObject::getOwnPropertySlotByIndex(JSObject* thisObject, JSGlobalObject* g
     }
         
     case ALL_ARRAY_STORAGE_INDEXING_TYPES: {
-        ArrayStorage* storage = thisObject->m_butterfly->arrayStorage();
+        ArrayStorage* storage = thisObject->butterfly()->arrayStorage();
         if (i >= storage->length())
             return false;
         
@@ -1079,7 +1094,7 @@ bool JSObject::putByIndex(JSCell* cell, JSGlobalObject* globalObject, unsigned p
         
     case NonArrayWithArrayStorage:
     case ArrayWithArrayStorage: {
-        ArrayStorage* storage = thisObject->m_butterfly->arrayStorage();
+        ArrayStorage* storage = thisObject->butterfly()->arrayStorage();
         
         if (propertyName >= storage->vectorLength())
             break;
@@ -1101,7 +1116,7 @@ bool JSObject::putByIndex(JSCell* cell, JSGlobalObject* globalObject, unsigned p
         
     case NonArrayWithSlowPutArrayStorage:
     case ArrayWithSlowPutArrayStorage: {
-        ArrayStorage* storage = thisObject->m_butterfly->arrayStorage();
+        ArrayStorage* storage = thisObject->butterfly()->arrayStorage();
         
         if (propertyName >= storage->vectorLength())
             break;
@@ -1189,7 +1204,7 @@ void JSObject::enterDictionaryIndexingMode(VM& vm)
             enterDictionaryIndexingModeWhenArrayStorageAlreadyExists(vm, storage);
         break;
     case ALL_ARRAY_STORAGE_INDEXING_TYPES:
-        enterDictionaryIndexingModeWhenArrayStorageAlreadyExists(vm, m_butterfly->arrayStorage());
+        enterDictionaryIndexingModeWhenArrayStorageAlreadyExists(vm, this->butterfly()->arrayStorage());
         break;
         
     default:
@@ -1239,7 +1254,7 @@ Butterfly* JSObject::createInitialIndexedStorage(VM& vm, unsigned length)
     unsigned propertyCapacity = structure->outOfLineCapacity();
     unsigned vectorLength = Butterfly::optimalContiguousVectorLength(propertyCapacity, length);
     Butterfly* newButterfly = Butterfly::createOrGrowArrayRight(
-        butterfly(), vm, this, structure, propertyCapacity, false, 0,
+        this->butterfly(), vm, this, structure, propertyCapacity, false, 0,
         sizeof(EncodedJSValue) * vectorLength);
     newButterfly->setPublicLength(length);
     newButterfly->setVectorLength(vectorLength);
@@ -1353,7 +1368,7 @@ ArrayStorage* JSObject::createArrayStorage(VM& vm, unsigned length, unsigned vec
     IndexingType oldType = indexingType();
     ASSERT_UNUSED(oldType, !hasIndexedProperties(oldType));
 
-    Butterfly* newButterfly = createArrayStorageButterfly(vm, this, oldStructure, length, vectorLength, butterfly());
+    Butterfly* newButterfly = createArrayStorageButterfly(vm, this, oldStructure, length, vectorLength, this->butterfly());
     ArrayStorage* result = newButterfly->arrayStorage();
     {
         DeferredStructureTransitionWatchpointFire deferred(vm, oldStructure);
@@ -1383,7 +1398,7 @@ ContiguousJSValues JSObject::convertUndecidedToInt32(VM& vm)
         DeferredStructureTransitionWatchpointFire deferred(vm, oldStructure);
         setStructure(vm, Structure::nonPropertyTransition(vm, oldStructure, TransitionKind::AllocateInt32, &deferred));
     }
-    return m_butterfly->contiguousInt32();
+    return this->butterfly()->contiguousInt32();
 }
 
 ContiguousDoubles JSObject::convertUndecidedToDouble(VM& vm)
@@ -1391,7 +1406,7 @@ ContiguousDoubles JSObject::convertUndecidedToDouble(VM& vm)
     ASSERT(Options::allowDoubleShape());
     ASSERT(hasUndecided(indexingType()));
 
-    Butterfly* butterfly = m_butterfly.get();
+    auto* butterfly = this->butterfly();
     for (unsigned i = butterfly->vectorLength(); i--;)
         butterfly->contiguousDouble().at(this, i) = PNaN;
     
@@ -1400,14 +1415,14 @@ ContiguousDoubles JSObject::convertUndecidedToDouble(VM& vm)
         DeferredStructureTransitionWatchpointFire deferred(vm, oldStructure);
         setStructure(vm, Structure::nonPropertyTransition(vm, oldStructure, TransitionKind::AllocateDouble, &deferred));
     }
-    return m_butterfly->contiguousDouble();
+    return this->butterfly()->contiguousDouble();
 }
 
 ContiguousJSValues JSObject::convertUndecidedToContiguous(VM& vm)
 {
     ASSERT(hasUndecided(indexingType()));
 
-    Butterfly* butterfly = m_butterfly.get();
+    auto* butterfly = this->butterfly();
     for (unsigned i = butterfly->vectorLength(); i--;)
         butterfly->contiguous().at(this, i).setWithoutWriteBarrier(JSValue());
 
@@ -1417,13 +1432,13 @@ ContiguousJSValues JSObject::convertUndecidedToContiguous(VM& vm)
         DeferredStructureTransitionWatchpointFire deferred(vm, oldStructure);
         setStructure(vm, Structure::nonPropertyTransition(vm, oldStructure, TransitionKind::AllocateContiguous, &deferred));
     }
-    return m_butterfly->contiguous();
+    return this->butterfly()->contiguous();
 }
 
 ArrayStorage* JSObject::constructConvertedArrayStorageWithoutCopyingElements(VM& vm, unsigned neededLength)
 {
     Structure* structure = this->structure();
-    unsigned publicLength = m_butterfly->publicLength();
+    unsigned publicLength = this->butterfly()->publicLength();
     unsigned propertyCapacity = structure->outOfLineCapacity();
 
     Butterfly* newButterfly = Butterfly::createUninitialized(vm, this, 0, propertyCapacity, true, ArrayStorage::sizeFor(neededLength));
@@ -1431,7 +1446,7 @@ ArrayStorage* JSObject::constructConvertedArrayStorageWithoutCopyingElements(VM&
     // memcpy is fine since newButterfly is not tied to any object yet.
     memcpy(
         static_cast<JSValue*>(newButterfly->base(0, propertyCapacity)),
-        static_cast<JSValue*>(m_butterfly->base(0, propertyCapacity)),
+        static_cast<JSValue*>(this->butterfly()->base(0, propertyCapacity)),
         propertyCapacity * sizeof(EncodedJSValue));
 
     ArrayStorage* newStorage = newButterfly->arrayStorage();
@@ -1449,7 +1464,7 @@ ArrayStorage* JSObject::convertUndecidedToArrayStorage(VM& vm, TransitionKind tr
     DeferGC deferGC(vm);
     ASSERT(hasUndecided(indexingType()));
 
-    unsigned vectorLength = m_butterfly->vectorLength();
+    unsigned vectorLength = this->butterfly()->vectorLength();
     ArrayStorage* storage = constructConvertedArrayStorageWithoutCopyingElements(vm, vectorLength);
     
     for (unsigned i = vectorLength; i--;)
@@ -1476,7 +1491,7 @@ ContiguousDoubles JSObject::convertInt32ToDouble(VM& vm)
     ASSERT(hasInt32(indexingType()));
     ASSERT(!isCopyOnWrite(indexingMode()));
 
-    Butterfly* butterfly = m_butterfly.get();
+    auto* butterfly = this->butterfly();
     for (unsigned i = butterfly->vectorLength(); i--;) {
         WriteBarrier<Unknown>* current = &butterfly->contiguous().atUnsafe(i);
         double* currentAsDouble = std::bit_cast<double*>(current);
@@ -1495,7 +1510,7 @@ ContiguousDoubles JSObject::convertInt32ToDouble(VM& vm)
         DeferredStructureTransitionWatchpointFire deferred(vm, oldStructure);
         setStructure(vm, Structure::nonPropertyTransition(vm, oldStructure, TransitionKind::AllocateDouble, &deferred));
     }
-    return m_butterfly->contiguousDouble();
+    return this->butterfly()->contiguousDouble();
 }
 
 ContiguousJSValues JSObject::convertInt32ToContiguous(VM& vm)
@@ -1507,7 +1522,7 @@ ContiguousJSValues JSObject::convertInt32ToContiguous(VM& vm)
         DeferredStructureTransitionWatchpointFire deferred(vm, oldStructure);
         setStructure(vm, Structure::nonPropertyTransition(vm, oldStructure, TransitionKind::AllocateContiguous, &deferred));
     }
-    return m_butterfly->contiguous();
+    return this->butterfly()->contiguous();
 }
 
 ArrayStorage* JSObject::convertInt32ToArrayStorage(VM& vm, TransitionKind transition)
@@ -1515,9 +1530,9 @@ ArrayStorage* JSObject::convertInt32ToArrayStorage(VM& vm, TransitionKind transi
     DeferGC deferGC(vm);
     ASSERT(hasInt32(indexingType()));
 
-    unsigned vectorLength = m_butterfly->vectorLength();
+    unsigned vectorLength = this->butterfly()->vectorLength();
     ArrayStorage* newStorage = constructConvertedArrayStorageWithoutCopyingElements(vm, vectorLength);
-    Butterfly* butterfly = m_butterfly.get();
+    auto* butterfly = this->butterfly();
     for (unsigned i = 0; i < vectorLength; i++) {
         JSValue v = butterfly->contiguous().at(this, i).get();
         newStorage->m_vector[i].setWithoutWriteBarrier(v);
@@ -1546,7 +1561,7 @@ ContiguousJSValues JSObject::convertDoubleToContiguous(VM& vm)
     ASSERT(hasDouble(indexingType()));
     ASSERT(!isCopyOnWrite(indexingMode()));
 
-    Butterfly* butterfly = m_butterfly.get();
+    auto* butterfly = this->butterfly();
     for (unsigned i = butterfly->vectorLength(); i--;) {
         double* current = &butterfly->contiguousDouble().atUnsafe(i);
         WriteBarrier<Unknown>* currentAsValue = std::bit_cast<WriteBarrier<Unknown>*>(current);
@@ -1565,7 +1580,7 @@ ContiguousJSValues JSObject::convertDoubleToContiguous(VM& vm)
         DeferredStructureTransitionWatchpointFire deferred(vm, oldStructure);
         setStructure(vm, Structure::nonPropertyTransition(vm, oldStructure, TransitionKind::AllocateContiguous, &deferred));
     }
-    return m_butterfly->contiguous();
+    return this->butterfly()->contiguous();
 }
 
 ArrayStorage* JSObject::convertDoubleToArrayStorage(VM& vm, TransitionKind transition)
@@ -1573,9 +1588,9 @@ ArrayStorage* JSObject::convertDoubleToArrayStorage(VM& vm, TransitionKind trans
     DeferGC deferGC(vm);
     ASSERT(hasDouble(indexingType()));
 
-    unsigned vectorLength = m_butterfly->vectorLength();
+    unsigned vectorLength = this->butterfly()->vectorLength();
     ArrayStorage* newStorage = constructConvertedArrayStorageWithoutCopyingElements(vm, vectorLength);
-    Butterfly* butterfly = m_butterfly.get();
+    auto* butterfly = this->butterfly();
     for (unsigned i = 0; i < vectorLength; i++) {
         double value = butterfly->contiguousDouble().at(this, i);
         if (value != value) {
@@ -1607,9 +1622,9 @@ ArrayStorage* JSObject::convertContiguousToArrayStorage(VM& vm, TransitionKind t
     DeferGC deferGC(vm);
     ASSERT(hasContiguous(indexingType()));
 
-    unsigned vectorLength = m_butterfly->vectorLength();
+    unsigned vectorLength = this->butterfly()->vectorLength();
     ArrayStorage* newStorage = constructConvertedArrayStorageWithoutCopyingElements(vm, vectorLength);
-    Butterfly* butterfly = m_butterfly.get();
+    auto* butterfly = this->butterfly();
     for (unsigned i = 0; i < vectorLength; i++) {
         JSValue v = butterfly->contiguous().at(this, i).get();
         newStorage->m_vector[i].setWithoutWriteBarrier(v);
@@ -1801,7 +1816,7 @@ void JSObject::convertFromCopyOnWrite(VM& vm)
     ASSERT(structure()->indexingMode() == indexingMode());
 
     const bool hasIndexingHeader = true;
-    Butterfly* oldButterfly = butterfly();
+    Butterfly* oldButterfly = this->butterfly();
     size_t propertyCapacity = 0;
     unsigned newVectorLength = Butterfly::optimalContiguousVectorLength(propertyCapacity, std::min<size_t>(nextLength(oldButterfly->vectorLength()), MAX_STORAGE_VECTOR_LENGTH));
     Butterfly* newButterfly = Butterfly::createUninitialized(vm, this, 0, propertyCapacity, hasIndexingHeader, newVectorLength * sizeof(JSValue));
@@ -1835,8 +1850,8 @@ void JSObject::convertFromCopyOnWrite(VM& vm)
 
 void JSObject::setIndexQuicklyToUndecided(VM& vm, unsigned index, JSValue value)
 {
-    ASSERT(index < m_butterfly->publicLength());
-    ASSERT(index < m_butterfly->vectorLength());
+    ASSERT(index < this->butterfly()->publicLength());
+    ASSERT(index < this->butterfly()->vectorLength());
     convertUndecidedForValue(vm, value);
     setIndexQuickly(vm, index, value);
 }
@@ -1863,7 +1878,7 @@ ContiguousJSValues JSObject::tryMakeWritableInt32Slow(VM& vm)
         if (leastUpperBoundOfIndexingTypes(indexingType() & IndexingShapeMask, Int32Shape) == Int32Shape) {
             ASSERT(hasInt32(indexingMode()));
             convertFromCopyOnWrite(vm);
-            return butterfly()->contiguousInt32();
+            return this->butterfly()->contiguousInt32();
         }
         return ContiguousJSValues();
     }
@@ -1900,7 +1915,7 @@ ContiguousDoubles JSObject::tryMakeWritableDoubleSlow(VM& vm)
         if (leastUpperBoundOfIndexingTypes(indexingType() & IndexingShapeMask, DoubleShape) == DoubleShape) {
             convertFromCopyOnWrite(vm);
             if (hasDouble(indexingMode()))
-                return butterfly()->contiguousDouble();
+                return this->butterfly()->contiguousDouble();
             ASSERT(hasInt32(indexingMode()));
         } else
             return ContiguousDoubles();
@@ -1939,7 +1954,7 @@ ContiguousJSValues JSObject::tryMakeWritableContiguousSlow(VM& vm)
         if (leastUpperBoundOfIndexingTypes(indexingType() & IndexingShapeMask, ContiguousShape) == ContiguousShape) {
             convertFromCopyOnWrite(vm);
             if (hasContiguous(indexingMode()))
-                return butterfly()->contiguous();
+                return this->butterfly()->contiguous();
             ASSERT(hasInt32(indexingMode()) || hasDouble(indexingMode()));
         } else
             return ContiguousJSValues();
@@ -2038,7 +2053,7 @@ ArrayStorage* JSObject::ensureArrayStorageExistsAndEnterDictionaryIndexingMode(V
         return enterDictionaryIndexingModeWhenArrayStorageAlreadyExists(vm, convertContiguousToArrayStorage(vm));
         
     case ALL_ARRAY_STORAGE_INDEXING_TYPES:
-        return enterDictionaryIndexingModeWhenArrayStorageAlreadyExists(vm, m_butterfly->arrayStorage());
+        return enterDictionaryIndexingModeWhenArrayStorageAlreadyExists(vm, this->butterfly()->arrayStorage());
         
     default:
         CRASH();
@@ -2441,7 +2456,7 @@ bool JSObject::deletePropertyByIndex(JSCell* cell, JSGlobalObject* globalObject,
     }
         
     case ALL_ARRAY_STORAGE_INDEXING_TYPES: {
-        ArrayStorage* storage = thisObject->m_butterfly->arrayStorage();
+        ArrayStorage* storage = thisObject->butterfly()->arrayStorage();
         
         if (i < storage->vectorLength()) {
             WriteBarrier<Unknown>& valueSlot = storage->m_vector[i];
@@ -2771,7 +2786,7 @@ void JSObject::getOwnIndexedPropertyNames(JSGlobalObject*, PropertyNameArrayBuil
         }
             
         case ALL_ARRAY_STORAGE_INDEXING_TYPES: {
-            ArrayStorage* storage = object->m_butterfly->arrayStorage();
+            ArrayStorage* storage = object->butterfly()->arrayStorage();
             
             unsigned usedVectorLength = std::min(storage->length(), storage->vectorLength());
             for (unsigned i = 0; i < usedVectorLength; ++i) {
@@ -3026,7 +3041,7 @@ bool JSObject::defineOwnIndexedProperty(JSGlobalObject* globalObject, unsigned i
     if (descriptor.attributes() & (PropertyAttribute::ReadOnly | PropertyAttribute::Accessor))
         notifyPresenceOfIndexedAccessors(vm);
 
-    SparseArrayValueMap* map = m_butterfly->arrayStorage()->m_sparseMap.get();
+    SparseArrayValueMap* map = this->butterfly()->arrayStorage()->m_sparseMap.get();
     RELEASE_ASSERT(map);
     
     // 1. Let current be the result of calling the [[GetOwnProperty]] internal method of O with property name P.
@@ -3054,7 +3069,7 @@ bool JSObject::defineOwnIndexedProperty(JSGlobalObject* globalObject, unsigned i
 
         PropertyDescriptor defaults(jsUndefined(), PropertyAttribute::DontDelete | PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
         putIndexedDescriptor(globalObject, map, entryInMap, descriptor, defaults);
-        Butterfly* butterfly = m_butterfly.get();
+        auto* butterfly = this->butterfly();
         if (index >= butterfly->arrayStorage()->length())
             butterfly->arrayStorage()->setLength(index + 1);
         return true;
@@ -3212,12 +3227,12 @@ bool JSObject::putByIndexBeyondVectorLengthWithoutAttributes(JSGlobalObject* glo
     ASSERT((indexingType() & IndexingShapeMask) == indexingShape);
     ASSERT(!indexingShouldBeSparse());
 
-    Butterfly* butterfly = m_butterfly.get();
-    
+    auto* butterfly = this->butterfly();
+
     // For us to get here, the index is either greater than the public length, or greater than
     // or equal to the vector length.
     ASSERT(i >= butterfly->vectorLength());
-    
+
     if (i > MAX_STORAGE_VECTOR_INDEX
         || (i >= MIN_SPARSE_ARRAY_INDEX && !isDenseEnoughForVector(i, countElements<indexingShape>(butterfly)))
         || indexIsSufficientlyBeyondLengthForSparseMap(i, butterfly->vectorLength())) {
@@ -3230,7 +3245,7 @@ bool JSObject::putByIndexBeyondVectorLengthWithoutAttributes(JSGlobalObject* glo
         throwOutOfMemoryError(globalObject, scope);
         return false;
     }
-    butterfly = m_butterfly.get();
+    butterfly = this->butterfly();
 
     RELEASE_ASSERT(i < butterfly->vectorLength());
     switch (indexingShape) {
@@ -3682,8 +3697,8 @@ ALWAYS_INLINE unsigned JSObject::getNewVectorLength(unsigned desiredLength)
     if (hasIndexedProperties(indexingType())) {
         if (ArrayStorage* storage = arrayStorageOrNull())
             indexBias = storage->m_indexBias;
-        vectorLength = m_butterfly->vectorLength();
-        length = m_butterfly->publicLength();
+        vectorLength = this->butterfly()->vectorLength();
+        length = this->butterfly()->publicLength();
     }
 
     return getNewVectorLength(indexBias, vectorLength, length, desiredLength);
@@ -3724,14 +3739,14 @@ unsigned JSObject::countElements()
         return 0;
         
     case ALL_INT32_INDEXING_TYPES:
-        return countElements<Int32Shape>(butterfly());
+        return countElements<Int32Shape>(this->butterfly());
         
     case ALL_DOUBLE_INDEXING_TYPES:
         ASSERT(Options::allowDoubleShape());
-        return countElements<DoubleShape>(butterfly());
+        return countElements<DoubleShape>(this->butterfly());
         
     case ALL_CONTIGUOUS_INDEXING_TYPES:
-        return countElements<ContiguousShape>(butterfly());
+        return countElements<ContiguousShape>(this->butterfly());
         
     default:
         CRASH();
@@ -3803,7 +3818,7 @@ bool JSObject::ensureLengthSlow(VM& vm, unsigned length)
 {
     if (isCopyOnWrite(indexingMode())) {
         convertFromCopyOnWrite(vm);
-        if (m_butterfly->vectorLength() >= length)
+        if (this->butterfly()->vectorLength() >= length)
             return true;
     }
 
@@ -3852,7 +3867,7 @@ bool JSObject::ensureLengthSlow(VM& vm, unsigned length)
     if (newButterfly) {
         butterfly->setVectorLength(newVectorLength);
         WTF::storeStoreFence();
-        m_butterfly.set(vm, this, newButterfly);
+        butterflyRef().set(vm, this, newButterfly);
     } else {
         WTF::storeStoreFence();
         butterfly->setVectorLength(newVectorLength);
@@ -3865,16 +3880,16 @@ void JSObject::reallocateAndShrinkButterfly(VM& vm, unsigned length)
 {
     ASSERT(length <= MAX_STORAGE_VECTOR_LENGTH);
     ASSERT(hasContiguous(indexingType()) || hasInt32(indexingType()) || hasDouble(indexingType()) || hasUndecided(indexingType()));
-    ASSERT(m_butterfly->vectorLength() > length);
-    ASSERT(m_butterfly->publicLength() >= length);
-    ASSERT(!m_butterfly->indexingHeader()->preCapacity(structure()));
+    ASSERT(this->butterfly()->vectorLength() > length);
+    ASSERT(this->butterfly()->publicLength() >= length);
+    ASSERT(!this->butterfly()->indexingHeader()->preCapacity(structure()));
 
     DeferGC deferGC(vm);
-    Butterfly* newButterfly = butterfly()->resizeArray(vm, this, structure(), 0, ArrayStorage::sizeFor(length));
+    Butterfly* newButterfly = this->butterfly()->resizeArray(vm, this, structure(), 0, ArrayStorage::sizeFor(length));
     newButterfly->setVectorLength(length);
     newButterfly->setPublicLength(length);
     WTF::storeStoreFence();
-    m_butterfly.set(vm, this, newButterfly);
+    butterflyRef().set(vm, this, newButterfly);
 
 }
 
@@ -3885,7 +3900,7 @@ Butterfly* JSObject::allocateMoreOutOfLineStorage(VM& vm, size_t oldSize, size_t
     // It's important that this function not rely on structure(), for the property
     // capacity, since we might have already mutated the structure in-place.
 
-    return Butterfly::createOrGrowPropertyStorage(butterfly(), vm, this, structure(), oldSize, newSize);
+    return Butterfly::createOrGrowPropertyStorage(this->butterfly(), vm, this, structure(), oldSize, newSize);
 }
 
 bool JSObject::getOwnPropertyDescriptor(JSGlobalObject* globalObject, PropertyName propertyName, PropertyDescriptor& descriptor)
@@ -4129,7 +4144,7 @@ uint32_t JSObject::getEnumerableLength()
     }
         
     case ALL_ARRAY_STORAGE_INDEXING_TYPES: {
-        ArrayStorage* storage = object->m_butterfly->arrayStorage();
+        ArrayStorage* storage = object->butterfly()->arrayStorage();
         if (storage->m_sparseMap.get())
             return 0;
         
@@ -4250,7 +4265,7 @@ void JSObject::putOwnDataPropertyBatching(VM& vm, UniquedStringImpl** properties
 
         // Flush batching here. Note that it is possible that offsets.size() is not equal to size, if we stop batching due to transition-watchpoint-firing.
 
-        Butterfly* newButterfly = butterfly();
+        Butterfly* newButterfly = this->butterfly();
         auto* oldStructure = this->structure();
         if (oldStructure->outOfLineCapacity() != structure->outOfLineCapacity()) {
             ASSERT(structure != oldStructure);

--- a/Source/JavaScriptCore/runtime/JSObject.h
+++ b/Source/JavaScriptCore/runtime/JSObject.h
@@ -94,6 +94,7 @@ class JSObject : public JSCell {
     friend class JIT;
     friend class JSCell;
     friend class JSFinalObject;
+    friend class JSObjectWithButterfly;
     friend class MarkedBlock;
 
     enum PutMode : uint8_t {
@@ -192,14 +193,14 @@ public:
     {
         if (!hasIndexedProperties(indexingType()))
             return 0;
-        return m_butterfly->publicLength();
+        return butterfly()->publicLength();
     }
-        
+
     unsigned getVectorLength()
     {
         if (!hasIndexedProperties(indexingType()))
             return 0;
-        return m_butterfly->vectorLength();
+        return butterfly()->vectorLength();
     }
     
     inline bool canHaveExistingOwnIndexedGetterSetterProperties(); // Defined in RenderObjectInlines.h
@@ -254,7 +255,7 @@ public:
             case ALL_WRITABLE_DOUBLE_INDEXING_TYPES:
             case ALL_WRITABLE_CONTIGUOUS_INDEXING_TYPES:
             case ALL_ARRAY_STORAGE_INDEXING_TYPES:
-                return propertyName < m_butterfly->vectorLength();
+                return propertyName < butterfly()->vectorLength();
             default:
                 if (isCopyOnWrite(indexingMode()))
                     return false;
@@ -488,7 +489,7 @@ public:
 
     void setIndexQuickly(VM& vm, unsigned i, JSValue v)
     {
-        Butterfly* butterfly = m_butterfly.get();
+        Butterfly* butterfly = this->butterfly();
         ASSERT(!isCopyOnWrite(indexingMode()));
         switch (indexingType()) {
         case ALL_INT32_INDEXING_TYPES: {
@@ -556,7 +557,7 @@ public:
         case ALL_CONTIGUOUS_INDEXING_TYPES:
             return false;
         case ALL_ARRAY_STORAGE_INDEXING_TYPES:
-            return !!m_butterfly->arrayStorage()->m_sparseMap;
+            return !!butterfly()->arrayStorage()->m_sparseMap;
         default:
             RELEASE_ASSERT_NOT_REACHED();
             return false;
@@ -573,7 +574,7 @@ public:
         case ALL_CONTIGUOUS_INDEXING_TYPES:
             return false;
         case ALL_ARRAY_STORAGE_INDEXING_TYPES:
-            return m_butterfly->arrayStorage()->inSparseMode();
+            return butterfly()->arrayStorage()->inSparseMode();
         default:
             RELEASE_ASSERT_NOT_REACHED();
             return false;
@@ -671,11 +672,11 @@ public:
     bool hasInlineStorage() const { return structure()->hasInlineStorage(); }
     ConstPropertyStorage inlineStorageUnsafe() const
     {
-        return std::bit_cast<ConstPropertyStorage>(this + 1);
+        return std::bit_cast<ConstPropertyStorage>(std::bit_cast<const char*>(this) + offsetOfInlineStorage());
     }
     PropertyStorage inlineStorageUnsafe()
     {
-        return std::bit_cast<PropertyStorage>(this + 1);
+        return std::bit_cast<PropertyStorage>(std::bit_cast<char*>(this) + offsetOfInlineStorage());
     }
     ConstPropertyStorage inlineStorage() const
     {
@@ -687,16 +688,25 @@ public:
         ASSERT(hasInlineStorage());
         return inlineStorageUnsafe();
     }
-        
-    const Butterfly* butterfly() const LIFETIME_BOUND { return m_butterfly.get(); }
-    Butterfly* butterfly() LIFETIME_BOUND { return m_butterfly.get(); }
-    Dependency fencedButterfly(Butterfly*& butterfly)
+
+    const Butterfly* butterfly() const LIFETIME_BOUND
     {
-        return Dependency::loadAndFence(static_cast<Butterfly**>(butterflyAddress()), butterfly);
+        return const_cast<JSObject*>(this)->butterfly();
     }
-    
-    ConstPropertyStorage outOfLineStorage() const { return m_butterfly->propertyStorage(); }
-    PropertyStorage outOfLineStorage() { return m_butterfly->propertyStorage(); }
+
+    Butterfly* butterfly() LIFETIME_BOUND
+    {
+        // Access m_butterfly field of JSObjectWithButterfly regardless of whether this object is a derived class of JSObjectWithButterfly.
+        // This is safe as atom of GC heap allocation is 16 bytes, thus the butterfly field, offset from 8 byte, is always accessible.
+        // We intentionally load it regardless to make this function branchless. This is critical to keep this fast while we have butterfly-less objects.
+        auto* b = *std::bit_cast<Butterfly**>(std::bit_cast<char*>(this) + butterflyOffset());
+        if (type() == WebAssemblyGCObjectType) [[unlikely]]
+            b = nullptr;
+        return b;
+    }
+
+    ConstPropertyStorage outOfLineStorage() const { return butterfly()->propertyStorage(); }
+    PropertyStorage outOfLineStorage() { return butterfly()->propertyStorage(); }
 
     ALWAYS_INLINE const WriteBarrierBase<Unknown>* locationForOffset(PropertyOffset offset) const
     {
@@ -845,7 +855,7 @@ public:
     ContiguousJSValues tryMakeWritableInt32(VM& vm)
     {
         if (hasInt32(indexingType()) && !isCopyOnWrite(indexingMode())) [[likely]]
-            return m_butterfly->contiguousInt32();
+            return butterfly()->contiguousInt32();
 
         return tryMakeWritableInt32Slow(vm);
     }
@@ -857,7 +867,7 @@ public:
     ContiguousDoubles tryMakeWritableDouble(VM& vm)
     {
         if (hasDouble(indexingType()) && !isCopyOnWrite(indexingMode())) [[likely]]
-            return m_butterfly->contiguousDouble();
+            return butterfly()->contiguousDouble();
 
         return tryMakeWritableDoubleSlow(vm);
     }
@@ -867,7 +877,7 @@ public:
     ContiguousJSValues tryMakeWritableContiguous(VM& vm)
     {
         if (hasContiguous(indexingType()) && !isCopyOnWrite(indexingMode())) [[likely]]
-            return m_butterfly->contiguous();
+            return butterfly()->contiguous();
 
         return tryMakeWritableContiguousSlow(vm);
     }
@@ -879,7 +889,7 @@ public:
     ArrayStorage* ensureArrayStorage(VM& vm)
     {
         if (hasAnyArrayStorage(indexingType())) [[likely]]
-            return m_butterfly->arrayStorage();
+            return butterfly()->arrayStorage();
 
         return ensureArrayStorageSlow(vm);
     }
@@ -890,18 +900,16 @@ public:
             convertFromCopyOnWrite(vm);
     }
 
-    static constexpr size_t offsetOfInlineStorage()
+    static constexpr size_t offsetOfInlineStorage();
+
+    static constexpr ptrdiff_t butterflyOffset()
     {
         return sizeof(JSObject);
     }
 
-    static constexpr ptrdiff_t butterflyOffset()
-    {
-        return OBJECT_OFFSETOF(JSObject, m_butterfly);
-    }
     void* butterflyAddress()
     {
-        return &m_butterfly;
+        return std::bit_cast<char*>(this) + butterflyOffset();
     }
 
     JS_EXPORT_PRIVATE JSValue getMethod(JSGlobalObject*, CallData&, const Identifier&, const String& errorMessage);
@@ -939,27 +947,27 @@ protected:
 
     // To instantiate objects you likely want JSFinalObject, below.
     // To create derived types you likely want JSNonFinalObject, below.
-    JSObject(VM&, Structure*, Butterfly* = nullptr);
+    JSObject(VM&, Structure*);
+
+    // Returns reference to butterfly field storage. Only valid for objects that have butterfly storage
+    // (JSObjectWithButterfly subclasses). Used by JSObject methods that manipulate butterfly storage.
+    ALWAYS_INLINE AuxiliaryBarrier<Butterfly*>& butterflyRef()
+    {
+        ASSERT(type() != WebAssemblyGCObjectType);
+        return *std::bit_cast<AuxiliaryBarrier<Butterfly*>*>(std::bit_cast<char*>(this) + butterflyOffset());
+    }
 
     JSObject(CreatingWellDefinedBuiltinCellTag, StructureID structureID, int32_t blob)
         : JSCell(CreatingWellDefinedBuiltinCell, structureID, blob)
-        , m_butterfly(nullptr, WriteBarrierEarlyInit)
     {
     }
-
-    // Visits the butterfly unless there is a race. Returns the structure if there was no race.
-    template<typename Visitor> Structure* visitButterfly(Visitor&);
-    
-    template<typename Visitor> Structure* visitButterflyImpl(Visitor&);
-    
-    template<typename Visitor> void markAuxiliaryAndVisitOutOfLineProperties(Visitor&, Butterfly*, Structure*, PropertyOffset maxOffset);
 
     // Call this if you know that the object is in a mode where it has array
     // storage. This will assert otherwise.
     ArrayStorage* arrayStorage()
     {
         ASSERT(hasAnyArrayStorage(indexingType()));
-        return m_butterfly->arrayStorage();
+        return butterfly()->arrayStorage();
     }
         
     // Call this if you want to predicate some actions on whether or not the
@@ -968,7 +976,7 @@ protected:
     {
         switch (indexingType()) {
         case ALL_ARRAY_STORAGE_INDEXING_TYPES:
-            return m_butterfly->arrayStorage();
+            return butterfly()->arrayStorage();
                 
         default:
             return nullptr;
@@ -1039,13 +1047,13 @@ protected:
         RELEASE_ASSERT(length <= MAX_STORAGE_VECTOR_LENGTH);
         ASSERT(hasContiguous(indexingType()) || hasInt32(indexingType()) || hasDouble(indexingType()) || hasUndecided(indexingType()));
 
-        if (m_butterfly->vectorLength() < length || isCopyOnWrite(indexingMode())) {
+        if (butterfly()->vectorLength() < length || isCopyOnWrite(indexingMode())) {
             if (!ensureLengthSlow(vm, length))
                 return false;
         }
-            
-        if (m_butterfly->publicLength() < length)
-            m_butterfly->setPublicLength(length);
+
+        if (butterfly()->publicLength() < length)
+            butterfly()->setPublicLength(length);
         return true;
     }
         
@@ -1105,27 +1113,82 @@ private:
     JS_EXPORT_PRIVATE ArrayStorage* ensureArrayStorageSlow(VM&);
 
     PropertyOffset prepareToPutDirectWithoutTransition(VM&, PropertyName, unsigned attributes, StructureID, Structure*);
+};
 
+// JSObjectWithButterfly is a JSObject that has out-of-line property storage (butterfly).
+// All normal JS objects go through this class. Wasm GC objects inherit JSObject directly
+// without butterfly to save 8 bytes per allocation.
+class JSObjectWithButterfly : public JSObject {
+    friend class JSObject;
+    friend class JSFinalObject;
+    friend class LLIntOffsetsExtractor;
+
+public:
+    using Base = JSObject;
+
+    DECLARE_VISIT_CHILDREN_WITH_MODIFIER(JS_EXPORT_PRIVATE);
+
+    DECLARE_EXPORT_INFO;
+
+    const Butterfly* butterfly() const LIFETIME_BOUND { return m_butterfly.get(); }
+    Butterfly* butterfly() LIFETIME_BOUND { return m_butterfly.get(); }
+    Dependency fencedButterfly(Butterfly*& butterfly)
+    {
+        return Dependency::loadAndFence(static_cast<Butterfly**>(butterflyAddress()), butterfly);
+    }
+
+    ConstPropertyStorage outOfLineStorage() const { return m_butterfly->propertyStorage(); }
+    PropertyStorage outOfLineStorage() { return m_butterfly->propertyStorage(); }
+
+    void* butterflyAddress()
+    {
+        return &m_butterfly;
+    }
+
+    // Visits the butterfly unless there is a race. Returns the structure if there was no race.
+    template<typename Visitor> Structure* visitButterfly(Visitor&);
+    template<typename Visitor> Structure* visitButterflyImpl(Visitor&);
+    template<typename Visitor> void markAuxiliaryAndVisitOutOfLineProperties(Visitor&, Butterfly*, Structure*, PropertyOffset maxOffset);
+
+protected:
+    JSObjectWithButterfly(VM& vm, Structure* structure, Butterfly* butterfly = nullptr)
+        : JSObject(vm, structure)
+        , m_butterfly(butterfly, WriteBarrierEarlyInit)
+    {
+    }
+
+    JSObjectWithButterfly(CreatingWellDefinedBuiltinCellTag, StructureID structureID, int32_t blob)
+        : JSObject(CreatingWellDefinedBuiltinCell, structureID, blob)
+        , m_butterfly(nullptr, WriteBarrierEarlyInit)
+    {
+    }
+
+private:
     AuxiliaryBarrier<Butterfly*> m_butterfly;
 #if CPU(ADDRESS32)
     unsigned m_32BitPadding;
 #endif
 };
 
+constexpr size_t JSObject::offsetOfInlineStorage()
+{
+    return sizeof(JSObjectWithButterfly);
+}
+
 // JSNonFinalObject is a type of JSObject that has some internal storage,
 // but also preserves some space in the collector cell for additional
 // data members in derived types.
-class JSNonFinalObject : public JSObject {
+class JSNonFinalObject : public JSObjectWithButterfly {
     friend class JSObject;
 
 public:
-    typedef JSObject Base;
+    typedef JSObjectWithButterfly Base;
 
     inline static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
 protected:
     explicit JSNonFinalObject(VM& vm, Structure* structure, Butterfly* butterfly = nullptr)
-        : JSObject(vm, structure, butterfly)
+        : JSObjectWithButterfly(vm, structure, butterfly)
     {
     }
 
@@ -1141,10 +1204,10 @@ protected:
 
 // JSFinalObject is a type of JSObject that contains sufficient internal
 // storage to fully make use of the collector cell containing it.
-class JSFinalObject final : public JSObject {
+class JSFinalObject final : public JSObjectWithButterfly {
     friend class JSObject;
 public:
-    using Base = JSObject;
+    using Base = JSObjectWithButterfly;
     static constexpr unsigned StructureFlags = Base::StructureFlags;
 
     template<typename CellType, SubspaceAccess>
@@ -1152,7 +1215,7 @@ public:
 
     static size_t allocationSize(Checked<size_t> inlineCapacity)
     {
-        return sizeof(JSObject) + inlineCapacity * sizeof(WriteBarrierBase<Unknown>);
+        return sizeof(JSObjectWithButterfly) + inlineCapacity * sizeof(WriteBarrierBase<Unknown>);
     }
 
     static inline constexpr TypeInfo typeInfo() { return TypeInfo(FinalObjectType, StructureFlags); }
@@ -1163,11 +1226,11 @@ public:
     }
 
     static constexpr unsigned defaultSizeInBytes = 64;
-    static constexpr unsigned defaultInlineCapacity = (defaultSizeInBytes - sizeof(JSObject)) / sizeof(WriteBarrier<Unknown>);
+    static constexpr unsigned defaultInlineCapacity = (defaultSizeInBytes - sizeof(JSObjectWithButterfly)) / sizeof(WriteBarrier<Unknown>);
     static_assert(defaultInlineCapacity < firstOutOfLineOffset);
 
     static constexpr unsigned maxSizeInBytes = 512;
-    static constexpr unsigned maxInlineCapacity = (maxSizeInBytes - sizeof(JSObject)) / sizeof(WriteBarrier<Unknown>);
+    static constexpr unsigned maxInlineCapacity = (maxSizeInBytes - sizeof(JSObjectWithButterfly)) / sizeof(WriteBarrier<Unknown>);
     static_assert(maxInlineCapacity < firstOutOfLineOffset);
 
     static JSFinalObject* create(VM&, Structure*);
@@ -1184,14 +1247,14 @@ private:
     friend class LLIntOffsetsExtractor;
 
     explicit JSFinalObject(VM& vm, Structure* structure, Butterfly* butterfly, size_t inlineCapacity)
-        : JSObject(vm, structure, butterfly)
+        : JSObjectWithButterfly(vm, structure, butterfly)
     {
         // We do not need to use gcSafeMemcpy since this object is not exposed yet.
         memset(inlineStorageUnsafe(), 0, inlineCapacity * sizeof(EncodedJSValue));
     }
 
     explicit JSFinalObject(CreatingWellDefinedBuiltinCellTag, StructureID structureID)
-        : JSObject(CreatingWellDefinedBuiltinCell, structureID, defaultTypeInfoBlob())
+        : JSObjectWithButterfly(CreatingWellDefinedBuiltinCell, structureID, defaultTypeInfoBlob())
     {
         // We do not need to use gcSafeMemcpy since this object is not exposed yet.
         memset(inlineStorageUnsafe(), 0, defaultInlineCapacity * sizeof(EncodedJSValue));
@@ -1265,7 +1328,7 @@ inline bool JSObject::isWithScope() const
 inline void JSObject::setStructure(VM& vm, Structure* structure)
 {
     ASSERT(structure);
-    ASSERT(!m_butterfly == !(structure->outOfLineCapacity() || structure->hasIndexingHeader(this)));
+    ASSERT(!butterfly() == !(structure->outOfLineCapacity() || structure->hasIndexingHeader(this)));
     JSCell::setStructure(vm, structure);
 }
 
@@ -1281,9 +1344,8 @@ inline JSObject* asObject(JSValue value)
     return asObject(value.asCell());
 }
 
-inline JSObject::JSObject(VM& vm, Structure* structure, Butterfly* butterfly)
+inline JSObject::JSObject(VM& vm, Structure* structure)
     : JSCell(vm, structure)
-    , m_butterfly(butterfly, WriteBarrierEarlyInit)
 {
 }
 
@@ -1525,7 +1587,9 @@ inline size_t maxOffsetRelativeToBase(PropertyOffset offset)
     return static_cast<size_t>(addressOffset);
 }
 
-static_assert(!(sizeof(JSObject) % sizeof(WriteBarrierBase<Unknown>)), "JSObject inline storage has correct alignment");
+static_assert(!(sizeof(JSObjectWithButterfly) % sizeof(WriteBarrierBase<Unknown>)), "JSObject inline storage has correct alignment");
+static_assert(sizeof(JSObject) == sizeof(JSCell), "JSObject should be the same size as JSCell (no butterfly)");
+static_assert(JSObject::butterflyOffset() == sizeof(JSObject), "butterfly offset must be right after JSObject");
 
 ALWAYS_INLINE Identifier makeIdentifier(VM& vm, ASCIILiteral literal)
 {

--- a/Source/JavaScriptCore/runtime/JSObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSObjectInlines.h
@@ -71,12 +71,12 @@ inline void JSObject::setButterfly(VM& vm, Butterfly* butterfly)
 {
     if (isX86() || vm.heap.mutatorShouldBeFenced()) {
         WTF::storeStoreFence();
-        m_butterfly.set(vm, this, butterfly);
+        butterflyRef().set(vm, this, butterfly);
         WTF::storeStoreFence();
         return;
     }
 
-    m_butterfly.set(vm, this, butterfly);
+    butterflyRef().set(vm, this, butterfly);
 }
 
 inline void JSObject::nukeStructureAndSetButterfly(VM& vm, StructureID oldStructureID, Butterfly* butterfly)
@@ -84,12 +84,12 @@ inline void JSObject::nukeStructureAndSetButterfly(VM& vm, StructureID oldStruct
     if (isX86() || vm.heap.mutatorShouldBeFenced()) {
         setStructureIDDirectly(oldStructureID.nuke());
         WTF::storeStoreFence();
-        m_butterfly.set(vm, this, butterfly);
+        butterflyRef().set(vm, this, butterfly);
         WTF::storeStoreFence();
         return;
     }
 
-    m_butterfly.set(vm, this, butterfly);
+    butterflyRef().set(vm, this, butterfly);
 }
 
 inline JSValue JSObject::get(JSGlobalObject* globalObject, PropertyName propertyName) const
@@ -1002,7 +1002,7 @@ void JSObject::forEachOwnIndexedProperty(JSGlobalObject* globalObject, const Fun
     case ALL_INT32_INDEXING_TYPES:
     case ALL_CONTIGUOUS_INDEXING_TYPES:
     case ALL_DOUBLE_INDEXING_TYPES: {
-        unsigned usedLength = m_butterfly->publicLength();
+        unsigned usedLength = butterfly()->publicLength();
         for (unsigned i = 0; i < usedLength; ++i) {
             JSValue value = getDirectIndex(globalObject, i);
             RETURN_IF_EXCEPTION(scope, void());
@@ -1013,7 +1013,7 @@ void JSObject::forEachOwnIndexedProperty(JSGlobalObject* globalObject, const Fun
     }
 
     case ALL_ARRAY_STORAGE_INDEXING_TYPES: {
-        ArrayStorage* storage = m_butterfly->arrayStorage();
+        ArrayStorage* storage = butterfly()->arrayStorage();
         unsigned usedVectorLength = std::min(storage->length(), storage->vectorLength());
         for (unsigned i = 0; i < usedVectorLength; ++i) {
             auto value = storage->m_vector[i];
@@ -1074,7 +1074,7 @@ inline void JSObject::initializeIndex(ObjectInitializationScope& scope, unsigned
 ALWAYS_INLINE void JSObject::initializeIndex(ObjectInitializationScope& scope, unsigned i, JSValue v, IndexingType indexingType)
 {
     VM& vm = scope.vm();
-    Butterfly* butterfly = m_butterfly.get();
+    auto* butterfly = this->butterfly();
     switch (indexingType) {
     case ALL_UNDECIDED_INDEXING_TYPES: {
         setIndexQuicklyToUndecided(vm, i, v);
@@ -1129,7 +1129,7 @@ inline void JSObject::initializeIndexWithoutBarrier(ObjectInitializationScope& s
 
 ALWAYS_INLINE void JSObject::initializeIndexWithoutBarrier(ObjectInitializationScope&, unsigned i, JSValue v, IndexingType indexingType)
 {
-    Butterfly* butterfly = m_butterfly.get();
+    auto* butterfly = this->butterfly();
     switch (indexingType) {
     case ALL_UNDECIDED_INDEXING_TYPES: {
         RELEASE_ASSERT_NOT_REACHED();
@@ -1181,7 +1181,7 @@ inline bool JSObject::canHaveExistingOwnIndexedGetterSetterProperties()
     case ALL_DOUBLE_INDEXING_TYPES:
         return false;
     case ALL_ARRAY_STORAGE_INDEXING_TYPES: {
-        SparseArrayValueMap* map = m_butterfly->arrayStorage()->m_sparseMap.get();
+        SparseArrayValueMap* map = butterfly()->arrayStorage()->m_sparseMap.get();
         if (!map)
             return false;
         return map->hasAnyKindOfGetterSetterProperties();
@@ -1203,9 +1203,9 @@ inline unsigned JSObject::canHaveExistingOwnIndexedProperties() const
     case ALL_INT32_INDEXING_TYPES:
     case ALL_CONTIGUOUS_INDEXING_TYPES:
     case ALL_DOUBLE_INDEXING_TYPES:
-        return m_butterfly->publicLength();
+        return butterfly()->publicLength();
     case ALL_ARRAY_STORAGE_INDEXING_TYPES: {
-        ArrayStorage* storage = m_butterfly->arrayStorage();
+        auto* storage = butterfly()->arrayStorage();
         unsigned usedVectorLength = std::min(storage->length(), storage->vectorLength());
         if (usedVectorLength)
             return true;

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -1468,7 +1468,6 @@ void BBQJIT::emitAllocateGCArrayUninitialized(GPRReg resultGPR, uint32_t typeInd
             m_jit.move(TrustedImm32(JSWebAssemblyArray::typeInfoBlob().blob()), scratchGPR2);
             static_assert(JSCell::structureIDOffset() + sizeof(int32_t) == JSCell::indexingTypeAndMiscOffset());
             m_jit.storePair32(scratchGPR, scratchGPR2, MacroAssembler::Address(resultGPR, JSCell::structureIDOffset()));
-            m_jit.storePtr(TrustedImmPtr(nullptr), MacroAssembler::Address(resultGPR, JSObject::butterflyOffset()));
             m_jit.store32(TrustedImm32(size.asI32()), MacroAssembler::Address(resultGPR, JSWebAssemblyArray::offsetOfSize()));
         } else {
             // FIXME: emitCCall can't handle being passed a destination... which is why we just jump to the slow path here.
@@ -1490,7 +1489,6 @@ void BBQJIT::emitAllocateGCArrayUninitialized(GPRReg resultGPR, uint32_t typeInd
         m_jit.move(TrustedImm32(JSWebAssemblyArray::typeInfoBlob().blob()), scratchGPR2);
         static_assert(JSCell::structureIDOffset() + sizeof(int32_t) == JSCell::indexingTypeAndMiscOffset());
         m_jit.storePair32(scratchGPR, scratchGPR2, MacroAssembler::Address(resultGPR, JSCell::structureIDOffset()));
-        m_jit.storePtr(TrustedImmPtr(nullptr), MacroAssembler::Address(resultGPR, JSObject::butterflyOffset()));
         m_jit.store32(sizeLocation.asGPR(), MacroAssembler::Address(resultGPR, JSWebAssemblyArray::offsetOfSize()));
     }
 
@@ -2006,7 +2004,6 @@ void BBQJIT::emitAllocateGCStructUninitialized(GPRReg resultGPR, uint32_t typeIn
         m_jit.move(TrustedImm32(JSWebAssemblyStruct::typeInfoBlob().blob()), scratchGPR2);
         static_assert(JSCell::structureIDOffset() + sizeof(int32_t) == JSCell::indexingTypeAndMiscOffset());
         m_jit.storePair32(scratchGPR, scratchGPR2, MacroAssembler::Address(resultGPR, JSCell::structureIDOffset()));
-        m_jit.storePtr(TrustedImmPtr(nullptr), MacroAssembler::Address(resultGPR, JSObject::butterflyOffset()));
     } else {
         // FIXME: emitCCall can't handle being passed a destination... which is why we just jump to the slow path here.
         slowPath.append(m_jit.jump());

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -4143,9 +4143,6 @@ Value* OMGIRGenerator::allocateWasmGCObject(Value* allocator, Value* structureID
     auto* storeUsefulBytes = m_currentBlock->appendNew<B3::MemoryValue>(m_proc, B3::Store, origin(), typeInfo, cell, safeCast<int32_t>(JSCell::indexingTypeAndMiscOffset()));
     m_heaps.decorateMemory(&m_heaps.JSCell_usefulBytes, storeUsefulBytes);
 
-    auto* storeButterfly = m_currentBlock->appendNew<B3::MemoryValue>(m_proc, B3::Store, origin(), constant(pointerType(), 0), cell, safeCast<int32_t>(JSObject::butterflyOffset()));
-    m_heaps.decorateMemory(&m_heaps.JSObject_butterfly, storeButterfly);
-
     return cell;
 }
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h
@@ -40,7 +40,7 @@ namespace JSC {
 
 // Ideally this would just subclass TrailingArray<JSWebAssemblyArray, uint8_t> but we need the m_size field to be in units
 // of element size rather than byte size.
-class JSWebAssemblyArray final : public WebAssemblyGCObjectBase {
+class alignas(8) JSWebAssemblyArray final : public WebAssemblyGCObjectBase {
 public:
     using Base = WebAssemblyGCObjectBase;
 
@@ -96,16 +96,16 @@ public:
     void setIsUnpopulated(bool value) { m_isUnpopulated = value; }
 #endif
 
-    // We add 8 bytes for v128 arrays since a non-PreciseAllocation will have the wrong alignment as the base pointer for a PreciseAllocation is shifted by 8.
+    // We add padding for v128 arrays since a non-PreciseAllocation will have the wrong alignment as the base pointer for a PreciseAllocation is shifted by 8.
     // Note: Technically this isn't needed since the GC/malloc always allocates 16 byte chunks so for non-precise v128 allocations
-    // there will be a 8 spare bytes at the end. This is just a bit more explicit and shouldn't make a difference.
-    static constexpr ptrdiff_t v128AlignmentShift = 8;
+    // there will be spare bytes at the end. This is just a bit more explicit and shouldn't make a difference.
+    static constexpr ptrdiff_t v128AlignmentShift() { return (16 - (offsetOfData() % 16)) % 16; }
     static std::optional<unsigned> allocationSizeInBytes(Wasm::FieldType fieldType, unsigned size)
     {
         unsigned elementSize = fieldType.type.elementSize();
         if (productOverflows<uint32_t>(elementSize, size) || elementSize * size > Wasm::maxArraySizeInBytes) [[unlikely]]
             return std::nullopt;
-        return sizeof(JSWebAssemblyArray) + size * elementSize + static_cast<size_t>(needsAlignmentCheck(fieldType.type) * v128AlignmentShift);
+        return sizeof(JSWebAssemblyArray) + size * elementSize + static_cast<size_t>(needsAlignmentCheck(fieldType.type) * v128AlignmentShift());
     }
 
     static constexpr ptrdiff_t offsetOfSize() { return OBJECT_OFFSETOF(JSWebAssemblyArray, m_size); }
@@ -133,7 +133,7 @@ private:
 static_assert(std::is_final_v<JSWebAssemblyArray>, "JSWebAssemblyArray is a TrailingArray-like object so must know about all members");
 // We still have to check for PreciseAllocations since those are correctly aligned for v128 but this asserts our shifted offset will be correct.
 // FIXME: Fix this check for 32-bit.
-static_assert(isAddress32Bit() || !((JSWebAssemblyArray::offsetOfData() + JSWebAssemblyArray::v128AlignmentShift) % 16), "JSWebAssemblyArray storage needs to be aligned for v128_t");
+static_assert(isAddress32Bit() || !((JSWebAssemblyArray::offsetOfData() + JSWebAssemblyArray::v128AlignmentShift()) % 16), "JSWebAssemblyArray storage needs to be aligned for v128_t");
 
 } // namespace JSC
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyGCObjectBase.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyGCObjectBase.h
@@ -34,10 +34,10 @@
 
 namespace JSC {
 
-class WebAssemblyGCObjectBase : public JSNonFinalObject {
+class WebAssemblyGCObjectBase : public JSObject {
 public:
-    using Base = JSNonFinalObject;
-    static constexpr unsigned StructureFlags = Base::StructureFlags | OverridesGetOwnPropertySlot | OverridesGetOwnPropertyNames | OverridesGetPrototype | OverridesPut | OverridesIsExtensible | InterceptsGetOwnPropertySlotByIndexEvenWhenLengthIsNotZero;
+    using Base = JSObject;
+    static constexpr unsigned StructureFlags = Base::StructureFlags | OverridesGetOwnPropertySlot | OverridesGetOwnPropertyNames | OverridesGetPrototype | OverridesPut | OverridesIsExtensible | InterceptsGetOwnPropertySlotByIndexEvenWhenLengthIsNotZero | ProhibitsPropertyCaching;
 
     DECLARE_INFO;
 


### PR DESCRIPTION
#### 55783b94e9df3e359b8f65c7a29e4f17899c0b7f
<pre>
[JSC] Introduce butterfly-less objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=310939">https://bugs.webkit.org/show_bug.cgi?id=310939</a>
<a href="https://rdar.apple.com/173551949">rdar://173551949</a>

Reviewed by Mark Lam.

This patch introduces butterfly-less objects. Wasm GC objects have no
way to have any properties, and no way to have any [[Prototype]] etc.
This means that they never cause Structure transitions. And they never have
butterfly. However they are currently having m_butterfly field as it is
JSObject. But this is always nullptr and wasteful.

To make Wasm GC objects size compact, we introduce butterfly-less
objects. Now JSObject does not have m_butterfly. And we introduce a new
class, JSObjectWithButterfly, and it should be a base of all JS objects
types. And instead, WebAssemblyGCObjectBase is inheriting JSObject
directly, thus we no longer has m_butterfly field for them.

But to keep JSObject::butterfly() access very efficient, we implement
JSObject::butterfly in this way.

```
Butterfly* butterfly()
{
    auto* b = *std::bit_cast&lt;Butterfly**&gt;(std::bit_cast&lt;char*&gt;(this) + butterflyOffset());
    if (type() == WebAssemblyGCObjectType) [[unlikely]]
        b = nullptr;
    return b;
}
```

Regardless of whether it is WebAssemblyGCObjectBase type, we always load
butterfly field and change it to nullptr when type() is WebAssemblyGCObjectType.
Always loading m_butterfly field is safe since HeapCell atom size is
always &gt;= 16 bytes, thus m_butterfly field (8 byte offset) is always accessible.
The above code makes sure that butterfly() call is branchless, and
type() is also on the same cache, so we will not get any performance
implication from this call.

JIT side of butterfly access does not need special case actually, as we
are always accessing them after doing some checks, like Structure,
indexing type. And WebAssemblyGCObjectBase cannot meet these checks so
we will not reach to the code which accesses to m_butterfly in JIT when
the object is WebAssemblyGCObjectBase.

* Source/JavaScriptCore/b3/B3LowerMacros.cpp:
* Source/JavaScriptCore/heap/PreciseAllocation.cpp:
* Source/JavaScriptCore/jit/AssemblyHelpers.cpp:
(JSC::AssemblyHelpers::loadProperty):
(JSC::AssemblyHelpers::storeProperty):
* Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm:
* Source/JavaScriptCore/llint/LowLevelInterpreter64.asm:
* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::JSObjectWithButterfly::markAuxiliaryAndVisitOutOfLineProperties):
(JSC::JSObjectWithButterfly::visitButterfly):
(JSC::JSObjectWithButterfly::visitButterflyImpl):
(JSC::JSObject::estimatedSize):
(JSC::JSObject::visitChildrenImpl):
(JSC::JSObjectWithButterfly::visitChildrenImpl):
(JSC::JSFinalObject::visitChildrenImpl):
(JSC::JSObject::getOwnPropertySlotByIndex):
(JSC::JSObject::putByIndex):
(JSC::JSObject::enterDictionaryIndexingMode):
(JSC::JSObject::createInitialIndexedStorage):
(JSC::JSObject::createArrayStorage):
(JSC::JSObject::convertUndecidedToInt32):
(JSC::JSObject::convertUndecidedToDouble):
(JSC::JSObject::convertUndecidedToContiguous):
(JSC::JSObject::constructConvertedArrayStorageWithoutCopyingElements):
(JSC::JSObject::convertUndecidedToArrayStorage):
(JSC::JSObject::convertInt32ToDouble):
(JSC::JSObject::convertInt32ToContiguous):
(JSC::JSObject::convertInt32ToArrayStorage):
(JSC::JSObject::convertDoubleToContiguous):
(JSC::JSObject::convertDoubleToArrayStorage):
(JSC::JSObject::convertContiguousToArrayStorage):
(JSC::JSObject::convertFromCopyOnWrite):
(JSC::JSObject::setIndexQuicklyToUndecided):
(JSC::JSObject::tryMakeWritableInt32Slow):
(JSC::JSObject::tryMakeWritableDoubleSlow):
(JSC::JSObject::tryMakeWritableContiguousSlow):
(JSC::JSObject::ensureArrayStorageExistsAndEnterDictionaryIndexingMode):
(JSC::JSObject::deletePropertyByIndex):
(JSC::JSObject::getOwnIndexedPropertyNames):
(JSC::JSObject::defineOwnIndexedProperty):
(JSC::JSObject::putByIndexBeyondVectorLengthWithoutAttributes):
(JSC::JSObject::getNewVectorLength):
(JSC::JSObject::countElements):
(JSC::JSObject::ensureLengthSlow):
(JSC::JSObject::reallocateAndShrinkButterfly):
(JSC::JSObject::allocateMoreOutOfLineStorage):
(JSC::JSObject::getEnumerableLength):
(JSC::JSObject::putOwnDataPropertyBatching):
(JSC::JSObject::markAuxiliaryAndVisitOutOfLineProperties): Deleted.
(JSC::JSObject::visitButterfly): Deleted.
(JSC::JSObject::visitButterflyImpl): Deleted.
* Source/JavaScriptCore/runtime/JSObject.h:
(JSC::JSObject::getArrayLength const):
(JSC::JSObject::getVectorLength):
(JSC::JSObject::putDirectIndex):
(JSC::JSObject::setIndexQuickly):
(JSC::JSObject::hasSparseMap):
(JSC::JSObject::inSparseIndexingMode):
(JSC::JSObject::inlineStorageUnsafe const):
(JSC::JSObject::inlineStorageUnsafe):
(JSC::JSObject::outOfLineStorage const):
(JSC::JSObject::outOfLineStorage):
(JSC::JSObject::tryMakeWritableInt32):
(JSC::JSObject::tryMakeWritableDouble):
(JSC::JSObject::tryMakeWritableContiguous):
(JSC::JSObject::ensureArrayStorage):
(JSC::JSObject::butterflyOffset):
(JSC::JSObject::butterflyAddress):
(JSC::JSObject::JSObject):
(JSC::JSObject::arrayStorage):
(JSC::JSObject::arrayStorageOrNull):
(JSC::JSObject::ensureLength):
(JSC::JSObjectWithButterfly::fencedButterfly):
(JSC::JSObjectWithButterfly::outOfLineStorage const):
(JSC::JSObjectWithButterfly::outOfLineStorage):
(JSC::JSObjectWithButterfly::butterflyAddress):
(JSC::JSObjectWithButterfly::JSObjectWithButterfly):
(JSC::JSObject::offsetOfInlineStorage):
(JSC::JSNonFinalObject::JSNonFinalObject):
(JSC::JSObject::setStructure):
(JSC::JSObject::fencedButterfly): Deleted.
* Source/JavaScriptCore/runtime/JSObjectInlines.h:
(JSC::JSObject::setButterfly):
(JSC::JSObject::nukeStructureAndSetButterfly):
(JSC::JSObject::forEachOwnIndexedProperty):
(JSC::JSObject::initializeIndex):
(JSC::JSObject::initializeIndexWithoutBarrier):
(JSC::JSObject::canHaveExistingOwnIndexedGetterSetterProperties):
(JSC::JSObject::canHaveExistingOwnIndexedProperties const):
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitAllocateGCArrayUninitialized):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitAllocateGCStructUninitialized):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::allocateWasmGCObject):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyGCObjectBase.h:

Canonical link: <a href="https://commits.webkit.org/310171@main">https://commits.webkit.org/310171@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f4941077ef7e48fb7b2743804e3d02b76b09ef0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152980 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25762 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19360 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161724 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26289 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26067 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118246 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155939 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20470 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/137337 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98959 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19544 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9560 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144992 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129197 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15211 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164198 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/13792 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7334 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16805 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126303 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25559 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21524 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126461 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25561 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137007 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82186 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23422 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21411 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13786 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184613 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25177 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89464 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47127 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24869 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25028 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24929 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->