### PR TITLE
[JSC] Micro-optimize AssemblyHelpers asm code for ARM64

### DIFF
--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -23587,8 +23587,7 @@ IGNORE_CLANG_WARNINGS_END
     LValue isStrictInt52(LValue int64Value)
     {
         LValue added = m_out.add(m_out.constInt64(0x0008000000000000ULL), int64Value);
-        LValue shifted = m_out.lShr(added, m_out.constInt32(52));
-        return m_out.isZero64(shifted);
+        return m_out.testIsZero64(added, m_out.constInt64(0xFFF0000000000000ULL));
     }
 
     LValue isNotStrictInt52(LValue int64Value)

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
@@ -840,6 +840,15 @@ void emitRandomThunkImpl(AssemblyHelpers& jit, GPRReg scratch0, GPRReg scratch1,
     // m_low = y;
     storeToLow(scratch1);
 
+#if CPU(ARM64)
+    // x ^= x << 23;
+    jit.xorLeftShift64(scratch0, scratch0, AssemblyHelpers::TrustedImm32(23), scratch0);
+    // x ^= x >> 17;
+    jit.xorUnsignedRightShift64(scratch0, scratch0, AssemblyHelpers::TrustedImm32(17), scratch0);
+    // x ^= y ^ (y >> 26);
+    jit.xorUnsignedRightShift64(scratch1, scratch1, AssemblyHelpers::TrustedImm32(26), scratch2);
+    jit.xor64(scratch2, scratch0);
+#else
     // x ^= x << 23;
     jit.lshift64(scratch0, AssemblyHelpers::TrustedImm32(23), scratch2);
     jit.xor64(scratch2, scratch0);
@@ -852,6 +861,7 @@ void emitRandomThunkImpl(AssemblyHelpers& jit, GPRReg scratch0, GPRReg scratch1,
     jit.urshift64(scratch1, AssemblyHelpers::TrustedImm32(26), scratch2);
     jit.xor64(scratch1, scratch2);
     jit.xor64(scratch2, scratch0);
+#endif
 
     // m_high = x;
     storeToHigh(scratch0);
@@ -1235,7 +1245,28 @@ void AssemblyHelpers::emitVirtualCallWithoutMovingGlobalObject(VM& vm, GPRReg ca
 void AssemblyHelpers::wangsInt64Hash(GPRReg inputAndResult, GPRReg scratch)
 {
     GPRReg input = inputAndResult;
-    // key += ~(key << 32);
+#if CPU(ARM64)
+    // key += ~(key << 32) => key = key - (key << 32) - 1
+    subLeftShift64(input, input, TrustedImm32(32), input);
+    sub64(TrustedImm32(1), input);
+    // key ^= (key >> 22)
+    xorUnsignedRightShift64(input, input, TrustedImm32(22), input);
+    // key += ~(key << 13) => key = key - (key << 13) - 1
+    subLeftShift64(input, input, TrustedImm32(13), input);
+    sub64(TrustedImm32(1), input);
+    // key ^= (key >> 8)
+    xorUnsignedRightShift64(input, input, TrustedImm32(8), input);
+    // key += (key << 3)
+    addLeftShift64(input, input, TrustedImm32(3), input);
+    // key ^= (key >> 15)
+    xorUnsignedRightShift64(input, input, TrustedImm32(15), input);
+    // key += ~(key << 27) => key = key - (key << 27) - 1
+    subLeftShift64(input, input, TrustedImm32(27), input);
+    sub64(TrustedImm32(1), input);
+    // key ^= (key >> 31)
+    xorUnsignedRightShift64(input, input, TrustedImm32(31), input);
+    UNUSED_PARAM(scratch);
+#else
     lshift64(input, TrustedImm32(32), scratch);
     not64(scratch);
     add64(scratch, input);
@@ -1262,6 +1293,7 @@ void AssemblyHelpers::wangsInt64Hash(GPRReg inputAndResult, GPRReg scratch)
     // key ^= (key >> 31);
     urshift64(input, TrustedImm32(31), scratch);
     xor64(scratch, input);
+#endif // CPU(ARM64)
 
     // return static_cast<unsigned>(result)
     void* mask = std::bit_cast<void*>(static_cast<uintptr_t>(UINT_MAX));

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.h
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.h
@@ -1529,17 +1529,15 @@ public:
     {
         // This moves the checking range (fail if N >= (1 << (52 - 1)) or N < -(1 << (52 - 1))) by subtracting a value.
         // So, valid value region starts with -1 and lower. In unsigned form, which means,
-        // 0x00000000000000000 to 0x000fffffffffffff . So, by shifting 52, we can extract 0x000 part, and we can check whether it is zero.
+        // 0x00000000000000000 to 0x000fffffffffffff. So, by ignoring 52 bits, we can extract 0x000 part, and we can check whether it is zero.
         add64(TrustedImm64(0x0008000000000000ULL), valueGPR, scratchGPR);
-        urshift64(TrustedImm32(52), scratchGPR);
-        return branchTest64(Zero, scratchGPR);
+        return branchTest64(Zero, scratchGPR, TrustedImm64(0xFFF0000000000000ULL));
     }
 
     Jump isNotStrictInt52(GPRReg valueGPR, GPRReg scratchGPR)
     {
         add64(TrustedImm64(0x0008000000000000ULL), valueGPR, scratchGPR);
-        urshift64(TrustedImm32(52), scratchGPR);
-        return branchTest64(NonZero, scratchGPR);
+        return branchTest64(NonZero, scratchGPR, TrustedImm64(0xFFF0000000000000ULL));
     }
 
     // Here are possible arrangements of source, target, scratch:


### PR DESCRIPTION
#### 22e1f2da1cbad1f2ae39bcff2d62e9ab7e7fb3e5
<pre>
[JSC] Micro-optimize AssemblyHelpers asm code for ARM64
<a href="https://bugs.webkit.org/show_bug.cgi?id=311012">https://bugs.webkit.org/show_bug.cgi?id=311012</a>
<a href="https://rdar.apple.com/173620352">rdar://173620352</a>

Reviewed by Keith Miller.

Let&apos;s use fused ARM64 instructions (shift and xor) to reduce instructions.
Also using branchTest64 for Int52 check which offers better instructions
for ARM64.

* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/jit/AssemblyHelpers.cpp:
(JSC::emitRandomThunkImpl):
(JSC::AssemblyHelpers::wangsInt64Hash):
* Source/JavaScriptCore/jit/AssemblyHelpers.h:
(JSC::AssemblyHelpers::isStrictInt52):
(JSC::AssemblyHelpers::isNotStrictInt52):

Canonical link: <a href="https://commits.webkit.org/310256@main">https://commits.webkit.org/310256@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ba8f2241e4da3790fe8b30a23e772e4943d5ef5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153003 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25785 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19383 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161747 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106460 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26312 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26090 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118264 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83729 "3 flakes 6 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155962 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20489 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137356 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98977 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19563 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17505 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9583 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/145015 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129216 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15229 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164221 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/14077 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7357 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16823 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126326 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25582 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21544 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126484 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25584 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137025 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82215 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23449 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21432 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13804 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184638 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25200 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89487 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47204 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24892 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25051 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24952 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->