### PR TITLE
Fix :placeholder-shown to match elements with empty placeholder attributes

### DIFF
--- a/LayoutTests/fast/css/placeholder-shown-basics-expected.html
+++ b/LayoutTests/fast/css/placeholder-shown-basics-expected.html
@@ -1,106 +1,154 @@
 <!DOCTYPE html>
-<html>
-<head>
-    <style>
-        input, textarea {
-            height: 8px;
-        }
-        .placeholder-shown {
-            background-color: green;
-        }
-    </style>
-</head>
-<body>
-    <p>This test checks how various input elements are styled when :placeholder-shown is applied.</p>
-    <div>
-        <textarea></textarea>
-        <textarea placeholder></textarea>
-        <textarea placeholder="WebKit" class="placeholder-shown"></textarea>
-        <textarea placeholder="WebKit">Foobar</textarea>
-    </div>
-    <div>
-        <input>
-        <input placeholder>
-        <input placeholder="WebKit" class="placeholder-shown">
-        <input placeholder="WebKit" value="Foobar">
-    </div>
-    <div>
-        <input type="">
-        <input type="" placeholder>
-        <input type="" placeholder="WebKit" class="placeholder-shown">
-        <input type="" placeholder="WebKit" value="Foobar">
-    </div>
-    <div>
-        <input type="hidden">
-        <input type="hidden" placeholder>
-        <input type="hidden" placeholder="WebKit" class="placeholder-shown">
-        <input type="hidden" placeholder="WebKit" value="Foobar">
-    </div>
-    <div>
-        <input type="text">
-        <input type="text" placeholder>
-        <input type="text" placeholder="WebKit" class="placeholder-shown">
-        <input type="text" placeholder="WebKit" value="Foobar">
-    </div>
-    <div>
-        <input type="tel">
-        <input type="tel" placeholder>
-        <input type="tel" placeholder="WebKit" class="placeholder-shown">
-        <input type="tel" placeholder="WebKit" value="Foobar">
-    </div>
-    <div>
-        <input type="url">
-        <input type="url" placeholder>
-        <input type="url" placeholder="WebKit" class="placeholder-shown">
-        <input type="url" placeholder="WebKit" value="Foobar">
-    </div>
-    <div>
-        <input type="email">
-        <input type="email" placeholder>
-        <input type="email" placeholder="WebKit" class="placeholder-shown">
-        <input type="email" placeholder="WebKit" value="Foobar">
-    </div>
-    <div>
-        <input type="password">
-        <input type="password" placeholder>
-        <input type="password" placeholder="WebKit" class="placeholder-shown">
-        <input type="password" placeholder="WebKit" value="Foobar">
-    </div>
-    <div>
-        <input type="datetime">
-        <input type="datetime" placeholder>
-        <input type="datetime" placeholder="WebKit" class="placeholder-shown">
-        <input type="datetime" placeholder="WebKit" value="Foobar">
-    </div>
-    <div>
-        <input type="number">
-        <input type="number" placeholder>
-        <input type="number" placeholder="WebKit" class="placeholder-shown">
-        <input type="number" placeholder="WebKit" value="0">
-    </div>
-    <div>
-        <input type="range">
-        <input type="range" placeholder>
-        <input type="range" placeholder="WebKit">
-        <input type="range" placeholder="WebKit" value="1">
-    </div>
-    <div>
-        <input type="checkbox">
-        <input type="checkbox" placeholder>
-        <input type="checkbox" placeholder="WebKit">
-        <input type="checkbox" placeholder="WebKit" value="Foobar">
-    </div>
-    <div>
-        <input type="radio">
-        <input type="radio" placeholder>
-        <input type="radio" placeholder="WebKit">
-        <input type="radio" placeholder="WebKit" value="Foobar">
-    </div>
-    <div>
-        <input type="submit">
-        <input type="submit" placeholder>
-        <input type="submit" placeholder="WebKit">
-        <input type="submit" placeholder="WebKit" value="Foobar">
-    </div>
-</body>
-</html>
+<style>
+    input, textarea {
+        height: 8px;
+    }
+    .placeholder-shown {
+        background-color: green;
+    }
+</style>
+<p>This test checks how various input elements are styled when :placeholder-shown is applied.</p>
+<div>
+    <textarea></textarea>
+    <textarea placeholder class="placeholder-shown"></textarea>
+    <textarea placeholder="Placeholder text" class="placeholder-shown"></textarea>
+    <textarea placeholder="Placeholder text">Foobar</textarea>
+</div>
+<div>
+    <input>
+    <input placeholder class="placeholder-shown">
+    <input placeholder="Placeholder text" class="placeholder-shown">
+    <input placeholder="Placeholder text" value="Foobar">
+</div>
+<div>
+    <input type="">
+    <input type="" placeholder class="placeholder-shown">
+    <input type="" placeholder="Placeholder text" class="placeholder-shown">
+    <input type="" placeholder="Placeholder text" value="Foobar">
+</div>
+<div>
+    <input type="hidden">
+    <input type="hidden" placeholder>
+    <input type="hidden" placeholder="Placeholder text">
+    <input type="hidden" placeholder="Placeholder text" value="Foobar">
+</div>
+<div>
+    <input type="text">
+    <input type="text" placeholder class="placeholder-shown">
+    <input type="text" placeholder="Placeholder text" class="placeholder-shown">
+    <input type="text" placeholder="Placeholder text" value="Foobar">
+</div>
+<div>
+    <input type="tel">
+    <input type="tel" placeholder class="placeholder-shown">
+    <input type="tel" placeholder="Placeholder text" class="placeholder-shown">
+    <input type="tel" placeholder="Placeholder text" value="Foobar">
+</div>
+<div>
+    <input type="url">
+    <input type="url" placeholder class="placeholder-shown">
+    <input type="url" placeholder="Placeholder text" class="placeholder-shown">
+    <input type="url" placeholder="Placeholder text" value="Foobar">
+</div>
+<div>
+    <input type="email">
+    <input type="email" placeholder class="placeholder-shown">
+    <input type="email" placeholder="Placeholder text" class="placeholder-shown">
+    <input type="email" placeholder="Placeholder text" value="Foobar">
+</div>
+<div>
+    <input type="password">
+    <input type="password" placeholder class="placeholder-shown">
+    <input type="password" placeholder="Placeholder text" class="placeholder-shown">
+    <input type="password" placeholder="Placeholder text" value="Foobar">
+</div>
+<div>
+    <input type="search">
+    <input type="search" placeholder class="placeholder-shown">
+    <input type="search" placeholder="Placeholder text" class="placeholder-shown">
+    <input type="search" placeholder="Placeholder text" value="Foobar">
+</div>
+<div>
+    <input type="date">
+    <input type="date" placeholder>
+    <input type="date" placeholder="Placeholder text">
+    <input type="date" placeholder="Placeholder text" value="Foobar">
+</div>
+<div>
+    <input type="month">
+    <input type="month" placeholder>
+    <input type="month" placeholder="Placeholder text">
+    <input type="month" placeholder="Placeholder text" value="Foobar">
+</div>
+<div>
+    <input type="week">
+    <input type="week" placeholder>
+    <input type="week" placeholder="Placeholder text">
+    <input type="week" placeholder="Placeholder text" value="Foobar">
+</div>
+<div>
+    <input type="time">
+    <input type="time" placeholder>
+    <input type="time" placeholder="Placeholder text">
+    <input type="time" placeholder="Placeholder text" value="Foobar">
+</div>
+<div>
+    <input type="datetime-local">
+    <input type="datetime-local" placeholder>
+    <input type="datetime-local" placeholder="Placeholder text">
+    <input type="datetime-local" placeholder="Placeholder text" value="Foobar">
+</div>
+<div>
+    <input type="number">
+    <input type="number" placeholder class="placeholder-shown">
+    <input type="number" placeholder="Placeholder text" class="placeholder-shown">
+    <input type="number" placeholder="Placeholder text" value="0">
+</div>
+<div>
+    <input type="range">
+    <input type="range" placeholder>
+    <input type="range" placeholder="Placeholder text">
+    <input type="range" placeholder="Placeholder text" value="1">
+</div>
+<div>
+    <input type="checkbox">
+    <input type="checkbox" placeholder>
+    <input type="checkbox" placeholder="Placeholder text">
+    <input type="checkbox" placeholder="Placeholder text" value="Foobar">
+</div>
+<div>
+    <input type="radio">
+    <input type="radio" placeholder>
+    <input type="radio" placeholder="Placeholder text">
+    <input type="radio" placeholder="Placeholder text" value="Foobar">
+</div>
+<div>
+    <input type="file">
+    <input type="file" placeholder>
+    <input type="file" placeholder="Placeholder text">
+    <input type="file" placeholder="Placeholder text" value="Foobar">
+</div>
+<div>
+    <input type="submit">
+    <input type="submit" placeholder>
+    <input type="submit" placeholder="Placeholder text">
+    <input type="submit" placeholder="Placeholder text" value="Foobar">
+</div>
+<div>
+    <input type="image">
+    <input type="image" placeholder>
+    <input type="image" placeholder="Placeholder text">
+    <input type="image" placeholder="Placeholder text" value="Foobar">
+</div>
+<div>
+    <input type="reset">
+    <input type="reset" placeholder>
+    <input type="reset" placeholder="Placeholder text">
+    <input type="reset" placeholder="Placeholder text" value="Foobar">
+</div>
+<div>
+    <input type="color">
+    <input type="color" placeholder>
+    <input type="color" placeholder="Placeholder text">
+    <input type="color" placeholder="Placeholder text" value="Foobar">
+</div>

--- a/LayoutTests/fast/css/placeholder-shown-basics.html
+++ b/LayoutTests/fast/css/placeholder-shown-basics.html
@@ -1,106 +1,154 @@
 <!DOCTYPE html>
-<html>
-<head>
-    <style>
-        input, textarea {
-            height: 8px;
-        }
-        :placeholder-shown {
-            background-color: green;
-        }
-    </style>
-</head>
-<body>
-    <p>This test checks how various input elements are styled when :placeholder-shown is applied.</p>
-    <div>
-        <textarea></textarea>
-        <textarea placeholder></textarea>
-        <textarea placeholder="WebKit"></textarea>
-        <textarea placeholder="WebKit">Foobar</textarea>
-    </div>
-    <div>
-        <input>
-        <input placeholder>
-        <input placeholder="WebKit">
-        <input placeholder="WebKit" value="Foobar">
-    </div>
-    <div>
-        <input type="">
-        <input type="" placeholder>
-        <input type="" placeholder="WebKit">
-        <input type="" placeholder="WebKit" value="Foobar">
-    </div>
-    <div>
-        <input type="hidden">
-        <input type="hidden" placeholder>
-        <input type="hidden" placeholder="WebKit">
-        <input type="hidden" placeholder="WebKit" value="Foobar">
-    </div>
-    <div>
-        <input type="text">
-        <input type="text" placeholder>
-        <input type="text" placeholder="WebKit">
-        <input type="text" placeholder="WebKit" value="Foobar">
-    </div>
-    <div>
-        <input type="tel">
-        <input type="tel" placeholder>
-        <input type="tel" placeholder="WebKit">
-        <input type="tel" placeholder="WebKit" value="Foobar">
-    </div>
-    <div>
-        <input type="url">
-        <input type="url" placeholder>
-        <input type="url" placeholder="WebKit">
-        <input type="url" placeholder="WebKit" value="Foobar">
-    </div>
-    <div>
-        <input type="email">
-        <input type="email" placeholder>
-        <input type="email" placeholder="WebKit">
-        <input type="email" placeholder="WebKit" value="Foobar">
-    </div>
-    <div>
-        <input type="password">
-        <input type="password" placeholder>
-        <input type="password" placeholder="WebKit">
-        <input type="password" placeholder="WebKit" value="Foobar">
-    </div>
-    <div>
-        <input type="datetime">
-        <input type="datetime" placeholder>
-        <input type="datetime" placeholder="WebKit">
-        <input type="datetime" placeholder="WebKit" value="Foobar">
-    </div>
-    <div>
-        <input type="number">
-        <input type="number" placeholder>
-        <input type="number" placeholder="WebKit">
-        <input type="number" placeholder="WebKit" value="0">
-    </div>
-    <div>
-        <input type="range">
-        <input type="range" placeholder>
-        <input type="range" placeholder="WebKit">
-        <input type="range" placeholder="WebKit" value="1">
-    </div>
-    <div>
-        <input type="checkbox">
-        <input type="checkbox" placeholder>
-        <input type="checkbox" placeholder="WebKit">
-        <input type="checkbox" placeholder="WebKit" value="Foobar">
-    </div>
-    <div>
-        <input type="radio">
-        <input type="radio" placeholder>
-        <input type="radio" placeholder="WebKit">
-        <input type="radio" placeholder="WebKit" value="Foobar">
-    </div>
-    <div>
-        <input type="submit">
-        <input type="submit" placeholder>
-        <input type="submit" placeholder="WebKit">
-        <input type="submit" placeholder="WebKit" value="Foobar">
-    </div>
-</body>
-</html>
+<style>
+    input, textarea {
+        height: 8px;
+    }
+    :placeholder-shown {
+        background-color: green;
+    }
+</style>
+<p>This test checks how various input elements are styled when :placeholder-shown is applied.</p>
+<div>
+    <textarea></textarea>
+    <textarea placeholder></textarea>
+    <textarea placeholder="Placeholder text"></textarea>
+    <textarea placeholder="Placeholder text">Foobar</textarea>
+</div>
+<div>
+    <input>
+    <input placeholder>
+    <input placeholder="Placeholder text">
+    <input placeholder="Placeholder text" value="Foobar">
+</div>
+<div>
+    <input type="">
+    <input type="" placeholder>
+    <input type="" placeholder="Placeholder text">
+    <input type="" placeholder="Placeholder text" value="Foobar">
+</div>
+<div>
+    <input type="hidden">
+    <input type="hidden" placeholder>
+    <input type="hidden" placeholder="Placeholder text">
+    <input type="hidden" placeholder="Placeholder text" value="Foobar">
+</div>
+<div>
+    <input type="text">
+    <input type="text" placeholder>
+    <input type="text" placeholder="Placeholder text">
+    <input type="text" placeholder="Placeholder text" value="Foobar">
+</div>
+<div>
+    <input type="tel">
+    <input type="tel" placeholder>
+    <input type="tel" placeholder="Placeholder text">
+    <input type="tel" placeholder="Placeholder text" value="Foobar">
+</div>
+<div>
+    <input type="url">
+    <input type="url" placeholder>
+    <input type="url" placeholder="Placeholder text">
+    <input type="url" placeholder="Placeholder text" value="Foobar">
+</div>
+<div>
+    <input type="email">
+    <input type="email" placeholder>
+    <input type="email" placeholder="Placeholder text">
+    <input type="email" placeholder="Placeholder text" value="Foobar">
+</div>
+<div>
+    <input type="password">
+    <input type="password" placeholder>
+    <input type="password" placeholder="Placeholder text">
+    <input type="password" placeholder="Placeholder text" value="Foobar">
+</div>
+<div>
+    <input type="search">
+    <input type="search" placeholder>
+    <input type="search" placeholder="Placeholder text">
+    <input type="search" placeholder="Placeholder text" value="Foobar">
+</div>
+<div>
+    <input type="date">
+    <input type="date" placeholder>
+    <input type="date" placeholder="Placeholder text">
+    <input type="date" placeholder="Placeholder text" value="Foobar">
+</div>
+<div>
+    <input type="month">
+    <input type="month" placeholder>
+    <input type="month" placeholder="Placeholder text">
+    <input type="month" placeholder="Placeholder text" value="Foobar">
+</div>
+<div>
+    <input type="week">
+    <input type="week" placeholder>
+    <input type="week" placeholder="Placeholder text">
+    <input type="week" placeholder="Placeholder text" value="Foobar">
+</div>
+<div>
+    <input type="time">
+    <input type="time" placeholder>
+    <input type="time" placeholder="Placeholder text">
+    <input type="time" placeholder="Placeholder text" value="Foobar">
+</div>
+<div>
+    <input type="datetime-local">
+    <input type="datetime-local" placeholder>
+    <input type="datetime-local" placeholder="Placeholder text">
+    <input type="datetime-local" placeholder="Placeholder text" value="Foobar">
+</div>
+<div>
+    <input type="number">
+    <input type="number" placeholder>
+    <input type="number" placeholder="Placeholder text">
+    <input type="number" placeholder="Placeholder text" value="0">
+</div>
+<div>
+    <input type="range">
+    <input type="range" placeholder>
+    <input type="range" placeholder="Placeholder text">
+    <input type="range" placeholder="Placeholder text" value="1">
+</div>
+<div>
+    <input type="checkbox">
+    <input type="checkbox" placeholder>
+    <input type="checkbox" placeholder="Placeholder text">
+    <input type="checkbox" placeholder="Placeholder text" value="Foobar">
+</div>
+<div>
+    <input type="radio">
+    <input type="radio" placeholder>
+    <input type="radio" placeholder="Placeholder text">
+    <input type="radio" placeholder="Placeholder text" value="Foobar">
+</div>
+<div>
+    <input type="file">
+    <input type="file" placeholder>
+    <input type="file" placeholder="Placeholder text">
+    <input type="file" placeholder="Placeholder text" value="Foobar">
+</div>
+<div>
+    <input type="submit">
+    <input type="submit" placeholder>
+    <input type="submit" placeholder="Placeholder text">
+    <input type="submit" placeholder="Placeholder text" value="Foobar">
+</div>
+<div>
+    <input type="image">
+    <input type="image" placeholder>
+    <input type="image" placeholder="Placeholder text">
+    <input type="image" placeholder="Placeholder text" value="Foobar">
+</div>
+<div>
+    <input type="reset">
+    <input type="reset" placeholder>
+    <input type="reset" placeholder="Placeholder text">
+    <input type="reset" placeholder="Placeholder text" value="Foobar">
+</div>
+<div>
+    <input type="color">
+    <input type="color" placeholder>
+    <input type="color" placeholder="Placeholder text">
+    <input type="color" placeholder="Placeholder text" value="Foobar">
+</div>

--- a/LayoutTests/fast/selectors/placeholder-shown-style-update-expected.txt
+++ b/LayoutTests/fast/selectors/placeholder-shown-style-update-expected.txt
@@ -8,17 +8,12 @@ PASS getComputedStyle(document.getElementById("input-with-renderer")).background
 PASS getComputedStyle(document.getElementById("textarea-with-renderer")).backgroundColor is "rgb(255, 255, 255)"
 PASS getComputedStyle(document.getElementById("input-without-renderer")).backgroundColor is "rgb(255, 255, 255)"
 PASS getComputedStyle(document.getElementById("textarea-without-renderer")).backgroundColor is "rgb(255, 255, 255)"
-Adding a valid placeholder matches.
+Adding a placeholder matches.
 PASS getComputedStyle(document.getElementById("input-with-renderer")).backgroundColor is "rgb(1, 2, 3)"
 PASS getComputedStyle(document.getElementById("textarea-with-renderer")).backgroundColor is "rgb(1, 2, 3)"
 PASS getComputedStyle(document.getElementById("input-without-renderer")).backgroundColor is "rgb(1, 2, 3)"
 PASS getComputedStyle(document.getElementById("textarea-without-renderer")).backgroundColor is "rgb(1, 2, 3)"
-Using an invalid placeholder value does not match.
-PASS getComputedStyle(document.getElementById("input-with-renderer")).backgroundColor is "rgb(255, 255, 255)"
-PASS getComputedStyle(document.getElementById("textarea-with-renderer")).backgroundColor is "rgb(255, 255, 255)"
-PASS getComputedStyle(document.getElementById("input-without-renderer")).backgroundColor is "rgb(255, 255, 255)"
-PASS getComputedStyle(document.getElementById("textarea-without-renderer")).backgroundColor is "rgb(255, 255, 255)"
-Adding back a placehoder and an empty value. An empty value does not prevent matching.
+Adding a placehoder and an empty value. An empty value does not prevent matching.
 PASS getComputedStyle(document.getElementById("input-with-renderer")).backgroundColor is "rgb(1, 2, 3)"
 PASS getComputedStyle(document.getElementById("textarea-with-renderer")).backgroundColor is "rgb(1, 2, 3)"
 PASS getComputedStyle(document.getElementById("input-without-renderer")).backgroundColor is "rgb(1, 2, 3)"

--- a/LayoutTests/fast/selectors/placeholder-shown-style-update.html
+++ b/LayoutTests/fast/selectors/placeholder-shown-style-update.html
@@ -1,7 +1,5 @@
 <!doctype html>
-<html>
-<head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 <style>
 input, textarea {
     background-color: white;
@@ -10,17 +8,14 @@ input, textarea {
     background-color: rgb(1, 2, 3);
 }
 </style>
-</head>
-<body>
-    <div>
-        <input id="input-with-renderer">
-        <textarea id="textarea-with-renderer"></textarea>
-    </div>
-    <div style="display:none;">
-        <input id="input-without-renderer">
-        <textarea id="textarea-without-renderer"></textarea>
-    </div>
-</body>
+<div>
+    <input id="input-with-renderer">
+    <textarea id="textarea-with-renderer"></textarea>
+</div>
+<div style="display:none;">
+    <input id="input-without-renderer">
+    <textarea id="textarea-without-renderer"></textarea>
+</div>
 <script>
 description('Test style update of the :placeholder-shown pseudo class.');
 
@@ -45,16 +40,10 @@ function setAttribute(attribute, value) {
 
 debug("Initial state is without placehoder.");
 testBackgroundColor(false);
-
-debug("Adding a valid placeholder matches.");
+debug("Adding a placeholder matches.");
 setAttribute("placeholder", "WebKit!");
 testBackgroundColor(true);
-
-debug("Using an invalid placeholder value does not match.");
-setAttribute("placeholder", "\n");
-testBackgroundColor(false);
-
-debug("Adding back a placehoder and an empty value. An empty value does not prevent matching.");
+debug("Adding a placehoder and an empty value. An empty value does not prevent matching.");
 setAttribute("placeholder", "WebKit!");
 inputCaseWithRenderer.value = "";
 textareaCaseWithRenderer.appendChild(document.createTextNode(""));
@@ -83,7 +72,7 @@ textareaCaseWithoutRenderer.appendChild(document.createTextNode("Foobar"));
 testBackgroundColor(false);
 
 debug("Removing the placeholder, we should not match.");
-setAttribute("placeholder", "");
+document.querySelectorAll('input, textarea').forEach(element => element.removeAttribute('placeholder'));
 testBackgroundColor(false);
 
 debug("Removing the value. We should still not match since the placeholder attribute was removed.");
@@ -111,5 +100,3 @@ inputCaseWithoutRenderer.value = "";
 textareaCaseWithoutRenderer.removeChild(textareaCaseWithoutRenderer.lastChild);
 testBackgroundColor(true);
 </script>
-<script src="../../resources/js-test-post.js"></script>
-</html>

--- a/LayoutTests/fast/selectors/placeholder-shown-with-input-basics-expected.txt
+++ b/LayoutTests/fast/selectors/placeholder-shown-with-input-basics-expected.txt
@@ -3,36 +3,36 @@ Check the basic features of the ":placeholder-shown" pseudo class with the <inpu
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS document.querySelectorAll(":placeholder-shown").length is 3
+PASS document.querySelectorAll(":placeholder-shown").length is 7
 PASS document.querySelectorAll(":placeholder-shown")[0] is document.getElementById("valid-placeholder")
 PASS document.querySelectorAll(":placeholder-shown")[1] is document.getElementById("valid-placeholder-with-empty-value")
 PASS document.querySelectorAll(":placeholder-shown")[2] is document.getElementById("valid-placeholder-with-empty-value2")
+PASS document.querySelectorAll(":placeholder-shown")[3] is document.getElementById("empty-placeholder")
+PASS document.querySelectorAll(":placeholder-shown")[4] is document.getElementById("empty-placeholder2")
+PASS document.querySelectorAll(":placeholder-shown")[5] is document.getElementById("placeholder-contains-only-newline")
+PASS document.querySelectorAll(":placeholder-shown")[6] is document.getElementById("placeholder-contains-only-carriageReturn")
 PASS getComputedStyle(document.getElementById("no-placeholder")).backgroundColor is "rgb(255, 255, 255)"
-PASS getComputedStyle(document.getElementById("empty-placeholder")).backgroundColor is "rgb(255, 255, 255)"
-PASS getComputedStyle(document.getElementById("empty-placeholder2")).backgroundColor is "rgb(255, 255, 255)"
-PASS getComputedStyle(document.getElementById("placeholder-contains-only-newline")).backgroundColor is "rgb(255, 255, 255)"
-PASS getComputedStyle(document.getElementById("placeholder-contains-only-carriageReturn")).backgroundColor is "rgb(255, 255, 255)"
 PASS getComputedStyle(document.getElementById("with-value")).backgroundColor is "rgb(255, 255, 255)"
 PASS getComputedStyle(document.getElementById("valid-placeholder")).backgroundColor is "rgb(1, 2, 3)"
 PASS getComputedStyle(document.getElementById("valid-placeholder-with-empty-value")).backgroundColor is "rgb(1, 2, 3)"
 PASS getComputedStyle(document.getElementById("valid-placeholder-with-empty-value2")).backgroundColor is "rgb(1, 2, 3)"
+PASS getComputedStyle(document.getElementById("empty-placeholder")).backgroundColor is "rgb(1, 2, 3)"
+PASS getComputedStyle(document.getElementById("empty-placeholder2")).backgroundColor is "rgb(1, 2, 3)"
+PASS getComputedStyle(document.getElementById("placeholder-contains-only-newline")).backgroundColor is "rgb(1, 2, 3)"
+PASS getComputedStyle(document.getElementById("placeholder-contains-only-carriageReturn")).backgroundColor is "rgb(1, 2, 3)"
 
-PASS document.querySelectorAll("input:not(:placeholder-shown)").length is 6
+PASS document.querySelectorAll("input:not(:placeholder-shown)").length is 2
 PASS document.querySelectorAll("input:not(:placeholder-shown)")[0] is document.getElementById("no-placeholder")
-PASS document.querySelectorAll("input:not(:placeholder-shown)")[1] is document.getElementById("empty-placeholder")
-PASS document.querySelectorAll("input:not(:placeholder-shown)")[2] is document.getElementById("empty-placeholder2")
-PASS document.querySelectorAll("input:not(:placeholder-shown)")[3] is document.getElementById("placeholder-contains-only-newline")
-PASS document.querySelectorAll("input:not(:placeholder-shown)")[4] is document.getElementById("placeholder-contains-only-carriageReturn")
-PASS document.querySelectorAll("input:not(:placeholder-shown)")[5] is document.getElementById("with-value")
+PASS document.querySelectorAll("input:not(:placeholder-shown)")[1] is document.getElementById("with-value")
 PASS getComputedStyle(document.getElementById("no-placeholder")).color is "rgb(4, 5, 6)"
-PASS getComputedStyle(document.getElementById("empty-placeholder")).color is "rgb(4, 5, 6)"
-PASS getComputedStyle(document.getElementById("empty-placeholder2")).color is "rgb(4, 5, 6)"
-PASS getComputedStyle(document.getElementById("placeholder-contains-only-newline")).color is "rgb(4, 5, 6)"
-PASS getComputedStyle(document.getElementById("placeholder-contains-only-carriageReturn")).color is "rgb(4, 5, 6)"
 PASS getComputedStyle(document.getElementById("with-value")).color is "rgb(4, 5, 6)"
 PASS getComputedStyle(document.getElementById("valid-placeholder")).color is "rgb(0, 0, 0)"
 PASS getComputedStyle(document.getElementById("valid-placeholder-with-empty-value")).color is "rgb(0, 0, 0)"
 PASS getComputedStyle(document.getElementById("valid-placeholder-with-empty-value2")).color is "rgb(0, 0, 0)"
+PASS getComputedStyle(document.getElementById("empty-placeholder")).color is "rgb(0, 0, 0)"
+PASS getComputedStyle(document.getElementById("empty-placeholder2")).color is "rgb(0, 0, 0)"
+PASS getComputedStyle(document.getElementById("placeholder-contains-only-newline")).color is "rgb(0, 0, 0)"
+PASS getComputedStyle(document.getElementById("placeholder-contains-only-carriageReturn")).color is "rgb(0, 0, 0)"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/selectors/placeholder-shown-with-input-basics.html
+++ b/LayoutTests/fast/selectors/placeholder-shown-with-input-basics.html
@@ -1,7 +1,5 @@
 <!doctype html>
-<html>
-<head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 <style>
 input {
     background-color: white;
@@ -14,70 +12,55 @@ input:not(:placeholder-shown) {
     color: rgb(4, 5, 6);
 }
 </style>
-</head>
-<body>
-    <div style="display:none">
-        <!-- Does not match: no placeholder defined. -->
-        <input type="text" id="no-placeholder">
+<div style="display:none">
+    <!-- Does not match: no placeholder defined. -->
+    <input type="text" id="no-placeholder">
 
-        <!-- Does not match: empty placeholder. -->
-        <input type="text" id="empty-placeholder" placeholder>
-        <input type="text" id="empty-placeholder2" placeholder="">
+    <!-- Does not match: the placeholder is not shown when a value is set -->
+    <input type="text" id="with-value" placeholder="WebKit" value="FooBar">
 
-        <!-- Does not match: placeholder contains only newline or carriage return characters. -->
-        <input type="text" id="placeholder-contains-only-newline">
-        <input type="text" id="placeholder-contains-only-carriageReturn">
-
-        <!-- Does not match: the placeholder is not shown when a value is set -->
-        <input type="text" id="with-value" placeholder="WebKit" value="FooBar">
-
-        <!-- Valid cases -->
-        <input type="text" id="valid-placeholder" placeholder="WebKit">
-        <input type="text" id="valid-placeholder-with-empty-value" placeholder="WebKit" value>
-        <input type="text" id="valid-placeholder-with-empty-value2" placeholder="WebKit" value="">
-    </div>
-</body>
+    <!-- Valid cases -->
+    <input type="text" id="valid-placeholder" placeholder="WebKit">
+    <input type="text" id="valid-placeholder-with-empty-value" placeholder="WebKit" value>
+    <input type="text" id="valid-placeholder-with-empty-value2" placeholder="WebKit" value="">
+    <input type="text" id="empty-placeholder" placeholder>
+    <input type="text" id="empty-placeholder2" placeholder="">
+    <input type="text" id="placeholder-contains-only-newline">
+    <input type="text" id="placeholder-contains-only-carriageReturn">
+</div>
 <script>
 description('Check the basic features of the ":placeholder-shown" pseudo class with the &lt;input&gt; element.');
 
 document.getElementById('placeholder-contains-only-newline').setAttribute('placeholder', '\n');
 document.getElementById('placeholder-contains-only-carriageReturn').setAttribute('placeholder', '\r');
-
-shouldBe('document.querySelectorAll(":placeholder-shown").length', '3');
+shouldBe('document.querySelectorAll(":placeholder-shown").length', '7');
 shouldBe('document.querySelectorAll(":placeholder-shown")[0]', 'document.getElementById("valid-placeholder")');
 shouldBe('document.querySelectorAll(":placeholder-shown")[1]', 'document.getElementById("valid-placeholder-with-empty-value")');
 shouldBe('document.querySelectorAll(":placeholder-shown")[2]', 'document.getElementById("valid-placeholder-with-empty-value2")');
-
+shouldBe('document.querySelectorAll(":placeholder-shown")[3]', 'document.getElementById("empty-placeholder")');
+shouldBe('document.querySelectorAll(":placeholder-shown")[4]', 'document.getElementById("empty-placeholder2")');
+shouldBe('document.querySelectorAll(":placeholder-shown")[5]', 'document.getElementById("placeholder-contains-only-newline")');
+shouldBe('document.querySelectorAll(":placeholder-shown")[6]', 'document.getElementById("placeholder-contains-only-carriageReturn")');
 shouldBeEqualToString('getComputedStyle(document.getElementById("no-placeholder")).backgroundColor', 'rgb(255, 255, 255)');
-shouldBeEqualToString('getComputedStyle(document.getElementById("empty-placeholder")).backgroundColor', 'rgb(255, 255, 255)');
-shouldBeEqualToString('getComputedStyle(document.getElementById("empty-placeholder2")).backgroundColor', 'rgb(255, 255, 255)');
-shouldBeEqualToString('getComputedStyle(document.getElementById("placeholder-contains-only-newline")).backgroundColor', 'rgb(255, 255, 255)');
-shouldBeEqualToString('getComputedStyle(document.getElementById("placeholder-contains-only-carriageReturn")).backgroundColor', 'rgb(255, 255, 255)');
 shouldBeEqualToString('getComputedStyle(document.getElementById("with-value")).backgroundColor', 'rgb(255, 255, 255)');
-
 shouldBeEqualToString('getComputedStyle(document.getElementById("valid-placeholder")).backgroundColor', 'rgb(1, 2, 3)');
 shouldBeEqualToString('getComputedStyle(document.getElementById("valid-placeholder-with-empty-value")).backgroundColor', 'rgb(1, 2, 3)');
 shouldBeEqualToString('getComputedStyle(document.getElementById("valid-placeholder-with-empty-value2")).backgroundColor', 'rgb(1, 2, 3)');
-
+shouldBeEqualToString('getComputedStyle(document.getElementById("empty-placeholder")).backgroundColor', 'rgb(1, 2, 3)');
+shouldBeEqualToString('getComputedStyle(document.getElementById("empty-placeholder2")).backgroundColor', 'rgb(1, 2, 3)');
+shouldBeEqualToString('getComputedStyle(document.getElementById("placeholder-contains-only-newline")).backgroundColor', 'rgb(1, 2, 3)');
+shouldBeEqualToString('getComputedStyle(document.getElementById("placeholder-contains-only-carriageReturn")).backgroundColor', 'rgb(1, 2, 3)');
 debug("");
-shouldBe('document.querySelectorAll("input:not(:placeholder-shown)").length', '6');
+shouldBe('document.querySelectorAll("input:not(:placeholder-shown)").length', '2');
 shouldBe('document.querySelectorAll("input:not(:placeholder-shown)")[0]', 'document.getElementById("no-placeholder")');
-shouldBe('document.querySelectorAll("input:not(:placeholder-shown)")[1]', 'document.getElementById("empty-placeholder")');
-shouldBe('document.querySelectorAll("input:not(:placeholder-shown)")[2]', 'document.getElementById("empty-placeholder2")');
-shouldBe('document.querySelectorAll("input:not(:placeholder-shown)")[3]', 'document.getElementById("placeholder-contains-only-newline")');
-shouldBe('document.querySelectorAll("input:not(:placeholder-shown)")[4]', 'document.getElementById("placeholder-contains-only-carriageReturn")');
-shouldBe('document.querySelectorAll("input:not(:placeholder-shown)")[5]', 'document.getElementById("with-value")');
-
+shouldBe('document.querySelectorAll("input:not(:placeholder-shown)")[1]', 'document.getElementById("with-value")');
 shouldBeEqualToString('getComputedStyle(document.getElementById("no-placeholder")).color', 'rgb(4, 5, 6)');
-shouldBeEqualToString('getComputedStyle(document.getElementById("empty-placeholder")).color', 'rgb(4, 5, 6)');
-shouldBeEqualToString('getComputedStyle(document.getElementById("empty-placeholder2")).color', 'rgb(4, 5, 6)');
-shouldBeEqualToString('getComputedStyle(document.getElementById("placeholder-contains-only-newline")).color', 'rgb(4, 5, 6)');
-shouldBeEqualToString('getComputedStyle(document.getElementById("placeholder-contains-only-carriageReturn")).color', 'rgb(4, 5, 6)');
 shouldBeEqualToString('getComputedStyle(document.getElementById("with-value")).color', 'rgb(4, 5, 6)');
-
 shouldBeEqualToString('getComputedStyle(document.getElementById("valid-placeholder")).color', 'rgb(0, 0, 0)');
 shouldBeEqualToString('getComputedStyle(document.getElementById("valid-placeholder-with-empty-value")).color', 'rgb(0, 0, 0)');
 shouldBeEqualToString('getComputedStyle(document.getElementById("valid-placeholder-with-empty-value2")).color', 'rgb(0, 0, 0)');
+shouldBeEqualToString('getComputedStyle(document.getElementById("empty-placeholder")).color', 'rgb(0, 0, 0)');
+shouldBeEqualToString('getComputedStyle(document.getElementById("empty-placeholder2")).color', 'rgb(0, 0, 0)');
+shouldBeEqualToString('getComputedStyle(document.getElementById("placeholder-contains-only-newline")).color', 'rgb(0, 0, 0)');
+shouldBeEqualToString('getComputedStyle(document.getElementById("placeholder-contains-only-carriageReturn")).color', 'rgb(0, 0, 0)');
 </script>
-<script src="../../resources/js-test-post.js"></script>
-</html>

--- a/LayoutTests/fast/selectors/placeholder-shown-with-textarea-basics-expected.txt
+++ b/LayoutTests/fast/selectors/placeholder-shown-with-textarea-basics-expected.txt
@@ -3,34 +3,34 @@ Check the basic features of the ":placeholder-shown" pseudo class with the <text
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS document.querySelectorAll(":placeholder-shown").length is 4
+PASS document.querySelectorAll(":placeholder-shown").length is 8
 PASS document.querySelectorAll(":placeholder-shown")[0] is document.getElementById("valid-placeholder")
-PASS document.querySelectorAll(":placeholder-shown")[1] is document.getElementById("valid-placeholder-with-value-attribute")
-PASS document.querySelectorAll(":placeholder-shown")[2] is document.getElementById("valid-placeholder-with-value-attribute2")
-PASS document.querySelectorAll(":placeholder-shown")[3] is document.getElementById("valid-placeholder-with-value-attribute3")
+PASS document.querySelectorAll(":placeholder-shown")[1] is document.getElementById("empty-placeholder")
+PASS document.querySelectorAll(":placeholder-shown")[2] is document.getElementById("empty-placeholder2")
+PASS document.querySelectorAll(":placeholder-shown")[3] is document.getElementById("placeholder-contains-only-newline")
+PASS document.querySelectorAll(":placeholder-shown")[4] is document.getElementById("placeholder-contains-only-carriageReturn")
+PASS document.querySelectorAll(":placeholder-shown")[5] is document.getElementById("valid-placeholder-with-value-attribute")
+PASS document.querySelectorAll(":placeholder-shown")[6] is document.getElementById("valid-placeholder-with-value-attribute2")
+PASS document.querySelectorAll(":placeholder-shown")[7] is document.getElementById("valid-placeholder-with-value-attribute3")
 PASS getComputedStyle(document.getElementById("no-placeholder")).backgroundColor is "rgb(255, 255, 255)"
-PASS getComputedStyle(document.getElementById("empty-placeholder")).backgroundColor is "rgb(255, 255, 255)"
-PASS getComputedStyle(document.getElementById("empty-placeholder2")).backgroundColor is "rgb(255, 255, 255)"
-PASS getComputedStyle(document.getElementById("placeholder-contains-only-newline")).backgroundColor is "rgb(255, 255, 255)"
-PASS getComputedStyle(document.getElementById("placeholder-contains-only-carriageReturn")).backgroundColor is "rgb(255, 255, 255)"
+PASS getComputedStyle(document.getElementById("empty-placeholder")).backgroundColor is "rgb(1, 2, 3)"
+PASS getComputedStyle(document.getElementById("empty-placeholder2")).backgroundColor is "rgb(1, 2, 3)"
+PASS getComputedStyle(document.getElementById("placeholder-contains-only-newline")).backgroundColor is "rgb(1, 2, 3)"
+PASS getComputedStyle(document.getElementById("placeholder-contains-only-carriageReturn")).backgroundColor is "rgb(1, 2, 3)"
 PASS getComputedStyle(document.getElementById("with-value")).backgroundColor is "rgb(255, 255, 255)"
 PASS getComputedStyle(document.getElementById("valid-placeholder")).backgroundColor is "rgb(1, 2, 3)"
 PASS getComputedStyle(document.getElementById("valid-placeholder-with-value-attribute")).backgroundColor is "rgb(1, 2, 3)"
 PASS getComputedStyle(document.getElementById("valid-placeholder-with-value-attribute2")).backgroundColor is "rgb(1, 2, 3)"
 PASS getComputedStyle(document.getElementById("valid-placeholder-with-value-attribute3")).backgroundColor is "rgb(1, 2, 3)"
 
-PASS document.querySelectorAll("textarea:not(:placeholder-shown)").length is 6
+PASS document.querySelectorAll("textarea:not(:placeholder-shown)").length is 2
 PASS document.querySelectorAll("textarea:not(:placeholder-shown)")[0] is document.getElementById("no-placeholder")
-PASS document.querySelectorAll("textarea:not(:placeholder-shown)")[1] is document.getElementById("empty-placeholder")
-PASS document.querySelectorAll("textarea:not(:placeholder-shown)")[2] is document.getElementById("empty-placeholder2")
-PASS document.querySelectorAll("textarea:not(:placeholder-shown)")[3] is document.getElementById("placeholder-contains-only-newline")
-PASS document.querySelectorAll("textarea:not(:placeholder-shown)")[4] is document.getElementById("placeholder-contains-only-carriageReturn")
-PASS document.querySelectorAll("textarea:not(:placeholder-shown)")[5] is document.getElementById("with-value")
+PASS document.querySelectorAll("textarea:not(:placeholder-shown)")[1] is document.getElementById("with-value")
 PASS getComputedStyle(document.getElementById("no-placeholder")).color is "rgb(4, 5, 6)"
-PASS getComputedStyle(document.getElementById("empty-placeholder")).color is "rgb(4, 5, 6)"
-PASS getComputedStyle(document.getElementById("empty-placeholder2")).color is "rgb(4, 5, 6)"
-PASS getComputedStyle(document.getElementById("placeholder-contains-only-newline")).color is "rgb(4, 5, 6)"
-PASS getComputedStyle(document.getElementById("placeholder-contains-only-carriageReturn")).color is "rgb(4, 5, 6)"
+PASS getComputedStyle(document.getElementById("empty-placeholder")).color is "rgb(0, 0, 0)"
+PASS getComputedStyle(document.getElementById("empty-placeholder2")).color is "rgb(0, 0, 0)"
+PASS getComputedStyle(document.getElementById("placeholder-contains-only-newline")).color is "rgb(0, 0, 0)"
+PASS getComputedStyle(document.getElementById("placeholder-contains-only-carriageReturn")).color is "rgb(0, 0, 0)"
 PASS getComputedStyle(document.getElementById("with-value")).color is "rgb(4, 5, 6)"
 PASS getComputedStyle(document.getElementById("valid-placeholder")).color is "rgb(0, 0, 0)"
 PASS getComputedStyle(document.getElementById("valid-placeholder-with-value-attribute")).color is "rgb(0, 0, 0)"

--- a/LayoutTests/fast/selectors/placeholder-shown-with-textarea-basics.html
+++ b/LayoutTests/fast/selectors/placeholder-shown-with-textarea-basics.html
@@ -1,7 +1,5 @@
 <!doctype html>
-<html>
-<head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 <style>
 textarea {
     background-color: white;
@@ -14,76 +12,60 @@ textarea:not(:placeholder-shown) {
     color: rgb(4, 5, 6);
 }
 </style>
-</head>
-<body>
-    <div style="display:none">
-        <!-- Does not match: no placeholder defined. -->
-        <textarea id="no-placeholder"></textarea>
+<div style="display:none">
+    <!-- Does not match: no placeholder defined. -->
+    <textarea id="no-placeholder"></textarea>
 
-        <!-- Does not match: empty placeholder. -->
-        <textarea id="empty-placeholder" placeholder></textarea>
-        <textarea id="empty-placeholder2" placeholder=""></textarea>
+    <!-- Does not match: the placeholder is not shown when a value is set -->
+    <textarea id="with-value" placeholder="WebKit">FooBar</textarea>
 
-        <!-- Does not match: placeholder contains only newline or carriage return characters. -->
-        <textarea id="placeholder-contains-only-newline"></textarea>
-        <textarea id="placeholder-contains-only-carriageReturn"></textarea>
+    <!-- Valid cases -->
+    <textarea id="valid-placeholder" placeholder="WebKit"></textarea>
+    <textarea id="empty-placeholder" placeholder></textarea>
+    <textarea id="empty-placeholder2" placeholder=""></textarea>
+    <textarea id="placeholder-contains-only-newline"></textarea>
+    <textarea id="placeholder-contains-only-carriageReturn"></textarea>
 
-        <!-- Does not match: the placeholder is not shown when a value is set -->
-        <textarea id="with-value" placeholder="WebKit">FooBar</textarea>
-
-        <!-- Valid cases -->
-        <textarea id="valid-placeholder" placeholder="WebKit"></textarea>
-
-        <!-- Value does not do anything on <textarea>, the content is the innerText -->
-        <textarea id="valid-placeholder-with-value-attribute" placeholder="WebKit" value></textarea>
-        <textarea id="valid-placeholder-with-value-attribute2" placeholder="WebKit" value=""></textarea>
-        <textarea id="valid-placeholder-with-value-attribute3" placeholder="WebKit" value="Rocks!"></textarea>
-    </div>
-</body>
+    <!-- Value does not do anything on <textarea>, the content is the innerText -->
+    <textarea id="valid-placeholder-with-value-attribute" placeholder="WebKit" value></textarea>
+    <textarea id="valid-placeholder-with-value-attribute2" placeholder="WebKit" value=""></textarea>
+    <textarea id="valid-placeholder-with-value-attribute3" placeholder="WebKit" value="Rocks!"></textarea>
+</div>
 <script>
 description('Check the basic features of the ":placeholder-shown" pseudo class with the &lt;textarea&gt; element.');
-
 document.getElementById('placeholder-contains-only-newline').setAttribute('placeholder', '\n');
 document.getElementById('placeholder-contains-only-carriageReturn').setAttribute('placeholder', '\r');
-
-shouldBe('document.querySelectorAll(":placeholder-shown").length', '4');
+shouldBe('document.querySelectorAll(":placeholder-shown").length', '8');
 shouldBe('document.querySelectorAll(":placeholder-shown")[0]', 'document.getElementById("valid-placeholder")');
-shouldBe('document.querySelectorAll(":placeholder-shown")[1]', 'document.getElementById("valid-placeholder-with-value-attribute")');
-shouldBe('document.querySelectorAll(":placeholder-shown")[2]', 'document.getElementById("valid-placeholder-with-value-attribute2")');
-shouldBe('document.querySelectorAll(":placeholder-shown")[3]', 'document.getElementById("valid-placeholder-with-value-attribute3")');
-
+shouldBe('document.querySelectorAll(":placeholder-shown")[1]', 'document.getElementById("empty-placeholder")');
+shouldBe('document.querySelectorAll(":placeholder-shown")[2]', 'document.getElementById("empty-placeholder2")');
+shouldBe('document.querySelectorAll(":placeholder-shown")[3]', 'document.getElementById("placeholder-contains-only-newline")');
+shouldBe('document.querySelectorAll(":placeholder-shown")[4]', 'document.getElementById("placeholder-contains-only-carriageReturn")');
+shouldBe('document.querySelectorAll(":placeholder-shown")[5]', 'document.getElementById("valid-placeholder-with-value-attribute")');
+shouldBe('document.querySelectorAll(":placeholder-shown")[6]', 'document.getElementById("valid-placeholder-with-value-attribute2")');
+shouldBe('document.querySelectorAll(":placeholder-shown")[7]', 'document.getElementById("valid-placeholder-with-value-attribute3")');
 shouldBeEqualToString('getComputedStyle(document.getElementById("no-placeholder")).backgroundColor', 'rgb(255, 255, 255)');
-shouldBeEqualToString('getComputedStyle(document.getElementById("empty-placeholder")).backgroundColor', 'rgb(255, 255, 255)');
-shouldBeEqualToString('getComputedStyle(document.getElementById("empty-placeholder2")).backgroundColor', 'rgb(255, 255, 255)');
-shouldBeEqualToString('getComputedStyle(document.getElementById("placeholder-contains-only-newline")).backgroundColor', 'rgb(255, 255, 255)');
-shouldBeEqualToString('getComputedStyle(document.getElementById("placeholder-contains-only-carriageReturn")).backgroundColor', 'rgb(255, 255, 255)');
+shouldBeEqualToString('getComputedStyle(document.getElementById("empty-placeholder")).backgroundColor', 'rgb(1, 2, 3)');
+shouldBeEqualToString('getComputedStyle(document.getElementById("empty-placeholder2")).backgroundColor', 'rgb(1, 2, 3)');
+shouldBeEqualToString('getComputedStyle(document.getElementById("placeholder-contains-only-newline")).backgroundColor', 'rgb(1, 2, 3)');
+shouldBeEqualToString('getComputedStyle(document.getElementById("placeholder-contains-only-carriageReturn")).backgroundColor', 'rgb(1, 2, 3)');
 shouldBeEqualToString('getComputedStyle(document.getElementById("with-value")).backgroundColor', 'rgb(255, 255, 255)');
-
 shouldBeEqualToString('getComputedStyle(document.getElementById("valid-placeholder")).backgroundColor', 'rgb(1, 2, 3)');
 shouldBeEqualToString('getComputedStyle(document.getElementById("valid-placeholder-with-value-attribute")).backgroundColor', 'rgb(1, 2, 3)');
 shouldBeEqualToString('getComputedStyle(document.getElementById("valid-placeholder-with-value-attribute2")).backgroundColor', 'rgb(1, 2, 3)');
 shouldBeEqualToString('getComputedStyle(document.getElementById("valid-placeholder-with-value-attribute3")).backgroundColor', 'rgb(1, 2, 3)');
-
 debug("");
-shouldBe('document.querySelectorAll("textarea:not(:placeholder-shown)").length', '6');
+shouldBe('document.querySelectorAll("textarea:not(:placeholder-shown)").length', '2');
 shouldBe('document.querySelectorAll("textarea:not(:placeholder-shown)")[0]', 'document.getElementById("no-placeholder")');
-shouldBe('document.querySelectorAll("textarea:not(:placeholder-shown)")[1]', 'document.getElementById("empty-placeholder")');
-shouldBe('document.querySelectorAll("textarea:not(:placeholder-shown)")[2]', 'document.getElementById("empty-placeholder2")');
-shouldBe('document.querySelectorAll("textarea:not(:placeholder-shown)")[3]', 'document.getElementById("placeholder-contains-only-newline")');
-shouldBe('document.querySelectorAll("textarea:not(:placeholder-shown)")[4]', 'document.getElementById("placeholder-contains-only-carriageReturn")');
-shouldBe('document.querySelectorAll("textarea:not(:placeholder-shown)")[5]', 'document.getElementById("with-value")');
-
+shouldBe('document.querySelectorAll("textarea:not(:placeholder-shown)")[1]', 'document.getElementById("with-value")');
 shouldBeEqualToString('getComputedStyle(document.getElementById("no-placeholder")).color', 'rgb(4, 5, 6)');
-shouldBeEqualToString('getComputedStyle(document.getElementById("empty-placeholder")).color', 'rgb(4, 5, 6)');
-shouldBeEqualToString('getComputedStyle(document.getElementById("empty-placeholder2")).color', 'rgb(4, 5, 6)');
-shouldBeEqualToString('getComputedStyle(document.getElementById("placeholder-contains-only-newline")).color', 'rgb(4, 5, 6)');
-shouldBeEqualToString('getComputedStyle(document.getElementById("placeholder-contains-only-carriageReturn")).color', 'rgb(4, 5, 6)');
+shouldBeEqualToString('getComputedStyle(document.getElementById("empty-placeholder")).color', 'rgb(0, 0, 0)');
+shouldBeEqualToString('getComputedStyle(document.getElementById("empty-placeholder2")).color', 'rgb(0, 0, 0)');
+shouldBeEqualToString('getComputedStyle(document.getElementById("placeholder-contains-only-newline")).color', 'rgb(0, 0, 0)');
+shouldBeEqualToString('getComputedStyle(document.getElementById("placeholder-contains-only-carriageReturn")).color', 'rgb(0, 0, 0)');
 shouldBeEqualToString('getComputedStyle(document.getElementById("with-value")).color', 'rgb(4, 5, 6)');
-
 shouldBeEqualToString('getComputedStyle(document.getElementById("valid-placeholder")).color', 'rgb(0, 0, 0)');
 shouldBeEqualToString('getComputedStyle(document.getElementById("valid-placeholder-with-value-attribute")).color', 'rgb(0, 0, 0)');
 shouldBeEqualToString('getComputedStyle(document.getElementById("valid-placeholder-with-value-attribute2")).color', 'rgb(0, 0, 0)');
 shouldBeEqualToString('getComputedStyle(document.getElementById("valid-placeholder-with-value-attribute3")).color', 'rgb(0, 0, 0)');
 </script>
-<script src="../../resources/js-test-post.js"></script>
-</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/placeholder-shown-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/placeholder-shown-expected.txt
@@ -2,6 +2,6 @@
 
 PASS Initially no placeholder text
 PASS Added placeholder text
-FAIL Set placeholder text to empty string assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+PASS Set placeholder text to empty string
 PASS Removed placeholder attribute
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/placeholder-shown-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/placeholder-shown-expected.txt
@@ -1,8 +1,8 @@
 Should be green Should be green Should be green Should be green Should be green Should be green Should be green
 
 PASS CSS Selectors Test: :placeholder-shown matching
-FAIL CSS Selectors Test: :placeholder-shown matching 1 assert_equals: Placeholder attribute without value expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-FAIL CSS Selectors Test: :placeholder-shown matching 2 assert_equals: Placeholder attribute - empty string expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS CSS Selectors Test: :placeholder-shown matching 1
+PASS CSS Selectors Test: :placeholder-shown matching 2
 PASS CSS Selectors Test: :placeholder-shown matching 3
 PASS CSS Selectors Test: :placeholder-shown matching 4
 PASS CSS Selectors Test: :placeholder-shown matching 5

--- a/Source/WebCore/html/HTMLTextAreaElement.cpp
+++ b/Source/WebCore/html/HTMLTextAreaElement.cpp
@@ -526,8 +526,7 @@ void HTMLTextAreaElement::setRows(unsigned rows)
 
 void HTMLTextAreaElement::updatePlaceholderText()
 {
-    auto& placeholderText = attributeWithoutSynchronization(placeholderAttr);
-    if (placeholderText.isEmpty()) {
+    if (!hasAttributeWithoutSynchronization(placeholderAttr)) {
         if (RefPtr placeholder = m_placeholder) {
             protect(userAgentShadowRoot())->removeChild(*placeholder);
             m_placeholder = nullptr;
@@ -538,7 +537,7 @@ void HTMLTextAreaElement::updatePlaceholderText()
         m_placeholder = TextControlPlaceholderElement::create(protect(document()));
         protect(userAgentShadowRoot())->insertBefore(*protect(m_placeholder), protect(innerTextElement()->nextSibling()));
     }
-    protect(m_placeholder)->setInnerText(String { placeholderText });
+    protect(m_placeholder)->setInnerText(String { attributeWithoutSynchronization(placeholderAttr) });
 }
 
 RenderStyle HTMLTextAreaElement::createInnerTextStyle(const RenderStyle& style)

--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -224,19 +224,11 @@ void HTMLTextFormControlElement::forwardEvent(Event& event)
         innerText->defaultEventHandler(event);
 }
 
-static bool NODELETE isNotLineBreak(char16_t ch) { return ch != newlineCharacter && ch != carriageReturn; }
-
-bool HTMLTextFormControlElement::isPlaceholderEmpty() const
-{
-    const AtomString& attributeValue = attributeWithoutSynchronization(placeholderAttr);
-    return attributeValue.string().find(isNotLineBreak) == notFound;
-}
-
 bool HTMLTextFormControlElement::placeholderShouldBeVisible() const
 {
     // This function is used by the style resolver to match the :placeholder-shown pseudo class.
     // Since it is used for styling, it must not use any value depending on the style.
-    return supportsPlaceholder() && isEmptyValue() && !isPlaceholderEmpty() && m_canShowPlaceholder && !(hovered() && m_pointerType == penPointerEventType());
+    return supportsPlaceholder() && isEmptyValue() && hasAttributeWithoutSynchronization(placeholderAttr) && m_canShowPlaceholder && !(hovered() && m_pointerType == penPointerEventType());
 }
 
 void HTMLTextFormControlElement::updatePlaceholderVisibility()

--- a/Source/WebCore/html/HTMLTextFormControlElement.h
+++ b/Source/WebCore/html/HTMLTextFormControlElement.h
@@ -122,7 +122,6 @@ public:
 
 protected:
     HTMLTextFormControlElement(const QualifiedName&, Document&, HTMLFormElement*);
-    bool isPlaceholderEmpty() const;
     virtual void updatePlaceholderText() = 0;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;

--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -633,12 +633,12 @@ void TextFieldInputType::updatePlaceholderText()
         return;
 
     Ref element = *this->element();
-    auto placeholderText = element->placeholder();
-    if (placeholderText.isEmpty()) {
+    if (!element->hasAttributeWithoutSynchronization(placeholderAttr)) {
         if (RefPtr placeholder = std::exchange(m_placeholder, nullptr))
             placeholder->remove();
         return;
     }
+    auto placeholderText = element->placeholder();
     if (!m_placeholder) {
         Ref placeholder = TextControlPlaceholderElement::create(protect(element->document()));
         m_placeholder = placeholder.copyRef();


### PR DESCRIPTION
#### b6ea7219106b96884ad93458fe50c25325dbbd0d
<pre>
Fix :placeholder-shown to match elements with empty placeholder attributes
<a href="https://bugs.webkit.org/show_bug.cgi?id=311002">https://bugs.webkit.org/show_bug.cgi?id=311002</a>
<a href="https://rdar.apple.com/173604635">rdar://173604635</a>

Reviewed by Ryosuke Niwa and Tim Nguyen.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Per the HTML spec [1], :placeholder-shown must match elements that have
a placeholder attribute &quot;whose value is currently being presented to
the user.&quot; An empty placeholder attribute still has a value (the empty
string) that is being presented. WebKit was incorrectly requiring
non-empty placeholder text.

Remove isPlaceholderEmpty() and check attribute presence instead.
Update TextFieldInputType and HTMLTextAreaElement to preserve the
placeholder shadow DOM element when the attribute is present but empty.

[1] <a href="https://html.spec.whatwg.org/#selector-placeholder-shown">https://html.spec.whatwg.org/#selector-placeholder-shown</a>

* Source/WebCore/html/HTMLTextAreaElement.cpp:
(WebCore::HTMLTextAreaElement::updatePlaceholderText):
* Source/WebCore/html/HTMLTextFormControlElement.cpp:
(WebCore::HTMLTextFormControlElement::placeholderShouldBeVisible const):
(WebCore::isNotLineBreak): Deleted.
(WebCore::HTMLTextFormControlElement::isPlaceholderEmpty const): Deleted.
* Source/WebCore/html/HTMLTextFormControlElement.h:
* Source/WebCore/html/TextFieldInputType.cpp:
(WebCore::TextFieldInputType::updatePlaceholderText):
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/placeholder-shown-expected.txt: Progression
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/placeholder-shown-expected.txt: Ditto

Add more tests below:

Merge: <a href="https://chromium.googlesource.com/chromium/src/+/c9a2ede805faf4305954df116f4b9cfdde1dc5d1">https://chromium.googlesource.com/chromium/src/+/c9a2ede805faf4305954df116f4b9cfdde1dc5d1</a>

* LayoutTests/fast/css/placeholder-shown-basics-expected.html:
* LayoutTests/fast/css/placeholder-shown-basics.html:

Update below:

Merge: <a href="https://chromium.googlesource.com/chromium/src/+/42a6faa36ca322b47d02bfce5c05684054141b48">https://chromium.googlesource.com/chromium/src/+/42a6faa36ca322b47d02bfce5c05684054141b48</a>

* LayoutTests/fast/css/placeholder-shown-basics-expected.html:
* LayoutTests/fast/selectors/placeholder-shown-style-update-expected.txt:
* LayoutTests/fast/selectors/placeholder-shown-style-update.html:
* LayoutTests/fast/selectors/placeholder-shown-with-input-basics-expected.txt:
* LayoutTests/fast/selectors/placeholder-shown-with-input-basics.html:
* LayoutTests/fast/selectors/placeholder-shown-with-textarea-basics-expected.txt:
* LayoutTests/fast/selectors/placeholder-shown-with-textarea-basics.html:

Canonical link: <a href="https://commits.webkit.org/310781@main">https://commits.webkit.org/310781@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6203d5ed0d052fdb4d17bf63837bbd964d012639

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154892 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28151 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21311 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163652 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108362 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7c5908e6-08d9-4528-9e47-9ce452578aff) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156765 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28290 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28000 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119830 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84702 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/84769266-6f18-414e-bfba-ee5acc8dfd4f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157851 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22106 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139100 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100523 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f4892f12-c685-461b-b7bf-34b9e590d7cb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21191 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19215 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11478 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130853 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16944 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166126 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9526 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18553 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127936 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27696 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23255 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128075 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34757 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27620 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138737 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84325 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22948 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15532 "Too many flaky failures: http/tests/cookies/same-site/popup-same-site-with-post-form.html, http/tests/misc/svg-image-delayed-size-negotiation.html, http/tests/navigation/process-swap-on-client-side-redirect-private.html, http/tests/navigation/subframe-pagehide-handler-starts-load2.html, http/tests/resourceLoadStatistics/non-sandboxed-nesting-iframe-with-non-sandboxed-iframe-redirect-ip-to-localhost-to-ip.html, http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-unfiltered-link-decoration-before-short-deletion.html, http/tests/security/cannot-read-cssrules.html, http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py, http/tests/security/contentSecurityPolicy/navigate-self-to-data-url.html, http/tests/security/contentSecurityPolicy/script-src-self-blocked-02.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27312 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91416 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26890 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27121 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26963 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->