### PR TITLE
CSSFontSelector: Don't resolve plain -webkit-* strings as generic families

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/generic-family-keywords-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/generic-family-keywords-003-expected.txt
@@ -5,7 +5,7 @@ PASS @font-face matching for quoted and unquoted cursive (drawing text in a canv
 PASS @font-face matching for quoted and unquoted fantasy (drawing text in a canvas)
 PASS @font-face matching for quoted and unquoted monospace (drawing text in a canvas)
 FAIL @font-face matching for quoted and unquoted system-ui (drawing text in a canvas) assert_equals: quoted system-ui matches  @font-face rule expected 125 but got 28.381288528442383
-FAIL @font-face matching for quoted and unquoted math (drawing text in a canvas) assert_equals: quoted math matches  @font-face rule expected 125 but got 33.375
+PASS @font-face matching for quoted and unquoted math (drawing text in a canvas)
 FAIL @font-face matching for quoted and unquoted generic(fangsong) (drawing text in a canvas) promise_test: Unhandled rejection with value: object "SyntaxError: The string did not match the expected pattern."
 FAIL @font-face matching for quoted and unquoted generic(kai) (drawing text in a canvas) promise_test: Unhandled rejection with value: object "SyntaxError: The string did not match the expected pattern."
 FAIL @font-face matching for quoted and unquoted generic(khmer-mul) (drawing text in a canvas) promise_test: Unhandled rejection with value: object "SyntaxError: The string did not match the expected pattern."

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-fonts/generic-family-keywords-002-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-fonts/generic-family-keywords-002-expected.txt
@@ -1,12 +1,12 @@
 00000
 00000
 
-PASS font-family: -webkit-serif treated as <font-family>, not <generic-name>
+FAIL font-family: -webkit-serif treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 25
 PASS font-family: -webkit-sans-serif treated as <font-family>, not <generic-name>
-PASS font-family: -webkit-cursive treated as <font-family>, not <generic-name>
-PASS font-family: -webkit-fantasy treated as <font-family>, not <generic-name>
-PASS font-family: -webkit-monospace treated as <font-family>, not <generic-name>
-PASS font-family: -webkit-system-ui treated as <font-family>, not <generic-name>
+FAIL font-family: -webkit-cursive treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 25
+FAIL font-family: -webkit-fantasy treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 25
+FAIL font-family: -webkit-monospace treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 30
+FAIL font-family: -webkit-system-ui treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 30
 PASS font-family: -webkit-math treated as <font-family>, not <generic-name>
 FAIL font-family: -webkit-generic(fangsong) treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 25
 FAIL font-family: -webkit-generic(kai) treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 25
@@ -18,8 +18,8 @@ PASS font-family: -webkit-ui-monospace treated as <font-family>, not <generic-na
 PASS font-family: -webkit-ui-rounded treated as <font-family>, not <generic-name>
 PASS font-family: NonGenericFontFamilyName treated as <font-family>, not <generic-name>
 FAIL font-family: -webkit-body treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 25
-PASS font-family: -webkit-standard treated as <font-family>, not <generic-name>
-FAIL font-family: -webkit-pictograph treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 65
+FAIL font-family: -webkit-standard treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 25
+PASS font-family: -webkit-pictograph treated as <font-family>, not <generic-name>
 PASS font-family: emoji treated as <font-family>, not <generic-name>
 PASS font-family: fangsong treated as <font-family>, not <generic-name>
 PASS font-family: BlinkMacSystemFont treated as <font-family>, not <generic-name>

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-fonts/generic-family-keywords-002-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-fonts/generic-family-keywords-002-expected.txt
@@ -1,11 +1,11 @@
 00000
 00000
 
-FAIL font-family: -webkit-serif treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 25
-FAIL font-family: -webkit-sans-serif treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 28
+PASS font-family: -webkit-serif treated as <font-family>, not <generic-name>
+PASS font-family: -webkit-sans-serif treated as <font-family>, not <generic-name>
 PASS font-family: -webkit-cursive treated as <font-family>, not <generic-name>
-FAIL font-family: -webkit-fantasy treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 34
-FAIL font-family: -webkit-monospace treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 31
+PASS font-family: -webkit-fantasy treated as <font-family>, not <generic-name>
+PASS font-family: -webkit-monospace treated as <font-family>, not <generic-name>
 PASS font-family: -webkit-system-ui treated as <font-family>, not <generic-name>
 PASS font-family: -webkit-math treated as <font-family>, not <generic-name>
 FAIL font-family: -webkit-generic(fangsong) treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 25
@@ -18,7 +18,7 @@ PASS font-family: -webkit-ui-monospace treated as <font-family>, not <generic-na
 PASS font-family: -webkit-ui-rounded treated as <font-family>, not <generic-name>
 PASS font-family: NonGenericFontFamilyName treated as <font-family>, not <generic-name>
 FAIL font-family: -webkit-body treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 25
-FAIL font-family: -webkit-standard treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 25
+PASS font-family: -webkit-standard treated as <font-family>, not <generic-name>
 FAIL font-family: -webkit-pictograph treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 65
 PASS font-family: emoji treated as <font-family>, not <generic-name>
 PASS font-family: fangsong treated as <font-family>, not <generic-name>

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-fonts/generic-family-keywords-002-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-fonts/generic-family-keywords-002-expected.txt
@@ -1,12 +1,12 @@
 00000
 00000
 
-PASS font-family: -webkit-serif treated as <font-family>, not <generic-name>
+FAIL font-family: -webkit-serif treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 25
 PASS font-family: -webkit-sans-serif treated as <font-family>, not <generic-name>
-PASS font-family: -webkit-cursive treated as <font-family>, not <generic-name>
-PASS font-family: -webkit-fantasy treated as <font-family>, not <generic-name>
-PASS font-family: -webkit-monospace treated as <font-family>, not <generic-name>
-PASS font-family: -webkit-system-ui treated as <font-family>, not <generic-name>
+FAIL font-family: -webkit-cursive treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 25
+FAIL font-family: -webkit-fantasy treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 25
+FAIL font-family: -webkit-monospace treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 30
+FAIL font-family: -webkit-system-ui treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 30
 PASS font-family: -webkit-math treated as <font-family>, not <generic-name>
 FAIL font-family: -webkit-generic(fangsong) treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 25
 FAIL font-family: -webkit-generic(kai) treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 25
@@ -18,8 +18,8 @@ PASS font-family: -webkit-ui-monospace treated as <font-family>, not <generic-na
 PASS font-family: -webkit-ui-rounded treated as <font-family>, not <generic-name>
 PASS font-family: NonGenericFontFamilyName treated as <font-family>, not <generic-name>
 FAIL font-family: -webkit-body treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 25
-PASS font-family: -webkit-standard treated as <font-family>, not <generic-name>
-FAIL font-family: -webkit-pictograph treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 65
+FAIL font-family: -webkit-standard treated as <font-family>, not <generic-name> assert_equals: expected 50 but got 25
+PASS font-family: -webkit-pictograph treated as <font-family>, not <generic-name>
 PASS font-family: emoji treated as <font-family>, not <generic-name>
 PASS font-family: fangsong treated as <font-family>, not <generic-name>
 PASS font-family: BlinkMacSystemFont treated as <font-family>, not <generic-name>

--- a/Source/WebCore/css/CSSFontSelector.cpp
+++ b/Source/WebCore/css/CSSFontSelector.cpp
@@ -428,10 +428,12 @@ static const MathFontList& mathFontList()
     return list;
 }
 
-FontRanges CSSFontSelector::fontRangesForFamily(const FontDescription& fontDescription, const AtomString& familyName)
+FontRanges CSSFontSelector::fontRangesForFamily(const FontDescription& fontDescription, const FontFamily& fontFamily)
 {
     // If this ASSERT() fires, it usually means you forgot a document.updateStyleIfNeeded() somewhere.
     ASSERT(!m_buildIsUnderway || m_computingRootStyleFontCount);
+
+    const auto& familyName = fontFamily.name;
 
     // FIXME: The spec (and Firefox) says user specified generic families (sans-serif etc.) should be resolved before the @font-face lookup too.
     bool resolveGenericFamilyFirst = familyName == m_fontFamilyNames.at(FamilyNamesIndex::StandardFamily);
@@ -440,6 +442,8 @@ FontRanges CSSFontSelector::fontRangesForFamily(const FontDescription& fontDescr
     auto isGenericFontFamily = IsGenericFontFamily::No;
     const FontDescription* fontDescriptionForLookup = &fontDescription;
     auto resolveAndAssignGenericFamily = [&] {
+        if (!fontFamily.isGeneric())
+            return;
         if (auto genericFamilyOptional = resolveGenericFamily(fontDescription, familyName)) {
             familyForLookup = *genericFamilyOptional;
             isGenericFontFamily = IsGenericFontFamily::Yes;
@@ -450,19 +454,19 @@ FontRanges CSSFontSelector::fontRangesForFamily(const FontDescription& fontDescr
     auto fontFeatureValues = lookupFontFeatureValues(familyName);
 
     // Handle the generic math font family a bit differently.
-    if (familyName == m_fontFamilyNames.at(FamilyNamesIndex::MathFamily)) {
+    if (fontFamily.isGeneric() && familyName == m_fontFamilyNames.at(FamilyNamesIndex::MathFamily)) {
         // First check if the user has defined a preference.
         const auto& settings = protect(scriptExecutionContext())->settingsValues();
         const String& preferredMathFamily = settings.fontGenericFamilies.mathFontFamily(fontDescription.script());
         if (!preferredMathFamily.isEmpty() && familyName != preferredMathFamily) {
-            auto ranges = fontRangesForFamily(fontDescription, AtomString(preferredMathFamily));
+            auto ranges = fontRangesForFamily(fontDescription, FontFamily { AtomString(preferredMathFamily), FontFamilyKind::Specified });
             if (!ranges.isNull())
                 return { WTF::move(ranges), IsGenericFontFamily::Yes };
         }
 
         // Otherwise, iterate through the font list to find a valid fallback.
         for (auto& family : mathFontList()) {
-            auto ranges = fontRangesForFamily(fontDescription, family);
+            auto ranges = fontRangesForFamily(fontDescription, FontFamily { family, FontFamilyKind::Specified });
             if (!ranges.isNull())
                 return { WTF::move(ranges), IsGenericFontFamily::Yes };
         }

--- a/Source/WebCore/css/CSSFontSelector.h
+++ b/Source/WebCore/css/CSSFontSelector.h
@@ -63,7 +63,7 @@ public:
     unsigned version() const final { return m_version; }
     unsigned uniqueId() const final { return m_uniqueId; }
 
-    FontRanges fontRangesForFamily(const FontDescription&, const AtomString&) final;
+    FontRanges fontRangesForFamily(const FontDescription&, const FontFamily&) final;
     size_t fallbackFontCount() final;
     RefPtr<Font> fallbackFontAt(const FontDescription&, size_t) final;
 

--- a/Source/WebCore/platform/graphics/FontCascadeDescription.h
+++ b/Source/WebCore/platform/graphics/FontCascadeDescription.h
@@ -57,7 +57,7 @@ typedef FontFamilySpecificationCoreText FontFamilyPlatformSpecification;
 typedef FontFamilySpecificationNull FontFamilyPlatformSpecification;
 #endif
 
-typedef Variant<AtomString, FontFamilyPlatformSpecification> FontFamilySpecification;
+typedef Variant<FontFamily, FontFamilyPlatformSpecification> FontFamilySpecification;
 
 class Font;
 

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
@@ -165,15 +165,15 @@ static FontRanges realizeNextFallback(const FontCascadeDescription& description,
 
     CheckedRef fontCache = FontCache::forCurrentThread();
     while (index < description.effectiveFamilyCount()) {
-        auto visitor = WTF::makeVisitor([&, fontSelector = RefPtr { fontSelector }](const AtomString& family) -> FontRanges {
-            if (family.isNull())
+        auto visitor = WTF::makeVisitor([&, fontSelector = RefPtr { fontSelector }](const FontFamily& fontFamily) -> FontRanges {
+            if (fontFamily.name.isNull())
                 return FontRanges();
             if (fontSelector) {
-                auto ranges = fontSelector->fontRangesForFamily(description, family);
+                auto ranges = fontSelector->fontRangesForFamily(description, fontFamily);
                 if (!ranges.isNull())
                     return ranges;
             }
-            if (auto font = fontCache->fontForFamily(description, family))
+            if (auto font = fontCache->fontForFamily(description, fontFamily.name))
                 return FontRanges(WTF::move(font));
             return FontRanges();
         }, [&](const FontFamilyPlatformSpecification& fontFamilySpecification) -> FontRanges {
@@ -208,7 +208,7 @@ const FontRanges& FontCascadeFonts::realizeFallbackRangesAt(const FontCascadeDes
     if (!index) {
         fontRanges = realizeNextFallback(description, m_lastRealizedFallbackIndex, fontSelector);
         if (fontRanges.isNull() && fontSelector)
-            fontRanges = fontSelector->fontRangesForFamily(description, *familyNamesData->at(FamilyNamesIndex::StandardFamily));
+            fontRanges = fontSelector->fontRangesForFamily(description, FontFamily { *familyNamesData->at(FamilyNamesIndex::StandardFamily), FontFamilyKind::Generic });
         if (fontRanges.isNull())
             fontRanges = FontRanges(protect(FontCache::forCurrentThread())->lastResortFallbackFont(description));
         return fontRanges;

--- a/Source/WebCore/platform/graphics/FontSelector.h
+++ b/Source/WebCore/platform/graphics/FontSelector.h
@@ -38,6 +38,7 @@ namespace WebCore {
 class FontCache;
 class FontCascadeDescription;
 class FontDescription;
+struct FontFamily;
 class FontSelectorClient;
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(FontAccessor);
@@ -55,7 +56,7 @@ class FontSelector : public RefCountedAndCanMakeWeakPtr<FontSelector> {
 public:
     virtual ~FontSelector() = default;
 
-    virtual FontRanges fontRangesForFamily(const FontDescription&, const AtomString&) = 0;
+    virtual FontRanges fontRangesForFamily(const FontDescription&, const FontFamily&) = 0;
     virtual RefPtr<Font> fallbackFontAt(const FontDescription&, size_t) = 0;
 
     virtual size_t fallbackFontCount() = 0;

--- a/Source/WebCore/platform/graphics/cocoa/FontDescriptionCocoa.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontDescriptionCocoa.cpp
@@ -40,9 +40,9 @@ unsigned FontCascadeDescription::effectiveFamilyCount() const
     // FIXME: Move all the other system font keywords from fontDescriptorWithFamilySpecialCase() to here.
     unsigned result = 0;
     for (unsigned i = 0; i < familyCount(); ++i) {
-        const auto& cssFamily = familyAt(i).name;
-        if (auto use = SystemFontDatabaseCoreText::forCurrentThread().matchSystemFontUse(cssFamily))
-            result += systemFontCascadeList(*this, cssFamily, *use, shouldAllowUserInstalledFonts()).size();
+        const auto& family = familyAt(i);
+        if (auto use = SystemFontDatabaseCoreText::forCurrentThread().matchSystemFontUse(family.name))
+            result += systemFontCascadeList(*this, family.name, *use, shouldAllowUserInstalledFonts()).size();
         else
             ++result;
     }
@@ -58,20 +58,20 @@ FontFamilySpecification FontCascadeDescription::effectiveFamilyAt(unsigned index
     // means that "src:local(system-ui)" can't follow the Core Text cascade list (the way it does for regular lookups).
     // These two behaviors should be unified, which would hopefully allow us to delete this duplicate code.
     for (unsigned i = 0; i < familyCount(); ++i) {
-        const auto& cssFamily = familyAt(i).name;
-        if (auto use = SystemFontDatabaseCoreText::forCurrentThread().matchSystemFontUse(cssFamily)) {
-            auto cascadeList = systemFontCascadeList(*this, cssFamily, *use, shouldAllowUserInstalledFonts());
+        const auto& family = familyAt(i);
+        if (auto use = SystemFontDatabaseCoreText::forCurrentThread().matchSystemFontUse(family.name)) {
+            auto cascadeList = systemFontCascadeList(*this, family.name, *use, shouldAllowUserInstalledFonts());
             if (index < cascadeList.size())
                 return FontFamilySpecification(cascadeList[index].get());
             index -= cascadeList.size();
         }
         else if (!index)
-            return cssFamily;
+            return family;
         else
             --index;
     }
     ASSERT_NOT_REACHED();
-    return nullAtom();
+    return FontFamily { nullAtom(), FontFamilyKind::Specified };
 }
 
 AtomString FontDescription::platformResolveGenericFamily(UScriptCode script, const AtomString& locale, const AtomString& familyName)

--- a/Source/WebCore/platform/graphics/harfbuzz/FontDescriptionHarfBuzz.cpp
+++ b/Source/WebCore/platform/graphics/harfbuzz/FontDescriptionHarfBuzz.cpp
@@ -35,7 +35,7 @@ unsigned FontCascadeDescription::effectiveFamilyCount() const
 
 FontFamilySpecification FontCascadeDescription::effectiveFamilyAt(unsigned index) const
 {
-    return familyAt(index).name;
+    return familyAt(index);
 }
 
 }

--- a/Source/WebCore/platform/graphics/skia/FontDescriptionSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontDescriptionSkia.cpp
@@ -35,7 +35,7 @@ unsigned FontCascadeDescription::effectiveFamilyCount() const
 
 FontFamilySpecification FontCascadeDescription::effectiveFamilyAt(unsigned index) const
 {
-    return familyAt(index).name;
+    return familyAt(index);
 }
 
 }

--- a/Source/WebCore/platform/graphics/win/FontDescriptionWin.cpp
+++ b/Source/WebCore/platform/graphics/win/FontDescriptionWin.cpp
@@ -35,7 +35,7 @@ unsigned FontCascadeDescription::effectiveFamilyCount() const
 
 FontFamilySpecification FontCascadeDescription::effectiveFamilyAt(unsigned index) const
 {
-    return familyAt(index).name;
+    return familyAt(index);
 }
 
 }

--- a/Source/WebCore/style/StyleResolveForDocument.cpp
+++ b/Source/WebCore/style/StyleResolveForDocument.cpp
@@ -89,7 +89,7 @@ RenderStyle resolveForDocument(const Document& document)
 
         FontCascadeDescription fontDescription;
         fontDescription.setSpecifiedLocale(document.contentLanguage());
-        fontDescription.setOneFamily(standardFamily);
+        fontDescription.setOneFamily(WebCore::FontFamily { standardFamily, FontFamilyKind::Generic });
         fontDescription.setShouldAllowUserInstalledFonts(settings.shouldAllowUserInstalledFonts() ? AllowUserInstalledFonts::Yes : AllowUserInstalledFonts::No);
         // FIXME: We need evaluationTimeZoomEnabled to be accessible from FontDescription, not only from RenderStyle. Would it be weird to move it to FontDescription (which is already accessible from RenderStyle)?
         fontDescription.setEvaluationTimeZoomEnabled(document.settings().evaluationTimeZoomEnabled());

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -646,7 +646,7 @@ std::unique_ptr<RenderStyle> Resolver::defaultStyleForElement(const Element* ele
     auto style = RenderStyle::createPtrWithRegisteredInitialValues(document().customPropertyRegistry());
 
     FontCascadeDescription fontDescription;
-    fontDescription.setOneFamily(standardFamily);
+    fontDescription.setOneFamily(WebCore::FontFamily { standardFamily, FontFamilyKind::Generic });
     fontDescription.setKeywordSizeFromIdentifier(CSSValueMedium);
 
     auto size = fontSizeForKeyword(CSSValueMedium, false, document());


### PR DESCRIPTION
#### 0ec6bdfb2c54e9b0813b567ca43e44bc44c5a768
<pre>
CSSFontSelector: Don&apos;t resolve plain -webkit-* strings as generic families
<a href="https://bugs.webkit.org/show_bug.cgi?id=310946">https://bugs.webkit.org/show_bug.cgi?id=310946</a>
<a href="https://rdar.apple.com/173557376">rdar://173557376</a>

Reviewed by Alan Baradlay.

CSS Fonts 4 defines generic families as a closed set of unquoted keywords
(<a href="https://drafts.csswg.org/css-fonts-4/#generic-font-families).">https://drafts.csswg.org/css-fonts-4/#generic-font-families).</a> Internal names like
-webkit-serif should only resolve as generics when they originate from CSS generic
keyword parsing, not when authored as plain font-family strings. Previously,
CSSFontSelector::resolveGenericFamily matched these internal names regardless of origin,
because the generic/specified distinction was lost in FontCascadeDescription storage.

Now that FontCascadeDescription stores FontFamily (which carries FontFamilyKind), we
propagate the full FontFamily through FontSelector::fontRangesForFamily instead of just
the name string. CSSFontSelector gates resolveGenericFamily and math font resolution on
FontFamily::isGeneric(), so plain strings like &quot;-webkit-serif&quot; are no longer resolved
as generic families.

* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/generic-family-keywords-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/generic-family-keywords-003-expected.txt:
* Source/WebCore/css/CSSFontSelector.cpp:
(WebCore::CSSFontSelector::fontRangesForFamily):
* Source/WebCore/css/CSSFontSelector.h:
* Source/WebCore/platform/graphics/FontCascadeDescription.h:
* Source/WebCore/platform/graphics/FontCascadeFonts.cpp:
(WebCore::realizeNextFallback):
(WebCore::FontCascadeFonts::realizeFallbackRangesAt):
* Source/WebCore/platform/graphics/FontSelector.h:
* Source/WebCore/platform/graphics/cocoa/FontDescriptionCocoa.cpp:
(WebCore::FontCascadeDescription::effectiveFamilyCount):
(WebCore::FontCascadeDescription::effectiveFamilyAt):
* Source/WebCore/platform/graphics/harfbuzz/FontDescriptionHarfBuzz.cpp:
(WebCore::FontCascadeDescription::effectiveFamilyAt):
* Source/WebCore/platform/graphics/skia/FontDescriptionSkia.cpp:
(WebCore::FontCascadeDescription::effectiveFamilyAt):
* Source/WebCore/platform/graphics/win/FontDescriptionWin.cpp:
(WebCore::FontCascadeDescription::effectiveFamilyAt):

Canonical link: <a href="https://commits.webkit.org/310440@main">https://commits.webkit.org/310440@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb66ec561b697106e2cee5f4d522b3a8f431fd70

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153827 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26611 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20228 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162578 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107288 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155700 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27140 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26933 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118935 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84094 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156786 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21202 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138127 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99645 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20282 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18241 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10410 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129930 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15986 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165052 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8182 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17580 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127026 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26408 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22270 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127193 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34511 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26410 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137781 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83088 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22087 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14565 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/185463 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26027 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90315 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/185463 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25718 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25878 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25778 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->