### PR TITLE
Remove redundant moves and dead code in FixedVector

### DIFF
--- a/Source/WTF/wtf/FixedVector.h
+++ b/Source/WTF/wtf/FixedVector.h
@@ -106,18 +106,15 @@ public:
 
     template<size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename VectorMalloc>
     explicit FixedVector(Vector<T, inlineCapacity, OverflowHandler, minCapacity, VectorMalloc>&& other)
-    {
-        auto target = WTF::move(other);
-        m_storage = target.isEmpty() ? nullptr : Storage::createFromVector(WTF::move(target)).moveToUniquePtr();
-    }
+        : m_storage(other.isEmpty() ? nullptr : Storage::createFromVector(WTF::move(other)).moveToUniquePtr())
+    { }
 
     // FIXME: Should we remove this now that it's not required for HashTable::add? This assignment is non-trivial and
     // should probably go through the explicit constructor.
     template<size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename VectorMalloc>
     FixedVector& operator=(Vector<T, inlineCapacity, OverflowHandler, minCapacity, VectorMalloc>&& other)
     {
-        auto target = WTF::move(other);
-        m_storage = target.isEmpty() ? nullptr : Storage::createFromVector(WTF::move(target)).moveToUniquePtr();
+        m_storage = other.isEmpty() ? nullptr : Storage::createFromVector(WTF::move(other)).moveToUniquePtr();
         return *this;
     }
 
@@ -184,12 +181,12 @@ public:
     bool operator==(const Self& other) const
     {
         if (!m_storage) {
-            if (!other.m_storage)
-                return true;
-            return other.m_storage->isEmpty();
+            ASSERT(!other.m_storage || !other.m_storage->isEmpty());
+            return !other.m_storage;
         }
+        ASSERT(!m_storage->isEmpty());
         if (!other.m_storage)
-            return m_storage->isEmpty();
+            return false;
         return *m_storage == *other.m_storage;
     }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/FixedVector.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/FixedVector.cpp
@@ -498,4 +498,56 @@ TEST(WTF_FixedVector, MoveAssignEmptyToEmpty)
     EXPECT_TRUE(vec2.isEmpty());
 }
 
+TEST(WTF_FixedVector, MoveVectorEmpty)
+{
+    Vector<unsigned> vec1;
+    FixedVector<unsigned> vec2(WTF::move(vec1));
+    EXPECT_TRUE(vec2.isEmpty());
+}
+
+TEST(WTF_FixedVector, MoveAssignVectorEmpty)
+{
+    FixedVector<unsigned> vec(3);
+    vec[0] = 0;
+    vec[1] = 1;
+    vec[2] = 2;
+
+    Vector<unsigned> empty;
+    vec = WTF::move(empty);
+    EXPECT_TRUE(vec.isEmpty());
+}
+
+TEST(WTF_FixedVector, MoveAssignVectorOverNonEmpty)
+{
+    Vector<bool> flags(3, false);
+    {
+        FixedVector<DestructorObserver> vec(3);
+        for (unsigned i = 0; i < 3; ++i)
+            vec[i] = DestructorObserver(&flags[i]);
+
+        // Move-assigning a Vector over a non-empty FixedVector must destroy old elements.
+        auto source = Vector<DestructorObserver>::from(DestructorObserver());
+        vec = WTF::move(source);
+        EXPECT_EQ(1U, vec.size());
+        for (unsigned i = 0; i < 3; ++i)
+            EXPECT_TRUE(flags[i]);
+    }
+}
+
+TEST(WTF_FixedVector, EqualDifferentSizes)
+{
+    FixedVector<unsigned> vec1 = { 1, 2, 3 };
+    FixedVector<unsigned> vec2 = { 1, 2 };
+    EXPECT_NE(vec1, vec2);
+    EXPECT_NE(vec2, vec1);
+}
+
+TEST(WTF_FixedVector, EqualEmptyAndNonEmpty)
+{
+    FixedVector<unsigned> empty;
+    FixedVector<unsigned> nonEmpty = { 1 };
+    EXPECT_NE(empty, nonEmpty);
+    EXPECT_NE(nonEmpty, empty);
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### fc66e95983f642254604aae6b143f715e3b1e0a4
<pre>
Remove redundant moves and dead code in FixedVector
<a href="https://bugs.webkit.org/show_bug.cgi?id=310966">https://bugs.webkit.org/show_bug.cgi?id=310966</a>

Reviewed by Geoffrey Garen.

Two minor cleanups to FixedVector:

The move-from-Vector constructor and assignment operator moved the
source Vector into a local variable, only for createFromVector to
move it again into its own local. Remove the unnecessary intermediate.

The operator== had isEmpty() fallback branches for the case where
m_storage is non-null but empty. This is unreachable since every
constructor guards storage creation with a non-empty check. Replace
the dead branches with ASSERTs that document this invariant.

Also add test coverage for empty-Vector construction/assignment and
for comparing vectors of different sizes and empty vs non-empty.

Test: Tools/TestWebKitAPI/Tests/WTF/FixedVector.cpp

* Source/WTF/wtf/FixedVector.h:
(WTF::FixedVector::FixedVector):
(WTF::FixedVector::operator=):
(WTF::FixedVector::operator== const):
* Tools/TestWebKitAPI/Tests/WTF/FixedVector.cpp:
(TestWebKitAPI::TEST(WTF_FixedVector, MoveVectorEmpty)):
(TestWebKitAPI::TEST(WTF_FixedVector, MoveAssignVectorEmpty)):
(TestWebKitAPI::TEST(WTF_FixedVector, MoveAssignVectorOverNonEmpty)):
(TestWebKitAPI::TEST(WTF_FixedVector, EqualDifferentSizes)):
(TestWebKitAPI::TEST(WTF_FixedVector, EqualEmptyAndNonEmpty)):

Canonical link: <a href="https://commits.webkit.org/310181@main">https://commits.webkit.org/310181@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ac813df71d76b3166b90d4c8d3b616f17a40bb8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153016 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25798 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19396 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161760 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106474 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154889 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26325 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26103 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118277 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155975 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/20507 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/137366 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98990 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19581 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9596 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/145028 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129234 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15239 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164234 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13829 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7370 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16833 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126339 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25595 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21556 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126497 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34309 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25597 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137035 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82235 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21444 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13814 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184651 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled JSC") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25213 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89500 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47210 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24905 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25064 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24965 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->