### PR TITLE
MediaElementAudioSourceNode should account for preservesPitch when resampling for playback rate

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6581,7 +6581,6 @@ imported/w3c/web-platform-tests/html/dom/render-blocking/remove-attr-unblocks-re
 imported/w3c/web-platform-tests/html/dom/self-origin.sub.html [ Skip ]
 imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-failure.https.html [ Skip ]
 imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/structured-cloning-error-extra.html [ Skip ]
-imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/preserves-pitch.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_navigation_download_allow_downloads.sub.tentative.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/delay-load-event-until-move-to-empty-source.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-move-into-script-disabled-iframe.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/preserves-pitch-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/preserves-pitch-expected.txt
@@ -6,6 +6,6 @@ PASS The default playbackRate should not affect pitch
 PASS The default playbackRate should not affect pitch, even with preservesPitch=false
 PASS Speed-ups should not change the pitch when preservesPitch=true
 PASS Slow-downs should not change the pitch when preservesPitch=true
-FAIL Speed-ups should change the pitch when preservesPitch=false assert_approx_equals: The actual pitch should be close to the expected pitch. expected 880 +/- 21.55425219941349 but got 452.63929618768327
-FAIL Slow-downs should change the pitch when preservesPitch=false assert_approx_equals: The actual pitch should be close to the expected pitch. expected 220 +/- 21.55425219941349 but got 0
+PASS Speed-ups should change the pitch when preservesPitch=false
+PASS Slow-downs should change the pitch when preservesPitch=false
 

--- a/Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.cpp
@@ -70,6 +70,7 @@ MediaElementAudioSourceNode::MediaElementAudioSourceNode(BaseAudioContext& conte
     : AudioNode(context, NodeTypeMediaElementAudioSource)
     , m_mediaElement(WTF::move(mediaElement))
     , m_playbackRate { abs(m_mediaElement->reportedPlaybackRate()) }
+    , m_preservesPitch { m_mediaElement->preservesPitch() }
 {
     // Default to stereo. This could change depending on what the media element .src is set to.
     addOutput(2);
@@ -127,10 +128,25 @@ void MediaElementAudioSourceNode::setPlaybackRate(double playbackRate)
     updateResamplerIfNeeded();
 }
 
+void MediaElementAudioSourceNode::setPreservesPitch(bool preservesPitch)
+{
+    if (preservesPitch == m_preservesPitch)
+        return;
+
+    Locker locker { m_processLock };
+    m_preservesPitch = preservesPitch;
+    updateResamplerIfNeeded();
+}
+
 void MediaElementAudioSourceNode::updateResamplerIfNeeded()
 {
-    // Account for both sample rate conversion and playback rate
-    double effectiveSampleRate = m_sourceSampleRate * m_playbackRate;
+    // Only factor in the playback rate when preservesPitch is false.
+    // The MTAudioProcessingTap captures audio before AVFoundation's
+    // time-pitch algorithm, so pitch shifting must be done here.
+    // When preservesPitch is true, the AudioContext should hear the
+    // original pitch regardless of playback rate.
+    double effectiveRate = m_preservesPitch ? 1.0 : m_playbackRate.load();
+    double effectiveSampleRate = m_sourceSampleRate * effectiveRate;
 
     if (effectiveSampleRate != sampleRate()) {
         double scaleFactor = effectiveSampleRate / sampleRate();

--- a/Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.h
+++ b/Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.h
@@ -57,6 +57,7 @@ public:
     // AudioSourceProviderClient
     void setFormat(size_t numberOfChannels, float sampleRate) final;
     void setPlaybackRate(double);
+    void setPreservesPitch(bool);
     void ref() const final { AudioNode::ref(); }
     void deref() const final { AudioNode::deref(); }
 
@@ -82,6 +83,7 @@ private:
     unsigned m_sourceNumberOfChannels WTF_GUARDED_BY_LOCK(m_processLock) { 0 };
     double m_sourceSampleRate WTF_GUARDED_BY_LOCK(m_processLock) { 0 };
     std::atomic<double> m_playbackRate { 1.0 };
+    std::atomic<bool> m_preservesPitch { true };
     bool m_muted WTF_GUARDED_BY_LOCK(m_processLock) { false };
 
     std::unique_ptr<MultiChannelResampler> m_multiChannelResampler WTF_GUARDED_BY_LOCK(m_processLock);

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -4377,6 +4377,11 @@ void HTMLMediaElement::setPreservesPitch(bool preservesPitch)
 
     m_preservesPitch = preservesPitch;
 
+#if ENABLE(WEB_AUDIO)
+    if (RefPtr audioSourceNode = m_audioSourceNode)
+        audioSourceNode->setPreservesPitch(preservesPitch);
+#endif
+
     if (!m_player)
         return;
 


### PR DESCRIPTION
#### 46cbc7d8b92c7a865fc3f60a13b347b2a76fc211
<pre>
MediaElementAudioSourceNode should account for preservesPitch when resampling for playback rate
<a href="https://bugs.webkit.org/show_bug.cgi?id=310951">https://bugs.webkit.org/show_bug.cgi?id=310951</a>
<a href="https://rdar.apple.com/173564158">rdar://173564158</a>

Reviewed by NOBODY (OOPS!).

The commit <a href="https://commits.webkit.org/310098@main">310098@main</a> added playback rate resampling in
MediaElementAudioSourceNode so that pitch shifts correctly when
preservesPitch=false and the element is connected to an AudioContext
via createMediaElementSource(). However, the resampling was applied
unconditionally, which also shifted pitch when preservesPitch=true.

The MTAudioProcessingTap captures decoded audio before AVFoundation&apos;s
time-pitch algorithm runs, so the AudioContext always receives the
original pitch. The resampler must therefore only apply the playback
rate factor when preservesPitch is false; when true, the user expects
the original pitch regardless of playback rate.

Add setPreservesPitch() to MediaElementAudioSourceNode and have
HTMLMediaElement notify it when the flag changes. In
updateResamplerIfNeeded(), use the playback rate as a resampling
factor only when preservesPitch is false.

With <a href="https://commits.webkit.org/310098@main">310098@main</a>, we progressed two subtests in `preserves-pitch.html`
WPT but regressed two as well (preservesPitch=true) cases. Now, this
patch fixes them and unskip whole test altogether.

* LayoutTests/TestExpectations: Unskip (if unskipped, it would have caught the issue before)
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/preserves-pitch-expected.txt:
* Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.cpp:
(WebCore::MediaElementAudioSourceNode::setPreservesPitch):
(WebCore::MediaElementAudioSourceNode::updateResamplerIfNeeded):
* Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::setPreservesPitch):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46cbc7d8b92c7a865fc3f60a13b347b2a76fc211

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152826 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25608 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19206 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161570 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106282 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154699 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26135 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25913 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118102 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/preserves-pitch.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83636 "9 flakes 5 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1faf9c6c-6a0d-4717-bb06-7f248a0e036c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155785 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20334 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137195 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98815 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bc5ddb89-b973-403e-bf46-c5046404ddf4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19409 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17346 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9406 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129061 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15069 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164044 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7180 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16663 "1 flakes") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126164 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/preserves-pitch.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25405 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21385 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126322 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25407 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136865 "Exiting early after 10 failures. 50 tests run. 1 flakes") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82011 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21275 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13644 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25023 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89310 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24715 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24874 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24775 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->