### PR TITLE
`FixedVector(size, value)` should not double-initialize non-POD elements

### DIFF
--- a/Source/WTF/wtf/EmbeddedFixedVector.h
+++ b/Source/WTF/wtf/EmbeddedFixedVector.h
@@ -85,6 +85,11 @@ public:
         return UniqueRef { *new (NotNull, Malloc::malloc(Base::allocationSize(size))) EmbeddedFixedVector(size, std::move_iterator { container.begin() }, std::move_iterator { container.end() }) };
     }
 
+    static UniqueRef<EmbeddedFixedVector> createFilled(unsigned size, const T& value)
+    {
+        return UniqueRef { *new (NotNull, Malloc::malloc(Base::allocationSize(size))) EmbeddedFixedVector(typename Base::FillWith { }, size, value) };
+    }
+
     template<typename... Args>
     static UniqueRef<EmbeddedFixedVector> createWithSizeAndConstructorArguments(unsigned size, Args&&... args)
     {
@@ -148,6 +153,11 @@ private:
     template<typename InputIterator>
     EmbeddedFixedVector(unsigned size, InputIterator first, InputIterator last)
         : Base(size, first, last)
+    {
+    }
+
+    EmbeddedFixedVector(typename Base::FillWith fillWith, unsigned size, const T& value)
+        : Base(fillWith, size, value)
     {
     }
 

--- a/Source/WTF/wtf/FixedVector.h
+++ b/Source/WTF/wtf/FixedVector.h
@@ -92,10 +92,8 @@ public:
     { }
 
     FixedVector(size_t size, const T& value)
-        : m_storage(size ? Storage::create(size).moveToUniquePtr() : nullptr)
-    {
-        fill(value);
-    }
+        : m_storage(size ? Storage::createFilled(size, value).moveToUniquePtr() : nullptr)
+    { }
 
     template<size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename VectorMalloc>
     explicit FixedVector(const Vector<T, inlineCapacity, OverflowHandler, minCapacity, VectorMalloc>& other)

--- a/Source/WTF/wtf/TrailingArray.h
+++ b/Source/WTF/wtf/TrailingArray.h
@@ -88,6 +88,14 @@ protected:
         std::uninitialized_copy(first, last, begin());
     }
 
+    struct FillWith { };
+    TrailingArray(FillWith, unsigned size, const T& value)
+        : m_size(size)
+    {
+        static_assert(std::is_final_v<Derived>);
+        VectorTypeOperations<T>::uninitializedFill(begin(), end(), value);
+    }
+
     template<typename... Args>
     TrailingArray(unsigned size, Args&&... args) // create with given size and constructor arguments for all elements
         : m_size(size)

--- a/Tools/TestWebKitAPI/Tests/WTF/FixedVector.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/FixedVector.cpp
@@ -436,4 +436,35 @@ TEST(WTF_FixedVector, Equal)
     }
 }
 
+TEST(WTF_FixedVector, SizeAndValueConstructorPOD)
+{
+    FixedVector<unsigned> vec(5, 42U);
+    EXPECT_EQ(5U, vec.size());
+    for (unsigned i = 0; i < vec.size(); ++i)
+        EXPECT_EQ(42U, vec[i]);
+}
+
+TEST(WTF_FixedVector, SizeAndValueConstructorNonPOD)
+{
+    String value = "hello"_s;
+    FixedVector<String> vec(3, value);
+    EXPECT_EQ(3U, vec.size());
+    for (unsigned i = 0; i < vec.size(); ++i)
+        EXPECT_STREQ("hello", vec[i].utf8().data());
+}
+
+TEST(WTF_FixedVector, SizeAndValueConstructorZeroSize)
+{
+    FixedVector<unsigned> vec(0, 42U);
+    EXPECT_TRUE(vec.isEmpty());
+    EXPECT_EQ(0U, vec.size());
+}
+
+TEST(WTF_FixedVector, SizeAndValueConstructorSingleElement)
+{
+    FixedVector<unsigned> vec(1, 99U);
+    EXPECT_EQ(1U, vec.size());
+    EXPECT_EQ(99U, vec[0]);
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 422833beda0776558098ecfdcdef658c91188837
<pre>
`FixedVector(size, value)` should not double-initialize non-POD elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=310963">https://bugs.webkit.org/show_bug.cgi?id=310963</a>

Reviewed by Sam Weinig.

The `FixedVector(size_t, const T&amp;)` constructor was first
default-constructing all elements via `Storage::create(size)`, then
copy-assigning over them with `fill(value)`. For non-POD types, this
means N default constructions + N copy assignments instead of just
N copy constructions.

Fix this by adding a `createFilled()` factory to `EmbeddedFixedVector`
backed by a new `TrailingArray` FillWith constructor that uses
`VectorTypeOperations::uninitializedFill`, matching what
`Vector(size, val)` already does.

Also add API test coverage for this constructor, which had none.

Test: Tools/TestWebKitAPI/Tests/WTF/FixedVector.cpp

* Source/WTF/wtf/EmbeddedFixedVector.h:
* Source/WTF/wtf/FixedVector.h:
(WTF::FixedVector::FixedVector):
* Source/WTF/wtf/TrailingArray.h:
(WTF::TrailingArray::TrailingArray):
* Tools/TestWebKitAPI/Tests/WTF/FixedVector.cpp:
(TestWebKitAPI::TEST(WTF_FixedVector, SizeAndValueConstructorPOD)):
(TestWebKitAPI::TEST(WTF_FixedVector, SizeAndValueConstructorNonPOD)):
(TestWebKitAPI::TEST(WTF_FixedVector, SizeAndValueConstructorZeroSize)):
(TestWebKitAPI::TEST(WTF_FixedVector, SizeAndValueConstructorSingleElement)):

Canonical link: <a href="https://commits.webkit.org/310167@main">https://commits.webkit.org/310167@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96cea8ff904f7ac626afe49ae615842b0b195022

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152854 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25636 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19234 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161598 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106310 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b4ecee8f-f4e2-4716-a58f-e2019ec2a584) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154727 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26163 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25941 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118129 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83649 "3 flakes 5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b2f50fc3-a219-4794-ba3b-82c5f493828b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155813 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20364 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137227 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98842 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/40f35d37-29ca-445a-8fb4-8f7bc266ba7f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19438 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17376 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9434 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144866 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129090 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15101 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164072 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13663 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7208 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16695 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126191 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25433 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21415 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126349 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34294 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25435 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136897 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82039 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21305 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13676 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184486 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25051 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89338 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47095 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24743 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24902 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24803 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->