### PR TITLE
[iOS] Add entitlement related to checked allocations

### DIFF
--- a/Source/WebKit/Scripts/process-entitlements.sh
+++ b/Source/WebKit/Scripts/process-entitlements.sh
@@ -99,11 +99,6 @@ function mac_process_webcontent_enhancedsecurity_entitlements()
         plistbuddy Add :com.apple.security.fatal-exceptions:0 string jit
     fi
 
-    if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 260000 ))
-    then
-        plistbuddy Add :com.apple.security.hardened-process.checked-allocations.no-tagged-receive bool YES
-    fi
-
     if [[ "${WK_USE_RESTRICTED_ENTITLEMENTS}" == YES ]]
     then
         plistbuddy Add :com.apple.private.webkit.use-xpc-endpoint bool YES
@@ -190,6 +185,10 @@ function mac_process_gpu_entitlements()
         then
             plistbuddy Add :com.apple.private.pac.exception bool YES
         fi
+        if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 260000 ))
+        then
+            plistbuddy Add :com.apple.security.hardened-process.checked-allocations.no-tagged-receive bool YES
+        fi
         plistbuddy Add :com.apple.security.hardened-process.checked-allocations.soft-mode bool YES # FIXME: Should be removed before release <rdar://171909082>
     fi
 }
@@ -245,7 +244,12 @@ function mac_process_network_entitlements()
         plistbuddy Add :com.apple.private.webkit.adattributiond bool YES
         plistbuddy Add :com.apple.private.webkit.webpush bool YES
         plistbuddy Add :com.apple.developer.hardened-process bool YES
+        if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 260000 ))
+        then
+            plistbuddy Add :com.apple.security.hardened-process.checked-allocations.no-tagged-receive bool YES
+        fi
         plistbuddy Add :com.apple.security.hardened-process.checked-allocations.soft-mode bool YES # FIXME: Should be removed before release <rdar://171909082>
+
         # FIXME: This should be removed after crash investigation as part of <rdar://problem/160965793>
         plistbuddy Add :com.apple.private.get-system-corpse bool YES
 
@@ -354,6 +358,10 @@ function mac_process_webcontent_shared_entitlements()
         fi
 
         plistbuddy Add :com.apple.developer.hardened-process bool YES
+        if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 260000 ))
+        then
+            plistbuddy Add :com.apple.security.hardened-process.checked-allocations.no-tagged-receive bool YES
+        fi
         plistbuddy Add :com.apple.security.hardened-process.checked-allocations.soft-mode bool YES # FIXME: Should be removed before release <rdar://171909082>
     fi
 
@@ -385,6 +393,17 @@ function mac_process_webpushd_entitlements()
 # ========================================
 # macCatalyst entitlements
 # ========================================
+
+function maccatalyst_process_webcontent_shared_entitlements()
+{
+    if [[ "${WK_USE_RESTRICTED_ENTITLEMENTS}" == YES ]]
+    then
+        if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 260000 ))
+        then
+            plistbuddy Add :com.apple.security.hardened-process.checked-allocations.no-tagged-receive bool YES
+        fi
+    fi
+}
 
 function maccatalyst_process_webcontent_entitlements()
 {
@@ -433,6 +452,8 @@ function maccatalyst_process_webcontent_entitlements()
     then
         plistbuddy Add :com.apple.private.disable-log-mach-ports bool YES
     fi
+
+    maccatalyst_process_webcontent_shared_entitlements
 }
 
 function maccatalyst_process_webcontent_captiveportal_entitlements()
@@ -482,6 +503,8 @@ function maccatalyst_process_webcontent_captiveportal_entitlements()
         plistbuddy Add :com.apple.private.verified-jit bool YES
         plistbuddy Add :com.apple.security.cs.single-jit bool YES
     fi
+
+    maccatalyst_process_webcontent_shared_entitlements
 }
 
 function maccatalyst_process_webcontent_enhancedsecurity_entitlements()
@@ -501,7 +524,6 @@ function maccatalyst_process_webcontent_enhancedsecurity_entitlements()
     if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 260000 ))
     then
         plistbuddy Add :com.apple.security.hardened-process.checked-allocations.soft-mode bool YES
-        plistbuddy Add :com.apple.security.hardened-process.checked-allocations.no-tagged-receive bool YES
     fi
 
     plistbuddy Add :com.apple.developer.kernel.extended-virtual-addressing bool YES
@@ -516,6 +538,8 @@ function maccatalyst_process_webcontent_enhancedsecurity_entitlements()
     fi
 
     plistbuddy Add :com.apple.private.disable-log-mach-ports bool YES
+
+    maccatalyst_process_webcontent_shared_entitlements
 }
 
 function maccatalyst_process_gpu_entitlements()
@@ -542,6 +566,10 @@ function maccatalyst_process_gpu_entitlements()
         if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 110000 ))
         then
             plistbuddy Add :com.apple.security.cs.jit-write-allowlist bool YES
+        fi
+        if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 260000 ))
+        then
+            plistbuddy Add :com.apple.security.hardened-process.checked-allocations.no-tagged-receive bool YES
         fi
     fi
 }
@@ -571,6 +599,10 @@ function maccatalyst_process_network_entitlements()
         if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 110000 ))
         then
             plistbuddy Add :com.apple.security.cs.jit-write-allowlist bool YES
+        fi
+        if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 260000 ))
+        then
+            plistbuddy Add :com.apple.security.hardened-process.checked-allocations.no-tagged-receive bool YES
         fi
     fi
 }
@@ -611,6 +643,7 @@ fi
     plistbuddy add :com.apple.coreaudio.LoadDecodersInProcess bool YES
     plistbuddy add :com.apple.coreaudio.allow-vorbis-decode bool YES
     plistbuddy Add :com.apple.developer.hardened-process bool YES
+    plistbuddy Add :com.apple.security.hardened-process.checked-allocations.no-tagged-receive bool YES
     plistbuddy Add :com.apple.security.hardened-process.checked-allocations.soft-mode bool YES # FIXME: Should be removed before release <rdar://171909082>
 
     if [[ "${WK_USE_FATAL_EXCEPTIONS}" == YES ]]
@@ -660,7 +693,6 @@ function ios_family_process_webcontent_enhancedsecurity_entitlements()
 {
     plistbuddy Add :com.apple.private.webkit.enhanced-security bool YES
     plistbuddy Add :com.apple.developer.kernel.extended-virtual-addressing bool YES
-    plistbuddy Add :com.apple.security.hardened-process.checked-allocations.no-tagged-receive bool YES
 
     ios_family_process_webcontent_shared_entitlements
 }
@@ -729,6 +761,7 @@ if [[ "${WK_PLATFORM_NAME}" == xros ]]; then
 fi
 
     plistbuddy Add :com.apple.developer.hardened-process bool YES
+    plistbuddy Add :com.apple.security.hardened-process.checked-allocations.no-tagged-receive bool YES
     plistbuddy Add :com.apple.security.hardened-process.checked-allocations.soft-mode bool YES # FIXME: Should be removed before release <rdar://171909082>
 
     plistbuddy Add :com.apple.developer.kernel.extended-virtual-addressing bool YES
@@ -749,6 +782,7 @@ function ios_family_process_model_entitlements()
     then
         plistbuddy Add :com.apple.private.pac.exception bool YES
     fi
+    plistbuddy Add :com.apple.security.hardened-process.checked-allocations.no-tagged-receive bool YES
     plistbuddy Add :com.apple.security.hardened-process.checked-allocations.soft-mode bool YES # FIXME: Should be removed before release <rdar://171909082>
 }
 
@@ -817,6 +851,7 @@ fi
     plistbuddy Add :com.apple.private.assets.accessible-asset-types array
     plistbuddy Add :com.apple.private.assets.accessible-asset-types:0 string com.apple.MobileAsset.WebContentRestrictions
     plistbuddy Add :com.apple.developer.hardened-process bool YES
+    plistbuddy Add :com.apple.security.hardened-process.checked-allocations.no-tagged-receive bool YES
     plistbuddy Add :com.apple.security.hardened-process.checked-allocations.soft-mode bool YES # FIXME: Should be removed before release <rdar://171909082>
 
     plistbuddy Add :com.apple.private.security.mutable-state-flags array


### PR DESCRIPTION
#### ed598b08761c4715373997ff339d0864a649db6d
<pre>
[iOS] Add entitlement related to checked allocations
<a href="https://rdar.apple.com/163493412">rdar://163493412</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=310718">https://bugs.webkit.org/show_bug.cgi?id=310718</a>

Reviewed by Brady Eidson.

This was previously landed in 310109@main. This patch fixes the build for Catalyst.

* Source/WebKit/Scripts/process-entitlements.sh:

Canonical link: <a href="https://commits.webkit.org/310166@main">https://commits.webkit.org/310166@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4dfe8736606a0bed3c8525a394c7f5fd1724469f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152894 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25676 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19274 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161638 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106350 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/21dd9b99-2afc-4d05-b301-0f046b1d59e2) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26203 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25981 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118161 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83663 "3 flakes 5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bb6befc3-69f1-4a68-a335-b4010c93ee75) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155853 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20396 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137260 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98874 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c8c64679-afcc-4112-b208-698fdf21f3d2) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/152215 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19470 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17409 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPICookies.ChangedEvent (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9474 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129123 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164112 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7248 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16728 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126223 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25473 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21448 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126381 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25475 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136930 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82081 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23420 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21338 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13709 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25091 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89378 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24783 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24942 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24843 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->