### PR TITLE
Fix scanEscapedAttributeValue() in HTML fast path parser only processing one character

### DIFF
--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
@@ -845,19 +845,21 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
             return didFail(HTMLFastPathResult::FailedParsingUnquotedEscapedAttributeValue, emptyAtom());
 
         auto quoteChar = m_parsingBuffer.consume();
-        if (m_parsingBuffer.hasCharactersRemaining() && *m_parsingBuffer != quoteChar) {
+        while (m_parsingBuffer.hasCharactersRemaining() && *m_parsingBuffer != quoteChar) {
             if (parsingFailed())
                 return emptyAtom();
             auto c = *m_parsingBuffer;
             if (c == '&')
-                scanHTMLCharacterReference(m_ucharBuffer);
+                scanHTMLCharacterReference(m_ucharBuffer, quoteChar);
             else if (c == '\r') {
                 m_parsingBuffer.advance();
                 // Normalize "\r\n" to "\n" according to https://infra.spec.whatwg.org/#normalize-newlines.
                 if (m_parsingBuffer.hasCharactersRemaining() && *m_parsingBuffer == '\n')
                     m_parsingBuffer.advance();
                 m_ucharBuffer.append('\n');
-            } else {
+            } else if (c == '\0') [[unlikely]]
+                return didFail(HTMLFastPathResult::FailedContainsNull, emptyAtom());
+            else {
                 m_ucharBuffer.append(c);
                 m_parsingBuffer.advance();
             }
@@ -868,13 +870,13 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         return HTMLNameCache::makeAttributeValue(m_ucharBuffer.span());
     }
 
-    void scanHTMLCharacterReference(Vector<char16_t>& out)
+    void scanHTMLCharacterReference(Vector<char16_t>& out, char16_t additionalAllowedCharacter = 0)
     {
         ASSERT(*m_parsingBuffer == '&');
         m_parsingBuffer.advance();
 
         if (m_parsingBuffer.lengthRemaining() >= 2) [[likely]] {
-            if (auto entity = consumeHTMLEntity(m_parsingBuffer); !entity.failed()) {
+            if (auto entity = consumeHTMLEntity(m_parsingBuffer, additionalAllowedCharacter); !entity.failed()) {
                 out.append(entity.span());
                 return;
             }

--- a/Source/WebCore/html/parser/HTMLEntityParser.cpp
+++ b/Source/WebCore/html/parser/HTMLEntityParser.cpp
@@ -281,14 +281,14 @@ DecodedHTMLEntity consumeHTMLEntity(SegmentedString& source, char16_t additional
     return consumeHTMLEntity(SegmentedStringSource { source }, additionalAllowedCharacter);
 }
 
-DecodedHTMLEntity consumeHTMLEntity(StringParsingBuffer<Latin1Character>& source)
+DecodedHTMLEntity consumeHTMLEntity(StringParsingBuffer<Latin1Character>& source, char16_t additionalAllowedCharacter)
 {
-    return consumeHTMLEntity(StringParsingBufferSource<Latin1Character> { source }, 0);
+    return consumeHTMLEntity(StringParsingBufferSource<Latin1Character> { source }, additionalAllowedCharacter);
 }
 
-DecodedHTMLEntity consumeHTMLEntity(StringParsingBuffer<char16_t>& source)
+DecodedHTMLEntity consumeHTMLEntity(StringParsingBuffer<char16_t>& source, char16_t additionalAllowedCharacter)
 {
-    return consumeHTMLEntity(StringParsingBufferSource<char16_t> { source }, 0);
+    return consumeHTMLEntity(StringParsingBufferSource<char16_t> { source }, additionalAllowedCharacter);
 }
 
 DecodedHTMLEntity decodeNamedHTMLEntityForXMLParser(const char* name)

--- a/Source/WebCore/html/parser/HTMLEntityParser.h
+++ b/Source/WebCore/html/parser/HTMLEntityParser.h
@@ -41,8 +41,8 @@ class SegmentedString;
 DecodedHTMLEntity consumeHTMLEntity(SegmentedString&, char16_t additionalAllowedCharacter = 0);
 
 // This function assumes the source is complete, and does not expect a null character.
-DecodedHTMLEntity consumeHTMLEntity(StringParsingBuffer<Latin1Character>&);
-DecodedHTMLEntity consumeHTMLEntity(StringParsingBuffer<char16_t>&);
+DecodedHTMLEntity consumeHTMLEntity(StringParsingBuffer<Latin1Character>&, char16_t additionalAllowedCharacter = 0);
+DecodedHTMLEntity consumeHTMLEntity(StringParsingBuffer<char16_t>&, char16_t additionalAllowedCharacter = 0);
 
 // This function does not check for "not enough characters" at all.
 DecodedHTMLEntity decodeNamedHTMLEntityForXMLParser(const char*);

--- a/Tools/TestWebKitAPI/Tests/WebCore/HTMLParserIdioms.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/HTMLParserIdioms.cpp
@@ -27,6 +27,7 @@
 
 #include "Test.h"
 #include <WebCore/DocumentFragment.h>
+#include <WebCore/Element.h>
 #include <WebCore/ExceptionOr.h>
 #include <WebCore/HTMLBodyElement.h>
 #include <WebCore/HTMLDivElement.h>
@@ -34,6 +35,7 @@
 #include <WebCore/HTMLDocumentParserFastPath.h>
 #include <WebCore/HTMLHtmlElement.h>
 #include <WebCore/HTMLInputElement.h>
+#include <WebCore/HTMLNames.h>
 #include <WebCore/HTMLParserIdioms.h>
 #include <WebCore/NodeInlines.h>
 #include <WebCore/ParserContentPolicy.h>
@@ -424,6 +426,116 @@ TEST(WebCoreHTMLParser, FastPathAttributeNameWithUnderscore)
     auto fragment = DocumentFragment::create(document);
     bool result = tryFastParsingHTMLFragment("<span data_value=\"test\"></span>"_s, document, fragment, div, { ParserContentPolicy::AllowScriptingContent });
     EXPECT_TRUE(result);
+}
+
+TEST(WebCoreHTMLParser, FastPathEscapedAttributeValues)
+{
+    ProcessWarming::initializeNames();
+
+    auto settings = Settings::create(nullptr);
+    auto document = HTMLDocument::create(nullptr, settings.get(), aboutBlankURL());
+    auto documentElement = HTMLHtmlElement::create(document);
+    document->appendChild(documentElement);
+    auto body = HTMLBodyElement::create(document);
+    documentElement->appendChild(body);
+
+    auto div = HTMLDivElement::create(document);
+    document->body()->appendChild(div);
+
+    auto testFastParserAttribute = [&](const String& input) -> String {
+        auto fragment = DocumentFragment::create(document);
+        bool result = tryFastParsingHTMLFragment(input, document, fragment, div, { ParserContentPolicy::AllowScriptingContent });
+        EXPECT_TRUE(result);
+        if (!result)
+            return String();
+        auto* element = dynamicDowncast<Element>(fragment->firstChild());
+        EXPECT_TRUE(element);
+        return element ? element->getAttribute(HTMLNames::titleAttr) : String();
+    };
+
+    // Single entity (this works today).
+    EXPECT_STREQ("&", testFastParserAttribute("<span title=\"&amp;\"></span>"_s).utf8().data());
+
+    // Entity followed by more text — exercises the missing while loop in scanEscapedAttributeValue().
+    EXPECT_STREQ("&b", testFastParserAttribute("<span title=\"&amp;b\"></span>"_s).utf8().data());
+
+    // Text before and after an entity.
+    EXPECT_STREQ("a&b", testFastParserAttribute("<span title=\"a&amp;b\"></span>"_s).utf8().data());
+
+    // Multiple entities in a single attribute value.
+    EXPECT_STREQ("<&>", testFastParserAttribute("<span title=\"&lt;&amp;&gt;\"></span>"_s).utf8().data());
+
+    // Entity with trailing text and single-quote delimiter.
+    EXPECT_STREQ("a&b", testFastParserAttribute("<span title='a&amp;b'></span>"_s).utf8().data());
+}
+
+TEST(WebCoreHTMLParser, FastPathRejectsNullInEscapedAttributeValue)
+{
+    ProcessWarming::initializeNames();
+
+    auto settings = Settings::create(nullptr);
+    auto document = HTMLDocument::create(nullptr, settings.get(), aboutBlankURL());
+    auto documentElement = HTMLHtmlElement::create(document);
+    document->appendChild(documentElement);
+    auto body = HTMLBodyElement::create(document);
+    documentElement->appendChild(body);
+
+    auto div = HTMLDivElement::create(document);
+    document->body()->appendChild(div);
+
+    // A \0 after an entity reaches scanEscapedAttributeValue's loop body.
+    // The entity forces the SIMD fast scan to hand off to the escaped path,
+    // and the \0 must be rejected there.
+    auto fragment = DocumentFragment::create(document);
+    bool result = tryFastParsingHTMLFragment("<span title=\"&amp;\0\"></span>"_s, document, fragment, div, { ParserContentPolicy::AllowScriptingContent });
+    EXPECT_FALSE(result);
+}
+
+TEST(WebCoreHTMLParser, FastPathEntityWithoutSemicolonInAttributeValue)
+{
+    ProcessWarming::initializeNames();
+
+    auto settings = Settings::create(nullptr);
+    auto document = HTMLDocument::create(nullptr, settings.get(), aboutBlankURL());
+    auto documentElement = HTMLHtmlElement::create(document);
+    document->appendChild(documentElement);
+    auto body = HTMLBodyElement::create(document);
+    documentElement->appendChild(body);
+
+    auto div = HTMLDivElement::create(document);
+    document->body()->appendChild(div);
+
+    auto testFastParserAttribute = [&](const String& input) -> String {
+        auto fragment = DocumentFragment::create(document);
+        bool result = tryFastParsingHTMLFragment(input, document, fragment, div, { ParserContentPolicy::AllowScriptingContent });
+        EXPECT_TRUE(result);
+        if (!result)
+            return String();
+        auto* element = dynamicDowncast<Element>(fragment->firstChild());
+        EXPECT_TRUE(element);
+        return element ? element->getAttribute(HTMLNames::titleAttr) : String();
+    };
+
+    // Per the HTML spec, named entities without a trailing semicolon followed by
+    // an alphanumeric character must NOT be consumed in attribute values.
+    // e.g. &ampX in an attribute should remain as literal "&ampX", not become "&X".
+    EXPECT_STREQ("&ampX", testFastParserAttribute("<span title=\"&ampX\"></span>"_s).utf8().data());
+    EXPECT_STREQ("&ampX", testFastParserAttribute("<span title='&ampX'></span>"_s).utf8().data());
+
+    // Entity without semicolon followed by '=' should also not be consumed.
+    EXPECT_STREQ("&amp=1", testFastParserAttribute("<span title=\"&amp=1\"></span>"_s).utf8().data());
+
+    // Entity WITH semicolon followed by alphanumeric should still be consumed.
+    EXPECT_STREQ("&X", testFastParserAttribute("<span title=\"&amp;X\"></span>"_s).utf8().data());
+
+    // Entity without semicolon NOT followed by alphanumeric should be consumed.
+    EXPECT_STREQ("& ", testFastParserAttribute("<span title=\"&amp \"></span>"_s).utf8().data());
+
+    // Named entity without semicolon (e.g. &AElig followed by alphanumeric).
+    EXPECT_STREQ("&AEligX", testFastParserAttribute("<span title=\"&AEligX\"></span>"_s).utf8().data());
+
+    // Named entity with semicolon (e.g. &AElig; followed by text).
+    EXPECT_STREQ("\xC3\x86X", testFastParserAttribute("<span title=\"&AElig;X\"></span>"_s).utf8().data());
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### adb5daa54873a149d9a2a74f304801788e444778
<pre>
Fix scanEscapedAttributeValue() in HTML fast path parser only processing one character
<a href="https://bugs.webkit.org/show_bug.cgi?id=310960">https://bugs.webkit.org/show_bug.cgi?id=310960</a>

Reviewed by Ryosuke Niwa.

`scanEscapedAttributeValue()` used an `if` instead of a `while` to iterate
over characters in the attribute value. This caused it to process only a
single character or entity reference, then immediately expect the closing
quote. Any attribute value with more than one special character or with
text surrounding an entity (e.g. title=&quot;a&amp;amp;b&quot;) would fail to parse,
causing an unnecessary fallback to the slow HTML parser.

Also added a missing null byte check in the loop body, matching the
existing check in the analogous `scanEscapedText()`.

Also plumbed the `additionalAllowedCharacter` parameter through to
`consumeHTMLEntity()` for `StringParsingBuffer` overloads, and passed
the quote character from `scanEscapedAttributeValue()`. Per the HTML
spec, named character references without a trailing semicolon that are
followed by an alphanumeric character or `=` must not be consumed in
attribute values. Without this, the fast path would incorrectly consume
entities like `&amp;AElig` followed by `X` in attributes, producing output
that differs from the full parser. This was caught by the
fast/tokenizer/entities-02.html test after I fixed the HTML fast
parser bug in `scanEscapedAttributeValue()`.

Test: Tools/TestWebKitAPI/Tests/WebCore/HTMLParserIdioms.cpp

* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(WebCore::HTMLFastPathParser::scanEscapedAttributeValue):
(WebCore::HTMLFastPathParser::scanHTMLCharacterReference):
* Source/WebCore/html/parser/HTMLEntityParser.cpp:
(WebCore::consumeHTMLEntity):
* Source/WebCore/html/parser/HTMLEntityParser.h:
* Tools/TestWebKitAPI/Tests/WebCore/HTMLParserIdioms.cpp:
(TestWebKitAPI::TEST(WebCoreHTMLParser, FastPathEscapedAttributeValues)):
(TestWebKitAPI::TEST(WebCoreHTMLParser, FastPathRejectsNullInEscapedAttributeValue)):
(TestWebKitAPI::TEST(WebCoreHTMLParser, FastPathEntityWithoutSemicolonInAttributeValue)):

Canonical link: <a href="https://commits.webkit.org/310209@main">https://commits.webkit.org/310209@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b109a79d3d95ccd9e220fdfba451141ecfbaef57

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152969 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25751 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19349 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161713 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106425 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154842 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26278 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26056 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118230 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83710 "7 flakes 5 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155928 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20462 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137328 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98943 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19536 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17474 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9549 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129189 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15202 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164187 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7323 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16796 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126292 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25548 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21514 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126450 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34331 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25550 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136998 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82174 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21399 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13777 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25166 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89453 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24858 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25017 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24918 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->