### PR TITLE
Use table writing mode for borderAfter() in collapsed border resolution

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-writing-mode-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-writing-mode-color-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Collapsed border between rows are table writing mode aware
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-writing-mode-color.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-writing-mode-color.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>Collapsed border resolution uses table writing mode, not cell writing mode</title>
+<link rel="help" href="https://drafts.csswg.org/css-tables/#border-collapsing">
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=311048">
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+<style>
+  #tabletest {
+    border-collapse: collapse;
+    writing-mode: horizontal-tb;
+  }
+  #tabletest td {
+    padding: 20px 50px;
+  }
+  #tabletest #top {
+    writing-mode: vertical-rl;
+    border: 2px solid blue;
+    border-left: 10px solid blue;
+  }
+  #tabletest #bottom {
+    border: 2px solid blue;
+    border-top: 3px solid green;
+  }
+</style>
+<table id="tabletest">
+  <tr><td id="top"></td></tr>
+  <tr><td id="bottom"></td></tr>
+</table>
+<script>
+  test(function() {
+    var table = document.getElementById("tabletest");
+    var top = document.getElementById("top");
+
+    // Initial state: border-left is 10px, border-bottom is 2px.
+    // With the bug, borderAfter() reads border-left (10px) instead of
+    // border-bottom (2px), creating a Frankenstein value that beats the
+    // bottom cell's 3px green → blue border between rows (WRONG).
+    // With the fix, border-bottom (2px) is correctly used, loses to
+    // the 3px green → green border between rows (CORRECT).
+
+    // Measure height with the thick border-left (triggers bug if present).
+    var h1 = table.offsetHeight;
+
+    // Temporarily set border-left to match border-bottom (2px). The bug
+    // has no visible effect here since both edges have the same value.
+    top.style.borderLeft = "2px solid blue";
+    document.body.offsetTop;
+    var h2 = table.offsetHeight;
+
+    // Restore the original border-left so the visual state shows the bug.
+    // The border between rows should be green (3px). If it is blue, the
+    // bug is present: border-left leaked into the inter-row border.
+    top.style.borderLeft = "10px solid blue";
+
+    // With the fix, both heights are the same because border-left never
+    // participates in the inter-row border. With the bug, h1 is taller
+    // because the 10px border-left leaked into the inter-row border.
+    assert_equals(h1, h2,
+      "Changing border-left on a vertical-rl cell must not affect " +
+      "the collapsed border between rows");
+  }, "Collapsed border between rows are table writing mode aware");
+</script>

--- a/Source/WebCore/rendering/RenderTableCell.cpp
+++ b/Source/WebCore/rendering/RenderTableCell.cpp
@@ -1028,7 +1028,7 @@ CollapsedBorderValue RenderTableCell::computeCollapsedBeforeBorder(IncludeBorder
     RenderTableCell* previousCell = table->cellAbove(this);
     if (previousCell) {
         // (2) A before cell's after border.
-        result = chooseBorder(CollapsedBorderValue(previousCell->style().borderAfter(), includeColor ? resolvedBorderColor(previousCell->style(), afterColorProperty) : Color(), BorderPrecedence::Cell, previousCell->style().usedZoomForLength()), result);
+        result = chooseBorder(CollapsedBorderValue(previousCell->style().borderAfter(tableWritingMode()), includeColor ? resolvedBorderColor(previousCell->style(), afterColorProperty) : Color(), BorderPrecedence::Cell, previousCell->style().usedZoomForLength()), result);
         if (!result.exists())
             return result;
     }
@@ -1047,7 +1047,7 @@ CollapsedBorderValue RenderTableCell::computeCollapsedBeforeBorder(IncludeBorder
             previousRow = previousCell->section()->lastRow();
     
         if (previousRow) {
-            result = chooseBorder(CollapsedBorderValue(previousRow->style().borderAfter(), includeColor ? resolvedBorderColor(previousRow->style(), afterColorProperty) : Color(), BorderPrecedence::Row, previousRow->style().usedZoomForLength()), result);
+            result = chooseBorder(CollapsedBorderValue(previousRow->style().borderAfter(tableWritingMode()), includeColor ? resolvedBorderColor(previousRow->style(), afterColorProperty) : Color(), BorderPrecedence::Row, previousRow->style().usedZoomForLength()), result);
             if (!result.exists())
                 return result;
         }
@@ -1064,7 +1064,7 @@ CollapsedBorderValue RenderTableCell::computeCollapsedBeforeBorder(IncludeBorder
         // (6) Previous row group's after border.
         currSection = table->sectionAbove(currSection, SkipEmptySections);
         if (currSection) {
-            result = chooseBorder(CollapsedBorderValue(currSection->style().borderAfter(), includeColor ? resolvedBorderColor(currSection->style(), afterColorProperty) : Color(), BorderPrecedence::RowGroup, currSection->style().usedZoomForLength()), result);
+            result = chooseBorder(CollapsedBorderValue(currSection->style().borderAfter(tableWritingMode()), includeColor ? resolvedBorderColor(currSection->style(), afterColorProperty) : Color(), BorderPrecedence::RowGroup, currSection->style().usedZoomForLength()), result);
             if (!result.exists())
                 return result;
         }
@@ -1135,7 +1135,7 @@ CollapsedBorderValue RenderTableCell::computeCollapsedAfterBorder(IncludeBorderC
     // of the last row in the span, not the first row.
     size_t lastRowIndex = rowIndex() + rowSpan() - 1;
     if (CheckedPtr lastRowInSpan = section()->rowRendererAt(lastRowIndex)) {
-        result = chooseBorder(result, CollapsedBorderValue(lastRowInSpan->style().borderAfter(), includeColor ? resolvedBorderColor(lastRowInSpan->style(), afterColorProperty) : Color(), BorderPrecedence::Row, lastRowInSpan->style().usedZoomForLength()));
+        result = chooseBorder(result, CollapsedBorderValue(lastRowInSpan->style().borderAfter(tableWritingMode()), includeColor ? resolvedBorderColor(lastRowInSpan->style(), afterColorProperty) : Color(), BorderPrecedence::Row, lastRowInSpan->style().usedZoomForLength()));
         if (!result.exists())
             return result;
     }


### PR DESCRIPTION
#### 81700e22624d49bfe09e9d0ad9ee53079a532df4
<pre>
Use table writing mode for borderAfter() in collapsed border resolution
<a href="https://bugs.webkit.org/show_bug.cgi?id=311048">https://bugs.webkit.org/show_bug.cgi?id=311048</a>
<a href="https://rdar.apple.com/problem/173655092">rdar://problem/173655092</a>

Reviewed by Oriol Brufau.

In computeCollapsedBeforeBorder and computeCollapsedAfterBorder, four
calls to borderAfter() used the element&apos;s own writing mode instead of
tableWritingMode(). Meanwhile, the border color property was resolved
using tableWritingMode(). When a cell has a different writing mode
than its table (e.g. vertical-rl in a horizontal-tb table), this
created a CollapsedBorderValue with width/style from one physical
edge and color from another, causing the wrong color to appear.

All other borderBefore()/borderAfter() calls in these functions
already correctly pass tableWritingMode().

Test: css/css-tables/collapsed-border-writing-mode-color.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-writing-mode-color-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-writing-mode-color.html: Added.
* Source/WebCore/rendering/RenderTableCell.cpp:
(WebCore::RenderTableCell::computeCollapsedBeforeBorder):
(WebCore::RenderTableCell::computeCollapsedAfterBorder):

Canonical link: <a href="https://commits.webkit.org/310303@main">https://commits.webkit.org/310303@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b8508e9d0ef54e1a06852fc71b9dfff718a59b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153365 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26149 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19748 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162110 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106823 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155238 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26675 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26469 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118563 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156324 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20808 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137686 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99275 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19885 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17835 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9945 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129532 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15556 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164584 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7720 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17150 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126626 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25945 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21868 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126783 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25948 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137352 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82615 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23460 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21724 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14130 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25565 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89851 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25256 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25415 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25316 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->