### PR TITLE
Simplify FixedVector move assignment operator

### DIFF
--- a/Source/WTF/wtf/FixedVector.h
+++ b/Source/WTF/wtf/FixedVector.h
@@ -53,7 +53,7 @@ public:
     FixedVector(const FixedVector& other)
         : m_storage(other.m_storage ? other.m_storage->clone().moveToUniquePtr() : nullptr)
     { }
-    FixedVector(FixedVector&& other) = default;
+    FixedVector(FixedVector&&) = default;
 
     FixedVector(std::initializer_list<T> initializerList)
         : m_storage(initializerList.size() ? Storage::create(initializerList).moveToUniquePtr() : nullptr)
@@ -80,12 +80,7 @@ public:
         return *this;
     }
 
-    FixedVector& operator=(FixedVector&& other)
-    {
-        FixedVector tmp(WTF::move(other));
-        swap(tmp);
-        return *this;
-    }
+    FixedVector& operator=(FixedVector&&) = default;
 
     explicit FixedVector(size_t size)
         : m_storage(size ? Storage::create(size).moveToUniquePtr() : nullptr)

--- a/Tools/TestWebKitAPI/Tests/WTF/FixedVector.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/FixedVector.cpp
@@ -467,4 +467,35 @@ TEST(WTF_FixedVector, SizeAndValueConstructorSingleElement)
     EXPECT_EQ(99U, vec[0]);
 }
 
+TEST(WTF_FixedVector, MoveAssignNonEmptyToNonEmpty)
+{
+    Vector<bool> flags(3, false);
+    {
+        FixedVector<DestructorObserver> vec1(3);
+        for (unsigned i = 0; i < 3; ++i)
+            vec1[i] = DestructorObserver(&flags[i]);
+
+        FixedVector<DestructorObserver> vec2(2);
+
+        // Move-assigning over vec2 must destroy its old storage.
+        vec2 = WTF::move(vec1);
+        EXPECT_EQ(3U, vec2.size());
+
+        // The original objects should still be alive (now owned by vec2).
+        for (unsigned i = 0; i < 3; ++i)
+            EXPECT_FALSE(flags[i]);
+    }
+    // After vec2 goes out of scope, all observers should be destructed.
+    for (unsigned i = 0; i < 3; ++i)
+        EXPECT_TRUE(flags[i]);
+}
+
+TEST(WTF_FixedVector, MoveAssignEmptyToEmpty)
+{
+    FixedVector<unsigned> vec1;
+    FixedVector<unsigned> vec2;
+    vec2 = WTF::move(vec1);
+    EXPECT_TRUE(vec2.isEmpty());
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 79257f1abce6b48700b632f007b903e7ea7d279e
<pre>
Simplify FixedVector move assignment operator
<a href="https://bugs.webkit.org/show_bug.cgi?id=310964">https://bugs.webkit.org/show_bug.cgi?id=310964</a>

Reviewed by Geoffrey Garen.

The move assignment operator used the copy-and-swap idiom, which is
unnecessary for a class whose only member is a unique_ptr. Replace
it with `= default`, which directly move-assigns the unique_ptr.

Also add test coverage for move-assigning over a non-empty vector,
verifying that old elements are properly destroyed.

Test: Tools/TestWebKitAPI/Tests/WTF/FixedVector.cpp

* Source/WTF/wtf/FixedVector.h:
* Tools/TestWebKitAPI/Tests/WTF/FixedVector.cpp:
(TestWebKitAPI::TEST(WTF_FixedVector, MoveAssignNonEmptyToNonEmpty)):
(TestWebKitAPI::TEST(WTF_FixedVector, MoveAssignEmptyToEmpty)):

Canonical link: <a href="https://commits.webkit.org/310178@main">https://commits.webkit.org/310178@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e07cd1d1f72ef6ee4795d8d024fe62895cc1e048

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152999 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25781 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19379 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161743 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106455 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154872 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26308 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26086 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118258 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155958 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20484 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137353 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98971 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19558 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9579 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/145011 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129211 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15226 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164217 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13811 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7353 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16820 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126321 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25578 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21540 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126479 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34307 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25580 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137022 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82210 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21427 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13801 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184634 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25196 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89483 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47201 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24888 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25047 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24948 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->