### PR TITLE
[site-isolation] Yahoo! Sign in page fails to load (login.yahoo.com)

### DIFF
--- a/LayoutTests/http/tests/site-isolation/nested-cross-origin-iframe-expected.html
+++ b/LayoutTests/http/tests/site-isolation/nested-cross-origin-iframe-expected.html
@@ -1,0 +1,3 @@
+<body bgcolor=blue>
+<div style="width:300px;height:150px;background-color:green;border:1px solid black;">
+</body>

--- a/LayoutTests/http/tests/site-isolation/nested-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/nested-cross-origin-iframe.html
@@ -1,0 +1,22 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!doctype HTML>
+<html>
+<head>
+<meta name="fuzzy" content="maxDifference=112; totalPixels=900"/>
+<script>
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+onmessage = (event) => {
+    if (window.testRunner && event.data == "onload") {
+        setTimeout(() => {
+            testRunner.notifyDone();
+        }, 100);
+    }
+}
+</script>
+</head>
+<body bgcolor=blue>
+<iframe src="http://localhost:8000/site-isolation/resources/nested-cross-origin-middle-iframe.html" frameborder=0 style="border:1px black solid"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/resources/nested-cross-origin-middle-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/resources/nested-cross-origin-middle-iframe.html
@@ -1,0 +1,6 @@
+<body style="margin:0">
+<iframe src="http://127.0.0.1:8000/site-isolation/resources/green-background.html" frameborder=0 style="width:300px;height:150px"></iframe>
+<script>
+onmessage = (event) => { window.parent.postMessage(event.data, "*"); }
+</script>
+</body>

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
@@ -270,6 +270,8 @@ String RemoteLayerTreeTransaction::description() const
         ts.dumpProperty("scrollOrigin"_s, m_scrollOrigin);
 
     ts.dumpProperty("root-layer"_s, m_rootLayerID);
+    if (remoteContextHostedIdentifier())
+        ts.dumpProperty("hosted-identifier"_s, *remoteContextHostedIdentifier());
 
     if (!m_createdLayers.isEmpty()) {
         TextStream::GroupScope group(ts);
@@ -277,6 +279,8 @@ String RemoteLayerTreeTransaction::description() const
         for (const auto& createdLayer : m_createdLayers) {
             TextStream::GroupScope group(ts);
             ts << createdLayer.type <<" " << createdLayer.layerID;
+            if (createdLayer.hostIdentifier())
+                ts << "(host " << *createdLayer.hostIdentifier() << ')';
             switch (createdLayer.type) {
             case WebCore::PlatformCALayer::LayerType::LayerTypeAVPlayerLayer:
                 ts << " (context-id "_s << createdLayer.hostingContextID() << ')';

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -405,7 +405,7 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTree(IPC::Connection& connectio
     WeakPtr weakThis { *this };
 
     for (auto& transaction : bundle.transactions) {
-        commitLayerTreeTransaction(connection, CheckedRef { transaction.first }.get(), transaction.second, bundle.mainFrameData, bundle.pageData, bundle.transactionID);
+        commitLayerTreeTransaction(connection, CheckedRef { transaction.first }.get(), transaction.second,  transaction.first.remoteContextHostedIdentifier() ? std::nullopt : bundle.mainFrameData, bundle.pageData, bundle.transactionID);
         if (!weakThis)
             return;
     }


### PR DESCRIPTION
#### f2d3449fcc50a59dda6acbcfbe6f3c8d236fae96
<pre>
[site-isolation] Yahoo! Sign in page fails to load (login.yahoo.com)
<a href="https://bugs.webkit.org/show_bug.cgi?id=311055">https://bugs.webkit.org/show_bug.cgi?id=311055</a>
&lt;<a href="https://rdar.apple.com/169742520">rdar://169742520</a>&gt;

Reviewed by Simon Fraser.

When we have multiple transactions from a single main-frame process, make sure
we only pass the main frame data to the transaction handler for the main-frame
itself.

Otherwise this can use the &apos;root frame&apos; from a subframe transaction, and make it
the root frame of the whole page.

* LayoutTests/http/tests/site-isolation/nested-cross-origin-iframe-expected.html: Added.
* LayoutTests/http/tests/site-isolation/nested-cross-origin-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/resources/nested-cross-origin-middle-iframe.html: Added.
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm:
(WebKit::RemoteLayerTreeTransaction::description const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTree):

Canonical link: <a href="https://commits.webkit.org/310248@main">https://commits.webkit.org/310248@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd082b549283da0741d06bbba850deed5b3d58da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153120 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25902 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19500 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161864 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106578 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26429 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26207 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118359 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83809 "2 flakes 6 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2d256c0e-34b1-46b8-9053-18b051f0c0c4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156079 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20595 "Found 1 new test failure: media/track/track-in-band-chapters.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137460 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99072 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eed90beb-444f-4cb3-bb69-90e90d2af166) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19669 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17615 "Found 3 new API test failures: TestWebKitAPI.WEBKIT.NavigationActionHasOpener12, TestWebKitAPI.SimulateClickOverText.ClickTargets, TestWebKitAPI.WKWebExtensionAPIAlarms.GetAllAlarms (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9700 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129322 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15333 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164338 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7474 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16927 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126420 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25699 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21651 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126578 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34363 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25701 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137129 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82358 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21527 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13908 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25317 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89604 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25010 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25168 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25069 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->