### PR TITLE
[SVG] SMIL parseClockValue should reject out-of-range minutes and seconds

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/smil-clock-value-out-of-range-minutes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/smil-clock-value-out-of-range-minutes-expected.txt
@@ -1,0 +1,3 @@
+
+PASS SMIL clock values with out-of-range minutes or seconds should be treated as invalid
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/smil-clock-value-out-of-range-minutes.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/smil-clock-value-out-of-range-minutes.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<title>SMIL clock values with out-of-range minutes or seconds should be treated as invalid</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="help" href="https://www.w3.org/TR/SMIL/smil-timing.html#q22">
+<svg height="0">
+  <rect id="valid" fill="green" width="20" height="20">
+    <animate attributeName="x" from="0" to="200" begin="0s" dur="00:30:01" fill="freeze"/>
+  </rect>
+  <rect id="invalidMinHHMMSS" fill="green" width="20" height="20">
+    <animate attributeName="x" from="0" to="200" begin="0s" dur="01:99:01" fill="freeze"/>
+  </rect>
+  <rect id="invalidMinMMSS" fill="green" width="20" height="20">
+    <animate attributeName="x" from="0" to="200" begin="0s" dur="99:01" fill="freeze"/>
+  </rect>
+  <rect id="invalidSecHHMMSS" fill="green" width="20" height="20">
+    <animate attributeName="x" from="0" to="200" begin="0s" dur="01:30:99" fill="freeze"/>
+  </rect>
+  <rect id="invalidSecMMSS" fill="green" width="20" height="20">
+    <animate attributeName="x" from="0" to="200" begin="0s" dur="30:99" fill="freeze"/>
+  </rect>
+  <rect id="boundaryValid" fill="green" width="20" height="20">
+    <animate attributeName="x" from="0" to="200" begin="0s" dur="00:59:59" fill="freeze"/>
+  </rect>
+</svg>
+<script>
+async_test(t => {
+  window.onload = t.step_func(() => {
+    let svg = document.querySelector("svg");
+    svg.pauseAnimations();
+    svg.setCurrentTime(60);
+
+    requestAnimationFrame(t.step_func_done(() => {
+      // Valid dur="00:30:01" (30 min 1 sec). At t=60s the animation should be running.
+      assert_not_equals(document.getElementById("valid").x.animVal.value, 0,
+        'dur="00:30:01" should be valid and animate');
+
+      // Invalid minutes in HH:MM:SS form.
+      assert_equals(document.getElementById("invalidMinHHMMSS").x.animVal.value, 0,
+        'dur="01:99:01" should be invalid (minutes > 59 in HH:MM:SS)');
+
+      // Invalid minutes in MM:SS form.
+      assert_equals(document.getElementById("invalidMinMMSS").x.animVal.value, 0,
+        'dur="99:01" should be invalid (minutes > 59 in MM:SS)');
+
+      // Invalid seconds in HH:MM:SS form.
+      assert_equals(document.getElementById("invalidSecHHMMSS").x.animVal.value, 0,
+        'dur="01:30:99" should be invalid (seconds > 59 in HH:MM:SS)');
+
+      // Invalid seconds in MM:SS form.
+      assert_equals(document.getElementById("invalidSecMMSS").x.animVal.value, 0,
+        'dur="30:99" should be invalid (seconds > 59 in MM:SS)');
+
+      // Valid boundary dur="00:59:59". Should animate.
+      assert_not_equals(document.getElementById("boundaryValid").x.animVal.value, 0,
+        'dur="00:59:59" should be valid and animate');
+    }));
+  });
+});
+</script>

--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -350,12 +350,14 @@ SMILTime SVGSMILElement::parseClockValue(StringView data)
     if (doublePointOne == 2 && doublePointTwo == 5 && parse.length() >= 8) {
         auto hour = parseInteger<uint8_t>(parse.left(2));
         auto minute = parseInteger<uint8_t>(parse.substring(3, 2));
-        if (!hour || !minute)
+        auto seconds = parseInteger<uint8_t>(parse.substring(6, 2));
+        if (!hour || !minute || *minute > 59 || !seconds || *seconds > 59)
             return SMILTime::unresolved();
         result = *hour * 60 * 60 + *minute * 60 + parse.substring(6).toDouble(ok);
-    } else if (doublePointOne == 2 && doublePointTwo == notFound && parse.length() >= 5) { 
+    } else if (doublePointOne == 2 && doublePointTwo == notFound && parse.length() >= 5) {
         auto minute = parseInteger<uint8_t>(parse.left(2));
-        if (!minute)
+        auto seconds = parseInteger<uint8_t>(parse.substring(3, 2));
+        if (!minute || *minute > 59 || !seconds || *seconds > 59)
             return SMILTime::unresolved();
         result = *minute * 60 + parse.substring(3).toDouble(ok);
     } else


### PR DESCRIPTION
#### 10f5b40c292e7707b4a1c5ee91368d94566abaa8
<pre>
[SVG] SMIL parseClockValue should reject out-of-range minutes and seconds
<a href="https://bugs.webkit.org/show_bug.cgi?id=310971">https://bugs.webkit.org/show_bug.cgi?id=310971</a>
<a href="https://rdar.apple.com/173577212">rdar://173577212</a>

Reviewed by Nikolas Zimmermann.

parseClockValue parses hours and minutes as uint8_t (0-255) with no
range check, and seconds via toDouble with no upper bound. Per the SMIL
timing spec [1], Minutes and Seconds in Full-clock-value (HH:MM:SS) and
Partial-clock-value (MM:SS) forms must be in the range 00-59. Values
like &quot;01:99:01&quot; or &quot;30:99&quot; were incorrectly accepted.

Add range validation for both minutes and seconds in both clock value forms.

[1] <a href="https://www.w3.org/TR/SMIL/smil-timing.html#q22">https://www.w3.org/TR/SMIL/smil-timing.html#q22</a>

* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(WebCore::SVGSMILElement::parseClockValue):
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/smil-clock-value-out-of-range-minutes-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/smil-clock-value-out-of-range-minutes.html: Added.

Canonical link: <a href="https://commits.webkit.org/310184@main">https://commits.webkit.org/310184@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1107b7da508a4bc6741475c1060fc90c3c9df8f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152870 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25652 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19250 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161614 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106326 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/54652be3-1bcf-49a1-ba2c-cd9c7f8e4cfc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154743 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26179 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25957 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118141 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83654 "2 flakes 5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dec137a8-b5b4-4812-a366-67cc84d21e2c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155829 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20375 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137239 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98854 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a340f6a8-274f-4725-9b85-fe9f5308cf3f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19449 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17390 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9450 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129101 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15113 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164088 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7224 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16707 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126203 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25449 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21429 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126361 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34311 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25451 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136909 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82055 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21319 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13688 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25067 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89354 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24759 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24918 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24819 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->