### PR TITLE
[Debug] WebKitTestRunner crashes during model-related runs

### DIFF
--- a/Source/WebKit/UIProcess/Model/ModelProcessProxy.h
+++ b/Source/WebKit/UIProcess/Model/ModelProcessProxy.h
@@ -59,6 +59,7 @@ struct SharedPreferencesForWebProcess;
 class ModelProcessProxy final : public AuxiliaryProcessProxy {
     WTF_MAKE_TZONE_ALLOCATED(ModelProcessProxy);
     WTF_MAKE_NONCOPYABLE(ModelProcessProxy);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ModelProcessProxy);
     friend LazyNeverDestroyed<ModelProcessProxy>;
 public:
     static Ref<ModelProcessProxy> getOrCreate();


### PR DESCRIPTION
#### ea544ba94313c79f42d8b66863d4fc1dcc3de865
<pre>
[Debug] WebKitTestRunner crashes during model-related runs

<a href="https://bugs.webkit.org/show_bug.cgi?id=311042">https://bugs.webkit.org/show_bug.cgi?id=311042</a>
<a href="https://rdar.apple.com/173646341">rdar://173646341</a>

Reviewed by Etienne Segonzac and Mike Wyrzykowski.

ModelProcessProxy is missing the WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR
macro, which is required for classes that participate in checked pointer
tracking.

* Source/WebKit/UIProcess/Model/ModelProcessProxy.h:

Canonical link: <a href="https://commits.webkit.org/310237@main">https://commits.webkit.org/310237@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb20222ec21168b4118e06af443bd5f9cb1433df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153097 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25879 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19477 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161841 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106555 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26406 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26184 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118340 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83793 "11 flakes 6 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e71eff2b-4049-4160-8f81-04013ed696bd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156056 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20571 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137447 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99053 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/769ea682-54d1-44e9-9e1b-e5fd0e442cdf) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19645 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17592 "Found 4 new API test failures: TestWebKitAPI.WEBKIT.NavigationActionHasOpener12, TestWebKitAPI.WKWebExtensionAPIExtension.GetViewsForMultipleTabs, TestWebKitAPI.WKWebExtensionAPINamespace.BrowserNamespaceIsAvailableInContentScripts, TestWebKitAPI.WKWebExtensionAPILocalization.CSSLocalization (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9677 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129298 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164315 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7451 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16914 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126400 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25676 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21629 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126558 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34354 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25678 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137116 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82335 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21508 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13895 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25294 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89581 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24987 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25145 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25046 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->