### PR TITLE
Adopt StringView in more places in InputType classes

### DIFF
--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -47,6 +47,7 @@ OBJC_CLASS NSString;
 namespace WTF {
 
 class AdaptiveStringSearcherTables;
+template<typename T> class ValueOrReference;
 
 // StringView is a non-owning reference to a string, similar to the proposed std::string_view.
 
@@ -64,6 +65,7 @@ public:
 
     StringView(const AtomString& string LIFETIME_BOUND);
     StringView(const String& string LIFETIME_BOUND);
+    StringView(const ValueOrReference<String>& string LIFETIME_BOUND);
     StringView(const StringImpl& string LIFETIME_BOUND);
     StringView(const StringImpl* string LIFETIME_BOUND);
     StringView(std::span<const Latin1Character> span LIFETIME_BOUND);
@@ -287,6 +289,7 @@ inline StringView emptyStringView() { return ""_span; }
 
 } // namespace WTF
 
+#include <wtf/ValueOrReference.h>
 #include <wtf/text/AtomString.h>
 #include <wtf/text/WTFString.h>
 
@@ -470,6 +473,11 @@ inline StringView::StringView(const String& string LIFETIME_BOUND)
 
 inline StringView::StringView(const AtomString& atomString LIFETIME_BOUND)
     : StringView(atomString.string())
+{
+}
+
+inline StringView::StringView(const ValueOrReference<String>& string LIFETIME_BOUND)
+    : StringView(string.get())
 {
 }
 

--- a/Source/WebCore/html/BaseDateAndTimeInputType.cpp
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.cpp
@@ -187,7 +187,7 @@ ExceptionOr<void> BaseDateAndTimeInputType::setValueAsDecimal(const Decimal& new
     return { };
 }
 
-bool BaseDateAndTimeInputType::typeMismatchFor(const String& value) const
+bool BaseDateAndTimeInputType::typeMismatchFor(StringView value) const
 {
     return !value.isEmpty() && !parseToDateComponents(value);
 }
@@ -211,7 +211,7 @@ Decimal BaseDateAndTimeInputType::defaultValueForStepUp() const
     return Decimal::fromDouble(ms + (offset * msPerMinute));
 }
 
-Decimal BaseDateAndTimeInputType::parseToNumber(const String& source, const Decimal& defaultValue) const
+Decimal BaseDateAndTimeInputType::parseToNumber(StringView source, const Decimal& defaultValue) const
 {
     auto date = parseToDateComponents(source);
     if (!date)
@@ -271,7 +271,7 @@ ValueOrReference<String> BaseDateAndTimeInputType::sanitizeValue(const String& p
     return proposedValue;
 }
 
-bool BaseDateAndTimeInputType::valueMissing(const String& value) const
+bool BaseDateAndTimeInputType::valueMissing(StringView value) const
 {
     ASSERT(element());
     return protect(element())->isMutable() && element()->isRequired() && value.isEmpty();

--- a/Source/WebCore/html/BaseDateAndTimeInputType.h
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.h
@@ -50,8 +50,8 @@ class BaseDateAndTimeInputType : public InputType, public DateTimeChooserClient,
     WTF_MAKE_TZONE_ALLOCATED(BaseDateAndTimeInputType);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(BaseDateAndTimeInputType);
 public:
-    bool typeMismatchFor(const String&) const final;
-    bool valueMissing(const String&) const final;
+    bool typeMismatchFor(StringView) const final;
+    bool valueMissing(StringView) const final;
     bool typeMismatch() const final;
     bool hasBadInput() const final;
 
@@ -75,7 +75,7 @@ protected:
 
     ~BaseDateAndTimeInputType();
 
-    Decimal parseToNumber(const String&, const Decimal&) const override;
+    Decimal parseToNumber(StringView, const Decimal&) const override;
     String serialize(const Decimal&) const final;
     String serializeWithComponents(const DateComponents&) const;
 

--- a/Source/WebCore/html/BaseTextInputType.cpp
+++ b/Source/WebCore/html/BaseTextInputType.cpp
@@ -40,7 +40,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(BaseTextInputType);
 
 using namespace HTMLNames;
 
-bool BaseTextInputType::patternMismatch(const String& value) const
+bool BaseTextInputType::patternMismatch(StringView value) const
 {
     ASSERT(element());
     Ref element = *this->element();
@@ -54,7 +54,7 @@ bool BaseTextInputType::patternMismatch(const String& value) const
         return false;
     }
 
-    auto valuePatternMismatch = [&regex](auto& value) {
+    auto valuePatternMismatch = [&regex](auto value) {
         int matchLength = 0;
         int valueLength = value.length();
         int matchOffset = regex.match(value, 0, &matchLength);
@@ -62,8 +62,11 @@ bool BaseTextInputType::patternMismatch(const String& value) const
     };
 
     if (isEmailField() && element->multiple()) {
-        auto values = value.split(',');
-        return values.findIf(valuePatternMismatch) != notFound;
+        for (auto splitValue : value.split(',')) {
+            if (valuePatternMismatch(splitValue))
+                return true;
+        }
+        return false;
     }
     return valuePatternMismatch(value);
 }

--- a/Source/WebCore/html/BaseTextInputType.h
+++ b/Source/WebCore/html/BaseTextInputType.h
@@ -41,7 +41,7 @@ class BaseTextInputType : public TextFieldInputType {
     WTF_MAKE_TZONE_ALLOCATED(BaseTextInputType);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(BaseTextInputType);
 public:
-    bool patternMismatch(const String&) const final;
+    bool patternMismatch(StringView) const final;
 
 protected:
     explicit BaseTextInputType(Type type, HTMLInputElement& element)

--- a/Source/WebCore/html/CheckboxInputType.cpp
+++ b/Source/WebCore/html/CheckboxInputType.cpp
@@ -73,7 +73,7 @@ const AtomString& CheckboxInputType::formControlType() const
     return InputTypeNames::checkbox();
 }
 
-bool CheckboxInputType::valueMissing(const String&) const
+bool CheckboxInputType::valueMissing(StringView) const
 {
     ASSERT(element());
     return element()->isRequired() && !element()->checked();

--- a/Source/WebCore/html/CheckboxInputType.h
+++ b/Source/WebCore/html/CheckboxInputType.h
@@ -55,7 +55,7 @@ public:
         return adoptRef(*new CheckboxInputType(element));
     }
 
-    bool valueMissing(const String&) const final;
+    bool valueMissing(StringView) const final;
     float switchAnimationVisuallyOnProgress() const;
     bool NODELETE isSwitchVisuallyOn() const;
     float switchAnimationHeldProgress() const;

--- a/Source/WebCore/html/EmailInputType.cpp
+++ b/Source/WebCore/html/EmailInputType.cpp
@@ -63,15 +63,15 @@ const AtomString& EmailInputType::formControlType() const
     return InputTypeNames::email();
 }
 
-bool EmailInputType::typeMismatchFor(const String& value) const
+bool EmailInputType::typeMismatchFor(StringView value) const
 {
     ASSERT(element());
     if (value.isEmpty())
         return false;
     if (!protect(element())->multiple())
         return !isValidEmailAddress(value);
-    for (auto& address : value.splitAllowingEmptyEntries(',')) {
-        if (!isValidEmailAddress(StringView(address).trim(isASCIIWhitespace<char16_t>)))
+    for (auto address : value.splitAllowingEmptyEntries(',')) {
+        if (!isValidEmailAddress(address.trim(isASCIIWhitespace<char16_t>)))
             return true;
     }
     return false;

--- a/Source/WebCore/html/EmailInputType.h
+++ b/Source/WebCore/html/EmailInputType.h
@@ -44,7 +44,7 @@ public:
         return adoptRef(*new EmailInputType(element));
     }
 
-    bool typeMismatchFor(const String&) const final;
+    bool typeMismatchFor(StringView) const final;
     bool typeMismatch() const final;
 
 private:

--- a/Source/WebCore/html/FileInputType.cpp
+++ b/Source/WebCore/html/FileInputType.cpp
@@ -142,7 +142,7 @@ bool FileInputType::appendFormData(DOMFormData& formData) const
     return true;
 }
 
-bool FileInputType::valueMissing(const String& value) const
+bool FileInputType::valueMissing(StringView value) const
 {
     ASSERT(element());
     return element()->isRequired() && value.isEmpty();

--- a/Source/WebCore/html/FileInputType.h
+++ b/Source/WebCore/html/FileInputType.h
@@ -61,7 +61,7 @@ public:
 
     static std::pair<Vector<FileChooserFileInfo>, String> filesFromFormControlState(const FormControlState&);
     bool canSetStringValue() const final;
-    bool valueMissing(const String&) const final;
+    bool valueMissing(StringView) const final;
 
 private:
     explicit FileInputType(HTMLInputElement&);

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -248,7 +248,7 @@ bool HTMLInputElement::shouldAutocomplete() const
     return HTMLTextFormControlElement::shouldAutocomplete();
 }
 
-bool HTMLInputElement::isValidValue(const String& value) const
+bool HTMLInputElement::isValidValue(StringView value) const
 {
     if (!m_inputType->isValidValue(value))
         return false;
@@ -1165,7 +1165,7 @@ ExceptionOr<void> HTMLInputElement::setValue(const String& value, TextFieldEvent
     Ref protectedThis { *this };
     EventQueueScope scope;
     auto sanitizedValue = sanitizeValue(value);
-    bool valueChanged = sanitizedValue != this->value();
+    bool valueChanged = sanitizedValue != this->value().get();
 
     setLastChangeWasNotUserEdit();
     setFormControlValueMatchesRenderer(false);

--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -201,7 +201,7 @@ public:
 
     // Checks if the specified string would be a valid value.
     // We should not call this for types with no string value such as CHECKBOX and RADIO.
-    bool isValidValue(const String&) const;
+    bool isValidValue(StringView) const;
     bool hasDirtyValue() const { return !m_valueIfDirty.isNull(); }
 
     String placeholder() const;

--- a/Source/WebCore/html/InputType.cpp
+++ b/Source/WebCore/html/InputType.cpp
@@ -108,7 +108,7 @@ template<typename T> static Ref<InputType> createInputType(HTMLInputElement& ele
 }
 
 template<typename DowncastedType>
-ALWAYS_INLINE bool isInvalidInputType(const DowncastedType& inputType, const String& value)
+ALWAYS_INLINE bool isInvalidInputType(const DowncastedType& inputType, StringView value)
 {
     return inputType.typeMismatch()
         || inputType.hasStepRangeViolation(value)
@@ -188,7 +188,7 @@ RefPtr<InputType> InputType::createIfDifferent(HTMLInputElement& element, const 
 
 InputType::~InputType() = default;
 
-template<typename T> static bool validateInputType(const T& inputType, const String& value)
+template<typename T> static bool validateInputType(const T& inputType, StringView value)
 {
     ASSERT(inputType.canSetStringValue());
     return !inputType.typeMismatchFor(value)
@@ -197,7 +197,7 @@ template<typename T> static bool validateInputType(const T& inputType, const Str
         && !inputType.valueMissing(value);
 }
 
-bool InputType::isValidValue(const String& value) const
+bool InputType::isValidValue(StringView value) const
 {
     switch (m_type) {
     case Type::Button:
@@ -324,7 +324,7 @@ bool InputType::supportsRequired() const
     return supportsValidation();
 }
 
-std::optional<std::pair<Decimal, StepRange>> InputType::parsedValueAndStepRange(const String& value) const
+std::optional<std::pair<Decimal, StepRange>> InputType::parsedValueAndStepRange(StringView value) const
 {
     if (!isSteppable())
         return std::nullopt;
@@ -334,7 +334,7 @@ std::optional<std::pair<Decimal, StepRange>> InputType::parsedValueAndStepRange(
     return { { numericValue, createStepRange(AnyStepHandling::Reject) } };
 }
 
-bool InputType::rangeUnderflow(const String& value) const
+bool InputType::rangeUnderflow(StringView value) const
 {
     auto parsed = parsedValueAndStepRange(value);
     if (!parsed)
@@ -348,7 +348,7 @@ bool InputType::rangeUnderflow(const String& value) const
     return numericValue < range.minimum();
 }
 
-bool InputType::rangeOverflow(const String& value) const
+bool InputType::rangeOverflow(StringView value) const
 {
     auto parsed = parsedValueAndStepRange(value);
     if (!parsed)
@@ -362,7 +362,7 @@ bool InputType::rangeOverflow(const String& value) const
     return numericValue > range.maximum();
 }
 
-bool InputType::isInvalid(const String& value) const
+bool InputType::isInvalid(StringView value) const
 {
     switch (m_type) {
     case Type::Button:
@@ -441,7 +441,7 @@ float InputType::decorationWidth(float) const
     return 0;
 }
 
-bool InputType::isInRange(const String& value) const
+bool InputType::isInRange(StringView value) const
 {
     if (!isSteppable())
         return false;
@@ -462,7 +462,7 @@ bool InputType::isInRange(const String& value) const
     return numericValue >= stepRange.minimum() && numericValue <= stepRange.maximum();
 }
 
-bool InputType::isOutOfRange(const String& value) const
+bool InputType::isOutOfRange(StringView value) const
 {
     if (!isSteppable() || value.isEmpty())
         return false;
@@ -483,7 +483,7 @@ bool InputType::isOutOfRange(const String& value) const
     return numericValue < stepRange.minimum() || numericValue > stepRange.maximum();
 }
 
-bool InputType::stepMismatch(const String& value) const
+bool InputType::stepMismatch(StringView value) const
 {
     auto parsed = parsedValueAndStepRange(value);
     if (!parsed)
@@ -493,7 +493,7 @@ bool InputType::stepMismatch(const String& value) const
     return range.stepMismatch(numericValue);
 }
 
-bool InputType::hasStepRangeViolation(const String& value) const
+bool InputType::hasStepRangeViolation(StringView value) const
 {
     auto parsed = parsedValueAndStepRange(value);
     if (!parsed)
@@ -645,13 +645,13 @@ void InputType::removeShadowSubtree()
     m_hasCreatedShadowSubtree = false;
 }
 
-Decimal InputType::parseToNumber(const String&, const Decimal& defaultValue) const
+Decimal InputType::parseToNumber(StringView, const Decimal& defaultValue) const
 {
     ASSERT_NOT_REACHED();
     return defaultValue;
 }
 
-Decimal InputType::parseToNumberOrNaN(const String& string) const
+Decimal InputType::parseToNumberOrNaN(StringView string) const
 {
     return parseToNumber(string, Decimal::nan());
 }

--- a/Source/WebCore/html/InputType.h
+++ b/Source/WebCore/html/InputType.h
@@ -164,7 +164,7 @@ public:
 
     virtual const AtomString& formControlType() const = 0;
 
-    bool isValidValue(const String&) const;
+    bool isValidValue(StringView) const;
 
     // Type query functions.
 
@@ -238,21 +238,21 @@ public:
     // Validation functions.
 
     virtual String validationMessage() const;
-    virtual bool typeMismatchFor(const String&) const { return false; }
+    virtual bool typeMismatchFor(StringView) const { return false; }
     virtual bool NODELETE supportsRequired() const;
-    virtual bool valueMissing(const String&) const { return false; }
+    virtual bool valueMissing(StringView) const { return false; }
     virtual bool hasBadInput() const { return false; }
-    virtual bool patternMismatch(const String&) const { return false; }
-    bool rangeUnderflow(const String&) const;
-    bool rangeOverflow(const String&) const;
-    bool isInRange(const String&) const;
-    bool isOutOfRange(const String&) const;
+    virtual bool patternMismatch(StringView) const { return false; }
+    bool rangeUnderflow(StringView) const;
+    bool rangeOverflow(StringView) const;
+    bool isInRange(StringView) const;
+    bool isOutOfRange(StringView) const;
     virtual Decimal defaultValueForStepUp() const;
     double minimum() const;
     double maximum() const;
     virtual bool sizeShouldIncludeDecoration(int defaultSize, int& preferredSize) const;
     virtual float decorationWidth(float inputWidth) const;
-    bool stepMismatch(const String&) const;
+    bool stepMismatch(StringView) const;
     virtual bool getAllowedValueStep(Decimal*) const;
     virtual StepRange createStepRange(AnyStepHandling) const;
     virtual ExceptionOr<void> stepUp(int);
@@ -267,7 +267,7 @@ public:
 
     // Returns true if the value violates any step/range constraint (stepMismatch,
     // rangeUnderflow, or rangeOverflow). Creates the StepRange only once.
-    bool hasStepRangeViolation(const String&) const;
+    bool hasStepRangeViolation(StringView) const;
 
     // Type check for the current input value. We do nothing for some types
     // though typeMismatchFor() does something for them because of value sanitization.
@@ -373,7 +373,7 @@ public:
     // the Decimal value for the parsing result if the parsing
     // succeeds; Returns defaultValue otherwise. This function can
     // return NaN or Infinity only if defaultValue is NaN or Infinity.
-    virtual Decimal parseToNumber(const String&, const Decimal& defaultValue) const;
+    virtual Decimal parseToNumber(StringView, const Decimal& defaultValue) const;
 
     // Create a string representation of the specified Decimal value for the
     // input type. If NaN or Infinity is specified, this returns an empty
@@ -385,7 +385,7 @@ public:
     virtual unsigned height() const;
     virtual unsigned width() const;
 
-    bool isInvalid(const String&) const;
+    bool isInvalid(StringView) const;
 
     void dispatchSimulatedClickIfActive(KeyboardEvent&) const;
 
@@ -411,7 +411,7 @@ protected:
 
     HTMLInputElement* element() const { return m_element; }
     Chrome* NODELETE chrome() const;
-    Decimal parseToNumberOrNaN(const String&) const;
+    Decimal parseToNumberOrNaN(StringView) const;
 
     // Derive the step base, following the HTML algorithm steps.
     Decimal findStepBase(const Decimal&) const;
@@ -419,7 +419,7 @@ protected:
 private:
     // Helper for stepUp()/stepDown(). Adds step value * count to the current value.
     ExceptionOr<void> applyStep(int count, AnyStepHandling, TextFieldEventBehavior);
-    std::optional<std::pair<Decimal, StepRange>> parsedValueAndStepRange(const String&) const;
+    std::optional<std::pair<Decimal, StepRange>> parsedValueAndStepRange(StringView) const;
 
     const Type m_type;
     bool m_hasCreatedShadowSubtree { false };

--- a/Source/WebCore/html/MonthInputType.cpp
+++ b/Source/WebCore/html/MonthInputType.cpp
@@ -112,7 +112,7 @@ StepRange MonthInputType::createStepRange(AnyStepHandling anyStepHandling) const
     return StepRange(stepBase, RangeLimitations::Valid, minimum, maximum, step, monthStepDescription);
 }
 
-Decimal MonthInputType::parseToNumber(const String& src, const Decimal& defaultValue) const
+Decimal MonthInputType::parseToNumber(StringView src, const Decimal& defaultValue) const
 {
     auto date = parseToDateComponents(src);
     if (!date)

--- a/Source/WebCore/html/MonthInputType.h
+++ b/Source/WebCore/html/MonthInputType.h
@@ -54,7 +54,7 @@ private:
     DateComponentsType dateType() const final;
     WallTime valueAsDate() const final;
     String serializeWithMilliseconds(double) const final;
-    Decimal parseToNumber(const String&, const Decimal&) const final;
+    Decimal parseToNumber(StringView, const Decimal&) const final;
     Decimal defaultValueForStepUp() const final;
     StepRange createStepRange(AnyStepHandling) const final;
     std::optional<DateComponents> parseToDateComponents(StringView) const final;

--- a/Source/WebCore/html/NumberInputType.cpp
+++ b/Source/WebCore/html/NumberInputType.cpp
@@ -133,7 +133,7 @@ ExceptionOr<void> NumberInputType::setValueAsDecimal(const Decimal& newValue, Te
     return { };
 }
 
-bool NumberInputType::typeMismatchFor(const String& value) const
+bool NumberInputType::typeMismatchFor(StringView value) const
 {
     return !value.isEmpty() && !std::isfinite(parseToDoubleForNumberType(value));
 }
@@ -330,7 +330,7 @@ auto NumberInputType::handleKeydownEvent(KeyboardEvent& event) -> ShouldCallBase
     return ShouldCallBaseEventHandler::Yes;
 }
 
-Decimal NumberInputType::parseToNumber(const String& src, const Decimal& defaultValue) const
+Decimal NumberInputType::parseToNumber(StringView src, const Decimal& defaultValue) const
 {
     return parseToDecimalForNumberType(src, defaultValue);
 }

--- a/Source/WebCore/html/NumberInputType.h
+++ b/Source/WebCore/html/NumberInputType.h
@@ -45,7 +45,7 @@ public:
         return adoptRef(*new NumberInputType(element));
     }
 
-    bool typeMismatchFor(const String&) const final;
+    bool typeMismatchFor(StringView) const final;
     bool typeMismatch() const final;
     bool hasBadInput() const final;
 
@@ -67,7 +67,7 @@ private:
     StepRange createStepRange(AnyStepHandling) const final;
     ShouldCallBaseEventHandler handleKeydownEvent(KeyboardEvent&) final;
     void handleBeforeTextInsertedEvent(BeforeTextInsertedEvent&) final;
-    Decimal parseToNumber(const String&, const Decimal&) const final;
+    Decimal parseToNumber(StringView, const Decimal&) const final;
     String serialize(const Decimal&) const final;
     String localizeValue(const String&) const final;
     String visibleValue() const final;

--- a/Source/WebCore/html/RadioInputType.cpp
+++ b/Source/WebCore/html/RadioInputType.cpp
@@ -48,7 +48,7 @@ const AtomString& RadioInputType::formControlType() const
     return InputTypeNames::radio();
 }
 
-bool RadioInputType::valueMissing(const String&) const
+bool RadioInputType::valueMissing(StringView) const
 {
     RefPtr element = this->element();
     ASSERT(element);

--- a/Source/WebCore/html/RadioInputType.h
+++ b/Source/WebCore/html/RadioInputType.h
@@ -48,7 +48,7 @@ public:
 
     static void forEachButtonInDetachedGroup(ContainerNode& rootName, const String& groupName, NOESCAPE const Function<bool(HTMLInputElement&)>&);
 
-    bool valueMissing(const String&) const final;
+    bool valueMissing(StringView) const final;
 
 private:
     explicit RadioInputType(HTMLInputElement& element)

--- a/Source/WebCore/html/RangeInputType.cpp
+++ b/Source/WebCore/html/RangeInputType.cpp
@@ -110,7 +110,7 @@ ExceptionOr<void> RangeInputType::setValueAsDecimal(const Decimal& newValue, Tex
     return { };
 }
 
-bool RangeInputType::typeMismatchFor(const String& value) const
+bool RangeInputType::typeMismatchFor(StringView value) const
 {
     return !value.isEmpty() && !std::isfinite(parseToDoubleForNumberType(value));
 }
@@ -315,7 +315,7 @@ RenderPtr<RenderElement> RangeInputType::createInputRenderer(RenderStyle&& style
     SUPPRESS_UNCOUNTED_ARG return createRenderer<RenderSlider>(*protect(element()), WTF::move(style));
 }
 
-Decimal RangeInputType::parseToNumber(const String& src, const Decimal& defaultValue) const
+Decimal RangeInputType::parseToNumber(StringView src, const Decimal& defaultValue) const
 {
     return parseToDecimalForNumberType(src, defaultValue);
 }

--- a/Source/WebCore/html/RangeInputType.h
+++ b/Source/WebCore/html/RangeInputType.h
@@ -46,7 +46,7 @@ public:
         return adoptRef(*new RangeInputType(element));
     }
 
-    bool typeMismatchFor(const String&) const final;
+    bool typeMismatchFor(StringView) const final;
 
 private:
     explicit RangeInputType(HTMLInputElement&);
@@ -60,7 +60,7 @@ private:
     ShouldCallBaseEventHandler handleKeydownEvent(KeyboardEvent&) final;
     RenderPtr<RenderElement> createInputRenderer(RenderStyle&&) final;
     void createShadowSubtree() final;
-    Decimal parseToNumber(const String&, const Decimal&) const final;
+    Decimal parseToNumber(StringView, const Decimal&) const final;
     String serialize(const Decimal&) const final;
     bool accessKeyAction(bool sendMouseEvents) final;
     void attributeChanged(const QualifiedName&) final;

--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -128,7 +128,7 @@ bool TextFieldInputType::isEmptyValue() const
     return true;
 }
 
-bool TextFieldInputType::valueMissing(const String& value) const
+bool TextFieldInputType::valueMissing(StringView value) const
 {
     ASSERT(element());
     Ref element = *this->element();

--- a/Source/WebCore/html/TextFieldInputType.h
+++ b/Source/WebCore/html/TextFieldInputType.h
@@ -52,7 +52,7 @@ class TextFieldInputType : public InputType, protected SpinButtonOwner, protecte
     WTF_MAKE_TZONE_ALLOCATED(TextFieldInputType);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(TextFieldInputType);
 public:
-    bool valueMissing(const String&) const final;
+    bool valueMissing(StringView) const final;
 
 protected:
     explicit TextFieldInputType(Type, HTMLInputElement&);

--- a/Source/WebCore/html/URLInputType.cpp
+++ b/Source/WebCore/html/URLInputType.cpp
@@ -47,9 +47,9 @@ const AtomString& URLInputType::formControlType() const
     return InputTypeNames::url();
 }
 
-bool URLInputType::typeMismatchFor(const String& value) const
+bool URLInputType::typeMismatchFor(StringView value) const
 {
-    return !value.isEmpty() && !URL(value).isValid();
+    return !value.isEmpty() && !URL(value.toStringWithoutCopying()).isValid();
 }
 
 bool URLInputType::typeMismatch() const

--- a/Source/WebCore/html/URLInputType.h
+++ b/Source/WebCore/html/URLInputType.h
@@ -44,7 +44,7 @@ public:
         return adoptRef(*new URLInputType(element));
     }
 
-    bool typeMismatchFor(const String&) const final;
+    bool typeMismatchFor(StringView) const final;
     bool typeMismatch() const final;
 
 private:


### PR DESCRIPTION
#### 67d931686f9e8cd74deeadd0da510cafd8686ba5
<pre>
Adopt StringView in more places in InputType classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=311022">https://bugs.webkit.org/show_bug.cgi?id=311022</a>

Reviewed by Ryosuke Niwa.

* Source/WTF/wtf/text/StringView.h:
(WTF::StringView::StringView):
* Source/WebCore/html/BaseDateAndTimeInputType.cpp:
(WebCore::BaseDateAndTimeInputType::typeMismatchFor const):
(WebCore::BaseDateAndTimeInputType::parseToNumber const):
(WebCore::BaseDateAndTimeInputType::valueMissing const):
* Source/WebCore/html/BaseDateAndTimeInputType.h:
* Source/WebCore/html/BaseTextInputType.cpp:
(WebCore::BaseTextInputType::patternMismatch const):
* Source/WebCore/html/BaseTextInputType.h:
* Source/WebCore/html/CheckboxInputType.cpp:
(WebCore::CheckboxInputType::valueMissing const):
* Source/WebCore/html/CheckboxInputType.h:
* Source/WebCore/html/EmailInputType.cpp:
(WebCore::EmailInputType::typeMismatchFor const):
* Source/WebCore/html/EmailInputType.h:
* Source/WebCore/html/FileInputType.cpp:
(WebCore::FileInputType::valueMissing const):
* Source/WebCore/html/FileInputType.h:
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::isValidValue const):
(WebCore::HTMLInputElement::setValue):
* Source/WebCore/html/HTMLInputElement.h:
* Source/WebCore/html/InputType.cpp:
(WebCore::isInvalidInputType):
(WebCore::validateInputType):
(WebCore::InputType::isValidValue const):
(WebCore::InputType::parsedValueAndStepRange const):
(WebCore::InputType::rangeUnderflow const):
(WebCore::InputType::rangeOverflow const):
(WebCore::InputType::isInvalid const):
(WebCore::InputType::isInRange const):
(WebCore::InputType::isOutOfRange const):
(WebCore::InputType::stepMismatch const):
(WebCore::InputType::hasStepRangeViolation const):
(WebCore::InputType::parseToNumber const):
(WebCore::InputType::parseToNumberOrNaN const):
* Source/WebCore/html/InputType.h:
(WebCore::InputType::typeMismatchFor const):
(WebCore::InputType::valueMissing const):
(WebCore::InputType::patternMismatch const):
* Source/WebCore/html/MonthInputType.cpp:
(WebCore::MonthInputType::parseToNumber const):
* Source/WebCore/html/MonthInputType.h:
* Source/WebCore/html/NumberInputType.cpp:
(WebCore::NumberInputType::typeMismatchFor const):
(WebCore::NumberInputType::parseToNumber const):
* Source/WebCore/html/NumberInputType.h:
* Source/WebCore/html/RadioInputType.cpp:
(WebCore::RadioInputType::valueMissing const):
* Source/WebCore/html/RadioInputType.h:
* Source/WebCore/html/RangeInputType.cpp:
(WebCore::RangeInputType::typeMismatchFor const):
(WebCore::RangeInputType::parseToNumber const):
* Source/WebCore/html/RangeInputType.h:
* Source/WebCore/html/TextFieldInputType.cpp:
(WebCore::TextFieldInputType::valueMissing const):
* Source/WebCore/html/TextFieldInputType.h:
* Source/WebCore/html/URLInputType.cpp:
(WebCore::URLInputType::typeMismatchFor const):
* Source/WebCore/html/URLInputType.h:

Canonical link: <a href="https://commits.webkit.org/310281@main">https://commits.webkit.org/310281@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8326e1eace8eccae9033790d11c5fcd9726e5b9f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153334 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26118 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19717 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162079 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6c4c03fd-b0da-4036-891b-2e911fd62982) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155207 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26644 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26438 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118543 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2637c14e-fb0e-4bb4-bda3-d14df6204e10) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156293 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20782 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137662 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99255 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/79b5dd93-d4b5-4b09-a9c7-a51247575542) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/19859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9914 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/145347 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129506 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15532 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164553 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/14154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7689 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17126 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126600 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25914 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21838 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126758 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34386 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25917 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137328 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/82584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21698 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14106 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184969 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25534 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89820 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47367 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25225 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25384 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/25285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->