### PR TITLE
Avoid redundant StepRange creation and value parsing during input validation

### DIFF
--- a/Source/WebCore/html/InputType.cpp
+++ b/Source/WebCore/html/InputType.cpp
@@ -111,9 +111,7 @@ template<typename DowncastedType>
 ALWAYS_INLINE bool isInvalidInputType(const DowncastedType& inputType, const String& value)
 {
     return inputType.typeMismatch()
-        || inputType.stepMismatch(value)
-        || inputType.rangeUnderflow(value)
-        || inputType.rangeOverflow(value)
+        || inputType.hasStepRangeViolation(value)
         || inputType.patternMismatch(value)
         || inputType.valueMissing(value)
         || inputType.hasBadInput();
@@ -194,9 +192,7 @@ template<typename T> static bool validateInputType(const T& inputType, const Str
 {
     ASSERT(inputType.canSetStringValue());
     return !inputType.typeMismatchFor(value)
-        && !inputType.stepMismatch(value)
-        && !inputType.rangeUnderflow(value)
-        && !inputType.rangeOverflow(value)
+        && !inputType.hasStepRangeViolation(value)
         && !inputType.patternMismatch(value)
         && !inputType.valueMissing(value);
 }
@@ -328,16 +324,23 @@ bool InputType::supportsRequired() const
     return supportsValidation();
 }
 
-bool InputType::rangeUnderflow(const String& value) const
+std::optional<std::pair<Decimal, StepRange>> InputType::parsedValueAndStepRange(const String& value) const
 {
     if (!isSteppable())
-        return false;
-
-    const Decimal numericValue = parseToNumberOrNaN(value);
+        return std::nullopt;
+    auto numericValue = parseToNumberOrNaN(value);
     if (!numericValue.isFinite())
+        return std::nullopt;
+    return { { numericValue, createStepRange(AnyStepHandling::Reject) } };
+}
+
+bool InputType::rangeUnderflow(const String& value) const
+{
+    auto parsed = parsedValueAndStepRange(value);
+    if (!parsed)
         return false;
 
-    auto range = createStepRange(AnyStepHandling::Reject);
+    auto& [numericValue, range] = *parsed;
 
     if (range.isReversible() && range.maximum() < range.minimum())
         return numericValue > range.maximum() && numericValue < range.minimum();
@@ -347,14 +350,11 @@ bool InputType::rangeUnderflow(const String& value) const
 
 bool InputType::rangeOverflow(const String& value) const
 {
-    if (!isSteppable())
+    auto parsed = parsedValueAndStepRange(value);
+    if (!parsed)
         return false;
 
-    const Decimal numericValue = parseToNumberOrNaN(value);
-    if (!numericValue.isFinite())
-        return false;
-
-    auto range = createStepRange(AnyStepHandling::Reject);
+    auto& [numericValue, range] = *parsed;
 
     if (range.isReversible() && range.maximum() < range.minimum())
         return numericValue > range.maximum() && numericValue < range.minimum();
@@ -485,14 +485,31 @@ bool InputType::isOutOfRange(const String& value) const
 
 bool InputType::stepMismatch(const String& value) const
 {
-    if (!isSteppable())
+    auto parsed = parsedValueAndStepRange(value);
+    if (!parsed)
         return false;
 
-    const Decimal numericValue = parseToNumberOrNaN(value);
-    if (!numericValue.isFinite())
+    auto& [numericValue, range] = *parsed;
+    return range.stepMismatch(numericValue);
+}
+
+bool InputType::hasStepRangeViolation(const String& value) const
+{
+    auto parsed = parsedValueAndStepRange(value);
+    if (!parsed)
         return false;
 
-    return createStepRange(AnyStepHandling::Reject).stepMismatch(numericValue);
+    auto& [numericValue, range] = *parsed;
+
+    if (range.isReversible() && range.maximum() < range.minimum()) {
+        if (numericValue > range.maximum() && numericValue < range.minimum())
+            return true;
+    } else {
+        if (numericValue < range.minimum() || numericValue > range.maximum())
+            return true;
+    }
+
+    return range.stepMismatch(numericValue);
 }
 
 String InputType::badInputText() const

--- a/Source/WebCore/html/InputType.h
+++ b/Source/WebCore/html/InputType.h
@@ -48,6 +48,7 @@ class BeforeTextInsertedEvent;
 class Chrome;
 class DOMFormData;
 class DateComponents;
+class Decimal;
 class DragData;
 class Event;
 class FileList;
@@ -264,6 +265,10 @@ public:
     virtual String visibleValue() const;
     virtual bool isEmptyValue() const;
 
+    // Returns true if the value violates any step/range constraint (stepMismatch,
+    // rangeUnderflow, or rangeOverflow). Creates the StepRange only once.
+    bool hasStepRangeViolation(const String&) const;
+
     // Type check for the current input value. We do nothing for some types
     // though typeMismatchFor() does something for them because of value sanitization.
     virtual bool typeMismatch() const { return false; }
@@ -414,6 +419,7 @@ protected:
 private:
     // Helper for stepUp()/stepDown(). Adds step value * count to the current value.
     ExceptionOr<void> applyStep(int count, AnyStepHandling, TextFieldEventBehavior);
+    std::optional<std::pair<Decimal, StepRange>> parsedValueAndStepRange(const String&) const;
 
     const Type m_type;
     bool m_hasCreatedShadowSubtree { false };

--- a/Source/WebCore/html/StepRange.cpp
+++ b/Source/WebCore/html/StepRange.cpp
@@ -51,6 +51,7 @@ StepRange::StepRange(const StepRange& stepRange)
     , m_stepDescription(stepRange.m_stepDescription)
     , m_hasRangeLimitations(stepRange.m_hasRangeLimitations)
     , m_hasStep(stepRange.m_hasStep)
+    , m_isReversible(stepRange.m_isReversible)
 {
 }
 


### PR DESCRIPTION
#### f396d230a2064186c8385e3ab0615614052a909f
<pre>
Avoid redundant StepRange creation and value parsing during input validation
<a href="https://bugs.webkit.org/show_bug.cgi?id=310977">https://bugs.webkit.org/show_bug.cgi?id=310977</a>

Reviewed by Anne van Kesteren.

The isInvalidInputType and validateInputType templates called stepMismatch(),
rangeUnderflow(), and rangeOverflow() individually. Each of those methods
independently parses the value string to a Decimal and constructs a StepRange,
resulting in 3 redundant parses and 3 redundant StepRange constructions per
validation for steppable input types.

Add InputType::hasStepRangeViolation() which performs a single parse and creates
a single StepRange, then checks all three constraints against it.

No behavior change for non-steppable types — hasStepRangeViolation() returns
false immediately, same as the three individual methods.

* Source/WebCore/html/InputType.cpp:
(WebCore::isInvalidInputType):
(WebCore::validateInputType):
(WebCore::InputType::parsedValueAndStepRange const):
(WebCore::InputType::rangeUnderflow const):
(WebCore::InputType::rangeOverflow const):
(WebCore::InputType::stepMismatch const):
(WebCore::InputType::hasStepRangeViolation const):
* Source/WebCore/html/InputType.h:
* Source/WebCore/html/StepRange.cpp:
(WebCore::StepRange::StepRange):

Canonical link: <a href="https://commits.webkit.org/310176@main">https://commits.webkit.org/310176@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccf5d7ccbb4c7a35670029403df8e4e3efb2584e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152989 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25771 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19369 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161733 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106445 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154862 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26298 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26076 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118250 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155948 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20479 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/137344 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98963 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19553 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9569 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129206 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15218 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164207 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7343 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16812 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126312 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25568 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21532 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126470 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34303 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25570 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137014 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82197 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21418 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13793 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25186 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89473 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24878 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25037 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24938 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->