### PR TITLE
Use std::midpoint() in more WebCore code

### DIFF
--- a/Source/WebCore/platform/graphics/UnitBezier.h
+++ b/Source/WebCore/platform/graphics/UnitBezier.h
@@ -28,6 +28,7 @@
 
 #include <array>
 #include <math.h>
+#include <numeric>
 
 namespace WebCore {
 
@@ -151,7 +152,7 @@ namespace WebCore {
                     t0 = t2;
                 else
                     t1 = t2;
-                t2 = (t1 + t0) * .5;
+                t2 = std::midpoint(t0, t1);
             }
 
             // Failure.

--- a/Source/WebCore/platform/graphics/opentype/OpenTypeTypes.h
+++ b/Source/WebCore/platform/graphics/opentype/OpenTypeTypes.h
@@ -29,6 +29,7 @@
 #endif
 
 #include "SharedBuffer.h"
+#include <numeric>
 #include <wtf/StdLibExtras.h>
 
 namespace WebCore::OpenType {
@@ -151,7 +152,7 @@ protected:
             // We do a binary search on the glyph indexes.
             uint32_t imin = 0, imax = glyphCount;
             while (imin < imax) {
-                uint32_t imid = (imin + imax) >> 1;
+                uint32_t imid = std::midpoint(imin, imax);
                 uint16_t glyphMid = coverage1->glyphArray[imid];
                 if (glyphMid == glyph) {
                     coverageIndex = imid;
@@ -175,7 +176,7 @@ protected:
             // We do a binary search on the ranges.
             uint32_t imin = 0, imax = rangeCount;
             while (imin < imax) {
-                uint32_t imid = (imin + imax) >> 1;
+                uint32_t imid = std::midpoint(imin, imax);
                 uint16_t rStart = coverage2->ranges[imid].start;
                 uint16_t rEnd = coverage2->ranges[imid].end;
                 if (rEnd < glyph)

--- a/Source/WebCore/platform/graphics/skia/SkiaImageAtlasLayoutBuilder.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaImageAtlasLayoutBuilder.cpp
@@ -28,6 +28,7 @@
 
 #if USE(SKIA)
 
+#include <numeric>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
@@ -236,7 +237,7 @@ size_t SkiaImageAtlasLayoutBuilder::findMaxPackableBatch(const Vector<IntSize>& 
     size_t maxPackable = 0;
 
     while (lo <= hi) {
-        size_t mid = lo + (hi - lo) / 2;
+        size_t mid = std::midpoint(lo, hi);
 
         Vector<IntSize> testBatch(mid, [&sizes](size_t index) {
             return sizes[index];

--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -56,6 +56,7 @@
 #include "StyledMarkedText.h"
 #include "TextPaintStyle.h"
 #include "TextPainter.h"
+#include <numeric>
 #include <ranges>
 
 #if ENABLE(WRITING_TOOLS)
@@ -1293,7 +1294,7 @@ static void drawWritingToolsUnderline(GraphicsContext& context, const FloatRect&
     auto maxX = rect.maxX();
     auto minY = rect.y();
     auto maxY = rect.maxY();
-    auto midY = (minY + maxY) / 2.0;
+    auto midY = std::midpoint(minY, maxY);
 
     auto frameX = frameSize.width();
     auto frameY = frameSize.height();

--- a/Source/WebCore/rendering/svg/SVGMarkerData.h
+++ b/Source/WebCore/rendering/svg/SVGMarkerData.h
@@ -22,6 +22,7 @@
 #include "FloatConversion.h"
 #include "Path.h"
 #include <array>
+#include <numeric>
 
 namespace WebCore {
 
@@ -103,7 +104,7 @@ private:
             // WK193015: Prevent bugs due to angles being non-continuous.
             if (std::abs(inAngle - outAngle) > 180)
                 inAngle += 360;
-            return narrowPrecisionToFloat((inAngle + outAngle) / 2);
+            return narrowPrecisionToFloat(std::midpoint(inAngle, outAngle));
         case SVGMarkerType::End:
             return narrowPrecisionToFloat(inAngle);
         }


### PR DESCRIPTION
#### 30a3e3cfaedc4b922d05aedee20a4761efcf7d2d
<pre>
Use std::midpoint() in more WebCore code
<a href="https://bugs.webkit.org/show_bug.cgi?id=310949">https://bugs.webkit.org/show_bug.cgi?id=310949</a>
<a href="https://rdar.apple.com/173562239">rdar://173562239</a>

Reviewed by Chris Dumez.

Use C++20&apos;s std::midpoint() [1] in more places across WebCore to compute
midpoints. std::midpoint() is more expressive and avoids potential
overflow issues compared to manual calculations like (a + b) / 2,
(a + b) &gt;&gt; 1, or (a + b) * .5.

[1] <a href="https://en.cppreference.com/w/cpp/numeric/midpoint">https://en.cppreference.com/w/cpp/numeric/midpoint</a>

* Source/WebCore/platform/graphics/UnitBezier.h:
(WebCore::UnitBezier::solveCurveX):
* Source/WebCore/platform/graphics/opentype/OpenTypeTypes.h:
(WebCore::OpenType::TableWithCoverage::getCoverageIndex const):
* Source/WebCore/platform/graphics/skia/SkiaImageAtlasLayoutBuilder.cpp:
(WebCore::SkiaImageAtlasLayoutBuilder::findMaxPackableBatch):
* Source/WebCore/rendering/TextBoxPainter.cpp:
(WebCore::drawWritingToolsUnderline):
* Source/WebCore/rendering/svg/SVGMarkerData.h:
(WebCore::SVGMarkerData::currentAngle const):

Canonical link: <a href="https://commits.webkit.org/310153@main">https://commits.webkit.org/310153@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f90413ebcde45448603a62a391f2902092fc8df7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152825 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25607 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19205 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161569 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106281 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6ed2b344-fbed-4ce6-badb-52fa26fd268c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154698 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26134 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25912 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118101 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83635 "3 flakes 5 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e170c26c-7368-4723-8130-e23a240e414f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155784 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20346 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137198 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98814 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19406 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17345 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9405 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129058 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15072 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164043 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7179 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16666 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126163 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25404 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21384 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126321 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34286 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25406 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136868 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82010 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21270 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13647 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25022 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89309 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24714 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24873 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24774 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->