### PR TITLE
WTF::Unexpected interface should be congruent with std::unexpected

### DIFF
--- a/Source/WTF/wtf/Expected.h
+++ b/Source/WTF/wtf/Expected.h
@@ -300,10 +300,10 @@ public:
     constexpr expected(value_type&& e) : base(__expected_detail::value_tag, std::forward<value_type>(e)) { }
     template<class... Args> constexpr explicit expected(std::in_place_t, Args&&... args) : base(__expected_detail::value_tag, value_type(std::forward<Args>(args)...)) { }
     // template<class U, class... Args> constexpr explicit expected(in_place_t, std::initializer_list<U>, Args&&...);
-    constexpr expected(const unexpected_type& u) : base(__expected_detail::error_tag, u.value()) { }
-    constexpr expected(unexpected_type&& u) : base(__expected_detail::error_tag, std::forward<unexpected_type>(u).value()) { }
-    template<class Err> constexpr expected(const unexpected<Err>& u) : base(__expected_detail::error_tag, u.value()) { }
-    template<class Err> constexpr expected(unexpected<Err>&& u) : base(__expected_detail::error_tag, std::forward<Err>(u.value())) { }
+    constexpr expected(const unexpected_type& u) : base(__expected_detail::error_tag, u.error()) { }
+    constexpr expected(unexpected_type&& u) : base(__expected_detail::error_tag, std::forward<unexpected_type>(u).error()) { }
+    template<class Err> constexpr expected(const unexpected<Err>& u) : base(__expected_detail::error_tag, u.error()) { }
+    template<class Err> constexpr expected(unexpected<Err>&& u) : base(__expected_detail::error_tag, std::forward<Err>(u.error())) { }
     template<class... Args> constexpr explicit expected(unexpected_t, Args&&... args) : base(__expected_detail::error_tag, error_type(std::forward<Args>(args)...)) { }
     // template<class U, class... Args> constexpr explicit expected(unexpected_t, std::initializer_list<U>, Args&&...);
 
@@ -363,9 +363,9 @@ public:
     constexpr expected(const expected&) = default;
     constexpr expected(expected&&) = default;
     // constexpr explicit expected(in_place_t);
-    constexpr expected(unexpected_type const& u) : base(u.value()) { }
-    constexpr expected(unexpected_type&& u) : base(std::forward<unexpected_type>(u).value()) { }
-    template<class Err> constexpr expected(unexpected<Err> const& u) : base(u.value()) { }
+    constexpr expected(unexpected_type const& u) : base(u.error()) { }
+    constexpr expected(unexpected_type&& u) : base(std::forward<unexpected_type>(u).error()) { }
+    template<class Err> constexpr expected(unexpected<Err> const& u) : base(u.error()) { }
 
     ~expected() = default;
 
@@ -394,7 +394,7 @@ template<class E> constexpr bool operator==(const expected<void, E>& x, const ex
 
 template<class T, class E> constexpr bool operator==(const expected<T, E>& x, const T& y) { return x && *x == y; }
 
-template<class T, class E> constexpr bool operator==(const expected<T, E>& x, const unexpected<E>& y) { return !x && x.error() == y.value(); }
+template<class T, class E> constexpr bool operator==(const expected<T, E>& x, const unexpected<E>& y) { return !x && x.error() == y.error(); }
 
 template<typename T, typename E> void swap(expected<T, E>& x, expected<T, E>& y) { x.swap(y); }
 

--- a/Source/WTF/wtf/Unexpected.h
+++ b/Source/WTF/wtf/Unexpected.h
@@ -79,16 +79,16 @@ public:
     unexpected() = delete;
     template <class U = E>
     constexpr explicit unexpected(U&& u) : val(std::forward<U>(u)) { }
-    constexpr const E& value() const & { return val; }
-    constexpr E& value() & { return val; }
-    constexpr E&& value() && { return WTF::move(val); }
-    constexpr const E&& value() const && { return WTF::move(val); }
+    constexpr const E& error() const & { return val; }
+    constexpr E& error() & { return val; }
+    constexpr E&& error() && { return WTF::move(val); }
+    constexpr const E&& error() const && { return WTF::move(val); }
 
 private:
     E val;
 };
 
-template<class E> constexpr bool operator==(const unexpected<E>& lhs, const unexpected<E>& rhs) { return lhs.value() == rhs.value(); }
+template<class E> constexpr bool operator==(const unexpected<E>& lhs, const unexpected<E>& rhs) { return lhs.error() == rhs.error(); }
 
 }}} // namespace std::experimental::fundamentals_v3
 

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -426,7 +426,7 @@ public:
             using Type = NativePromise<T, E>;
         };
 
-        using RejectValueType = std::remove_reference_t<decltype(PC::convertError(std::declval<IPC::Error>()).value())>;
+        using RejectValueType = std::remove_reference_t<decltype(PC::convertError(std::declval<IPC::Error>()).error())>;
         using Type = typename Promise<typename BasePromise::ResolveValueType, RejectValueType>::Type;
     };
     struct NoOpPromiseConverter {

--- a/Tools/TestWebKitAPI/Tests/WTF/Expected.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Expected.cpp
@@ -47,7 +47,7 @@ inline namespace fundamentals_v3 {
 
 template<class E> std::ostream& operator<<(std::ostream& os, const Unexpected<E>& u)
 {
-    return os << u.value();
+    return os << u.error();
 }
 
 template<class T, class E> std::ostream& operator<<(std::ostream& os, const Expected<T, E>& e)
@@ -76,19 +76,19 @@ TEST(WTF_Expected, Unexpected)
 {
     {
         auto u = Unexpected<int>(42);
-        EXPECT_EQ(u.value(), 42);
+        EXPECT_EQ(u.error(), 42);
         constexpr auto c = makeUnexpected(42);
-        EXPECT_EQ(c.value(), 42);
+        EXPECT_EQ(c.error(), 42);
         EXPECT_EQ(u, c);
         EXPECT_FALSE(u != c);
     }
     {
         auto c = makeUnexpected(oops);
-        EXPECT_EQ(c.value(), oops);
+        EXPECT_EQ(c.error(), oops);
     }
     {
         auto s = makeUnexpected(std::string(oops));
-        EXPECT_EQ(s.value(), oops);
+        EXPECT_EQ(s.error(), oops);
     }
     {
         constexpr auto s0 = makeUnexpected(oops);


### PR DESCRIPTION
#### 3fe3c3a6ce378bdf1899627165106decf891f479
<pre>
WTF::Unexpected interface should be congruent with std::unexpected
<a href="https://bugs.webkit.org/show_bug.cgi?id=311015">https://bugs.webkit.org/show_bug.cgi?id=311015</a>
<a href="https://rdar.apple.com/173623209">rdar://173623209</a>

Reviewed by Richard Robinson.

This is a mechanical patch where s/value/error to make WTF::Unexpected
mirror std::unexpected API. This will make the eventual transition to
the standard version easier.

* Source/WTF/wtf/Expected.h:
(std::experimental::fundamentals_v3::expected::expected):
(std::experimental::fundamentals_v3::operator==):
* Source/WTF/wtf/Unexpected.h:
(std::experimental::fundamentals_v3::unexpected::error const):
(std::experimental::fundamentals_v3::unexpected::error):
(std::experimental::fundamentals_v3::operator==):
(std::experimental::fundamentals_v3::unexpected::value const): Deleted.
(std::experimental::fundamentals_v3::unexpected::value): Deleted.
* Source/WebKit/Platform/IPC/Connection.h:
* Tools/TestWebKitAPI/Tests/WTF/Expected.cpp:
(std::experimental::fundamentals_v3::operator&lt;&lt;):
(TestWebKitAPI::TEST(WTF_Expected, Unexpected)):

Canonical link: <a href="https://commits.webkit.org/310190@main">https://commits.webkit.org/310190@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae6a2a132e4e782247fb7932278b871222e71ef5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153013 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25795 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19393 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161757 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106471 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154886 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26322 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26100 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118269 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83732 "7 flakes 6 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155972 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20500 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137365 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98982 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19574 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17513 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9593 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/145025 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129227 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15238 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164231 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13826 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7367 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16832 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126331 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25592 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21552 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126489 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34315 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25594 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137034 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82238 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21438 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13813 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184648 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25210 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89497 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47208 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24902 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25061 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24962 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->