### PR TITLE
StringConcatenate: Reduce redundant StringTypeAdapter constructions in tuple adapter

### DIFF
--- a/Source/WTF/wtf/text/StringConcatenate.h
+++ b/Source/WTF/wtf/text/StringConcatenate.h
@@ -286,9 +286,10 @@ template<typename... StringTypes> class StringTypeAdapter<std::tuple<StringTypes
 public:
     StringTypeAdapter(const std::tuple<StringTypes...>& tuple)
         : m_tuple { tuple }
-        , m_length { std::apply(computeLength, tuple) }
-        , m_is8Bit { std::apply(computeIs8Bit, tuple) }
     {
+        std::apply([&](const StringTypes&... strings) {
+            (..., accumulateProperties(strings));
+        }, tuple);
     }
 
     unsigned length() const { return m_length; }
@@ -297,26 +298,30 @@ public:
     {
         std::apply([&](const StringTypes&... strings) {
             unsigned offset = 0;
-            (..., (
-                StringTypeAdapter<StringTypes>(strings).writeTo(destination.subspan(offset)),
-                offset += StringTypeAdapter<StringTypes>(strings).length()
-            ));
+            (..., (offset += writeOne(destination.subspan(offset), strings)));
         }, m_tuple);
     }
 
 private:
-    static unsigned computeLength(const StringTypes&... strings)
+    template<typename StringType>
+    void accumulateProperties(const StringType& string)
     {
-        return (... + StringTypeAdapter<StringTypes>(strings).length());
+        StringTypeAdapter<StringType> adapter(string);
+        m_length += adapter.length();
+        m_is8Bit = m_is8Bit && adapter.is8Bit();
     }
 
-    static bool computeIs8Bit(const StringTypes&... strings)
+    template<typename CharacterType, typename StringType>
+    static unsigned writeOne(std::span<CharacterType> destination, const StringType& string)
     {
-        return (... && StringTypeAdapter<StringTypes>(strings).is8Bit());
+        StringTypeAdapter<StringType> adapter(string);
+        adapter.writeTo(destination);
+        return adapter.length();
     }
+
     const std::tuple<StringTypes...>& m_tuple;
-    unsigned m_length;
-    bool m_is8Bit;
+    unsigned m_length { 0 };
+    bool m_is8Bit { true };
 };
 
 template<typename UnderlyingElementType> struct PaddingSpecification {


### PR DESCRIPTION
#### 8877d7e6f89debabfe375cdfeeb9a44e8f0db9e6
<pre>
StringConcatenate: Reduce redundant StringTypeAdapter constructions in tuple adapter
<a href="https://bugs.webkit.org/show_bug.cgi?id=311051">https://bugs.webkit.org/show_bug.cgi?id=311051</a>

Reviewed by Darin Adler.

Previously each element&apos;s `StringTypeAdapter` was constructed four times:
once in `computeLength`, once in `computeIs8Bit`, and twice in `writeTo`.
This is wasteful for adapters with expensive constructors (e.g.
`const char16_t*` doing a strlen-like scan, or `span&lt;const char8_t&gt;`
doing full UTF-8 validation).

Merge `computeLength` and `computeIs8Bit` into a single-pass helper
(`accumulateProperties`) and use a `writeOne` helper in `writeTo`,
reducing constructions to one per phase. Helper member function
templates are used instead of lambdas in fold expressions to avoid
incomplete-type errors on GCC.

* Source/WTF/wtf/text/StringConcatenate.h:

Canonical link: <a href="https://commits.webkit.org/310273@main">https://commits.webkit.org/310273@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17caaeeaa88a4f6d022f447dbc30095075d4f038

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153110 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25892 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19490 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161854 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106568 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a47c33a8-c832-4e47-9171-4bf59981cd20) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26419 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26197 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118357 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83804 "4 flakes 6 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1ed5c0fa-d0ad-4b18-a8e4-8ea17e6dd523) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156069 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20590 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137464 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99070 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/23362acf-0452-4527-b374-b3e5175c9b9d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19664 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17609 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9690 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/145122 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129317 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15337 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164328 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13924 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7464 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16931 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126414 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25689 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21645 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126572 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34382 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25691 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137133 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82348 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21530 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13912 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184745 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25307 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89594 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47233 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25000 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25158 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25059 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->