### PR TITLE
Reduce unnecessary protected local variables in no-delete context in WebCore

### DIFF
--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -461,11 +461,11 @@ void HTMLModelElement::didUpdateBoundingBox(ModelPlayer&, const FloatPoint3D& ce
 
 RefPtr<GraphicsLayer> HTMLModelElement::graphicsLayer() const
 {
-    RefPtr page = document().page();
+    auto* page = document().page();
     if (!page)
         return nullptr;
 
-    CheckedPtr renderLayerModelObject = dynamicDowncast<RenderLayerModelObject>(this->renderer());
+    auto* renderLayerModelObject = dynamicDowncast<RenderLayerModelObject>(this->renderer());
     if (!renderLayerModelObject)
         return nullptr;
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -452,7 +452,7 @@ bool Element::isKeyboardFocusable(const FocusEventData&) const
             return false;
     }
     // Popovers with invokers delegate focus.
-    if (RefPtr popover = dynamicDowncast<HTMLElement>(*this)) {
+    if (auto* popover = dynamicDowncast<HTMLElement>(*this)) {
         if (popover->isPopoverShowing() && popover->popoverData()->invoker())
             return false;
     }
@@ -6401,7 +6401,7 @@ void Element::setVisibilityAdjustment(OptionSet<VisibilityAdjustment> adjustment
     if (!adjustment)
         return;
 
-    if (RefPtr page = document().page())
+    if (auto* page = document().page())
         page->didSetVisibilityAdjustment();
 }
 

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -1191,8 +1191,8 @@ bool Node::isShadowIncludingDescendantOf(const Node& other) const
 
 bool Node::isComposedTreeDescendantOf(const Node& node) const
 {
-    for (CheckedPtr currentAncestor = parentElementInComposedTree(); currentAncestor; currentAncestor = currentAncestor->parentElementInComposedTree()) {
-        if (currentAncestor.get() == &node)
+    for (auto* currentAncestor = parentElementInComposedTree(); currentAncestor; currentAncestor = currentAncestor->parentElementInComposedTree()) {
+        if (currentAncestor == &node)
             return true;
     }
     return false;

--- a/Source/WebCore/dom/Position.cpp
+++ b/Source/WebCore/dom/Position.cpp
@@ -338,7 +338,7 @@ Position::AnchorType Position::anchorTypeForLegacyEditingPosition(Node* anchorNo
 // FIXME: This method is confusing (does it return anchorNode() or containerNode()?) and should be renamed or removed
 RefPtr<Element> Position::anchorElementAncestor() const
 {
-    for (RefPtr node = anchorNode(); node; node = node->parentNode()) {
+    for (auto* node = anchorNode(); node; node = node->parentNode()) {
         if (auto* element = dynamicDowncast<Element>(*node))
             return element;
     }

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -903,7 +903,7 @@ bool shouldEmitNewlinesBeforeAndAfterNode(Node& node)
 {
     // Block flow (versus inline flow) is represented by having
     // a newline both before and after the element.
-    CheckedPtr renderer = node.renderer();
+    auto* renderer = node.renderer();
     if (!renderer) {
         if (hasDisplayContents(node))
             return false;
@@ -955,7 +955,7 @@ static bool shouldEmitNewlineAfterNode(Node& node, bool emitsCharactersBetweenAl
     // Don't emit a new line at the end of the document unless we're matching the behavior of VisiblePosition.
     if (emitsCharactersBetweenAllVisiblePositions)
         return true;
-    RefPtr subsequentNode = node;
+    auto* subsequentNode = &node;
     while ((subsequentNode = NodeTraversal::nextSkippingChildren(*subsequentNode))) {
         if (subsequentNode->renderer())
             return true;

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -114,13 +114,13 @@ private:
 RepaintBlocker::RepaintBlocker(Document& document)
     : m_document(document)
 {
-    if (CheckedPtr view = m_document->view())
+    if (auto* view = m_document->view())
         view->layoutContext().blockRepaints();
 }
 
 RepaintBlocker::~RepaintBlocker()
 {
-    if (CheckedPtr view = m_document->view())
+    if (auto* view = m_document->view())
         view->layoutContext().allowRepaints();
 }
 
@@ -473,7 +473,7 @@ bool LocalFrameViewLayoutContext::needsLayoutInternal() const
     // This can return true in cases where the document does not have a body yet.
     // Document::shouldScheduleLayout takes care of preventing us from scheduling
     // layout in that case.
-    CheckedPtr renderView = this->renderView();
+    auto* renderView = this->renderView();
     return isLayoutPending()
         || (renderView && renderView->needsLayout())
         || subtreeLayoutRoot()

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1572,7 +1572,7 @@ void Page::setInteractionRegionsEnabled(bool enable)
 
 const VisibleSelection& Page::selection() const
 {
-    RefPtr focusedOrMainFrame = focusController().focusedOrMainFrame();
+    auto* focusedOrMainFrame = focusController().focusedOrMainFrame();
     if (!focusedOrMainFrame)
         return VisibleSelection::emptySelection();
     return focusedOrMainFrame->selection().selection();

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
@@ -139,7 +139,7 @@ void ScrollAnchoringController::updateScrollableAreaRegistration()
 
 LocalFrameView& ScrollAnchoringController::frameView() const
 {
-    if (CheckedPtr renderLayerScrollableArea = dynamicDowncast<RenderLayerScrollableArea>(m_owningScrollableArea.get()))
+    if (auto* renderLayerScrollableArea = dynamicDowncast<RenderLayerScrollableArea>(m_owningScrollableArea.get()))
         return renderLayerScrollableArea->layer().renderer().view().frameView();
 
     return downcast<LocalFrameView>(downcast<ScrollView>(m_owningScrollableArea));
@@ -282,7 +282,7 @@ FloatPoint ScrollAnchoringController::computeOffsetFromOwningScroller(RenderObje
 
 void ScrollAnchoringController::notifyChildHadSuppressingStyleChange(RenderElement& renderer)
 {
-    CheckedPtr scrollerBox = scrollableAreaBox();
+    auto* scrollerBox = scrollableAreaBox();
 
 #if LOG_DISABLED
     UNUSED_PARAM(renderer);
@@ -364,7 +364,7 @@ AnchorSearchStatus ScrollAnchoringController::examinePriorityCandidate(RenderEle
 
 static bool NODELETE overflowAnchorProhibitsAnchoring(const RenderElement& object, const RenderBox& scrollingAncestor)
 {
-    for (CheckedPtr renderer = &object; renderer; renderer = renderer->parent()) {
+    for (auto* renderer = &object; renderer; renderer = renderer->parent()) {
         if (renderer->style().overflowAnchor() == OverflowAnchor::None)
             return true;
 
@@ -548,14 +548,14 @@ bool ScrollAnchoringController::anchoringSuppressedByStyleChange() const
     if (!m_anchorObject)
         return false;
 
-    CheckedPtr scrollerBox = scrollableAreaBox();
+    auto* scrollerBox = scrollableAreaBox();
 
     // ...any element in the path from the anchor node to the scrollable element (or document), inclusive of both.
     // m_anchorObject can be a RenderText, but that will never have scrollAnchoringSuppressionStyleChanged() set.
-    if (CheckedPtr renderer = dynamicDowncast<RenderElement>(*m_anchorObject); renderer && renderer->scrollAnchoringSuppressionStyleChanged())
+    if (auto* renderer = dynamicDowncast<RenderElement>(*m_anchorObject); renderer && renderer->scrollAnchoringSuppressionStyleChanged())
         return true;
 
-    for (CheckedPtr renderer = m_anchorObject->parent(); renderer; renderer = renderer->parent()) {
+    for (auto* renderer = m_anchorObject->parent(); renderer; renderer = renderer->parent()) {
         if (renderer->scrollAnchoringSuppressionStyleChanged())
             return true;
 

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -163,7 +163,7 @@ RenderObject::RenderObject(Type type, Node& node, OptionSet<TypeFlag> typeFlags,
     , m_typeSpecificFlags(typeSpecificFlags)
 {
     ASSERT(!typeFlags.contains(TypeFlag::IsAnonymous));
-    if (CheckedPtr renderView = node.document().renderView())
+    if (auto* renderView = node.document().renderView())
         renderView->didCreateRenderer();
 }
 
@@ -1005,7 +1005,7 @@ static inline bool fullRepaintIsScheduled(const RenderObject& renderer)
 {
     if (!renderer.view().usesCompositing() && !renderer.document().ownerElement())
         return false;
-    for (CheckedPtr ancestorLayer = renderer.enclosingLayer(); ancestorLayer; ancestorLayer = ancestorLayer->paintOrderParent()) {
+    for (auto* ancestorLayer = renderer.enclosingLayer(); ancestorLayer; ancestorLayer = ancestorLayer->paintOrderParent()) {
         if (ancestorLayer->needsFullRepaint())
             return canRelyOnAncestorLayerFullRepaint(renderer, *ancestorLayer);
     }


### PR DESCRIPTION
#### 663449702f7cc8b66024b36f605c9f3fa91cbf46
<pre>
Reduce unnecessary protected local variables in no-delete context in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=310997">https://bugs.webkit.org/show_bug.cgi?id=310997</a>
<a href="https://rdar.apple.com/173601203">rdar://173601203</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::graphicsLayer const):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::isKeyboardFocusable const):
(WebCore::Element::setVisibilityAdjustment):
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::isComposedTreeDescendantOf const):
* Source/WebCore/dom/Position.cpp:
(WebCore::Position::anchorElementAncestor const):
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::shouldEmitNewlinesBeforeAndAfterNode):
(WebCore::shouldEmitNewlineAfterNode):
* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::RepaintBlocker::RepaintBlocker):
(WebCore::RepaintBlocker::~RepaintBlocker):
(WebCore::LocalFrameViewLayoutContext::needsLayoutInternal const):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::selection const):
* Source/WebCore/page/scrolling/ScrollAnchoringController.cpp:
(WebCore::ScrollAnchoringController::frameView const):
(WebCore::ScrollAnchoringController::notifyChildHadSuppressingStyleChange):
(WebCore::overflowAnchorProhibitsAnchoring):
(WebCore::ScrollAnchoringController::anchoringSuppressedByStyleChange const):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::RenderObject):
(WebCore::fullRepaintIsScheduled):

Canonical link: <a href="https://commits.webkit.org/310244@main">https://commits.webkit.org/310244@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f38ca5b6ffdb8c87b2a15b289daaf7014491580f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152930 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25712 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19310 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161674 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106386 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154803 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26239 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26017 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118193 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155889 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20427 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137291 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98906 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19501 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17440 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9510 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129154 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15165 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164148 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7284 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16759 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126255 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25509 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21480 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126413 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34360 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25511 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136961 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82130 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21368 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13740 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25127 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89414 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24819 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24978 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24879 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->