### PR TITLE
Resync `html/semantics/document-metadata/the-link-element` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -12567,6 +12567,7 @@
         "web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-change-href-ref.html",
         "web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-empty-href-ref.html",
         "web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-media-ref.html",
+        "web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-remove-href-ref.html",
         "web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-with-base-ref.html",
         "web-platform-tests/html/semantics/document-metadata/the-meta-element/pragma-directives/attr-meta-http-equiv-refresh/support/refresh.sub.html",
         "web-platform-tests/html/semantics/document-metadata/the-meta-element/pragma-directives/http-equiv-enumerated-ascii-case-insensitive-lower.html",

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/WEB_FEATURES.yml
@@ -1,0 +1,10 @@
+features:
+- name: link
+  files: "**"
+- name: base
+  files:
+  - stylesheet-empty-href.html
+  - stylesheet-with-base.html
+- name: fetch-priority
+  files:
+  - attr-link-fetchpriority.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/attr-link-fetchpriority-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/attr-link-fetchpriority-expected.txt
@@ -1,0 +1,4 @@
+
+PASS fetchpriority attribute on <link> elements should reflect valid IDL values
+PASS default fetchpriority attribute on <link> elements should be 'auto'
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/attr-link-fetchpriority.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/attr-link-fetchpriority.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<title>Fetch Priority - Link element</title>
+<meta name="author" title="Dominic Farolino" href="mailto:domfarolino@gmail.com">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<link id=link1 href=resources/stylesheet.css fetchpriority=high>
+<link id=link2 href=resources/stylesheet.css fetchpriority=low>
+<link id=link3 href=resources/stylesheet.css fetchpriority=auto>
+<link id=link4 href=resources/stylesheet.css fetchpriority=xyz>
+<link id=link5 href=resources/stylesheet.css>
+
+<script>
+  test(() => {
+    assert_equals(link1.fetchPriority, "high", "high fetchPriority is a valid IDL value on the link element");
+    assert_equals(link2.fetchPriority, "low", "low fetchPriority is a valid IDL value on the link element");
+    assert_equals(link3.fetchPriority, "auto", "auto fetchPriority is a valid IDL value on the link element");
+    assert_equals(link4.fetchPriority, "auto", "invalid fetchPriority reflects as 'auto' IDL attribute on the link element");
+    assert_equals(link5.fetchPriority, "auto", "missing fetchPriority reflects as 'auto' IDL attribute on the link element");
+  }, "fetchpriority attribute on <link> elements should reflect valid IDL values");
+
+  test(() => {
+    const link = document.createElement("link");
+    assert_equals(link.fetchPriority, "auto");
+  }, "default fetchpriority attribute on <link> elements should be 'auto'");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-href-attribute-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-href-attribute-crash.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<link rel=help href="https://github.com/servo/servo/issues/42477">
+<link id="link" href="does-not-exist-A.css">
+<script>
+  link.rel = "stylesheet";
+  link.href = "does-not-exist-B.css";
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-style-error-limited-quirks.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-style-error-limited-quirks.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//" "">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <title>link: error events in limited quirks mode</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-type-attribute-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-type-attribute-crash.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<link rel=help href="https://github.com/servo/servo/issues/42259">
+<link id="link" rel="stylesheet" href="data:text/css,div { background-color: green !important; }">
+<script>
+  link.type = "text/css";
+  link.type = "text/css";
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-media-change-no-fetch-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-media-change-no-fetch-expected.txt
@@ -1,0 +1,5 @@
+hello
+
+
+FAIL stylesheet should not re-fetch when media changes. The media change should apply immediately assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-media-change-no-fetch.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-media-change-no-fetch.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>stylesheet should not re-fetch when media changes. The media change should apply immediately</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/links.html#link-type-stylesheet">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#processing-the-media-attribute">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  p {
+    color: red;
+  }
+</style>
+<body></body>
+<script>
+  promise_test(async t => {
+    const link = document.createElement("link");
+    function waitForStylesheet() {
+      return new Promise(resolve => link.addEventListener("load", resolve, {once: true}));
+    }
+    link.media = "none";
+    link.rel = "stylesheet";
+    link.href = "resources/good.css";
+    const p = document.createElement("p");
+    p.textContent = "hello";
+    document.body.appendChild(p);
+    document.body.appendChild(link);
+    await waitForStylesheet();
+    assert_equals(getComputedStyle(p).color, "rgb(255, 0, 0)");
+    link.media = "all";
+    assert_equals(getComputedStyle(p).color, "rgb(0, 128, 0)");
+    const loaded = waitForStylesheet().then(() => "load");
+    const timeout = new Promise(resolve => t.step_timeout(() => resolve("timeout"), 100));
+    const result = await Promise.race([loaded, timeout]);
+    assert_equals(result, "timeout");
+  });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-remove-href-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-remove-href-expected.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<meta charset="utf-8">
+<style>
+  p {
+    color: green;
+  }
+</style>
+<p>This text should be green on a white background

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-remove-href-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-remove-href-ref.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<meta charset="utf-8">
+<style>
+  p {
+    color: green;
+  }
+</style>
+<p>This text should be green on a white background

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-remove-href.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-remove-href.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Removing href should remove previously applied styles</title>
+<link rel=match href=stylesheet-change-href-ref.html>
+<style>
+p {
+  color: green;
+}
+</style>
+<script>
+  function removeHref() {
+    var elem = document.getElementById('stylesheet');
+    elem.removeAttribute('href');
+    elem.onload = null;
+  }
+</script>
+<link id=stylesheet rel=stylesheet href="resources/bad.css" onload="removeHref()">
+<p>This text should be green on a white background

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/w3c-import.log
@@ -14,10 +14,13 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/all
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/all.headers
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/attr-link-fetchpriority.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/document-without-browsing-context.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-error-fired-before-scripting-unblocked.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-href-attribute-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-load-error-events.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-load-error-events.https.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-load-event.html
@@ -32,6 +35,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-style-error-01.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-style-error-limited-quirks.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-style-error-quirks.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-type-attribute-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-type-attribute-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-type-attribute-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-type-attribute.html
@@ -43,11 +47,15 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-empty-href-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-empty-href-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-empty-href.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-media-change-no-fetch.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-media-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-media-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-media.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-non-OK-status.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-not-removed-until-next-stylesheet-loads.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-remove-href-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-remove-href-ref.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-remove-href.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-with-base-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-with-base-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-with-base.html


### PR DESCRIPTION
#### 7daec9a5e95fff4425cdbb3fa10a7173bb8e914a
<pre>
Resync `html/semantics/document-metadata/the-link-element` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=310953">https://bugs.webkit.org/show_bug.cgi?id=310953</a>
<a href="https://rdar.apple.com/173566520">rdar://173566520</a>

Reviewed by Vitor Roriz and Brandon Stewart.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/066334c420e10623d0612177dbfae1db063efaad">https://github.com/web-platform-tests/wpt/commit/066334c420e10623d0612177dbfae1db063efaad</a>

* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/attr-link-fetchpriority-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/attr-link-fetchpriority.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-href-attribute-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-style-error-limited-quirks.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-type-attribute-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-media-change-no-fetch-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-media-change-no-fetch.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-remove-href-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-remove-href-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-remove-href.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/310147@main">https://commits.webkit.org/310147@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ffb11c4f37c12b1b36b11d77b3eefde811cac4b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152834 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25616 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19214 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161578 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8df16d0a-f20a-4088-85ff-4bd1b4198122) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26143 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25921 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118106 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ea6077f2-3450-47cb-a001-995751944ab4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155793 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20338 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137202 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98819 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/78145a37-fc21-4e60-a4dc-e4c1f2606f94) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19413 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9414 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129065 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15076 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164052 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16670 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126168 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25413 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21390 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126326 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34279 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25415 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136872 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82019 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21284 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13651 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25031 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24723 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24882 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24783 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->