### PR TITLE
Allow underscore in attribute names in the HTML fast path parser

### DIFF
--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
@@ -239,7 +239,7 @@ template<typename CharacterType> static inline bool NODELETE isValidAttributeNam
 {
     if (character == '=') // Early return for the most common way to end an attribute.
         return false;
-    return isASCIIAlphanumeric(character) || character == '-';
+    return isASCIIAlphanumeric(character) || character == '-' || character == '_';
 }
 
 template<typename CharacterType> static inline bool NODELETE isCharAfterTagNameOrAttribute(CharacterType character)

--- a/Tools/TestWebKitAPI/Tests/WebCore/HTMLParserIdioms.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/HTMLParserIdioms.cpp
@@ -405,4 +405,25 @@ TEST(WebCoreHTMLParser, FastPathFailsWithNestedLi)
     EXPECT_FALSE(result);
 }
 
+TEST(WebCoreHTMLParser, FastPathAttributeNameWithUnderscore)
+{
+    ProcessWarming::initializeNames();
+
+    auto settings = Settings::create(nullptr);
+    auto document = HTMLDocument::create(nullptr, settings.get(), aboutBlankURL());
+    auto documentElement = HTMLHtmlElement::create(document);
+    document->appendChild(documentElement);
+    auto body = HTMLBodyElement::create(document);
+    documentElement->appendChild(body);
+
+    auto div = HTMLDivElement::create(document);
+    document->body()->appendChild(div);
+
+    // Underscore is valid in HTML attribute names but isValidAttributeNameChar() rejects it,
+    // causing an unnecessary fallback to the slow parser.
+    auto fragment = DocumentFragment::create(document);
+    bool result = tryFastParsingHTMLFragment("<span data_value=\"test\"></span>"_s, document, fragment, div, { ParserContentPolicy::AllowScriptingContent });
+    EXPECT_TRUE(result);
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 49049c9b57fd89ca87f478dd8e01324bb6f32389
<pre>
Allow underscore in attribute names in the HTML fast path parser
<a href="https://bugs.webkit.org/show_bug.cgi?id=310961">https://bugs.webkit.org/show_bug.cgi?id=310961</a>

Reviewed by Anne van Kesteren.

isValidAttributeNameChar() only accepted alphanumeric characters and &apos;-&apos;,
rejecting &apos;_&apos; which is valid per the HTML spec. This caused unnecessary
fallback to the slow parser for attributes like data_value=&quot;...&quot;.

Test: Tools/TestWebKitAPI/Tests/WebCore/HTMLParserIdioms.cpp

* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(WebCore::isValidAttributeNameChar):
* Tools/TestWebKitAPI/Tests/WebCore/HTMLParserIdioms.cpp:
(TestWebKitAPI::TEST(WebCoreHTMLParser, FastPathAttributeNameWithUnderscore)):

Canonical link: <a href="https://commits.webkit.org/310152@main">https://commits.webkit.org/310152@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d44ec0409f1dbd42f236a4f8d76ffae7e29907c1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152850 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25632 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19230 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161594 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e7399450-fffa-4634-89dd-9cb50b9cc854) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154723 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26159 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25937 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118119 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0b32d4f8-0f7c-4186-888b-93061299f643) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155809 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20356 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137213 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98832 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2a25f59d-00b2-431e-a937-56fbb4438406) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19430 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9430 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129082 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15087 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164068 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7204 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16681 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126181 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25429 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21409 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126339 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34284 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25431 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136883 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82035 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21292 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13662 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25047 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89334 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24739 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24898 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24799 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->