### PR TITLE
[css-anchor-position-1] Interpret position-try-order logical axis using the containing block's writing mode

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7764,7 +7764,6 @@ imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-nested-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/container-queries/anchored-fallback-color-change.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/container-queries/anchored-fallback-style-containment.html [ ImageOnlyFailure ]
-webkit.org/b/306830 imported/w3c/web-platform-tests/css/css-anchor-position/position-try-order-logical.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-with-position-002.html
 imported/w3c/web-platform-tests/css/css-anchor-position/position-area-overflow-icb-001.html [ ImageOnlyFailure ]
 

--- a/Source/WebCore/rendering/style/PositionTryOrder.cpp
+++ b/Source/WebCore/rendering/style/PositionTryOrder.cpp
@@ -29,20 +29,26 @@
 namespace WebCore {
 namespace Style {
 
-LogicalBoxAxis boxAxisForPositionTryOrder(PositionTryOrder order, WritingMode writingMode)
+LogicalBoxAxis selfAxisForPositionTryOrder(PositionTryOrder order, WritingMode selfWritingMode, WritingMode containingBlockWritingMode)
 {
+    bool shouldFlipLogicalAxis = selfWritingMode.isOrthogonal(containingBlockWritingMode);
+
     switch (order) {
     case PositionTryOrder::MostWidth:
-        return mapAxisPhysicalToLogical(writingMode, BoxAxis::Horizontal);
+        return mapAxisPhysicalToLogical(selfWritingMode, BoxAxis::Horizontal);
     case PositionTryOrder::MostHeight:
-        return mapAxisPhysicalToLogical(writingMode, BoxAxis::Vertical);
+        return mapAxisPhysicalToLogical(selfWritingMode, BoxAxis::Vertical);
+
+    // "Logical directions are resolved against the writing mode of the containing block."
     case PositionTryOrder::MostBlockSize:
-        return LogicalBoxAxis::Block;
+        return !shouldFlipLogicalAxis ? LogicalBoxAxis::Block : LogicalBoxAxis::Inline;
     case PositionTryOrder::MostInlineSize:
-        return LogicalBoxAxis::Inline;
+        return !shouldFlipLogicalAxis ? LogicalBoxAxis::Inline : LogicalBoxAxis::Block;
+
     case PositionTryOrder::Normal:
         break;
     }
+
     ASSERT_NOT_REACHED();
     return LogicalBoxAxis::Inline;
 }

--- a/Source/WebCore/rendering/style/PositionTryOrder.h
+++ b/Source/WebCore/rendering/style/PositionTryOrder.h
@@ -39,7 +39,7 @@ enum class PositionTryOrder : uint8_t {
     MostInlineSize
 };
 
-LogicalBoxAxis NODELETE boxAxisForPositionTryOrder(PositionTryOrder, WritingMode);
+LogicalBoxAxis NODELETE selfAxisForPositionTryOrder(PositionTryOrder, WritingMode selfWritingMode, WritingMode containingBlockWritingMode);
 
 WTF::TextStream& operator<<(WTF::TextStream&, PositionTryOrder);
 

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -1713,7 +1713,7 @@ void TreeResolver::sortPositionOptionsIfNeeded(PositionOptions& options, const S
         // "For each entry in the position options list, apply that position option to the box, and find
         // the specified inset-modified containing block size that results from those styles."
         // https://drafts.csswg.org/css-anchor-position-1/#position-try-order-property
-        auto boxAxis = boxAxisForPositionTryOrder(order, options.originalStyle().writingMode());
+        auto boxAxis = selfAxisForPositionTryOrder(order, box->style().writingMode(), box->container()->style().writingMode());
 
         struct SortingOption {
             PositionOption option;


### PR DESCRIPTION
#### 121963fe307487a6d7d2cdb6a124f22c322a6e98
<pre>
[css-anchor-position-1] Interpret position-try-order logical axis using the containing block&apos;s writing mode
<a href="https://rdar.apple.com/169501069">rdar://169501069</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=306830">https://bugs.webkit.org/show_bug.cgi?id=306830</a>

Reviewed by Elika Etemad.

CSSWG resolves [1] that position-try-fallbacks tactic keywords and position-try-order
should be interpreted using the containing block&apos;s writing mode. This patch implements
this new behavior for position-try-order.

[1]: <a href="https://github.com/w3c/csswg-drafts/issues/12869#issuecomment-3406959070">https://github.com/w3c/csswg-drafts/issues/12869#issuecomment-3406959070</a>

Test: imported/w3c/web-platform-tests/css/css-anchor-position/position-try-order-logical.html

* LayoutTests/TestExpectations:
* Source/WebCore/rendering/style/PositionTryOrder.cpp:
(WebCore::Style::selfAxisForPositionTryOrder):
(WebCore::Style::boxAxisForPositionTryOrder): Deleted.
* Source/WebCore/rendering/style/PositionTryOrder.h:
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::sortPositionOptionsIfNeeded):

Canonical link: <a href="https://commits.webkit.org/310277@main">https://commits.webkit.org/310277@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab73e2ed4eb6c2a4916390148406786b2b7338e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153263 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26047 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19645 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162008 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106721 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/63a66d03-8f04-4748-ac16-73c565c80d9c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155136 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26573 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26350 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118491 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/36cc2c6b-fabe-4849-b0e4-d6382b3f8f9f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156222 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20738 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137603 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99204 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19815 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17756 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9843 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129462 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15473 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164482 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7617 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17067 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126550 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25842 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21789 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/semantics/structured-clone/shared.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126708 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34384 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25844 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137268 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82513 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21655 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14047 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25462 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89747 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25153 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25312 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25214 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->