### PR TITLE
URL: fix bug in SpecialRelativeOrAuthority state

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/url/a-element-origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/a-element-origin-expected.txt
@@ -68,6 +68,7 @@ PASS Parsing origin: <http://[::127.0.0.1]> against <http://example.org/foo/bar>
 PASS Parsing origin: <http://[0:0:0:0:0:0:13.1.68.3]> against <http://example.org/foo/bar>
 PASS Parsing origin: <http://[2001::1]:80> against <http://example.org/foo/bar>
 PASS Parsing origin: <http:/example.com/> against <http://example.org/foo/bar>
+PASS Parsing origin: <http:/> against <http://example.com/>
 PASS Parsing origin: <ftp:/example.com/> against <http://example.org/foo/bar>
 PASS Parsing origin: <https:/example.com/> against <http://example.org/foo/bar>
 PASS Parsing origin: <madeupscheme:/example.com/> against <http://example.org/foo/bar>

--- a/LayoutTests/imported/w3c/web-platform-tests/url/a-element-origin-xhtml-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/a-element-origin-xhtml-expected.txt
@@ -68,6 +68,7 @@ PASS Parsing origin: <http://[::127.0.0.1]> against <http://example.org/foo/bar>
 PASS Parsing origin: <http://[0:0:0:0:0:0:13.1.68.3]> against <http://example.org/foo/bar>
 PASS Parsing origin: <http://[2001::1]:80> against <http://example.org/foo/bar>
 PASS Parsing origin: <http:/example.com/> against <http://example.org/foo/bar>
+PASS Parsing origin: <http:/> against <http://example.com/>
 PASS Parsing origin: <ftp:/example.com/> against <http://example.org/foo/bar>
 PASS Parsing origin: <https:/example.com/> against <http://example.org/foo/bar>
 PASS Parsing origin: <madeupscheme:/example.com/> against <http://example.org/foo/bar>

--- a/LayoutTests/imported/w3c/web-platform-tests/url/a-element-xhtml_exclude=(file_javascript_mailto)-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/a-element-xhtml_exclude=(file_javascript_mailto)-expected.txt
@@ -80,6 +80,7 @@ PASS Parsing: <http://[::127.0.0.1.]> against <http://example.org/foo/bar>
 PASS Parsing: <http://[0:0:0:0:0:0:13.1.68.3]> against <http://example.org/foo/bar>
 PASS Parsing: <http://[2001::1]:80> against <http://example.org/foo/bar>
 PASS Parsing: <http:/example.com/> against <http://example.org/foo/bar>
+PASS Parsing: <http:/> against <http://example.com/>
 PASS Parsing: <ftp:/example.com/> against <http://example.org/foo/bar>
 PASS Parsing: <https:/example.com/> against <http://example.org/foo/bar>
 PASS Parsing: <madeupscheme:/example.com/> against <http://example.org/foo/bar>

--- a/LayoutTests/imported/w3c/web-platform-tests/url/a-element_exclude=(file_javascript_mailto)-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/a-element_exclude=(file_javascript_mailto)-expected.txt
@@ -81,6 +81,7 @@ PASS Parsing: <http://[::127.0.0.1.]> against <http://example.org/foo/bar>
 PASS Parsing: <http://[0:0:0:0:0:0:13.1.68.3]> against <http://example.org/foo/bar>
 PASS Parsing: <http://[2001::1]:80> against <http://example.org/foo/bar>
 PASS Parsing: <http:/example.com/> against <http://example.org/foo/bar>
+PASS Parsing: <http:/> against <http://example.com/>
 PASS Parsing: <ftp:/example.com/> against <http://example.org/foo/bar>
 PASS Parsing: <https:/example.com/> against <http://example.org/foo/bar>
 PASS Parsing: <madeupscheme:/example.com/> against <http://example.org/foo/bar>

--- a/LayoutTests/imported/w3c/web-platform-tests/url/resources/urltestdata.json
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/resources/urltestdata.json
@@ -1045,6 +1045,21 @@
     "hash": ""
   },
   {
+    "input": "http:/",
+    "base": "http://example.com/",
+    "href": "http://example.com/",
+    "origin": "http://example.com",
+    "protocol": "http:",
+    "username": "",
+    "password": "",
+    "host": "example.com",
+    "hostname": "example.com",
+    "port": "",
+    "pathname": "/",
+    "search": "",
+    "hash": ""
+  },
+  {
     "input": "ftp:/example.com/",
     "base": "http://example.org/foo/bar",
     "href": "ftp://example.com/",

--- a/LayoutTests/imported/w3c/web-platform-tests/url/url-constructor.any.worker_exclude=(file_javascript_mailto)-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/url-constructor.any.worker_exclude=(file_javascript_mailto)-expected.txt
@@ -80,6 +80,7 @@ PASS Parsing: <http://[::127.0.0.1.]> against <http://example.org/foo/bar>
 PASS Parsing: <http://[0:0:0:0:0:0:13.1.68.3]> against <http://example.org/foo/bar>
 PASS Parsing: <http://[2001::1]:80> against <http://example.org/foo/bar>
 PASS Parsing: <http:/example.com/> against <http://example.org/foo/bar>
+PASS Parsing: <http:/> against <http://example.com/>
 PASS Parsing: <ftp:/example.com/> against <http://example.org/foo/bar>
 PASS Parsing: <https:/example.com/> against <http://example.org/foo/bar>
 PASS Parsing: <madeupscheme:/example.com/> against <http://example.org/foo/bar>

--- a/LayoutTests/imported/w3c/web-platform-tests/url/url-constructor.any_exclude=(file_javascript_mailto)-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/url-constructor.any_exclude=(file_javascript_mailto)-expected.txt
@@ -80,6 +80,7 @@ PASS Parsing: <http://[::127.0.0.1.]> against <http://example.org/foo/bar>
 PASS Parsing: <http://[0:0:0:0:0:0:13.1.68.3]> against <http://example.org/foo/bar>
 PASS Parsing: <http://[2001::1]:80> against <http://example.org/foo/bar>
 PASS Parsing: <http:/example.com/> against <http://example.org/foo/bar>
+PASS Parsing: <http:/> against <http://example.com/>
 PASS Parsing: <ftp:/example.com/> against <http://example.org/foo/bar>
 PASS Parsing: <https:/example.com/> against <http://example.org/foo/bar>
 PASS Parsing: <madeupscheme:/example.com/> against <http://example.org/foo/bar>

--- a/LayoutTests/imported/w3c/web-platform-tests/url/url-origin.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/url-origin.any-expected.txt
@@ -68,6 +68,7 @@ PASS Origin parsing: <http://[::127.0.0.1]> against <http://example.org/foo/bar>
 PASS Origin parsing: <http://[0:0:0:0:0:0:13.1.68.3]> against <http://example.org/foo/bar>
 PASS Origin parsing: <http://[2001::1]:80> against <http://example.org/foo/bar>
 PASS Origin parsing: <http:/example.com/> against <http://example.org/foo/bar>
+PASS Origin parsing: <http:/> against <http://example.com/>
 PASS Origin parsing: <ftp:/example.com/> against <http://example.org/foo/bar>
 PASS Origin parsing: <https:/example.com/> against <http://example.org/foo/bar>
 PASS Origin parsing: <madeupscheme:/example.com/> against <http://example.org/foo/bar>

--- a/LayoutTests/imported/w3c/web-platform-tests/url/url-origin.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/url-origin.any.worker-expected.txt
@@ -68,6 +68,7 @@ PASS Origin parsing: <http://[::127.0.0.1]> against <http://example.org/foo/bar>
 PASS Origin parsing: <http://[0:0:0:0:0:0:13.1.68.3]> against <http://example.org/foo/bar>
 PASS Origin parsing: <http://[2001::1]:80> against <http://example.org/foo/bar>
 PASS Origin parsing: <http:/example.com/> against <http://example.org/foo/bar>
+PASS Origin parsing: <http:/> against <http://example.com/>
 PASS Origin parsing: <ftp:/example.com/> against <http://example.org/foo/bar>
 PASS Origin parsing: <https:/example.com/> against <http://example.org/foo/bar>
 PASS Origin parsing: <madeupscheme:/example.com/> against <http://example.org/foo/bar>

--- a/Source/WTF/wtf/URLParser.cpp
+++ b/Source/WTF/wtf/URLParser.cpp
@@ -1312,11 +1312,7 @@ void URLParser::parse(std::span<const CharacterType> input, const URL& base, con
             if (*c == '/') {
                 appendToASCIIBuffer('/');
                 advance(c);
-                if (c.atEnd()) {
-                    failure();
-                    return;
-                }
-                if (*c == '/') {
+                if (!c.atEnd() && *c == '/') {
                     appendToASCIIBuffer('/');
                     state = State::SpecialAuthorityIgnoreSlashes;
                     ++c;

--- a/Tools/TestWebKitAPI/Tests/WTF/URLParser.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/URLParser.cpp
@@ -701,7 +701,7 @@ TEST_F(WTF_URLParser, ParserDifferences)
         { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http:/"_s });
     checkRelativeURL("http:"_s, "about:blank"_s, { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http:"_s });
     checkRelativeURLDifferences("http:/"_s, "http://host"_s,
-        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http:/"_s });
+        { "http"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "http://host/"_s });
     checkURLDifferences("http:/"_s,
         { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http:/"_s });
     checkURL("http:"_s, { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http:"_s });


### PR DESCRIPTION
#### d5b4478380e7e6a45c78bfaaf10e8fe1a8653f94
<pre>
URL: fix bug in SpecialRelativeOrAuthority state
<a href="https://bugs.webkit.org/show_bug.cgi?id=310984">https://bugs.webkit.org/show_bug.cgi?id=310984</a>

Reviewed by Youenn Fablet.

Reaching end-of-input in this state should not terminate the parser. We
should continue in the RelativeSlash state.

See

    <a href="https://url.spec.whatwg.org/#special-relative-or-authority-state">https://url.spec.whatwg.org/#special-relative-or-authority-state</a>

for context.

Upstream:

    <a href="https://github.com/web-platform-tests/wpt/pull/58839">https://github.com/web-platform-tests/wpt/pull/58839</a>

Canonical link: <a href="https://commits.webkit.org/310300@main">https://commits.webkit.org/310300@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb717ab6e83c29171db2d8fd33f0d5ba77ed2098

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153376 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26160 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19759 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162121 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155249 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26686 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26480 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118575 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156335 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20822 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137698 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99287 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9aaa1085-a68f-41f1-9520-0fe189ac692b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19899 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17842 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9956 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/145389 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129547 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15568 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164595 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/14197 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7731 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17162 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126637 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25957 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21875 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/semantics/structured-clone/shared.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126794 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25959 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137364 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82626 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23458 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21733 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14144 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/185011 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25576 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89862 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47452 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25267 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25426 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25327 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->