### PR TITLE
Cache display lists for Canvas drawText's

### DIFF
--- a/LayoutTests/fast/canvas/fillText-edge-shadow-mix-expected.html
+++ b/LayoutTests/fast/canvas/fillText-edge-shadow-mix-expected.html
@@ -1,0 +1,30 @@
+<html>
+<body>
+<canvas width="100" height="100" style="border: solid 1px gray"></canvas>
+<script>
+const shadowOffsetX = -20;
+const iterations = 10;
+const increment = 4;
+
+const canvas = document.getElementsByTagName('canvas')[0];
+const width = canvas.width;
+const ctx = canvas.getContext('2d');
+
+ctx.font = "10px monospace";
+
+for (let i = 0; i < iterations; ++i) {
+  const x = width + (i - iterations / 2) * increment;
+  const y = i * 10;
+  if (i % 2) { // Shadow only every 2nd text.
+    ctx.fillStyle = "black";
+    ctx.fillText("Hi", x + shadowOffsetX, y);
+  }
+  if (x < width) {
+    ctx.fillStyle = "blue";
+    ctx.fillText("Hi", x, y);
+  }
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/canvas/fillText-edge-shadow-mix.html
+++ b/LayoutTests/fast/canvas/fillText-edge-shadow-mix.html
@@ -1,0 +1,31 @@
+<html>
+<body>
+<canvas width="100" height="100" style="border: solid 1px gray"></canvas>
+<script>
+const shadowOffsetX = -20;
+const iterations = 10;
+const increment = 4;
+
+const canvas = document.getElementsByTagName('canvas')[0];
+const width = canvas.width;
+const ctx = canvas.getContext('2d');
+
+ctx.shadowColor = "black";
+
+ctx.font = "10px monospace";
+ctx.fillStyle = "blue";
+
+for (let i = 0; i < iterations; ++i) {
+  const x = width + (i - iterations / 2) * increment;
+  const y = i * 10;
+  if (i % 2) { // Shadow only every 2nd text.
+    ctx.shadowOffsetX = shadowOffsetX;
+  } else {
+    ctx.shadowOffsetX = 0;
+  }
+  ctx.fillText("Hi", x, y);
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -4521,6 +4521,7 @@ fast/flexbox/missing-repaint-when-flext-item-never-had-layout.html [ Skip ] # Fa
 
 fast/canvas/fillText-edge-clip-shadow.html [ ImageOnlyFailure ]
 fast/canvas/fillText-edge-shadow.html [ ImageOnlyFailure ]
+fast/canvas/fillText-edge-shadow-mix.html [ ImageOnlyFailure ]
 
 webkit.org/b/286284 fast/canvas/canvas-image-shadow.html [ Failure ]
 webkit.org/b/286284 webgl/2.0.y/conformance/canvas/to-data-url-test.html [ Failure ]

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -85,6 +85,7 @@
 #include "StyleResolver.h"
 #include "TextMetrics.h"
 #include "TextRun.h"
+#include "TextShapingResultAndDisplayList.h"
 #include "TextUtil.h"
 #include "WebCodecsVideoFrame.h"
 #include <JavaScriptCore/ConsoleTypes.h>
@@ -2883,14 +2884,15 @@ void CanvasRenderingContext2DBase::drawTextUnchecked(const TextRun& textRun, dou
     auto& fontCascade = this->fontProxy()->fontCascade();
     auto& fontMetrics = fontProxy()->metricsOfPrimaryFont();
 
-    const TextShapingResult* cachedShapedText = nullptr;
-    if (canUseCachedShapedText(textRun)) {
+    auto* cachedShapedText = [&]() -> TextShapingResultAndDisplayList* {
+        if (!canUseCachedShapedText(textRun))
+            return nullptr;
         RefPtr fonts = fontCascade.fonts();
         ASSERT(fonts);
-        cachedShapedText = fonts->getOrCreateCachedShapedText(textRun, fontCascade, 0, std::nullopt, ForTextEmphasis::No);
-    }
+        return fonts->getOrCreateCachedShapedText(textRun, fontCascade, 0, std::nullopt, ForTextEmphasis::No);
+    }();
 
-    float fontWidth = cachedShapedText ? cachedShapedText->width : fontCascade.width(textRun);
+    float fontWidth = cachedShapedText ? cachedShapedText->textShapingResult.width : fontCascade.width(textRun);
 
     bool useMaxWidth = maxWidth && maxWidth.value() < fontWidth;
     float width = useMaxWidth ? maxWidth.value() : fontWidth;
@@ -2910,12 +2912,40 @@ void CanvasRenderingContext2DBase::drawTextUnchecked(const TextRun& textRun, dou
     auto* c = effectiveDrawingContext();
     auto& fontProxy = *this->fontProxy();
 
+    bool cachedDisplayListNeedsStateSave = false;
+    // Any shadow could add display list items to draw glyphs a 2nd time with different context attributes.
+    if (cachedShapedText && !cachedShapedText->displayList && !cachedShapedText->textShapingResult.glyphBuffer.isEmpty() && !c->dropShadow()) {
+        cachedShapedText->displayList = fontCascade.displayListForGlyphBuffer(*c, cachedShapedText->textShapingResult.glyphBuffer, FontCascade::CustomFontNotReadyAction::UseFallbackIfFontNotReady);
+
+        if (cachedShapedText->displayList) {
+            for (auto& item : cachedShapedText->displayList->items()) {
+                if (std::holds_alternative<DisplayList::SetInlineFillColor>(item)
+                    || std::holds_alternative<DisplayList::SetInlineStroke>(item)) {
+                    cachedDisplayListNeedsStateSave = true;
+                    break;
+                }
+            }
+        }
+    }
+
     auto drawText = [&](GraphicsContext& context, const FloatPoint& point) {
         if (cachedShapedText) {
-            const auto& glyphBuffer = cachedShapedText->glyphBuffer;
-            if (!glyphBuffer.isEmpty()) {
-                FloatPoint startPoint = point + WebCore::size(glyphBuffer.initialAdvance());
-                fontCascade.drawGlyphBuffer(context, glyphBuffer, startPoint, FontCascade::CustomFontNotReadyAction::UseFallbackIfFontNotReady);
+            const auto& glyphBuffer = cachedShapedText->textShapingResult.glyphBuffer;
+            if (!cachedShapedText->textShapingResult.glyphBuffer.isEmpty()) {
+                if (cachedShapedText->displayList && !context.hasDropShadow()) {
+                    if (cachedDisplayListNeedsStateSave) {
+                        GraphicsContextStateSaver stateSaver(context);
+                        context.translate(point);
+                        context.drawDisplayList(*cachedShapedText->displayList);
+                    } else {
+                        context.translate(point);
+                        context.drawDisplayList(*cachedShapedText->displayList);
+                        context.translate(-point);
+                    }
+                } else {
+                    FloatPoint startPoint = point + WebCore::size(glyphBuffer.initialAdvance());
+                    fontCascade.drawGlyphBuffer(context, glyphBuffer, startPoint, FontCascade::CustomFontNotReadyAction::UseFallbackIfFontNotReady);
+                }
             }
         } else
             fontProxy.drawBidiText(context, textRun, point, FontCascade::CustomFontNotReadyAction::UseFallbackIfFontNotReady);

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -35,6 +35,7 @@
 #include "GraphicsContext.h"
 #include "LayoutRect.h"
 #include "TextRun.h"
+#include "TextShapingResultAndDisplayList.h"
 #include "WidthIterator.h"
 #include <ranges>
 #include <wtf/MainThread.h>
@@ -177,7 +178,7 @@ TextShapingResult FontCascade::layoutText(CodePath codePathToUse, const TextRun&
 {
     if (RefPtr fonts = this->fonts()) {
         if (auto* cached = fonts->getOrCreateCachedShapedText(run, *this, from, to, forTextEmphasis))
-            return *cached;
+            return cached->textShapingResult;
     }
 
     if (shouldUseComplexTextController(codePathToUse))
@@ -229,6 +230,13 @@ RefPtr<const DisplayList::DisplayList> FontCascade::displayListForTextRun(Graphi
 
     auto glyphBuffer = layoutText(codePathToUse, run, from, destination).glyphBuffer;
     glyphBuffer.flatten();
+
+    return displayListForGlyphBuffer(context, glyphBuffer, customFontNotReadyAction);
+}
+
+RefPtr<const DisplayList::DisplayList> FontCascade::displayListForGlyphBuffer(GraphicsContext& context, const GlyphBuffer& glyphBuffer,  CustomFontNotReadyAction customFontNotReadyAction) const
+{
+    ASSERT(!context.paintingDisabled());
 
     if (glyphBuffer.isEmpty())
         return nullptr;

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -27,6 +27,7 @@
 #include <WebCore/Font.h>
 #include <WebCore/FontCascadeDescription.h>
 #include <WebCore/FontCascadeEnums.h>
+#include <WebCore/GlyphBuffer.h>
 #include <optional>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
@@ -203,6 +204,7 @@ public:
     static constexpr float syntheticObliqueAngle() { return 14; }
 
     RefPtr<const DisplayList::DisplayList> displayListForTextRun(GraphicsContext&, const TextRun&, unsigned from = 0, std::optional<unsigned> to = { }, CustomFontNotReadyAction = CustomFontNotReadyAction::DoNotPaintIfFontNotReady) const;
+    RefPtr<const DisplayList::DisplayList> displayListForGlyphBuffer(GraphicsContext&, const GlyphBuffer&, CustomFontNotReadyAction) const;
 
     unsigned generation() const { return m_generation; }
 

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
@@ -33,6 +33,7 @@
 #include "FontCache.h"
 #include "FontCascade.h"
 #include "GlyphPage.h"
+#include "TextShapingResultAndDisplayList.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -571,9 +572,11 @@ void FontCascadeFonts::pruneSystemFallbacks()
     m_shapedTextCache.clear();
 }
 
-const TextShapingResult* FontCascadeFonts::getOrCreateCachedShapedText(const TextRun& run, const FontCascade& fontCascade, unsigned from, std::optional<unsigned> to, ForTextEmphasis forTextEmphasis)
+TextShapingResultAndDisplayList* FontCascadeFonts::getOrCreateCachedShapedText(const TextRun& run, const FontCascade& fontCascade, unsigned from, std::optional<unsigned> to, ForTextEmphasis forTextEmphasis)
 {
     auto isCacheable = [&] {
+        if (!isMainThread())
+            return false;
         unsigned destination = to.value_or(run.length());
         if (from || destination != run.length() || forTextEmphasis == ForTextEmphasis::Yes)
             return false;
@@ -590,7 +593,7 @@ const TextShapingResult* FontCascadeFonts::getOrCreateCachedShapedText(const Tex
         return nullptr;
 
     // FIXME: TextMeasurementCache callers use the pattern of "adding" an empty entry as a way to perform a search with the same constraints that ::add enforces (no letter-spacing, no word-spacing, etc). We should properly encapsulate these requirements in both the ::add method and a dedicated ::find method.
-    CachedTextShapingResult* cacheEntry = m_shapedTextCache.add(run, nullptr, TextShapingContext { fontCascade });
+    auto* cacheEntry = m_shapedTextCache.add(run, nullptr, TextShapingContext { fontCascade });
 
     if (!cacheEntry)
         return nullptr;
@@ -599,14 +602,13 @@ const TextShapingResult* FontCascadeFonts::getOrCreateCachedShapedText(const Tex
         return cacheEntry->get();
 
     auto codePath = fontCascade.codePath(run);
-    TextShapingResult result;
-    if (fontCascade.shouldUseComplexTextController(codePath))
-        result = fontCascade.layoutComplexText(run, 0, run.length(), ForTextEmphasis::No);
-    else
-        result = fontCascade.layoutSimpleText(run, 0, run.length(), ForTextEmphasis::No);
+    auto result =
+        (fontCascade.shouldUseComplexTextController(codePath))
+        ? fontCascade.layoutComplexText(run, 0, run.length(), ForTextEmphasis::No)
+        : fontCascade.layoutSimpleText(run, 0, run.length(), ForTextEmphasis::No);
     result.glyphBuffer.flatten();
 
-    *cacheEntry = WTF::makeUnique<TextShapingResult>(WTF::move(result));
+    *cacheEntry = WTF::makeUnique<TextShapingResultAndDisplayList>(WTF::move(result));
 
     return cacheEntry->get();
 }

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.h
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.h
@@ -55,7 +55,7 @@ class GraphicsContext;
 class IntRect;
 class MixedFontGlyphPage;
 
-struct TextShapingResult;
+struct TextShapingResultAndDisplayList;
 
 struct GlyphOverflow {
     // FIXME: May need clearer&safer storage and names. See webkit.org/b/307002
@@ -79,8 +79,6 @@ static constexpr int maxInterval = -3; // Never ramp up sampling, stay aggressiv
 static constexpr unsigned maxSize = 3000; // Shaped text entries are large due to GlyphBuffer
 static constexpr unsigned maxTextLength = 128; // Larger than default to cache longer canvas text
 }
-
-using CachedTextShapingResult = std::unique_ptr<TextShapingResult>;
 
 } // namespace WebCore
 
@@ -134,8 +132,9 @@ public:
     GlyphGeometryCache& glyphGeometryCache() LIFETIME_BOUND { return m_glyphGeometryCache; }
     const GlyphGeometryCache& glyphGeometryCache() const LIFETIME_BOUND { return m_glyphGeometryCache; }
 
+    using CachedTextShapingResultAndDisplayList = std::unique_ptr<TextShapingResultAndDisplayList>;
     using ShapedTextCache = TextMeasurementCache<
-        CachedTextShapingResult,
+        CachedTextShapingResultAndDisplayList,
         ShapedTextCacheDefaults::initialInterval,
         ShapedTextCacheDefaults::minInterval,
         ShapedTextCacheDefaults::maxInterval,
@@ -145,7 +144,7 @@ public:
     ShapedTextCache& shapedTextCache() LIFETIME_BOUND { return m_shapedTextCache; }
     const ShapedTextCache& shapedTextCache() const LIFETIME_BOUND { return m_shapedTextCache; }
 
-    const TextShapingResult* getOrCreateCachedShapedText(const TextRun&, const FontCascade&, unsigned from, std::optional<unsigned> to, ForTextEmphasis);
+    TextShapingResultAndDisplayList* getOrCreateCachedShapedText(const TextRun&, const FontCascade&, unsigned from, std::optional<unsigned> to, ForTextEmphasis);
 
     const Font& primaryFont(const FontCascadeDescription&, FontSelector*);
     const Font* NODELETE cachedPrimaryFont() const { return m_cachedPrimaryFont.get(); }

--- a/Source/WebCore/platform/graphics/TextMeasurementCache.h
+++ b/Source/WebCore/platform/graphics/TextMeasurementCache.h
@@ -134,6 +134,9 @@ public:
 
     CachedType* add(StringView text, CachedType&& entry)
     {
+        if (!isMainThread())
+            return nullptr;
+
         unsigned length = text.length();
 
         // Do not allow length = 0. This allows SmallStringKey empty-value-is-zero.
@@ -153,6 +156,9 @@ public:
 
     CachedType* add(const TextRun& run, CachedType&& entry, TextShapingContext shapingContext)
     {
+        if (!isMainThread())
+            return nullptr;
+
         // The width cache is not really profitable unless we're doing expensive glyph transformations.
         if (!shapingContext.hasKerningOrLigatures)
             return nullptr;
@@ -171,6 +177,7 @@ public:
 
     void clear()
     {
+        ASSERT(isMainThread());
         m_singleCharMap.clear();
         m_map.clear();
     }

--- a/Source/WebCore/platform/graphics/TextShapingResultAndDisplayList.h
+++ b/Source/WebCore/platform/graphics/TextShapingResultAndDisplayList.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ *
+ */
+
+#pragma once
+
+#include <WebCore/DisplayList.h>
+#include <WebCore/FontCascade.h>
+#include <wtf/RefPtr.h>
+
+namespace WebCore {
+
+struct TextShapingResultAndDisplayList {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(TextShapingResultAndDisplayList);
+public:
+    TextShapingResult textShapingResult;
+    RefPtr<const DisplayList::DisplayList> displayList;
+};
+
+} // namespace WebCore


### PR DESCRIPTION
#### 81d99fe8121cb4d9c7f827e15313baa35d8f1a48
<pre>
Cache display lists for Canvas drawText&apos;s
<a href="https://bugs.webkit.org/show_bug.cgi?id=311039">https://bugs.webkit.org/show_bug.cgi?id=311039</a>
<a href="https://rdar.apple.com/172135737">rdar://172135737</a>

Reviewed by Matt Woodrow.

Some drawText operations are particularly expensive, in particular the
generation of images associated with emojis. And they occupy the main
content thread for most of the rendering time during some benchmarking
tests.

This can be mitigated by caching display lists (which contain these
images and more), and reuse them during similar-enough later calls.

Don&apos;t cache display list for texts with any shadow information that
could potentially output extra display list items; however when reusing
a cached display list, it&apos;s fine that there&apos;s just no *visible* shadow.

Also display list are only expected to work on the main thread, so only
allow caching there.

Covered by existing tests.
Extra test involving the same text with and without shadow:
fast/canvas/fillText-edge-shadow-mix.html

* LayoutTests/fast/canvas/fillText-edge-shadow-mix-expected.html: Added.
* LayoutTests/fast/canvas/fillText-edge-shadow-mix.html: Added.
* LayoutTests/platform/win/TestExpectations:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::drawTextUnchecked):
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::layoutText const):
(WebCore::FontCascade::displayListForTextRun const):
(WebCore::FontCascade::displayListForGlyphBuffer const):
* Source/WebCore/platform/graphics/FontCascade.h:
* Source/WebCore/platform/graphics/FontCascadeFonts.cpp:
(WebCore::FontCascadeFonts::getOrCreateCachedShapedText):
* Source/WebCore/platform/graphics/FontCascadeFonts.h:
* Source/WebCore/platform/graphics/TextMeasurementCache.h:
(WebCore::TextMeasurementCache::add):
(WebCore::TextMeasurementCache::clear):
* Source/WebCore/platform/graphics/TextShapingResultAndDisplayList.h: Added.

Canonical link: <a href="https://commits.webkit.org/310389@main">https://commits.webkit.org/310389@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f52e8a6e332bbce5fa5686070723c71dcb2a9d30

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153595 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26379 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19996 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162345 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107053 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/026350aa-1ea5-4dd0-b66f-a38d37afef3c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155468 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26907 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26701 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118747 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/107053 "An unexpected error occured. Recent messages:Printed configuration") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/20a26c5d-79d7-4749-b96f-7abbea683366) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156554 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21002 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137906 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99458 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ace771ad-413f-4bbb-951c-bc9ff986e720) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20081 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18021 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10178 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129728 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15766 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164816 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7950 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17360 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126822 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26176 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22057 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126986 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34467 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26178 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137561 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82846 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21903 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14342 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25795 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90082 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25486 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25646 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25546 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->