### PR TITLE
SMIL values attribute should preserve empty values and handle trailing semicolons as per spec

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/scripted/smil-values-empty-segments-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/scripted/smil-values-empty-segments-expected.txt
@@ -1,0 +1,6 @@
+
+PASS Trailing semicolon in values attribute is ignored for length animation
+PASS Trailing semicolon in values attribute is ignored for class animation
+PASS Double trailing semicolon in values preserves empty value between them
+PASS Empty value in the middle of values attribute is preserved
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/scripted/smil-values-empty-segments.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/scripted/smil-values-empty-segments.html
@@ -1,0 +1,85 @@
+<!doctype html>
+<title>Empty values in SMIL 'values' attribute should be preserved</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/rendering-utils.js"></script>
+<link rel="help" href="https://svgwg.org/specs/animations/#ValuesAttribute">
+<style>
+  .red   { fill: red; }
+  .green { fill: green; }
+</style>
+<svg id="svg" width="400" height="400">
+  <!-- values: length with trailing semicolon (2 values: "0", "100") -->
+  <rect id="rect-values-length" x="0" width="100" height="100" fill="green">
+    <animate attributeName="x" values="0;100;" dur="4s" fill="freeze"/>
+  </rect>
+
+  <!-- values: class with trailing semicolon (2 values: "red", "green") -->
+  <rect id="rect-values-class-trailing" width="100" height="100">
+    <animate attributeName="class" values="red;green;" dur="4s"
+             fill="freeze" calcMode="discrete"/>
+  </rect>
+
+  <!-- values: class with double trailing semicolon (3 values: "red", "green", "") -->
+  <rect id="rect-values-class-double" width="100" height="100">
+    <animate attributeName="class" values="red;green;;" dur="3s"
+             fill="freeze" calcMode="discrete"/>
+  </rect>
+
+  <!-- values: class with empty value in the middle (3 values: "red", "", "green") -->
+  <rect id="rect-values-class-middle" width="100" height="100">
+    <animate attributeName="class" values="red;;green" dur="3s"
+             fill="freeze" calcMode="discrete"/>
+  </rect>
+</svg>
+<script>
+  const svg = document.getElementById('svg');
+
+  promise_test(async t => {
+    svg.pauseAnimations();
+    svg.setCurrentTime(4);
+    await waitForAtLeastOneFrame();
+    const rect = document.getElementById('rect-values-length');
+    assert_equals(rect.x.animVal.value, 100,
+      'values="0;100;" with trailing semicolon should animate x to 100');
+  }, 'Trailing semicolon in values attribute is ignored for length animation');
+
+  promise_test(async t => {
+    svg.pauseAnimations();
+    svg.setCurrentTime(3);
+    await waitForAtLeastOneFrame();
+    const rect = document.getElementById('rect-values-class-trailing');
+    const fill = getComputedStyle(rect).fill;
+    assert_equals(fill, 'rgb(0, 128, 0)',
+      'values="red;green;" should end on "green" (trailing semicolon ignored)');
+  }, 'Trailing semicolon in values attribute is ignored for class animation');
+
+  promise_test(async t => {
+    svg.pauseAnimations();
+    // Seek well past the 2/3 boundary of dur=3s. With 3 values in discrete mode,
+    // index = floor(percent * 3). At t=2.5s, percent=5/6, index=floor(2.5)=2.
+    // The 3rd value is "" (empty class = default black fill).
+    svg.setCurrentTime(2.5);
+    await waitForAtLeastOneFrame();
+    const rect = document.getElementById('rect-values-class-double');
+    const fill = getComputedStyle(rect).fill;
+    assert_not_equals(fill, 'rgb(255, 0, 0)',
+      'Should not be red — empty class value should clear the class');
+    assert_not_equals(fill, 'rgb(0, 128, 0)',
+      'Should not be green — empty class value should clear the class');
+  }, 'Double trailing semicolon in values preserves empty value between them');
+
+  promise_test(async t => {
+    svg.pauseAnimations();
+    // At t=1.5s (percent=0.5), index = floor(0.5 * 3) = 1.
+    // The 2nd value is "" (empty class = default black fill).
+    svg.setCurrentTime(1.5);
+    await waitForAtLeastOneFrame();
+    const rect = document.getElementById('rect-values-class-middle');
+    const fill = getComputedStyle(rect).fill;
+    assert_not_equals(fill, 'rgb(255, 0, 0)',
+      'Should not be red — empty class value should clear the class');
+    assert_not_equals(fill, 'rgb(0, 128, 0)',
+      'Should not be green — empty class value should clear the class');
+  }, 'Empty value in the middle of values attribute is preserved');
+</script>

--- a/Source/WebCore/svg/SVGAnimationElement.cpp
+++ b/Source/WebCore/svg/SVGAnimationElement.cpp
@@ -172,11 +172,13 @@ void SVGAnimationElement::attributeChanged(const QualifiedName& name, const Atom
         // and white space before and after semicolon separators, is allowed and will be ignored.
         // http://www.w3.org/TR/SVG11/animate.html#ValuesAttribute
         m_values.clear();
-        newValue.string().split(';', [this](StringView innerValue) {
-            auto trimmed = innerValue.trim(isASCIIWhitespace<char16_t>).toString();
-            if (!trimmed.isEmpty())
-                m_values.append(WTF::move(trimmed));
+        newValue.string().splitAllowingEmptyEntries(';', [this](StringView innerValue) {
+            m_values.append(innerValue.trim(isASCIIWhitespace<char16_t>).toString());
         });
+        // Per the SMIL specification, if the last semicolon separator is followed by
+        // just white space or no more characters, ignore the trailing empty value.
+        if (!m_values.isEmpty() && m_values.last().isEmpty())
+            m_values.removeLast();
         updateAnimationMode();
         break;
     case AttributeNames::keyTimesAttr:


### PR DESCRIPTION
#### b96c3b022beffb2a1e79281d90062ef6b0b5fc37
<pre>
SMIL values attribute should preserve empty values and handle trailing semicolons as per spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=310988">https://bugs.webkit.org/show_bug.cgi?id=310988</a>
<a href="https://rdar.apple.com/173594455">rdar://173594455</a>

Reviewed by Simon Fraser.

The SMIL values attribute parser was using String::split() which silently
drops empty entries. This meant values=&quot;red;green;;&quot; produced only
[&quot;red&quot;, &quot;green&quot;] instead of [&quot;red&quot;, &quot;green&quot;, &quot;&quot;], losing the meaningful
empty value between the consecutive semicolons. Similarly,
values=&quot;red;;green&quot; lost the empty middle value.

Per the spec [1], &quot;If the last semicolon separator is followed by either
just white space or no more characters, ignore both the separator and the
trailing white space.&quot;

Switch to splitAllowingEmptyEntries so empty values are preserved, then
explicitly strip a single trailing empty entry per the spec rule above.

[1] <a href="https://svgwg.org/specs/animations/#ValuesAttribute">https://svgwg.org/specs/animations/#ValuesAttribute</a>

* Source/WebCore/svg/SVGAnimationElement.cpp:
(WebCore::SVGAnimationElement::attributeChanged): Use
splitAllowingEmptyEntries for values attribute, then strip a single
trailing empty value per spec.
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/scripted/smil-values-empty-segments-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/scripted/smil-values-empty-segments.html: Added.

Canonical link: <a href="https://commits.webkit.org/311502@main">https://commits.webkit.org/311502@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15775db3b6df63e850241396706695a8720d36c9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152914 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25696 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19294 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161658 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106370 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154787 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26223 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26001 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118175 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83676 "2 flakes 5 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155873 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20414 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137279 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98888 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19488 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17426 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9494 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129141 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15153 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164132 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7268 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16747 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126239 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25493 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21466 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126397 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35204 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25495 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136949 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82105 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21354 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13728 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25111 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89398 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24803 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24962 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24863 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->