### PR TITLE
Text effect snapshot don't look correct.

### DIFF
--- a/Source/WebCore/dom/DocumentMarkerController.cpp
+++ b/Source/WebCore/dom/DocumentMarkerController.cpp
@@ -130,7 +130,7 @@ bool DocumentMarkerController::addMarker(const SimpleRange& range, DocumentMarke
 
 #if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
     if (needsTextEffect) {
-        RefPtr decorationIndicator = page->textEffectController().createTextIndicatorForRange(range);
+        RefPtr decorationIndicator = page->textEffectController().createTextIndicatorForRange(range, IncludeDocumentMarkers::Yes);
         page->textEffectController().addTextEffect(range, WTF::move(textIndicator), WTF::move(decorationIndicator));
         for (auto& textPiece : collectTextRanges(range))
             m_appliedGrammarTextEffectRanges.append(SimpleRange { BoundaryPoint { textPiece.node.copyRef(), textPiece.range.start }, BoundaryPoint { textPiece.node.copyRef(), textPiece.range.end } });

--- a/Source/WebCore/page/FrameSnapshotting.cpp
+++ b/Source/WebCore/page/FrameSnapshotting.cpp
@@ -114,6 +114,8 @@ RefPtr<ImageBuffer> snapshotFrameRectWithClip(LocalFrame& frame, const IntRect& 
         paintBehavior.add(PaintBehavior::FixedAndStickyLayersOnly);
     if (options.flags.contains(SnapshotFlags::DraggableElement))
         paintBehavior.add(PaintBehavior::DraggableSnapshot);
+    if (options.flags.contains(SnapshotFlags::IncludeDocumentMarkers))
+        paintBehavior.add(PaintBehavior::IncludeDocumentMarkers);
 
     // Other paint behaviors are set by paintContentsForSnapshot.
     frame.view()->setPaintBehavior(paintBehavior);

--- a/Source/WebCore/page/FrameSnapshotting.h
+++ b/Source/WebCore/page/FrameSnapshotting.h
@@ -59,6 +59,7 @@ enum class SnapshotFlags : uint16_t {
     ExcludeText                             = 1 << 11,
     FixedAndStickyLayersOnly                = 1 << 12,
     DraggableElement                        = 1 << 13,
+    IncludeDocumentMarkers                  = 1 << 14,
 };
 
 struct SnapshotOptions {

--- a/Source/WebCore/page/TextIndicator.cpp
+++ b/Source/WebCore/page/TextIndicator.cpp
@@ -215,6 +215,9 @@ static SnapshotOptions snapshotOptionsForTextIndicatorOptions(OptionSet<TextIndi
     if (options.contains(TextIndicatorOption::SnapshotContentAt3xBaseScale))
         snapshotOptions.flags.add(SnapshotFlags::PaintWith3xBaseScale);
 
+    if (options.contains(TextIndicatorOption::IncludeDocumentMarkers))
+        snapshotOptions.flags.add(SnapshotFlags::IncludeDocumentMarkers);
+
     return snapshotOptions;
 }
 

--- a/Source/WebCore/page/TextIndicator.h
+++ b/Source/WebCore/page/TextIndicator.h
@@ -127,6 +127,9 @@ enum class TextIndicatorOption : uint16_t {
 
     // If this option is set, perform the snapshot with 3x as the base scale, rather than the device scale factor
     SnapshotContentAt3xBaseScale = 1 << 14,
+
+    // Include document markers in the snapshot
+    IncludeDocumentMarkers = 1 << 15,
 };
 
 struct TextIndicatorData {

--- a/Source/WebCore/page/writing-tools/TextEffectController.h
+++ b/Source/WebCore/page/writing-tools/TextEffectController.h
@@ -43,6 +43,8 @@ class TextIndicator;
 
 struct SimpleRange;
 
+enum class IncludeDocumentMarkers : bool { No, Yes };
+
 class TextEffectController final {
     WTF_MAKE_TZONE_ALLOCATED(TextEffectController);
     WTF_MAKE_NONCOPYABLE(TextEffectController);
@@ -54,7 +56,7 @@ public:
     void removeTextEffect(const SimpleRange&);
     void removeAllTextEffects();
 
-    RefPtr<TextIndicator> createTextIndicatorForRange(const SimpleRange&);
+    RefPtr<TextIndicator> createTextIndicatorForRange(const SimpleRange&, IncludeDocumentMarkers = IncludeDocumentMarkers::No);
 
     WEBCORE_EXPORT void updateUnderlyingTextVisibilityForTextEffectID(const WTF::UUID&, bool visible, CompletionHandler<void()>&&);
     WEBCORE_EXPORT void createTextIndicatorForTextEffectID(const WTF::UUID&, CompletionHandler<void(RefPtr<TextIndicator>&&)>&&);

--- a/Source/WebCore/page/writing-tools/TextEffectController.mm
+++ b/Source/WebCore/page/writing-tools/TextEffectController.mm
@@ -137,14 +137,17 @@ std::optional<SimpleRange> TextEffectController::rangeForTextEffectID(const WTF:
     return std::nullopt;
 }
 
-RefPtr<TextIndicator> TextEffectController::createTextIndicatorForRange(const SimpleRange& range)
+RefPtr<TextIndicator> TextEffectController::createTextIndicatorForRange(const SimpleRange& range, IncludeDocumentMarkers includeDocumentMarkers)
 {
-    static constexpr OptionSet textIndicatorOptions {
+    OptionSet textIndicatorOptions {
         TextIndicatorOption::IncludeSnapshotOfAllVisibleContentWithoutSelection,
         TextIndicatorOption::ExpandClipBeyondVisibleRect,
         TextIndicatorOption::SkipReplacedContent,
         TextIndicatorOption::RespectTextColor,
     };
+
+    if (includeDocumentMarkers == IncludeDocumentMarkers::Yes)
+        textIndicatorOptions.add(TextIndicatorOption::IncludeDocumentMarkers);
 
     return TextIndicator::createWithRange(range, textIndicatorOptions, TextIndicatorPresentationTransition::None, { });
 }

--- a/Source/WebCore/rendering/PaintPhase.h
+++ b/Source/WebCore/rendering/PaintPhase.h
@@ -80,6 +80,7 @@ enum class PaintBehavior : uint32_t {
     FixedAndStickyLayersOnly                    = 1 << 21,
     DrawsHDRContent                             = 1 << 22,
     DraggableSnapshot                           = 1 << 23,
+    IncludeDocumentMarkers                      = 1 << 24,
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -3838,6 +3838,7 @@ void RenderLayer::paintLayerContents(GraphicsContext& context, const LayerPainti
             PaintBehavior::ExcludeText,
             PaintBehavior::FixedAndStickyLayersOnly,
             PaintBehavior::DrawsHDRContent,
+            PaintBehavior::IncludeDocumentMarkers,
         };
         OptionSet<PaintBehavior> paintBehavior = paintingInfo.paintBehavior & flagsToCopy;
 
@@ -6747,6 +6748,7 @@ TextStream& operator<<(TextStream& ts, PaintBehavior behavior)
     case PaintBehavior::FixedAndStickyLayersOnly: ts << "FixedAndStickyLayersOnly"_s; break;
     case PaintBehavior::DrawsHDRContent: ts << "DrawsHDRContent"_s; break;
     case PaintBehavior::DraggableSnapshot: ts << "DraggableSnapshot"_s; break;
+    case PaintBehavior::IncludeDocumentMarkers: ts << "IncludeDocumentMarkers"_s; break;
     }
 
     return ts;

--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -224,7 +224,7 @@ void TextBoxPainter::paint()
     if (m_paintInfo.paintBehavior.contains(PaintBehavior::ExcludeText))
         return;
 
-    if (m_paintInfo.phase == PaintPhase::Selection && !m_haveSelection)
+    if (m_paintInfo.phase == PaintPhase::Selection && !m_haveSelection && !m_paintInfo.paintBehavior.contains(PaintBehavior::IncludeDocumentMarkers))
         return;
 
     if (m_paintInfo.phase == PaintPhase::EventRegion) {
@@ -251,6 +251,9 @@ void TextBoxPainter::paint()
 
         return;
     }
+
+    if (m_paintInfo.phase == PaintPhase::Selection && m_paintInfo.paintBehavior.contains(PaintBehavior::IncludeDocumentMarkers))
+        paintPlatformDocumentMarkers();
 
     if (m_paintInfo.phase == PaintPhase::Foreground) {
         auto shouldPaintBackgroundFill = [&] {
@@ -1246,6 +1249,9 @@ static std::optional<MarkedText> NODELETE markedTextForTextDecorationLineGrammar
 
 void TextBoxPainter::paintPlatformDocumentMarkers()
 {
+    if (m_paintInfo.paintBehavior.contains(PaintBehavior::Snapshotting) && !m_paintInfo.paintBehavior.contains(PaintBehavior::IncludeDocumentMarkers))
+        return;
+
     auto markedTexts = MarkedText::collectForDocumentMarkers(m_renderer, m_selectableRange, MarkedText::PaintPhase::Decoration);
     // We want to paint text-decoration-line: spelling-error and grammar-error the same way we natively paint text marked with spelling errors
     auto textDecorationLineSpellingErrorAsMarkedText = markedTextForTextDecorationLineSpellingError(m_renderer);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -5891,6 +5891,7 @@ enum class WebCore::TextIndicatorPresentationTransition : uint8_t {
     UseUserSelectAllCommonAncestor,
     SkipReplacedContent,
     SnapshotContentAt3xBaseScale,
+    IncludeDocumentMarkers,
 };
 
 using WebCore::IDBConnectionIdentifier = WebCore::ProcessIdentifier;


### PR DESCRIPTION
#### f6b4b28047b31d983c5faebad27a7bb14db15e61
<pre>
Text effect snapshot don&apos;t look correct.
<a href="https://bugs.webkit.org/show_bug.cgi?id=310956">https://bugs.webkit.org/show_bug.cgi?id=310956</a>
<a href="https://rdar.apple.com/173568821">rdar://173568821</a>

Reviewed by Wenson Hsieh and Alan Baradlay.

The snapshot that was supposed to include
text decorations did not. We did not have
the plumbing to include the text decorations
in the snapshot. Add that plumbing and update
the painting to paint the decorations when needed.

* Source/WebCore/dom/DocumentMarkerController.cpp:
(WebCore::DocumentMarkerController::addMarker):
* Source/WebCore/page/FrameSnapshotting.cpp:
(WebCore::snapshotFrameRectWithClip):
* Source/WebCore/page/FrameSnapshotting.h:
* Source/WebCore/page/TextIndicator.cpp:
(WebCore::snapshotOptionsForTextIndicatorOptions):
* Source/WebCore/page/TextIndicator.h:
* Source/WebCore/page/writing-tools/TextEffectController.h:
* Source/WebCore/page/writing-tools/TextEffectController.mm:
(WebCore::TextEffectController::createTextIndicatorForRange):
* Source/WebCore/rendering/PaintPhase.h:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::paintLayerContents):
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/TextBoxPainter.cpp:
(WebCore::TextBoxPainter::paint):
(WebCore::TextBoxPainter::paintPlatformDocumentMarkers):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/310339@main">https://commits.webkit.org/310339@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ee3a81ff3778b75043c73251b1192fab02c113e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153533 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26317 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19918 "Failed to compile WebKit") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162282 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155406 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26844 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26639 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/118707 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/116aee28-8ed6-4e2f-99b8-e0eb5819313a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156492 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20954 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/137839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99418 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c0e26782-bd74-4076-a788-386c06cfdbe2) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/20033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10116 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/129680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/15709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164754 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/7888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/17303 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/126775 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26114 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/22012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/126940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34423 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26116 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137505 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82784 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/21862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/14285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25733 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90020 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25424 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25584 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25484 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->