### PR TITLE
Avoid compiling the pattern attribute regex twice in patternMismatch()

### DIFF
--- a/LayoutTests/fast/forms/ValidityState-patternMismatch-expected.txt
+++ b/LayoutTests/fast/forms/ValidityState-patternMismatch-expected.txt
@@ -1,3 +1,33 @@
+CONSOLE MESSAGE: Pattern attribute value '[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?' is not a valid regular expression.
+CONSOLE MESSAGE: Pattern attribute value '[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?' is not a valid regular expression.
+CONSOLE MESSAGE: Pattern attribute value '[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?' is not a valid regular expression.
+CONSOLE MESSAGE: Pattern attribute value '[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?' is not a valid regular expression.
+CONSOLE MESSAGE: Pattern attribute value ')foo(' is not a valid regular expression.
+CONSOLE MESSAGE: Pattern attribute value ')foo(' is not a valid regular expression.
+CONSOLE MESSAGE: Pattern attribute value ')foo(' is not a valid regular expression.
+CONSOLE MESSAGE: Pattern attribute value ')foo(' is not a valid regular expression.
+CONSOLE MESSAGE: Pattern attribute value ')foo(' is not a valid regular expression.
+CONSOLE MESSAGE: Pattern attribute value ')foo(' is not a valid regular expression.
+CONSOLE MESSAGE: Pattern attribute value 'foo\' is not a valid regular expression.
+CONSOLE MESSAGE: Pattern attribute value 'foo\' is not a valid regular expression.
+CONSOLE MESSAGE: Pattern attribute value '[0-9' is not a valid regular expression.
+CONSOLE MESSAGE: Pattern attribute value '[0-9' is not a valid regular expression.
+CONSOLE MESSAGE: Pattern attribute value '[0-9' is not a valid regular expression.
+CONSOLE MESSAGE: Pattern attribute value '[0-9' is not a valid regular expression.
+CONSOLE MESSAGE: Pattern attribute value 'foo\'bar' is not a valid regular expression.
+CONSOLE MESSAGE: Pattern attribute value 'foo\'bar' is not a valid regular expression.
+CONSOLE MESSAGE: Pattern attribute value 'foo\'bar' is not a valid regular expression.
+CONSOLE MESSAGE: Pattern attribute value 'foo\'bar' is not a valid regular expression.
+CONSOLE MESSAGE: Pattern attribute value '[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?' is not a valid regular expression.
+CONSOLE MESSAGE: Pattern attribute value '[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?' is not a valid regular expression.
+CONSOLE MESSAGE: Pattern attribute value ')foo(' is not a valid regular expression.
+CONSOLE MESSAGE: Pattern attribute value ')foo(' is not a valid regular expression.
+CONSOLE MESSAGE: Pattern attribute value ')foo(' is not a valid regular expression.
+CONSOLE MESSAGE: Pattern attribute value 'foo\' is not a valid regular expression.
+CONSOLE MESSAGE: Pattern attribute value '[0-9' is not a valid regular expression.
+CONSOLE MESSAGE: Pattern attribute value '[0-9' is not a valid regular expression.
+CONSOLE MESSAGE: Pattern attribute value 'foo\'bar' is not a valid regular expression.
+CONSOLE MESSAGE: Pattern attribute value 'foo\'bar' is not a valid regular expression.
 This test checks validity.patternMismatch.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".

--- a/Source/JavaScriptCore/yarr/RegularExpression.cpp
+++ b/Source/JavaScriptCore/yarr/RegularExpression.cpp
@@ -29,10 +29,13 @@
 #include "RegularExpression.h"
 
 #include "Yarr.h"
+#include "YarrFlags.h"
 #include "YarrInterpreter.h"
+#include "YarrSyntaxChecker.h"
 #include <wtf/Assertions.h>
 #include <wtf/BumpPointerAllocator.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/text/MakeString.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -42,20 +45,30 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RegularExpression);
 
 class RegularExpression::Private : public RefCounted<RegularExpression::Private> {
 public:
-    static Ref<Private> create(StringView pattern, OptionSet<Flags> flags)
+    static Ref<Private> create(StringView pattern, OptionSet<Flags> flags, MatchMode matchMode)
     {
-        return adoptRef(*new Private(pattern, flags));
+        return adoptRef(*new Private(pattern, flags, matchMode));
     }
 
 private:
-    Private(StringView pattern, OptionSet<Flags> flags)
-        : m_regExpByteCode(compile(pattern, flags))
+    Private(StringView pattern, OptionSet<Flags> flags, MatchMode matchMode)
+        : m_regExpByteCode(compile(pattern, flags, matchMode))
     {
     }
 
-    std::unique_ptr<BytecodePattern> compile(StringView patternString, OptionSet<Flags> flags)
+    std::unique_ptr<BytecodePattern> compile(StringView patternString, OptionSet<Flags> flags, MatchMode matchMode)
     {
         ASSERT(!(flags - OptionSet<Flags> { Flags::IgnoreCase, Flags::Multiline, Flags::UnicodeSets }));
+
+        if (matchMode == MatchMode::EntireInput) {
+            // Validate the raw pattern syntax first since wrapping with ^(?:...)$
+            // can turn an invalid pattern into a valid one (e.g. "a)(b" becomes "^(?:a)(b)$").
+            auto syntaxCheckFlags = flagsString(flags);
+            if (checkSyntax(patternString, StringView::fromLatin1(syntaxCheckFlags.data())) != ErrorCode::NoError)
+                return nullptr;
+            auto anchoredPattern = makeString("^(?:"_s, patternString, ")$"_s);
+            return compile(anchoredPattern, flags, MatchMode::Partial);
+        }
 
         YarrPattern pattern(patternString, flags, m_constructionErrorCode);
         if (hasError(m_constructionErrorCode)) {
@@ -77,8 +90,8 @@ public:
     std::unique_ptr<BytecodePattern> m_regExpByteCode;
 };
 
-RegularExpression::RegularExpression(StringView pattern, OptionSet<Flags> flags)
-    : d(Private::create(pattern, flags))
+RegularExpression::RegularExpression(StringView pattern, OptionSet<Flags> flags, MatchMode matchMode)
+    : d(Private::create(pattern, flags, matchMode))
 {
 }
 

--- a/Source/JavaScriptCore/yarr/RegularExpression.h
+++ b/Source/JavaScriptCore/yarr/RegularExpression.h
@@ -32,10 +32,15 @@
 
 namespace JSC { namespace Yarr {
 
+enum class MatchMode : uint8_t {
+    Partial, // Default: match anywhere in the string.
+    EntireInput // Anchored: pattern must match the entire input (equivalent to ^(?:pattern)$).
+};
+
 class JS_EXPORT_PRIVATE RegularExpression {
     WTF_MAKE_TZONE_ALLOCATED(RegularExpression);
 public:
-    explicit RegularExpression(StringView, OptionSet<Flags> = { });
+    explicit RegularExpression(StringView, OptionSet<Flags> = { }, MatchMode = MatchMode::Partial);
     ~RegularExpression();
 
     RegularExpression(const RegularExpression&);

--- a/Source/WebCore/html/BaseTextInputType.cpp
+++ b/Source/WebCore/html/BaseTextInputType.cpp
@@ -25,9 +25,11 @@
 #include "config.h"
 #include "BaseTextInputType.h"
 
+#include "Document.h"
 #include "ElementInlines.h"
 #include "HTMLInputElement.h"
 #include "HTMLNames.h"
+#include <JavaScriptCore/ConsoleTypes.h>
 #include <JavaScriptCore/RegularExpression.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
@@ -42,14 +44,16 @@ bool BaseTextInputType::patternMismatch(const String& value) const
 {
     ASSERT(element());
     Ref element = *this->element();
-    // FIXME: We should execute RegExp parser first to check validity instead of creating an actual RegularExpression.
-    // https://bugs.webkit.org/show_bug.cgi?id=183361
     const AtomString& rawPattern = element->attributeWithoutSynchronization(patternAttr);
-    if (rawPattern.isNull() || value.isEmpty() || !JSC::Yarr::RegularExpression(rawPattern, { JSC::Yarr::Flags::UnicodeSets }).isValid())
+    if (rawPattern.isNull() || value.isEmpty())
         return false;
 
-    String pattern = makeString("^(?:"_s, rawPattern, ")$"_s);
-    JSC::Yarr::RegularExpression regex(pattern, { JSC::Yarr::Flags::UnicodeSets });
+    JSC::Yarr::RegularExpression regex(rawPattern, { JSC::Yarr::Flags::UnicodeSets }, JSC::Yarr::MatchMode::EntireInput);
+    if (!regex.isValid()) {
+        protect(element->document())->addConsoleMessage(MessageSource::Other, MessageLevel::Warning, makeString("Pattern attribute value '"_s, rawPattern, "' is not a valid regular expression."_s));
+        return false;
+    }
+
     auto valuePatternMismatch = [&regex](auto& value) {
         int matchLength = 0;
         int valueLength = value.length();


### PR DESCRIPTION
#### 3591ed5ffe0f087d9aee7914803a518605ba43c3
<pre>
Avoid compiling the pattern attribute regex twice in patternMismatch()
<a href="https://bugs.webkit.org/show_bug.cgi?id=310978">https://bugs.webkit.org/show_bug.cgi?id=310978</a>

Reviewed by Yusuke Suzuki and Sam Weinig.

patternMismatch() was compiling the raw pattern regex just to check
isValid(), then compiling it again with ^(?:...)$ anchoring for the
actual match. Add a MatchMode::EntireInput option to
JSC::Yarr::RegularExpression that internally validates the raw pattern
syntax via a lightweight Yarr::checkSyntax() call (parse-only, no
bytecode generation), then compiles only the anchored form. This
avoids the redundant full compilation of the raw pattern.

The raw pattern syntax must be validated separately because wrapping
with ^(?:...)$ can turn an invalid pattern into a valid one (e.g.
&quot;a)(b&quot; becomes &quot;^(?:a)(b)$&quot;).

Also add a JS console message when the regular expression parsing fails,
as recommended by the specification.

* LayoutTests/fast/forms/ValidityState-patternMismatch-expected.txt:
* Source/JavaScriptCore/yarr/RegularExpression.cpp:
(JSC::Yarr::RegularExpression::Private::create):
(JSC::Yarr::RegularExpression::Private::Private):
(JSC::Yarr::RegularExpression::Private::compile):
(JSC::Yarr::RegularExpression::RegularExpression):
* Source/JavaScriptCore/yarr/RegularExpression.h:
* Source/WebCore/html/BaseTextInputType.cpp:
(WebCore::BaseTextInputType::patternMismatch const):

Canonical link: <a href="https://commits.webkit.org/310197@main">https://commits.webkit.org/310197@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/785bdd09e551c0b6dd5e00a5027f1a6ec07be7b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153008 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25790 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19388 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161752 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106465 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154881 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26317 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26095 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118266 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83731 "5 flakes 6 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155967 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20495 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137360 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98979 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19569 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17509 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9588 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/145020 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129222 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15233 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164226 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13821 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7362 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16827 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126328 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25587 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21548 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126486 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34324 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25589 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137029 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82222 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21434 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13808 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184643 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25205 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89492 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47206 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24897 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25056 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24957 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->