### PR TITLE
[JSC] Leverage 4 byte in JSWebAssemblyArray if possible

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -5721,14 +5721,15 @@ Location BBQJIT::allocateStack(Value value)
 void BBQJIT::emitArrayGetPayload(StorageType type, GPRReg arrayGPR, GPRReg payloadGPR)
 {
     ASSERT(arrayGPR != payloadGPR);
-    if (!JSWebAssemblyArray::needsAlignmentCheck(type)) {
-        m_jit.addPtr(MacroAssembler::TrustedImm32(JSWebAssemblyArray::offsetOfData()), arrayGPR, payloadGPR);
+    if (JSWebAssemblyArray::needsV128AlignmentMask(type)) {
+        // V128 needs runtime masking: PreciseAllocation only guarantees 8-byte alignment.
+        m_jit.addPtr(MacroAssembler::TrustedImm32(JSWebAssemblyArray::offsetOfData() + 15), arrayGPR, payloadGPR);
+        m_jit.andPtr(MacroAssembler::TrustedImm32(-16), payloadGPR);
         return;
     }
-
-    // Round-up to 16x for PreciseAllocation + V128 array data handling.
-    m_jit.addPtr(MacroAssembler::TrustedImm32(JSWebAssemblyArray::offsetOfData() + 15), arrayGPR, payloadGPR);
-    m_jit.andPtr(MacroAssembler::TrustedImm32(-16), payloadGPR);
+    // For all other types, alignment shift is a compile-time constant
+    // since JSCell always has >=8-byte alignment.
+    m_jit.addPtr(MacroAssembler::TrustedImm32(JSWebAssemblyArray::alignedOffsetOfData(type.elementSize())), arrayGPR, payloadGPR);
 }
 
 } // namespace JSC::Wasm::BBQJITImpl

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -1482,7 +1482,7 @@ void BBQJIT::emitAllocateGCArrayUninitialized(GPRReg resultGPR, uint32_t typeInd
         ASSERT(hasOneBitSet(elementSize));
         m_jit.zeroExtend32ToWord(sizeLocation.asGPR(), scratchGPR);
         m_jit.lshift64(scratchGPR, TrustedImm32(getLSBSet(elementSize)), scratchGPR);
-        m_jit.add64(TrustedImm64(sizeof(JSWebAssemblyArray)), scratchGPR);
+        m_jit.add64(TrustedImm64(JSWebAssemblyArray::allocationMetadataSize(elementSize)), scratchGPR);
 
         m_jit.emitAllocateVariableSized(resultGPR, JITAllocator::variableNonNull(), allocatorBufferBase, scratchGPR, scratchGPR, scratchGPR2, slowPath, AssemblyHelpers::SlowAllocationResult::UndefinedBehavior);
         m_jit.load32(structureIDAddress, scratchGPR);
@@ -1541,7 +1541,8 @@ void BBQJIT::emitAllocateGCArrayUninitialized(GPRReg resultGPR, uint32_t typeInd
             m_jit.probeDebug([=] (Probe::Context& context) {
                 auto* arrayPtr = context.gpr<JSWebAssemblyArray*>(resultGPR);
                 if (!arrayPtr->isPreciseAllocation())
-                    ASSERT(arrayPtr->sizeInBytes() + sizeof(JSWebAssemblyArray) <= arrayPtr->markedBlock().handle().cellSize());
+                    ASSERT(arrayPtr->sizeInBytes() + JSWebAssemblyArray::allocationMetadataSize(elementType.elementSize())
+                        <= arrayPtr->markedBlock().handle().cellSize());
                 auto span = arrayPtr->refTypeSpan();
                 for (uint64_t value : span)
                     validateWasmValue(value, elementType.unpacked());

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -3625,14 +3625,17 @@ bool OMGIRGenerator::emitNullCheckBeforeAccess(Value* ref, ptrdiff_t offset)
 
 Value* OMGIRGenerator::emitGetArrayPayloadBase(Wasm::StorageType fieldType, Value* arrayref)
 {
-    auto payloadBase = m_currentBlock->appendNew<Value>(m_proc, Add, pointerType(), origin(), pointerOfWasmRef(arrayref), constant(pointerType(), JSWebAssemblyArray::offsetOfData()));
-    if (JSWebAssemblyArray::needsAlignmentCheck(fieldType)) {
+    if (JSWebAssemblyArray::needsV128AlignmentMask(fieldType)) {
+        auto payloadBase = m_currentBlock->appendNew<Value>(m_proc, Add, pointerType(), origin(),
+            pointerOfWasmRef(arrayref), constant(pointerType(), JSWebAssemblyArray::offsetOfData()));
         // Round-up to 16x for PreciseAllocation + V128 array data handling.
         return m_currentBlock->appendNew<Value>(m_proc, BitAnd, origin(),
             m_currentBlock->appendNew<Value>(m_proc, Add, origin(), payloadBase, constant(pointerType(), 15)),
             constant(pointerType(), -16));
     }
-    return payloadBase;
+    return m_currentBlock->appendNew<Value>(m_proc, Add, pointerType(), origin(),
+        pointerOfWasmRef(arrayref),
+        constant(pointerType(), JSWebAssemblyArray::alignedOffsetOfData(fieldType.elementSize())));
 }
 
 // Does the array set without null check and bounds checks -- can be
@@ -4160,7 +4163,7 @@ Value* OMGIRGenerator::allocateWasmGCArrayUninitialized(uint32_t typeIndex, Valu
     size_t elementSize = typeDefinition->elementType().type.elementSize();
     auto* extended = pointerOfInt32(size);
     auto* shifted = m_currentBlock->appendNew<Value>(m_proc, Shl, origin(), extended, constant(Int32, getLSBSet(elementSize)));
-    auto* sizeInBytes = m_currentBlock->appendNew<Value>(m_proc, Add, pointerType(), origin(), shifted, constant(pointerType(), sizeof(JSWebAssemblyArray)));
+    auto* sizeInBytes = m_currentBlock->appendNew<Value>(m_proc, Add, pointerType(), origin(), shifted, constant(pointerType(), JSWebAssemblyArray::allocationMetadataSize(elementSize)));
     auto* allocator = allocatorForWasmGCHeapCellSize(sizeInBytes, slowPath);
     auto* typeInfo = constant(Int32, JSWebAssemblyArray::typeInfoBlob().blob());
     auto* cell = allocateWasmGCObject(allocator, structureID, typeInfo, slowPath);

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h
@@ -40,7 +40,7 @@ namespace JSC {
 
 // Ideally this would just subclass TrailingArray<JSWebAssemblyArray, uint8_t> but we need the m_size field to be in units
 // of element size rather than byte size.
-class alignas(8) JSWebAssemblyArray final : public WebAssemblyGCObjectBase {
+class JSWebAssemblyArray final : public WebAssemblyGCObjectBase {
 public:
     using Base = WebAssemblyGCObjectBase;
 
@@ -61,7 +61,8 @@ public:
 
     static Wasm::FieldType elementType(const WebAssemblyGCStructure* structure) { return structure->typeDefinition().as<Wasm::ArrayType>()->elementType(); }
     Wasm::FieldType elementType() const { return elementType(gcStructure()); }
-    static bool needsAlignmentCheck(Wasm::StorageType type) { return type.unpacked().isV128(); }
+    // Only v128 needs runtime masking (PreciseAllocation only guarantees 8-byte alignment).
+    static bool needsV128AlignmentMask(Wasm::StorageType type) { return type.unpacked().isV128(); }
     size_t size() const { return m_size; }
     size_t sizeInBytes() const { return size() * elementType().type.elementSize(); }
 
@@ -96,16 +97,34 @@ public:
     void setIsUnpopulated(bool value) { m_isUnpopulated = value; }
 #endif
 
-    // We add padding for v128 arrays since a non-PreciseAllocation will have the wrong alignment as the base pointer for a PreciseAllocation is shifted by 8.
-    // Note: Technically this isn't needed since the GC/malloc always allocates 16 byte chunks so for non-precise v128 allocations
-    // there will be spare bytes at the end. This is just a bit more explicit and shouldn't make a difference.
-    static constexpr ptrdiff_t v128AlignmentShift() { return (16 - (offsetOfData() % 16)) % 16; }
+    // Compile-time alignment shift for a given element size.
+    // Valid for elements up to 8 bytes (JSCell is always >= 8-byte aligned).
+    static constexpr ptrdiff_t alignmentShift(size_t elementSize)
+    {
+        return (elementSize - (offsetOfData() % elementSize)) % elementSize;
+    }
+
+    // Offset from object start to aligned data, for elements <= 8 bytes.
+    static constexpr ptrdiff_t alignedOffsetOfData(size_t elementSize)
+    {
+        return offsetOfData() + alignmentShift(elementSize);
+    }
+
+    // Fixed overhead per array allocation: object header plus worst-case alignment padding.
+    // Accounts for PreciseAllocation (cell at 8 mod 16) where v128 (16-byte) elements
+    // need additional padding beyond alignmentShift().
+    static constexpr size_t allocationMetadataSize(size_t elementSize)
+    {
+        ptrdiff_t preciseShift = (elementSize - ((offsetOfData() + PreciseAllocation::halfAlignment) % elementSize)) % elementSize;
+        return sizeof(JSWebAssemblyArray) + std::max(alignmentShift(elementSize), preciseShift);
+    }
+
     static std::optional<unsigned> allocationSizeInBytes(Wasm::FieldType fieldType, unsigned size)
     {
         unsigned elementSize = fieldType.type.elementSize();
         if (productOverflows<uint32_t>(elementSize, size) || elementSize * size > Wasm::maxArraySizeInBytes) [[unlikely]]
             return std::nullopt;
-        return sizeof(JSWebAssemblyArray) + size * elementSize + static_cast<size_t>(needsAlignmentCheck(fieldType.type) * v128AlignmentShift());
+        return allocationMetadataSize(elementSize) + size * elementSize;
     }
 
     static constexpr ptrdiff_t offsetOfSize() { return OBJECT_OFFSETOF(JSWebAssemblyArray, m_size); }
@@ -131,9 +150,25 @@ private:
 };
 
 static_assert(std::is_final_v<JSWebAssemblyArray>, "JSWebAssemblyArray is a TrailingArray-like object so must know about all members");
-// We still have to check for PreciseAllocations since those are correctly aligned for v128 but this asserts our shifted offset will be correct.
+// Verify v128 alignment for both MarkedBlock (cell at 0 mod 16) and PreciseAllocation (cell at 8 mod 16).
 // FIXME: Fix this check for 32-bit.
-static_assert(isAddress32Bit() || !((JSWebAssemblyArray::offsetOfData() + JSWebAssemblyArray::v128AlignmentShift()) % 16), "JSWebAssemblyArray storage needs to be aligned for v128_t");
+static_assert(isAddress32Bit() || !((JSWebAssemblyArray::offsetOfData() + JSWebAssemblyArray::alignmentShift(16)) % 16), "JSWebAssemblyArray storage needs to be aligned for v128_t (MarkedBlock)");
+
+#if USE(JSVALUE64)
+#if !ASSERT_ENABLED
+static_assert(JSWebAssemblyArray::alignmentShift(1) == 0);
+static_assert(JSWebAssemblyArray::alignmentShift(2) == 0);
+static_assert(JSWebAssemblyArray::alignmentShift(4) == 0);
+static_assert(JSWebAssemblyArray::alignmentShift(8) == 4);
+static_assert(JSWebAssemblyArray::alignmentShift(16) == 4);
+
+static_assert(JSWebAssemblyArray::allocationMetadataSize(1) == sizeof(JSWebAssemblyArray));
+static_assert(JSWebAssemblyArray::allocationMetadataSize(2) == sizeof(JSWebAssemblyArray));
+static_assert(JSWebAssemblyArray::allocationMetadataSize(4) == sizeof(JSWebAssemblyArray));
+static_assert(JSWebAssemblyArray::allocationMetadataSize(8) == sizeof(JSWebAssemblyArray) + 4);
+static_assert(JSWebAssemblyArray::allocationMetadataSize(16) == sizeof(JSWebAssemblyArray) + 12);
+#endif
+#endif
 
 } // namespace JSC
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyArrayInlines.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyArrayInlines.h
@@ -56,7 +56,7 @@ std::span<T> JSWebAssemblyArray::span() LIFETIME_BOUND
     if constexpr (std::is_same_v<T, v128_t>)
         data = WTF::roundUpToMultipleOf<16>(data);
     else
-        ASSERT(!needsAlignmentCheck(elementType().type));
+        data += alignmentShift(sizeof(T));
     ASSERT(data == this->bytes().data());
     return { std::bit_cast<T*>(data), size() };
 }
@@ -69,9 +69,12 @@ std::span<uint64_t> JSWebAssemblyArray::refTypeSpan() LIFETIME_BOUND
 
 std::span<uint8_t> JSWebAssemblyArray::bytes()
 {
-    if (!needsAlignmentCheck(elementType().type))
-        return { data(), sizeInBytes() };
-    return { WTF::roundUpToMultipleOf<16>(data()), sizeInBytes() };
+    uint8_t* start = data();
+    if (needsV128AlignmentMask(elementType().type))
+        start = WTF::roundUpToMultipleOf<16>(start);
+    else
+        start += alignmentShift(elementType().type.elementSize());
+    return { start, sizeInBytes() };
 }
 
 auto JSWebAssemblyArray::visitSpan(auto functor)


### PR DESCRIPTION
#### 818d5a456c551d3cd6fa2b1d6fd717f37b7ecddb
<pre>
[JSC] Leverage 4 byte in JSWebAssemblyArray if possible
<a href="https://bugs.webkit.org/show_bug.cgi?id=311046">https://bugs.webkit.org/show_bug.cgi?id=311046</a>
<a href="https://rdar.apple.com/173651614">rdar://173651614</a>

Reviewed by Keith Miller and Yijia Huang.

JSWebAssemblyArray has 4 byte padding right now. Let&apos;s use this region
if element size is &lt;= 4.

* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitArrayGetPayload):
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitAllocateGCArrayUninitialized):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayNew):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::emitGetArrayPayloadBase):
(JSC::Wasm::OMGIRGenerator::allocateWasmGCArrayUninitialized):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyArrayInlines.h:
(JSC::JSWebAssemblyArray::bytes):

Canonical link: <a href="https://commits.webkit.org/310274@main">https://commits.webkit.org/310274@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccbd267441c26ce49735fd89078e1e9608a3f566

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153314 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26098 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19697 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162059 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2eecb49c-52cc-46fa-989d-cc34a738e479) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26624 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26418 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118528 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f938efdc-c847-4b24-a779-673be6e3ad65) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156273 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20766 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137639 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99240 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fe18a60e-9944-4f98-8fb6-04b97834186a) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/19843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9894 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/145327 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129490 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15509 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164533 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/14131 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7669 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17103 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126587 "Passed tests") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/25894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/21825 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126745 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25897 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137305 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/82564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23452 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21688 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14083 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184949 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25514 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89800 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47360 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25205 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/25364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/25265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->