### PR TITLE
RemoteScrollingTree EventRegion helpers need not return pointers from EventRegion references

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -451,9 +451,9 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTree(IPC::Connection& connectio
 WebCore::TrackingType RemoteLayerTreeDrawingAreaProxy::eventTrackingTypeForPoint(WebCore::EventTrackingRegions::EventType eventType, IntPoint location)
 {
     FloatPoint localLocation = location;
-    if (auto* eventRegion = eventRegionForPoint(remoteLayerTreeHost().rootLayer(), localLocation))
-        return eventRegion->eventTrackingTypeForPoint(eventType, roundedIntPoint(localLocation));
-    return WebCore::TrackingType::NotTracking;
+    return eventRegionForPoint(remoteLayerTreeHost().rootLayer(), localLocation).transform([eventType, &localLocation](const WebCore::EventRegion& eventRegion) {
+        return eventRegion.eventTrackingTypeForPoint(eventType, roundedIntPoint(localLocation));
+    }).value_or(WebCore::TrackingType::NotTracking);
 }
 #endif
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/cocoa/RemoteScrollingTreeCocoa.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/cocoa/RemoteScrollingTreeCocoa.h
@@ -37,9 +37,10 @@ OBJC_CLASS CALayer;
 
 namespace WebKit {
 
-const WebCore::EventRegion* eventRegionForLayer(CALayer*);
+using OptionalEventRegionConstRef = std::optional<std::reference_wrapper<const WebCore::EventRegion>>;
+OptionalEventRegionConstRef eventRegionForLayer(CALayer*);
 bool layerEventRegionContainsPoint(CALayer*, CGPoint);
-const WebCore::EventRegion* eventRegionForPoint(CALayer*, WebCore::FloatPoint& location);
+OptionalEventRegionConstRef eventRegionForPoint(CALayer*, WebCore::FloatPoint& location);
 
 }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/cocoa/RemoteScrollingTreeCocoa.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/cocoa/RemoteScrollingTreeCocoa.mm
@@ -36,36 +36,34 @@
 namespace WebKit {
 using namespace WebCore;
 
-const EventRegion* eventRegionForLayer(CALayer *layer)
+OptionalEventRegionConstRef eventRegionForLayer(CALayer *layer)
 {
-    if (auto* layerTreeNode = RemoteLayerTreeNode::forCALayer(layer))
-        return &layerTreeNode->eventRegion();
-    return nullptr;
+    if (RefPtr layerTreeNode = RemoteLayerTreeNode::forCALayer(layer))
+        return std::cref(layerTreeNode->eventRegion());
+    return std::nullopt;
 }
 
 bool layerEventRegionContainsPoint(CALayer *layer, CGPoint localPoint)
 {
-    auto* eventRegion = eventRegionForLayer(layer);
-    if (!eventRegion)
-        return false;
-
-    // Scrolling changes boundsOrigin on the scroll container layer, but we computed its event region ignoring scroll position, so factor out bounds origin.
-    FloatPoint boundsOrigin = layer.bounds.origin;
-    FloatPoint originRelativePoint = localPoint - toFloatSize(boundsOrigin);
-    return eventRegion->contains(roundedIntPoint(originRelativePoint));
+    return eventRegionForLayer(layer).transform([layerBounds = layer.bounds, localPoint](const WebCore::EventRegion& eventRegion) {
+        // Scrolling changes boundsOrigin on the scroll container layer, but we computed its event region ignoring scroll position, so factor out bounds origin.
+        FloatPoint boundsOrigin = layerBounds.origin;
+        FloatPoint originRelativePoint = localPoint - toFloatSize(boundsOrigin);
+        return eventRegion.contains(roundedIntPoint(originRelativePoint));
+    }).value_or(false);
 }
 
-const EventRegion* eventRegionForPoint(CALayer* rootLayer, FloatPoint& location)
+OptionalEventRegionConstRef eventRegionForPoint(CALayer* rootLayer, FloatPoint& location)
 {
     Vector<LayerAndPoint, 16> layersAtPoint;
     collectDescendantLayersAtPoint(layersAtPoint, rootLayer, location, layerEventRegionContainsPoint);
 
     if (layersAtPoint.isEmpty())
-        return nullptr;
+        return std::nullopt;
 
     auto [hitLayer, localPoint] = layersAtPoint.last();
     if (!hitLayer)
-        return nullptr;
+        return std::nullopt;
 
     location = roundedIntPoint(localPoint);
     return eventRegionForLayer(hitLayer.get());

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
@@ -540,11 +540,9 @@ OptionSet<EventListenerRegionType> RemoteScrollingTreeMac::eventListenerRegionTy
 
     auto rootContentsLayer = rootScrollingNode->rootContentsLayer();
 
-    auto* eventRegion = eventRegionForPoint(rootScrollingNode->rootContentsLayer().get(), point);
-    if (!eventRegion)
-        return { };
-
-    return eventRegion->eventListenerRegionTypesForPoint(roundedIntPoint(point));
+    return eventRegionForPoint(rootScrollingNode->rootContentsLayer().get(), point).transform([&point](const WebCore::EventRegion& eventRegion) {
+        return eventRegion.eventListenerRegionTypesForPoint(roundedIntPoint(point));
+    }).value_or(OptionSet<EventListenerRegionType> { });
 }
 #endif
 


### PR DESCRIPTION
#### 3585d8a0db29cf712ddff26e97e1000ee4df7897
<pre>
RemoteScrollingTree EventRegion helpers need not return pointers from EventRegion references
<a href="https://bugs.webkit.org/show_bug.cgi?id=310947">https://bugs.webkit.org/show_bug.cgi?id=310947</a>
<a href="https://rdar.apple.com/173559109">rdar://173559109</a>

Reviewed by Aditya Keerthi.

The EventRegion getter in RemoteLayerTreeNode returns a const lvalue ref.

Returning a pointer destroys this non-null guarantee. Currently, the
pointer is used to indicate nullity for other reasons (not because the
EventRegion instance itself is null). As such, let&apos;s change these
interfaces to return std::optional&lt;const EventRegion&amp;&gt; instead. Note
that std::optional cannot hold T&amp; before C++26, so we instead make use
of std::reference_wrapper&lt;const EventRegion&gt;.

Furthermore, we retrofit call sites to both adopt the new API and adopt
the monadic operations now available because of this std::optional return
value.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::eventTrackingTypeForPoint):
* Source/WebKit/UIProcess/RemoteLayerTree/cocoa/RemoteScrollingTreeCocoa.h:
* Source/WebKit/UIProcess/RemoteLayerTree/cocoa/RemoteScrollingTreeCocoa.mm:
(WebKit::eventRegionForLayer):
(WebKit::layerEventRegionContainsPoint):
(WebKit::eventRegionForPoint):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::eventListenerRegionTypesForPoint const):

Canonical link: <a href="https://commits.webkit.org/310247@main">https://commits.webkit.org/310247@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d1702f7bfa8ba098df8a79fbdfbc5e53879b238

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152817 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25598 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19197 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161561 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106273 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a2d87614-2982-4b14-a97a-5ea8cebe5f13) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26126 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25904 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118092 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83632 "6 flakes 5 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/55fcb736-3499-4030-bc5c-f4105c5089f2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155776 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20319 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137190 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98805 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19394 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17336 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9397 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129046 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164034 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7171 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16658 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126153 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25396 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21375 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126311 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34361 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25398 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136860 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82002 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21274 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13639 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25014 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89301 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24706 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24865 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24766 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->