### PR TITLE
Factor Overflow Handlers out of CheckedArithmetic.h, and update OverflowPolicy accordingly.

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -967,6 +967,7 @@
 		FE1E2C42224187C600F6B729 /* PlatformRegisters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE1E2C41224187C600F6B729 /* PlatformRegisters.cpp */; };
 		FE35D09227DC5ECC009DFA5B /* StackCheck.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE35D09127DC5ECC009DFA5B /* StackCheck.cpp */; };
 		FE499A6F2CD153B000E34F32 /* OverflowPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = FE499A6E2CD153B000E34F32 /* OverflowPolicy.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FE499A712CD153B000E34F32 /* OverflowHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = FE499A702CD153B000E34F32 /* OverflowHandler.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FE6997E129D241630078B9C6 /* ReasonSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = FE6997E029D241630078B9C6 /* ReasonSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FE7ACFEF285DC2F9007FC8E9 /* RawHex.h in Headers */ = {isa = PBXBuildFile; fileRef = FE7ACFEE285DC2F8007FC8E9 /* RawHex.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FE9B8B1A28B1453D0088C6E1 /* CodePtr.h in Headers */ = {isa = PBXBuildFile; fileRef = FE9B8B1928B1453D0088C6E1 /* CodePtr.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -2063,6 +2064,7 @@
 		FE35D09127DC5ECC009DFA5B /* StackCheck.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StackCheck.cpp; sourceTree = "<group>"; };
 		FE3842342325CC80009DD445 /* ResourceUsage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ResourceUsage.h; sourceTree = "<group>"; };
 		FE499A6E2CD153B000E34F32 /* OverflowPolicy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OverflowPolicy.h; sourceTree = "<group>"; };
+		FE499A702CD153B000E34F32 /* OverflowHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OverflowHandler.h; sourceTree = "<group>"; };
 		FE6997E029D241630078B9C6 /* ReasonSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ReasonSPI.h; sourceTree = "<group>"; };
 		FE7497E4208FFCAA0003565B /* PtrTag.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PtrTag.h; sourceTree = "<group>"; };
 		FE7ACFEE285DC2F8007FC8E9 /* RawHex.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RawHex.h; sourceTree = "<group>"; };
@@ -2593,6 +2595,7 @@
 				7CBBA07319BB7FDC00BBF025 /* OSObjectPtr.h */,
 				A8A472DA151A825B004123FF /* OSRandomSource.cpp */,
 				A8A472DB151A825B004123FF /* OSRandomSource.h */,
+				FE499A702CD153B000E34F32 /* OverflowHandler.h */,
 				FE499A6E2CD153B000E34F32 /* OverflowPolicy.h */,
 				E34CD0D022810A020020D299 /* Packed.h */,
 				E36895CB23A445CD008DD4C8 /* PackedRef.h */,
@@ -3755,6 +3758,7 @@
 				DD3DC87227A4BF8E007E5B61 /* OSObjectPtr.h in Headers */,
 				DD3DC98327A4BF8E007E5B61 /* OSRandomSource.h in Headers */,
 				DDF306E427C08654006A526F /* OSVariantSPI.h in Headers */,
+				FE499A712CD153B000E34F32 /* OverflowHandler.h in Headers */,
 				FE499A6F2CD153B000E34F32 /* OverflowPolicy.h in Headers */,
 				DD3DC86127A4BF8E007E5B61 /* Packed.h in Headers */,
 				DD3DC98D27A4BF8E007E5B61 /* PackedRef.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -220,6 +220,7 @@ set(WTF_PUBLIC_HEADERS
     OptionalOrReference.h
     OptionSetHash.h
     OrderMaker.h
+    OverflowHandler.h
     OverflowPolicy.h
     Packed.h
     PackedRef.h

--- a/Source/WTF/wtf/CheckedArithmetic.h
+++ b/Source/WTF/wtf/CheckedArithmetic.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <wtf/Assertions.h>
+#include <wtf/OverflowHandler.h>
 
 #include <limits>
 #include <stdint.h>
@@ -76,67 +77,6 @@ namespace WTF {
 enum class CheckedState {
     DidOverflow,
     DidNotOverflow
-};
-
-class AssertNoOverflow {
-public:
-    static NO_RETURN_DUE_TO_ASSERT void overflowed()
-    {
-        ASSERT_NOT_REACHED();
-    }
-
-    void clearOverflow() { }
-
-    static NO_RETURN_DUE_TO_CRASH void crash()
-    {
-        CRASH();
-    }
-
-public:
-    constexpr bool hasOverflowed() const { return false; }
-};
-
-class CrashOnOverflow {
-public:
-    static NO_RETURN_DUE_TO_CRASH void overflowed()
-    {
-        crash();
-    }
-
-    void clearOverflow() { }
-
-    static NO_RETURN_DUE_TO_CRASH void crash()
-    {
-        CRASH();
-    }
-
-public:
-    bool hasOverflowed() const { return false; }
-};
-
-class RecordOverflow {
-protected:
-    RecordOverflow()
-        : m_overflowed(false)
-    {
-    }
-
-    void clearOverflow()
-    {
-        m_overflowed = false;
-    }
-
-    static NO_RETURN_DUE_TO_CRASH void crash()
-    {
-        CRASH();
-    }
-
-public:
-    bool hasOverflowed() const { return m_overflowed; }
-    void overflowed() { m_overflowed = true; }
-
-private:
-    unsigned char m_overflowed;
 };
 
 template<typename, typename = CrashOnOverflow> class Checked;
@@ -1021,7 +961,6 @@ inline ToType safeCast(FromType value)
 
 }
 
-using WTF::AssertNoOverflow;
 using WTF::Checked;
 using WTF::CheckedState;
 using WTF::CheckedInt8;
@@ -1033,8 +972,6 @@ using WTF::CheckedUint32;
 using WTF::CheckedInt64;
 using WTF::CheckedUint64;
 using WTF::CheckedSize;
-using WTF::CrashOnOverflow;
-using WTF::RecordOverflow;
 using WTF::checkedSum;
 using WTF::checkedDifference;
 using WTF::checkedProduct;

--- a/Source/WTF/wtf/OverflowHandler.h
+++ b/Source/WTF/wtf/OverflowHandler.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2011-2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Assertions.h>
+#include <wtf/OverflowPolicy.h>
+
+namespace WTF {
+
+class AssertNoOverflow {
+public:
+    static constexpr OverflowPolicy policy = OverflowPolicy::AssertNoOverflow;
+
+    static NO_RETURN_DUE_TO_ASSERT void overflowed()
+    {
+        ASSERT_NOT_REACHED();
+    }
+
+    void clearOverflow() { }
+
+    static NO_RETURN_DUE_TO_CRASH void crash()
+    {
+        CRASH();
+    }
+
+public:
+    constexpr bool hasOverflowed() const { return false; }
+};
+
+class CrashOnOverflow {
+public:
+    static constexpr OverflowPolicy policy = OverflowPolicy::CrashOnOverflow;
+
+    static NO_RETURN_DUE_TO_CRASH void overflowed()
+    {
+        crash();
+    }
+
+    void clearOverflow() { }
+
+    static NO_RETURN_DUE_TO_CRASH void crash()
+    {
+        CRASH();
+    }
+
+public:
+    bool hasOverflowed() const { return false; }
+};
+
+class RecordOverflow {
+protected:
+    RecordOverflow()
+        : m_overflowed(false)
+    {
+    }
+
+    void clearOverflow()
+    {
+        m_overflowed = false;
+    }
+
+    static NO_RETURN_DUE_TO_CRASH void crash()
+    {
+        CRASH();
+    }
+
+public:
+    static constexpr OverflowPolicy policy = OverflowPolicy::RecordOverflow;
+
+    bool hasOverflowed() const { return m_overflowed; }
+    void overflowed() { m_overflowed = true; }
+
+private:
+    unsigned char m_overflowed;
+};
+
+} // namespace WTF
+
+using WTF::AssertNoOverflow;
+using WTF::CrashOnOverflow;
+using WTF::RecordOverflow;

--- a/Source/WTF/wtf/OverflowPolicy.h
+++ b/Source/WTF/wtf/OverflowPolicy.h
@@ -29,7 +29,16 @@
 
 namespace WTF {
 
-enum class OverflowPolicy : uint8_t { CrashOnOverflow, RecordOverflow };
+enum class OverflowPolicy : uint8_t { CrashOnOverflow, RecordOverflow, AssertNoOverflow };
+
+static constexpr bool shouldCrashOnOverflow(OverflowPolicy policy)
+{
+#ifdef ASSERT_ENABLED
+    if (policy == OverflowPolicy::AssertNoOverflow)
+        return true;
+#endif
+    return policy == OverflowPolicy::CrashOnOverflow;
+}
 
 } // namespace WTF
 

--- a/Source/WTF/wtf/text/StringBuilder.h
+++ b/Source/WTF/wtf/text/StringBuilder.h
@@ -133,7 +133,7 @@ template<typename CharacterType> bool equal(const StringBuilder&, std::span<cons
 // Inline function implementations.
 
 inline StringBuilder::StringBuilder(OverflowPolicy policy)
-    : m_shouldCrashOnOverflow { policy == OverflowPolicy::CrashOnOverflow }
+    : m_shouldCrashOnOverflow { WTF::shouldCrashOnOverflow(policy) }
 {
 }
 


### PR DESCRIPTION
#### 5eb7a8756f8cd03dbdceeb3b33263876ca491f5b
<pre>
Factor Overflow Handlers out of CheckedArithmetic.h, and update OverflowPolicy accordingly.
<a href="https://bugs.webkit.org/show_bug.cgi?id=310998">https://bugs.webkit.org/show_bug.cgi?id=310998</a>
radar://173602523

Reviewed by Keith Miller.

This makes OverflowPolicy consistent with the available Overflow Handlers (basically, adds
AssertNoOverflow), and allows Overflow Handlers to be used by clients without having to
include all of CheckedArithmetic.h.

No new tests because there is no behavior change.

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/CheckedArithmetic.h:
(WTF::AssertNoOverflow::overflowed): Deleted.
(WTF::AssertNoOverflow::clearOverflow): Deleted.
(WTF::AssertNoOverflow::crash): Deleted.
(WTF::AssertNoOverflow::hasOverflowed const): Deleted.
(WTF::CrashOnOverflow::overflowed): Deleted.
(WTF::CrashOnOverflow::clearOverflow): Deleted.
(WTF::CrashOnOverflow::crash): Deleted.
(WTF::CrashOnOverflow::hasOverflowed const): Deleted.
(WTF::RecordOverflow::RecordOverflow): Deleted.
(WTF::RecordOverflow::clearOverflow): Deleted.
(WTF::RecordOverflow::crash): Deleted.
(WTF::RecordOverflow::hasOverflowed const): Deleted.
(WTF::RecordOverflow::overflowed): Deleted.
* Source/WTF/wtf/OverflowHandler.h: Added.
(WTF::AssertNoOverflow::overflowed):
(WTF::AssertNoOverflow::clearOverflow):
(WTF::AssertNoOverflow::crash):
(WTF::AssertNoOverflow::hasOverflowed const):
(WTF::CrashOnOverflow::overflowed):
(WTF::CrashOnOverflow::clearOverflow):
(WTF::CrashOnOverflow::crash):
(WTF::CrashOnOverflow::hasOverflowed const):
(WTF::RecordOverflow::RecordOverflow):
(WTF::RecordOverflow::clearOverflow):
(WTF::RecordOverflow::crash):
(WTF::RecordOverflow::hasOverflowed const):
(WTF::RecordOverflow::overflowed):
* Source/WTF/wtf/OverflowPolicy.h:
(WTF::shouldCrashOnOverflow):
* Source/WTF/wtf/text/StringBuilder.h:
(WTF::StringBuilder::StringBuilder):

Canonical link: <a href="https://commits.webkit.org/310165@main">https://commits.webkit.org/310165@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f45436bd3b753f4b5c16106c70455e62f99f91ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152936 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25718 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/19316 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161680 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d7be70ce-922c-4d5c-b5e9-adfca7a64387) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26245 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26023 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/118202 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7a1b495e-3056-4acd-9d15-a4040325392b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155895 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20436 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/137298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98915 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0a2cab29-2803-484e-ba94-73e4a40c3c06) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19510 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9516 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144948 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129163 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/15172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164154 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13748 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7290 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/16766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/126265 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25515 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21485 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/126423 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25517 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/136968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82138 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23419 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21378 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/13747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184569 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25133 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89420 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47120 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24825 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24984 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24885 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->