### PR TITLE
Crash due to nullptr deref in WebLocalFrameLoaderClient::dispatchDidChangeProvisionalURL()

### DIFF
--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -271,12 +271,8 @@ void DocumentLoader::setRequest(ResourceRequest&& req)
     ASSERT(!m_committed);
 
     m_request = WTF::move(req);
-    if (shouldNotifyAboutProvisionalURLChange) {
-        // Logging for <rdar://problem/54830233>.
-        if (!frameLoader()->provisionalDocumentLoader())
-            DOCUMENTLOADER_RELEASE_LOG("DocumentLoader::setRequest: With no provisional document loader");
+    if (shouldNotifyAboutProvisionalURLChange)
         protect(frameLoader()->client())->dispatchDidChangeProvisionalURL();
-    }
 }
 
 void DocumentLoader::setMainDocumentError(const ResourceError& error)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -376,7 +376,7 @@ void WebLocalFrameLoaderClient::dispatchDidReceiveServerRedirectForProvisionalLo
 
     RefPtr documentLoader = m_localFrame->loader().provisionalDocumentLoader();
     if (!documentLoader) {
-        WebLocalFrameLoaderClient_RELEASE_LOG_FAULT(Loading, "dispatchDidReceiveServerRedirectForProvisionalLoad: Called with no provisional DocumentLoader (frameState=%hhu, stateForDebugging=%i)", static_cast<uint8_t>(m_localFrame->loader().state()), m_localFrame->loader().stateMachine().stateForDebugging());
+        WebLocalFrameLoaderClient_RELEASE_LOG_FAULT(Loading, "dispatchDidReceiveServerRedirectForProvisionalLoad: Called with no provisional DocumentLoader (frameState=%hhu, stateForDebugging=%i)", std::to_underlying(m_localFrame->loader().state()), m_localFrame->loader().stateMachine().stateForDebugging());
         return;
     }
 
@@ -397,7 +397,12 @@ void WebLocalFrameLoaderClient::dispatchDidChangeProvisionalURL()
     if (!webPage)
         return;
 
-    Ref documentLoader { *m_localFrame->loader().provisionalDocumentLoader() };
+    RefPtr documentLoader = m_localFrame->loader().provisionalDocumentLoader();
+    if (!documentLoader) {
+        WebLocalFrameLoaderClient_RELEASE_LOG_FAULT(Loading, "dispatchDidChangeProvisionalURL: Called with no provisional DocumentLoader (frameState=%hhu, stateForDebugging=%i)", std::to_underlying(m_localFrame->loader().state()), m_localFrame->loader().stateMachine().stateForDebugging());
+        return;
+    }
+
     webPage->send(Messages::WebPageProxy::DidChangeProvisionalURLForFrame(m_frame->frameID(), documentLoader->navigationID(), documentLoader->url()));
 }
 


### PR DESCRIPTION
#### 682966d153bc87682a8e73f726765e50664ea1e4
<pre>
Crash due to nullptr deref in WebLocalFrameLoaderClient::dispatchDidChangeProvisionalURL()
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=311020">https://bugs.webkit.org/show_bug.cgi?id=311020</a>&gt;
&lt;<a href="https://rdar.apple.com/112727550">rdar://112727550</a>&gt;

Reviewed by Charlie Wolfe.

Add a null check for `provisionalDocumentLoader()` in
`dispatchDidChangeProvisionalURL()`, matching the identical
pattern in the adjacent
`dispatchDidReceiveServerRedirectForProvisionalLoad()` (added
in Bug 199123, 213141@main).  The function unconditionally
dereferences the raw pointer via `Ref`, crashing when
`provisionalDocumentLoader()` returns nullptr during redirect
processing.

Remove the diagnostic-only nullptr check in the caller,
`DocumentLoader::setRequest()` (added in Bug 203837,
217227@main), since the callee now handles this case with a
`RELEASE_LOG_FAULT` and early return.

Also adopt `std::to_underlying()` in place of
`static_cast&lt;uint8_t&gt;()` for the `FrameState` enum in the
adjacent function&apos;s existing `RELEASE_LOG_FAULT` call.

Unable to write a layout test or API test to trigger the
crash.

* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::setRequest):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::dispatchDidReceiveServerRedirectForProvisionalLoad):
(WebKit::WebLocalFrameLoaderClient::dispatchDidChangeProvisionalURL):

Canonical link: <a href="https://commits.webkit.org/310279@main">https://commits.webkit.org/310279@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4c33fa181af433ea74230967e470156bedf7730

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153055 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25837 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19435 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161799 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106513 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/52f5bd5d-ee63-4660-9a53-844e0b62c487) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154928 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26364 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26142 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118302 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83755 "5 flakes 6 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0ec9f805-d38d-4270-b57e-9cfe9d7c4586) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156014 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20536 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137402 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99015 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/99b82a22-2234-4fe1-ae1b-a39d152a7e41) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19610 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17552 "Found 1 new API test failure: TestWebKitAPI.WKBrowsingContextLoadDelegateTest.SimpleLoad (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9635 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129263 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15275 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164273 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7409 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16869 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126364 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25634 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21591 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126522 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25636 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137071 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82276 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23454 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21474 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13850 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25252 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89539 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24945 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25103 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25004 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->