### PR TITLE
Deprecate href on all MathML elements except `<a>`

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2166,12 +2166,6 @@ imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-marg
 imported/w3c/web-platform-tests/mathml/relations/css-styling/table-width-3.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/relations/css-styling/width-height-002.html [ ImageOnlyFailure ]
 
-# https://bugs.webkit.org/show_bug.cgi?id=310864
-imported/w3c/web-platform-tests/mathml/relations/html5-tree/href-click-001.tentative.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/mathml/relations/html5-tree/href-click-002.tentative.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/mathml/relations/html5-tree/href-click-004.tentative.html [ Timeout ]
-imported/w3c/web-platform-tests/mathml/relations/html5-tree/link-color-002.tentative.html [ ImageOnlyFailure ]
-
 # This MathML test should be rewritten.
 webkit.org/b/201356 mathml/presentation/stretchy-depth-height-symmetric.html [ Skip ]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/href-click-004.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/href-click-004.tentative-expected.txt
@@ -1,3 +1,30 @@
-FAIL: Timed out waiting for notifyDone to be called
 
-{"error": {"code": 404, "message": "404"}}
+FAIL annotation with href attribute does not react to click. promise_test: Unhandled rejection with value: object "Error: element click intercepted error"
+FAIL annotation-xml with href attribute does not react to click. promise_test: Unhandled rejection with value: object "Error: element click intercepted error"
+PASS maction with href attribute does not react to click.
+PASS menclose with href attribute does not react to click.
+PASS merror with href attribute does not react to click.
+PASS mfrac with href attribute does not react to click.
+PASS mi with href attribute does not react to click.
+PASS mmultiscripts with href attribute does not react to click.
+PASS mn with href attribute does not react to click.
+PASS mo with href attribute does not react to click.
+PASS mover with href attribute does not react to click.
+PASS mpadded with href attribute does not react to click.
+PASS mphantom with href attribute does not react to click.
+PASS mroot with href attribute does not react to click.
+PASS mrow with href attribute does not react to click.
+PASS ms with href attribute does not react to click.
+PASS msqrt with href attribute does not react to click.
+PASS mstyle with href attribute does not react to click.
+PASS msub with href attribute does not react to click.
+PASS msubsup with href attribute does not react to click.
+PASS msup with href attribute does not react to click.
+PASS mtable with href attribute does not react to click.
+PASS mtd with href attribute does not react to click.
+PASS mtext with href attribute does not react to click.
+PASS mtr with href attribute does not react to click.
+PASS munder with href attribute does not react to click.
+PASS munderover with href attribute does not react to click.
+PASS semantics with href attribute does not react to click.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/tabindex-focus-001.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/tabindex-focus-001.tentative-expected.txt
@@ -5,5 +5,5 @@
 
 
 
-FAIL invalid tabindex attribute does not make the element focusable assert_not_equals: <math href=#> should not be focusable got disallowed value Element node <math href="#" data-focusable="false"></math>
+PASS invalid tabindex attribute does not make the element focusable
 

--- a/LayoutTests/mathml/non-core/semantics-href-expected.html
+++ b/LayoutTests/mathml/non-core/semantics-href-expected.html
@@ -7,7 +7,7 @@
 body {
   font-family: Ahem;
 }
-+</style>
+</style>
 </head>
 <body>
 

--- a/LayoutTests/mathml/non-core/semantics-href.html
+++ b/LayoutTests/mathml/non-core/semantics-href.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ MathMLDisableHrefOnNonAnchorElement=false ] -->
 <html>
 <head>
 <meta charset="utf-8"/>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -4916,6 +4916,20 @@ MathFontFamily:
     WebCore:
       default: '""_str'
 
+MathMLDisableHrefOnNonAnchorElement:
+  type: bool
+  status: testable
+  category: dom
+  humanReadableName: "Disable href attribute on MathML elements"
+  humanReadableDescription: "The only MathML element on which href is allowed is <a>."
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 MathMLEnabled:
   type: bool
   status: embedder

--- a/Source/WebCore/mathml/MathMLElement.cpp
+++ b/Source/WebCore/mathml/MathMLElement.cpp
@@ -88,7 +88,7 @@ void MathMLElement::attributeChanged(const QualifiedName& name, const AtomString
 {
     switch (name.nodeName()) {
     case AttributeNames::hrefAttr:
-        setIsLink(!newValue.isNull() && !shouldProhibitLinks(this));
+        setIsLink(!newValue.isNull() && !shouldProhibitLinks(this) && allowsHref());
         break;
     case AttributeNames::columnspanAttr:
     case AttributeNames::rowspanAttr:
@@ -337,7 +337,14 @@ bool MathMLElement::isMouseFocusable() const
 
 bool MathMLElement::isURLAttribute(const Attribute& attribute) const
 {
+    if (!allowsHref())
+        return false;
     return attribute.name().localName() == hrefAttr || StyledElement::isURLAttribute(attribute);
+}
+
+bool MathMLElement::allowsHref() const
+{
+    return !document().settings().mathMLDisableHrefOnNonAnchorElement() || localName() == HTMLNames::aTag;
 }
 
 bool MathMLElement::supportsFocus() const

--- a/Source/WebCore/mathml/MathMLElement.h
+++ b/Source/WebCore/mathml/MathMLElement.h
@@ -83,6 +83,7 @@ private:
     bool isKeyboardFocusable(const FocusEventData&) const final;
     bool isMouseFocusable() const final;
     bool NODELETE isURLAttribute(const Attribute&) const final;
+    bool NODELETE allowsHref() const;
     bool supportsFocus() const final;
 };
 


### PR DESCRIPTION
#### 58780c46605225fce11f07e303a07247d035a27c
<pre>
Deprecate href on all MathML elements except `&lt;a&gt;`
<a href="https://bugs.webkit.org/show_bug.cgi?id=310864">https://bugs.webkit.org/show_bug.cgi?id=310864</a>

Reviewed by Frédéric Wang Nélar.

Add a new MathMLDisableHrefOnNonAnchorElement preference. When enabled,
it makes MathML elements other than a ignore the href attribute.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/href-click-004.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/tabindex-focus-001.tentative-expected.txt:
* LayoutTests/mathml/non-core/semantics-href-expected.html: Renamed from LayoutTests/mathml/presentation/semantics-href-expected.html.
* LayoutTests/mathml/non-core/semantics-href.html: Renamed from LayoutTests/mathml/presentation/semantics-href.html.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/mathml/MathMLElement.cpp:
(WebCore::MathMLElement::attributeChanged):
(WebCore::MathMLElement::isURLAttribute const):
(WebCore::MathMLElement::allowsHref const):
* Source/WebCore/mathml/MathMLElement.h:

Canonical link: <a href="https://commits.webkit.org/311550@main">https://commits.webkit.org/311550@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c50a3b8cefcbc1a96a9f9622886d886027aeb6a5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154672 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27931 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21090 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163432 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108141 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156545 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28065 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27780 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119648 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84609 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157631 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21937 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138919 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100342 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21023 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19039 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11258 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/146722 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130685 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16763 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165906 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/15503 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9119 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18372 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127748 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27476 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23079 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127887 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35235 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27400 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138556 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84083 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22787 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15350 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/186406 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27092 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91194 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47785 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26670 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26901 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26743 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->