### PR TITLE
Use "= default" for constructors in WebCore

### DIFF
--- a/Source/WebCore/Modules/gamepad/GamepadButton.cpp
+++ b/Source/WebCore/Modules/gamepad/GamepadButton.cpp
@@ -30,9 +30,7 @@
 
 namespace WebCore {
 
-GamepadButton::GamepadButton()
-{
-}
+GamepadButton::GamepadButton() = default;
 
 bool GamepadButton::pressed() const
 {

--- a/Source/WebCore/Modules/indexeddb/IDBValue.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBValue.cpp
@@ -34,9 +34,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(IDBValue);
 
-IDBValue::IDBValue()
-{
-}
+IDBValue::IDBValue() = default;
 
 IDBValue::IDBValue(const SerializedScriptValue& scriptValue)
     : m_data(ThreadSafeDataBuffer::copyData(scriptValue.wireBytes()))

--- a/Source/WebCore/Modules/indexeddb/shared/IDBResultData.cpp
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBResultData.cpp
@@ -32,9 +32,7 @@
 
 namespace WebCore {
 
-IDBResultData::IDBResultData()
-{
-}
+IDBResultData::IDBResultData() = default;
 
 IDBResultData::IDBResultData(const IDBResourceIdentifier& requestIdentifier)
     : m_requestIdentifier(requestIdentifier)

--- a/Source/WebCore/Modules/mediastream/RTCController.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCController.cpp
@@ -45,9 +45,7 @@
 
 namespace WebCore {
 
-RTCController::RTCController()
-{
-}
+RTCController::RTCController() = default;
 
 #if ENABLE(WEB_RTC)
 

--- a/Source/WebCore/Modules/webdatabase/DatabaseTask.cpp
+++ b/Source/WebCore/Modules/webdatabase/DatabaseTask.cpp
@@ -37,9 +37,7 @@
 
 namespace WebCore {
 
-DatabaseTaskSynchronizer::DatabaseTaskSynchronizer()
-{
-}
+DatabaseTaskSynchronizer::DatabaseTaskSynchronizer() = default;
 
 void DatabaseTaskSynchronizer::waitForTaskCompletion()
 {

--- a/Source/WebCore/Modules/webtransport/DatagramByteSource.cpp
+++ b/Source/WebCore/Modules/webtransport/DatagramByteSource.cpp
@@ -36,9 +36,7 @@
 
 namespace WebCore {
 
-DatagramByteSource::DatagramByteSource()
-{
-}
+DatagramByteSource::DatagramByteSource() = default;
 
 DatagramByteSource::~DatagramByteSource() = default;
 

--- a/Source/WebCore/Modules/webtransport/WebTransportReceiveStreamSource.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransportReceiveStreamSource.cpp
@@ -37,9 +37,7 @@
 
 namespace WebCore {
 
-WebTransportReceiveStreamSource::WebTransportReceiveStreamSource()
-{
-}
+WebTransportReceiveStreamSource::WebTransportReceiveStreamSource() = default;
 
 WebTransportReceiveStreamSource::WebTransportReceiveStreamSource(WebTransport& transport, WebTransportStreamIdentifier identifier)
     : m_transport(transport)

--- a/Source/WebCore/animation/ElementAnimationRareData.cpp
+++ b/Source/WebCore/animation/ElementAnimationRareData.cpp
@@ -36,9 +36,7 @@
 namespace WebCore {
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(ElementAnimationRareData);
 
-ElementAnimationRareData::ElementAnimationRareData()
-{
-}
+ElementAnimationRareData::ElementAnimationRareData() = default;
 
 ElementAnimationRareData::~ElementAnimationRareData()
 {

--- a/Source/WebCore/css/CSSSegmentedFontFace.cpp
+++ b/Source/WebCore/css/CSSSegmentedFontFace.cpp
@@ -37,9 +37,7 @@
 namespace WebCore {
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSSegmentedFontFace);
 
-CSSSegmentedFontFace::CSSSegmentedFontFace()
-{
-}
+CSSSegmentedFontFace::CSSSegmentedFontFace() = default;
 
 CSSSegmentedFontFace::~CSSSegmentedFontFace()
 {

--- a/Source/WebCore/css/parser/MediaQueryBlockWatcher.cpp
+++ b/Source/WebCore/css/parser/MediaQueryBlockWatcher.cpp
@@ -34,9 +34,7 @@
 
 namespace WebCore {
 
-MediaQueryBlockWatcher::MediaQueryBlockWatcher()
-{
-}
+MediaQueryBlockWatcher::MediaQueryBlockWatcher() = default;
 
 void MediaQueryBlockWatcher::handleToken(const CSSParserToken& token)
 {

--- a/Source/WebCore/dom/ElementData.cpp
+++ b/Source/WebCore/dom/ElementData.cpp
@@ -127,9 +127,7 @@ ElementData::ElementData(const ElementData& other, bool isUnique)
     // NOTE: The inline style is copied by the subclass copy constructor since we don't know what to do with it here.
 }
 
-UniqueElementData::UniqueElementData()
-{
-}
+UniqueElementData::UniqueElementData() = default;
 
 UniqueElementData::UniqueElementData(const UniqueElementData& other)
     : ElementData(other, true)

--- a/Source/WebCore/editing/EditorCommand.cpp
+++ b/Source/WebCore/editing/EditorCommand.cpp
@@ -1890,9 +1890,7 @@ bool Editor::commandIsSupportedFromMenuOrKeyBinding(const String& commandName)
     return internalCommand(commandName);
 }
 
-Editor::Command::Command()
-{
-}
+Editor::Command::Command() = default;
 
 Editor::Command::Command(const EditorInternalCommand* command, EditorCommandSource source, Document& document)
     : m_command(command)

--- a/Source/WebCore/editing/RenderedPosition.cpp
+++ b/Source/WebCore/editing/RenderedPosition.cpp
@@ -66,9 +66,7 @@ static inline const RenderObject* rendererFromPosition(const Position& position)
     return rendererNode->renderer();
 }
 
-RenderedPosition::RenderedPosition()
-{
-}
+RenderedPosition::RenderedPosition() = default;
 
 RenderedPosition::RenderedPosition(const RenderObject* renderer, InlineIterator::LeafBoxIterator box, unsigned offset)
     : m_renderer(renderer)

--- a/Source/WebCore/fileapi/FileReaderSync.cpp
+++ b/Source/WebCore/fileapi/FileReaderSync.cpp
@@ -40,9 +40,7 @@
 
 namespace WebCore {
 
-FileReaderSync::FileReaderSync()
-{
-}
+FileReaderSync::FileReaderSync() = default;
 
 ExceptionOr<RefPtr<ArrayBuffer>> FileReaderSync::readAsArrayBuffer(ScriptExecutionContext& scriptExecutionContext, Blob& blob)
 {

--- a/Source/WebCore/html/TimeRanges.cpp
+++ b/Source/WebCore/html/TimeRanges.cpp
@@ -45,9 +45,7 @@ Ref<TimeRanges> TimeRanges::create(const PlatformTimeRanges& other)
     return adoptRef(*new TimeRanges(other));
 }
 
-TimeRanges::TimeRanges()
-{
-}
+TimeRanges::TimeRanges() = default;
 
 TimeRanges::TimeRanges(double start, double end)
     : m_ranges(PlatformTimeRanges(MediaTime::createWithDouble(start), MediaTime::createWithDouble(end)))

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
@@ -296,9 +296,7 @@ HTMLTreeBuilder::HTMLTreeBuilder(HTMLDocumentParser& parser, DocumentFragment& f
 #endif
 }
 
-HTMLTreeBuilder::FragmentParsingContext::FragmentParsingContext()
-{
-}
+HTMLTreeBuilder::FragmentParsingContext::FragmentParsingContext() = default;
 
 HTMLTreeBuilder::FragmentParsingContext::FragmentParsingContext(DocumentFragment& fragment, Element& contextElement)
     : m_fragment(&fragment)

--- a/Source/WebCore/layout/formattingContexts/table/TableGrid.cpp
+++ b/Source/WebCore/layout/formattingContexts/table/TableGrid.cpp
@@ -76,9 +76,7 @@ TableGrid::Slot::Slot(TableGridCell& cell, bool isColumnSpanned, bool isRowSpann
 {
 }
 
-TableGrid::TableGrid()
-{
-}
+TableGrid::TableGrid() = default;
 
 TableGrid::Slot* TableGrid::slot(SlotPosition position)
 {

--- a/Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp
@@ -121,9 +121,7 @@ std::unique_ptr<Layout::LayoutTree> TreeBuilder::buildLayoutTree(const RenderVie
     return makeUnique<LayoutTree>(WTF::move(rootLayoutBox));
 }
 
-TreeBuilder::TreeBuilder()
-{
-}
+TreeBuilder::TreeBuilder() = default;
 
 std::unique_ptr<Box> TreeBuilder::createReplacedBox(Box::ElementAttributes elementAttributes, ElementBox::ReplacedAttributes&& replacedAttributes, RenderStyle&& style)
 {

--- a/Source/WebCore/loader/CrossOriginPreflightResultCache.cpp
+++ b/Source/WebCore/loader/CrossOriginPreflightResultCache.cpp
@@ -42,9 +42,7 @@ namespace WebCore {
 static const auto defaultPreflightCacheTimeout = 5_s;
 static const auto maxPreflightCacheTimeout = 600_s; // Should be short enough to minimize the risk of using a poisoned cache after switching to a secure network.
 
-CrossOriginPreflightResultCache::CrossOriginPreflightResultCache()
-{
-}
+CrossOriginPreflightResultCache::CrossOriginPreflightResultCache() = default;
 
 static bool parseAccessControlMaxAge(const String& string, Seconds& expiryDelta)
 {

--- a/Source/WebCore/loader/archive/mhtml/MHTMLArchive.cpp
+++ b/Source/WebCore/loader/archive/mhtml/MHTMLArchive.cpp
@@ -92,9 +92,7 @@ static String replaceNonPrintableCharacters(const String& text)
     return stringBuilder.toString();
 }
 
-MHTMLArchive::MHTMLArchive()
-{
-}
+MHTMLArchive::MHTMLArchive() = default;
 
 MHTMLArchive::~MHTMLArchive()
 {

--- a/Source/WebCore/page/ResourceUsageThread.cpp
+++ b/Source/WebCore/page/ResourceUsageThread.cpp
@@ -35,9 +35,7 @@
 
 namespace WebCore {
 
-ResourceUsageThread::ResourceUsageThread()
-{
-}
+ResourceUsageThread::ResourceUsageThread() = default;
 
 ResourceUsageThread& ResourceUsageThread::singleton()
 {

--- a/Source/WebCore/page/UserContentProvider.cpp
+++ b/Source/WebCore/page/UserContentProvider.cpp
@@ -43,9 +43,7 @@
 
 namespace WebCore {
 
-UserContentProvider::UserContentProvider()
-{
-}
+UserContentProvider::UserContentProvider() = default;
 
 UserContentProvider::~UserContentProvider()
 {

--- a/Source/WebCore/page/VisitedLinkStore.cpp
+++ b/Source/WebCore/page/VisitedLinkStore.cpp
@@ -30,9 +30,7 @@
 
 namespace WebCore {
 
-VisitedLinkStore::VisitedLinkStore()
-{
-}
+VisitedLinkStore::VisitedLinkStore() = default;
 
 VisitedLinkStore::~VisitedLinkStore()
 {

--- a/Source/WebCore/platform/ContextMenu.cpp
+++ b/Source/WebCore/platform/ContextMenu.cpp
@@ -33,9 +33,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ContextMenu);
 
-ContextMenu::ContextMenu()
-{
-}
+ContextMenu::ContextMenu() = default;
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/animation/AcceleratedEffectStack.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffectStack.cpp
@@ -39,9 +39,7 @@ Ref<AcceleratedEffectStack> AcceleratedEffectStack::create()
     return adoptRef(*new AcceleratedEffectStack());
 }
 
-AcceleratedEffectStack::AcceleratedEffectStack()
-{
-}
+AcceleratedEffectStack::AcceleratedEffectStack() = default;
 
 bool AcceleratedEffectStack::hasEffects() const
 {

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -68,9 +68,7 @@ static std::atomic<unsigned> lastFontCascadeGeneration { 0 };
 // FontCascade Implementation (Cross-Platform Portion)
 // ============================================================================================
 
-FontCascade::FontCascade()
-{
-}
+FontCascade::FontCascade() = default;
 
 FontCascade::FontCascade(FontCascadeDescription&& description)
     : m_fontDescription(WTF::move(description))

--- a/Source/WebCore/platform/graphics/FontPlatformData.cpp
+++ b/Source/WebCore/platform/graphics/FontPlatformData.cpp
@@ -41,9 +41,7 @@ FontPlatformData::FontPlatformData(WTF::HashTableDeletedValueType)
 {
 }
 
-FontPlatformData::FontPlatformData()
-{
-}
+FontPlatformData::FontPlatformData() = default;
 
 FontPlatformData::FontPlatformData(float size, bool syntheticBold, bool syntheticOblique, FontOrientation orientation, FontWidthVariant widthVariant, TextRenderingMode textRenderingMode, const FontCustomPlatformData* customPlatformData)
     : m_size(size)

--- a/Source/WebCore/platform/graphics/ImageFrame.cpp
+++ b/Source/WebCore/platform/graphics/ImageFrame.cpp
@@ -30,9 +30,7 @@
 
 namespace WebCore {
 
-ImageFrame::ImageFrame()
-{
-}
+ImageFrame::ImageFrame() = default;
 
 ImageFrame::ImageFrame(Ref<NativeImage>&& nativeImage)
 {

--- a/Source/WebCore/platform/graphics/PlatformTimeRanges.cpp
+++ b/Source/WebCore/platform/graphics/PlatformTimeRanges.cpp
@@ -37,9 +37,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(PlatformTimeRanges);
 
-PlatformTimeRanges::PlatformTimeRanges()
-{
-}
+PlatformTimeRanges::PlatformTimeRanges() = default;
 
 PlatformTimeRanges::PlatformTimeRanges(const MediaTime& start, const MediaTime& end)
 {

--- a/Source/WebCore/platform/graphics/Region.cpp
+++ b/Source/WebCore/platform/graphics/Region.cpp
@@ -44,9 +44,7 @@ DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(Region);
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(Region::Shape);
 
-Region::Region()
-{
-}
+Region::Region() = default;
 
 Region::Region(const IntRect& rect)
     : m_bounds(rect)

--- a/Source/WebCore/platform/image-decoders/ScalableImageDecoderFrame.cpp
+++ b/Source/WebCore/platform/image-decoders/ScalableImageDecoderFrame.cpp
@@ -30,9 +30,7 @@
 
 namespace WebCore {
 
-ScalableImageDecoderFrame::ScalableImageDecoderFrame()
-{
-}
+ScalableImageDecoderFrame::ScalableImageDecoderFrame() = default;
 
 ScalableImageDecoderFrame::~ScalableImageDecoderFrame() = default;
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerDisplayCaptureDeviceManager.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerDisplayCaptureDeviceManager.cpp
@@ -39,9 +39,7 @@ GStreamerDisplayCaptureDeviceManager& GStreamerDisplayCaptureDeviceManager::sing
     return manager;
 }
 
-GStreamerDisplayCaptureDeviceManager::GStreamerDisplayCaptureDeviceManager()
-{
-}
+GStreamerDisplayCaptureDeviceManager::GStreamerDisplayCaptureDeviceManager() = default;
 
 GStreamerDisplayCaptureDeviceManager::~GStreamerDisplayCaptureDeviceManager()
 {

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp
@@ -75,9 +75,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(LibWebRTCProvider);
 
-LibWebRTCProvider::LibWebRTCProvider()
-{
-}
+LibWebRTCProvider::LibWebRTCProvider() = default;
 
 LibWebRTCProvider::~LibWebRTCProvider() = default;
 

--- a/Source/WebCore/platform/network/ResourceResponseBase.cpp
+++ b/Source/WebCore/platform/network/ResourceResponseBase.cpp
@@ -57,9 +57,7 @@ bool isScriptAllowedByNosniff(const ResourceResponse& response)
     return MIMETypeRegistry::isSupportedJavaScriptMIMEType(mimeType);
 }
 
-ResourceResponseBase::ResourceResponseBase()
-{
-}
+ResourceResponseBase::ResourceResponseBase() = default;
 
 ResourceResponseBase::ResourceResponseBase(URL&& url, String&& mimeType, long long expectedLength, String&& textEncodingName)
     : m_url(WTF::move(url))

--- a/Source/WebCore/platform/win/WCDataObject.cpp
+++ b/Source/WebCore/platform/win/WCDataObject.cpp
@@ -169,9 +169,7 @@ HRESULT WCDataObject::createInstance(WCDataObject** result, const DragDataMap& d
     return S_OK;
 }
 
-WCDataObject::WCDataObject()
-{
-}
+WCDataObject::WCDataObject() = default;
 
 STDMETHODIMP WCDataObject::QueryInterface(_In_ REFIID riid, _COM_Outptr_ void** ppvObject)
 {

--- a/Source/WebCore/rendering/RenderTextLineBoxes.cpp
+++ b/Source/WebCore/rendering/RenderTextLineBoxes.cpp
@@ -36,9 +36,7 @@
 
 namespace WebCore {
 
-RenderTextLineBoxes::RenderTextLineBoxes()
-{
-}
+RenderTextLineBoxes::RenderTextLineBoxes() = default;
 
 LegacyInlineTextBox* RenderTextLineBoxes::createAndAppendLineBox(RenderSVGInlineText& renderText)
 {

--- a/Source/WebCore/rendering/svg/SVGTextChunkBuilder.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextChunkBuilder.cpp
@@ -28,9 +28,7 @@
 
 namespace WebCore {
 
-SVGTextChunkBuilder::SVGTextChunkBuilder()
-{
-}
+SVGTextChunkBuilder::SVGTextChunkBuilder() = default;
 
 unsigned SVGTextChunkBuilder::totalCharacters() const
 {

--- a/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
+++ b/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
@@ -49,9 +49,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGResources);
 
-SVGResources::SVGResources()
-{
-}
+SVGResources::SVGResources() = default;
 
 static MemoryCompactLookupOnlyRobinHoodHashSet<AtomString> tagSet(std::span<decltype(SVGNames::aTag)* const> tags)
 {

--- a/Source/WebCore/storage/StorageNamespaceProvider.cpp
+++ b/Source/WebCore/storage/StorageNamespaceProvider.cpp
@@ -38,9 +38,7 @@ namespace WebCore {
 // Suggested by the HTML5 spec.
 unsigned localStorageDatabaseQuotaInBytes = 5 * 1024 * 1024;
 
-StorageNamespaceProvider::StorageNamespaceProvider()
-{
-}
+StorageNamespaceProvider::StorageNamespaceProvider() = default;
 
 StorageNamespaceProvider::~StorageNamespaceProvider() = default;
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -7449,9 +7449,7 @@ String Internals::highlightPseudoElementColor(const AtomString& highlightName, E
     return serializationForCSS(resolvedStyle->style->color());
 }
     
-Internals::TextIndicatorInfo::TextIndicatorInfo()
-{
-}
+Internals::TextIndicatorInfo::TextIndicatorInfo() = default;
 
 Internals::TextIndicatorInfo::TextIndicatorInfo(const WebCore::TextIndicatorData& data)
     : textBoundingRectInRootViewCoordinates(DOMRect::create(data.textBoundingRectInRootViewCoordinates))

--- a/Source/WebCore/workers/WorkerRunLoop.cpp
+++ b/Source/WebCore/workers/WorkerRunLoop.cpp
@@ -114,9 +114,7 @@ private:
     bool m_allowEventLoopTasks;
 };
 
-WorkerDedicatedRunLoop::WorkerDedicatedRunLoop()
-{
-}
+WorkerDedicatedRunLoop::WorkerDedicatedRunLoop() = default;
 
 WorkerDedicatedRunLoop::~WorkerDedicatedRunLoop()
 {
@@ -426,9 +424,7 @@ WorkerDedicatedRunLoop::Task::Task(ScriptExecutionContext::Task&& task, const St
 {
 }
 
-WorkerMainRunLoop::WorkerMainRunLoop()
-{
-}
+WorkerMainRunLoop::WorkerMainRunLoop() = default;
 
 void WorkerMainRunLoop::setGlobalScope(WorkerOrWorkletGlobalScope& globalScope)
 {


### PR DESCRIPTION
#### c6a0e440dd2a2821124ea9d891f6a919158596d9
<pre>
Use &quot;= default&quot; for constructors in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=311017">https://bugs.webkit.org/show_bug.cgi?id=311017</a>
<a href="https://rdar.apple.com/173624255">rdar://173624255</a>

Reviewed by Chris Dumez.

This extends our &quot;= default&quot; usage across few leftover empty constructors
in WebCore code.

* Source/WebCore/Modules/gamepad/GamepadButton.cpp:
(WebCore::GamepadButton::GamepadButton): Deleted.
* Source/WebCore/Modules/indexeddb/IDBValue.cpp:
* Source/WebCore/Modules/indexeddb/shared/IDBResultData.cpp:
* Source/WebCore/Modules/mediastream/RTCController.cpp:
(WebCore::RTCController::RTCController): Deleted.
* Source/WebCore/Modules/webdatabase/DatabaseTask.cpp:
(WebCore::DatabaseTaskSynchronizer::DatabaseTaskSynchronizer): Deleted.
* Source/WebCore/Modules/webtransport/DatagramByteSource.cpp:
(WebCore::DatagramByteSource::DatagramByteSource): Deleted.
* Source/WebCore/Modules/webtransport/WebTransportReceiveStreamSource.cpp:
* Source/WebCore/animation/ElementAnimationRareData.cpp:
(WebCore::ElementAnimationRareData::ElementAnimationRareData): Deleted.
* Source/WebCore/css/CSSSegmentedFontFace.cpp:
(WebCore::CSSSegmentedFontFace::CSSSegmentedFontFace): Deleted.
* Source/WebCore/css/parser/MediaQueryBlockWatcher.cpp:
(WebCore::MediaQueryBlockWatcher::MediaQueryBlockWatcher): Deleted.
* Source/WebCore/dom/ElementData.cpp:
* Source/WebCore/editing/EditorCommand.cpp:
* Source/WebCore/editing/RenderedPosition.cpp:
* Source/WebCore/fileapi/FileReaderSync.cpp:
(WebCore::FileReaderSync::FileReaderSync): Deleted.
* Source/WebCore/html/TimeRanges.cpp:
* Source/WebCore/html/parser/HTMLTreeBuilder.cpp:
* Source/WebCore/layout/formattingContexts/table/TableGrid.cpp:
(WebCore::Layout::TableGrid::TableGrid): Deleted.
* Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp:
(WebCore::Layout::TreeBuilder::TreeBuilder): Deleted.
* Source/WebCore/loader/CrossOriginPreflightResultCache.cpp:
(WebCore::CrossOriginPreflightResultCache::CrossOriginPreflightResultCache): Deleted.
* Source/WebCore/loader/archive/mhtml/MHTMLArchive.cpp:
(WebCore::MHTMLArchive::MHTMLArchive): Deleted.
* Source/WebCore/page/ResourceUsageThread.cpp:
(WebCore::ResourceUsageThread::ResourceUsageThread): Deleted.
* Source/WebCore/page/UserContentProvider.cpp:
(WebCore::UserContentProvider::UserContentProvider): Deleted.
* Source/WebCore/page/VisitedLinkStore.cpp:
(WebCore::VisitedLinkStore::VisitedLinkStore): Deleted.
* Source/WebCore/platform/ContextMenu.cpp:
(WebCore::ContextMenu::ContextMenu): Deleted.
* Source/WebCore/platform/animation/AcceleratedEffectStack.cpp:
(WebCore::AcceleratedEffectStack::AcceleratedEffectStack): Deleted.
* Source/WebCore/platform/graphics/FontCascade.cpp:
* Source/WebCore/platform/graphics/FontPlatformData.cpp:
* Source/WebCore/platform/graphics/ImageFrame.cpp:
* Source/WebCore/platform/graphics/PlatformTimeRanges.cpp:
* Source/WebCore/platform/graphics/Region.cpp:
* Source/WebCore/platform/image-decoders/ScalableImageDecoderFrame.cpp:
(WebCore::ScalableImageDecoderFrame::ScalableImageDecoderFrame): Deleted.
* Source/WebCore/platform/mediastream/gstreamer/GStreamerDisplayCaptureDeviceManager.cpp:
(WebCore::GStreamerDisplayCaptureDeviceManager::GStreamerDisplayCaptureDeviceManager): Deleted.
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp:
(WebCore::LibWebRTCProvider::LibWebRTCProvider): Deleted.
* Source/WebCore/platform/network/ResourceResponseBase.cpp:
* Source/WebCore/platform/win/WCDataObject.cpp:
(WebCore::WCDataObject::WCDataObject): Deleted.
* Source/WebCore/rendering/RenderTextLineBoxes.cpp:
(WebCore::RenderTextLineBoxes::RenderTextLineBoxes): Deleted.
* Source/WebCore/rendering/svg/SVGTextChunkBuilder.cpp:
(WebCore::SVGTextChunkBuilder::SVGTextChunkBuilder): Deleted.
* Source/WebCore/rendering/svg/legacy/SVGResources.cpp:
(WebCore::SVGResources::SVGResources): Deleted.
* Source/WebCore/storage/StorageNamespaceProvider.cpp:
(WebCore::StorageNamespaceProvider::StorageNamespaceProvider): Deleted.
* Source/WebCore/testing/Internals.cpp:
* Source/WebCore/workers/WorkerRunLoop.cpp:
(WebCore::WorkerDedicatedRunLoop::WorkerDedicatedRunLoop): Deleted.
(WebCore::WorkerMainRunLoop::WorkerMainRunLoop): Deleted.

Canonical link: <a href="https://commits.webkit.org/310182@main">https://commits.webkit.org/310182@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a15848fa8d633c14d9e8c8a6b1e9a2325774eaf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153017 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25799 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19397 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161761 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106475 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154890 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26326 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26104 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118270 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155976 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20502 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137370 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98983 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19576 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17515 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9597 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129229 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15243 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164235 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7371 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16837 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126333 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25596 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21554 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126491 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34310 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25598 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137039 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82236 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21445 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13818 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25214 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89501 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24906 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25065 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24966 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->