### PR TITLE
Improve HTMLCollection memoryCost() accuracy

### DIFF
--- a/Source/WebCore/dom/CollectionIndexCache.h
+++ b/Source/WebCore/dom/CollectionIndexCache.h
@@ -45,7 +45,7 @@ public:
 
     bool hasValidCache() const { return m_current || m_nodeCountValid || m_listValid; }
     inline void invalidate();
-    size_t memoryCost()
+    size_t memoryCost() const
     {
         // memoryCost() may be invoked concurrently from a GC thread, and we need to be careful
         // about what data we access here and how. Accessing m_cachedList.capacity() is safe

--- a/Source/WebCore/html/HTMLCollection.h
+++ b/Source/WebCore/html/HTMLCollection.h
@@ -114,9 +114,10 @@ protected:
 
 inline size_t CollectionNamedElementCache::memoryCost() const
 {
-    // memoryCost() may be invoked concurrently from a GC thread, and we need to be careful about what data we access here and how.
-    // It is safe to access m_idMap.size(), m_nameMap.size(), and m_propertyNames.size() because they don't chase pointers.
-    return (m_idMap.size() + m_nameMap.size()) * sizeof(Element*) + m_propertyNames.size() * sizeof(AtomString);
+    // memoryCost() may be invoked concurrently from a GC thread. This is safe because
+    // the named element cache is immutable after creation and its lifetime is protected
+    // by m_namedElementCacheAssignmentLock in HTMLCollection::memoryCost().
+    return m_idMap.byteSize() + m_nameMap.byteSize() + m_propertyNames.capacity() * sizeof(AtomString);
 }
 
 inline CollectionType HTMLCollection::type() const


### PR DESCRIPTION
#### 3be22f2c041ad7c342aeccd4fb5970c940c44a5b
<pre>
Improve HTMLCollection memoryCost() accuracy
<a href="https://bugs.webkit.org/show_bug.cgi?id=311043">https://bugs.webkit.org/show_bug.cgi?id=311043</a>

Reviewed by Ryosuke Niwa.

CollectionNamedElementCache::memoryCost() was significantly underestimating
memory usage by counting each HashMap entry as sizeof(Element*) (8 bytes),
when the actual per-bucket cost includes the key, the Vector&lt;WeakRef&lt;Element&gt;&gt;
value, and HashMap bucket overhead. Use HashMap::byteSize() which returns
the exact allocation size of the hash table. Also use Vector::capacity()
instead of size() for m_propertyNames to account for over-allocation.

The old comment incorrectly claimed HashMap::size() doesn&apos;t chase pointers;
it does (via m_table). Thread safety is actually ensured by the cache being
immutable after creation and its lifetime being protected by
m_namedElementCacheAssignmentLock. Updated the comment to reflect this.

Also add missing `const` qualifier to CollectionIndexCache::memoryCost().

* Source/WebCore/dom/CollectionIndexCache.h:
(WebCore::CollectionIndexCache::memoryCost const):
(WebCore::CollectionIndexCache::memoryCost): Deleted.
* Source/WebCore/html/HTMLCollection.h:
(WebCore::CollectionNamedElementCache::memoryCost const):

Canonical link: <a href="https://commits.webkit.org/310211@main">https://commits.webkit.org/310211@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c6f38b08d02549f7a45c32610c3887c43bfcf2d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153093 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25875 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19473 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161837 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106551 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/184dd2a4-71d0-4eb7-bf51-ac2eed894cc9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154966 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26402 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26180 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118335 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83791 "3 flakes 6 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/159347ab-035e-4c04-8227-5d0522a4a956) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156052 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20577 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137441 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99048 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/10612f08-c633-49eb-8123-bd9bafaf3de5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19651 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17589 "Found 5 new API test failures: TestWebKitAPI.Navigation.FormResubmited, TestWebKitAPI.WKWebExtensionAPIExtension.GetBackgroundPageForServiceWorker, TestWebKitAPI.WKWebExtensionAPIExtension.GetViewsForMultipleTabs, TestWebKitAPI.WKWebExtensionAPICommands.CommandEvent, TestWebKitAPI.WKWebExtensionAPICookies.ErrorsRead (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9673 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129304 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15314 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164311 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7447 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16908 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/api/crashtests/huge-fetch.any.sharedworker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126398 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25672 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21626 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126556 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34332 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25674 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137110 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82331 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21512 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13889 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25290 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89577 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24983 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25141 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25042 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->