### PR TITLE
Use "= default" for destructor in WebCore

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpReceiverTransformBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpReceiverTransformBackend.cpp
@@ -38,9 +38,7 @@ GStreamerRtpReceiverTransformBackend::GStreamerRtpReceiverTransformBackend(const
 {
 }
 
-GStreamerRtpReceiverTransformBackend::~GStreamerRtpReceiverTransformBackend()
-{
-}
+GStreamerRtpReceiverTransformBackend::~GStreamerRtpReceiverTransformBackend() = default;
 
 void GStreamerRtpReceiverTransformBackend::setTransformableFrameCallback(Callback&& callback)
 {

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderTransformBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderTransformBackend.cpp
@@ -42,9 +42,7 @@ GStreamerRtpSenderTransformBackend::GStreamerRtpSenderTransformBackend(const GRe
 {
 }
 
-GStreamerRtpSenderTransformBackend::~GStreamerRtpSenderTransformBackend()
-{
-}
+GStreamerRtpSenderTransformBackend::~GStreamerRtpSenderTransformBackend() = default;
 
 void GStreamerRtpSenderTransformBackend::setTransformableFrameCallback(Callback&& callback)
 {

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCIceTransportBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCIceTransportBackend.cpp
@@ -200,9 +200,7 @@ LibWebRTCIceTransportBackend::LibWebRTCIceTransportBackend(webrtc::scoped_refptr
 {
 }
 
-LibWebRTCIceTransportBackend::~LibWebRTCIceTransportBackend()
-{
-}
+LibWebRTCIceTransportBackend::~LibWebRTCIceTransportBackend() = default;
 
 void LibWebRTCIceTransportBackend::registerClient(RTCIceTransportBackendClient& client)
 {

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverTransformBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverTransformBackend.cpp
@@ -42,9 +42,7 @@ LibWebRTCRtpReceiverTransformBackend::LibWebRTCRtpReceiverTransformBackend(Ref<w
 {
 }
 
-LibWebRTCRtpReceiverTransformBackend::~LibWebRTCRtpReceiverTransformBackend()
-{
-}
+LibWebRTCRtpReceiverTransformBackend::~LibWebRTCRtpReceiverTransformBackend() = default;
 
 void LibWebRTCRtpReceiverTransformBackend::setTransformableFrameCallback(Callback&& callback)
 {

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderTransformBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderTransformBackend.cpp
@@ -45,9 +45,7 @@ LibWebRTCRtpSenderTransformBackend::LibWebRTCRtpSenderTransformBackend(Ref<webrt
 {
 }
 
-LibWebRTCRtpSenderTransformBackend::~LibWebRTCRtpSenderTransformBackend()
-{
-}
+LibWebRTCRtpSenderTransformBackend::~LibWebRTCRtpSenderTransformBackend() = default;
 
 void LibWebRTCRtpSenderTransformBackend::setTransformableFrameCallback(Callback&& callback)
 {

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransformableFrame.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransformableFrame.cpp
@@ -46,9 +46,7 @@ LibWebRTCRtpTransformableFrame::LibWebRTCRtpTransformableFrame(std::unique_ptr<w
 {
 }
 
-LibWebRTCRtpTransformableFrame::~LibWebRTCRtpTransformableFrame()
-{
-}
+LibWebRTCRtpTransformableFrame::~LibWebRTCRtpTransformableFrame() = default;
 
 std::unique_ptr<webrtc::TransformableFrameInterface> LibWebRTCRtpTransformableFrame::takeRTCFrame()
 {

--- a/Source/WebCore/Modules/notifications/NotificationResourcesLoader.cpp
+++ b/Source/WebCore/Modules/notifications/NotificationResourcesLoader.cpp
@@ -150,9 +150,7 @@ NotificationResourcesLoader::ResourceLoader::ResourceLoader(ScriptExecutionConte
     m_loader = ThreadableLoader::create(context, *this, ResourceRequest(URL { url }), options);
 }
 
-NotificationResourcesLoader::ResourceLoader::~ResourceLoader()
-{
-}
+NotificationResourcesLoader::ResourceLoader::~ResourceLoader() = default;
 
 void NotificationResourcesLoader::ResourceLoader::cancel()
 {

--- a/Source/WebCore/Modules/webtransport/WebTransportSendStreamSink.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransportSendStreamSink.cpp
@@ -49,9 +49,7 @@ WebTransportSendStreamSink::WebTransportSendStreamSink(WebTransport& transport, 
 {
 }
 
-WebTransportSendStreamSink::~WebTransportSendStreamSink()
-{
-}
+WebTransportSendStreamSink::~WebTransportSendStreamSink() = default;
 
 RefPtr<WritableStream> WebTransportSendStreamSink::stream() const
 {

--- a/Source/WebCore/PAL/pal/crypto/commoncrypto/CryptoDigestCommonCrypto.cpp
+++ b/Source/WebCore/PAL/pal/crypto/commoncrypto/CryptoDigestCommonCrypto.cpp
@@ -49,9 +49,7 @@ CryptoDigest::CryptoDigest()
 {
 }
 
-CryptoDigest::~CryptoDigest()
-{
-}
+CryptoDigest::~CryptoDigest() = default;
 
 static std::unique_ptr<pal::Digest> createCryptoDigest(CryptoDigest::Algorithm algorithm)
 {

--- a/Source/WebCore/bindings/js/DOMGCOutputConstraint.cpp
+++ b/Source/WebCore/bindings/js/DOMGCOutputConstraint.cpp
@@ -50,9 +50,7 @@ DOMGCOutputConstraint::DOMGCOutputConstraint(VM& vm, JSHeapData& heapData)
 {
 }
 
-DOMGCOutputConstraint::~DOMGCOutputConstraint()
-{
-}
+DOMGCOutputConstraint::~DOMGCOutputConstraint() = default;
 
 template<typename Visitor>
 void DOMGCOutputConstraint::executeImplImpl(Visitor& visitor)

--- a/Source/WebCore/bindings/js/JSLazyEventListener.cpp
+++ b/Source/WebCore/bindings/js/JSLazyEventListener.cpp
@@ -104,9 +104,7 @@ void JSLazyEventListener::checkValidityForEventTarget(EventTarget& eventTarget)
 }
 #endif
 
-JSLazyEventListener::~JSLazyEventListener()
-{
-}
+JSLazyEventListener::~JSLazyEventListener() = default;
 
 JSObject* JSLazyEventListener::initializeJSFunction(ScriptExecutionContext& executionContext) const
 {

--- a/Source/WebCore/html/track/VTTCue.cpp
+++ b/Source/WebCore/html/track/VTTCue.cpp
@@ -305,9 +305,7 @@ VTTCue::VTTCue(Document& document, Ref<WebVTTCueData>&& cueData)
     setCueSettings(cueData->settings());
 }
 
-VTTCue::~VTTCue()
-{
-}
+VTTCue::~VTTCue() = default;
 
 RefPtr<VTTCueBox> VTTCue::createDisplayTree()
 {

--- a/Source/WebCore/layout/FormattingState.cpp
+++ b/Source/WebCore/layout/FormattingState.cpp
@@ -41,9 +41,7 @@ FormattingState::FormattingState(Type type, LayoutState& layoutState)
 {
 }
 
-FormattingState::~FormattingState()
-{
-}
+FormattingState::~FormattingState() = default;
 
 BoxGeometry& FormattingState::boxGeometry(const Box& layoutBox)
 {

--- a/Source/WebCore/layout/formattingContexts/block/BlockFormattingState.cpp
+++ b/Source/WebCore/layout/formattingContexts/block/BlockFormattingState.cpp
@@ -40,9 +40,7 @@ BlockFormattingState::BlockFormattingState(LayoutState& layoutState, const Eleme
 {
 }
 
-BlockFormattingState::~BlockFormattingState()
-{
-}
+BlockFormattingState::~BlockFormattingState() = default;
 
 void BlockFormattingState::shrinkToFit()
 {

--- a/Source/WebCore/layout/formattingContexts/table/TableFormattingState.cpp
+++ b/Source/WebCore/layout/formattingContexts/table/TableFormattingState.cpp
@@ -96,9 +96,7 @@ TableFormattingState::TableFormattingState(LayoutState& layoutState, const Eleme
 {
 }
 
-TableFormattingState::~TableFormattingState()
-{
-}
+TableFormattingState::~TableFormattingState() = default;
 
 }
 }

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
@@ -106,9 +106,7 @@ BoxTreeUpdater::BoxTreeUpdater(RenderBlock& rootRenderer, const Document& docume
 {
 }
 
-BoxTreeUpdater::~BoxTreeUpdater()
-{
-}
+BoxTreeUpdater::~BoxTreeUpdater() = default;
 
 CheckedRef<Layout::ElementBox> BoxTreeUpdater::build()
 {

--- a/Source/WebCore/layout/layouttree/LayoutBoxGeometry.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutBoxGeometry.cpp
@@ -56,9 +56,7 @@ BoxGeometry::BoxGeometry(const BoxGeometry& other)
 {
 }
 
-BoxGeometry::~BoxGeometry()
-{
-}
+BoxGeometry::~BoxGeometry() = default;
 
 Rect BoxGeometry::marginBox() const
 {

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -111,9 +111,7 @@ ContextMenuController::ContextMenuController(Page& page, UniqueRef<ContextMenuCl
 {
 }
 
-ContextMenuController::~ContextMenuController()
-{
-}
+ContextMenuController::~ContextMenuController() = default;
 
 Page& ContextMenuController::page()
 {

--- a/Source/WebCore/page/csp/ContentSecurityPolicyDirective.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyDirective.cpp
@@ -33,9 +33,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ContentSecurityPolicyDirective);
 
-ContentSecurityPolicyDirective::~ContentSecurityPolicyDirective()
-{
-}
+ContentSecurityPolicyDirective::~ContentSecurityPolicyDirective() = default;
 
 bool ContentSecurityPolicyDirective::isDefaultSrc() const
 {

--- a/Source/WebCore/platform/Pasteboard.h
+++ b/Source/WebCore/platform/Pasteboard.h
@@ -410,9 +410,7 @@ extern const ASCIILiteral WebURLsWithTitlesPboardType;
 
 #if !PLATFORM(GTK) && !PLATFORM(WPE)
 
-inline Pasteboard::~Pasteboard()
-{
-}
+inline Pasteboard::~Pasteboard() = default;
 
 #endif
 

--- a/Source/WebCore/platform/ScrollingEffectsController.cpp
+++ b/Source/WebCore/platform/ScrollingEffectsController.cpp
@@ -601,9 +601,7 @@ void ScrollingEffectsController::stopDeferringWheelEventTestCompletion(WheelEven
 // Currently, only Mac supports momentum srolling-based scrollsnapping and rubber banding
 // so all of these methods are a noop on non-Mac platforms.
 #if !PLATFORM(MAC)
-ScrollingEffectsController::~ScrollingEffectsController()
-{
-}
+ScrollingEffectsController::~ScrollingEffectsController() = default;
 
 void ScrollingEffectsController::stopAllTimers()
 {

--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
@@ -46,9 +46,7 @@ BifurcatedGraphicsContext::BifurcatedGraphicsContext(GraphicsContext& primaryCon
     VERIFY_STATE_SYNCHRONIZATION();
 }
 
-BifurcatedGraphicsContext::~BifurcatedGraphicsContext()
-{
-}
+BifurcatedGraphicsContext::~BifurcatedGraphicsContext() = default;
 
 bool BifurcatedGraphicsContext::hasPlatformContext() const
 {

--- a/Source/WebCore/platform/graphics/Region.cpp
+++ b/Source/WebCore/platform/graphics/Region.cpp
@@ -65,9 +65,7 @@ Region::Region(Region&& other)
 {
 }
 
-Region::~Region()
-{
-}
+Region::~Region() = default;
 
 Region& Region::operator=(const Region& other)
 {

--- a/Source/WebCore/platform/graphics/cairo/CairoPaintingEngineThreaded.cpp
+++ b/Source/WebCore/platform/graphics/cairo/CairoPaintingEngineThreaded.cpp
@@ -63,9 +63,7 @@ PaintingEngineThreaded::PaintingEngineThreaded(unsigned numThreads)
 {
 }
 
-PaintingEngineThreaded::~PaintingEngineThreaded()
-{
-}
+PaintingEngineThreaded::~PaintingEngineThreaded() = default;
 
 void PaintingEngineThreaded::paint(GraphicsLayer& layer, CoordinatedTileBuffer& buffer, const IntRect& sourceRect, const IntRect& mappedSourceRect, const IntRect& targetRect, float contentsScale)
 {

--- a/Source/WebCore/platform/graphics/egl/PlatformDisplayDefault.cpp
+++ b/Source/WebCore/platform/graphics/egl/PlatformDisplayDefault.cpp
@@ -53,9 +53,7 @@ PlatformDisplayDefault::PlatformDisplayDefault(Ref<GLDisplay>&& glDisplay)
 #endif
 }
 
-PlatformDisplayDefault::~PlatformDisplayDefault()
-{
-}
+PlatformDisplayDefault::~PlatformDisplayDefault() = default;
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/egl/PlatformDisplaySurfaceless.cpp
+++ b/Source/WebCore/platform/graphics/egl/PlatformDisplaySurfaceless.cpp
@@ -60,8 +60,6 @@ PlatformDisplaySurfaceless::PlatformDisplaySurfaceless(Ref<GLDisplay>&& glDispla
 #endif
 }
 
-PlatformDisplaySurfaceless::~PlatformDisplaySurfaceless()
-{
-}
+PlatformDisplaySurfaceless::~PlatformDisplaySurfaceless() = default;
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/gbm/PlatformDisplayGBM.cpp
+++ b/Source/WebCore/platform/graphics/gbm/PlatformDisplayGBM.cpp
@@ -62,9 +62,7 @@ PlatformDisplayGBM::PlatformDisplayGBM(Ref<GLDisplay>&& glDisplay, struct gbm_de
 #endif
 }
 
-PlatformDisplayGBM::~PlatformDisplayGBM()
-{
-}
+PlatformDisplayGBM::~PlatformDisplayGBM() = default;
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/glib/IconGLib.cpp
+++ b/Source/WebCore/platform/graphics/glib/IconGLib.cpp
@@ -40,9 +40,7 @@ Icon::Icon(GRefPtr<GIcon>&& icon)
 {
 }
 
-Icon::~Icon()
-{
-}
+Icon::~Icon() = default;
 
 RefPtr<Icon> Icon::create(GRefPtr<GIcon>&& icon)
 {

--- a/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.cpp
+++ b/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.cpp
@@ -49,9 +49,7 @@ MediaPlayerPrivateHolePunch::MediaPlayerPrivateHolePunch(MediaPlayer& player)
     m_readyTimer.startOneShot(0_s);
 }
 
-MediaPlayerPrivateHolePunch::~MediaPlayerPrivateHolePunch()
-{
-}
+MediaPlayerPrivateHolePunch::~MediaPlayerPrivateHolePunch() = default;
 
 #if USE(COORDINATED_GRAPHICS)
 PlatformLayer* MediaPlayerPrivateHolePunch::platformLayer() const

--- a/Source/WebCore/platform/image-decoders/ScalableImageDecoderFrame.cpp
+++ b/Source/WebCore/platform/image-decoders/ScalableImageDecoderFrame.cpp
@@ -34,9 +34,7 @@ ScalableImageDecoderFrame::ScalableImageDecoderFrame()
 {
 }
 
-ScalableImageDecoderFrame::~ScalableImageDecoderFrame()
-{
-}
+ScalableImageDecoderFrame::~ScalableImageDecoderFrame() = default;
 
 ScalableImageDecoderFrame& ScalableImageDecoderFrame::operator=(const ScalableImageDecoderFrame& other)
 {

--- a/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp
+++ b/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp
@@ -113,9 +113,7 @@ LibWebRTCVPXVideoDecoder::LibWebRTCVPXVideoDecoder(Type type, const Config& conf
 {
 }
 
-LibWebRTCVPXVideoDecoder::~LibWebRTCVPXVideoDecoder()
-{
-}
+LibWebRTCVPXVideoDecoder::~LibWebRTCVPXVideoDecoder() = default;
 
 Ref<VideoDecoder::DecodePromise> LibWebRTCVPXVideoDecoder::decode(EncodedFrame&& frame)
 {

--- a/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.cpp
+++ b/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.cpp
@@ -112,9 +112,7 @@ LibWebRTCVPXVideoEncoder::LibWebRTCVPXVideoEncoder(Type type, OutputCallback&& o
 {
 }
 
-LibWebRTCVPXVideoEncoder::~LibWebRTCVPXVideoEncoder()
-{
-}
+LibWebRTCVPXVideoEncoder::~LibWebRTCVPXVideoEncoder() = default;
 
 int LibWebRTCVPXVideoEncoder::initialize(LibWebRTCVPXVideoEncoder::Type type, const VideoEncoder::Config& config)
 {

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateMock.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateMock.cpp
@@ -52,9 +52,7 @@ MediaRecorderPrivateMock::MediaRecorderPrivateMock(MediaStreamPrivate& stream)
     }
 }
 
-MediaRecorderPrivateMock::~MediaRecorderPrivateMock()
-{
-}
+MediaRecorderPrivateMock::~MediaRecorderPrivateMock() = default;
 
 void MediaRecorderPrivateMock::stopRecording(CompletionHandler<void()>&& completionHandler)
 {

--- a/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp
@@ -119,9 +119,7 @@ DisplayCaptureSourceCocoa::DisplayCaptureSourceCocoa(const std::function<UniqueR
 {
 }
 
-DisplayCaptureSourceCocoa::~DisplayCaptureSourceCocoa()
-{
-}
+DisplayCaptureSourceCocoa::~DisplayCaptureSourceCocoa() = default;
 
 const RealtimeMediaSourceCapabilities& DisplayCaptureSourceCocoa::capabilities()
 {

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp
@@ -99,9 +99,7 @@ void GStreamerCapturer::tearDown(bool disconnectSignals)
     m_caps = nullptr;
 }
 
-GStreamerCapturerObserver::~GStreamerCapturerObserver()
-{
-}
+GStreamerCapturerObserver::~GStreamerCapturerObserver() = default;
 
 void GStreamerCapturer::setDevice(std::optional<GStreamerCaptureDevice>&& device)
 {

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCAudioModule.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCAudioModule.cpp
@@ -44,9 +44,7 @@ LibWebRTCAudioModule::LibWebRTCAudioModule()
     ASSERT(isMainThread());
 }
 
-LibWebRTCAudioModule::~LibWebRTCAudioModule()
-{
-}
+LibWebRTCAudioModule::~LibWebRTCAudioModule() = default;
 
 int32_t LibWebRTCAudioModule::RegisterAudioCallback(webrtc::AudioTransport* audioTransport)
 {

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp
@@ -79,9 +79,7 @@ LibWebRTCProvider::LibWebRTCProvider()
 {
 }
 
-LibWebRTCProvider::~LibWebRTCProvider()
-{
-}
+LibWebRTCProvider::~LibWebRTCProvider() = default;
 
 #if !PLATFORM(COCOA)
 void LibWebRTCProvider::registerWebKitVP9Decoder()

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProviderCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProviderCocoa.cpp
@@ -57,9 +57,7 @@ UniqueRef<WebRTCProvider> WebRTCProvider::create()
     return makeUniqueRef<LibWebRTCProviderCocoa>();
 }
 
-LibWebRTCProviderCocoa::~LibWebRTCProviderCocoa()
-{
-}
+LibWebRTCProviderCocoa::~LibWebRTCProviderCocoa() = default;
 
 std::unique_ptr<webrtc::VideoDecoderFactory> LibWebRTCProviderCocoa::createDecoderFactory()
 {

--- a/Source/WebCore/platform/mock/MockRealtimeAudioSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeAudioSource.cpp
@@ -85,9 +85,7 @@ MockRealtimeAudioSource::MockRealtimeAudioSource(String&& deviceID, AtomString&&
     initializeEchoCancellation(std::get<MockMicrophoneProperties>(m_device.properties).echoCancellation.value_or(true));
 }
 
-MockRealtimeAudioSource::~MockRealtimeAudioSource()
-{
-}
+MockRealtimeAudioSource::~MockRealtimeAudioSource() = default;
 
 const RealtimeMediaSourceSettings& MockRealtimeAudioSource::settings()
 {

--- a/Source/WebCore/platform/network/curl/CurlFormDataStream.cpp
+++ b/Source/WebCore/platform/network/curl/CurlFormDataStream.cpp
@@ -53,10 +53,7 @@ CurlFormDataStream::CurlFormDataStream(const RefPtr<FormData>& formData)
     m_formData = m_formData->resolveBlobReferences(blobRegistry()->blobRegistryImpl());
 }
 
-CurlFormDataStream::~CurlFormDataStream()
-{
-
-}
+CurlFormDataStream::~CurlFormDataStream() = default;
 
 void CurlFormDataStream::clean()
 {

--- a/Source/WebCore/rendering/BidiRun.cpp
+++ b/Source/WebCore/rendering/BidiRun.cpp
@@ -39,8 +39,6 @@ BidiRun::BidiRun(unsigned start, unsigned stop, RenderObject& renderer, BidiCont
     ASSERT(!is<RenderText>(m_renderer) || static_cast<unsigned>(stop) <= downcast<RenderText>(m_renderer).text().length());
 }
 
-BidiRun::~BidiRun()
-{
-}
+BidiRun::~BidiRun() = default;
 
 }

--- a/Source/WebCore/rendering/LegacyInlineBox.h
+++ b/Source/WebCore/rendering/LegacyInlineBox.h
@@ -352,9 +352,7 @@ protected:
 
 #if ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
 
-inline LegacyInlineBox::~LegacyInlineBox()
-{
-}
+inline LegacyInlineBox::~LegacyInlineBox() = default;
 
 inline void LegacyInlineBox::assertNotDeleted() const
 {

--- a/Source/WebCore/rendering/LegacyRootInlineBox.cpp
+++ b/Source/WebCore/rendering/LegacyRootInlineBox.cpp
@@ -62,9 +62,7 @@ LegacyRootInlineBox::LegacyRootInlineBox(RenderBlockFlow& block)
     setIsHorizontal(block.isHorizontalWritingMode());
 }
 
-LegacyRootInlineBox::~LegacyRootInlineBox()
-{
-}
+LegacyRootInlineBox::~LegacyRootInlineBox() = default;
 
 void LegacyRootInlineBox::adjustPosition(float dx, float dy)
 {

--- a/Source/WebCore/rendering/RenderLineBreak.cpp
+++ b/Source/WebCore/rendering/RenderLineBreak.cpp
@@ -52,9 +52,7 @@ RenderLineBreak::RenderLineBreak(HTMLElement& element, RenderStyle&& style)
     ASSERT(isRenderLineBreak());
 }
 
-RenderLineBreak::~RenderLineBreak()
-{
-}
+RenderLineBreak::~RenderLineBreak() = default;
 
 int RenderLineBreak::caretMinOffset() const
 {

--- a/Source/WebCore/storage/StorageNamespaceProvider.cpp
+++ b/Source/WebCore/storage/StorageNamespaceProvider.cpp
@@ -42,9 +42,7 @@ StorageNamespaceProvider::StorageNamespaceProvider()
 {
 }
 
-StorageNamespaceProvider::~StorageNamespaceProvider()
-{
-}
+StorageNamespaceProvider::~StorageNamespaceProvider() = default;
 
 Ref<StorageArea> StorageNamespaceProvider::localStorageArea(Document& document)
 {

--- a/Source/WebCore/workers/WorkerEventLoop.cpp
+++ b/Source/WebCore/workers/WorkerEventLoop.cpp
@@ -43,9 +43,7 @@ WorkerEventLoop::WorkerEventLoop(WorkerOrWorkletGlobalScope& context)
     addAssociatedContext(context);
 }
 
-WorkerEventLoop::~WorkerEventLoop()
-{
-}
+WorkerEventLoop::~WorkerEventLoop() = default;
 
 void WorkerEventLoop::scheduleToRun()
 {

--- a/Source/WebCore/workers/service/ExtendableEvent.cpp
+++ b/Source/WebCore/workers/service/ExtendableEvent.cpp
@@ -48,9 +48,7 @@ ExtendableEvent::ExtendableEvent(enum EventInterfaceType eventInterface, const A
 {
 }
 
-ExtendableEvent::~ExtendableEvent()
-{
-}
+ExtendableEvent::~ExtendableEvent() = default;
 
 // https://w3c.github.io/ServiceWorker/#dom-extendableevent-waituntil
 ExceptionOr<void> ExtendableEvent::waitUntil(Ref<DOMPromise>&& promise)

--- a/Source/WebCore/workers/service/ExtendableMessageEvent.cpp
+++ b/Source/WebCore/workers/service/ExtendableMessageEvent.cpp
@@ -90,9 +90,7 @@ ExtendableMessageEvent::ExtendableMessageEvent(const AtomString& type, Ref<Secur
 {
 }
 
-ExtendableMessageEvent::~ExtendableMessageEvent()
-{
-}
+ExtendableMessageEvent::~ExtendableMessageEvent() = default;
 
 String ExtendableMessageEvent::origin() const
 {

--- a/Source/WebCore/workers/service/ServiceWorkerClient.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerClient.cpp
@@ -53,9 +53,7 @@ ServiceWorkerClient::ServiceWorkerClient(ServiceWorkerGlobalScope& context, Serv
 {
 }
 
-ServiceWorkerClient::~ServiceWorkerClient()
-{
-}
+ServiceWorkerClient::~ServiceWorkerClient() = default;
 
 const URL& ServiceWorkerClient::url() const
 {

--- a/Source/WebCore/workers/service/ServiceWorkerProvider.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerProvider.cpp
@@ -38,9 +38,7 @@ namespace WebCore {
 
 static ServiceWorkerProvider* sharedProvider;
 
-ServiceWorkerProvider::~ServiceWorkerProvider()
-{
-}
+ServiceWorkerProvider::~ServiceWorkerProvider() = default;
 
 ServiceWorkerProvider& ServiceWorkerProvider::singleton()
 {

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchEvent.cpp
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchEvent.cpp
@@ -44,9 +44,7 @@ BackgroundFetchEvent::BackgroundFetchEvent(enum EventInterfaceType eventInterfac
 {
 }
 
-BackgroundFetchEvent::~BackgroundFetchEvent()
-{
-}
+BackgroundFetchEvent::~BackgroundFetchEvent() = default;
 
 BackgroundFetchRegistration& BackgroundFetchEvent::registration() const
 {

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchManager.cpp
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchManager.cpp
@@ -46,9 +46,7 @@ BackgroundFetchManager::BackgroundFetchManager(ServiceWorkerRegistration& regist
 {
 }
 
-BackgroundFetchManager::~BackgroundFetchManager()
-{
-}
+BackgroundFetchManager::~BackgroundFetchManager() = default;
 
 static ExceptionOr<Vector<Ref<FetchRequest>>> buildBackgroundFetchRequests(ScriptExecutionContext& context, BackgroundFetchManager::Requests&& backgroundFetchRequests)
 {

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchRecord.cpp
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchRecord.cpp
@@ -40,9 +40,7 @@ BackgroundFetchRecord::BackgroundFetchRecord(ScriptExecutionContext& context, Ba
     // FIXME: We should provide a body to the request.
 }
 
-BackgroundFetchRecord::~BackgroundFetchRecord()
-{
-}
+BackgroundFetchRecord::~BackgroundFetchRecord() = default;
 
 void BackgroundFetchRecord::settleResponseReadyPromise(ExceptionOr<Ref<FetchResponse>>&& result)
 {

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.cpp
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.cpp
@@ -71,9 +71,7 @@ BackgroundFetchRegistration::BackgroundFetchRegistration(ScriptExecutionContext&
 {
 }
 
-BackgroundFetchRegistration::~BackgroundFetchRegistration()
-{
-}
+BackgroundFetchRegistration::~BackgroundFetchRegistration() = default;
 
 void BackgroundFetchRegistration::abort(ScriptExecutionContext& context, DOMPromiseDeferred<IDLBoolean>&& promise)
 {

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchUpdateUIEvent.cpp
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchUpdateUIEvent.cpp
@@ -44,9 +44,7 @@ BackgroundFetchUpdateUIEvent::BackgroundFetchUpdateUIEvent(const AtomString& typ
 {
 }
 
-BackgroundFetchUpdateUIEvent::~BackgroundFetchUpdateUIEvent()
-{
-}
+BackgroundFetchUpdateUIEvent::~BackgroundFetchUpdateUIEvent() = default;
 
 void BackgroundFetchUpdateUIEvent::updateUI(BackgroundFetchUIOptions&&, DOMPromiseDeferred<void>&&)
 {

--- a/Source/WebCore/workers/service/background-fetch/ServiceWorkerRegistrationBackgroundFetchAPI.cpp
+++ b/Source/WebCore/workers/service/background-fetch/ServiceWorkerRegistrationBackgroundFetchAPI.cpp
@@ -40,9 +40,7 @@ ServiceWorkerRegistrationBackgroundFetchAPI::ServiceWorkerRegistrationBackground
 {
 }
 
-ServiceWorkerRegistrationBackgroundFetchAPI::~ServiceWorkerRegistrationBackgroundFetchAPI()
-{
-}
+ServiceWorkerRegistrationBackgroundFetchAPI::~ServiceWorkerRegistrationBackgroundFetchAPI() = default;
 
 BackgroundFetchManager& ServiceWorkerRegistrationBackgroundFetchAPI::backgroundFetch(ServiceWorkerRegistration& serviceWorkerRegistration)
 {

--- a/Source/WebCore/workers/service/server/SWServerJobQueue.cpp
+++ b/Source/WebCore/workers/service/server/SWServerJobQueue.cpp
@@ -50,9 +50,7 @@ SWServerJobQueue::SWServerJobQueue(SWServer& server, const ServiceWorkerRegistra
 {
 }
 
-SWServerJobQueue::~SWServerJobQueue()
-{
-}
+SWServerJobQueue::~SWServerJobQueue() = default;
 
 bool SWServerJobQueue::isCurrentlyProcessingJob(const ServiceWorkerJobDataIdentifier& jobDataIdentifier) const
 {

--- a/Source/WebCore/workers/service/server/SWServerToContextConnection.cpp
+++ b/Source/WebCore/workers/service/server/SWServerToContextConnection.cpp
@@ -43,9 +43,7 @@ SWServerToContextConnection::SWServerToContextConnection(SWServer& server, Site&
 {
 }
 
-SWServerToContextConnection::~SWServerToContextConnection()
-{
-}
+SWServerToContextConnection::~SWServerToContextConnection() = default;
 
 SWServer* SWServerToContextConnection::server() const
 {

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -126,9 +126,7 @@ XMLHttpRequest::XMLHttpRequest(ScriptExecutionContext& context)
 {
 }
 
-XMLHttpRequest::~XMLHttpRequest()
-{
-}
+XMLHttpRequest::~XMLHttpRequest() = default;
 
 ScriptExecutionContext* XMLHttpRequest::scriptExecutionContext() const
 {


### PR DESCRIPTION
#### 156bb2ec040149c8ad79c6c8f80d084bad8dcf59
<pre>
Use &quot;= default&quot; for destructor in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=310942">https://bugs.webkit.org/show_bug.cgi?id=310942</a>
<a href="https://rdar.apple.com/173555515">rdar://173555515</a>

Reviewed by Chris Dumez.

This extends our &quot;= default&quot; usage across few leftover empty destructors
in WebCore code.

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpReceiverTransformBackend.cpp:
(WebCore::GStreamerRtpReceiverTransformBackend::~GStreamerRtpReceiverTransformBackend): Deleted.
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderTransformBackend.cpp:
(WebCore::GStreamerRtpSenderTransformBackend::~GStreamerRtpSenderTransformBackend): Deleted.
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCIceTransportBackend.cpp:
(WebCore::LibWebRTCIceTransportBackend::~LibWebRTCIceTransportBackend): Deleted.
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverTransformBackend.cpp:
(WebCore::LibWebRTCRtpReceiverTransformBackend::~LibWebRTCRtpReceiverTransformBackend): Deleted.
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderTransformBackend.cpp:
(WebCore::LibWebRTCRtpSenderTransformBackend::~LibWebRTCRtpSenderTransformBackend): Deleted.
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransformableFrame.cpp:
(WebCore::LibWebRTCRtpTransformableFrame::~LibWebRTCRtpTransformableFrame): Deleted.
* Source/WebCore/Modules/notifications/NotificationResourcesLoader.cpp:
(WebCore::NotificationResourcesLoader::ResourceLoader::~ResourceLoader): Deleted.
* Source/WebCore/Modules/webtransport/WebTransportSendStreamSink.cpp:
(WebCore::WebTransportSendStreamSink::~WebTransportSendStreamSink): Deleted.
* Source/WebCore/PAL/pal/crypto/commoncrypto/CryptoDigestCommonCrypto.cpp:
(PAL::Crypto::CryptoDigest::~CryptoDigest): Deleted.
* Source/WebCore/bindings/js/DOMGCOutputConstraint.cpp:
(WebCore::DOMGCOutputConstraint::~DOMGCOutputConstraint): Deleted.
* Source/WebCore/bindings/js/JSLazyEventListener.cpp:
(WebCore::JSLazyEventListener::~JSLazyEventListener): Deleted.
* Source/WebCore/html/track/VTTCue.cpp:
(WebCore::VTTCue::~VTTCue): Deleted.
* Source/WebCore/layout/FormattingState.cpp:
(WebCore::Layout::FormattingState::~FormattingState): Deleted.
* Source/WebCore/layout/formattingContexts/block/BlockFormattingState.cpp:
(WebCore::Layout::BlockFormattingState::~BlockFormattingState): Deleted.
* Source/WebCore/layout/formattingContexts/table/TableFormattingState.cpp:
(WebCore::Layout::TableFormattingState::~TableFormattingState): Deleted.
* Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp:
(WebCore::LayoutIntegration::BoxTreeUpdater::~BoxTreeUpdater): Deleted.
* Source/WebCore/layout/layouttree/LayoutBoxGeometry.cpp:
(WebCore::Layout::BoxGeometry::~BoxGeometry): Deleted.
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::ContextMenuController::~ContextMenuController): Deleted.
* Source/WebCore/page/csp/ContentSecurityPolicyDirective.cpp:
(WebCore::ContentSecurityPolicyDirective::~ContentSecurityPolicyDirective): Deleted.
* Source/WebCore/platform/Pasteboard.h:
(WebCore::Pasteboard::~Pasteboard): Deleted.
* Source/WebCore/platform/ScrollingEffectsController.cpp:
(WebCore::ScrollingEffectsController::~ScrollingEffectsController): Deleted.
* Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp:
(WebCore::BifurcatedGraphicsContext::~BifurcatedGraphicsContext): Deleted.
* Source/WebCore/platform/graphics/Region.cpp:
(WebCore::Region::~Region): Deleted.
* Source/WebCore/platform/graphics/cairo/CairoPaintingEngineThreaded.cpp:
(WebCore::Cairo::PaintingEngineThreaded::~PaintingEngineThreaded): Deleted.
* Source/WebCore/platform/graphics/egl/PlatformDisplayDefault.cpp:
(WebCore::PlatformDisplayDefault::~PlatformDisplayDefault): Deleted.
* Source/WebCore/platform/graphics/egl/PlatformDisplaySurfaceless.cpp:
(WebCore::PlatformDisplaySurfaceless::~PlatformDisplaySurfaceless): Deleted.
* Source/WebCore/platform/graphics/gbm/PlatformDisplayGBM.cpp:
(WebCore::PlatformDisplayGBM::~PlatformDisplayGBM): Deleted.
* Source/WebCore/platform/graphics/glib/IconGLib.cpp:
(WebCore::Icon::~Icon): Deleted.
* Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.cpp:
(WebCore::MediaPlayerPrivateHolePunch::~MediaPlayerPrivateHolePunch): Deleted.
* Source/WebCore/platform/image-decoders/ScalableImageDecoderFrame.cpp:
(WebCore::ScalableImageDecoderFrame::~ScalableImageDecoderFrame): Deleted.
* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp:
(WebCore::LibWebRTCVPXVideoDecoder::~LibWebRTCVPXVideoDecoder): Deleted.
* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.cpp:
(WebCore::LibWebRTCVPXVideoEncoder::~LibWebRTCVPXVideoEncoder): Deleted.
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateMock.cpp:
(WebCore::MediaRecorderPrivateMock::~MediaRecorderPrivateMock): Deleted.
* Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp:
(WebCore::DisplayCaptureSourceCocoa::~DisplayCaptureSourceCocoa): Deleted.
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp:
(WebCore::GStreamerCapturerObserver::~GStreamerCapturerObserver): Deleted.
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCAudioModule.cpp:
(WebCore::LibWebRTCAudioModule::~LibWebRTCAudioModule): Deleted.
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp:
(WebCore::LibWebRTCProvider::~LibWebRTCProvider): Deleted.
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProviderCocoa.cpp:
(WebCore::LibWebRTCProviderCocoa::~LibWebRTCProviderCocoa): Deleted.
* Source/WebCore/platform/mock/MockRealtimeAudioSource.cpp:
(WebCore::MockRealtimeAudioSource::~MockRealtimeAudioSource): Deleted.
* Source/WebCore/platform/network/curl/CurlFormDataStream.cpp:
(WebCore::CurlFormDataStream::~CurlFormDataStream): Deleted.
* Source/WebCore/rendering/BidiRun.cpp:
(WebCore::BidiRun::~BidiRun): Deleted.
* Source/WebCore/rendering/LegacyInlineBox.h:
(WebCore::LegacyInlineBox::~LegacyInlineBox): Deleted.
* Source/WebCore/rendering/LegacyRootInlineBox.cpp:
(WebCore::LegacyRootInlineBox::~LegacyRootInlineBox): Deleted.
* Source/WebCore/rendering/RenderLineBreak.cpp:
(WebCore::RenderLineBreak::~RenderLineBreak): Deleted.
* Source/WebCore/storage/StorageNamespaceProvider.cpp:
(WebCore::StorageNamespaceProvider::~StorageNamespaceProvider): Deleted.
* Source/WebCore/workers/WorkerEventLoop.cpp:
(WebCore::WorkerEventLoop::~WorkerEventLoop): Deleted.
* Source/WebCore/workers/service/ExtendableEvent.cpp:
(WebCore::ExtendableEvent::~ExtendableEvent): Deleted.
* Source/WebCore/workers/service/ExtendableMessageEvent.cpp:
(WebCore::ExtendableMessageEvent::~ExtendableMessageEvent): Deleted.
* Source/WebCore/workers/service/ServiceWorkerClient.cpp:
(WebCore::ServiceWorkerClient::~ServiceWorkerClient): Deleted.
* Source/WebCore/workers/service/ServiceWorkerProvider.cpp:
(WebCore::ServiceWorkerProvider::~ServiceWorkerProvider): Deleted.
* Source/WebCore/workers/service/background-fetch/BackgroundFetchEvent.cpp:
(WebCore::BackgroundFetchEvent::~BackgroundFetchEvent): Deleted.
* Source/WebCore/workers/service/background-fetch/BackgroundFetchManager.cpp:
(WebCore::BackgroundFetchManager::~BackgroundFetchManager): Deleted.
* Source/WebCore/workers/service/background-fetch/BackgroundFetchRecord.cpp:
(WebCore::BackgroundFetchRecord::~BackgroundFetchRecord): Deleted.
* Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.cpp:
(WebCore::BackgroundFetchRegistration::~BackgroundFetchRegistration): Deleted.
* Source/WebCore/workers/service/background-fetch/BackgroundFetchUpdateUIEvent.cpp:
(WebCore::BackgroundFetchUpdateUIEvent::~BackgroundFetchUpdateUIEvent): Deleted.
* Source/WebCore/workers/service/background-fetch/ServiceWorkerRegistrationBackgroundFetchAPI.cpp:
(WebCore::ServiceWorkerRegistrationBackgroundFetchAPI::~ServiceWorkerRegistrationBackgroundFetchAPI): Deleted.
* Source/WebCore/workers/service/server/SWServerJobQueue.cpp:
(WebCore::SWServerJobQueue::~SWServerJobQueue): Deleted.
* Source/WebCore/workers/service/server/SWServerToContextConnection.cpp:
(WebCore::SWServerToContextConnection::~SWServerToContextConnection): Deleted.
* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::~XMLHttpRequest): Deleted.

Canonical link: <a href="https://commits.webkit.org/310150@main">https://commits.webkit.org/310150@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1c4c5f544df98d115cefccfff955e95901063c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152804 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25585 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19184 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161548 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106260 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154677 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26113 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25891 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118085 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155763 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20318 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137178 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98798 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/45067eef-d974-4406-a0fa-c5fdd352ffd2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19393 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17328 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9384 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129045 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15052 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164021 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7158 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16646 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126147 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25383 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21367 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126305 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34281 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25385 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136848 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81989 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21259 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13627 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25001 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89288 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24693 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24852 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24753 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->