### PR TITLE
Zero-initialize CSSParserToken union to fix valgrind uninitialised value error

### DIFF
--- a/Source/WebCore/css/parser/CSSParserToken.cpp
+++ b/Source/WebCore/css/parser/CSSParserToken.cpp
@@ -376,9 +376,9 @@ CSSParserToken::CSSParserToken(CSSParserTokenType type, char16_t c)
 CSSParserToken::CSSParserToken(CSSParserTokenType type, StringView value, BlockType blockType)
     : m_type(type)
     , m_blockType(blockType)
+    , m_id(-1)
 {
     initValueFromStringView(value);
-    m_id = -1;
 }
 
 CSSParserToken::CSSParserToken(double numericValue, NumericValueType numericValueType, NumericSign sign, StringView originalText)

--- a/Source/WebCore/css/parser/CSSParserToken.h
+++ b/Source/WebCore/css/parser/CSSParserToken.h
@@ -180,7 +180,7 @@ private:
     union {
         char16_t m_delimiter;
         HashTokenType m_hashTokenType;
-        double m_numericValue;
+        double m_numericValue { 0 };
         mutable int m_id;
         unsigned m_whitespaceCount;
     };


### PR DESCRIPTION
#### ed517e412084a29ec14c7952131f6d3462ca381c
<pre>
Zero-initialize CSSParserToken union to fix valgrind uninitialised value error
<a href="https://bugs.webkit.org/show_bug.cgi?id=311013">https://bugs.webkit.org/show_bug.cgi?id=311013</a>

Reviewed by Michael Catanzaro.

The CSSParserToken union (8 bytes) was left partially or fully uninitialized
by several constructors. When tokens were copied into a CSSVariableData Vector
buffer, the uninitialized bytes propagated. During style resolution, inlined
substitution resolution code in resolveSubstitutionFunctions() read from these
token bytes, triggering a valgrind &quot;Conditional jump or move depends on
uninitialised value(s)&quot; error.

Valgrind trace:
  ==1187609== Conditional jump or move depends on uninitialised value(s)
  ==1187609==    at 0x9B8181E: WebCore::Style::Builder::resolveSubstitutionFunctions(...)
  ==1187609==    by 0x9B80CDF: WebCore::Style::Builder::applyProperty(...)
  ==1187609==    by 0x9B7F63B: WebCore::Style::Builder::applyCascadeProperty(...)
  ==1187609==    by 0x9B7F0FC: WebCore::Style::Builder::applyHighPriorityProperties()
  ==1187609==  Uninitialised value was created by a heap allocation
  ==1187609==    at 0x4846828: malloc
  ==1187609==    at ...: bmalloc_allocate_auxiliary_impl_casual_case(...)
  ==1187609==    at 0x8841600: WebCore::CSSVariableReferenceValue::create(...)
  ==1187609==    at 0x88D6DE7: WebCore::consumeStyleProperty(...)

To fix, add a { 0 } default initializer to double m_numericValue (the largest
union member, 8 bytes), ensuring all union bytes are zero-initialized for
constructors that don&apos;t explicitly set a different member.

Covered by existing tests.

* Source/WebCore/css/parser/CSSParserToken.cpp:
(WebCore::CSSParserToken::CSSParserToken):
* Source/WebCore/css/parser/CSSParserToken.h:

Canonical link: <a href="https://commits.webkit.org/316573@main">https://commits.webkit.org/316573@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11381eaaf2b89141360a3a8e74eb8ba2eac9679c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172825 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46744 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40217 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182290 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130381 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174690 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48037 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46420 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134418 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175783 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37811 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114887 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/36456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30882 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146879 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34493 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184816 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37558 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143218 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46415 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143091 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38624 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47093 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112095 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38083 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118853 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45610 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/9436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45011 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45242 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45069 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->