### PR TITLE
Fix uninitialized member variables in WebAnimation and StyleOriginatedAnimation

### DIFF
--- a/Source/WebCore/animation/StyleOriginatedAnimation.h
+++ b/Source/WebCore/animation/StyleOriginatedAnimation.h
@@ -97,7 +97,7 @@ private:
 
     WeakPtr<Element, WeakPtrImplWithEventTargetData> m_owningElement;
     std::optional<Style::PseudoElementIdentifier> m_owningPseudoElementIdentifier;
-    double m_previousIteration;
+    double m_previousIteration { 0 };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -263,9 +263,9 @@ private:
     int m_suspendCount { 0 };
 
     bool m_isSuspended { false };
-    bool m_finishNotificationStepsMicrotaskPending;
-    bool m_isRelevant;
-    bool m_shouldSkipUpdatingFinishedStateWhenResolving;
+    bool m_finishNotificationStepsMicrotaskPending { false };
+    bool m_isRelevant { false };
+    bool m_shouldSkipUpdatingFinishedStateWhenResolving { false };
     bool m_hasScheduledEventsDuringTick { false };
     bool m_autoAlignStartTime { false };
     TimeToRunPendingTask m_timeToRunPendingPlayTask { TimeToRunPendingTask::NotScheduled };


### PR DESCRIPTION
#### 1af4da6b6ac226b8f57b64d9288cea145b2dcd94
<pre>
Fix uninitialized member variables in WebAnimation and StyleOriginatedAnimation
<a href="https://bugs.webkit.org/show_bug.cgi?id=311001">https://bugs.webkit.org/show_bug.cgi?id=311001</a>

Reviewed by Antoine Quint.

Add default initializers to 4 member variables that were missing them,
while all surrounding members had proper initializers.

Valgrind trace:

==1173712== Conditional jump or move depends on uninitialised value(s)
==1173712==    at 0x8652740: WebCore::WebAnimation::updateFinishedState(WebCore::WebAnimation::DidSeek, WebCore::WebAnimation::SynchronouslyNotify)
==1173712==    by 0x8652FA0: WebCore::WebAnimation::runPendingPlayTask()
==1173712==    by 0x86539A6: WebCore::WebAnimation::maybeMarkAsReady()
==1173712==    by 0x8641449: WebCore::WebAnimation::tick()
==1173712==    by 0x86413BA: WebCore::StyleOriginatedAnimation::tick()
==1173712==    by 0x860BA17: WebCore::AnimationTimelinesController::updateAnimationsAndSendEvents(WTF::Seconds)
==1173712==    by 0x8AC1CBA: WebCore::Document::updateAnimationsAndSendEvents()

Covered by existing tests.

* Source/WebCore/animation/StyleOriginatedAnimation.h:
* Source/WebCore/animation/WebAnimation.h:

Canonical link: <a href="https://commits.webkit.org/310179@main">https://commits.webkit.org/310179@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d0191a7937f6c89ca5cc4f890df5ca201023fbe4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152939 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25721 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19319 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161683 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106395 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154812 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26248 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26026 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118201 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83689 "3 flakes 5 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155898 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20433 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137304 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98914 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19507 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17446 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9519 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129160 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15178 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164157 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7293 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16772 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; 3 flakes") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126264 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25518 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21486 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126422 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34305 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25520 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136974 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82141 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21373 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13753 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25136 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89423 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24828 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24987 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24888 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->