### PR TITLE
:in-range and :out-of-range pseudo-classes are wrong for time inputs with reversed ranges

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/inrange-outofrange-time-reversed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/inrange-outofrange-time-reversed-expected.txt
@@ -1,0 +1,6 @@
+
+PASS ':in-range' matches time inputs whose value is within a reversed range (>= min OR <= max)
+PASS ':out-of-range' matches time inputs whose value is in the gap of a reversed range (> max AND < min)
+PASS Dynamic update from in-range to out-of-range in a reversed time range
+PASS Dynamic update from out-of-range to in-range in a reversed time range
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/inrange-outofrange-time-reversed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/inrange-outofrange-time-reversed.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Selector: pseudo-classes (:in-range, :out-of-range) with reversed time ranges</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#selector-in-range">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#selector-out-of-range">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/input.html#has-a-reversed-range">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="utils.js"></script>
+<div id="log"></div>
+
+<!-- Reversed range: min="21:00" max="03:00" wraps around midnight.
+     Valid values: >= 21:00:00 OR <= 03:00:00
+     Out-of-range values: > 03:00:00 AND < 21:00:00 (the gap) -->
+
+<!-- In range: value is after min, before midnight -->
+<input type="time" min="21:00:00" max="03:00:00" value="22:00:00" id="time-after-min">
+<!-- In range: value is after midnight, before max -->
+<input type="time" min="21:00:00" max="03:00:00" value="02:00:00" id="time-before-max">
+<!-- In range: value is exactly at min -->
+<input type="time" min="21:00:00" max="03:00:00" value="21:00:00" id="time-at-min">
+<!-- In range: value is exactly at max -->
+<input type="time" min="21:00:00" max="03:00:00" value="03:00:00" id="time-at-max">
+<!-- Out of range: value is in the gap -->
+<input type="time" min="21:00:00" max="03:00:00" value="12:00:00" id="time-in-gap">
+<!-- Out of range: value is just past max -->
+<input type="time" min="21:00:00" max="03:00:00" value="04:00:00" id="time-past-max">
+<!-- Out of range: value is just before min -->
+<input type="time" min="21:00:00" max="03:00:00" value="20:00:00" id="time-before-min">
+
+<script>
+  testSelectorIdsMatch(":in-range",
+    ["time-after-min", "time-before-max", "time-at-min", "time-at-max"],
+    "':in-range' matches time inputs whose value is within a reversed range (>= min OR <= max)");
+
+  testSelectorIdsMatch(":out-of-range",
+    ["time-in-gap", "time-past-max", "time-before-min"],
+    "':out-of-range' matches time inputs whose value is in the gap of a reversed range (> max AND < min)");
+
+  // Dynamic update: move an in-range value into the gap.
+  document.getElementById("time-after-min").value = "12:00:00";
+  test(function() {
+    assert_false(document.getElementById("time-after-min").matches(":in-range"));
+    assert_true(document.getElementById("time-after-min").matches(":out-of-range"));
+  }, "Dynamic update from in-range to out-of-range in a reversed time range");
+
+  // Dynamic update: move an out-of-range value into the valid range.
+  document.getElementById("time-in-gap").value = "23:00:00";
+  test(function() {
+    assert_true(document.getElementById("time-in-gap").matches(":in-range"));
+    assert_false(document.getElementById("time-in-gap").matches(":out-of-range"));
+  }, "Dynamic update from out-of-range to in-range in a reversed time range");
+</script>

--- a/Source/WebCore/html/InputType.cpp
+++ b/Source/WebCore/html/InputType.cpp
@@ -450,11 +450,14 @@ bool InputType::isInRange(const String& value) const
     if (!stepRange.hasRangeLimitations())
         return false;
 
-    // This function should return true if both of validity.rangeUnderflow and
+    // This function should return true if both validity.rangeUnderflow and
     // validity.rangeOverflow are false. If the INPUT has no value, they are false.
     const Decimal numericValue = parseToNumberOrNaN(value);
     if (!numericValue.isFinite())
         return true;
+
+    if (stepRange.isReversible() && stepRange.maximum() < stepRange.minimum())
+        return numericValue >= stepRange.minimum() || numericValue <= stepRange.maximum();
 
     return numericValue >= stepRange.minimum() && numericValue <= stepRange.maximum();
 }
@@ -468,11 +471,14 @@ bool InputType::isOutOfRange(const String& value) const
     if (!stepRange.hasRangeLimitations())
         return false;
 
-    // This function should return true if both of validity.rangeUnderflow and
-    // validity.rangeOverflow are true. If the INPUT has no value, they are false.
+    // This function should return true if either validity.rangeUnderflow or
+    // validity.rangeOverflow is true. If the INPUT has no value, they are false.
     const Decimal numericValue = parseToNumberOrNaN(value);
     if (!numericValue.isFinite())
         return false;
+
+    if (stepRange.isReversible() && stepRange.maximum() < stepRange.minimum())
+        return numericValue > stepRange.maximum() && numericValue < stepRange.minimum();
 
     return numericValue < stepRange.minimum() || numericValue > stepRange.maximum();
 }


### PR DESCRIPTION
#### b14fa1947cf562889d71ed3581fa184c27ab6536
<pre>
:in-range and :out-of-range pseudo-classes are wrong for time inputs with reversed ranges
<a href="https://bugs.webkit.org/show_bug.cgi?id=310976">https://bugs.webkit.org/show_bug.cgi?id=310976</a>

Reviewed by Anne van Kesteren.

InputType::isInRange() and InputType::isOutOfRange() did not account for
reversed ranges. For &lt;input type=&quot;time&quot;&gt;, the range can wrap around midnight
(e.g. min=&quot;21:00&quot; max=&quot;03:00&quot;), making valid values those &gt;= min OR &lt;= max.
The existing code only handled the non-reversed case (value &gt;= min AND
value &lt;= max), causing both functions to return incorrect results for any
time input with min &gt; max.

rangeUnderflow() and rangeOverflow() already handled this correctly via
StepRange::isReversible(), but isInRange() and isOutOfRange() were missing
the equivalent check.

Also fixed a misleading comment on isOutOfRange() that said &quot;both&quot; where
the logic checks &quot;either&quot;.

Test: imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/inrange-outofrange-time-reversed.html

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/inrange-outofrange-time-reversed-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/inrange-outofrange-time-reversed.html: Added.
* Source/WebCore/html/InputType.cpp:
(WebCore::InputType::isInRange const):
(WebCore::InputType::isOutOfRange const):

Canonical link: <a href="https://commits.webkit.org/310156@main">https://commits.webkit.org/310156@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0bae72d5af8dc4df4b67714808683982ba46a84a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152885 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25667 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19265 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161629 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/17c6f91b-0cba-4bac-8c09-c69f72eb3627) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154758 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26194 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25972 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118152 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dfc2d691-1be4-433f-ac88-782a92dcba3f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155844 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20385 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137248 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98865 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aec0db21-fbed-4833-9bf3-bc4394e43f34) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19459 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9465 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129111 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15122 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164103 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7239 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16716 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126213 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25464 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21436 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126371 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34288 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25466 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136918 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82070 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21326 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13697 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25082 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89369 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24774 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24933 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24834 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->