### PR TITLE
[Reland][List Marker] Collapse anonymous blocks created for outside marker when block level elements prevents line-box parenting.

### DIFF
--- a/LayoutTests/fast/lists/list-marker-before-content-table-expected.txt
+++ b/LayoutTests/fast/lists/list-marker-before-content-table-expected.txt
@@ -1,18 +1,18 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x160
-  RenderBlock {HTML} at (0,0) size 800x160
-    RenderBody {BODY} at (8,32) size 784x96
-      RenderBlock {UL} at (0,0) size 784x96
-        RenderListItem {LI} at (40,0) size 744x96 [color=#008000]
-          RenderBlock (anonymous) at (0,0) size 744x32
+layer at (0,0) size 800x128
+  RenderBlock {HTML} at (0,0) size 800x128
+    RenderBody {BODY} at (8,32) size 784x64
+      RenderBlock {UL} at (0,0) size 784x64
+        RenderListItem {LI} at (40,0) size 744x64 [color=#008000]
+          RenderBlock (anonymous) at (0,0) size 744x0
             RenderListMarker at (-25,0) size 11x32: bullet
-          RenderTable at (0,32) size 128x32
+          RenderTable at (0,0) size 128x32
             RenderTableSection (anonymous) at (0,0) size 128x32
               RenderTableRow (anonymous) at (0,0) size 128x32 [color=#0000FF]
                 RenderTableCell (anonymous) at (0,0) size 128x32 [r=0 c=0 rs=1 cs=1]
                   RenderText at (0,0) size 128x32
                     text run at (0,0) width 128: "ABCD"
-          RenderBlock (anonymous) at (0,64) size 744x32
+          RenderBlock (anonymous) at (0,32) size 744x32
             RenderText {#text} at (0,0) size 128x32
               text run at (0,0) width 128: "EFGH"

--- a/LayoutTests/fast/lists/list-marker-crash-1-expected.txt
+++ b/LayoutTests/fast/lists/list-marker-crash-1-expected.txt
@@ -1,0 +1,2 @@
+PASS if no crash
+

--- a/LayoutTests/fast/lists/list-marker-crash-1.html
+++ b/LayoutTests/fast/lists/list-marker-crash-1.html
@@ -1,0 +1,34 @@
+<style>
+    html {
+        word-spacing: 0px;
+    }
+    body {
+        -webkit-user-modify: read-write-plaintext-only;
+    }
+    .empty {
+        visibility: hidden;
+        column-count: 2;
+    }
+    #remove_me_too {
+        column-span: all;
+    }
+</style>
+
+<li class=empty>
+    <span id=remove_me></span>
+    <ul id=remove_me_too></ul>
+</li>
+text
+<li id=invalidate_me></li>
+
+<script>
+    document.execCommand("selectAll");
+    document.execCommand("insertHTML", true, "PASS if no crash");
+    
+    remove_me.remove();
+    remove_me_too.remove();
+    
+    invalidate_me.setAttribute("onmousewheel", "");
+    
+    window.testRunner?.dumpAsText();
+</script>

--- a/LayoutTests/fast/lists/list-marker-outside-flex-collapse-anonymous-block-expected.html
+++ b/LayoutTests/fast/lists/list-marker-outside-flex-collapse-anonymous-block-expected.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<style>
+    div.item {
+      font-family: Ahem;
+      font-size: 20px;
+    }
+</style>
+<div class="item">
+    <div style="display: flex">
+        <img style="width: 20px; height: 20px">
+        <div></div>
+        X
+    </div>
+    <div style="display: flex">
+        <img style="width: 20px; height: 20px">
+        <div></div>
+        X
+    </div>
+</div>

--- a/LayoutTests/fast/lists/list-marker-outside-flex-collapse-anonymous-block.html
+++ b/LayoutTests/fast/lists/list-marker-outside-flex-collapse-anonymous-block.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<style>
+    ul {
+      margin: 0;
+      padding: 0;
+    }
+    li {
+      font-family: Ahem;
+      font-size: 20px;
+      list-style-position: outside;
+      color: transparent;
+    }
+    li > * {
+      color: black;
+    }
+</style>
+<ul>
+    <li>
+        <div style="display: flex">
+            <img style="width: 20px; height: 20px">
+            <div></div>
+            X
+        </div>
+    </li>
+    <li>
+        <div style="display: flex">
+            <img style="display: block; width: 20px; height: 20px">
+            <div></div>
+            X
+        </div>
+    </li>
+</ul>

--- a/LayoutTests/platform/glib/fast/css-generated-content/table-row-group-with-before-expected.txt
+++ b/LayoutTests/platform/glib/fast/css-generated-content/table-row-group-with-before-expected.txt
@@ -9,16 +9,16 @@ layer at (0,0) size 800x600
             text run at (0,0) width 220: "This test passes if it does not crash."
         RenderText {#text} at (0,0) size 0x0
         RenderBR {BR} at (220,0) size 0x18
-      RenderBlock {UL} at (0,34) size 784x54
-        RenderListItem {LI} at (40,0) size 744x54
-          RenderBlock (anonymous) at (0,0) size 744x18
+      RenderBlock {UL} at (0,34) size 784x36
+        RenderListItem {LI} at (40,0) size 744x36
+          RenderBlock (anonymous) at (0,0) size 744x0
             RenderListMarker at (-17,0) size 7x18: bullet
-          RenderTable at (0,18) size 31x18
+          RenderTable at (0,0) size 31x18
             RenderTableSection (anonymous) at (0,0) size 31x18
               RenderTableRow (anonymous) at (0,0) size 31x18
                 RenderTableCell (anonymous) at (0,0) size 31x18 [r=0 c=0 rs=1 cs=1]
                   RenderText at (0,0) size 31x18
                     text run at (0,0) width 31: "hello"
-          RenderBlock (anonymous) at (0,36) size 744x18
+          RenderBlock (anonymous) at (0,18) size 744x18
             RenderText {#text} at (0,0) size 21x18
               text run at (0,0) width 21: "test"

--- a/LayoutTests/platform/glib/fast/css-generated-content/table-row-with-before-expected.txt
+++ b/LayoutTests/platform/glib/fast/css-generated-content/table-row-with-before-expected.txt
@@ -9,16 +9,16 @@ layer at (0,0) size 800x600
             text run at (0,0) width 220: "This test passes if it does not crash."
         RenderText {#text} at (0,0) size 0x0
         RenderBR {BR} at (220,0) size 0x18
-      RenderBlock {UL} at (0,34) size 784x54
-        RenderListItem {LI} at (40,0) size 744x54
-          RenderBlock (anonymous) at (0,0) size 744x18
+      RenderBlock {UL} at (0,34) size 784x36
+        RenderListItem {LI} at (40,0) size 744x36
+          RenderBlock (anonymous) at (0,0) size 744x0
             RenderListMarker at (-17,0) size 7x18: bullet
-          RenderTable at (0,18) size 31x18
+          RenderTable at (0,0) size 31x18
             RenderTableSection (anonymous) at (0,0) size 31x18
               RenderTableRow (anonymous) at (0,0) size 31x18
                 RenderTableCell (anonymous) at (0,0) size 31x18 [r=0 c=0 rs=1 cs=1]
                   RenderText at (0,0) size 31x18
                     text run at (0,0) width 31: "hello"
-          RenderBlock (anonymous) at (0,36) size 744x18
+          RenderBlock (anonymous) at (0,18) size 744x18
             RenderText {#text} at (0,0) size 21x18
               text run at (0,0) width 21: "test"

--- a/LayoutTests/platform/glib/fast/css-generated-content/table-with-before-expected.txt
+++ b/LayoutTests/platform/glib/fast/css-generated-content/table-with-before-expected.txt
@@ -9,16 +9,16 @@ layer at (0,0) size 800x600
             text run at (0,0) width 220: "This test passes if it does not crash."
         RenderText {#text} at (0,0) size 0x0
         RenderBR {BR} at (220,0) size 0x18
-      RenderBlock {UL} at (0,34) size 784x54
-        RenderListItem {LI} at (40,0) size 744x54
-          RenderBlock (anonymous) at (0,0) size 744x18
+      RenderBlock {UL} at (0,34) size 784x36
+        RenderListItem {LI} at (40,0) size 744x36
+          RenderBlock (anonymous) at (0,0) size 744x0
             RenderListMarker at (-17,0) size 7x18: bullet
-          RenderTable at (0,18) size 31x18
+          RenderTable at (0,0) size 31x18
             RenderTableSection (anonymous) at (0,0) size 31x18
               RenderTableRow (anonymous) at (0,0) size 31x18
                 RenderTableCell (anonymous) at (0,0) size 31x18 [r=0 c=0 rs=1 cs=1]
                   RenderText at (0,0) size 31x18
                     text run at (0,0) width 31: "hello"
-          RenderBlock (anonymous) at (0,36) size 744x18
+          RenderBlock (anonymous) at (0,18) size 744x18
             RenderText {#text} at (0,0) size 21x18
               text run at (0,0) width 21: "test"

--- a/LayoutTests/platform/glib/fast/forms/form-hides-table-expected.txt
+++ b/LayoutTests/platform/glib/fast/forms/form-hides-table-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 785x658
+layer at (0,0) size 785x640
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x658
-  RenderBlock {HTML} at (0,0) size 785x658
-    RenderBody {BODY} at (8,8) size 769x642
+layer at (0,0) size 785x640
+  RenderBlock {HTML} at (0,0) size 785x640
+    RenderBody {BODY} at (8,8) size 769x624
       RenderBlock {P} at (0,0) size 769x18
         RenderText {#text} at (0,0) size 551x18
           text run at (0,0) width 551: "This page has a few tables within form elements within divs with various display styles."
@@ -32,18 +32,18 @@ layer at (0,0) size 785x658
                   RenderTableCell {TD} at (2,2) size 90x20 [r=0 c=0 rs=1 cs=1]
                     RenderText {#text} at (1,1) size 88x18
                       text run at (1,1) width 88: "display: block"
-      RenderBlock {DIV} at (0,148) size 769x42
-        RenderListItem {DIV} at (0,0) size 769x42
-          RenderBlock (anonymous) at (0,0) size 769x18
+      RenderBlock {DIV} at (0,148) size 769x24
+        RenderListItem {DIV} at (0,0) size 769x24
+          RenderBlock (anonymous) at (0,0) size 769x0
             RenderListMarker at (-17,0) size 7x18: bullet
-          RenderBlock {FORM} at (0,18) size 769x24
+          RenderBlock {FORM} at (0,0) size 769x24
             RenderTable {TABLE} at (0,0) size 109x24
               RenderTableSection {TBODY} at (0,0) size 109x24
                 RenderTableRow {TR} at (0,2) size 109x20
                   RenderTableCell {TD} at (2,2) size 105x20 [r=0 c=0 rs=1 cs=1]
                     RenderText {#text} at (1,1) size 103x18
                       text run at (1,1) width 103: "display: list-item"
-      RenderBlock {DIV} at (0,206) size 769x24
+      RenderBlock {DIV} at (0,188) size 769x24
         RenderBlock {DIV} at (0,0) size 769x24
           RenderBlock {FORM} at (0,0) size 769x24
             RenderTable {TABLE} at (0,0) size 112x24
@@ -52,7 +52,7 @@ layer at (0,0) size 785x658
                   RenderTableCell {TD} at (2,2) size 108x20 [r=0 c=0 rs=1 cs=1]
                     RenderText {#text} at (1,1) size 106x18
                       text run at (1,1) width 106: "display: compact"
-      RenderBlock {DIV} at (0,246) size 769x40
+      RenderBlock {DIV} at (0,228) size 769x40
         RenderBlock {DIV} at (0,0) size 134x40
           RenderBlock {FORM} at (0,0) size 134x24
             RenderTable {TABLE} at (0,0) size 134x24
@@ -61,7 +61,7 @@ layer at (0,0) size 785x658
                   RenderTableCell {TD} at (2,2) size 130x20 [r=0 c=0 rs=1 cs=1]
                     RenderText {#text} at (1,1) size 128x18
                       text run at (1,1) width 128: "display: inline-block"
-      RenderBlock {DIV} at (0,286) size 769x40
+      RenderBlock {DIV} at (0,268) size 769x40
         RenderTable {DIV} at (0,0) size 89x40
           RenderTableSection (anonymous) at (0,0) size 89x40
             RenderTableRow (anonymous) at (0,0) size 89x40
@@ -73,7 +73,7 @@ layer at (0,0) size 785x658
                         RenderTableCell {TD} at (2,2) size 85x20 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 83x18
                             text run at (1,1) width 83: "display: table"
-      RenderBlock {DIV} at (0,326) size 769x40
+      RenderBlock {DIV} at (0,308) size 769x40
         RenderTable {DIV} at (0,0) size 129x40
           RenderTableSection (anonymous) at (0,0) size 129x40
             RenderTableRow (anonymous) at (0,0) size 129x40
@@ -85,7 +85,7 @@ layer at (0,0) size 785x658
                         RenderTableCell {TD} at (2,2) size 125x20 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 123x18
                             text run at (1,1) width 123: "display: inline-table"
-      RenderBlock {DIV} at (0,366) size 769x40
+      RenderBlock {DIV} at (0,348) size 769x40
         RenderTable at (0,0) size 161x40
           RenderTableSection {DIV} at (0,0) size 161x40
             RenderTableRow (anonymous) at (0,0) size 161x40
@@ -97,7 +97,7 @@ layer at (0,0) size 785x658
                         RenderTableCell {TD} at (2,2) size 157x20 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 155x18
                             text run at (1,1) width 155: "display: table-row-group"
-      RenderBlock {DIV} at (0,406) size 769x40
+      RenderBlock {DIV} at (0,388) size 769x40
         RenderTable at (0,0) size 178x40
           RenderTableSection {DIV} at (0,0) size 178x40
             RenderTableRow (anonymous) at (0,0) size 178x40
@@ -109,7 +109,7 @@ layer at (0,0) size 785x658
                         RenderTableCell {TD} at (2,2) size 174x20 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 172x18
                             text run at (1,1) width 172: "display: table-header-group"
-      RenderBlock {DIV} at (0,446) size 769x40
+      RenderBlock {DIV} at (0,428) size 769x40
         RenderTable at (0,0) size 173x40
           RenderTableSection {DIV} at (0,0) size 173x40
             RenderTableRow (anonymous) at (0,0) size 173x40
@@ -121,7 +121,7 @@ layer at (0,0) size 785x658
                         RenderTableCell {TD} at (2,2) size 169x20 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 167x18
                             text run at (1,1) width 167: "display: table-footer-group"
-      RenderBlock {DIV} at (0,486) size 769x40
+      RenderBlock {DIV} at (0,468) size 769x40
         RenderTable at (0,0) size 119x40
           RenderTableSection (anonymous) at (0,0) size 119x40
             RenderTableRow {DIV} at (0,0) size 119x40
@@ -133,14 +133,14 @@ layer at (0,0) size 785x658
                         RenderTableCell {TD} at (2,2) size 115x20 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 113x18
                             text run at (1,1) width 113: "display: table-row"
-      RenderBlock {DIV} at (0,526) size 769x0
+      RenderBlock {DIV} at (0,508) size 769x0
         RenderTable at (0,0) size 0x0
           RenderTableCol {DIV} at (0,0) size 0x0
-      RenderBlock {DIV} at (0,526) size 769x0
+      RenderBlock {DIV} at (0,508) size 769x0
         RenderTable at (0,0) size 0x0
           RenderTableCol at (0,0) size 0x0
             RenderTableCol {DIV} at (0,0) size 0x0
-      RenderBlock {DIV} at (0,526) size 769x40
+      RenderBlock {DIV} at (0,508) size 769x40
         RenderTable at (0,0) size 116x40
           RenderTableSection (anonymous) at (0,0) size 116x40
             RenderTableRow (anonymous) at (0,0) size 116x40
@@ -152,7 +152,7 @@ layer at (0,0) size 785x658
                         RenderTableCell {TD} at (2,2) size 112x20 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 110x18
                             text run at (1,1) width 110: "display: table-cell"
-      RenderBlock {DIV} at (0,566) size 769x76
+      RenderBlock {DIV} at (0,548) size 769x76
         RenderTable at (0,0) size 55x76
           RenderBlock {DIV} at (0,0) size 55x76
             RenderBlock {FORM} at (0,0) size 55x60

--- a/LayoutTests/platform/glib/fast/lists/ordered-list-with-no-ol-tag-expected.txt
+++ b/LayoutTests/platform/glib/fast/lists/ordered-list-with-no-ol-tag-expected.txt
@@ -1,15 +1,15 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x539
-  RenderBlock {HTML} at (0,0) size 800x539
-    RenderBody {BODY} at (8,19) size 784x512
+layer at (0,0) size 800x503
+  RenderBlock {HTML} at (0,0) size 800x503
+    RenderBody {BODY} at (8,19) size 784x476
       RenderBlock {H2} at (0,0) size 784x27
         RenderText {#text} at (0,0) size 303x27
           text run at (0,0) width 303: "A regular two level nested list"
       RenderBlock {P} at (0,46) size 784x19
         RenderText {#text} at (0,0) size 551x18
           text run at (0,0) width 551: "The outer list is numbered using decimal numerals, the inner lists with lower case letters"
-      RenderBlock {DIV} at (24,80) size 760x431 [border: (1px solid #000000)]
+      RenderBlock {DIV} at (24,80) size 760x395 [border: (1px solid #000000)]
         RenderListItem {DIV} at (33,1) size 726x20 [border: (1px solid #000000)]
           RenderListMarker at (-20,1) size 16x18: "1"
           RenderText {#text} at (33,1) size 40x18
@@ -67,15 +67,15 @@ layer at (0,0) size 800x539
           RenderListMarker at (-20,1) size 16x18: "4"
           RenderText {#text} at (33,1) size 40x18
             text run at (33,1) width 40: "Item 4"
-        RenderListItem {DIV} at (33,297) size 726x112 [border: (1px solid #000000)]
+        RenderListItem {DIV} at (33,297) size 726x76 [border: (1px solid #000000)]
           RenderBlock (anonymous) at (33,1) size 692x18
             RenderListMarker at (-53,0) size 16x18: "5"
             RenderText {#text} at (0,0) size 40x18
               text run at (0,0) width 40: "Item 5"
-          RenderListItem {TABLE} at (33,19) size 692x46 [border: (1px dashed #000000)]
-            RenderBlock (anonymous) at (1,1) size 690x18
+          RenderListItem {TABLE} at (33,19) size 692x28 [border: (1px dashed #000000)]
+            RenderBlock (anonymous) at (1,1) size 690x0
               RenderListMarker at (-20,0) size 15x18: "a"
-            RenderTable at (1,19) size 191x26
+            RenderTable at (1,1) size 191x26
               RenderTableSection {TBODY} at (0,0) size 191x26
                 RenderTableRow {TR} at (0,2) size 191x22
                   RenderTableCell {TD} at (2,2) size 93x22 [border: (1px dotted #000000)] [r=0 c=0 rs=1 cs=1]
@@ -84,10 +84,10 @@ layer at (0,0) size 800x539
                   RenderTableCell {TD} at (96,2) size 93x22 [border: (1px dotted #000000)] [r=0 c=1 rs=1 cs=1]
                     RenderText {#text} at (2,2) size 88x18
                       text run at (2,2) width 88: "Table Cell B1"
-          RenderListItem {TABLE} at (33,65) size 692x46 [border: (1px dashed #000000)]
-            RenderBlock (anonymous) at (1,1) size 690x18
+          RenderListItem {TABLE} at (33,47) size 692x28 [border: (1px dashed #000000)]
+            RenderBlock (anonymous) at (1,1) size 690x0
               RenderListMarker at (-21,0) size 16x18: "b"
-            RenderTable at (1,19) size 215x26
+            RenderTable at (1,1) size 215x26
               RenderTableSection {TBODY} at (0,0) size 215x26
                 RenderTableRow {TR} at (0,2) size 215x22
                   RenderTableCell {TD} at (2,2) size 105x22 [border: (1px dotted #000000)] [r=0 c=0 rs=1 cs=1]
@@ -96,7 +96,7 @@ layer at (0,0) size 800x539
                   RenderTableCell {TD} at (108,2) size 105x22 [border: (1px dotted #000000)] [r=0 c=1 rs=1 cs=1]
                     RenderText {#text} at (2,2) size 100x18
                       text run at (2,2) width 100: "Table 2 Cell B1"
-        RenderListItem {DIV} at (33,409) size 726x20 [border: (1px solid #000000)]
+        RenderListItem {DIV} at (33,373) size 726x20 [border: (1px solid #000000)]
           RenderListMarker at (-20,1) size 16x18: "6"
           RenderText {#text} at (33,1) size 40x18
             text run at (33,1) width 40: "Item 6"

--- a/LayoutTests/platform/ios/fast/css-generated-content/table-row-group-with-before-expected.txt
+++ b/LayoutTests/platform/ios/fast/css-generated-content/table-row-group-with-before-expected.txt
@@ -9,16 +9,16 @@ layer at (0,0) size 800x600
             text run at (0,0) width 226: "This test passes if it does not crash."
         RenderText {#text} at (0,0) size 0x0
         RenderBR {BR} at (225,0) size 1x20
-      RenderBlock {UL} at (0,36) size 784x60
-        RenderListItem {LI} at (40,0) size 744x60
-          RenderBlock (anonymous) at (0,0) size 744x20
+      RenderBlock {UL} at (0,36) size 784x40
+        RenderListItem {LI} at (40,0) size 744x40
+          RenderBlock (anonymous) at (0,0) size 744x0
             RenderListMarker at (-18,0) size 7x20: bullet
-          RenderTable at (0,20) size 32x20
+          RenderTable at (0,0) size 32x20
             RenderTableSection (anonymous) at (0,0) size 32x20
               RenderTableRow (anonymous) at (0,0) size 32x20
                 RenderTableCell (anonymous) at (0,0) size 32x20 [r=0 c=0 rs=1 cs=1]
                   RenderText at (0,0) size 32x20
                     text run at (0,0) width 32: "hello"
-          RenderBlock (anonymous) at (0,40) size 744x20
+          RenderBlock (anonymous) at (0,20) size 744x20
             RenderText {#text} at (0,0) size 23x20
               text run at (0,0) width 23: "test"

--- a/LayoutTests/platform/ios/fast/css-generated-content/table-row-with-before-expected.txt
+++ b/LayoutTests/platform/ios/fast/css-generated-content/table-row-with-before-expected.txt
@@ -9,16 +9,16 @@ layer at (0,0) size 800x600
             text run at (0,0) width 226: "This test passes if it does not crash."
         RenderText {#text} at (0,0) size 0x0
         RenderBR {BR} at (225,0) size 1x20
-      RenderBlock {UL} at (0,36) size 784x60
-        RenderListItem {LI} at (40,0) size 744x60
-          RenderBlock (anonymous) at (0,0) size 744x20
+      RenderBlock {UL} at (0,36) size 784x40
+        RenderListItem {LI} at (40,0) size 744x40
+          RenderBlock (anonymous) at (0,0) size 744x0
             RenderListMarker at (-18,0) size 7x20: bullet
-          RenderTable at (0,20) size 32x20
+          RenderTable at (0,0) size 32x20
             RenderTableSection (anonymous) at (0,0) size 32x20
               RenderTableRow (anonymous) at (0,0) size 32x20
                 RenderTableCell (anonymous) at (0,0) size 32x20 [r=0 c=0 rs=1 cs=1]
                   RenderText at (0,0) size 32x20
                     text run at (0,0) width 32: "hello"
-          RenderBlock (anonymous) at (0,40) size 744x20
+          RenderBlock (anonymous) at (0,20) size 744x20
             RenderText {#text} at (0,0) size 23x20
               text run at (0,0) width 23: "test"

--- a/LayoutTests/platform/ios/fast/css-generated-content/table-with-before-expected.txt
+++ b/LayoutTests/platform/ios/fast/css-generated-content/table-with-before-expected.txt
@@ -9,16 +9,16 @@ layer at (0,0) size 800x600
             text run at (0,0) width 226: "This test passes if it does not crash."
         RenderText {#text} at (0,0) size 0x0
         RenderBR {BR} at (225,0) size 1x20
-      RenderBlock {UL} at (0,36) size 784x60
-        RenderListItem {LI} at (40,0) size 744x60
-          RenderBlock (anonymous) at (0,0) size 744x20
+      RenderBlock {UL} at (0,36) size 784x40
+        RenderListItem {LI} at (40,0) size 744x40
+          RenderBlock (anonymous) at (0,0) size 744x0
             RenderListMarker at (-18,0) size 7x20: bullet
-          RenderTable at (0,20) size 32x20
+          RenderTable at (0,0) size 32x20
             RenderTableSection (anonymous) at (0,0) size 32x20
               RenderTableRow (anonymous) at (0,0) size 32x20
                 RenderTableCell (anonymous) at (0,0) size 32x20 [r=0 c=0 rs=1 cs=1]
                   RenderText at (0,0) size 32x20
                     text run at (0,0) width 32: "hello"
-          RenderBlock (anonymous) at (0,40) size 744x20
+          RenderBlock (anonymous) at (0,20) size 744x20
             RenderText {#text} at (0,0) size 23x20
               text run at (0,0) width 23: "test"

--- a/LayoutTests/platform/ios/fast/forms/form-hides-table-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/form-hides-table-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 800x694
+layer at (0,0) size 800x674
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x694
-  RenderBlock {HTML} at (0,0) size 800x694
-    RenderBody {BODY} at (8,8) size 784x678
+layer at (0,0) size 800x674
+  RenderBlock {HTML} at (0,0) size 800x674
+    RenderBody {BODY} at (8,8) size 784x658
       RenderBlock {P} at (0,0) size 784x20
         RenderText {#text} at (0,0) size 564x20
           text run at (0,0) width 564: "This page has a few tables within form elements within divs with various display styles."
@@ -32,18 +32,18 @@ layer at (0,0) size 800x694
                   RenderTableCell {TD} at (2,2) size 93x22 [r=0 c=0 rs=1 cs=1]
                     RenderText {#text} at (1,1) size 91x20
                       text run at (1,1) width 91: "display: block"
-      RenderBlock {DIV} at (0,156) size 784x46
-        RenderListItem {DIV} at (0,0) size 784x46
-          RenderBlock (anonymous) at (0,0) size 784x20
+      RenderBlock {DIV} at (0,156) size 784x26
+        RenderListItem {DIV} at (0,0) size 784x26
+          RenderBlock (anonymous) at (0,0) size 784x0
             RenderListMarker at (-18,0) size 7x20: bullet
-          RenderBlock {FORM} at (0,20) size 784x26
+          RenderBlock {FORM} at (0,0) size 784x26
             RenderTable {TABLE} at (0,0) size 114x26
               RenderTableSection {TBODY} at (0,0) size 114x26
                 RenderTableRow {TR} at (0,2) size 114x22
                   RenderTableCell {TD} at (2,2) size 110x22 [r=0 c=0 rs=1 cs=1]
                     RenderText {#text} at (1,1) size 108x20
                       text run at (1,1) width 108: "display: list-item"
-      RenderBlock {DIV} at (0,218) size 784x26
+      RenderBlock {DIV} at (0,198) size 784x26
         RenderBlock {DIV} at (0,0) size 784x26
           RenderBlock {FORM} at (0,0) size 784x26
             RenderTable {TABLE} at (0,0) size 115x26
@@ -52,7 +52,7 @@ layer at (0,0) size 800x694
                   RenderTableCell {TD} at (2,2) size 111x22 [r=0 c=0 rs=1 cs=1]
                     RenderText {#text} at (1,1) size 109x20
                       text run at (1,1) width 109: "display: compact"
-      RenderBlock {DIV} at (0,260) size 784x42
+      RenderBlock {DIV} at (0,240) size 784x42
         RenderBlock {DIV} at (0,0) size 138x42
           RenderBlock {FORM} at (0,0) size 138x26
             RenderTable {TABLE} at (0,0) size 138x26
@@ -61,7 +61,7 @@ layer at (0,0) size 800x694
                   RenderTableCell {TD} at (2,2) size 134x22 [r=0 c=0 rs=1 cs=1]
                     RenderText {#text} at (1,1) size 132x20
                       text run at (1,1) width 132: "display: inline-block"
-      RenderBlock {DIV} at (0,302) size 784x42
+      RenderBlock {DIV} at (0,282) size 784x42
         RenderTable {DIV} at (0,0) size 92x42
           RenderTableSection (anonymous) at (0,0) size 92x42
             RenderTableRow (anonymous) at (0,0) size 92x42
@@ -73,7 +73,7 @@ layer at (0,0) size 800x694
                         RenderTableCell {TD} at (2,2) size 88x22 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 86x20
                             text run at (1,1) width 86: "display: table"
-      RenderBlock {DIV} at (0,344) size 784x42
+      RenderBlock {DIV} at (0,324) size 784x42
         RenderTable {DIV} at (0,0) size 134x42
           RenderTableSection (anonymous) at (0,0) size 134x42
             RenderTableRow (anonymous) at (0,0) size 134x42
@@ -85,7 +85,7 @@ layer at (0,0) size 800x694
                         RenderTableCell {TD} at (2,2) size 130x22 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 128x20
                             text run at (1,1) width 128: "display: inline-table"
-      RenderBlock {DIV} at (0,386) size 784x42
+      RenderBlock {DIV} at (0,366) size 784x42
         RenderTable at (0,0) size 165x42
           RenderTableSection {DIV} at (0,0) size 165x42
             RenderTableRow (anonymous) at (0,0) size 165x42
@@ -97,7 +97,7 @@ layer at (0,0) size 800x694
                         RenderTableCell {TD} at (2,2) size 161x22 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 159x20
                             text run at (1,1) width 159: "display: table-row-group"
-      RenderBlock {DIV} at (0,428) size 784x42
+      RenderBlock {DIV} at (0,408) size 784x42
         RenderTable at (0,0) size 183x42
           RenderTableSection {DIV} at (0,0) size 183x42
             RenderTableRow (anonymous) at (0,0) size 183x42
@@ -109,7 +109,7 @@ layer at (0,0) size 800x694
                         RenderTableCell {TD} at (2,2) size 179x22 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 177x20
                             text run at (1,1) width 177: "display: table-header-group"
-      RenderBlock {DIV} at (0,470) size 784x42
+      RenderBlock {DIV} at (0,450) size 784x42
         RenderTable at (0,0) size 178x42
           RenderTableSection {DIV} at (0,0) size 178x42
             RenderTableRow (anonymous) at (0,0) size 178x42
@@ -121,7 +121,7 @@ layer at (0,0) size 800x694
                         RenderTableCell {TD} at (2,2) size 174x22 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 172x20
                             text run at (1,1) width 172: "display: table-footer-group"
-      RenderBlock {DIV} at (0,512) size 784x42
+      RenderBlock {DIV} at (0,492) size 784x42
         RenderTable at (0,0) size 122x42
           RenderTableSection (anonymous) at (0,0) size 122x42
             RenderTableRow {DIV} at (0,0) size 122x42
@@ -133,14 +133,14 @@ layer at (0,0) size 800x694
                         RenderTableCell {TD} at (2,2) size 118x22 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 116x20
                             text run at (1,1) width 116: "display: table-row"
-      RenderBlock {DIV} at (0,554) size 784x0
+      RenderBlock {DIV} at (0,534) size 784x0
         RenderTable at (0,0) size 0x0
           RenderTableCol {DIV} at (0,0) size 0x0
-      RenderBlock {DIV} at (0,554) size 784x0
+      RenderBlock {DIV} at (0,534) size 784x0
         RenderTable at (0,0) size 0x0
           RenderTableCol at (0,0) size 0x0
             RenderTableCol {DIV} at (0,0) size 0x0
-      RenderBlock {DIV} at (0,554) size 784x42
+      RenderBlock {DIV} at (0,534) size 784x42
         RenderTable at (0,0) size 121x42
           RenderTableSection (anonymous) at (0,0) size 121x42
             RenderTableRow (anonymous) at (0,0) size 121x42
@@ -152,7 +152,7 @@ layer at (0,0) size 800x694
                         RenderTableCell {TD} at (2,2) size 117x22 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 115x20
                             text run at (1,1) width 115: "display: table-cell"
-      RenderBlock {DIV} at (0,596) size 784x82
+      RenderBlock {DIV} at (0,576) size 784x82
         RenderTable at (0,0) size 57x82
           RenderBlock {DIV} at (0,0) size 57x82
             RenderBlock {FORM} at (0,0) size 57x66

--- a/LayoutTests/platform/ios/fast/lists/ordered-list-with-no-ol-tag-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/ordered-list-with-no-ol-tag-expected.txt
@@ -1,15 +1,15 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x586
-  RenderBlock {HTML} at (0,0) size 800x586
-    RenderBody {BODY} at (8,19) size 784x559
+layer at (0,0) size 800x546
+  RenderBlock {HTML} at (0,0) size 800x546
+    RenderBody {BODY} at (8,19) size 784x519
       RenderBlock {H2} at (0,0) size 784x30
         RenderText {#text} at (0,1) size 302x28
           text run at (0,1) width 302: "A regular two level nested list"
       RenderBlock {P} at (0,49) size 784x21
         RenderText {#text} at (0,0) size 566x20
           text run at (0,0) width 566: "The outer list is numbered using decimal numerals, the inner lists with lower case letters"
-      RenderBlock {DIV} at (24,85) size 760x473 [border: (1px solid #000000)]
+      RenderBlock {DIV} at (24,85) size 760x433 [border: (1px solid #000000)]
         RenderListItem {DIV} at (33,1) size 726x22 [border: (1px solid #000000)]
           RenderListMarker at (-21,1) size 16x20: "1"
           RenderText {#text} at (33,1) size 42x20
@@ -67,15 +67,15 @@ layer at (0,0) size 800x586
           RenderListMarker at (-21,1) size 16x20: "4"
           RenderText {#text} at (33,1) size 42x20
             text run at (33,1) width 42: "Item 4"
-        RenderListItem {DIV} at (33,327) size 726x122 [border: (1px solid #000000)]
+        RenderListItem {DIV} at (33,327) size 726x82 [border: (1px solid #000000)]
           RenderBlock (anonymous) at (33,1) size 692x20
             RenderListMarker at (-54,0) size 16x20: "5"
             RenderText {#text} at (0,0) size 42x20
               text run at (0,0) width 42: "Item 5"
-          RenderListItem {TABLE} at (33,21) size 692x50 [border: (1px dashed #000000)]
-            RenderBlock (anonymous) at (1,1) size 690x20
+          RenderListItem {TABLE} at (33,21) size 692x30 [border: (1px dashed #000000)]
+            RenderBlock (anonymous) at (1,1) size 690x0
               RenderListMarker at (-22,0) size 16x20: "a"
-            RenderTable at (1,21) size 193x28
+            RenderTable at (1,1) size 193x28
               RenderTableSection {TBODY} at (0,0) size 193x28
                 RenderTableRow {TR} at (0,2) size 193x24
                   RenderTableCell {TD} at (2,2) size 94x24 [border: (1px dotted #000000)] [r=0 c=0 rs=1 cs=1]
@@ -84,10 +84,10 @@ layer at (0,0) size 800x586
                   RenderTableCell {TD} at (97,2) size 94x24 [border: (1px dotted #000000)] [r=0 c=1 rs=1 cs=1]
                     RenderText {#text} at (2,2) size 89x20
                       text run at (2,2) width 89: "Table Cell B1"
-          RenderListItem {TABLE} at (33,71) size 692x50 [border: (1px dashed #000000)]
-            RenderBlock (anonymous) at (1,1) size 690x20
+          RenderListItem {TABLE} at (33,51) size 692x30 [border: (1px dashed #000000)]
+            RenderBlock (anonymous) at (1,1) size 690x0
               RenderListMarker at (-22,0) size 16x20: "b"
-            RenderTable at (1,21) size 217x28
+            RenderTable at (1,1) size 217x28
               RenderTableSection {TBODY} at (0,0) size 217x28
                 RenderTableRow {TR} at (0,2) size 217x24
                   RenderTableCell {TD} at (2,2) size 106x24 [border: (1px dotted #000000)] [r=0 c=0 rs=1 cs=1]
@@ -96,7 +96,7 @@ layer at (0,0) size 800x586
                   RenderTableCell {TD} at (109,2) size 106x24 [border: (1px dotted #000000)] [r=0 c=1 rs=1 cs=1]
                     RenderText {#text} at (2,2) size 101x20
                       text run at (2,2) width 101: "Table 2 Cell B1"
-        RenderListItem {DIV} at (33,449) size 726x22 [border: (1px solid #000000)]
+        RenderListItem {DIV} at (33,409) size 726x22 [border: (1px solid #000000)]
           RenderListMarker at (-21,1) size 16x20: "6"
           RenderText {#text} at (33,1) size 42x20
             text run at (33,1) width 42: "Item 6"

--- a/LayoutTests/platform/mac/fast/css-generated-content/table-row-group-with-before-expected.txt
+++ b/LayoutTests/platform/mac/fast/css-generated-content/table-row-group-with-before-expected.txt
@@ -9,16 +9,16 @@ layer at (0,0) size 800x600
             text run at (0,0) width 226: "This test passes if it does not crash."
         RenderText {#text} at (0,0) size 0x0
         RenderBR {BR} at (225,0) size 1x18
-      RenderBlock {UL} at (0,34) size 784x54
-        RenderListItem {LI} at (40,0) size 744x54
-          RenderBlock (anonymous) at (0,0) size 744x18
+      RenderBlock {UL} at (0,34) size 784x36
+        RenderListItem {LI} at (40,0) size 744x36
+          RenderBlock (anonymous) at (0,0) size 744x0
             RenderListMarker at (-17,0) size 7x18: bullet
-          RenderTable at (0,18) size 32x18
+          RenderTable at (0,0) size 32x18
             RenderTableSection (anonymous) at (0,0) size 32x18
               RenderTableRow (anonymous) at (0,0) size 32x18
                 RenderTableCell (anonymous) at (0,0) size 32x18 [r=0 c=0 rs=1 cs=1]
                   RenderText at (0,0) size 32x18
                     text run at (0,0) width 32: "hello"
-          RenderBlock (anonymous) at (0,36) size 744x18
+          RenderBlock (anonymous) at (0,18) size 744x18
             RenderText {#text} at (0,0) size 23x18
               text run at (0,0) width 23: "test"

--- a/LayoutTests/platform/mac/fast/css-generated-content/table-row-with-before-expected.txt
+++ b/LayoutTests/platform/mac/fast/css-generated-content/table-row-with-before-expected.txt
@@ -9,16 +9,16 @@ layer at (0,0) size 800x600
             text run at (0,0) width 226: "This test passes if it does not crash."
         RenderText {#text} at (0,0) size 0x0
         RenderBR {BR} at (225,0) size 1x18
-      RenderBlock {UL} at (0,34) size 784x54
-        RenderListItem {LI} at (40,0) size 744x54
-          RenderBlock (anonymous) at (0,0) size 744x18
+      RenderBlock {UL} at (0,34) size 784x36
+        RenderListItem {LI} at (40,0) size 744x36
+          RenderBlock (anonymous) at (0,0) size 744x0
             RenderListMarker at (-17,0) size 7x18: bullet
-          RenderTable at (0,18) size 32x18
+          RenderTable at (0,0) size 32x18
             RenderTableSection (anonymous) at (0,0) size 32x18
               RenderTableRow (anonymous) at (0,0) size 32x18
                 RenderTableCell (anonymous) at (0,0) size 32x18 [r=0 c=0 rs=1 cs=1]
                   RenderText at (0,0) size 32x18
                     text run at (0,0) width 32: "hello"
-          RenderBlock (anonymous) at (0,36) size 744x18
+          RenderBlock (anonymous) at (0,18) size 744x18
             RenderText {#text} at (0,0) size 23x18
               text run at (0,0) width 23: "test"

--- a/LayoutTests/platform/mac/fast/css-generated-content/table-with-before-expected.txt
+++ b/LayoutTests/platform/mac/fast/css-generated-content/table-with-before-expected.txt
@@ -9,16 +9,16 @@ layer at (0,0) size 800x600
             text run at (0,0) width 226: "This test passes if it does not crash."
         RenderText {#text} at (0,0) size 0x0
         RenderBR {BR} at (225,0) size 1x18
-      RenderBlock {UL} at (0,34) size 784x54
-        RenderListItem {LI} at (40,0) size 744x54
-          RenderBlock (anonymous) at (0,0) size 744x18
+      RenderBlock {UL} at (0,34) size 784x36
+        RenderListItem {LI} at (40,0) size 744x36
+          RenderBlock (anonymous) at (0,0) size 744x0
             RenderListMarker at (-17,0) size 7x18: bullet
-          RenderTable at (0,18) size 32x18
+          RenderTable at (0,0) size 32x18
             RenderTableSection (anonymous) at (0,0) size 32x18
               RenderTableRow (anonymous) at (0,0) size 32x18
                 RenderTableCell (anonymous) at (0,0) size 32x18 [r=0 c=0 rs=1 cs=1]
                   RenderText at (0,0) size 32x18
                     text run at (0,0) width 32: "hello"
-          RenderBlock (anonymous) at (0,36) size 744x18
+          RenderBlock (anonymous) at (0,18) size 744x18
             RenderText {#text} at (0,0) size 23x18
               text run at (0,0) width 23: "test"

--- a/LayoutTests/platform/mac/fast/forms/form-hides-table-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/form-hides-table-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 785x658
+layer at (0,0) size 785x640
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x658
-  RenderBlock {HTML} at (0,0) size 785x658
-    RenderBody {BODY} at (8,8) size 769x642
+layer at (0,0) size 785x640
+  RenderBlock {HTML} at (0,0) size 785x640
+    RenderBody {BODY} at (8,8) size 769x624
       RenderBlock {P} at (0,0) size 769x18
         RenderText {#text} at (0,0) size 564x18
           text run at (0,0) width 564: "This page has a few tables within form elements within divs with various display styles."
@@ -32,18 +32,18 @@ layer at (0,0) size 785x658
                   RenderTableCell {TD} at (2,2) size 93x20 [r=0 c=0 rs=1 cs=1]
                     RenderText {#text} at (1,1) size 91x18
                       text run at (1,1) width 91: "display: block"
-      RenderBlock {DIV} at (0,148) size 769x42
-        RenderListItem {DIV} at (0,0) size 769x42
-          RenderBlock (anonymous) at (0,0) size 769x18
+      RenderBlock {DIV} at (0,148) size 769x24
+        RenderListItem {DIV} at (0,0) size 769x24
+          RenderBlock (anonymous) at (0,0) size 769x0
             RenderListMarker at (-17,0) size 7x18: bullet
-          RenderBlock {FORM} at (0,18) size 769x24
+          RenderBlock {FORM} at (0,0) size 769x24
             RenderTable {TABLE} at (0,0) size 114x24
               RenderTableSection {TBODY} at (0,0) size 114x24
                 RenderTableRow {TR} at (0,2) size 114x20
                   RenderTableCell {TD} at (2,2) size 110x20 [r=0 c=0 rs=1 cs=1]
                     RenderText {#text} at (1,1) size 108x18
                       text run at (1,1) width 108: "display: list-item"
-      RenderBlock {DIV} at (0,206) size 769x24
+      RenderBlock {DIV} at (0,188) size 769x24
         RenderBlock {DIV} at (0,0) size 769x24
           RenderBlock {FORM} at (0,0) size 769x24
             RenderTable {TABLE} at (0,0) size 115x24
@@ -52,7 +52,7 @@ layer at (0,0) size 785x658
                   RenderTableCell {TD} at (2,2) size 111x20 [r=0 c=0 rs=1 cs=1]
                     RenderText {#text} at (1,1) size 109x18
                       text run at (1,1) width 109: "display: compact"
-      RenderBlock {DIV} at (0,246) size 769x40
+      RenderBlock {DIV} at (0,228) size 769x40
         RenderBlock {DIV} at (0,0) size 138x40
           RenderBlock {FORM} at (0,0) size 138x24
             RenderTable {TABLE} at (0,0) size 138x24
@@ -61,7 +61,7 @@ layer at (0,0) size 785x658
                   RenderTableCell {TD} at (2,2) size 134x20 [r=0 c=0 rs=1 cs=1]
                     RenderText {#text} at (1,1) size 132x18
                       text run at (1,1) width 132: "display: inline-block"
-      RenderBlock {DIV} at (0,286) size 769x40
+      RenderBlock {DIV} at (0,268) size 769x40
         RenderTable {DIV} at (0,0) size 92x40
           RenderTableSection (anonymous) at (0,0) size 92x40
             RenderTableRow (anonymous) at (0,0) size 92x40
@@ -73,7 +73,7 @@ layer at (0,0) size 785x658
                         RenderTableCell {TD} at (2,2) size 88x20 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 86x18
                             text run at (1,1) width 86: "display: table"
-      RenderBlock {DIV} at (0,326) size 769x40
+      RenderBlock {DIV} at (0,308) size 769x40
         RenderTable {DIV} at (0,0) size 134x40
           RenderTableSection (anonymous) at (0,0) size 134x40
             RenderTableRow (anonymous) at (0,0) size 134x40
@@ -85,7 +85,7 @@ layer at (0,0) size 785x658
                         RenderTableCell {TD} at (2,2) size 130x20 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 128x18
                             text run at (1,1) width 128: "display: inline-table"
-      RenderBlock {DIV} at (0,366) size 769x40
+      RenderBlock {DIV} at (0,348) size 769x40
         RenderTable at (0,0) size 165x40
           RenderTableSection {DIV} at (0,0) size 165x40
             RenderTableRow (anonymous) at (0,0) size 165x40
@@ -97,7 +97,7 @@ layer at (0,0) size 785x658
                         RenderTableCell {TD} at (2,2) size 161x20 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 159x18
                             text run at (1,1) width 159: "display: table-row-group"
-      RenderBlock {DIV} at (0,406) size 769x40
+      RenderBlock {DIV} at (0,388) size 769x40
         RenderTable at (0,0) size 183x40
           RenderTableSection {DIV} at (0,0) size 183x40
             RenderTableRow (anonymous) at (0,0) size 183x40
@@ -109,7 +109,7 @@ layer at (0,0) size 785x658
                         RenderTableCell {TD} at (2,2) size 179x20 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 177x18
                             text run at (1,1) width 177: "display: table-header-group"
-      RenderBlock {DIV} at (0,446) size 769x40
+      RenderBlock {DIV} at (0,428) size 769x40
         RenderTable at (0,0) size 178x40
           RenderTableSection {DIV} at (0,0) size 178x40
             RenderTableRow (anonymous) at (0,0) size 178x40
@@ -121,7 +121,7 @@ layer at (0,0) size 785x658
                         RenderTableCell {TD} at (2,2) size 174x20 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 172x18
                             text run at (1,1) width 172: "display: table-footer-group"
-      RenderBlock {DIV} at (0,486) size 769x40
+      RenderBlock {DIV} at (0,468) size 769x40
         RenderTable at (0,0) size 122x40
           RenderTableSection (anonymous) at (0,0) size 122x40
             RenderTableRow {DIV} at (0,0) size 122x40
@@ -133,14 +133,14 @@ layer at (0,0) size 785x658
                         RenderTableCell {TD} at (2,2) size 118x20 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 116x18
                             text run at (1,1) width 116: "display: table-row"
-      RenderBlock {DIV} at (0,526) size 769x0
+      RenderBlock {DIV} at (0,508) size 769x0
         RenderTable at (0,0) size 0x0
           RenderTableCol {DIV} at (0,0) size 0x0
-      RenderBlock {DIV} at (0,526) size 769x0
+      RenderBlock {DIV} at (0,508) size 769x0
         RenderTable at (0,0) size 0x0
           RenderTableCol at (0,0) size 0x0
             RenderTableCol {DIV} at (0,0) size 0x0
-      RenderBlock {DIV} at (0,526) size 769x40
+      RenderBlock {DIV} at (0,508) size 769x40
         RenderTable at (0,0) size 121x40
           RenderTableSection (anonymous) at (0,0) size 121x40
             RenderTableRow (anonymous) at (0,0) size 121x40
@@ -152,7 +152,7 @@ layer at (0,0) size 785x658
                         RenderTableCell {TD} at (2,2) size 117x20 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 115x18
                             text run at (1,1) width 115: "display: table-cell"
-      RenderBlock {DIV} at (0,566) size 769x76
+      RenderBlock {DIV} at (0,548) size 769x76
         RenderTable at (0,0) size 57x76
           RenderBlock {DIV} at (0,0) size 57x76
             RenderBlock {FORM} at (0,0) size 57x60

--- a/LayoutTests/platform/mac/fast/lists/ordered-list-with-no-ol-tag-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/ordered-list-with-no-ol-tag-expected.txt
@@ -1,15 +1,15 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x540
-  RenderBlock {HTML} at (0,0) size 800x540
-    RenderBody {BODY} at (8,19) size 784x513
+layer at (0,0) size 800x504
+  RenderBlock {HTML} at (0,0) size 800x504
+    RenderBody {BODY} at (8,19) size 784x477
       RenderBlock {H2} at (0,0) size 784x28
         RenderText {#text} at (0,0) size 302x28
           text run at (0,0) width 302: "A regular two level nested list"
       RenderBlock {P} at (0,47) size 784x19
         RenderText {#text} at (0,0) size 566x18
           text run at (0,0) width 566: "The outer list is numbered using decimal numerals, the inner lists with lower case letters"
-      RenderBlock {DIV} at (24,81) size 760x431 [border: (1px solid #000000)]
+      RenderBlock {DIV} at (24,81) size 760x395 [border: (1px solid #000000)]
         RenderListItem {DIV} at (33,1) size 726x20 [border: (1px solid #000000)]
           RenderListMarker at (-20,1) size 16x18: "1"
           RenderText {#text} at (33,1) size 42x18
@@ -67,15 +67,15 @@ layer at (0,0) size 800x540
           RenderListMarker at (-20,1) size 16x18: "4"
           RenderText {#text} at (33,1) size 42x18
             text run at (33,1) width 42: "Item 4"
-        RenderListItem {DIV} at (33,297) size 726x112 [border: (1px solid #000000)]
+        RenderListItem {DIV} at (33,297) size 726x76 [border: (1px solid #000000)]
           RenderBlock (anonymous) at (33,1) size 692x18
             RenderListMarker at (-53,0) size 16x18: "5"
             RenderText {#text} at (0,0) size 42x18
               text run at (0,0) width 42: "Item 5"
-          RenderListItem {TABLE} at (33,19) size 692x46 [border: (1px dashed #000000)]
-            RenderBlock (anonymous) at (1,1) size 690x18
+          RenderListItem {TABLE} at (33,19) size 692x28 [border: (1px dashed #000000)]
+            RenderBlock (anonymous) at (1,1) size 690x0
               RenderListMarker at (-21,0) size 16x18: "a"
-            RenderTable at (1,19) size 193x26
+            RenderTable at (1,1) size 193x26
               RenderTableSection {TBODY} at (0,0) size 193x26
                 RenderTableRow {TR} at (0,2) size 193x22
                   RenderTableCell {TD} at (2,2) size 94x22 [border: (1px dotted #000000)] [r=0 c=0 rs=1 cs=1]
@@ -84,10 +84,10 @@ layer at (0,0) size 800x540
                   RenderTableCell {TD} at (97,2) size 94x22 [border: (1px dotted #000000)] [r=0 c=1 rs=1 cs=1]
                     RenderText {#text} at (2,2) size 89x18
                       text run at (2,2) width 89: "Table Cell B1"
-          RenderListItem {TABLE} at (33,65) size 692x46 [border: (1px dashed #000000)]
-            RenderBlock (anonymous) at (1,1) size 690x18
+          RenderListItem {TABLE} at (33,47) size 692x28 [border: (1px dashed #000000)]
+            RenderBlock (anonymous) at (1,1) size 690x0
               RenderListMarker at (-21,0) size 16x18: "b"
-            RenderTable at (1,19) size 217x26
+            RenderTable at (1,1) size 217x26
               RenderTableSection {TBODY} at (0,0) size 217x26
                 RenderTableRow {TR} at (0,2) size 217x22
                   RenderTableCell {TD} at (2,2) size 106x22 [border: (1px dotted #000000)] [r=0 c=0 rs=1 cs=1]
@@ -96,7 +96,7 @@ layer at (0,0) size 800x540
                   RenderTableCell {TD} at (109,2) size 106x22 [border: (1px dotted #000000)] [r=0 c=1 rs=1 cs=1]
                     RenderText {#text} at (2,2) size 101x18
                       text run at (2,2) width 101: "Table 2 Cell B1"
-        RenderListItem {DIV} at (33,409) size 726x20 [border: (1px solid #000000)]
+        RenderListItem {DIV} at (33,373) size 726x20 [border: (1px solid #000000)]
           RenderListMarker at (-20,1) size 16x18: "6"
           RenderText {#text} at (33,1) size 42x18
             text run at (33,1) width 42: "Item 6"

--- a/Source/WebCore/layout/formattingContexts/inline/InlineQuirks.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineQuirks.cpp
@@ -31,6 +31,8 @@
 #include "LayoutBoxInlines.h"
 #include "InlineLineBox.h"
 #include "LayoutBoxGeometry.h"
+#include "LayoutBoxInlines.h"
+#include "LayoutElementBox.h"
 #include "RenderStyle+GettersInlines.h"
 
 namespace WebCore {
@@ -220,8 +222,14 @@ bool InlineQuirks::shouldCollapseLineBoxHeight(const Line::RunList& lineContent,
     if (!lineContent.size() || numberOfOutsideListMarkers != 1)
         return false;
 
-    if (!lineContent[0].isListMarkerOutside()) {
-        ASSERT(lineContent[0].isListMarkerInside());
+    auto& marker = lineContent[0];
+    auto* markerBox = dynamicDowncast<Layout::ElementBox>(marker.layoutBox());
+    ASSERT(markerBox);
+    if (!markerBox)
+        return false;
+
+    if (!marker.isListMarkerOutside()) {
+        ASSERT(marker.isListMarkerInside());
         return false;
     }
 
@@ -235,14 +243,18 @@ bool InlineQuirks::shouldCollapseLineBoxHeight(const Line::RunList& lineContent,
             ++emptyInlineBoxCount;
     }
 
-    if (lineContent[0].isListMarkerOutside() && emptyInlineBoxCount && emptyInlineBoxCount == lineContent.size() - 1) {
-        // This is to handle non-contentful lines introduced by block boxes. They are supposed to be collapsed so that
-        // the block content can be placed next to the list marker.
-        // Regular inline content would never produced a line with inline box only runs. Also inline content like <li><span><br>
-        // is not supposed to produce a collapsed line box.
-        // The underlying issue is the assumption that we shouldn’t collapse when rootBox is a list item (see below).
+    // This is to handle non-contentful lines introduced by block boxes. They are supposed to be collapsed so that
+    // the block content can be placed next to the list marker.
+    // Regular inline content would never produced a line with inline box only runs. Also inline content like <li><span><br>
+    // is not supposed to produce a collapsed line box.
+    // The underlying issue is the assumption that we shouldn’t collapse when rootBox is a list item (see below).
+    if (emptyInlineBoxCount && emptyInlineBoxCount == lineContent.size() - 1)
         return true;
-    }
+
+    // When an outside marker ends up in an anonymous block because blockification (e.g., by a flex/grid container)
+    // prevented finding a line box parent, collapse the line box so it doesn’t inflate the list item.
+    if (markerBox->shouldCollapseAnonymousBlockParentForListMarker())
+        return true;
 
     auto& rootBox = formattingContext().root();
     if (rootBox.isAnonymous() || rootBox.isListItem())

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
@@ -230,6 +230,19 @@ void BoxTreeUpdater::adjustStyleIfNeeded(const RenderElement& renderer, RenderSt
         adjustStyle(*firstLineStyle);
 }
 
+static void updateListMarkerAttributes(const RenderListMarker& listMarkerRenderer, Layout::ElementBox& layoutBox)
+{
+    auto listMarkerAttributes = EnumSet<Layout::ElementBox::ListMarkerAttribute> { };
+    if (listMarkerRenderer.isImage())
+        listMarkerAttributes.add(Layout::ElementBox::ListMarkerAttribute::Image);
+    if (!listMarkerRenderer.isInside())
+        listMarkerAttributes.add(Layout::ElementBox::ListMarkerAttribute::Outside);
+    if (listMarkerRenderer.shouldCollapseAnonymousBlockParent())
+        listMarkerAttributes.add(Layout::ElementBox::ListMarkerAttribute::ShouldCollapseAnonymousBlockParent);
+
+    layoutBox.setListMarkerAttributes(listMarkerAttributes);
+}
+
 UniqueRef<Layout::Box> BoxTreeUpdater::createLayoutBox(RenderObject& renderer)
 {
     std::unique_ptr<RenderStyle> firstLineStyle = firstLineStyleFor(renderer);
@@ -284,12 +297,9 @@ UniqueRef<Layout::Box> BoxTreeUpdater::createLayoutBox(RenderObject& renderer)
     adjustStyleIfNeeded(renderElement, style, firstLineStyle.get());
 
     if (CheckedPtr listMarkerRenderer = dynamicDowncast<RenderListMarker>(renderElement)) {
-        EnumSet<Layout::ElementBox::ListMarkerAttribute> listMarkerAttributes;
-        if (listMarkerRenderer->isImage())
-            listMarkerAttributes.add(Layout::ElementBox::ListMarkerAttribute::Image);
-        if (!listMarkerRenderer->isInside())
-            listMarkerAttributes.add(Layout::ElementBox::ListMarkerAttribute::Outside);
-        return makeUniqueRef<Layout::ElementBox>(elementAttributes(renderElement), listMarkerAttributes, WTF::move(style), WTF::move(firstLineStyle));
+        auto layoutBox = makeUniqueRef<Layout::ElementBox>(elementAttributes(renderElement), EnumSet<Layout::ElementBox::ListMarkerAttribute> { }, WTF::move(style), WTF::move(firstLineStyle));
+        updateListMarkerAttributes(*listMarkerRenderer, layoutBox.get());
+        return layoutBox;
     }
 
     return makeUniqueRef<Layout::ElementBox>(elementAttributes(renderElement), WTF::move(style), WTF::move(firstLineStyle));
@@ -365,17 +375,6 @@ static void updateContentCharacteristic(const RenderText& rendererText, Layout::
         contentCharacteristic.add(Layout::InlineTextBox::ContentCharacteristic::CanUseSimplifiedContentMeasuring);
 
     inlineTextBox.setContentCharacteristic(contentCharacteristic);
-}
-
-static void updateListMarkerAttributes(const RenderListMarker& listMarkerRenderer, Layout::ElementBox& layoutBox)
-{
-    auto listMarkerAttributes = EnumSet<Layout::ElementBox::ListMarkerAttribute> { };
-    if (listMarkerRenderer.isImage())
-        listMarkerAttributes.add(Layout::ElementBox::ListMarkerAttribute::Image);
-    if (!listMarkerRenderer.isInside())
-        listMarkerAttributes.add(Layout::ElementBox::ListMarkerAttribute::Outside);
-
-    layoutBox.setListMarkerAttributes(listMarkerAttributes);
 }
 
 void BoxTreeUpdater::updateStyle(const RenderObject& renderer)

--- a/Source/WebCore/layout/layouttree/LayoutElementBox.h
+++ b/Source/WebCore/layout/layouttree/LayoutElementBox.h
@@ -43,9 +43,10 @@ class ElementBox : public Box {
 public:
     ElementBox(ElementAttributes&&, RenderStyle&&, std::unique_ptr<RenderStyle>&& firstLineStyle = nullptr, EnumSet<BaseTypeFlag> = { ElementBoxFlag });
 
-    enum class ListMarkerAttribute : bool {
+    enum class ListMarkerAttribute : uint8_t {
         Image,
         Outside,
+        ShouldCollapseAnonymousBlockParent,
     };
     ElementBox(ElementAttributes&&, EnumSet<ListMarkerAttribute>, RenderStyle&&, std::unique_ptr<RenderStyle>&& firstLineStyle = nullptr);
 
@@ -94,6 +95,7 @@ public:
 
     bool isListMarkerImage() const { return m_replacedData && m_replacedData->listMarkerAttributes.contains(ListMarkerAttribute::Image); }
     bool isListMarkerOutside() const { return m_replacedData && m_replacedData->listMarkerAttributes.contains(ListMarkerAttribute::Outside); }
+    bool shouldCollapseAnonymousBlockParentForListMarker() const { return m_replacedData && m_replacedData->listMarkerAttributes.contains(ListMarkerAttribute::ShouldCollapseAnonymousBlockParent); }
 
     // FIXME: This is temporary until after list marker content is accessible by IFC (webkit.org/b/294342)
     void setListMarkerLayoutBounds(std::pair<float, float> layoutBounds) { m_replacedData->layoutBounds = layoutBounds; }

--- a/Source/WebCore/rendering/RenderListMarker.h
+++ b/Source/WebCore/rendering/RenderListMarker.h
@@ -76,6 +76,17 @@ public:
 
     std::pair<float, float> layoutBounds() const { return m_layoutBounds; }
 
+    bool shouldCollapseAnonymousBlockParent() const { return m_shouldCollapseAnonymousBlockParent; }
+    void setShouldCollapseAnonymousBlockParent(bool value)
+    {
+        if (value) {
+            ASSERT(parent());
+            ASSERT(parent()->isAnonymousBlock());
+            ASSERT(!isInside());
+        }
+        m_shouldCollapseAnonymousBlockParent = value;
+    }
+
 private:
     void willBeDestroyed() final;
     ASCIILiteral renderName() const final { return "RenderListMarker"_s; }
@@ -112,6 +123,7 @@ private:
     LayoutUnit m_lineOffsetForListItem;
     LayoutUnit m_lineLogicalOffsetForListItem;
     std::pair<float, float> m_layoutBounds;
+    bool m_shouldCollapseAnonymousBlockParent { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp
@@ -38,10 +38,18 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderTreeBuilder::List);
 
-static std::pair<RenderBlock*, RenderBlock*> findParentOfEmptyOrFirstLineBox(RenderBlock& blockContainer, const RenderListMarker& marker)
+struct LineBoxParentSearchResult {
+    CheckedPtr<RenderBlock> parent;
+    CheckedPtr<RenderBlock> fallbackParent;
+    // FIXME: handle all block level children, not just replaced elements that got blockified.
+    bool failedDueToBlockification { false };
+};
+
+static LineBoxParentSearchResult findParentOfEmptyOrFirstLineBox(RenderBlock& blockContainer, const RenderListMarker& marker)
 {
     auto inQuirksMode = blockContainer.document().inQuirksMode();
     RenderBlock* fallbackParent = { };
+    bool failedDueToBlockification = false;
 
     for (auto& child : childrenOfType<RenderObject>(blockContainer)) {
         if (&child == &marker)
@@ -49,7 +57,7 @@ static std::pair<RenderBlock*, RenderBlock*> findParentOfEmptyOrFirstLineBox(Ren
 
         if (child.isInline()) {
             if (!is<RenderInline>(child) || !isEmptyInline(downcast<RenderInline>(child)))
-                return { &blockContainer, { } };
+                return { &blockContainer, { }, false };
             fallbackParent = &blockContainer;
         }
 
@@ -62,39 +70,53 @@ static std::pair<RenderBlock*, RenderBlock*> findParentOfEmptyOrFirstLineBox(Ren
         if (is<RenderListItem>(blockContainer) && inQuirksMode && child.node() && isHTMLListElement(*child.node()))
             break;
 
-        if (!is<RenderBlock>(child) || is<RenderTable>(child) || child.style().display() == Style::DisplayType::BlockRuby)
+        if (!is<RenderBlock>(child) || is<RenderTable>(child) || child.style().display() == Style::DisplayType::BlockRuby) {
+            failedDueToBlockification = true;
             break;
+        }
 
         auto& blockChild = downcast<RenderBlock>(child);
-        auto [ nestedParent, nestedFallbackParent ] = findParentOfEmptyOrFirstLineBox(blockChild, marker);
-        if (nestedParent)
-            return { nestedParent, { } };
+        auto nestedResult = findParentOfEmptyOrFirstLineBox(blockChild, marker);
+        if (nestedResult.parent) {
+            // Finding a line box parent is mutually exclusive with blockification failure.
+            ASSERT(!nestedResult.failedDueToBlockification);
+            return { nestedResult.parent, { }, false };
+        }
+
+        // Propagate the blockification failure bit from nested searches so that we know whether the search failed due to blockification or because there was no inline content.
+        failedDueToBlockification |= nestedResult.failedDueToBlockification;
 
         if (!fallbackParent) {
-            if (nestedFallbackParent)
-                fallbackParent = nestedFallbackParent;
+            if (nestedResult.fallbackParent)
+                fallbackParent = nestedResult.fallbackParent;
             else if (auto* firstInFlowChild = blockChild.firstInFlowChild(); !firstInFlowChild || firstInFlowChild == &marker)
                 fallbackParent = &blockChild;
         }
     }
 
-    return { { }, fallbackParent };
+    return { { }, fallbackParent, failedDueToBlockification };
 }
 
-static RenderBlock* parentCandidateForMarker(RenderListItem& listItemRenderer, const RenderListMarker& marker)
+struct MarkerParentSearchResult {
+    CheckedPtr<RenderBlock> parent;
+    bool shouldCollapseAnonymousBlockParent { false };
+};
+
+static MarkerParentSearchResult parentCandidateForMarker(RenderListItem& listItemRenderer, const RenderListMarker& marker)
 {
     if (marker.isInside()) {
         if (auto* firstChild = dynamicDowncast<RenderBlock>(listItemRenderer.firstChild())) {
             if (!firstChild->isAnonymous())
-                return &listItemRenderer;
+                return { &listItemRenderer, false };
             // We may have created this anonymous block for the marker itself. Let's keep it in there.
             if (firstChild->firstChild() == &marker && !marker.nextSibling())
-                return firstChild;
+                return { firstChild, false };
         }
-        return findParentOfEmptyOrFirstLineBox(listItemRenderer, marker).first;
+        auto result = findParentOfEmptyOrFirstLineBox(listItemRenderer, marker);
+        return { result.parent, false };
     }
-    auto [parentCandidate, fallbackParent] = findParentOfEmptyOrFirstLineBox(listItemRenderer, marker);
-    return parentCandidate ? parentCandidate : fallbackParent;
+    auto result = findParentOfEmptyOrFirstLineBox(listItemRenderer, marker);
+    return { result.parent ? result.parent : result.fallbackParent, result.failedDueToBlockification };
 }
 
 static RenderObject* firstNonMarkerChild(RenderBlock& parent)
@@ -135,42 +157,49 @@ void RenderTreeBuilder::List::updateItemMarker(RenderListItem& listItemRenderer)
             return;
         }
 
-        auto* newParent = parentCandidateForMarker(listItemRenderer, *markerRenderer);
-        if (!newParent) {
+        auto searchResult = parentCandidateForMarker(listItemRenderer, *markerRenderer);
+        if (!searchResult.parent) {
             if (currentParent->isAnonymousBlock()) {
-                // If the marker is currently contained inside an anonymous box. then we are the only item in that anonymous box
-                // (since no line box parent was found). It's ok to just leave the marker where it is in this case.
+                // For outside markers, if the search failed because a flex/grid container blockified a replaced
+                // child (e.g., <img>), we should collapse the anonymous block's height so it doesn't inflate the list item.
+                markerRenderer->setShouldCollapseAnonymousBlockParent(searchResult.shouldCollapseAnonymousBlockParent);
+                // If the marker is currently contained inside an anonymous box, we are the only item in that anonymous box
+                // since no line box parent was found. It's ok to just leave the marker where it is in this case.
                 return;
             }
-            newParent = &listItemRenderer;
+            searchResult.parent = &listItemRenderer;
             if (auto* multiColumnFlow = listItemRenderer.multiColumnFlow())
-                newParent = multiColumnFlow;
+                searchResult.parent = multiColumnFlow;
         }
 
-        if (newParent == currentParent)
+        if (searchResult.parent == currentParent)
             return;
 
-        m_builder.attach(*newParent, m_builder.detach(*currentParent, *markerRenderer, WillBeDestroyed::No, RenderTreeBuilder::CanCollapseAnonymousBlock::No), firstNonMarkerChild(*newParent));
+        m_builder.attach(*searchResult.parent, m_builder.detach(*currentParent, *markerRenderer, WillBeDestroyed::No, RenderTreeBuilder::CanCollapseAnonymousBlock::No), firstNonMarkerChild(*searchResult.parent));
+
         // If current parent is an anonymous block that has lost all its children, destroy it.
-        if (currentParent->isAnonymousBlock() && !currentParent->firstChild())
+        if (currentParent->isAnonymousBlock() && !currentParent->firstChild()) {
+            // Clear the CheckedPtr first because m_builder.destroy may delete the block that searchResult.parent points to.
+            searchResult.parent = nullptr;
             m_builder.destroy(*currentParent);
+        }
         return;
     }
 
     RenderPtr<RenderListMarker> newMarkerRenderer = WebCore::createRenderer<RenderListMarker>(listItemRenderer, WTF::move(newStyle));
     newMarkerRenderer->initializeStyle();
     listItemRenderer.setMarkerRenderer(*newMarkerRenderer);
-    auto* newParent = parentCandidateForMarker(listItemRenderer, *newMarkerRenderer);
-    if (!newParent) {
-        // If the marker is currently contained inside an anonymous box,
-        // then we are the only item in that anonymous box (since no line box
-        // parent was found). It's ok to just leave the marker where it is
-        // in this case.
-        newParent = &listItemRenderer;
+    auto searchResult = parentCandidateForMarker(listItemRenderer, *newMarkerRenderer);
+    auto shouldCollapseAnonymousBlockParent = !searchResult.parent && !newMarkerRenderer->isInside() && searchResult.shouldCollapseAnonymousBlockParent;
+    if (!searchResult.parent) {
+        searchResult.parent = &listItemRenderer;
         if (auto* multiColumnFlow = listItemRenderer.multiColumnFlow())
-            newParent = multiColumnFlow;
+            searchResult.parent = multiColumnFlow;
     }
-    m_builder.attach(*newParent, WTF::move(newMarkerRenderer), firstNonMarkerChild(*newParent));
+    m_builder.attach(*searchResult.parent, WTF::move(newMarkerRenderer), firstNonMarkerChild(*searchResult.parent));
+    // For outside markers, if the search failed because a flex/grid container blockified a replaced
+    // child (e.g., <img>), we should collapse the anonymous block's height so it doesn't inflate the list item.
+    listItemRenderer.markerRenderer()->setShouldCollapseAnonymousBlockParent(shouldCollapseAnonymousBlockParent);
 }
 
 }


### PR DESCRIPTION
#### e30f6fb87635988779e19e177fc2203c8ee334f8
<pre>
[Reland][List Marker] Collapse anonymous blocks created for outside marker when block level elements prevents line-box parenting.
<a href="https://bugs.webkit.org/show_bug.cgi?id=311038">https://bugs.webkit.org/show_bug.cgi?id=311038</a>
&lt;<a href="https://rdar.apple.com/173417560">rdar://173417560</a>&gt;

Reviewed by Alan Baradlay.

This PR relands 309272@main and 309466@main which were reverted in 309904@main due to
a CheckedPtrDeleteCheckException.

[Bug Summary]

The crash was caused by the original PR switching raw pointers to checked pointers.
This switch exposed a latent bug where:

m_builder.destroy(*currentParent);

destroyed the block searchResult.parent points to and causing a CheckedPtrDeleteCheckException.

Note that the previous raw pointer was never dereferenced so we didn’t run into any use-after-free issues.

[Bug Fix]

See RenderTreeBuilder::List::updateItemMarker, line 183:

We now explicitly clear searchResult.parent before calling m_builder.destroy.

A new test has been added in list-marker-crash-1.html

[Combined Commit Message]

findParentOfEmptyOrFirstLineBox fails to find a suitable line-box parent
when we run into a block item. In this case, we fall back to creating an
anonymous block to parent the list marker. However, the anonymous block inherites
line height and pushed the visual content down and no longer next to the list marker,
resulting in unintended behavior.

This PR fixes the issue by detecting parenting failure due to block items
and flagging the marker to collapse its parent block.

This PR fixes the behavior for explicitly (&quot;display: block&quot;) and implicitly (&quot;display: flex&quot;) blockified items.

* LayoutTests/fast/lists/list-marker-before-content-table-expected.txt:
* LayoutTests/fast/lists/list-marker-crash-1-expected.txt: Added.
* LayoutTests/fast/lists/list-marker-crash-1.html: Added.
* LayoutTests/fast/lists/list-marker-outside-flex-collapse-anonymous-block-expected.html: Added.
* LayoutTests/fast/lists/list-marker-outside-flex-collapse-anonymous-block.html: Added.
* LayoutTests/platform/glib/fast/css-generated-content/table-row-group-with-before-expected.txt:
* LayoutTests/platform/glib/fast/css-generated-content/table-row-with-before-expected.txt:
* LayoutTests/platform/glib/fast/css-generated-content/table-with-before-expected.txt:
* LayoutTests/platform/glib/fast/forms/form-hides-table-expected.txt:
* LayoutTests/platform/glib/fast/lists/ordered-list-with-no-ol-tag-expected.txt:
* LayoutTests/platform/ios/fast/css-generated-content/table-row-group-with-before-expected.txt:
* LayoutTests/platform/ios/fast/css-generated-content/table-row-with-before-expected.txt:
* LayoutTests/platform/ios/fast/css-generated-content/table-with-before-expected.txt:
* LayoutTests/platform/ios/fast/forms/form-hides-table-expected.txt:
* LayoutTests/platform/ios/fast/lists/ordered-list-with-no-ol-tag-expected.txt:
* LayoutTests/platform/mac/fast/css-generated-content/table-row-group-with-before-expected.txt:
* LayoutTests/platform/mac/fast/css-generated-content/table-row-with-before-expected.txt:
* LayoutTests/platform/mac/fast/css-generated-content/table-with-before-expected.txt:
* LayoutTests/platform/mac/fast/forms/form-hides-table-expected.txt:
* LayoutTests/platform/mac/fast/lists/ordered-list-with-no-ol-tag-expected.txt:
* Source/WebCore/layout/formattingContexts/inline/InlineQuirks.cpp:
(WebCore::Layout::InlineQuirks::shouldCollapseLineBoxHeight const):
* Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp:
(WebCore::LayoutIntegration::updateListMarkerAttributes):
(WebCore::LayoutIntegration::BoxTreeUpdater::createLayoutBox):
* Source/WebCore/layout/layouttree/LayoutElementBox.h:
(WebCore::Layout::ElementBox::shouldCollapseAnonymousBlockParentForListMarker const):
* Source/WebCore/rendering/RenderListMarker.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp:
(WebCore::findParentOfEmptyOrFirstLineBox):
(WebCore::parentCandidateForMarker):
(WebCore::RenderTreeBuilder::List::updateItemMarker):

Canonical link: <a href="https://commits.webkit.org/311221@main">https://commits.webkit.org/311221@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16fa8cd6b202fe327b3b2ec49c006174e65b86d3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153089 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25871 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19469 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161833 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106547 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d21fa41a-7d60-485d-af6b-245b388928ea) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154962 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26398 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/29725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118334 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/85087 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b3026419-5692-4b0f-ba73-e37d01c8ab79) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156048 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20597 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137435 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99047 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e4a82cb4-32b3-463e-a3c3-52499f306e4e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19641 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9669 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129294 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15308 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164307 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7443 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16902 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126393 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25668 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21622 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126551 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35029 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25670 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137104 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82325 "Built successfully") | | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/23799 "The change is no longer eligible for processing.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21504 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13883 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25286 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89573 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24979 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25137 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25038 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->