### PR TITLE
[PlayStation] Fix alert/confirm/prompt dialogs not working in MiniBrowser

### DIFF
--- a/Tools/MiniBrowser/playstation/WebViewWindow.cpp
+++ b/Tools/MiniBrowser/playstation/WebViewWindow.cpp
@@ -223,9 +223,9 @@ WebViewWindow::WebViewWindow(WKPageConfigurationRef configuration, Client&& wind
         [](WKPageRef page, WKPageConfigurationRef configuration, WKNavigationActionRef, WKWindowFeaturesRef, const void* clientInfo) ->WKPageRef {
             return toWebView(clientInfo)->createNewPage(page, configuration);
         },
-        nullptr, // runJavaScriptAlert
-        nullptr, // runJavaScriptConfirm
-        nullptr, // runJavaScriptPrompt
+        runJavaScriptAlert,
+        runJavaScriptConfirm,
+        runJavaScriptPrompt,
         nullptr // checkUserMediaPermissionForOrigin
     };
     WKPageSetPageUIClient(page(), &uiClient.base);
@@ -450,4 +450,37 @@ WKPageRef WebViewWindow::createNewPage(WKPageRef, WKPageConfigurationRef configu
         return newPage;
     }
     return nullptr;
+}
+
+void WebViewWindow::runJavaScriptAlert(WKPageRef, WKStringRef alertText, WKFrameRef, WKSecurityOriginRef, WKPageRunJavaScriptAlertResultListenerRef listener, const void*)
+{
+    MessageDialog::showModal(toUTF8String(alertText).c_str());
+    WKPageRunJavaScriptAlertResultListenerCall(listener);
+}
+
+void WebViewWindow::runJavaScriptConfirm(WKPageRef, WKStringRef message, WKFrameRef, WKSecurityOriginRef, WKPageRunJavaScriptConfirmResultListenerRef listener, const void*)
+{
+    bool result = MessageDialog::showModal(toUTF8String(message).c_str()) == MessageDialog::Result::kOK;
+    WKPageRunJavaScriptConfirmResultListenerCall(listener, result);
+}
+
+void WebViewWindow::runJavaScriptPrompt(WKPageRef, WKStringRef message, WKStringRef defaultValue, WKFrameRef, WKSecurityOriginRef, WKPageRunJavaScriptPromptResultListenerRef listener, const void*)
+{
+    std::string messageStr = toUTF8String(message);
+    std::string defaultValueStr = toUTF8String(defaultValue);
+
+    // FIXME: See <https://bugs.webkit.org/show_bug.cgi?id=311407>.
+    size_t finalSize = messageStr.size() + defaultValueStr.size();
+    std::string finalMessage;
+    finalMessage.reserve(finalSize);
+
+    finalMessage.append(messageStr.data(), messageStr.size() - 1);
+    finalMessage.push_back('\n');
+    finalMessage.append(defaultValueStr.data(), defaultValueStr.size() - 1);
+
+    bool result = MessageDialog::showModal(finalMessage.c_str()) == MessageDialog::Result::kOK;
+    if (result)
+        WKPageRunJavaScriptPromptResultListenerCall(listener, defaultValue);
+    else
+        WKPageRunJavaScriptPromptResultListenerCall(listener, nullptr);
 }

--- a/Tools/MiniBrowser/playstation/WebViewWindow.h
+++ b/Tools/MiniBrowser/playstation/WebViewWindow.h
@@ -85,6 +85,9 @@ private:
     void updateProgress();
 
     WKPageRef createNewPage(WKPageRef, WKPageConfigurationRef);
+    static void runJavaScriptAlert(WKPageRef, WKStringRef, WKFrameRef, WKSecurityOriginRef, WKPageRunJavaScriptAlertResultListenerRef, const void* clientInfo);
+    static void runJavaScriptConfirm(WKPageRef, WKStringRef, WKFrameRef, WKSecurityOriginRef, WKPageRunJavaScriptConfirmResultListenerRef, const void* clientInfo);
+    static void runJavaScriptPrompt(WKPageRef, WKStringRef, WKStringRef, WKFrameRef, WKSecurityOriginRef, WKPageRunJavaScriptPromptResultListenerRef, const void* clientInfo);
 
     WKRetainPtr<WKViewRef> m_view;
     std::shared_ptr<WebContext> m_context;


### PR DESCRIPTION
#### 1cda92774256dec8ee77977a5dd3ab1d0c39af44
<pre>
[PlayStation] Fix alert/confirm/prompt dialogs not working in MiniBrowser
<a href="https://bugs.webkit.org/show_bug.cgi?id=310967">https://bugs.webkit.org/show_bug.cgi?id=310967</a>

Reviewed by Don Olmstead.

This patch fixes the issue where alert, confirm, and prompt dialogs were
not working in MiniBrowser on PlayStation. The problem was caused by
missing handling of JavaScript dialog callbacks in
WebViewWindow.

The patch implements proper handling in
WebViewWindow::runJavaScriptPrompt,
WebViewWindow::runJavaScriptConfirm,
WebViewWindow::runJavaScriptPrompt,
ensuring that dialogs are correctly triggered and responses are returned
to the WebKit layer.

* Tools/MiniBrowser/playstation/WebViewWindow.cpp:
(WebViewWindow::WebViewWindow):
(WebViewWindow::runJavaScriptPrompt):
(WebViewWindow::runJavaScriptConfirm):
(WebViewWindow::runJavaScriptPrompt):
* Tools/MiniBrowser/playstation/WebViewWindow.h:

Canonical link: <a href="https://commits.webkit.org/310742@main">https://commits.webkit.org/310742@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fde391e1ba66230ba3bb7b3de34076dd23c97d3b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154612 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27871 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21030 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163370 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108081 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156485 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28004 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27720 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119589 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84575 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157571 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21888 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138858 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100286 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20973 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18979 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11198 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130636 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16702 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165842 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18311 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127692 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27416 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23019 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127835 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34727 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27340 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138495 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/84022 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22729 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15288 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27032 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26610 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26841 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26683 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->