### PR TITLE
Resync `html/semantics/document-metadata/the-style-element` from WPT Upstream

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -8353,3 +8353,6 @@ imported/w3c/web-platform-tests/css/css-text/line-breaking/segment-break-transfo
 imported/w3c/web-platform-tests/css/css-text/line-breaking/segment-break-transformation-punctuation-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-text/line-breaking/segment-break-transformation-punctuation-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-text/line-breaking/segment-break-transformation-punctuation-003.html [ ImageOnlyFailure ]
+
+imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/tentative/style-element-csp-allowed.html [ Skip ] # timeout
+imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/tentative/style-element-csp-blocked.html [ Skip ] # timeout - two subtests pass

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: style
+  files: "**"

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/non-parser-created-doc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/non-parser-created-doc-expected.txt
@@ -1,0 +1,3 @@
+
+PASS CSS API should work on non-parser-created documents
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/non-parser-created-doc.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/non-parser-created-doc.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>CSS API on style element in non-parser-created document</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <link rel=help href="https://bugzilla.mozilla.org/show_bug.cgi?id=1991800">
+  </head>
+  <body>
+    <script>
+      test(function() {
+        let doc = document.implementation.createHTMLDocument("");
+        let style = doc.createElement("style");
+        doc.head.appendChild(style)
+        assert_true(!!style.sheet, "The style element should have the sheet property.");
+      }, "CSS API should work on non-parser-created documents");
+    </script>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/style-load-mutate-while-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/style-load-mutate-while-parsing-expected.txt
@@ -1,0 +1,3 @@
+
+PASS The 'load' event on the style element should not fire for mutations while it's on the stack of open elements
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/style-load-mutate-while-parsing.xhtml
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/style-load-mutate-while-parsing.xhtml
@@ -1,0 +1,25 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>The 'load' event on the style element should not fire for mutations while it's on the stack of open elements</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <style>
+   body { background-color: transparent; }
+
+   <script>
+   window.t = async_test((t) => {
+     window.style = document.querySelector('style');
+     style.onload = t.unreached_func('load event fired for mutation');
+     style.append('body { color: inherit; }');
+   });
+   </script>
+
+   <script>
+   style.onload = t.step_func(() => {
+     t.done();
+   });
+   </script>
+  </style>
+ </head>
+ <body/>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/tentative/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/tentative/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: style
+  files: "**"

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/tentative/style-element-basic-import-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/tentative/style-element-basic-import-expected.txt
@@ -1,0 +1,5 @@
+Test content
+
+Harness Error (FAIL), message = TypeError: Import attribute type "css" is not valid
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/tentative/style-element-basic-import.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/tentative/style-element-basic-import.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<meta charset="utf-8" />
+<meta name="author" title="Kurt Catti-Schmidt" href="mailto:kschmi@microsoft.com" />
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element" />
+<link rel="help" href="https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/ShadowDOM/explainer.md" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style type="module" specifier="foo">
+    #test {color:blue}
+</style>
+
+<div id="test">Test content</div>
+
+<script type="module">
+  const test_element = document.getElementById("test");
+  assert_equals(getComputedStyle(test_element).color, "rgb(0, 0, 0)",
+    "Styles from the declarative module are not applied automatically.");
+  assert_equals(test_element.sheet, undefined, "The 'sheet' element is not exposed for declarative modules.");
+
+  import sheet from "foo" with { type: "css"};
+  test(function (t) {
+    assert_equals(
+      sheet.cssRules.length, 1,
+      "Declaratively defined rules were imported imperatively.",
+    );
+
+    document.adoptedStyleSheets = [sheet];
+    assert_equals(getComputedStyle(test_element).color, "rgb(0, 0, 255)",
+      "Declarative styles were applied.");
+
+  }, "CSS Modules can be defined declaratively.");
+</script>
+
+<style type="module" specifier="foo">
+    #test {color:red}
+</style>
+
+<script type="module">
+  import sheet from "foo" with { type: "css"};
+
+  test(function (t) {
+    assert_equals(
+      sheet.cssRules[0].cssText, "#test { color: blue; }",
+      "Only the first declarative <style> module with a given specififer is imported.",
+    );
+  }, "Duplicate specifiers.");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/tentative/style-element-csp-allowed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/tentative/style-element-csp-allowed.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8" />
+<meta name="author" title="Kurt Catti-Schmidt" href="mailto:kschmi@microsoft.com" />
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element" />
+<link rel="help" href="https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/ShadowDOM/explainer.md" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<meta http-equiv="Content-Security-Policy" content="style-src 'self' 'unsafe-inline' data: blob:;">
+
+<script>
+  const t1 = async_test("Test securitypolicyviolation event doesn't fire on Declarative CSS Module when allowed via CSP");
+  document.documentElement.addEventListener("securitypolicyviolation", t1.unreached_func("securitypolicyviolation error fired."));
+
+  const t2 = async_test("Test error event doesn't fire on Declarative CSS Module when allowed via CSP");
+</script>
+
+<style type="module" specifier="foo" onerror="t2.unreached_func('onerror fired');">
+    #test {color:blue}
+</style>
+
+</head>
+<body>
+
+<div id="test">Test content</div>
+
+<script type="module">
+  import sheet from "foo" with { type: "css"};
+
+  test(function (t) {
+    assert_equals(
+      sheet.cssRules.length,
+      1,
+      "Declaratively defined rules were imported with `unsafe-inline` CSP.",
+    );
+
+    document.adoptedStyleSheets = [sheet];
+    const test_element = document.getElementById("test");
+    assert_equals(getComputedStyle(test_element)
+              .color, "rgb(0, 0, 255)",
+              "Declarative styles were applied.");
+
+  }, "CSS Modules can be defined declaratively with `style-src` CSP set to `unsafe-inline` with the data protocol permitted.");
+  t1.done();
+  t2.done();
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/tentative/style-element-csp-blocked.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/tentative/style-element-csp-blocked.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8" />
+<meta name="author" title="Kurt Catti-Schmidt" href="mailto:kschmi@microsoft.com" />
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element" />
+<link rel="help" href="https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/ShadowDOM/explainer.md" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<meta http-equiv="Content-Security-Policy" content="style-src 'none';">
+
+<script>
+  async_test(function(t1) {
+    document.documentElement.addEventListener("securitypolicyviolation",
+      t1.done());
+  }, "securitypolicyviolation events should be fired for declarative style violations.");
+
+  const t2 = async_test("Test error event fires on inline style");
+</script>
+
+<style type="module" specifier="foo" onerror="t2.done();">
+    #test {color:blue}
+</style>
+
+</head>
+<body>
+
+<div id="test">Test content</div>
+
+<script type="module">
+  test(function (t) {
+    const test_element = document.getElementById("test");
+    assert_equals(getComputedStyle(test_element)
+              .color, "rgb(0, 0, 0)",
+              "Declarative styles were blocked via CSP.");
+
+  }, "style-src CSP can block Declarative CSS Modules.");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/tentative/style-element-fixed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/tentative/style-element-fixed-expected.txt
@@ -1,0 +1,5 @@
+Test content
+
+Harness Error (FAIL), message = TypeError: Import attribute type "css" is not valid
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/tentative/style-element-fixed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/tentative/style-element-fixed.html
@@ -1,0 +1,104 @@
+<!doctype html>
+<meta charset="utf-8" />
+<meta name="author" title="Kurt Catti-Schmidt" href="mailto:kschmi@microsoft.com" />
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element" />
+<link rel="help" href="https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/ShadowDOM/explainer.md" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style type="module" specifier="foo" id="style_element">
+    #test_element {color:blue}
+</style>
+
+<div id="test_element">Test content</div>
+
+<script type="module">
+  const test_element = document.getElementById("test_element");
+  import sheet from "foo" with { type: "css"};
+  document.adoptedStyleSheets = [sheet];
+
+  test(function (t) {
+    assert_equals(
+      sheet.cssRules.length, 1,
+      "Declaratively defined rules were imported imperatively.",
+    );
+
+    assert_equals(
+      getComputedStyle(test_element).color, "rgb(0, 0, 255)",
+      "Declarative styles were applied.");
+  }, "CSS Modules can be defined declaratively.");
+
+  test(function (t) {
+    test_element.setAttribute("specifier", "bar");
+    import('bar').then(module => {
+      assert_unreached("The declarative <style> element should not create new module entries when the specifier is changed, so the import should fail.");
+    }).catch(error => {
+      assert_equals(error.name, 'TypeError');
+    });
+  }, "The specifier mapping is fixed at initial parse time.");
+
+  // Validate that a module cannot be turned into a regular <style> element.
+  const style_element = document.getElementById("style_element");
+  test(function (t) {
+    style_element.innerText = "#test_element {color: red}";
+    assert_equals(getComputedStyle(test_element).color, "rgb(0, 0, 255)",
+      "The stylesheet generated when parsing declarative <style> modules does not change when the element's content is modified.");
+  }, "Declarative modules content is static at parse time.");
+
+  test(function (t) {
+    document.adoptedStyleSheets = [];
+    assert_equals(getComputedStyle(test_element).color, "rgb(0, 0, 0)",
+      "Styles from the declarative module are no longer applied after the stylesheet is removed from adoptedStyleSheets.");
+  }, "Removing the stylesheet from adoptedStyleSheets causes styles to no longer apply.");
+
+  test(function (t) {
+    style_element.removeAttribute("type");
+    assert_equals(getComputedStyle(test_element).color, "rgb(0, 0, 0)",
+      "The stylesheet generated from the declarative <style> module is not applied after the type attribute is removed.");
+  }, "Removing type=\"module\" does not turn the module into a regular <style> tag.");
+
+  test(function (t) {
+    style_element.removeAttribute("specifier");
+    assert_equals(getComputedStyle(test_element).color, "rgb(0, 0, 0)",
+      "The stylesheet generated from the declarative <style> module is not applied after the specifier attribute is removed.");
+
+    import('foo', { with: { type: "css" } }).then(module => {
+      assert_equals(module.default.cssRules[0].cssText, "#test_element { color: blue; }",);
+    }).catch(error => {
+      assert_unreached("The declarative <style> element should not create new module entries when the specifier is changed, so the import should still succeed.");
+    });
+  }, "Removing specifier does not turn the module into a regular <style> tag or impact the module map.");
+
+  test(function (t) {
+    document.head.removeChild(style_element);
+    document.head.appendChild(style_element);
+    assert_equals(getComputedStyle(test_element).color, "rgb(0, 0, 0)",
+      "The stylesheet generated from the declarative <style> module is not applied after the element is removed and re-inserted.");
+  }, "Removing and re-inserting the <style> module does not convert it into a regular <style> tag.");
+
+  // Verify that a non-module <style> element cannot be turned into a module by changing its attributes.
+  const new_style_element = document.createElement("style");
+  test(function (t) {
+    new_style_element.innerText = "#test_element {color: blue}";
+    document.head.appendChild(new_style_element);
+    assert_equals(getComputedStyle(test_element).color, "rgb(0, 0, 255)",
+      "The new style element's styles were applied to the test element.");
+
+    new_style_element.setAttribute("type", "module");
+    new_style_element.setAttribute("specifier", "bar");
+    import('bar', { with: { type: "css" } }).then(module => {
+      assert_unreached("The non-module <style> element should not be turned into a module, so the import should fail.");
+    }).catch(error => {
+      assert_equals(error.name, 'TypeError');
+    });
+
+    document.head.removeChild(new_style_element);
+    document.head.appendChild(new_style_element);
+    import('bar').then(module => {
+      assert_unreached("The non-module <style> element should not be turned into a module, so the import should fail.");
+    }).catch(error => {
+      assert_equals(error.name, 'TypeError');
+    });
+  }, "A non-module <style> element cannot be turned into a declarative module.");
+</script>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/tentative/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/tentative/w3c-import.log
@@ -1,0 +1,21 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/tentative/WEB_FEATURES.yml
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/tentative/style-element-basic-import.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/tentative/style-element-csp-allowed.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/tentative/style-element-csp-blocked.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/tentative/style-element-fixed.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/w3c-import.log
@@ -14,13 +14,16 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/historical.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/html_style_in_comment-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/html_style_in_comment-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/html_style_in_comment.xhtml
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/mutations.window.js
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/non-parser-created-doc.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/style-error-01.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/style-load-after-mutate.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/style-load-mutate-while-parsing.xhtml
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/style_disabled.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/style_events.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/style_load_async.html


### PR DESCRIPTION
#### aa51f2d8bdf6a12a59dff71a008a6e160b10a425
<pre>
Resync `html/semantics/document-metadata/the-style-element` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=310954">https://bugs.webkit.org/show_bug.cgi?id=310954</a>
<a href="https://rdar.apple.com/173567182">rdar://173567182</a>

Reviewed by Vitor Roriz and Brandon Stewart.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/066334c420e10623d0612177dbfae1db063efaad">https://github.com/web-platform-tests/wpt/commit/066334c420e10623d0612177dbfae1db063efaad</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/non-parser-created-doc-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/non-parser-created-doc.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/style-load-mutate-while-parsing-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/style-load-mutate-while-parsing.xhtml: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/tentative/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/tentative/style-element-basic-import-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/tentative/style-element-basic-import.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/tentative/style-element-csp-allowed.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/tentative/style-element-csp-blocked.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/tentative/style-element-fixed-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/tentative/style-element-fixed.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/tentative/w3c-import.log: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/310149@main">https://commits.webkit.org/310149@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3f5a102b55f776a6a7fa31013341776ab4dd9f6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152836 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25618 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19216 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161580 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fd3b5241-3ef5-4d5e-b68b-9571b24bcedd) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26145 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25923 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118107 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/45919f35-5d60-4e8d-bb31-5baafbb5696c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155795 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20339 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137204 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98820 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19414 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9416 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129066 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15078 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164054 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16672 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126169 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25415 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21392 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126327 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34280 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25417 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136874 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82021 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21281 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13653 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25033 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24725 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24884 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24785 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->