### PR TITLE
[CMake] Deprecation warnings about SQLite::SQLite3

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -2132,7 +2132,7 @@ set(WebCore_USER_AGENT_STYLE_SHEETS
 set(WebCore_LIBRARIES
     ICU::uc
     LibXml2::LibXml2
-    SQLite::SQLite3
+    SQLite3::SQLite3
     ZLIB::ZLIB
 )
 set(WebCore_FRAMEWORKS

--- a/Source/WebCore/PlatformMac.cmake
+++ b/Source/WebCore/PlatformMac.cmake
@@ -27,6 +27,10 @@ find_library(XML2_LIBRARY XML2)
 find_package(SQLite3 REQUIRED)
 find_package(ZLIB REQUIRED)
 
+if (NOT TARGET SQLite3::SQLite3) # CMake < 4.3
+    add_library(SQLite3::SQLite3 ALIAS SQLite::SQLite3)
+endif ()
+
 list(APPEND WebCore_UNIFIED_SOURCE_LIST_FILES
     "SourcesCocoa.txt"
 )

--- a/Source/cmake/OptionsGTK.cmake
+++ b/Source/cmake/OptionsGTK.cmake
@@ -25,6 +25,10 @@ find_package(ZLIB REQUIRED)
 find_package(WebP REQUIRED COMPONENTS demux)
 find_package(ATSPI 2.5.3)
 
+if (NOT TARGET SQLite3::SQLite3) # CMake < 4.3
+    add_library(SQLite3::SQLite3 ALIAS SQLite::SQLite3)
+endif ()
+
 include(GStreamerDefinitions)
 include(FindGLibCompileResources)
 

--- a/Source/cmake/OptionsPlayStation.cmake
+++ b/Source/cmake/OptionsPlayStation.cmake
@@ -132,9 +132,12 @@ if (ENABLE_WEBCORE)
         list(APPEND PlayStationModule_TARGETS LibXml2::LibXml2)
     endif ()
 
-    if (NOT TARGET SQLite::SQLite3)
+    if (NOT TARGET SQLite3::SQLite3)
         find_package(SQLite3 3.23.1 REQUIRED)
-        list(APPEND PlayStationModule_TARGETS SQLite::SQLite3)
+        if (NOT TARGET SQLite3::SQLite3) # CMake < 4.3
+            add_library(SQLite3::SQLite3 ALIAS SQLite::SQLite3)
+        endif ()
+        list(APPEND PlayStationModule_TARGETS SQLite3::SQLite3)
     endif ()
 
     if (NOT TARGET WebP::libwebp)

--- a/Source/cmake/OptionsWPE.cmake
+++ b/Source/cmake/OptionsWPE.cmake
@@ -23,6 +23,10 @@ find_package(Unifdef REQUIRED)
 find_package(WebP REQUIRED COMPONENTS demux)
 find_package(ZLIB REQUIRED)
 
+if (NOT TARGET SQLite3::SQLite3) # CMake < 4.3
+    add_library(SQLite3::SQLite3 ALIAS SQLite::SQLite3)
+endif ()
+
 if (ANDROID)
     find_package(Android REQUIRED COMPONENTS Android Log)
 

--- a/Source/cmake/OptionsWin.cmake
+++ b/Source/cmake/OptionsWin.cmake
@@ -55,6 +55,10 @@ find_package(ZLIB 1.2.11 REQUIRED)
 find_package(LibPSL 0.20.2 REQUIRED)
 find_package(WebP REQUIRED COMPONENTS demux)
 
+if (NOT TARGET SQLite3::SQLite3) # CMake < 4.3
+    add_library(SQLite3::SQLite3 ALIAS SQLite::SQLite3)
+endif ()
+
 WEBKIT_OPTION_BEGIN()
 
 # FIXME: Most of these options should not be public.


### PR DESCRIPTION
#### 83a0ed064cfbc8138cb38e27f7b2ffe0026eb3a8
<pre>
[CMake] Deprecation warnings about SQLite::SQLite3
<a href="https://bugs.webkit.org/show_bug.cgi?id=311018">https://bugs.webkit.org/show_bug.cgi?id=311018</a>

Reviewed by Adrian Perez de Castro.

Add a SQLite3::SQLite3 alias to SQLite::SQLite3 for old CMake versions, as recommended in
<a href="https://cmake.org/cmake/help/latest/module/FindSQLite3.html">https://cmake.org/cmake/help/latest/module/FindSQLite3.html</a>

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/PlatformMac.cmake:
* Source/cmake/OptionsGTK.cmake:
* Source/cmake/OptionsPlayStation.cmake:
* Source/cmake/OptionsWPE.cmake:
* Source/cmake/OptionsWin.cmake:

Canonical link: <a href="https://commits.webkit.org/310205@main">https://commits.webkit.org/310205@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4892ed55c5c3057803a08a7644fa406a8b14c196

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153043 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25825 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19423 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161787 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106501 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154916 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26352 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26130 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118290 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83751 "8 flakes 6 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156002 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20527 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137399 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99003 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19601 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17541 "Found 3 new API test failures: TestWebKitAPI.WKWebExtensionAPIExtension.GetBackgroundPageFromTab, TestWebKitAPI.RequiresUserActionForPlaybackTest.DeprecatedRequiresUserActionForVideoButNotAudioPlayback, TestWebKitAPI.WKWebExtensionAPILocalization.CSSLocalizationInRegisteredContentScript (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9623 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/145055 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129254 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15272 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164261 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13856 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7397 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16866 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126351 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25622 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21580 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126509 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34329 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25624 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137068 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82264 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21459 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13847 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184678 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25240 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89527 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47221 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24933 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25091 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24992 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->