### PR TITLE
Static NodeList subclasses should report their memoryCost to the GC

### DIFF
--- a/Source/WebCore/dom/StaticNodeList.h
+++ b/Source/WebCore/dom/StaticNodeList.h
@@ -46,6 +46,7 @@ public:
 
     WEBCORE_EXPORT unsigned length() const override;
     WEBCORE_EXPORT Node* item(unsigned index) const override;
+    size_t memoryCost() const override { return m_nodes.capacity() * sizeof(Ref<Node>); }
 
 private:
     WEBCORE_EXPORT StaticNodeList(Vector<Ref<Node>>&& nodes);
@@ -62,6 +63,7 @@ public:
 
     unsigned length() const override;
     Node* item(unsigned index) const override;
+    size_t memoryCost() const override { return m_nodeList->memoryCost(); }
 
 private:
     StaticWrapperNodeList(NodeList& nodeList)
@@ -81,6 +83,7 @@ public:
 
     unsigned length() const override;
     Element* item(unsigned index) const override;
+    size_t memoryCost() const override { return m_elements.capacity() * sizeof(Ref<Element>); }
 
 private:
     StaticElementList(Vector<Ref<Element>>&& elements)


### PR DESCRIPTION
#### 27813d31905562646dbe49b2e0cc3473ca3a3bfe
<pre>
Static NodeList subclasses should report their memoryCost to the GC
<a href="https://bugs.webkit.org/show_bug.cgi?id=311044">https://bugs.webkit.org/show_bug.cgi?id=311044</a>

Reviewed by Ryosuke Niwa.

StaticNodeList, StaticElementList, and StaticWrapperNodeList did not
override memoryCost(), so the base NodeList implementation always
reported 0 to the JS garbage collector. This means the GC had no
visibility into memory held by these lists, which are used by
querySelectorAll(), MutationRecord, and other APIs.

* Source/WebCore/dom/StaticNodeList.h:

Canonical link: <a href="https://commits.webkit.org/310208@main">https://commits.webkit.org/310208@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d03104a3fd478e0f10c98e0bfbef27e847a0541e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153095 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25877 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19475 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161839 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106553 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c313a375-5f8f-4ed7-aa9d-8a2ca489a641) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154968 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26404 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26182 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118337 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83792 "3 flakes 6 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ab400872-7ab3-4ab8-a1ff-1926ac3cc2be) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156054 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20570 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137444 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99050 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1db1a732-74a5-45f5-adeb-611803e4318e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19644 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17590 "Found 3 new API test failures: TestWebKitAPI.WKWebExtensionAPIExtension.GetViewsForMultipleTabs, TestWebKitAPI.WKWebExtensionController.BackgroundWithMultipleServiceWorkerScripts, TestWebKitAPI.WKWebExtension.ContentScriptImport (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9675 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129297 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15317 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164313 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7449 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16911 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126397 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25674 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21627 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126555 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34333 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25676 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137113 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82333 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21505 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13892 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25292 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89579 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24985 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25143 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25044 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->