### PR TITLE
Remove PointerLockOptionsEnabled preference

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/pointerlock/idlharness.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerlock/idlharness.window-expected.txt
@@ -44,7 +44,7 @@ PASS Document interface: window.document must inherit property "onpointerlockerr
 PASS Document interface: window.document must inherit property "exitPointerLock()" with the proper type
 PASS Document interface: window.document must inherit property "pointerLockElement" with the proper type
 PASS ShadowRoot interface: attribute pointerLockElement
-FAIL Element interface: operation requestPointerLock(optional PointerLockOptions) assert_unreached: Throws "TypeError: Can only call Element.requestPointerLock on instances of Element" instead of rejecting promise Reached unreachable code
+PASS Element interface: operation requestPointerLock(optional PointerLockOptions)
 PASS Element interface: window.document.documentElement must inherit property "requestPointerLock(optional PointerLockOptions)" with the proper type
 PASS Element interface: calling requestPointerLock(optional PointerLockOptions) on window.document.documentElement with too few arguments must throw TypeError
 

--- a/LayoutTests/platform/ios/pointer-lock/pointer-lock-option-unadjusted-movement-expected.txt
+++ b/LayoutTests/platform/ios/pointer-lock/pointer-lock-option-unadjusted-movement-expected.txt
@@ -12,11 +12,6 @@ PASS [object Promise] is non-null.
      unadjustedMovement is supported.
      Unlock
 PASS onpointerlockchange received after: Unlock
-     Lock with PointerLockOptionsEnabled = false
-PASS undefined is undefined.
-PASS onpointerlockchange received after: Lock with PointerLockOptionsEnabled = false
-     Unlock
-PASS onpointerlockchange received after: Unlock
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/platform/mac/pointer-lock/pointer-lock-option-unadjusted-movement-expected.txt
+++ b/LayoutTests/platform/mac/pointer-lock/pointer-lock-option-unadjusted-movement-expected.txt
@@ -12,11 +12,6 @@ PASS [object Promise] is non-null.
      unadjustedMovement is supported.
      Unlock
 PASS onpointerlockchange received after: Unlock
-     Lock with PointerLockOptionsEnabled = false
-PASS undefined is undefined.
-PASS onpointerlockchange received after: Lock with PointerLockOptionsEnabled = false
-     Unlock
-PASS onpointerlockchange received after: Unlock
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/pointer-lock/lock-element-not-in-dom.html
+++ b/LayoutTests/pointer-lock/lock-element-not-in-dom.html
@@ -21,9 +21,7 @@
             expectOnlyErrorEvent("Remove targetDiv1 from document, and try to lock it.");
             targetDiv1.parentElement.removeChild(targetDiv1);
             shouldBe("targetDiv1.parentElement", "null");
-            const promise = targetDiv1.requestPointerLock();
-            // handle promise error if PointerLockOptionsEnabled
-            if (promise) promise.catch(e => {});
+            targetDiv1.requestPointerLock().catch(e => {});
             // doNextStep called by event handler.
         },
     ];

--- a/LayoutTests/pointer-lock/locked-element-removed-from-dom.html
+++ b/LayoutTests/pointer-lock/locked-element-removed-from-dom.html
@@ -38,9 +38,7 @@
             expectOnlyErrorEvent("Remove targetDiv1's parent from iframe & immediately lock target2. (main document handler)");
             expectOnlyChangeEvent("Remove targetDiv1's parent from iframe & immediately lock target2. (iframe handler)", targetIframe1.contentDocument);
             targetDiv1.parentElement.parentElement.removeChild(targetDiv1.parentElement);
-            const promise = targetDiv2.requestPointerLock();
-            // handle promise error if PointerLockOptionsEnabled
-            if (promise) promise.catch(e => {});
+            targetDiv2.requestPointerLock().catch(e => {});
             shouldBe("document.pointerLockElement", "null");
             shouldBe("targetDiv1.parentElement.parentElement", "null");
             // doNextStep called by event handler.

--- a/LayoutTests/pointer-lock/pending-locked-element-removed-from-dom.html
+++ b/LayoutTests/pointer-lock/pending-locked-element-removed-from-dom.html
@@ -11,7 +11,6 @@
 <script>
     description("Test removing an element with a pending pointer lock cancels the lock.")
     window.jsTestIsAsync = true;
-    window.internals.settings.setPointerLockOptionsEnabled(true);
     window.testRunner?.setHasMouseDeviceForTesting(true);
 
     targetDiv = document.getElementById("target");

--- a/LayoutTests/pointer-lock/pointer-lock-option-unadjusted-movement-expected.txt
+++ b/LayoutTests/pointer-lock/pointer-lock-option-unadjusted-movement-expected.txt
@@ -12,11 +12,6 @@ PASS [object Promise] is non-null.
      unadjustedMovement is not supported.
      Unlock
 PASS onpointerlockchange received after: Unlock
-     Lock with PointerLockOptionsEnabled = false
-PASS undefined is undefined.
-PASS onpointerlockchange received after: Lock with PointerLockOptionsEnabled = false
-     Unlock
-PASS onpointerlockchange received after: Unlock
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/pointer-lock/pointer-lock-option-unadjusted-movement.html
+++ b/LayoutTests/pointer-lock/pointer-lock-option-unadjusted-movement.html
@@ -20,7 +20,6 @@
     todo = [
         // verify that requestPointerLock returns a promise
         async () => {
-            window.internals.settings.setPointerLockOptionsEnabled(true);
             debug("     requestPointerLock()")
             const promise = targetDiv1.requestPointerLock();
             shouldBeNonNull(promise);
@@ -53,18 +52,6 @@
             doNextStep();
         },
         // remove pointer lock
-        () => {
-            expectOnlyChangeEvent("Unlock");
-            document.exitPointerLock();
-        },
-        // verify that requestPointerLock doesn't return a promise when PointerLockOptionsEnabled = false
-        () => {
-            window.internals.settings.setPointerLockOptionsEnabled(false);
-            expectOnlyChangeEvent("Lock with PointerLockOptionsEnabled = false");
-            const promise = targetDiv1.requestPointerLock();
-            shouldBeUndefined(promise);
-        },
-        // remove pointer lock again
         () => {
             expectOnlyChangeEvent("Unlock");
             document.exitPointerLock();

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -6299,21 +6299,6 @@ PointerLockEnabled:
     WebCore:
       default: false
 
-PointerLockOptionsEnabled:
-  type: bool
-  status: stable
-  category: dom
-  condition: ENABLE(POINTER_LOCK)
-  humanReadableName: "Pointer Lock Options"
-  humanReadableDescription: "Element.requestPointerLock(options) and promise support."
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
-
 PopoverAttributeEnabled:
   type: bool
   status: stable

--- a/Source/WebCore/dom/Element+PointerLock.idl
+++ b/Source/WebCore/dom/Element+PointerLock.idl
@@ -27,6 +27,5 @@
     Conditional=POINTER_LOCK,
     EnabledBySetting=PointerLockEnabled
 ] partial interface Element {
-    // Returns Promise<undefined> if PointerLockOptionsEnabled Runtime Flag is set, otherwise returns undefined.
-    [CallWith=CurrentGlobalObject] any requestPointerLock(optional PointerLockOptions options = {});
+    Promise<undefined> requestPointerLock(optional PointerLockOptions options = {});
 };

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -5212,24 +5212,15 @@ bool Element::hasPointerCapture(int32_t pointerId)
 
 #if ENABLE(POINTER_LOCK)
 
-JSC::JSValue Element::requestPointerLock(JSC::JSGlobalObject& lexicalGlobalObject, PointerLockOptions&& options)
+void Element::requestPointerLock(PointerLockOptions&& options, Ref<DeferredPromise>&& promise)
 {
-    RefPtr<DeferredPromise> promise;
-    if (RefPtr page = document().page()) {
-        bool optionsEnabled = document().settings().pointerLockOptionsEnabled();
-
-        if (optionsEnabled)
-            promise = DeferredPromise::create(*JSC::jsSecureCast<JSDOMGlobalObject*>(&lexicalGlobalObject), DeferredPromise::Mode::RetainPromiseOnResolve);
-
-        page->pointerLockController().requestPointerLock(this, optionsEnabled ? std::optional(WTF::move(options)) : std::nullopt, promise);
+    RefPtr page = document().page();
+    if (!page) {
+        promise->resolve();
+        return;
     }
-    return promise ? promise->promise() : JSC::jsUndefined();
-}
 
-void Element::requestPointerLock()
-{
-    if (RefPtr page = document().page())
-        page->pointerLockController().requestPointerLock(this);
+    page->pointerLockController().requestPointerLock(this, WTF::move(options), WTF::move(promise));
 }
 
 #endif

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -745,8 +745,7 @@ public:
     bool hasPointerCapture(int32_t);
 
 #if ENABLE(POINTER_LOCK)
-    JSC::JSValue requestPointerLock(JSC::JSGlobalObject& lexicalGlobalObject, PointerLockOptions&&);
-    WEBCORE_EXPORT void requestPointerLock();
+    void requestPointerLock(PointerLockOptions&&, Ref<DeferredPromise>&&);
 #endif
 
     OptionSet<VisibilityAdjustment> NODELETE visibilityAdjustment() const;

--- a/Source/WebCore/dom/PointerLockOptions.idl
+++ b/Source/WebCore/dom/PointerLockOptions.idl
@@ -25,7 +25,7 @@
 // https://w3c.github.io/pointerlock/#pointerlockoptions-dictionary
 [
     Conditional=POINTER_LOCK,
-    EnabledBySetting=PointerLockEnabled&PointerLockOptionsEnabled,
+    EnabledBySetting=PointerLockEnabled
 ] dictionary PointerLockOptions {
     boolean unadjustedMovement = false;
 };

--- a/Source/WebCore/page/PointerLockController.cpp
+++ b/Source/WebCore/page/PointerLockController.cpp
@@ -74,20 +74,18 @@ void PointerLockController::deref() const
 }
 
 
-void PointerLockController::requestPointerLock(Element* target, std::optional<PointerLockOptions>&& options, RefPtr<DeferredPromise> promise)
+void PointerLockController::requestPointerLock(Element* target, PointerLockOptions&& options, Ref<DeferredPromise>&& promise)
 {
     if (!target || !target->isConnected() || m_documentOfRemovedElementWhileWaitingForUnlock) {
         enqueueEvent(eventNames().pointerlockerrorEvent, target);
-        if (promise)
-            promise->reject(ExceptionCode::WrongDocumentError, "Pointer lock target must be in an active document."_s);
+        promise->reject(ExceptionCode::WrongDocumentError, "Pointer lock target must be in an active document."_s);
         return;
     }
 
     if (m_documentAllowedToRelockWithoutUserGesture != &target->document() && !UserGestureIndicator::processingUserGesture()) {
         enqueueEvent(eventNames().pointerlockerrorEvent, target);
         // If the request was not started from an engagement gesture and the Document has not previously released a successful Pointer Lock with exitPointerLock():
-        if (promise)
-            promise->reject(ExceptionCode::NotAllowedError, "Pointer lock requires a user gesture."_s);
+        promise->reject(ExceptionCode::NotAllowedError, "Pointer lock requires a user gesture."_s);
         return;
     }
 
@@ -97,16 +95,14 @@ void PointerLockController::requestPointerLock(Element* target, std::optional<Po
         target->document().addConsoleMessage(MessageSource::Security, MessageLevel::Error, reason);
         enqueueEvent(eventNames().pointerlockerrorEvent, target);
         // If this's node document's active sandboxing flag set has the sandboxed pointer lock browsing context flag set:
-        if (promise)
-            promise->reject(ExceptionCode::SecurityError, reason);
+        promise->reject(ExceptionCode::SecurityError, reason);
         return;
     }
 
-    if (options && options->unadjustedMovement && !supportsUnadjustedMovement()) {
+    if (options.unadjustedMovement && !supportsUnadjustedMovement()) {
         // If options["unadjustedMovement"] is true and the platform does not support unadjustedMovement:
         enqueueEvent(eventNames().pointerlockerrorEvent, target);
-        if (promise)
-            promise->reject(ExceptionCode::NotSupportedError, "Unadjusted movement is unavailable."_s);
+        promise->reject(ExceptionCode::NotSupportedError, "Unadjusted movement is unavailable."_s);
         return;
     }
 
@@ -114,21 +110,18 @@ void PointerLockController::requestPointerLock(Element* target, std::optional<Po
         if (&m_element->document() != &target->document()) {
             enqueueEvent(eventNames().pointerlockerrorEvent, target);
             // If the user agent's pointer-lock target is an element whose shadow-including root is not equal to this's shadow-including root, then:
-            if (promise)
-                promise->reject(ExceptionCode::InvalidStateError, "Pointer lock cannot be moved to an element in a different document."_s);
+            promise->reject(ExceptionCode::InvalidStateError, "Pointer lock cannot be moved to an element in a different document."_s);
             return;
         }
         m_element = target;
         m_options = WTF::move(options);
         if (m_lockPending) {
             // m_lockPending means an answer from the ChromeClient for a previous requestPointerLock on the page is pending. It's currently unknown which way that will go, whether the request will be approved or rejected. Therefore queue the promise for later when that's known and don't send out any pointerlockchangeEvent yet.
-            if (promise)
-                m_promises.append(promise.releaseNonNull());
+            m_promises.append(WTF::move(promise));
         } else {
             // !m_lockPending means the pointer lock is currently held on the page, and page is just re-targeting it or changing the options.
             enqueueEvent(eventNames().pointerlockchangeEvent, target);
-            if (promise)
-                promise->resolve();
+            promise->resolve();
             // FIXME: https://bugs.webkit.org/show_bug.cgi?id=261786
             // This probably needs to be called in all code paths.
             m_page->pointerCaptureController().pointerLockWasApplied();
@@ -137,8 +130,7 @@ void PointerLockController::requestPointerLock(Element* target, std::optional<Po
         m_lockPending = true;
         m_element = target;
         m_options = WTF::move(options);
-        if (promise)
-            m_promises.append(promise.releaseNonNull());
+        m_promises.append(WTF::move(promise));
 
         m_page->chrome().client().requestPointerLock([this, protectedThis = Ref { *this }, target = RefPtr { target }](PointerLockRequestResult result) {
             switch (result) {
@@ -281,7 +273,7 @@ void PointerLockController::dispatchLockedMouseEvent(const PlatformMouseEvent& e
         return;
 
     Ref protectedElement { *m_element };
-    protectedElement->dispatchMouseEvent((m_options && m_options->unadjustedMovement) ? UnadjustedMovementPlatformMouseEvent(event) : event, eventType, event.clickCount());
+    protectedElement->dispatchMouseEvent(m_options.unadjustedMovement ? UnadjustedMovementPlatformMouseEvent(event) : event, eventType, event.clickCount());
 
     // Create click events
     if (eventType == eventNames().mouseupEvent)
@@ -301,7 +293,7 @@ void PointerLockController::clearElement()
 {
     m_lockPending = false;
     m_element = nullptr;
-    m_options = std::nullopt;
+    m_options = { };
     ASSERT(m_promises.isEmpty());
 }
 

--- a/Source/WebCore/page/PointerLockController.h
+++ b/Source/WebCore/page/PointerLockController.h
@@ -60,7 +60,7 @@ class PointerLockController {
 public:
     explicit PointerLockController(Page&);
     ~PointerLockController();
-    void requestPointerLock(Element* target, std::optional<PointerLockOptions>&& = std::nullopt, RefPtr<DeferredPromise> = nullptr);
+    void requestPointerLock(Element* target, PointerLockOptions&&, Ref<DeferredPromise>&&);
 
     void NODELETE ref() const;
     void deref() const;
@@ -93,7 +93,7 @@ private:
     bool m_lockPending { false };
     bool m_unlockPending { false };
     bool m_forceCursorVisibleUponUnlock { false };
-    std::optional<PointerLockOptions> m_options;
+    PointerLockOptions m_options;
     RefPtr<Element> m_element;
     Vector<Ref<DeferredPromise>> m_promises;
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_documentOfRemovedElementWhileWaitingForUnlock;

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMElementGtk.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMElementGtk.cpp
@@ -940,15 +940,8 @@ void webkit_dom_element_insert_adjacent_text(WebKitDOMElement* self, const gchar
 
 void webkit_dom_element_request_pointer_lock(WebKitDOMElement* self)
 {
-#if ENABLE(POINTER_LOCK)
-    WebCore::JSMainThreadNullState state;
-    g_return_if_fail(WEBKIT_DOM_IS_ELEMENT(self));
-    WebCore::Element* item = WebKit::core(self);
-    item->requestPointerLock();
-#else
     UNUSED_PARAM(self);
     WEBKIT_WARN_FEATURE_NOT_PRESENT("Pointer Lock")
-#endif /* ENABLE(POINTER_LOCK) */
 }
 
 void webkit_dom_element_remove(WebKitDOMElement* self, GError** error)


### PR DESCRIPTION
#### 2abd9773f013347990ceb87c4b67bfd13198f032
<pre>
Remove PointerLockOptionsEnabled preference
<a href="https://bugs.webkit.org/show_bug.cgi?id=311025">https://bugs.webkit.org/show_bug.cgi?id=311025</a>

Reviewed by Adrian Perez de Castro.

It&apos;s been stable for well over a year.

This also removes support for requestPointerLock() from a deprecated
GTK API (webkit_dom_element_request_pointer_lock) as that cannot easily
construct a DeferredPromise.

Canonical link: <a href="https://commits.webkit.org/310301@main">https://commits.webkit.org/310301@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4cd18094d2d396e78e3bedcad26f47bed2ee62bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153381 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26165 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19764 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162126 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e667d8e4-7c87-4d52-86cc-9ea8c87ec25a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155254 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26691 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26485 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118582 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5427c023-6e7a-4e4f-8479-5cd60bba9078) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156340 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20824 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137700 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99294 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f72b082f-5120-4638-8029-dc02dcf049e1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19901 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17848 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9961 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/145394 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129549 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15570 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164600 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/14202 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7736 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17164 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126644 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25962 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21881 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126801 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25964 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137366 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82631 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23459 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21737 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14146 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/185016 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25581 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89867 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47454 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25272 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25431 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25332 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->