### PR TITLE
SIMD-accelerate equalIgnoringASCIICaseWithLength and equalLettersIgnoringASCIICaseWithLength

### DIFF
--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -458,10 +458,47 @@ bool NODELETE equal(const StringClass& string, std::span<const char8_t> span)
     return Unicode::equal(string.span16(), span);
 }
 
-template<typename CharacterTypeA, typename CharacterTypeB> inline bool NODELETE equalIgnoringASCIICaseWithLength(std::span<const CharacterTypeA> a, std::span<const CharacterTypeB> b, size_t lengthToCheck)
+template<typename CharacterTypeA, typename CharacterTypeB> SUPPRESS_NODELETE inline bool NODELETE equalIgnoringASCIICaseWithLength(std::span<const CharacterTypeA> a, std::span<const CharacterTypeB> b, size_t lengthToCheck)
 {
     ASSERT(a.size() >= lengthToCheck);
     ASSERT(b.size() >= lengthToCheck);
+
+#if CPU(ARM64) || CPU(X86_64)
+    if constexpr (sizeof(CharacterTypeA) == sizeof(CharacterTypeB)) {
+        using UnsignedType = SameSizeUnsignedInteger<CharacterTypeA>;
+        constexpr size_t stride = SIMD::stride<UnsignedType>;
+
+        if (lengthToCheck >= stride) {
+            auto upperA = SIMD::splat<UnsignedType>('A');
+            auto range = SIMD::splat<UnsignedType>(static_cast<UnsignedType>('Z' - 'A'));
+            auto caseBit = SIMD::splat<UnsignedType>(0x20);
+
+            auto toLower = [&](auto vec) ALWAYS_INLINE_LAMBDA {
+                auto offset = SIMD::sub(vec, upperA);
+                auto isUpper = SIMD::lessThanOrEqual(offset, range);
+                return SIMD::bitOr(vec, SIMD::bitAnd(isUpper, caseBit));
+            };
+
+            size_t i = 0;
+            for (; i + stride <= lengthToCheck; i += stride) {
+                auto aVec = SIMD::load(std::bit_cast<const UnsignedType*>(a.data() + i));
+                auto bVec = SIMD::load(std::bit_cast<const UnsignedType*>(b.data() + i));
+                if (SIMD::isNonZero(SIMD::bitNot(SIMD::equal(toLower(aVec), toLower(bVec)))))
+                    return false;
+            }
+
+            if (i < lengthToCheck) {
+                auto aVec = SIMD::load(std::bit_cast<const UnsignedType*>(a.data() + lengthToCheck - stride));
+                auto bVec = SIMD::load(std::bit_cast<const UnsignedType*>(b.data() + lengthToCheck - stride));
+                if (SIMD::isNonZero(SIMD::bitNot(SIMD::equal(toLower(aVec), toLower(bVec)))))
+                    return false;
+            }
+
+            return true;
+        }
+    }
+#endif
+
     for (size_t i = 0; i < lengthToCheck; ++i) {
         if (toASCIILower(a[i]) != toASCIILower(b[i]))
             return false;
@@ -988,10 +1025,41 @@ concept SearchableStringByOneByteCharacter =
 
 template<typename CharacterType, typename OneByteCharacterType>
     requires SearchableStringByOneByteCharacter<CharacterType, OneByteCharacterType>
-inline bool NODELETE equalLettersIgnoringASCIICaseWithLength(std::span<const CharacterType> characters, std::span<const OneByteCharacterType> lowercaseLetters, size_t length)
+SUPPRESS_NODELETE inline bool NODELETE equalLettersIgnoringASCIICaseWithLength(std::span<const CharacterType> characters, std::span<const OneByteCharacterType> lowercaseLetters, size_t length)
 {
     ASSERT(characters.size() >= length);
     ASSERT(lowercaseLetters.size() >= length);
+
+#if CPU(ARM64) || CPU(X86_64)
+    if constexpr (sizeof(CharacterType) == sizeof(OneByteCharacterType)) {
+        using UnsignedType = SameSizeUnsignedInteger<CharacterType>;
+        constexpr size_t stride = SIMD::stride<UnsignedType>;
+
+        if (length >= stride) {
+            auto caseBit = SIMD::splat<UnsignedType>(0x20);
+
+            size_t i = 0;
+            for (; i + stride <= length; i += stride) {
+                auto charVec = SIMD::load(std::bit_cast<const UnsignedType*>(characters.data() + i));
+                auto lowerVec = SIMD::load(std::bit_cast<const UnsignedType*>(lowercaseLetters.data() + i));
+                auto charLowered = SIMD::bitOr(charVec, caseBit);
+                if (SIMD::isNonZero(SIMD::bitNot(SIMD::equal(charLowered, lowerVec))))
+                    return false;
+            }
+
+            if (i < length) {
+                auto charVec = SIMD::load(std::bit_cast<const UnsignedType*>(characters.data() + length - stride));
+                auto lowerVec = SIMD::load(std::bit_cast<const UnsignedType*>(lowercaseLetters.data() + length - stride));
+                auto charLowered = SIMD::bitOr(charVec, caseBit);
+                if (SIMD::isNonZero(SIMD::bitNot(SIMD::equal(charLowered, lowerVec))))
+                    return false;
+            }
+
+            return true;
+        }
+    }
+#endif
+
     for (size_t i = 0; i < length; ++i) {
         if (!isASCIIAlphaCaselessEqual(characters[i], lowercaseLetters[i]))
             return false;


### PR DESCRIPTION
#### 85a8086c469f2f34a84ee9318c4cdb705517658e
<pre>
SIMD-accelerate equalIgnoringASCIICaseWithLength and equalLettersIgnoringASCIICaseWithLength
<a href="https://bugs.webkit.org/show_bug.cgi?id=311056">https://bugs.webkit.org/show_bug.cgi?id=311056</a>

Reviewed by Yusuke Suzuki.

Add SIMD fast paths using the cross-platform helpers from SIMDHelpers.h
for case-insensitive string comparison. The SIMD paths activate on ARM64
and x86_64 when both character types have the same size and the length
meets the minimum stride (16 for 8-bit, 8 for 16-bit). An overlap-tail
technique handles non-stride-aligned lengths without a scalar cleanup loop.

For equalIgnoringASCIICase, case folding uses the unsigned subtraction
trick: subtract &apos;A&apos;, compare &lt;= 25 to identify uppercase, then
conditionally OR with 0x20. For equalLettersIgnoringASCIICase, the second
argument is guaranteed to be lowercase letters, so an unconditional OR
with 0x20 suffices.

Microbenchmark results on Apple M4 (clang -O2, best of averaged runs):

equalIgnoringASCIICase (uint8_t, matching):
  len=16:  10.5 -&gt; 1.7 ns (6.2x)
  len=32:  20.4 -&gt; 2.6 ns (8.0x)
  len=64:  40.4 -&gt; 3.2 ns (12.7x)
  len=256: 168  -&gt; 10.9 ns (15.4x)
  len=1024: 644 -&gt; 43.3 ns (14.9x)

equalIgnoringASCIICase (uint16_t, matching):
  len=8:   5.4 -&gt; 1.6 ns (3.4x)
  len=32:  20.0 -&gt; 3.2 ns (6.3x)
  len=64:  40.9 -&gt; 5.8 ns (7.1x)
  len=256: 164  -&gt; 21.9 ns (7.5x)

equalLettersIgnoringASCIICase (uint8_t, matching):
  len=16:  6.2 -&gt; 1.4 ns (4.5x)
  len=64:  24.4 -&gt; 2.3 ns (10.7x)
  len=256: 105  -&gt; 5.9 ns (17.9x)
  len=1024: 400 -&gt; 17.5 ns (22.9x)

Early-out on mismatch is also faster (e.g. 6-15x for uint8_t) since
SIMD detects differences in 16-byte chunks rather than per character.

No change for lengths below the SIMD stride or for mixed-width
comparisons (e.g. Latin1 vs char16_t), which continue to use the
existing scalar loop.

* Source/WTF/wtf/text/StringCommon.h:
(WTF::equalIgnoringASCIICaseWithLength):
(WTF::equalLettersIgnoringASCIICaseWithLength):

Canonical link: <a href="https://commits.webkit.org/310361@main">https://commits.webkit.org/310361@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45414d25d1f0f620f10c51e37bedfeb29b007910

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153138 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25920 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19518 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161882 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106596 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/493203ad-26a7-4874-b138-e6164f5f1ac5) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26447 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26225 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118384 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83823 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fda4d291-9746-4077-ac94-c9cde84490d5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156097 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20617 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137488 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99097 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/edd234d2-64af-4a3b-86a8-f820fe66fcaf) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19691 "Found 1 new test failure: imported/w3c/web-platform-tests/navigation-api/navigate-event/signal-abort-window-stop-after-intercept.html (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17637 "Found 3 new API test failures: TestWebKitAPI.WKWebExtension.ContentScriptImport, TestWebKitAPI.WKWebExtensionAPINamespace.NoWebNavigationObjectWithoutPermission, TestWebKitAPI.VideoQualityDisplayCompositing.Enabled (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9718 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/145150 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129343 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15361 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164356 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13953 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7492 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16955 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126442 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25717 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21672 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126600 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34443 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25719 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137157 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82382 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21557 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13936 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184773 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25335 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89622 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47317 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25028 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25186 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25087 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->