### PR TITLE
Fix encodeHostName() for inputs containing %

### DIFF
--- a/Source/WTF/wtf/URL.cpp
+++ b/Source/WTF/wtf/URL.cpp
@@ -766,7 +766,7 @@ void URL::setPath(StringView path)
 
     parseAllowingC0AtEnd(makeString(
         StringView(m_string).left(pathStart()),
-        path.startsWith('/') || (path.startsWith('\\') && (hasSpecialScheme() || protocolIsFile())) || (!hasSpecialScheme() && path.isEmpty() && m_schemeEnd + 1U < pathStart()) ? ""_s : "/"_s,
+        path.startsWith('/') || (path.startsWith('\\') && hasSpecialScheme()) || (!hasSpecialScheme() && path.isEmpty() && m_schemeEnd + 1U < pathStart()) ? ""_s : "/"_s,
         !hasSpecialScheme() && host().isEmpty() && path.startsWith("//"_s) && path.length() > 2 ? "/."_s : ""_s,
         escapePathWithoutCopying(path),
         StringView(m_string).substring(m_pathEnd)

--- a/Source/WTF/wtf/URL.h
+++ b/Source/WTF/wtf/URL.h
@@ -138,7 +138,7 @@ public:
     bool isValid() const;
 
     // Since we overload operator NSURL * we have this to prevent accidentally using that operator
-    // when placing a URL in an if statment.
+    // when placing a URL in an if statement.
     operator bool() const = delete;
 
     const String& string() const LIFETIME_BOUND { return m_string; }

--- a/Source/WTF/wtf/URLHelpers.cpp
+++ b/Source/WTF/wtf/URLHelpers.cpp
@@ -643,7 +643,7 @@ std::optional<String> mapHostName(const String& hostName, URLDecodeFunction deco
         return String();
 
     String string;
-    if (decodeFunction && string.contains('%'))
+    if (decodeFunction && hostName.contains('%'))
         string = (*decodeFunction)(hostName);
     else
         string = hostName;
@@ -679,6 +679,10 @@ static void collectRangesThatNeedMapping(const String& string, unsigned location
 {
     // Generally, we want to optimize for the case where there is one host name that does not need mapping.
     // Therefore, we use null to indicate no mapping here and an empty array to indicate error.
+
+    // IPv6 addresses are bracketed and don't need IDN processing.
+    if (length && string[location] == '[')
+        return;
 
     String substring = string.substringSharingImpl(location, length);
     std::optional<String> host = mapHostName(substring, decodeFunction);
@@ -731,7 +735,7 @@ static void applyHostNameFunctionToMailToURLString(const String& string, URLDeco
                 current = hostNameEnd;
                 done = false;
             }
-            
+
             // Process host name range.
             collectRangesThatNeedMapping(string, hostNameStart, hostNameEnd - hostNameStart, array, decodeFunction);
 
@@ -812,7 +816,7 @@ String mapHostNames(const String& string, URLDecodeFunction decodeFunction)
 {
     // Generally, we want to optimize for the case where there is one host name that does not need mapping.
     
-    if (decodeFunction && string.containsOnlyASCII())
+    if (decodeFunction && string.containsOnlyASCII() && !string.contains('%'))
         return string;
     
     // Make a list of ranges that actually need mapping.
@@ -842,7 +846,7 @@ static String escapeUnsafeCharacters(const String& sourceBuffer)
     unsigned i;
     for (i = 0; i < length; ) {
         char32_t c = sourceBuffer.codePointAt(i);
-        if (isLookalikeCharacter(previousCodePoint, sourceBuffer.codePointAt(i)))
+        if (isLookalikeCharacter(previousCodePoint, c))
             break;
         previousCodePoint = c;
         i += U16_LENGTH(c);
@@ -888,7 +892,7 @@ static String escapeUnsafeCharacters(const String& sourceBuffer)
 String userVisibleURL(const CString& url)
 {
     auto before = url.span();
-    int length = url.length();
+    size_t length = url.length();
 
     if (!length)
         return { };
@@ -904,7 +908,7 @@ String userVisibleURL(const CString& url)
     size_t afterIndex = 0;
     {
         auto p = before;
-        for (int i = 0; i < length; i++) {
+        for (size_t i = 0; i < length; i++) {
             unsigned char c = p[i];
             // unescape escape sequences that indicate bytes greater than 0x7f
             if (c == '%' && i + 2 < length && isASCIIHexDigit(p[i + 1]) && isASCIIHexDigit(p[i + 2])) {
@@ -938,7 +942,7 @@ String userVisibleURL(const CString& url)
         // Shift current string to the end of the buffer
         // then we will copy back bytes to the start of the buffer 
         // as we convert.
-        int afterlength = afterIndex;
+        size_t afterlength = afterIndex;
         auto p = after.mutableSpan().subspan(bufferLength.value() - afterlength - 1);
         memmoveSpan(p, after.span().first(afterlength + 1)); // copies trailing '\0'
         afterIndex = 0;

--- a/Source/WTF/wtf/URLParser.cpp
+++ b/Source/WTF/wtf/URLParser.cpp
@@ -350,7 +350,7 @@ ALWAYS_INLINE bool URLParser::isForbiddenDomainCodePoint(CharacterType character
     return character <= 0x7F && characterClassTable[character] & ForbiddenDomain;
 }
 
-ALWAYS_INLINE static bool shouldPercentEncodeQueryByte(uint8_t byte, const bool& urlIsSpecial)
+ALWAYS_INLINE static bool shouldPercentEncodeQueryByte(uint8_t byte, bool urlIsSpecial)
 {
     if (characterClassTable[byte] & QueryEncode)
         return true;

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
@@ -294,6 +294,30 @@ TEST(URLExtras, URLExtras_Space)
     EXPECT_WK_STREQ("site.com\xE3\x80\x80othersite.org", [@"site.com\xE3\x80\x80othersite.org" _wk_decodeHostName]);
 }
 
+TEST(URLExtras, URLExtras_PercentEncodedIDN)
+{
+    // Percent-encoded IDN hostnames should be decoded before UIDNA processing.
+    // m%C3%BCnchen.de should decode to münchen.de, then encode to xn--mnchen-3ya.de.
+    EXPECT_STREQ("xn--mnchen-3ya.de", [WTF::encodeHostName(@"m%C3%BCnchen.de") UTF8String]);
+    EXPECT_STREQ("http://xn--mnchen-3ya.de/", originalDataAsString(WTF::URLWithUserTypedString(@"http://m%C3%BCnchen.de/", nil)));
+}
+
+TEST(URLExtras, URLExtras_IPv6)
+{
+    // IPv6 hosts pass through unchanged.
+    EXPECT_STREQ("http://[::1]/", originalDataAsString(WTF::URLWithUserTypedString(@"http://[::1]/", nil)));
+    EXPECT_STREQ("http://[::1]:8080/", originalDataAsString(WTF::URLWithUserTypedString(@"http://[::1]:8080/", nil)));
+
+    // IPv6 hosts in URLs containing '%' must skip IDN processing rather than be
+    // mistaken for a hostname starting with '['.
+    EXPECT_STREQ("http://[::1]/path%20x", originalDataAsString(WTF::URLWithUserTypedString(@"http://[::1]/path%20x", nil)));
+    EXPECT_STREQ("http://[::1]:8080/?q=%20", originalDataAsString(WTF::URLWithUserTypedString(@"http://[::1]:8080/?q=%20", nil)));
+    EXPECT_STREQ("http://user@[::1]/path%20x", originalDataAsString(WTF::URLWithUserTypedString(@"http://user@[::1]/path%20x", nil)));
+
+    // Same for mailto: URLs whose address is an IPv6 literal.
+    EXPECT_STREQ("mailto:user@[::1]?subject=hi%20there", originalDataAsString(WTF::URLWithUserTypedString(@"mailto:user@[::1]?subject=hi%20there", nil)));
+}
+
 TEST(URLExtras, URLExtras_File)
 {
     EXPECT_STREQ("file:///%E2%98%83", [[WTF::URLWithUserTypedString(@"file:///☃", nil) absoluteString] UTF8String]);


### PR DESCRIPTION
#### 8449fc1aaccab18301e786f3e337b8e5540cd99e
<pre>
Fix encodeHostName() for inputs containing %
<a href="https://bugs.webkit.org/show_bug.cgi?id=310982">https://bugs.webkit.org/show_bug.cgi?id=310982</a>

Reviewed by Alex Christensen.

There were two issues with encodeHostName():

1. mapHostNames() would return early for ASCII-only input, even when
   that input contains %.
2. mapHostName() checked the wrong variable for %.
3. Fixing (1) meant URLs containing % could now reach the host-range
   detection code, which doesn&apos;t understand bracketed IPv6 syntax:
   for <a href="http://[">http://[</a>::1]/path%20x it would pick &apos;[&apos; as the host, which
   then failed UIDNA. Skip IDN processing for host ranges starting
   with &apos;[&apos; in collectRangesThatNeedMapping().

We also fix various trivial issues in the URL code:

1. protocolIsFile() is redundant with hasSpecialScheme().
2. Some type mismatches.
3. A redundant call to codePointAt(i).

Test: Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
Canonical link: <a href="https://commits.webkit.org/314167@main">https://commits.webkit.org/314167@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b81b91feee3fcbe3dc62393606aa37636192ee45

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164205 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37689 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30908 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173234 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121457 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/05e3edbf-32af-4f42-ad3d-7cc4dd509df4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166074 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38023 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37689 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127564 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89754 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6a9e5de4-c1e8-41ae-8414-ffb154d7d3a6) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167164 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed webkitperl tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29864 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147611 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108112 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a18dfb85-db8b-4fe6-8d7c-b3ea37d361ff) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/163526 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28911 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27538 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20998 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/156356 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138813 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25328 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175760 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/25097 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28581 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26996 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135875 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/163602 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37359 "Build is in progress. Recent messages:OS: Tahoe (26.4.1), Xcode: 26.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31653 "Found 1 new test failure: http/tests/storageAccess/aggregate-sorted-data-with-storage-access.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135845 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36858 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38145 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147123 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100450 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31163 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23979 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/196608 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36955 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110000 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51628 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36352 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2034 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36602 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36502 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->