### PR TITLE
Reduce code duplication in the HTML faster parser

### DIFF
--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
@@ -602,6 +602,30 @@ private:
             didFail(HTMLFastPathResult::FailedDidntReachEndOfInput);
     }
 
+    // Shared SIMD helper: given a low-nibble lookup table (as a vectorEquals8Bit
+    // callable) and a scalar fallback, find the first special character in |span|.
+    // https://lemire.me/blog/2024/06/08/scan-html-faster-with-simd-instructions-chrome-edition/
+    template<typename VectorEquals8BitFunction, typename ScalarMatchFunction>
+    ALWAYS_INLINE static std::span<const CharacterType> findSpecialCharacter(std::span<const CharacterType> span, VectorEquals8BitFunction&& vectorEquals8Bit, ScalarMatchFunction&& scalarMatch)
+    {
+        if constexpr (sizeof(CharacterType) == 1) {
+            auto vectorMatch = [&](auto input) ALWAYS_INLINE_LAMBDA {
+                return SIMD::findFirstNonZeroIndex(vectorEquals8Bit(input));
+            };
+            auto* it = SIMD::find(span, vectorMatch, scalarMatch);
+            return span.subspan(it - span.data());
+        } else {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+            auto vectorMatch = [&](auto input) ALWAYS_INLINE_LAMBDA {
+                constexpr simde_uint8x16_t zeros = SIMD::splat8(0);
+                return SIMD::findFirstNonZeroIndex(SIMD::bitAnd(vectorEquals8Bit(input.val[0]), SIMD::equal(input.val[1], zeros)));
+            };
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+            auto* it = SIMD::findInterleaved(span, vectorMatch, scalarMatch);
+            return span.subspan(it - span.data());
+        }
+    }
+
     // We first try to scan text as an unmodified subsequence of the input.
     // However, if there are escape sequences, we have to copy the text to a
     // separate buffer and we might go outside of `Char` range if we are in an
@@ -627,7 +651,6 @@ private:
         };
 
         auto vectorEquals8Bit = [&](auto input) ALWAYS_INLINE_LAMBDA {
-            // https://lemire.me/blog/2024/06/08/scan-html-faster-with-simd-instructions-chrome-edition/
             // By looking up the table via lower 4bit, we can identify the category.
             // '\0' => 0000 0000
             // '&'  => 0010 0110
@@ -638,23 +661,7 @@ private:
             return SIMD::equal(simde_vqtbl1q_u8(lowNibbleMask, SIMD::bitAnd(input, v0f)), input);
         };
 
-        std::span<const CharacterType> cursor;
-        if constexpr (sizeof(CharacterType) == 1) {
-            auto vectorMatch = [&](auto input) ALWAYS_INLINE_LAMBDA {
-                return SIMD::findFirstNonZeroIndex(vectorEquals8Bit(input));
-            };
-            auto* it = SIMD::find(start, vectorMatch, scalarMatch);
-            cursor = start.subspan(it - start.data());
-        } else {
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-            auto vectorMatch = [&](auto input) ALWAYS_INLINE_LAMBDA {
-                constexpr simde_uint8x16_t zeros = SIMD::splat8(0);
-                return SIMD::findFirstNonZeroIndex(SIMD::bitAnd(vectorEquals8Bit(input.val[0]), SIMD::equal(input.val[1], zeros)));
-            };
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-            auto* it = SIMD::findInterleaved(start, vectorMatch, scalarMatch);
-            cursor = start.subspan(it - start.data());
-        }
+        auto cursor = findSpecialCharacter(start, vectorEquals8Bit, scalarMatch);
         m_parsingBuffer.setPosition(cursor);
 
         if (!cursor.empty()) {
@@ -785,7 +792,6 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
                 };
 
                 auto vectorEquals8Bit = [&](auto input) ALWAYS_INLINE_LAMBDA {
-                    // https://lemire.me/blog/2024/06/08/scan-html-faster-with-simd-instructions-chrome-edition/
                     // By looking up the table via lower 4bit, we can identify the category.
                     // '\0' => 0000 0000
                     // '&'  => 0010 0110
@@ -803,22 +809,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
                     return SIMD::equal(simde_vqtbl1q_u8(lowNibbleMask, SIMD::bitAnd(input, v0f)), input);
                 };
 
-                if constexpr (sizeof(CharacterType) == 1) {
-                    auto vectorMatch = [&](auto input) ALWAYS_INLINE_LAMBDA {
-                        return SIMD::findFirstNonZeroIndex(vectorEquals8Bit(input));
-                    };
-                    auto* it = SIMD::find(span, vectorMatch, scalarMatch);
-                    return span.subspan(it - span.data());
-                } else {
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-                    auto vectorMatch = [&](auto input) ALWAYS_INLINE_LAMBDA {
-                        constexpr simde_uint8x16_t zeros = SIMD::splat8(0);
-                        return SIMD::findFirstNonZeroIndex(SIMD::bitAnd(vectorEquals8Bit(input.val[0]), SIMD::equal(input.val[1], zeros)));
-                    };
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-                    auto* it = SIMD::findInterleaved(span, vectorMatch, scalarMatch);
-                    return span.subspan(it - span.data());
-                }
+                return findSpecialCharacter(span, vectorEquals8Bit, scalarMatch);
             };
 
             start = m_parsingBuffer.span();


### PR DESCRIPTION
#### 35d6c4c6661025eaff3aea0de80d101b9536ea1f
<pre>
Reduce code duplication in the HTML faster parser
<a href="https://bugs.webkit.org/show_bug.cgi?id=310962">https://bugs.webkit.org/show_bug.cgi?id=310962</a>

Reviewed by Yusuke Suzuki.

* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(WebCore::HTMLFastPathParser::findSpecialCharacter):
(WebCore::HTMLFastPathParser::scanText):
(WebCore::HTMLFastPathParser::scanAttributeValue):

Canonical link: <a href="https://commits.webkit.org/310174@main">https://commits.webkit.org/310174@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e51414c0488846132c3b7ad77b15516997b017f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152853 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25635 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19233 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161597 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106309 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154726 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26162 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25940 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118122 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83646 "4 flakes 5 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155812 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20354 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137215 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98835 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19428 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17369 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9433 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129080 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15089 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164071 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7207 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16683 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126185 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25432 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21408 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126343 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34301 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25434 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136885 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82038 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21295 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13664 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25050 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89337 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24742 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24901 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24802 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->