### PR TITLE
Changing the media attribute on a <link rel="stylesheet"> should not re-fetch the stylesheet

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-media-change-no-fetch-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-media-change-no-fetch-expected.txt
@@ -1,5 +1,5 @@
 hello
 
 
-FAIL stylesheet should not re-fetch when media changes. The media change should apply immediately assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+PASS stylesheet should not re-fetch when media changes. The media change should apply immediately
 

--- a/Source/WebCore/html/HTMLLinkElement.cpp
+++ b/Source/WebCore/html/HTMLLinkElement.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2001 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2003-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2009 Rob Buis (rwlbuis@gmail.com)
  * Copyright (C) 2011 Google Inc. All rights reserved.
  *
@@ -257,9 +257,14 @@ void HTMLLinkElement::attributeChanged(const QualifiedName& name, const AtomStri
         if (media == m_media)
             return;
         m_media = WTF::move(media);
-        process();
-        if (m_sheet && !isDisabled())
-            m_styleScope->didChangeActiveStyleSheetCandidates();
+        // A media change is not a reason to re-fetch the stylesheet.
+        // https://html.spec.whatwg.org/multipage/links.html#link-type-stylesheet
+        if (m_sheet) {
+            m_sheet->setMediaQueries(MQ::MediaQueryParser::parse(m_media, document().cssParserContext()));
+            if (!isDisabled())
+                m_styleScope->didChangeStyleSheetContents();
+        } else
+            process();
         break;
     }
     case AttributeNames::disabledAttr:


### PR DESCRIPTION
#### 8e96fcdda80be7c148241892007479e0a3a50bb1
<pre>
Changing the media attribute on a &lt;link rel=&quot;stylesheet&quot;&gt; should not re-fetch the stylesheet
<a href="https://bugs.webkit.org/show_bug.cgi?id=310968">https://bugs.webkit.org/show_bug.cgi?id=310968</a>
<a href="https://rdar.apple.com/173575596">rdar://173575596</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Blink / Chromium.

Per spec [1], the media property of a CSS style sheet created by
&lt;link rel=&quot;stylesheet&quot;&gt; is a reference to the attribute, not a
copy of its current value. Changing the media attribute should take
effect immediately without triggering re-processing.

Previously, any media attribute change called process(), which tears
down the existing cached stylesheet and re-fetches it. Instead, when
a sheet already exists, update its media queries in place and notify
the style scope that the sheet&apos;s interpretation has changed, which
triggers a style resolver rebuild without a network request.

[1] <a href="https://html.spec.whatwg.org/multipage/links.html#link-type-stylesheet">https://html.spec.whatwg.org/multipage/links.html#link-type-stylesheet</a>

* Source/WebCore/html/HTMLLinkElement.cpp:
(WebCore::HTMLLinkElement::attributeChanged):
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-media-change-no-fetch-expected.txt: Progression
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e96fcdda80be7c148241892007479e0a3a50bb1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152865 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25647 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19245 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161609 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106321 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d4299259-6515-462a-9cf1-efebec2af4fe) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154738 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26174 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25952 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118136 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83661 "2 flakes 5 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155824 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20369 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137233 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98849 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ee7b443c-479f-463f-9415-4652055239eb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19443 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17382 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9445 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129095 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15107 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164083 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7219 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16701 "Found 1 new test failure: inspector/css/stylesheet-events-basic.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126198 "Found 1 new test failure: inspector/css/stylesheet-events-basic.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25444 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21421 "Found 1 new test failure: inspector/css/stylesheet-events-basic.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126356 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25446 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136903 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82050 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21310 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13682 "Found 1 new test failure: inspector/css/stylesheet-events-basic.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25062 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89349 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24754 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24913 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24814 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->