### PR TITLE
[Site Isolation] Add layout tests for UIProcess back/forward navigation edge cases

### DIFF
--- a/LayoutTests/http/tests/site-isolation/history/about-blank-iframe-back-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/history/about-blank-iframe-back-expected.txt
@@ -1,0 +1,11 @@
+Verifies that an about:blank iframe is handled correctly during back navigation with site isolation.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS document.querySelectorAll('iframe').length is 2
+PASS event.data.includes('id=cross') is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/history/about-blank-iframe-back.html
+++ b/LayoutTests/http/tests/site-isolation/history/about-blank-iframe-back.html
@@ -1,0 +1,36 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true UsesBackForwardCache=false ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Verifies that an about:blank iframe is handled correctly during back navigation with site isolation.");
+jsTestIsAsync = true;
+
+var loadCount = 0;
+
+onmessage = (event) => {
+    loadCount++;
+
+    if (sessionStorage.verifyPhase) {
+        // After back navigation, the page is restored. The about:blank iframe
+        // should exist (re-created from HTML source).
+        shouldBe("document.querySelectorAll('iframe').length", "2");
+        // The cross-origin iframe should report its URL.
+        shouldBeTrue("event.data.includes('id=cross')");
+        delete sessionStorage.verifyPhase;
+        finishJSTest();
+        return;
+    }
+
+    if (loadCount === 1) {
+        // Cross-origin iframe loaded. The about:blank iframe doesn't fire onload via postMessage.
+        // Navigate the cross-origin iframe.
+        document.getElementById("cross").src =
+            "http://localhost:8000/site-isolation/history/resources/report-url.html?id=cross&navigated=true";
+    } else if (loadCount === 2) {
+        // Cross-origin iframe navigated. Navigate main frame away.
+        sessionStorage.verifyPhase = "true";
+        location.href = "/site-isolation/history/resources/go-back.html";
+    }
+};
+</script>
+<iframe id="blank" src="about:blank"></iframe>
+<iframe id="cross" src="http://localhost:8000/site-isolation/history/resources/report-url.html?id=cross"></iframe>

--- a/LayoutTests/http/tests/site-isolation/history/add-iframe-then-go-back-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/history/add-iframe-then-go-back-expected.txt
@@ -1,0 +1,10 @@
+Verifies that back navigation restores the correct frame tree even when an iframe was dynamically added before navigating away.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS iframeAUrl.includes('id=a&navigated=true') is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/history/add-iframe-then-go-back.html
+++ b/LayoutTests/http/tests/site-isolation/history/add-iframe-then-go-back.html
@@ -1,0 +1,44 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true UsesBackForwardCache=false ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Verifies that back navigation restores the correct frame tree even when an iframe was dynamically added before navigating away.");
+jsTestIsAsync = true;
+
+var loadCount = 0;
+var iframeAUrl = "";
+
+onmessage = (event) => {
+    var url = event.data;
+    if (url.includes("id=a"))
+        iframeAUrl = url;
+    loadCount++;
+
+    if (sessionStorage.verifyPhase) {
+        // After back, the page should be restored to the state when we left.
+        // The dynamically added iframe should NOT be present (it was added after the
+        // back/forward list entry was created for iframe A's navigation).
+        // Only iframe A (from the HTML source) should be restored.
+        shouldBeTrue("iframeAUrl.includes('id=a&navigated=true')");
+        delete sessionStorage.verifyPhase;
+        finishJSTest();
+        return;
+    }
+
+    if (loadCount === 1) {
+        // Original iframe loaded. Navigate it.
+        document.getElementById("a").src =
+            "http://localhost:8000/site-isolation/history/resources/report-url.html?id=a&navigated=true";
+    } else if (loadCount === 2) {
+        // iframe A navigated. Dynamically add a second iframe.
+        var iframe = document.createElement("iframe");
+        iframe.id = "dynamic";
+        iframe.src = "http://localhost:8000/site-isolation/history/resources/report-url.html?id=dynamic";
+        document.body.appendChild(iframe);
+    } else if (loadCount === 3) {
+        // Dynamic iframe loaded. Navigate main frame away.
+        sessionStorage.verifyPhase = "true";
+        location.href = "/site-isolation/history/resources/go-back.html";
+    }
+};
+</script>
+<iframe id="a" src="http://localhost:8000/site-isolation/history/resources/report-url.html?id=a"></iframe>

--- a/LayoutTests/http/tests/site-isolation/history/fragment-navigation-in-iframe-back-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/history/fragment-navigation-in-iframe-back-expected.txt
@@ -1,0 +1,10 @@
+Verifies that fragment navigations in a cross-origin iframe are preserved across back navigation.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS iframeUrl.endsWith('#section2') is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/history/fragment-navigation-in-iframe-back.html
+++ b/LayoutTests/http/tests/site-isolation/history/fragment-navigation-in-iframe-back.html
@@ -1,0 +1,32 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true UsesBackForwardCache=false ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Verifies that fragment navigations in a cross-origin iframe are preserved across back navigation.");
+jsTestIsAsync = true;
+
+var reportCount = 0;
+var iframeUrl = "";
+
+onmessage = (event) => {
+    iframeUrl = event.data;
+    reportCount++;
+
+    if (sessionStorage.verifyPhase) {
+        // After back, iframe should be restored to the URL with fragment.
+        shouldBeTrue("iframeUrl.endsWith('#section2')");
+        delete sessionStorage.verifyPhase;
+        finishJSTest();
+        return;
+    }
+
+    if (reportCount === 1) {
+        // Initial load complete. Tell iframe to navigate to #section2.
+        document.getElementById("frame").contentWindow.postMessage("navigate-hash:section2", "*");
+    } else if (reportCount === 2) {
+        // hashchange reported. Navigate main frame away.
+        sessionStorage.verifyPhase = "true";
+        location.href = "/site-isolation/history/resources/go-back.html";
+    }
+};
+</script>
+<iframe id="frame" src="http://localhost:8000/site-isolation/history/resources/report-url-on-request.html"></iframe>

--- a/LayoutTests/http/tests/site-isolation/history/iframe-redirect-back-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/history/iframe-redirect-back-expected.txt
@@ -1,0 +1,11 @@
+Verifies that a cross-origin iframe that was navigated via client-side redirect is correctly restored after back navigation.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS iframeUrl.includes('id=redirected') is true
+PASS iframeUrl.includes('redirect-to') is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/history/iframe-redirect-back.html
+++ b/LayoutTests/http/tests/site-isolation/history/iframe-redirect-back.html
@@ -1,0 +1,35 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true UsesBackForwardCache=false ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Verifies that a cross-origin iframe that was navigated via client-side redirect is correctly restored after back navigation.");
+jsTestIsAsync = true;
+
+var reportCount = 0;
+var iframeUrl = "";
+
+onmessage = (event) => {
+    iframeUrl = event.data;
+    reportCount++;
+
+    if (sessionStorage.verifyPhase) {
+        // After back, iframe should be at the redirect target, not the redirect source.
+        shouldBeTrue("iframeUrl.includes('id=redirected')");
+        shouldBeFalse("iframeUrl.includes('redirect-to')");
+        delete sessionStorage.verifyPhase;
+        finishJSTest();
+        return;
+    }
+
+    if (reportCount === 1) {
+        // Initial load. Navigate iframe to a page that redirects.
+        document.getElementById("frame").src =
+            "http://localhost:8000/site-isolation/history/resources/redirect-to.html?url=" +
+            encodeURIComponent("/site-isolation/history/resources/report-url.html?id=redirected");
+    } else if (reportCount === 2) {
+        // Redirect completed, final page loaded. Navigate main frame away.
+        sessionStorage.verifyPhase = "true";
+        location.href = "/site-isolation/history/resources/go-back.html";
+    }
+};
+</script>
+<iframe id="frame" src="http://localhost:8000/site-isolation/history/resources/report-url.html?id=initial"></iframe>

--- a/LayoutTests/http/tests/site-isolation/history/js-history-go-from-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/history/js-history-go-from-cross-origin-iframe-expected.txt
@@ -1,0 +1,11 @@
+Verifies that history.go(-1) from a cross-origin iframe works correctly via the UIProcess path.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS iframeUrl.includes('page=a') is true
+PASS iframeUrl.includes('page=b') is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/history/js-history-go-from-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/history/js-history-go-from-cross-origin-iframe.html
@@ -1,0 +1,29 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true UsesBackForwardCache=false ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Verifies that history.go(-1) from a cross-origin iframe works correctly via the UIProcess path.");
+jsTestIsAsync = true;
+
+var reportCount = 0;
+var iframeUrl = "";
+
+onmessage = (event) => {
+    iframeUrl = event.data;
+    reportCount++;
+
+    if (reportCount === 1) {
+        // Initial load (page A). Navigate iframe to page B.
+        document.getElementById("frame").src =
+            "http://localhost:8000/site-isolation/history/resources/report-url-on-request.html?id=frame&page=b";
+    } else if (reportCount === 2) {
+        // Page B loaded. Tell iframe to go back via history.go(-1).
+        document.getElementById("frame").contentWindow.postMessage("go-back", "*");
+    } else if (reportCount === 3) {
+        // Should be back at page A.
+        shouldBeTrue("iframeUrl.includes('page=a')");
+        shouldBeFalse("iframeUrl.includes('page=b')");
+        finishJSTest();
+    }
+};
+</script>
+<iframe id="frame" src="http://localhost:8000/site-isolation/history/resources/report-url-on-request.html?id=frame&page=a"></iframe>

--- a/LayoutTests/http/tests/site-isolation/history/mixed-same-cross-origin-iframes-back-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/history/mixed-same-cross-origin-iframes-back-expected.txt
@@ -1,0 +1,11 @@
+Verifies that back navigation correctly restores a mix of same-origin and cross-origin iframes.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS crossOriginUrl is "http://localhost:8000/site-isolation/history/resources/report-url.html?id=cross&navigated=true"
+PASS sameOriginUrl is "http://127.0.0.1:8000/site-isolation/history/resources/report-url.html?id=same"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/history/mixed-same-cross-origin-iframes-back.html
+++ b/LayoutTests/http/tests/site-isolation/history/mixed-same-cross-origin-iframes-back.html
@@ -1,0 +1,41 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true UsesBackForwardCache=false ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Verifies that back navigation correctly restores a mix of same-origin and cross-origin iframes.");
+jsTestIsAsync = true;
+
+var loadCount = 0;
+var sameOriginUrl = "";
+var crossOriginUrl = "";
+
+onmessage = (event) => {
+    var url = event.data;
+    if (url.includes("id=same"))
+        sameOriginUrl = url;
+    else if (url.includes("id=cross"))
+        crossOriginUrl = url;
+    loadCount++;
+
+    if (sessionStorage.verifyPhase) {
+        if (loadCount < 2)
+            return;
+        shouldBeEqualToString("crossOriginUrl", "http://localhost:8000/site-isolation/history/resources/report-url.html?id=cross&navigated=true");
+        shouldBeEqualToString("sameOriginUrl", "http://127.0.0.1:8000/site-isolation/history/resources/report-url.html?id=same");
+        delete sessionStorage.verifyPhase;
+        finishJSTest();
+        return;
+    }
+
+    if (loadCount === 2) {
+        // Both iframes loaded. Navigate the cross-origin iframe.
+        document.getElementById("cross").src =
+            "http://localhost:8000/site-isolation/history/resources/report-url.html?id=cross&navigated=true";
+    } else if (loadCount === 3) {
+        // Cross-origin iframe navigated. Navigate main frame away.
+        sessionStorage.verifyPhase = "true";
+        location.href = "/site-isolation/history/resources/go-back.html";
+    }
+};
+</script>
+<iframe id="same" src="http://127.0.0.1:8000/site-isolation/history/resources/report-url.html?id=same"></iframe>
+<iframe id="cross" src="http://localhost:8000/site-isolation/history/resources/report-url.html?id=cross"></iframe>

--- a/LayoutTests/http/tests/site-isolation/history/multiple-cross-origin-iframes-back-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/history/multiple-cross-origin-iframes-back-expected.txt
@@ -1,0 +1,11 @@
+Verifies that back navigation correctly restores multiple cross-origin iframes.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS iframeAUrl is "http://localhost:8000/site-isolation/history/resources/report-url.html?id=a&navigated=true"
+PASS iframeBUrl is "http://localhost:8000/site-isolation/history/resources/report-url.html?id=b"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/history/multiple-cross-origin-iframes-back.html
+++ b/LayoutTests/http/tests/site-isolation/history/multiple-cross-origin-iframes-back.html
@@ -1,0 +1,41 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true UsesBackForwardCache=false ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Verifies that back navigation correctly restores multiple cross-origin iframes.");
+jsTestIsAsync = true;
+
+var loadCount = 0;
+var iframeAUrl = "";
+var iframeBUrl = "";
+
+onmessage = (event) => {
+    var url = event.data;
+    if (url.includes("id=a"))
+        iframeAUrl = url;
+    else if (url.includes("id=b"))
+        iframeBUrl = url;
+    loadCount++;
+
+    if (sessionStorage.verifyPhase) {
+        if (loadCount < 2)
+            return;
+        shouldBeEqualToString("iframeAUrl", "http://localhost:8000/site-isolation/history/resources/report-url.html?id=a&navigated=true");
+        shouldBeEqualToString("iframeBUrl", "http://localhost:8000/site-isolation/history/resources/report-url.html?id=b");
+        delete sessionStorage.verifyPhase;
+        finishJSTest();
+        return;
+    }
+
+    if (loadCount === 2) {
+        // Both iframes loaded initially. Navigate iframe A to a new URL.
+        document.getElementById("a").src =
+            "http://localhost:8000/site-isolation/history/resources/report-url.html?id=a&navigated=true";
+    } else if (loadCount === 3) {
+        // iframe A navigated. Navigate main frame away, triggering a back navigation.
+        sessionStorage.verifyPhase = "true";
+        location.href = "/site-isolation/history/resources/go-back.html";
+    }
+};
+</script>
+<iframe id="a" src="http://localhost:8000/site-isolation/history/resources/report-url.html?id=a"></iframe>
+<iframe id="b" src="http://localhost:8000/site-isolation/history/resources/report-url.html?id=b"></iframe>

--- a/LayoutTests/http/tests/site-isolation/history/pushstate-in-cross-origin-iframe-back-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/history/pushstate-in-cross-origin-iframe-back-expected.txt
@@ -1,0 +1,10 @@
+Verifies that pushState entries in a cross-origin iframe are preserved across back navigation.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS iframeUrl.includes('state=2') is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/history/pushstate-in-cross-origin-iframe-back.html
+++ b/LayoutTests/http/tests/site-isolation/history/pushstate-in-cross-origin-iframe-back.html
@@ -1,0 +1,35 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true UsesBackForwardCache=false ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Verifies that pushState entries in a cross-origin iframe are preserved across back navigation.");
+jsTestIsAsync = true;
+
+var reportCount = 0;
+var iframeUrl = "";
+
+onmessage = (event) => {
+    iframeUrl = event.data;
+    reportCount++;
+
+    if (sessionStorage.verifyPhase) {
+        // After back, iframe should be at the pushState URL.
+        shouldBeTrue("iframeUrl.includes('state=2')");
+        delete sessionStorage.verifyPhase;
+        finishJSTest();
+        return;
+    }
+
+    if (reportCount === 1) {
+        // Initial load. Tell iframe to do pushState to URLs that map to real resources.
+        var iframe = document.getElementById("frame");
+        iframe.contentWindow.postMessage("pushstate:/site-isolation/history/resources/report-url-on-request.html?state=1", "*");
+        iframe.contentWindow.postMessage("pushstate:/site-isolation/history/resources/report-url-on-request.html?state=2", "*");
+        iframe.contentWindow.postMessage("report", "*");
+    } else if (reportCount === 2) {
+        // pushState done. Navigate main frame away.
+        sessionStorage.verifyPhase = "true";
+        location.href = "/site-isolation/history/resources/go-back.html";
+    }
+};
+</script>
+<iframe id="frame" src="http://localhost:8000/site-isolation/history/resources/report-url-on-request.html"></iframe>

--- a/LayoutTests/http/tests/site-isolation/history/remove-iframe-then-go-back-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/history/remove-iframe-then-go-back-expected.txt
@@ -1,0 +1,11 @@
+Verifies that back navigation restores iframes correctly after one iframe was removed from DOM.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS iframeAUrl is "http://localhost:8000/site-isolation/history/resources/report-url.html?id=a"
+PASS iframeBUrl is "http://localhost:8000/site-isolation/history/resources/report-url.html?id=b&navigated=true"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/history/remove-iframe-then-go-back.html
+++ b/LayoutTests/http/tests/site-isolation/history/remove-iframe-then-go-back.html
@@ -1,0 +1,44 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true UsesBackForwardCache=false ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Verifies that back navigation restores iframes correctly after one iframe was removed from DOM.");
+jsTestIsAsync = true;
+
+var loadCount = 0;
+var iframeAUrl = "";
+var iframeBUrl = "";
+
+onmessage = (event) => {
+    var url = event.data;
+    if (url.includes("id=a"))
+        iframeAUrl = url;
+    else if (url.includes("id=b"))
+        iframeBUrl = url;
+    loadCount++;
+
+    if (sessionStorage.verifyPhase) {
+        if (loadCount < 2)
+            return;
+        // After back navigation, both iframes should be restored from history
+        // even though iframe A was removed before navigating away.
+        shouldBeEqualToString("iframeAUrl", "http://localhost:8000/site-isolation/history/resources/report-url.html?id=a");
+        shouldBeEqualToString("iframeBUrl", "http://localhost:8000/site-isolation/history/resources/report-url.html?id=b&navigated=true");
+        delete sessionStorage.verifyPhase;
+        finishJSTest();
+        return;
+    }
+
+    if (loadCount === 2) {
+        // Both iframes loaded. Navigate iframe B to a new URL.
+        document.getElementById("b").src =
+            "http://localhost:8000/site-isolation/history/resources/report-url.html?id=b&navigated=true";
+    } else if (loadCount === 3) {
+        // iframe B navigated. Remove iframe A from DOM, then navigate main frame away.
+        document.getElementById("a").remove();
+        sessionStorage.verifyPhase = "true";
+        location.href = "/site-isolation/history/resources/go-back.html";
+    }
+};
+</script>
+<iframe id="a" src="http://localhost:8000/site-isolation/history/resources/report-url.html?id=a"></iframe>
+<iframe id="b" src="http://localhost:8000/site-isolation/history/resources/report-url.html?id=b"></iframe>

--- a/LayoutTests/http/tests/site-isolation/history/resources/redirect-to.html
+++ b/LayoutTests/http/tests/site-isolation/history/resources/redirect-to.html
@@ -1,0 +1,9 @@
+<script>
+// Client-side redirect: navigates to the URL specified in the ?url= query parameter.
+onload = () => {
+    var params = new URLSearchParams(location.search);
+    var target = params.get("url");
+    if (target)
+        location.replace(target);
+};
+</script>

--- a/LayoutTests/http/tests/site-isolation/history/resources/report-url-on-request.html
+++ b/LayoutTests/http/tests/site-isolation/history/resources/report-url-on-request.html
@@ -1,0 +1,18 @@
+<script>
+onload = () => {
+    parent.postMessage(location.href, "*");
+};
+onhashchange = () => {
+    parent.postMessage(location.href, "*");
+};
+onmessage = (event) => {
+    if (event.data === "report")
+        parent.postMessage(location.href, "*");
+    else if (event.data === "go-back")
+        history.go(-1);
+    else if (event.data.startsWith("navigate-hash:"))
+        location.hash = event.data.substring("navigate-hash:".length);
+    else if (event.data.startsWith("pushstate:"))
+        history.pushState({}, "", event.data.substring("pushstate:".length));
+};
+</script>

--- a/LayoutTests/http/tests/site-isolation/history/resources/report-url.html
+++ b/LayoutTests/http/tests/site-isolation/history/resources/report-url.html
@@ -1,0 +1,5 @@
+<script>
+onload = () => {
+    parent.postMessage(location.href, "*");
+};
+</script>

--- a/LayoutTests/http/tests/site-isolation/history/srcdoc-iframe-back-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/history/srcdoc-iframe-back-expected.txt
@@ -1,0 +1,12 @@
+Verifies that a srcdoc iframe coexists correctly with a cross-origin iframe during back navigation.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS document.querySelectorAll('iframe').length is 2
+PASS event.data.includes('id=cross&navigated=true') is true
+PASS srcdocContent is "Hello from srcdoc"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/history/srcdoc-iframe-back.html
+++ b/LayoutTests/http/tests/site-isolation/history/srcdoc-iframe-back.html
@@ -1,0 +1,36 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true UsesBackForwardCache=false ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Verifies that a srcdoc iframe coexists correctly with a cross-origin iframe during back navigation.");
+jsTestIsAsync = true;
+
+var loadCount = 0;
+var srcdocContent = "";
+
+onmessage = (event) => {
+    loadCount++;
+
+    if (sessionStorage.verifyPhase) {
+        // After back navigation, verify both iframes exist and the cross-origin one has correct URL.
+        shouldBe("document.querySelectorAll('iframe').length", "2");
+        shouldBeTrue("event.data.includes('id=cross&navigated=true')");
+        // Verify srcdoc iframe content is restored.
+        srcdocContent = document.getElementById("srcdoc").contentDocument.body.textContent;
+        shouldBeEqualToString("srcdocContent", "Hello from srcdoc");
+        delete sessionStorage.verifyPhase;
+        finishJSTest();
+        return;
+    }
+
+    if (loadCount === 1) {
+        // Cross-origin iframe loaded. Navigate it.
+        document.getElementById("cross").src =
+            "http://localhost:8000/site-isolation/history/resources/report-url.html?id=cross&navigated=true";
+    } else if (loadCount === 2) {
+        sessionStorage.verifyPhase = "true";
+        location.href = "/site-isolation/history/resources/go-back.html";
+    }
+};
+</script>
+<iframe id="srcdoc" srcdoc="<body>Hello from srcdoc</body>"></iframe>
+<iframe id="cross" src="http://localhost:8000/site-isolation/history/resources/report-url.html?id=cross"></iframe>


### PR DESCRIPTION
#### a36c4ad4c0dc07a468327cad0603f3bc6bbd5df6
<pre>
[Site Isolation] Add layout tests for UIProcess back/forward navigation edge cases
<a href="https://bugs.webkit.org/show_bug.cgi?id=311040">https://bugs.webkit.org/show_bug.cgi?id=311040</a>
<a href="https://rdar.apple.com/173643699">rdar://173643699</a>

Reviewed by NOBODY (OOPS!).

Add 10 layout tests covering edge cases in the UseUIProcessForBackForwardItemLoading
path where the sibling-index-based frame state lookup is exercised under various
frame tree topologies and navigation patterns.

UseUIProcessForBackForwardItemLoading is implicitly enabled when SiteIsolationEnabled
is true, so the tests only specify SiteIsolationEnabled=true.

Core frame tree:
- multiple-cross-origin-iframes-back: Two cross-origin iframes, navigate one, go back
- mixed-same-cross-origin-iframes-back: Same-origin + cross-origin iframe mix
- remove-iframe-then-go-back: Remove iframe from DOM before navigating away

Navigation features:
- fragment-navigation-in-iframe-back: Hash fragment navigation in cross-origin iframe
- js-history-go-from-cross-origin-iframe: history.go(-1) from cross-origin iframe
- pushstate-in-cross-origin-iframe-back: pushState entries in cross-origin iframe

Special content:
- about-blank-iframe-back: about:blank iframe alongside cross-origin iframe
- srcdoc-iframe-back: srcdoc iframe alongside cross-origin iframe
- iframe-redirect-back: Client-side redirect in cross-origin iframe

Complex topologies:
- add-iframe-then-go-back: Dynamically added iframe before navigating away

* LayoutTests/http/tests/site-isolation/history/about-blank-iframe-back-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/history/about-blank-iframe-back.html: Added.
* LayoutTests/http/tests/site-isolation/history/add-iframe-then-go-back-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/history/add-iframe-then-go-back.html: Added.
* LayoutTests/http/tests/site-isolation/history/fragment-navigation-in-iframe-back-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/history/fragment-navigation-in-iframe-back.html: Added.
* LayoutTests/http/tests/site-isolation/history/iframe-redirect-back-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/history/iframe-redirect-back.html: Added.
* LayoutTests/http/tests/site-isolation/history/js-history-go-from-cross-origin-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/history/js-history-go-from-cross-origin-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/history/mixed-same-cross-origin-iframes-back-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/history/mixed-same-cross-origin-iframes-back.html: Added.
* LayoutTests/http/tests/site-isolation/history/multiple-cross-origin-iframes-back-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/history/multiple-cross-origin-iframes-back.html: Added.
* LayoutTests/http/tests/site-isolation/history/pushstate-in-cross-origin-iframe-back-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/history/pushstate-in-cross-origin-iframe-back.html: Added.
* LayoutTests/http/tests/site-isolation/history/remove-iframe-then-go-back-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/history/remove-iframe-then-go-back.html: Added.
* LayoutTests/http/tests/site-isolation/history/resources/redirect-to.html: Added.
* LayoutTests/http/tests/site-isolation/history/resources/report-url-on-request.html: Added.
* LayoutTests/http/tests/site-isolation/history/resources/report-url.html: Added.
* LayoutTests/http/tests/site-isolation/history/srcdoc-iframe-back-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/history/srcdoc-iframe-back.html: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/207bebe5e8f0ffdd16d46382dd33e27a9f615dd5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169424 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43346 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36635 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178781 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127136 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dc136706-a126-4604-a4c0-8721dffe5b2b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43610 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42974 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131977 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92911 "9 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f9df1366-a53f-4657-a36a-4674bdb4aaaf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172383 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34665 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152290 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112481 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9d5905b3-5131-42bf-a6e5-80cbaefccbea) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33648 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32119 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27480 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143638 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31690 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181381 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36287 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140430 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43002 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151761 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140266 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43691 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28666 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107782 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35538 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42201 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6755 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41594 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41849 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41737 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->