### PR TITLE
[JSC] Fix O(n^2) list building in offlineasm

### DIFF
--- a/Source/JavaScriptCore/offlineasm/arm64e.rb
+++ b/Source/JavaScriptCore/offlineasm/arm64e.rb
@@ -100,7 +100,7 @@ class Instruction
                 newList << node.cloneWithNewOperands(newOperands)
                 wasHandled = true
             end
-            newList += postInstructions if wasHandled
+            newList.concat(postInstructions) if wasHandled
         end
         return wasHandled, newList
     end

--- a/Source/JavaScriptCore/offlineasm/risc.rb
+++ b/Source/JavaScriptCore/offlineasm/risc.rb
@@ -505,7 +505,7 @@ def riscLowerMisplacedAddresses(list)
             else
                 newList << node
             end
-            newList += postInstructions
+            newList.concat(postInstructions)
         else
             newList << node
         end

--- a/Source/JavaScriptCore/offlineasm/transform.rb
+++ b/Source/JavaScriptCore/offlineasm/transform.rb
@@ -93,7 +93,7 @@ class Sequence
             | item |
             item = item.resolveSettings(settings)
             if item.is_a? Sequence
-                newList += item.list
+                newList.concat(item.list)
             else
                 newList << item
             end
@@ -452,7 +452,7 @@ class Sequence
                 if item.annotation
                     newList << Instruction.new(item.codeOrigin, "localAnnotation", [], item.annotation)
                 end
-                newList += macro.body.substitute(mapping).demacroify(myMyMacros).renameLabels(item.originalName).list
+                newList.concat(macro.body.substitute(mapping).demacroify(myMyMacros).renameLabels(item.originalName).list)
 
                 @@demacroifyStack.pop
             else


### PR DESCRIPTION
#### 59d83df397a34126663e75a955bb5de8813500e0
<pre>
[JSC] Fix O(n^2) list building in offlineasm
<a href="https://bugs.webkit.org/show_bug.cgi?id=310979">https://bugs.webkit.org/show_bug.cgi?id=310979</a>

Reviewed by Yusuke Suzuki.

Ruby&apos;s `a += b` is sugar for `a = a + b`, which allocates a new array
and copies every element even when b is empty. Several lowering passes
append to a growing instruction list this way inside a loop, making them
O(n^2) in the list length. riscLowerMisplacedAddresses is the worst
offender, iterating ~49,000 times per configuration.

Switching to Array#concat (in-place append) brings LLIntAssembly.h
generation from 5.85s down to 4.31s on Apple Silicon with the macOS
system Ruby. Output is byte-identical.

* Source/JavaScriptCore/offlineasm/arm64e.rb:
* Source/JavaScriptCore/offlineasm/risc.rb:
* Source/JavaScriptCore/offlineasm/transform.rb:

Canonical link: <a href="https://commits.webkit.org/310180@main">https://commits.webkit.org/310180@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3df11c6ad618515ae32539a43c088bdfc163573

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152890 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25672 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19270 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161634 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106346 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26199 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25977 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118158 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83662 "3 flakes 5 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155849 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20393 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137255 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98871 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19467 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17404 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9470 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144902 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129120 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15129 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164108 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13699 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7244 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16723 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126220 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25469 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21443 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126378 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34308 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25471 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136925 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82075 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21333 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13704 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184523 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25087 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89374 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47106 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24779 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24938 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24839 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->