### PR TITLE
[GStreamer][WebRTC][1.28] imported/w3c/web-platform-tests/webrtc/simulcast/rid-manipulation.html fails

### DIFF
--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/media-capabilities/decodingInfo.webrtc-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/media-capabilities/decodingInfo.webrtc-expected.txt
@@ -14,6 +14,8 @@ PASS Test that decodingInfo returns supported true for the codec audio/opus retu
 PASS Test that decodingInfo returns supported true for the codec audio/G722 returned by RTCRtpReceiver.getCapabilities()
 PASS Test that decodingInfo returns supported true for the codec audio/PCMU returned by RTCRtpReceiver.getCapabilities()
 PASS Test that decodingInfo returns supported true for the codec audio/PCMA returned by RTCRtpReceiver.getCapabilities()
+PASS Test that decodingInfo returns supported true for the codec video/H264; level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42c01f returned by RTCRtpReceiver.getCapabilities()
+PASS Test that decodingInfo returns supported true for the codec video/H264; level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42c01f returned by RTCRtpReceiver.getCapabilities()
 PASS Test that decodingInfo returns supported true for the codec video/H264; level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f returned by RTCRtpReceiver.getCapabilities()
 PASS Test that decodingInfo returns supported true for the codec video/H264; level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42e01f returned by RTCRtpReceiver.getCapabilities()
 PASS Test that decodingInfo returns supported true for the codec video/H264; level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=640c1f returned by RTCRtpReceiver.getCapabilities()

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/media-capabilities/encodingInfo.webrtc-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/media-capabilities/encodingInfo.webrtc-expected.txt
@@ -14,6 +14,8 @@ PASS Test that encodingInfo returns supported true for the codec audio/opus retu
 PASS Test that encodingInfo returns supported true for the codec audio/G722 returned by RTCRtpSender.getCapabilities()
 PASS Test that encodingInfo returns supported true for the codec audio/PCMU returned by RTCRtpSender.getCapabilities()
 PASS Test that encodingInfo returns supported true for the codec audio/PCMA returned by RTCRtpSender.getCapabilities()
+PASS Test that encodingInfo returns supported true for the codec video/H264; level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42c01f returned by RTCRtpSender.getCapabilities()
+PASS Test that encodingInfo returns supported true for the codec video/H264; level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42c01f returned by RTCRtpSender.getCapabilities()
 PASS Test that encodingInfo returns supported true for the codec video/H264; level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f returned by RTCRtpSender.getCapabilities()
 PASS Test that encodingInfo returns supported true for the codec video/H264; level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42e01f returned by RTCRtpSender.getCapabilities()
 PASS Test that encodingInfo returns supported true for the codec video/H264; level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=640c1f returned by RTCRtpSender.getCapabilities()

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -1263,7 +1263,8 @@ void GStreamerRegistryScanner::fillVideoRtpCapabilities(Configuration configurat
             element = gst_element_factory_make("webkitvideoencoder", nullptr);
 
         if (element) {
-            static constexpr std::array<std::pair<ASCIILiteral, unsigned>, 4> profiles = { {
+            static constexpr std::array<std::pair<ASCIILiteral, unsigned>, 5> profiles = { {
+                { "42c01f"_s, 0x42c01f },
                 { "42e01f"_s, 0x42e01f },
                 { "640c1f"_s, 0x640c1f },
                 { "42001f"_s, 0x42001f },


### PR DESCRIPTION
#### f2e935e81d2d07090536fd8ade3ad9303d8eb1a1
<pre>
[GStreamer][WebRTC][1.28] imported/w3c/web-platform-tests/webrtc/simulcast/rid-manipulation.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=308926">https://bugs.webkit.org/show_bug.cgi?id=308926</a>

Reviewed by Xabier Rodriguez-Calvar.

Since GStreamer 1.28 the H.264 profiles are more thoroughly checked in the SDP. Without advertizing
the constrained-baseline profile with level 3.1 in our offers and answers the rid-manipulation.html
would fail to negotiate its munged SDP values.

* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp:
(WebCore::GStreamerRegistryScanner::fillVideoRtpCapabilities):

Canonical link: <a href="https://commits.webkit.org/310639@main">https://commits.webkit.org/310639@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3d1a55e1bb1f9cfa122276fd60009b58ee5a954

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153042 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25824 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19422 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161786 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106500 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154915 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26351 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26129 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118288 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83750 "7 flakes 6 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156001 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20521 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137396 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99001 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19595 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17539 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9622 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129248 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15269 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164260 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7396 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16863 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126350 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25621 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21578 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126508 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34651 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25623 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137065 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82263 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21471 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13844 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25239 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89526 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24932 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25090 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24991 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->