### PR TITLE
media/media-vp8-hiddenframes.html is sometimes crashing on EWS

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -388,8 +388,8 @@ private:
     MediaTime m_lastSeekTime WTF_GUARDED_BY_CAPABILITY(runningQueue());
     std::optional<SeekTarget> m_pendingSeek WTF_GUARDED_BY_CAPABILITY(mainThread);
     std::atomic<bool> m_hasPendingSeek { false };
-    std::optional<GenericPromise::Producer> m_waitForTimeBufferedPromise WTF_GUARDED_BY_CAPABILITY(runningQueue());
-    const Ref<NativePromiseRequest> m_rendererSeekRequest;
+    std::optional<GenericPromise::AutoRejectProducer> m_waitForTimeBufferedPromise WTF_GUARDED_BY_CAPABILITY(runningQueue());
+    Ref<NativePromiseRequest> m_rendererSeekRequest;
     std::atomic<bool> m_seeking { false };
 #if HAVE(SPATIAL_TRACKING_LABEL)
     String m_defaultSpatialTrackingLabel WTF_GUARDED_BY_CAPABILITY(mainThread);

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -130,14 +130,25 @@ MediaPlayerPrivateWebM::MediaPlayerPrivateWebM(MediaPlayer& player)
 #endif
 }
 
-// Destructor runs on main thread (DestructionThread::Main). At this point all running-queue
-// work has drained, so accessing running-queue-guarded members is safe at runtime even though
-// the static analyzer cannot prove it.
 MediaPlayerPrivateWebM::~MediaPlayerPrivateWebM() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
 {
     ALWAYS_LOG(LOGIDENTIFIER);
 
-    cancelPendingSeek();
+    // cancelPendingSeek() requires being on m_runningQueue because disconnecting a
+    // NativePromiseRequest requires being on the queue the callback was registered on.
+    // Move the seek request out and dispatch to that queue.
+    m_runningQueue->dispatch([seekRequest = std::exchange(m_rendererSeekRequest, NativePromiseRequest::create())]() mutable {
+        if (seekRequest->hasCallback())
+            seekRequest->disconnect();
+    });
+
+    // clearTracks() and cancelLoad() access running-queue-guarded members on the main thread.
+    // This is safe because the destructor runs only after the ref count reaches zero. Any
+    // running-queue lambda that captures weakThis must successfully lock it to a strong Ref
+    // before accessing those members; locking requires the ref count to be non-zero, which
+    // is impossible at this point. Therefore no running-queue code can concurrently access
+    // those members, and the static-analysis annotation is the only thing suppressed here.
+    m_waitForTimeBufferedPromise.reset();
 
     clearTracks();
 
@@ -621,12 +632,12 @@ void MediaPlayerPrivateWebM::seekInternal()
     });
 }
 
-void MediaPlayerPrivateWebM::cancelPendingSeek() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
+void MediaPlayerPrivateWebM::cancelPendingSeek()
 {
+    assertIsCurrent(runningQueue());
     if (m_rendererSeekRequest->hasCallback())
-        m_rendererSeekRequest->disconnect();
-    if (auto promise = std::exchange(m_waitForTimeBufferedPromise, std::nullopt))
-        promise->reject();
+        protect(m_rendererSeekRequest)->disconnect();
+    m_waitForTimeBufferedPromise.reset();
 }
 
 void MediaPlayerPrivateWebM::startSeek(const MediaTime& seekTime)
@@ -641,7 +652,7 @@ void MediaPlayerPrivateWebM::startSeek(const MediaTime& seekTime)
         if (!protectedThis)
             return;
 
-        protectedThis->m_rendererSeekRequest->complete();
+        protect(protectedThis->m_rendererSeekRequest)->complete();
 
         if (!result) {
             ASSERT(result.error() == PlatformMediaError::RequiresFlushToResume);
@@ -651,7 +662,7 @@ void MediaPlayerPrivateWebM::startSeek(const MediaTime& seekTime)
             return protectedThis->startSeek(seekTime);
         }
         protectedThis->completeSeek(*result);
-    })->track(m_rendererSeekRequest.get());
+    })->track(m_rendererSeekRequest);
 }
 
 void MediaPlayerPrivateWebM::completeSeek(const MediaTime& seekedTime)


### PR DESCRIPTION
#### 95cfc9759c8aa34bcff01b498339ae55e4a072e3
<pre>
media/media-vp8-hiddenframes.html is sometimes crashing on EWS
<a href="https://bugs.webkit.org/show_bug.cgi?id=310965">https://bugs.webkit.org/show_bug.cgi?id=310965</a>
<a href="https://rdar.apple.com/173480850">rdar://173480850</a>

Reviewed by Jer Noble.

A NativePromiseRequest must be disconnected or completed on the thread
the completion handler will run.
For ease, make m_waitForTimeBufferedPromise an AutoRejectProducer.

Covered by existing tests.

* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::cancelPendingSeek):

Canonical link: <a href="https://commits.webkit.org/310263@main">https://commits.webkit.org/310263@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f304ebba7c0012ba88dff421d9bb27de68cf75bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152985 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25767 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19365 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161729 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106441 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4b46720b-422d-4988-a505-05a01189b653) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154858 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26294 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26072 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118244 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83715 "2 flakes 6 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bb3fcaaa-cb85-487c-899b-5a5351b581df) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155944 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20471 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137342 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98957 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9b47cc75-1df5-48f3-90b9-241b1dcae630) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19545 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17488 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9565 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129198 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15216 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164203 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7339 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16810 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126308 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25564 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21528 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126466 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34374 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25566 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137012 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82191 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21412 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13791 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25182 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89469 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24874 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25033 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24934 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->