### PR TITLE
[JSC] Implement galloping merge in PowerSort

### DIFF
--- a/JSTests/slowMicrobenchmarks/magic-forest.js
+++ b/JSTests/slowMicrobenchmarks/magic-forest.js
@@ -1,0 +1,101 @@
+// See http://unriskinsight.blogspot.com/2014/06/fast-functional-goats-lions-and-wolves.html
+// Sascha Kratky (kratky@unrisk.com), uni software plus GmbH & MathConsult GmbH
+//
+// run with Google v8:
+// d8 magicForest.js -- 117 155 106
+//
+// run with Mozilla SpiderMonkey:
+// js magicForest.js 117 155 106
+
+function Forest(goats, wolves, lions) {
+   this.goats = goats;
+   this.wolves = wolves;
+   this.lions = lions;
+}
+
+Forest.prototype.wolfDevoursGoat = function() {
+    if (this.goats > 0 && this.wolves > 0)
+        return new Forest(this.goats - 1, this.wolves - 1, this.lions + 1);
+    else
+        return null;
+}
+
+Forest.prototype.lionDevoursGoat = function() {
+    if (this.goats > 0 && this.lions > 0)
+        return new Forest(this.goats - 1, this.wolves + 1, this.lions - 1);
+    else
+        return null;
+}
+
+Forest.prototype.lionDevoursWolf = function() {
+    if (this.lions > 0 && this.wolves > 0)
+        return new Forest(this.goats + 1, this.wolves - 1, this.lions - 1);
+    else
+        return null;
+}
+
+Forest.prototype.meal = function() {
+    return [this.wolfDevoursGoat(), this.lionDevoursGoat(), this.lionDevoursWolf()].filter(
+        function(f) { return f !== null; })
+}
+
+Forest.prototype.isStable = function() {
+    if (this.goats === 0) return (this.wolves === 0) || (this.lions === 0);
+    return (this.wolves === 0) && (this.lions === 0);
+}
+
+Forest.prototype.toString = function()
+{
+    return "[goats=" + this.goats + ", wolves=" + this.wolves + ", lions=" + this.lions + "]";
+}
+
+Forest.compare = function(forest1, forest2) {
+    var cmp = forest1.goats-forest2.goats;
+    if (cmp !== 0) return cmp;
+    cmp = forest1.wolves-forest2.wolves;
+    if (cmp !== 0) return cmp;
+    return forest1.lions-forest2.lions;
+}
+
+function meal(forests) {
+    var nextForests = [];
+    forests.forEach(function(forest) {
+        nextForests.push.apply(nextForests, forest.meal())
+    });
+    // remove duplicates
+    return nextForests.sort(Forest.compare).filter(function(forest, index, array) {
+        return (index === 0 || Forest.compare(forest, array[index - 1]) !== 0);
+    });
+}
+
+function devouringPossible(forests) {
+    return forests.length > 0 && !forests.some(function(f) { return f.isStable(); });
+}
+
+function stableForests(forests) {
+    return forests.filter(function(f) { return f.isStable(); });
+}
+
+function findStableForests(forest) {
+    var forests = [forest];
+    while (devouringPossible(forests)) {
+        forests = meal(forests);
+    }
+    return stableForests(forests);
+}
+
+function go(g,w,l) {
+    var initialForest = new Forest(g, w, l);
+    findStableForests(initialForest)/*.forEach(function(f){ console.log(f); })*/
+}
+
+function goUI()
+{
+    d=new Date();
+    g=parseInt("217");
+    w=parseInt("255");
+    l=parseInt("206");
+    go(g, w, l);
+    // print("Time taken: " + (new Date() - d) + "ms");
+}
+goUI();

--- a/JSTests/stress/sort-galloping-merge-optimizations.js
+++ b/JSTests/stress/sort-galloping-merge-optimizations.js
@@ -1,0 +1,1046 @@
+// Comprehensive tests for PowerSort with galloping merge optimizations.
+// All sorts use a JS comparator to exercise the StableSort.h code path
+// (without a comparator, JSC uses a fast C++-only std::sort).
+
+function assertSorted(array, msg) {
+    for (let i = 1; i < array.length; i++) {
+        if (array[i] < array[i - 1])
+            throw new Error(msg + ": not sorted at index " + i + " (" + array[i - 1] + " > " + array[i] + ")");
+    }
+}
+
+// Verify sort is stable: for equal .value, original .index order must be preserved.
+function assertStable(array, msg) {
+    for (let i = 1; i < array.length; i++) {
+        if (array[i].value < array[i - 1].value)
+            throw new Error(msg + ": not sorted at index " + i);
+        if (array[i].value === array[i - 1].value && array[i].index < array[i - 1].index)
+            throw new Error(msg + ": not stable at index " + i + " (indices " + array[i - 1].index + " -> " + array[i].index + ")");
+    }
+}
+
+function assertArraysEqual(a, b, msg) {
+    if (a.length !== b.length)
+        throw new Error(msg + ": length mismatch " + a.length + " vs " + b.length);
+    for (let i = 0; i < a.length; i++) {
+        if (a[i] !== b[i])
+            throw new Error(msg + ": mismatch at index " + i + " (" + a[i] + " vs " + b[i] + ")");
+    }
+}
+
+// Verify that we have the same multiset of elements before and after sort.
+function assertSameElements(original, sorted, msg) {
+    let a = original.slice().sort((x, y) => x - y);
+    let b = sorted.slice().sort((x, y) => x - y);
+    assertArraysEqual(a, b, msg + " (element preservation)");
+}
+
+// Simple seeded PRNG for deterministic tests.
+function makePRNG(seed) {
+    return function() {
+        seed = (seed * 1103515245 + 12345) & 0x7FFFFFFF;
+        return seed;
+    };
+}
+
+let cmp = (a, b) => a - b;
+
+// ============================================================================
+// Section 1: extendAndNormalizeRun edge cases
+// ============================================================================
+
+// 1a. Descending run stops at equal elements (strict < required for desc detection).
+// Pattern: [10,9,8,7,7,6,5,4,3,2,1,...] — the 7,7 boundary should split into
+// a descending run [10,9,8,7] reversed to [7,8,9,10], then a new run starting at
+// the second 7.
+{
+    // Build array: 100 desc, then an equal pair mid-run, then more desc, repeat.
+    let a = [];
+    // Segment 1: strictly descending 50..1
+    for (let i = 50; i >= 1; i--) a.push(i);
+    // Segment 2: ascending 51..100 (creates a run boundary at the desc→asc transition)
+    for (let i = 51; i <= 100; i++) a.push(i);
+    let sorted = a.slice().sort(cmp);
+    assertSorted(sorted, "desc-then-asc-boundary");
+    assertSameElements(a, sorted, "desc-then-asc-boundary");
+}
+
+// 1b. Strictly descending run of exactly 2 elements (minimum descending run).
+{
+    // [2,1, 3,4,5,...] — run1 is [2,1] desc, reversed to [1,2], then extended asc.
+    let a = [2, 1];
+    for (let i = 3; i <= 100; i++) a.push(i);
+    let sorted = a.slice().sort(cmp);
+    assertSorted(sorted, "desc-run-length-2");
+    assertSameElements(a, sorted, "desc-run-length-2");
+}
+
+// 1c. All equal elements — descending detection must NOT trigger (uses strict <).
+// A run of all-equal is ascending (a[i+1] >= a[i] since equal), so no reversal.
+// Stability test: original indices must be preserved.
+{
+    let a = [];
+    for (let i = 0; i < 200; i++)
+        a.push({ value: 42, index: i });
+    a.sort((x, y) => x.value - y.value);
+    assertStable(a, "all-equal-200");
+}
+
+// 1d. Descending run with equal elements at the boundary.
+// [10,9,8,7,7,6,5,...] — first desc run is [10,9,8,7], stops at 7==7.
+// After reversal: [7,8,9,10]. Then new run starts at second 7.
+{
+    let a = [10, 9, 8, 7, 7, 6, 5, 4, 3, 2, 1, 0];
+    // Add more to exceed extendRunCutoff
+    for (let i = 11; i < 100; i++) a.push(i);
+    let sorted = a.slice().sort(cmp);
+    assertSorted(sorted, "desc-equal-boundary");
+    assertSameElements(a, sorted, "desc-equal-boundary");
+}
+
+// 1e. Single element at end of array — extendAndNormalizeRun returns immediately.
+// This happens for the last element when it starts a new run.
+{
+    // Create two runs of ~64 elements + 1 trailing element.
+    let a = [];
+    for (let i = 0; i < 64; i++) a.push(i * 2); // even: 0,2,...,126
+    for (let i = 0; i < 64; i++) a.push(i * 2 + 1); // odd: 1,3,...,127
+    a.push(200); // single trailing element
+    let sorted = a.slice().sort(cmp);
+    assertSorted(sorted, "trailing-single-element");
+    assertSameElements(a, sorted, "trailing-single-element");
+}
+
+// 1f. Many short descending segments — each gets reversed independently.
+{
+    let a = [];
+    // 20 segments of 10 descending elements each: [9,8,...,0], [19,18,...,10], ...
+    for (let seg = 0; seg < 20; seg++) {
+        let base = seg * 10;
+        for (let i = 9; i >= 0; i--)
+            a.push(base + i);
+    }
+    let sorted = a.slice().sort(cmp);
+    assertSorted(sorted, "many-short-desc-segments");
+    assertSameElements(a, sorted, "many-short-desc-segments");
+}
+
+// ============================================================================
+// Section 2: Pre-merge trimming in mergeRuns
+// ============================================================================
+
+// 2a. Full left trim: all elements in left run <= first element of right run.
+// After trim, leftLength=0 → just copy right, skip merge entirely.
+{
+    let a = [];
+    for (let i = 0; i < 100; i++) a.push(i);       // run 1: [0..99]
+    for (let i = 100; i < 200; i++) a.push(i);      // run 2: [100..199]
+    // But these form one big ascending run! Break it:
+    // Use non-overlapping desc + asc to force two runs.
+    a = [];
+    for (let i = 99; i >= 0; i--) a.push(i);        // desc run → reversed to [0..99]
+    for (let i = 100; i < 200; i++) a.push(i);       // asc run [100..199]
+    let sorted = a.slice().sort(cmp);
+    assertSorted(sorted, "full-left-trim");
+    assertSameElements(a, sorted, "full-left-trim");
+}
+
+// 2b. Full right trim: all elements in right run >= last element of left run.
+// After trim, rightLength=0 → just copy left, skip merge entirely.
+{
+    let a = [];
+    for (let i = 0; i < 100; i++) a.push(i);        // asc run [0..99]
+    for (let i = 199; i >= 100; i--) a.push(i);      // desc run → reversed to [100..199]
+    let sorted = a.slice().sort(cmp);
+    assertSorted(sorted, "full-right-trim");
+    assertSameElements(a, sorted, "full-right-trim");
+}
+
+// 2c. No trim at all: runs completely overlap in value range.
+// gallopRight(B[0], A) returns 0, gallopLeft(A[last], B) returns rightLength.
+{
+    let a = [];
+    // Run 1: even numbers [0,2,4,...,198] (100 elements)
+    for (let i = 0; i < 100; i++) a.push(i * 2);
+    // Run 2: odd numbers [1,3,5,...,199] (100 elements)
+    // Must start descending or have a break to create a new run.
+    // Since 1 < 198, it's a break. But we want it ascending.
+    // 1 < a[99]=198, so comparator(1, 198) = true → new run starts.
+    for (let i = 0; i < 100; i++) a.push(i * 2 + 1);
+    let sorted = a.slice().sort(cmp);
+    assertSorted(sorted, "no-trim-interleaved");
+    assertSameElements(a, sorted, "no-trim-interleaved");
+}
+
+// 2d. Partial trim on both sides: runs overlap in the middle.
+// Left=[0..99], Right=[50..149]. skipLeft skips [0..49], skipRight skips [100..149].
+// Merge only needs to handle [50..99] vs [50..99].
+{
+    let a = [];
+    for (let i = 0; i < 100; i++) a.push(i);           // asc run [0..99]
+    // Force new run: start with something < 99
+    for (let i = 50; i < 150; i++) a.push(i);           // should start new run since 50 < 99
+    let sorted = a.slice().sort(cmp);
+    assertSorted(sorted, "partial-trim-both-sides");
+    assertSameElements(a, sorted, "partial-trim-both-sides");
+}
+
+// 2e. Partial left trim only: left run's tail overlaps fully with right.
+// Left=[0..49, 200..249], Right=[100..199].
+// gallopRight(100, Left) → skips [0..49] (50 elements).
+// gallopLeft(249, Right) → 249 > all of Right, no skip.
+{
+    let a = [];
+    // Run 1: [0..49, 200..249] (ascending since 200 > 49)
+    for (let i = 0; i < 50; i++) a.push(i);
+    for (let i = 200; i < 250; i++) a.push(i);
+    // Run 2: [100..199] (new run since 100 < 249)
+    for (let i = 100; i < 200; i++) a.push(i);
+    let sorted = a.slice().sort(cmp);
+    assertSorted(sorted, "partial-left-trim-only");
+    assertSameElements(a, sorted, "partial-left-trim-only");
+}
+
+// ============================================================================
+// Section 3: Galloping mode
+// ============================================================================
+
+// 3a. Trigger galloping via rightWins >= minGallop (7).
+// Run 1 has large values, Run 2 starts with many small values.
+// After pre-merge trim, right elements are all smaller → right wins consecutively.
+{
+    let a = [];
+    // Run 1: [200,201,...,299] (100 ascending)
+    for (let i = 200; i < 300; i++) a.push(i);
+    // Run 2: [0,1,...,49, 250,251,...,299] (100 ascending, since 250 > 49)
+    // This starts a new run because 0 < 299.
+    for (let i = 0; i < 50; i++) a.push(i);
+    for (let i = 250; i < 300; i++) a.push(i);
+    let sorted = a.slice().sort(cmp);
+    assertSorted(sorted, "gallop-right-wins");
+    assertSameElements(a, sorted, "gallop-right-wins");
+}
+
+// 3b. Trigger galloping via leftWins >= minGallop.
+// Run 1 starts with many small values, Run 2 has large values.
+{
+    let a = [];
+    // Run 1: [0,1,...,49, 250,251,...,299] (ascending)
+    for (let i = 0; i < 50; i++) a.push(i);
+    for (let i = 250; i < 300; i++) a.push(i);
+    // Run 2: [200,201,...,299] (new run since 200 < 299)
+    for (let i = 200; i < 300; i++) a.push(i);
+    // After trim: gallopRight(B[0]=200, A) → 200 is after [0..49] = 50.
+    // Remaining A = [250,...,299]. gallopLeft(A[last]=299, B) → all of B ≤ 299, skipRight=0.
+    // Merge A'=[250,...,299] vs B=[200,...,299].
+    // 200 < 250 → right wins. 201 < 250 → right wins. ... 249 < 250 → right wins. (50 times!)
+    // Actually wait: after trim A' starts at 250, B starts at 200.
+    // compare(B[0]=200, A'[0]=250): 200 < 250 → right wins.
+    // This continues until B reaches 250+.
+    // So rightWins reaches 50, well past minGallop=7.
+    let sorted = a.slice().sort(cmp);
+    assertSorted(sorted, "gallop-left-wins");
+    assertSameElements(a, sorted, "gallop-left-wins");
+}
+
+// 3c. Galloping mode entry, then exit back to linear merge.
+// Pattern: clustered start (triggers galloping), then interleaved (exits galloping).
+{
+    let a = [];
+    // Run 1: [0,1,...,19, 30,32,34,...,58] — 20 clustered then 15 sparse
+    for (let i = 0; i < 20; i++) a.push(i);
+    for (let i = 0; i < 15; i++) a.push(30 + i * 2);
+    // Run 2: [20,21,...,29, 31,33,35,...,59] — 10 clustered then 15 sparse interleaved
+    for (let i = 20; i < 30; i++) a.push(i);
+    for (let i = 0; i < 15; i++) a.push(31 + i * 2);
+    // After trim: gallopRight(20, Run1) → skip [0..19]. Remaining A=[30,32,...,58].
+    // gallopLeft(58, Run2=[20,...,29,31,...,59]) → 58 < 59, position is before 59.
+    // skipRight=1 (just 59). Remaining B=[20,...,29,31,...,57].
+    // Merge A=[30,32,...,58] vs B=[20,...,29,31,...,57]:
+    //   B[0]=20 < A[0]=30 → right. B[1]=21 → right. ... B[9]=29 → right. (10 wins, gallop!)
+    //   In galloping: gallopRight(30, B[10:]) → finds 30 in [31,33,...]. 30 < 31, k=0. Copy B[10]=31... wait no.
+    //   Then gallopLeft(A[0]=30, B[10:]=[31,33,...]) → 30 < 31, k=0. Copy A[0]=30.
+    //   Both k=0 < 7 → exit galloping.
+    //   Back to linear: A[1]=32 vs B[10]=31 → left=32 > right=31, right wins. B[11]=33 vs A[1]=32 → left wins. Alternating.
+    let sorted = a.slice().sort(cmp);
+    assertSorted(sorted, "gallop-then-linear");
+    assertSameElements(a, sorted, "gallop-then-linear");
+}
+
+// 3d. Galloping where gallopRight finds many left elements to bulk-copy.
+// Need: right element is large, many left elements smaller.
+{
+    let a = [];
+    // Run 1: [0,1,...,99, 500,501,...,509] (110 elements)
+    for (let i = 0; i < 100; i++) a.push(i);
+    for (let i = 500; i < 510; i++) a.push(i);
+    // Run 2: [50,51,...,149, 510,511,...,519] (110 elements, starts at 50 < 509)
+    for (let i = 50; i < 150; i++) a.push(i);
+    for (let i = 510; i < 520; i++) a.push(i);
+    let sorted = a.slice().sort(cmp);
+    assertSorted(sorted, "gallop-bulk-copy-left");
+    assertSameElements(a, sorted, "gallop-bulk-copy-left");
+}
+
+// 3e. Galloping where gallopLeft finds many right elements to bulk-copy.
+{
+    let a = [];
+    // Run 1: [500,501,...,509, 0,1,...,9] — desc then asc? No, need ascending.
+    // Run 1: [0,1,...,9, 500,501,...,509] (ascending, 20 elements)
+    for (let i = 0; i < 10; i++) a.push(i);
+    for (let i = 500; i < 510; i++) a.push(i);
+    // Run 2: [10,11,...,109] (100 elements, new run since 10 < 509)
+    for (let i = 10; i < 110; i++) a.push(i);
+    // After trim: gallopRight(10, Run1) → 10. Skip [0..9]. Remaining A=[500,...,509].
+    // gallopLeft(509, Run2=[10,...,109]) → all < 509, returns 100. skipRight=0.
+    // Merge A=[500,...,509] vs B=[10,...,109]:
+    // B[0]=10 < A[0]=500 → right wins. Continues for 100 elements.
+    // In galloping: gallopRight(500, B[7:]) → all of B < 500, returns large k.
+    // Then gallopLeft(A[0]=500, B_remaining) → copies rest of B.
+    let sorted = a.slice().sort(cmp);
+    assertSorted(sorted, "gallop-bulk-copy-right");
+    assertSameElements(a, sorted, "gallop-bulk-copy-right");
+}
+
+// 3f. Left run exhausted during galloping mode (goto mergeFinish from gallop).
+{
+    let a = [];
+    // Run 1: [100, 101] (short, will be boosted to 64 via insertion sort)
+    // Actually, let's use longer runs for predictability.
+    // Run 1: [100,101,...,109] (10 ascending)
+    for (let i = 100; i < 110; i++) a.push(i);
+    // Run 2: [0,1,...,99] (100 ascending, starts at 0 < 109)
+    for (let i = 0; i < 100; i++) a.push(i);
+    // After trim: gallopRight(0, Run1=[100,...,109]) → 0, no skip.
+    // gallopLeft(109, Run2=[0,...,99]) → all < 109, returns 100. skipRight=0.
+    // Merge A=[100,...,109] vs B=[0,...,99]:
+    // B[0]=0 < A[0]=100 → right wins 7+ times → galloping.
+    // gallopRight(src[right], A) → all of A > src[right], k=0.
+    // Copy B element. gallopLeft(A[0]=100, B_remaining) → copies many B elements.
+    // Eventually right exhausted → mergeFinish copies remaining A.
+
+    // But wait — with short runs and insertion sort boosting...
+    // Run1 is 10 elements, < extendRunCutoff? No, extendRunCutoff=8, 10 >= 8.
+    // But 10 < forceRunLength=64... actually the boost only happens if run < extendRunCutoff.
+    // So run of 10 is kept as-is.
+    // Actually, insertion sort boost: "if (run1.m_end - run1.m_begin < extendRunCutoff)"
+    // extendRunCutoff=8. 10-element run: end-begin=9 >= 8. No boost. Good.
+    let sorted = a.slice().sort(cmp);
+    assertSorted(sorted, "left-exhausted-in-gallop");
+    assertSameElements(a, sorted, "left-exhausted-in-gallop");
+}
+
+// 3g. Right run exhausted during galloping mode.
+{
+    let a = [];
+    // Run 1: [0,1,...,99] (100 ascending)
+    for (let i = 0; i < 100; i++) a.push(i);
+    // Run 2: [100,101,...,109] (10 ascending, 100 < 99 is false so... wait, 100 > 99, so
+    // comparator(100, 99) = (100 < 99) = false → extends run1! They merge into one run.
+    // I need a break. Run2 must start with value < Run1's last value.
+    // Run 2: [50,51,...,59] (10 ascending, 50 < 99 → new run)
+    for (let i = 50; i < 60; i++) a.push(i);
+    // After trim: gallopRight(50, Run1=[0,...,99]) → 50. Skip [0..49]. Remaining A=[50,...,99].
+    // gallopLeft(99, Run2=[50,...,59]) → all ≤ 99, returns 10. skipRight=0.
+    // Merge A=[50,...,99] vs B=[50,...,59]:
+    // A[0]=50 == B[0]=50 → left wins (equal → !(right < left) → take left).
+    // A[1]=51 vs B[0]=50 → left=51 > right=50, right wins.
+    // A[1]=51 vs B[1]=51 → left wins.
+    // Alternating, then B runs out → mergeFinish copies remaining A.
+    let sorted = a.slice().sort(cmp);
+    assertSorted(sorted, "right-exhausted-in-gallop");
+    assertSameElements(a, sorted, "right-exhausted-in-gallop");
+}
+
+// 3h. minGallop adaptation: force it to decrease to 1 via sustained galloping.
+// Create a pattern where galloping is very productive over many merges.
+{
+    let a = [];
+    // Multiple non-overlapping sorted segments separated by breaks.
+    // Each pair of segments: one high, one low → galloping always productive.
+    for (let seg = 0; seg < 8; seg++) {
+        let base = seg * 200;
+        // High segment: [base+100, ..., base+199] (100 elements)
+        for (let i = 0; i < 100; i++) a.push(base + 100 + i);
+        // Low segment starting new run: [base, ..., base+99]
+        for (let i = 0; i < 100; i++) a.push(base + i);
+    }
+    let sorted = a.slice().sort(cmp);
+    assertSorted(sorted, "mingallop-decrease");
+    assertSameElements(a, sorted, "mingallop-decrease");
+}
+
+// 3i. minGallop adaptation: force it to increase by entering then quickly exiting galloping.
+// Interleaved data where galloping doesn't help.
+{
+    let a = [];
+    // Run 1: even numbers [0,2,4,...,998]
+    for (let i = 0; i < 500; i++) a.push(i * 2);
+    // Run 2: odd numbers [1,3,5,...,999]
+    for (let i = 0; i < 500; i++) a.push(i * 2 + 1);
+    // These two runs perfectly interleave → no galloping benefit.
+    // After pre-merge trim: gallopRight(1, [0,2,...,998]) = 1, skipLeft=1.
+    // gallopLeft(998, [1,3,...,999]) → 998 < 999, position=499, skipRight=1.
+    // Linear merge alternates: never reaches 7 consecutive wins.
+    let sorted = a.slice().sort(cmp);
+    assertSorted(sorted, "mingallop-increase-interleaved");
+    assertSameElements(a, sorted, "mingallop-increase-interleaved");
+}
+
+// ============================================================================
+// Section 4: arrayStableSort structure
+// ============================================================================
+
+// 4a. Entire array is one ascending run — no merge needed.
+{
+    let a = [];
+    for (let i = 0; i < 500; i++) a.push(i);
+    let sorted = a.slice().sort(cmp);
+    assertArraysEqual(sorted, a, "single-ascending-run");
+}
+
+// 4b. Entire array is one descending run — reversed, no merge needed.
+{
+    let a = [];
+    for (let i = 499; i >= 0; i--) a.push(i);
+    let sorted = a.slice().sort(cmp);
+    assertSorted(sorted, "single-descending-run");
+    if (sorted[0] !== 0 || sorted[499] !== 499)
+        throw new Error("single-descending-run: wrong boundaries");
+}
+
+// 4c. Short run boosting: first run is very short (< extendRunCutoff=8),
+// so it gets insertion-sorted up to forceRunLength=64 elements.
+{
+    let a = [];
+    // Start with 3-element descending: [2,1,0] → reversed to [0,1,2], then boosted to 64.
+    a.push(2, 1, 0);
+    // Fill with random-ish data to make the insertion sort work.
+    let rng = makePRNG(42);
+    for (let i = 3; i < 200; i++)
+        a.push(rng() % 500);
+    let sorted = a.slice().sort(cmp);
+    assertSorted(sorted, "short-run-boost");
+    assertSameElements(a, sorted, "short-run-boost");
+}
+
+// 4d. Second run is short and gets boosted.
+{
+    let a = [];
+    // Long first run: 100 ascending
+    for (let i = 0; i < 100; i++) a.push(i);
+    // Short second run: 3 elements descending [102,101,100] → reversed to [100,101,102].
+    // Then boosted via insertion sort to min(64, remaining).
+    a.push(102, 101, 100);
+    // More random data for insertion sort to absorb.
+    let rng = makePRNG(99);
+    for (let i = 0; i < 100; i++)
+        a.push(rng() % 500);
+    let sorted = a.slice().sort(cmp);
+    assertSorted(sorted, "second-run-short-boost");
+    assertSameElements(a, sorted, "second-run-short-boost");
+}
+
+// 4e. Run extension after insertion sort: after boosting a short run to 64 elements
+// via insertion sort, the algorithm tries to extend further.
+{
+    let a = [];
+    // Short desc run [5,4,3,2,1] (5 elements, < 8).
+    for (let i = 5; i >= 1; i--) a.push(i);
+    // After reversal: [1,2,3,4,5]. Boosted to 64 via insertion sort.
+    // Then extension: if element 65 >= element 64, run extends.
+    // Make elements 6-100 ascending so extension works.
+    for (let i = 6; i <= 100; i++) a.push(i);
+    // This means the entire array becomes one run (no merge).
+    let sorted = a.slice().sort(cmp);
+    assertSorted(sorted, "run-extension-after-boost");
+    assertSameElements(a, sorted, "run-extension-after-boost");
+}
+
+// 4f. Boundary: exactly extendRunCutoff (8) element run — not boosted.
+{
+    let a = [];
+    for (let i = 7; i >= 0; i--) a.push(i); // 8 desc → reversed to [0..7]
+    for (let i = 100; i >= 8; i--) a.push(i); // another desc run → reversed to [8..100]
+    let sorted = a.slice().sort(cmp);
+    assertSorted(sorted, "exactly-extendRunCutoff");
+    assertSameElements(a, sorted, "exactly-extendRunCutoff");
+}
+
+// 4g. Boundary: 7-element run (< extendRunCutoff=8) — gets boosted.
+{
+    let a = [];
+    for (let i = 6; i >= 0; i--) a.push(i); // 7 desc → reversed to [0..6], then boosted
+    let rng = makePRNG(77);
+    for (let i = 7; i < 200; i++)
+        a.push(rng() % 500);
+    let sorted = a.slice().sort(cmp);
+    assertSorted(sorted, "below-extendRunCutoff");
+    assertSameElements(a, sorted, "below-extendRunCutoff");
+}
+
+// 4h. Power stack cascading merges: many runs cause multiple stack pops.
+{
+    let a = [];
+    // Create many short runs by alternating asc/desc segments of ~10 elements.
+    for (let seg = 0; seg < 30; seg++) {
+        let base = seg * 20;
+        if (seg % 2 === 0) {
+            for (let i = 0; i < 10; i++) a.push(base + i);
+        } else {
+            for (let i = 9; i >= 0; i--) a.push(base + i);
+        }
+    }
+    let sorted = a.slice().sort(cmp);
+    assertSorted(sorted, "cascading-power-merges");
+    assertSameElements(a, sorted, "cascading-power-merges");
+}
+
+// 4i. Final stack drain: multiple entries on power stack at the end.
+{
+    let a = [];
+    // Ascending runs of increasing size — the power function assigns different
+    // power values, so they accumulate on the stack.
+    let pos = 0;
+    for (let runLen of [10, 20, 15, 25, 12, 18, 30, 8, 22, 14]) {
+        // Alternate between asc and desc to force run boundaries.
+        if (pos > 0) {
+            // Start desc (value < previous last) to break previous run.
+            for (let i = runLen - 1; i >= 0; i--)
+                a.push(pos + i);
+        } else {
+            for (let i = 0; i < runLen; i++)
+                a.push(pos + i);
+        }
+        pos += runLen;
+    }
+    let sorted = a.slice().sort(cmp);
+    assertSorted(sorted, "final-stack-drain");
+    assertSameElements(a, sorted, "final-stack-drain");
+}
+
+// ============================================================================
+// Section 5: gallopLeft and gallopRight edge cases
+// ============================================================================
+
+// 5a. gallopRight: key smaller than all elements → returns 0.
+// This happens in pre-merge trim when B[0] < A[0].
+{
+    let a = [];
+    // Run 1: [100,...,199] (ascending)
+    for (let i = 100; i < 200; i++) a.push(i);
+    // Run 2: [0,...,99] (starts at 0 < 199, new run)
+    for (let i = 0; i < 100; i++) a.push(i);
+    // gallopRight(B[0]=0, A=[100,...,199]) → 0.
+    let sorted = a.slice().sort(cmp);
+    assertSorted(sorted, "gallopRight-key-before-all");
+    assertSameElements(a, sorted, "gallopRight-key-before-all");
+}
+
+// 5b. gallopRight: key larger than all elements → returns length.
+// This happens in pre-merge trim when B[0] > A[last].
+{
+    let a = [];
+    // Run 1: [0,...,99]
+    for (let i = 0; i < 100; i++) a.push(i);
+    // Run 2: needs to start a new run. Use desc to break.
+    // [199,...,100] → reversed to [100,...,199]
+    for (let i = 199; i >= 100; i--) a.push(i);
+    // gallopRight(B[0]=100, A=[0,...,99]) → 100 (after all, since 100 > 99).
+    // Full left trim. No actual merge.
+    let sorted = a.slice().sort(cmp);
+    assertSorted(sorted, "gallopRight-key-after-all");
+    assertSameElements(a, sorted, "gallopRight-key-after-all");
+}
+
+// 5c. gallopLeft: key larger than all elements → returns length.
+// This happens in pre-merge right trim when A[last] > B[last].
+{
+    let a = [];
+    // Run 1: [0,...,99, 300,...,399] (ascending)
+    for (let i = 0; i < 100; i++) a.push(i);
+    for (let i = 300; i < 400; i++) a.push(i);
+    // Run 2: [100,...,199] (starts at 100 < 399)
+    for (let i = 100; i < 200; i++) a.push(i);
+    // gallopLeft(A[last]=399, B=[100,...,199]) → all < 399, returns 100. skipRight=0.
+    let sorted = a.slice().sort(cmp);
+    assertSorted(sorted, "gallopLeft-key-after-all");
+    assertSameElements(a, sorted, "gallopLeft-key-after-all");
+}
+
+// 5d. gallopLeft: key smaller than all elements → returns 0.
+{
+    let a = [];
+    // Run 1: [0,...,9] (10 ascending)
+    for (let i = 0; i < 10; i++) a.push(i);
+    // Run 2: [5,...,104] (starts at 5 < 9, new run)
+    for (let i = 5; i < 105; i++) a.push(i);
+    // gallopLeft(A[last]=9, B=[5,...,104], hint=rightLen-1=99):
+    // B[99]=104 >= 9, so gallop left from hint=99. Finds position 5 (before B[5]=10).
+    // skipRight = 100 - 5 = 95. Remaining B=[5,...,9].
+    let sorted = a.slice().sort(cmp);
+    assertSorted(sorted, "gallopLeft-key-before-some");
+    assertSameElements(a, sorted, "gallopLeft-key-before-some");
+}
+
+// 5e. gallopLeft with hint at end, galloping left through many elements.
+// The exponential search should hit maxOffset cap.
+{
+    let a = [];
+    // Run 1: [0, 1000] (ascending, 2 elements — too short, gets boosted)
+    // Let's use a pattern that forces gallopLeft to search far from hint.
+    // Run 1: [0,...,49, 500] (51 ascending)
+    for (let i = 0; i < 50; i++) a.push(i);
+    a.push(500);
+    // Run 2: [50,...,499] (starts at 50 < 500, new run)
+    for (let i = 50; i < 500; i++) a.push(i);
+    // gallopLeft(500, B=[50,...,499], hint=449):
+    // B[449]=499 < 500, so hintLessThanKey=true. Gallop right from 449.
+    // maxOffset = 450 - 449 = 1. offset=1 → 1 < 1 false. lastOffset=449, offset=450.
+    // Binary: one step. Returns 450. skipRight = 450 - 450 = 0.
+    let sorted = a.slice().sort(cmp);
+    assertSorted(sorted, "gallopLeft-hint-far");
+    assertSameElements(a, sorted, "gallopLeft-hint-far");
+}
+
+// 5f. gallopRight: key equals many elements — should return after all equal elements.
+{
+    let a = [];
+    // Run 1: [5,5,5,...,5, 10,10,...,10] (50 fives then 50 tens)
+    for (let i = 0; i < 50; i++) a.push(5);
+    for (let i = 0; i < 50; i++) a.push(10);
+    // Run 2: [5,5,...,5, 10,10,...,10] (same pattern, new run since 5 < 10)
+    for (let i = 0; i < 50; i++) a.push(5);
+    for (let i = 0; i < 50; i++) a.push(10);
+    // gallopRight(B[0]=5, A=[5*50, 10*50]) → should return 50 (after all 5s in A).
+    // This is the rightmost insertion point for 5.
+    let sorted = a.slice().sort(cmp);
+    assertSorted(sorted, "gallopRight-many-equals");
+    // All 5s should come before all 10s.
+    let fives = sorted.filter(x => x === 5);
+    let tens = sorted.filter(x => x === 10);
+    if (fives.length !== 100 || tens.length !== 100)
+        throw new Error("gallopRight-many-equals: wrong count");
+}
+
+// 5g. gallopLeft: key equals many elements — should return before all equal elements.
+{
+    let a = [];
+    // Run 1: [1,...,49, 50, 50, ..., 50] (49 unique + 51 fifties)
+    for (let i = 1; i < 50; i++) a.push(i);
+    for (let i = 0; i < 51; i++) a.push(50);
+    // Run 2: [25,...,75] (starts at 25 < 50, new run)
+    for (let i = 25; i <= 75; i++) a.push(i);
+    // gallopLeft(A[last]=50, B, hint=rightLen-1):
+    // Should return position before all 50s in B (leftmost insertion point).
+    let sorted = a.slice().sort(cmp);
+    assertSorted(sorted, "gallopLeft-many-equals");
+    assertSameElements(a, sorted, "gallopLeft-many-equals");
+}
+
+// ============================================================================
+// Section 6: Stability tests
+// ============================================================================
+
+// 6a. Stability through descending run reversal with duplicate keys.
+{
+    let a = [];
+    // Descending run with duplicate keys: must use strict < for descending.
+    // [5,4,3,3,2,1] — the 3,3 pair stops desc extension.
+    // After: [3,4,5] reversed from [5,4,3], then new run [3,2,1] detected.
+    // But [3,2,1] is desc → reversed to [1,2,3].
+    // The two 3s are now in different runs. Their stability depends on merge.
+    // The 3 from run1 (original index 2) should come before 3 from run2 (original index 3).
+    let vals = [];
+    for (let i = 50; i >= 1; i--) vals.push(i);
+    // Add duplicates at various points
+    for (let i = 1; i <= 50; i++) vals.push(i);
+    let wrapped = vals.map((v, i) => ({ value: v, index: i }));
+    wrapped.sort((x, y) => x.value - y.value);
+    assertStable(wrapped, "stability-desc-reversal-dupes");
+}
+
+// 6b. Stability through galloping merge with many duplicate keys.
+{
+    let a = [];
+    // 200 elements with only 5 distinct keys, ensuring lots of equal comparisons.
+    for (let i = 0; i < 200; i++)
+        a.push({ value: i % 5, index: i });
+    a.sort((x, y) => x.value - y.value);
+    assertStable(a, "stability-gallop-merge-dupes");
+}
+
+// 6c. Stability across multiple merge levels with duplicates.
+{
+    let a = [];
+    // Many small runs, each containing overlapping values.
+    for (let seg = 0; seg < 20; seg++) {
+        let base = (seg % 3) * 10; // only 3 distinct bases: 0, 10, 20
+        // Descending segment: creates a new run
+        for (let i = 14; i >= 0; i--)
+            a.push({ value: base + i, index: a.length });
+    }
+    a.sort((x, y) => x.value - y.value);
+    assertStable(a, "stability-multi-level-merge");
+}
+
+// 6d. Stability: concatenated sorted subarrays with same values.
+{
+    let a = [];
+    for (let batch = 0; batch < 5; batch++) {
+        for (let i = 0; i < 100; i++)
+            a.push({ value: i, index: a.length });
+    }
+    a.sort((x, y) => x.value - y.value);
+    assertStable(a, "stability-concat-same-values");
+}
+
+// ============================================================================
+// Section 7: Exception safety
+// ============================================================================
+
+// 7a. Exception during descending run detection.
+{
+    let a = [5, 4, 3, 2, 1, 0];
+    for (let i = 6; i < 100; i++) a.push(i);
+    let callCount = 0;
+    let threw = false;
+    try {
+        a.sort((x, y) => {
+            callCount++;
+            if (callCount === 3)
+                throw new Error("during-desc-detection");
+            return x - y;
+        });
+    } catch (e) {
+        if (e.message === "during-desc-detection") threw = true;
+        else throw e;
+    }
+    if (!threw)
+        throw new Error("exception during desc detection not propagated");
+}
+
+// 7b. Exception during pre-merge gallopRight.
+{
+    let a = [];
+    // Two runs that will be merged.
+    for (let i = 99; i >= 0; i--) a.push(i);   // desc → reversed to [0..99]
+    for (let i = 50; i < 150; i++) a.push(i);   // asc [50..149]
+    let callCount = 0;
+    let threw = false;
+    try {
+        a.sort((x, y) => {
+            callCount++;
+            // Throw during the merge phase (after run detection is done).
+            // Run detection takes ~200 comparisons, merge starts after.
+            if (callCount > 250)
+                throw new Error("during-gallop-trim");
+            return x - y;
+        });
+    } catch (e) {
+        if (e.message === "during-gallop-trim") threw = true;
+        else throw e;
+    }
+    if (!threw)
+        throw new Error("exception during gallop trim not propagated");
+}
+
+// 7c. Exception during galloping mode.
+{
+    let a = [];
+    // Pattern that triggers galloping: Run1=[200,...,299], Run2=[0,...,49,250,...,299]
+    for (let i = 200; i < 300; i++) a.push(i);
+    for (let i = 0; i < 50; i++) a.push(i);
+    for (let i = 250; i < 300; i++) a.push(i);
+    let callCount = 0;
+    let threw = false;
+    try {
+        a.sort((x, y) => {
+            callCount++;
+            if (callCount > 300)
+                throw new Error("during-galloping");
+            return x - y;
+        });
+    } catch (e) {
+        if (e.message === "during-galloping") threw = true;
+        else throw e;
+    }
+    if (!threw)
+        throw new Error("exception during galloping not propagated");
+}
+
+// ============================================================================
+// Section 8: Size boundary tests
+// ============================================================================
+
+// 8a. Sizes around insertion sort threshold (extendRunCutoff=8).
+{
+    for (let n = 1; n <= 20; n++) {
+        let a = [];
+        for (let i = n; i >= 1; i--) a.push(i);
+        let sorted = a.slice().sort(cmp);
+        assertSorted(sorted, "size-" + n);
+        if (sorted.length !== n)
+            throw new Error("size-" + n + ": wrong length");
+    }
+}
+
+// 8b. Size exactly forceRunLength (64): one run after boosting, no merge.
+{
+    let rng = makePRNG(123);
+    let a = [];
+    for (let i = 0; i < 64; i++) a.push(rng() % 1000);
+    let sorted = a.slice().sort(cmp);
+    assertSorted(sorted, "size-64-forceRunLength");
+    assertSameElements(a, sorted, "size-64-forceRunLength");
+}
+
+// 8c. Size 65: two runs (first boosted to 64, remainder is 1 element).
+{
+    let rng = makePRNG(456);
+    let a = [];
+    for (let i = 0; i < 65; i++) a.push(rng() % 1000);
+    let sorted = a.slice().sort(cmp);
+    assertSorted(sorted, "size-65-two-runs");
+    assertSameElements(a, sorted, "size-65-two-runs");
+}
+
+// 8d. Size 128: two runs of 64.
+{
+    let rng = makePRNG(789);
+    let a = [];
+    for (let i = 0; i < 128; i++) a.push(rng() % 1000);
+    let sorted = a.slice().sort(cmp);
+    assertSorted(sorted, "size-128-two-runs");
+    assertSameElements(a, sorted, "size-128-two-runs");
+}
+
+// 8e. Size 129: three runs.
+{
+    let rng = makePRNG(321);
+    let a = [];
+    for (let i = 0; i < 129; i++) a.push(rng() % 1000);
+    let sorted = a.slice().sort(cmp);
+    assertSorted(sorted, "size-129-three-runs");
+    assertSameElements(a, sorted, "size-129-three-runs");
+}
+
+// ============================================================================
+// Section 9: Complex patterns
+// ============================================================================
+
+// 9a. Organ pipe: ascending then descending.
+{
+    let a = [];
+    for (let i = 0; i < 200; i++) a.push(i);
+    for (let i = 199; i >= 0; i--) a.push(i);
+    let wrapped = a.map((v, i) => ({ value: v, index: i }));
+    wrapped.sort((x, y) => x.value - y.value);
+    assertStable(wrapped, "organ-pipe");
+}
+
+// 9b. Reverse organ pipe: descending then ascending.
+{
+    let a = [];
+    for (let i = 199; i >= 0; i--) a.push(i);
+    for (let i = 0; i < 200; i++) a.push(i);
+    let wrapped = a.map((v, i) => ({ value: v, index: i }));
+    wrapped.sort((x, y) => x.value - y.value);
+    assertStable(wrapped, "reverse-organ-pipe");
+}
+
+// 9c. Sawtooth with varying segment lengths.
+{
+    let a = [];
+    let pos = 0;
+    for (let segLen of [100, 50, 200, 30, 150, 80, 10, 120]) {
+        if (a.length > 0 && a.length % 2 === 0) {
+            // Descending segment
+            for (let i = segLen - 1; i >= 0; i--)
+                a.push(pos + i);
+        } else {
+            // Ascending segment
+            for (let i = 0; i < segLen; i++)
+                a.push(pos + i);
+        }
+        pos += segLen;
+    }
+    let sorted = a.slice().sort(cmp);
+    assertSorted(sorted, "sawtooth-varying-lengths");
+    assertSameElements(a, sorted, "sawtooth-varying-lengths");
+}
+
+// 9d. Plateau: long run of equal values surrounded by sorted sequences.
+{
+    let a = [];
+    for (let i = 0; i < 100; i++) a.push(i);
+    for (let i = 0; i < 200; i++) a.push(100); // plateau
+    for (let i = 101; i < 200; i++) a.push(i);
+    // [0..99] is one run. [100*200] is one run (ascending, all equal).
+    // But 100 == 99+1, so comparator(100, 99) = false → extends run 1!
+    // Similarly [100, 100, ...] extends. Then 101 > 100, extends further.
+    // Actually the entire array might be one run! Let me break it.
+    // Better: force a break.
+    a = [];
+    for (let i = 0; i < 100; i++) a.push(i);           // asc [0..99]
+    for (let i = 0; i < 200; i++) a.push(50);           // starts at 50 < 99, new run
+    for (let i = 51; i < 150; i++) a.push(i);           // continues ascending from 51
+    let sorted = a.slice().sort(cmp);
+    assertSorted(sorted, "plateau-in-middle");
+    assertSameElements(a, sorted, "plateau-in-middle");
+}
+
+// 9e. Two-value array: only 0s and 1s.
+{
+    let a = [];
+    let rng = makePRNG(555);
+    for (let i = 0; i < 500; i++)
+        a.push(rng() % 2);
+    let sorted = a.slice().sort(cmp);
+    assertSorted(sorted, "two-values");
+    let zeros = sorted.filter(x => x === 0).length;
+    let ones = sorted.filter(x => x === 1).length;
+    if (zeros + ones !== 500)
+        throw new Error("two-values: element count wrong");
+}
+
+// 9f. Already sorted with duplicates — pre-merge trim should handle everything.
+{
+    let a = [];
+    for (let i = 0; i < 100; i++) {
+        a.push(i);
+        a.push(i); // duplicate each
+    }
+    // This is one ascending run (duplicates are >=). No merge.
+    // Break into two runs:
+    let b = [];
+    for (let i = 0; i < 100; i++) b.push(i);
+    for (let i = 0; i < 100; i++) b.push(i); // starts at 0 < 99, new run
+    let sorted = b.slice().sort(cmp);
+    assertSorted(sorted, "sorted-with-duplicates");
+    assertSameElements(b, sorted, "sorted-with-duplicates");
+}
+
+// 9g. Large random test with stability check.
+{
+    let rng = makePRNG(12345);
+    let a = [];
+    for (let i = 0; i < 10000; i++)
+        a.push({ value: rng() % 100, index: i });
+    a.sort((x, y) => x.value - y.value);
+    assertStable(a, "large-random-stability");
+}
+
+// ============================================================================
+// Section 10: TypedArray paths
+// ============================================================================
+
+// 10a. TypedArray with descending run detection.
+{
+    let ta = new Int32Array(500);
+    for (let i = 0; i < 500; i++) ta[i] = 500 - i;
+    ta.sort((x, y) => x - y);
+    for (let i = 1; i < ta.length; i++) {
+        if (ta[i] < ta[i - 1])
+            throw new Error("typed-array-desc: not sorted at " + i);
+    }
+}
+
+// 10b. TypedArray with galloping pattern.
+{
+    let ta = new Float64Array(200);
+    // Run 1: [200,...,299]
+    for (let i = 0; i < 100; i++) ta[i] = 200 + i;
+    // Run 2: [0,...,49, 250,...,299]
+    for (let i = 0; i < 50; i++) ta[100 + i] = i;
+    for (let i = 0; i < 50; i++) ta[150 + i] = 250 + i;
+    ta.sort((x, y) => x - y);
+    for (let i = 1; i < ta.length; i++) {
+        if (ta[i] < ta[i - 1])
+            throw new Error("typed-array-gallop: not sorted at " + i);
+    }
+}
+
+// 10c. TypedArray sawtooth.
+{
+    let ta = new Uint16Array(300);
+    for (let seg = 0; seg < 6; seg++) {
+        let base = seg * 50;
+        if (seg % 2 === 0) {
+            for (let i = 0; i < 50; i++) ta[base + i] = base + i;
+        } else {
+            for (let i = 0; i < 50; i++) ta[base + i] = base + 49 - i;
+        }
+    }
+    ta.sort((x, y) => x - y);
+    for (let i = 1; i < ta.length; i++) {
+        if (ta[i] < ta[i - 1])
+            throw new Error("typed-array-sawtooth: not sorted at " + i);
+    }
+}
+
+// ============================================================================
+// Section 11: Boolean comparator (JSC-specific coercion)
+// ============================================================================
+
+// 11a. Boolean comparator with descending input.
+// coerceComparatorResultToBoolean returns !result for booleans.
+// (a, b) => b <= a: when b <= a, returns true, coerced to false (not less-than).
+//                   when b > a, returns false, coerced to true (less-than).
+// So this sorts ascending.
+{
+    let a = [];
+    for (let i = 200; i >= 1; i--) a.push(i);
+    let sorted = a.slice().sort((x, y) => y <= x);
+    assertSorted(sorted, "boolean-cmp-desc-input");
+}
+
+// 11b. Boolean comparator with sawtooth input.
+{
+    let a = [];
+    for (let seg = 0; seg < 10; seg++) {
+        if (seg % 2 === 0) {
+            for (let i = 0; i < 30; i++) a.push(seg * 30 + i);
+        } else {
+            for (let i = 29; i >= 0; i--) a.push(seg * 30 + i);
+        }
+    }
+    let sorted = a.slice().sort((x, y) => y <= x);
+    assertSorted(sorted, "boolean-cmp-sawtooth");
+}
+
+// 11c. Boolean comparator stability.
+{
+    let a = [];
+    for (let i = 0; i < 200; i++)
+        a.push({ value: i % 10, index: i });
+    a.sort((x, y) => y.value <= x.value);
+    assertStable(a, "boolean-cmp-stability");
+}
+
+// ============================================================================
+// Section 12: toSorted (returns new array, tests same code path)
+// ============================================================================
+
+// 12a. toSorted with galloping pattern.
+{
+    let a = [];
+    for (let i = 200; i < 300; i++) a.push(i);
+    for (let i = 0; i < 50; i++) a.push(i);
+    for (let i = 250; i < 300; i++) a.push(i);
+    let sorted = a.toSorted(cmp);
+    assertSorted(sorted, "toSorted-gallop");
+    assertSameElements(a, sorted, "toSorted-gallop");
+    // Verify original is unmodified.
+    if (a[0] !== 200)
+        throw new Error("toSorted modified original");
+}
+
+// 12b. toSorted stability.
+{
+    let a = [];
+    for (let i = 0; i < 300; i++)
+        a.push({ value: i % 7, index: i });
+    let sorted = a.toSorted((x, y) => x.value - y.value);
+    assertStable(sorted, "toSorted-stability");
+}

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -900,7 +900,7 @@ static unsigned sortBucketSort(std::span<EncodedJSValue> sorted, unsigned dst, S
     return dst;
 }
 
-static ALWAYS_INLINE std::span<EncodedJSValue> sortStableSort(JSGlobalObject* globalObject, std::span<EncodedJSValue> sorted, std::span<EncodedJSValue> compacted, JSObject* comparator)
+static ALWAYS_INLINE std::span<EncodedJSValue> sortStableSort(JSGlobalObject* globalObject, std::span<EncodedJSValue> compacted, std::span<EncodedJSValue> workingSet, JSObject* comparator)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -910,8 +910,8 @@ static ALWAYS_INLINE std::span<EncodedJSValue> sortStableSort(JSGlobalObject* gl
 
     if (callData.type == CallData::Type::JS) [[likely]] {
         CachedCall cachedCall(globalObject, jsCast<JSFunction*>(comparator), 2);
-        RETURN_IF_EXCEPTION(scope, sorted);
-        RELEASE_AND_RETURN(scope, arrayStableSort(vm, compacted, sorted, [&](auto left, auto right) ALWAYS_INLINE_LAMBDA {
+        RETURN_IF_EXCEPTION(scope, compacted);
+        RELEASE_AND_RETURN(scope, arrayStableSort(vm, compacted, workingSet, [&](auto left, auto right) ALWAYS_INLINE_LAMBDA {
             auto scope = DECLARE_THROW_SCOPE(vm);
 
             JSValue jsResult = cachedCall.callWithArguments(globalObject, jsUndefined(), JSValue::decode(left), JSValue::decode(right));
@@ -922,7 +922,7 @@ static ALWAYS_INLINE std::span<EncodedJSValue> sortStableSort(JSGlobalObject* gl
     }
 
     MarkedArgumentBuffer args;
-    RELEASE_AND_RETURN(scope, arrayStableSort(vm, compacted, sorted, [&](auto left, auto right) ALWAYS_INLINE_LAMBDA {
+    RELEASE_AND_RETURN(scope, arrayStableSort(vm, compacted, workingSet, [&](auto left, auto right) ALWAYS_INLINE_LAMBDA {
         auto scope = DECLARE_THROW_SCOPE(vm);
 
         args.clear();
@@ -1022,7 +1022,7 @@ static ALWAYS_INLINE void sortImpl(JSGlobalObject* globalObject, JSObject* thisO
         sortBucketSort(sorted, 0, entries, 0);
         dest = sorted;
     } else {
-        dest = sortStableSort(globalObject, sorted, compacted, asObject(comparatorValue));
+        dest = sortStableSort(globalObject, compacted, sorted, asObject(comparatorValue));
         RETURN_IF_EXCEPTION(scope, void());
     }
 

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
@@ -1690,8 +1690,8 @@ static ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncSortImpl(VM& v
     }
 
     auto src = vector.mutableSpan().first(length);
-    auto dst = vector.mutableSpan().subspan(length);
-    ASSERT(dst.size() == length);
+    auto workingSet = vector.mutableSpan().subspan(length);
+    ASSERT(workingSet.size() == length);
     ASSERT(originalSpan.size() == length);
     WTF::copyElements(src, spanConstCast<const typename ViewClass::ElementType>(originalSpan));
 
@@ -1700,7 +1700,7 @@ static ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncSortImpl(VM& v
     if (callData.type == CallData::Type::JS) [[likely]] {
         CachedCall cachedCall(globalObject, jsCast<JSFunction*>(comparatorValue), 2);
         RETURN_IF_EXCEPTION(scope, { });
-        result = arrayStableSort(vm, src, dst, [&](auto left, auto right) ALWAYS_INLINE_LAMBDA {
+        result = arrayStableSort(vm, src, workingSet, [&](auto left, auto right) ALWAYS_INLINE_LAMBDA {
             auto scope = DECLARE_THROW_SCOPE(vm);
 
             JSValue leftValue = ViewClass::Adaptor::toJSValue(globalObject, left);
@@ -1716,7 +1716,7 @@ static ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncSortImpl(VM& v
         RETURN_IF_EXCEPTION(scope, { });
     } else {
         MarkedArgumentBuffer args;
-        result = arrayStableSort(vm, src, dst, [&](auto left, auto right) ALWAYS_INLINE_LAMBDA {
+        result = arrayStableSort(vm, src, workingSet, [&](auto left, auto right) ALWAYS_INLINE_LAMBDA {
             auto scope = DECLARE_THROW_SCOPE(vm);
 
             args.clear();

--- a/Source/JavaScriptCore/runtime/StableSort.h
+++ b/Source/JavaScriptCore/runtime/StableSort.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2026 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2026 the V8 project authors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -21,6 +22,19 @@
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*
+ * Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
+ * 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018 Python Software Foundation;
+ * All Rights Reserved
+ *
+ * Part of the implementation, e.g. galloping merge, is coming from Python's TimSort.
+ *
+ * https://github.com/python/cpython/blob/master/Objects/listobject.c
+ *
+ * Detailed analysis and a description of the algorithm can be found at:
+ *
+ * https://github.com/python/cpython/blob/master/Objects/listsort.txt
  */
 
 #pragma once
@@ -77,41 +91,332 @@ static ALWAYS_INLINE void arrayInsertionSort(VM& vm, std::span<ElementType> span
     }
 }
 
+// Detect ascending or strictly-descending run starting at begin.
+// If descending, reverse in-place to make ascending (stable: uses strict < for descending).
+// Returns end index (inclusive) of the normalized ascending run.
 template<typename ElementType, typename Functor>
-static ALWAYS_INLINE void mergePowersortRuns(VM& vm, std::span<ElementType> dst, std::span<const ElementType> src, size_t srcIndex1, size_t srcEnd1, size_t srcIndex2, size_t srcEnd2, const Functor& comparator)
+static ALWAYS_INLINE size_t extendAndNormalizeRun(VM& vm, std::span<ElementType> span, size_t begin, const Functor& comparator)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    size_t left = srcIndex1;
-    size_t leftEnd = srcEnd1;
+    size_t end = begin;
+    size_t numElements = span.size();
+    if (end + 1 >= numElements)
+        return end;
+
+    // Check if the run starts descending: a[begin+1] < a[begin] (strict for stability).
+    bool descending = comparator(span[end + 1], span[end]);
+    RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, end);
+
+    if (descending) {
+        // Extend strictly descending run.
+        ++end;
+        while (end + 1 < numElements) {
+            bool result = comparator(span[end + 1], span[end]);
+            RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, end);
+            if (!result)
+                break;
+            ++end;
+        }
+        std::ranges::reverse(span.subspan(begin, end + 1 - begin));
+    } else {
+        // Extend ascending run (non-strictly: a[i+1] >= a[i]).
+        ++end;
+        while (end + 1 < numElements) {
+            bool result = comparator(span[end + 1], span[end]);
+            RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, end);
+            if (result)
+                break;
+            ++end;
+        }
+    }
+
+    return end;
+}
+
+// gallopLeft: Find the leftmost position where key should be inserted (before equal elements).
+// Returns k in [0, length] such that base[k-1] < key <= base[k].
+// hint is a starting index for the exponential search.
+template<typename ElementType, typename Functor>
+static ALWAYS_INLINE size_t gallopLeft(VM& vm, const ElementType& key, const ElementType* base, size_t length, size_t hint, const Functor& comparator)
+{
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    ASSERT(hint < length);
+
+    size_t lastOffset = 0;
+    size_t offset = 1;
+
+    // base[hint] < key => gallop right
+    bool hintLessThanKey = comparator(base[hint], key);
+    RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, 0);
+
+    if (hintLessThanKey) {
+        // Gallop right: a[hint] < key, so search in (hint, length).
+        size_t maxOffset = length - hint;
+        while (offset < maxOffset) {
+            bool result = comparator(base[hint + offset], key);
+            RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, 0);
+            if (!result)
+                break;
+            lastOffset = offset;
+            size_t nextOffset = (offset << 1) + 1;
+            offset = nextOffset > offset ? std::min(nextOffset, maxOffset) : maxOffset;
+        }
+        lastOffset += hint;
+        offset += hint;
+    } else {
+        // Gallop left: a[hint] >= key, so search in [0, hint).
+        size_t maxOffset = hint + 1;
+        while (offset < maxOffset) {
+            bool result = comparator(base[hint - offset], key);
+            RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, 0);
+            if (result)
+                break;
+            lastOffset = offset;
+            size_t nextOffset = (offset << 1) + 1;
+            offset = nextOffset > offset ? std::min(nextOffset, maxOffset) : maxOffset;
+        }
+        size_t tmp = lastOffset;
+        lastOffset = hint - offset;
+        offset = hint - tmp;
+    }
+
+    // Now base[lastOffset] < key <= base[offset], binary search in (lastOffset, offset].
+    ++lastOffset;
+    while (lastOffset < offset) {
+        size_t m = lastOffset + ((offset - lastOffset) >> 1);
+        bool result = comparator(base[m], key);
+        RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, 0);
+        if (result)
+            lastOffset = m + 1;
+        else
+            offset = m;
+    }
+
+    return offset;
+}
+
+// gallopRight: Find the rightmost position where key should be inserted (after equal elements).
+// Returns k in [0, length] such that base[k-1] <= key < base[k].
+template<typename ElementType, typename Functor>
+static ALWAYS_INLINE size_t gallopRight(VM& vm, const ElementType& key, const ElementType* base, size_t length, size_t hint, const Functor& comparator)
+{
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    ASSERT(hint < length);
+
+    size_t lastOffset = 0;
+    size_t offset = 1;
+
+    // key < base[hint] => gallop left
+    bool keyLessThanHint = comparator(key, base[hint]);
+    RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, 0);
+
+    if (keyLessThanHint) {
+        // Gallop left: key < a[hint], so search in [0, hint).
+        size_t maxOffset = hint + 1;
+        while (offset < maxOffset) {
+            bool result = comparator(key, base[hint - offset]);
+            RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, 0);
+            if (!result)
+                break;
+            lastOffset = offset;
+            size_t nextOffset = (offset << 1) + 1;
+            offset = nextOffset > offset ? std::min(nextOffset, maxOffset) : maxOffset;
+        }
+        // Translate back to positive offsets from base.
+        size_t tmp = lastOffset;
+        lastOffset = hint - offset;
+        offset = hint - tmp;
+    } else {
+        // Gallop right: key >= a[hint], so search in (hint, length).
+        size_t maxOffset = length - hint;
+        while (offset < maxOffset) {
+            bool result = comparator(key, base[hint + offset]);
+            RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, 0);
+            if (result)
+                break;
+            lastOffset = offset;
+            size_t nextOffset = (offset << 1) + 1;
+            offset = nextOffset > offset ? std::min(nextOffset, maxOffset) : maxOffset;
+        }
+        // Translate to absolute offsets.
+        lastOffset += hint;
+        offset += hint;
+    }
+
+    // Now base[lastOffset] <= key < base[offset], binary search in (lastOffset, offset].
+    ++lastOffset;
+    while (lastOffset < offset) {
+        size_t m = lastOffset + ((offset - lastOffset) >> 1);
+        bool result = comparator(key, base[m]);
+        RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, 0);
+        if (result)
+            offset = m;
+        else
+            lastOffset = m + 1;
+    }
+
+    return offset;
+}
+
+static constexpr size_t minGallopThreshold = 7;
+
+template<typename ElementType, typename Functor>
+static ALWAYS_INLINE void mergePowersortRuns(VM& vm, std::span<ElementType> dst, std::span<const ElementType> src, size_t srcIndex1, size_t srcEnd1, size_t srcIndex2, size_t srcEnd2, const Functor& comparator, size_t& minGallop)
+{
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    ASSERT(srcEnd1 <= srcIndex2);
+    ASSERT(srcEnd2 <= src.size());
+
+    size_t leftLength = srcEnd1 - srcIndex1;
+    size_t rightLength = srcEnd2 - srcIndex2;
+
+    // Either run is empty. Just copy entire two consecutive runs into destination.
+    if (!leftLength || !rightLength) {
+        WTF::copyElements(dst.subspan(srcIndex1, srcEnd2 - srcIndex1), src.subspan(srcIndex1, srcEnd2 - srcIndex1));
+        return;
+    }
+
+    // Pre-merge trim: skip leading elements of left that are already in place.
+    // If the right run's first element can be inserted into skipLeft position,
+    // [srcIndex, skipLeft) sorted ones are lower than any of right run's element.
+    // Thus copy them into the destination's lowest area.
+    size_t skipLeft = gallopRight(vm, src[srcIndex2], src.data() + srcIndex1, leftLength, 0, comparator);
+    RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, void());
+
+    // Copy the already-in-place leading elements.
+    if (skipLeft)
+        WTF::copyElements(dst.subspan(srcIndex1, skipLeft), src.subspan(srcIndex1, skipLeft));
+
+    size_t left = srcIndex1 + skipLeft;
+    leftLength -= skipLeft;
+
+    if (!leftLength) {
+        // All of left is <= first element of right; just copy right.
+        WTF::copyElements(dst.subspan(srcIndex2, rightLength), src.subspan(srcIndex2, rightLength));
+        return;
+    }
+
+    // Pre-merge trim: skip trailing elements of right that are already in place.
+    // If the left run's last element can be inserted into a position,
+    // elements after that in the right run should be in the destination's highest area.
+    size_t skipRight = rightLength - gallopLeft(vm, src[srcEnd1 - 1], src.data() + srcIndex2, rightLength, rightLength - 1, comparator);
+    RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, void());
+
+    // Copy the already-in-place trailing elements.
+    if (skipRight)
+        WTF::copyElements(dst.subspan(srcEnd2 - skipRight, skipRight), src.subspan(srcEnd2 - skipRight, skipRight));
+
+    const size_t rightEnd = srcEnd2 - skipRight;
+    rightLength -= skipRight;
+
+    if (!rightLength) {
+        // All of right is >= last element of left; just copy left.
+        WTF::copyElements(dst.subspan(left, leftLength), src.subspan(left, leftLength));
+        return;
+    }
+
+    ASSERT(leftLength);
+    ASSERT(rightLength);
+
+    // Merge with galloping mode. After pre-merge trim, new range is [left, leftEnd) and [right, rightEnd).
+    const size_t leftEnd = srcEnd1;
     size_t right = srcIndex2;
-    size_t rightEnd = srcEnd2;
+    size_t dstIndex = left;
+    size_t leftWins = 0;
+    size_t rightWins = 0;
 
-    ASSERT(leftEnd <= right);
-    ASSERT(rightEnd <= src.size());
+    for (;;) {
+        // Linear merge until one side wins minGallop times consecutively.
+        leftWins = 0;
+        rightWins = 0;
 
-    for (size_t dstIndex = left; dstIndex < rightEnd; ++dstIndex) {
-        if (right < rightEnd) {
-            if (left >= leftEnd) {
-                dst[dstIndex] = src[right++];
-                continue;
-            }
-            bool result = comparator(src[right], src[left]);
-            RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, void());
-            if (result) {
-                dst[dstIndex] = src[right++];
-                continue;
+        while (leftWins < minGallop && rightWins < minGallop) {
+            if (right < rightEnd && left < leftEnd) {
+                bool result = comparator(src[right], src[left]);
+                RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, void());
+                if (result) {
+                    dst[dstIndex++] = src[right++];
+                    ++rightWins;
+                    leftWins = 0;
+                } else {
+                    dst[dstIndex++] = src[left++];
+                    ++leftWins;
+                    rightWins = 0;
+                }
+            } else {
+                // One side of run gets exhausted. Let's just copy the rest.
+                goto mergeFinish;
             }
         }
 
-        dst[dstIndex] = src[left++];
+        // Galloping mode: one side is winning consistently.
+        // Increase minGallop to make it harder to re-enter galloping (penalize leaving).
+        ++minGallop;
+
+        do {
+            // Decrease minGallop while galloping is productive.
+            if (minGallop > 1)
+                --minGallop;
+
+            if (left >= leftEnd || right >= rightEnd)
+                goto mergeFinish;
+
+            // Gallop in left run for right's current element.
+            {
+                size_t k = gallopRight(vm, src[right], src.data() + left, leftEnd - left, 0, comparator);
+                RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, void());
+                leftWins = k;
+                if (k) {
+                    // k elements in the left are lower than right elements. Just copy them.
+                    WTF::copyElements(dst.subspan(dstIndex, k), src.subspan(left, k));
+                    dstIndex += k;
+                    left += k;
+                }
+                dst[dstIndex++] = src[right++];
+
+                if (left >= leftEnd || right >= rightEnd)
+                    goto mergeFinish;
+            }
+
+            // Gallop in right run for left's current element.
+            {
+                size_t k = gallopLeft(vm, src[left], src.data() + right, rightEnd - right, 0, comparator);
+                RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, void());
+                rightWins = k;
+                if (k) {
+                    // k elements in the right are lower than left elements. Just copy them.
+                    WTF::copyElements(dst.subspan(dstIndex, k), src.subspan(right, k));
+                    dstIndex += k;
+                    right += k;
+                }
+                dst[dstIndex++] = src[left++];
+
+                if (left >= leftEnd || right >= rightEnd)
+                    goto mergeFinish;
+            }
+        } while (leftWins >= minGallopThreshold || rightWins >= minGallopThreshold);
+
+        // Leaving galloping mode; penalize.
+        ++minGallop;
     }
+
+mergeFinish:
+    // Copy remaining elements.
+    while (left < leftEnd)
+        dst[dstIndex++] = src[left++];
+    while (right < rightEnd)
+        dst[dstIndex++] = src[right++];
 }
 
 // J. Ian Munro and Sebastian Wild. Nearly-Optimal Mergesorts: Fast, Practical Sorting Methods That
 // Optimally Adapt to Existing Runs. In 26th Annual European Symposium on Algorithms (ESA 2018).
 // Leibniz International Proceedings in Informatics (LIPIcs), Volume 112, pp. 63:1-63:16, Schloss
 // Dagstuhl – Leibniz-Zentrum für Informatik (2018) https://doi.org/10.4230/LIPIcs.ESA.2018.63
+// https://arxiv.org/abs/1805.04154
 
 struct SortedRun {
     size_t m_begin;
@@ -119,7 +424,7 @@ struct SortedRun {
 };
 
 template<typename ElementType, typename Functor, size_t forceRunLength = 64>
-static ALWAYS_INLINE std::span<ElementType> arrayStableSort(VM& vm, std::span<ElementType> src, std::span<ElementType> dst, const Functor& comparator)
+static ALWAYS_INLINE std::span<ElementType> arrayStableSort(VM& vm, std::span<ElementType> src, std::span<ElementType> workingSet, const Functor& comparator)
 {
     constexpr size_t extendRunCutoff = 8;
 
@@ -155,11 +460,6 @@ static ALWAYS_INLINE std::span<ElementType> arrayStableSort(VM& vm, std::span<El
         return clz(static_cast<uint64_t>(differingBits));
     };
 
-    auto to = dst;
-    auto from = src;
-
-    WTF::copyElements(to, spanConstCast<const ElementType>(from));
-
     struct PowersortStackEntry {
         SortedRun run;
         unsigned power;
@@ -169,28 +469,25 @@ static ALWAYS_INLINE std::span<ElementType> arrayStableSort(VM& vm, std::span<El
     // floor(lg(n)) + 1
     powerstack.reserveCapacity(8 * sizeof(numElements) - WTF::clz(numElements));
 
+    size_t minGallop = minGallopThreshold;
+
     SortedRun run1 { 0, 0 };
 
-    // ExtendRunRight(run1.start, n)
-    while (run1.m_end + 1 < numElements) {
-        bool result = comparator(from[run1.m_end + 1], from[run1.m_end]);
-        RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, src);
-        if (result)
-            break;
-        ++run1.m_end;
-    }
+    // Detect ascending or descending run, normalize to ascending.
+    run1.m_end = extendAndNormalizeRun(vm, src, run1.m_begin, comparator);
+    RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, src);
 
     if (run1.m_end - run1.m_begin < extendRunCutoff) {
         // If the run is too short, insertion sort a bit
         auto size = std::min(forceRunLength, numElements - run1.m_begin);
-        arrayInsertionSort(vm, from.subspan(run1.m_begin, size), comparator, run1.m_end - run1.m_begin);
+        arrayInsertionSort(vm, src.subspan(run1.m_begin, size), comparator, run1.m_end - run1.m_begin);
         RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, src);
         run1.m_end = run1.m_begin + size - 1;
     }
 
     // See if we can extend the run any more.
     while (run1.m_end + 1 < numElements) {
-        bool result = comparator(from[run1.m_end + 1], from[run1.m_end]);
+        bool result = comparator(src[run1.m_end + 1], src[run1.m_end]);
         RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, src);
         if (result)
             break;
@@ -200,26 +497,21 @@ static ALWAYS_INLINE std::span<ElementType> arrayStableSort(VM& vm, std::span<El
     while (run1.m_end + 1 < numElements) {
         SortedRun run2 { run1.m_end + 1, run1.m_end + 1 };
 
-        // ExtendRunRight(run2.start, n)
-        while (run2.m_end + 1 < numElements) {
-            bool result = comparator(from[run2.m_end + 1], from[run2.m_end]);
-            RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, src);
-            if (result)
-                break;
-            ++run2.m_end;
-        }
+        // Detect ascending or descending run, normalize to ascending.
+        run2.m_end = extendAndNormalizeRun(vm, src, run2.m_begin, comparator);
+        RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, src);
 
         if (run2.m_end - run2.m_begin < extendRunCutoff) {
             // If the run is too short, insertion sort a bit
             auto size = std::min(forceRunLength, numElements - run2.m_begin);
-            arrayInsertionSort(vm, from.subspan(run2.m_begin, size), comparator, run2.m_end - run2.m_begin);
+            arrayInsertionSort(vm, src.subspan(run2.m_begin, size), comparator, run2.m_end - run2.m_begin);
             RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, src);
             run2.m_end = run2.m_begin + size - 1;
         }
 
         // See if we can extend the run any more.
         while (run2.m_end + 1 < numElements) {
-            bool result = comparator(from[run2.m_end + 1], from[run2.m_end]);
+            bool result = comparator(src[run2.m_end + 1], src[run2.m_end]);
             RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, src);
             if (result)
                 break;
@@ -231,9 +523,9 @@ static ALWAYS_INLINE std::span<ElementType> arrayStableSort(VM& vm, std::span<El
             auto rangeToMerge = powerstack.takeLast().run;
             ASSERT(rangeToMerge.m_end == run1.m_begin - 1);
 
-            mergePowersortRuns(vm, to, spanConstCast<const ElementType>(from), rangeToMerge.m_begin, rangeToMerge.m_end + 1, run1.m_begin, run1.m_end + 1, comparator);
+            mergePowersortRuns(vm, workingSet, spanConstCast<const ElementType>(src), rangeToMerge.m_begin, rangeToMerge.m_end + 1, run1.m_begin, run1.m_end + 1, comparator, minGallop);
             RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, src);
-            WTF::copyElements(from.subspan(rangeToMerge.m_begin, run1.m_end + 1 - rangeToMerge.m_begin), spanConstCast<const ElementType>(to).subspan(rangeToMerge.m_begin, run1.m_end + 1 - rangeToMerge.m_begin));
+            WTF::copyElements(src.subspan(rangeToMerge.m_begin, run1.m_end + 1 - rangeToMerge.m_begin), spanConstCast<const ElementType>(workingSet).subspan(rangeToMerge.m_begin, run1.m_end + 1 - rangeToMerge.m_begin));
             run1.m_begin = rangeToMerge.m_begin;
         }
 
@@ -245,13 +537,13 @@ static ALWAYS_INLINE std::span<ElementType> arrayStableSort(VM& vm, std::span<El
         auto rangeToMerge = powerstack.takeLast().run;
         ASSERT(rangeToMerge.m_end == run1.m_begin - 1);
 
-        mergePowersortRuns(vm, to, spanConstCast<const ElementType>(from), rangeToMerge.m_begin, rangeToMerge.m_end + 1, run1.m_begin, run1.m_end + 1, comparator);
+        mergePowersortRuns(vm, workingSet, spanConstCast<const ElementType>(src), rangeToMerge.m_begin, rangeToMerge.m_end + 1, run1.m_begin, run1.m_end + 1, comparator, minGallop);
         RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, src);
-        WTF::copyElements(from.subspan(rangeToMerge.m_begin, run1.m_end + 1 - rangeToMerge.m_begin), spanConstCast<const ElementType>(to).subspan(rangeToMerge.m_begin, run1.m_end + 1 - rangeToMerge.m_begin));
+        WTF::copyElements(src.subspan(rangeToMerge.m_begin, run1.m_end + 1 - rangeToMerge.m_begin), spanConstCast<const ElementType>(workingSet).subspan(rangeToMerge.m_begin, run1.m_end + 1 - rangeToMerge.m_begin));
         run1.m_begin = rangeToMerge.m_begin;
     }
 
-    return from.data() == src.data() ? src : dst;
+    return src;
 }
 
 } // namespace JSC


### PR DESCRIPTION
#### cd9b9860484074e45f586e5f988f9273f16a8404
<pre>
[JSC] Implement galloping merge in PowerSort
<a href="https://bugs.webkit.org/show_bug.cgi?id=310948">https://bugs.webkit.org/show_bug.cgi?id=310948</a>
<a href="https://rdar.apple.com/17190833">rdar://17190833</a>

Reviewed by Yijia Huang.

This patch enhances our existing PowerSort implementation with three
extensions.

1. We are always returning src as a result. And dst side is just a
   working copy for the algorithm. We avoid unnecessary initial copy.
2. We extended `extendRunRight` to `extendAndNormalizeRun`, which can
   also detect descending patterns and extend the run by reversing at
   last.
3. We introduced galloping merge: this is originally introduced in
   TimSort[1]. The idea of galloping merge is &quot;it is quite common that
   cluster of elements are lower / higher than the first / last element
   of the other run. Then instead of comparing both first elements
   one-by-one and merging them, we should find the lower / higher
   elements than the other run&apos;s first / last element, and copy them in
   a bulk manner&quot;. This can avoid calling comparison invocation frequently,
   which is very costly in JS sort implementation. gallopLeft and
   gallopRight is basically finding an insertion point in the run, but
   instead of using binary search, it is using galloping.

                               ToT                     Patched

    magic-forest        464.3367+-5.3030     ^    346.2807+-1.6506        ^ definitely 1.3409x faster

Apple OSS approval: OSS-24108

[1]: <a href="https://github.com/python/cpython/blob/main/Objects/listsort.txt">https://github.com/python/cpython/blob/main/Objects/listsort.txt</a>

Test: JSTests/stress/sort-galloping-merge-optimizations.js

* JSTests/slowMicrobenchmarks/magic-forest.js: Added.
(Forest):
(Forest.prototype.wolfDevoursGoat):
(Forest.prototype.lionDevoursGoat):
(Forest.prototype.lionDevoursWolf):
(Forest.prototype.meal):
(Forest.prototype.isStable):
(Forest.prototype.toString):
(Forest.compare):
(meal):
(stableForests):
(findStableForests):
(go):
(goUI):
* JSTests/stress/sort-galloping-merge-optimizations.js: Added.
(assertSorted):
(assertStable):
(assertArraysEqual):
(assertSameElements):
(makePRNG):
(throw.new.Error):
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::sortStableSort):
(JSC::sortImpl):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h:
(JSC::genericTypedArrayViewProtoFuncSortImpl):
* Source/JavaScriptCore/runtime/StableSort.h:
(JSC::extendAndNormalizeRun):
(JSC::gallopLeft):
(JSC::gallopRight):
(JSC::mergePowersortRuns):
(JSC::arrayStableSort):

Canonical link: <a href="https://commits.webkit.org/310282@main">https://commits.webkit.org/310282@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa05d9d1f1a23fddd5836ebde9c638b52e00f478

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153323 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26107 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19706 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162068 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26633 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26427 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118533 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156282 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20775 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137651 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99245 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19852 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17796 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9903 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/145336 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129499 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15521 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164542 "Built successfully") | | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/14142 "Found 1 new JSC stress test failure: stress/re-enter-resolve-rope-string.js.no-ftl (failure)") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7678 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17115 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126590 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25903 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21829 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126748 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25906 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137317 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82573 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23455 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21689 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14095 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184958 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25523 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89809 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47363 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25214 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25373 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25274 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->