### PR TITLE
[YARR] Fix infinite loop in nested FixedCount ParenContext backtrack

### DIFF
--- a/JSTests/stress/regexp-nested-fixedcount-paren-context-backtrack.js
+++ b/JSTests/stress/regexp-nested-fixedcount-paren-context-backtrack.js
@@ -1,0 +1,67 @@
+//@ runDefault
+
+// A fixed-count parenthesis that takes the ParenContext path would hang when
+// its body itself contained another ParenContext-using term. restoreParenContext
+// rewrites every nested frame slot, including the inner term's parenContextHead.
+// The content-backtrack path then walked and freed that inner chain before the
+// middle layer's Begin.bt re-restored the same pointer from its own ParenContext,
+// at which point the pointer sat on the freelist and the skip loop followed it
+// forever. FixedCount backtrack now reuses contexts in place instead of freeing
+// them, so all outer snapshots stay valid.
+
+function test(re, input, expected) {
+    const actual = re.exec(input);
+    const actualStr = actual === null ? "null" : JSON.stringify(Array.from(actual));
+    const expectedStr = expected === null ? "null" : JSON.stringify(expected);
+    if (actualStr !== expectedStr)
+        throw new Error(`FAIL: ${re} on ${JSON.stringify(input)}: expected ${expectedStr}, got ${actualStr}`);
+}
+
+// Three nested capturing FixedCount — the original hang. Input lengths 5-7
+// exercise the backtrack path where the outermost iteration partially
+// succeeds before the innermost runs out of input.
+test(/(((a){2}){2}){2}/, "aaaaa", null);
+test(/(((a){2}){2}){2}/, "aaaaaa", null);
+test(/(((a){2}){2}){2}/, "aaaaaaa", null);
+test(/(((a){2}){2}){2}/, "aaaaaaaa", ["aaaaaaaa", "aaaa", "aa", "a"]);
+test(/(((a){2}){2}){2}/, "aaaaaaaaa", ["aaaaaaaa", "aaaa", "aa", "a"]);
+
+// Four levels.
+test(/((((a){2}){2}){2}){2}/, "a".repeat(15), null);
+test(/((((a){2}){2}){2}){2}/, "a".repeat(16), ["a".repeat(16), "a".repeat(8), "aaaa", "aa", "a"]);
+
+// Variations on count and inner-term width.
+test(/(((ab){2}){2}){2}/, "ababababab", null);
+test(/(((ab){2}){2}){2}/, "abababababababab", ["abababababababab", "abababab", "abab", "ab"]);
+test(/(((a){2}){3}){2}/, "a".repeat(11), null);
+test(/(((a){2}){3}){2}/, "a".repeat(12), ["a".repeat(12), "a".repeat(6), "aa", "a"]);
+
+// Named capture variant.
+test(/(((?<n>a){2}){2}){2}/, "aaaaa", null);
+test(/(((?<n>a){2}){2}){2}/, "aaaaaaaa", ["aaaaaaaa", "aaaa", "aa", "a"]);
+
+// Backtrackable innermost content (greedy sub-term, multiple alternatives).
+test(/(((a+){2}){2}){2}/, "aaaaaaa", null);
+test(/(((a+){2}){2}){2}/, "aaaaaaaa", ["aaaaaaaa", "aaaa", "aa", "a"]);
+test(/(((a|aa){2}){2}){2}/, "aaaaaaa", null);
+test(/(((a|aa){2}){2}){2}/, "aaaaaaaa", ["aaaaaaaa", "aaaa", "aa", "a"]);
+test(/((((a+){2}){2}){2}){2}/, "a".repeat(15), null);
+test(/((((a+){2}){2}){2}){2}/, "a".repeat(16), ["a".repeat(16), "a".repeat(8), "aaaa", "aa", "a"]);
+
+// Sibling FixedCount subtrees inside one outer FixedCount.
+for (let len = 8; len <= 15; ++len)
+    test(/((((a){2}){2})(((b){2}){2})){2}/, "aaaabbbbaaaabbbb".slice(0, len), null);
+test(/((((a){2}){2})(((b){2}){2})){2}/, "aaaabbbbaaaabbbb", ["aaaabbbbaaaabbbb", "aaaabbbb", "aaaa", "aa", "a", "bbbb", "bb", "b"]);
+
+// Inner Greedy / NonGreedy (also ParenContext-using) under an outer FixedCount.
+test(/((a)+){2}/, "aaa", ["aaa", "a", "a"]);
+test(/((a)*?b){2}/, "abab", ["abab", "ab", "a"]);
+test(/((a)*?b){2}/, "abb", ["abb", "b", null]);
+
+// Controls that were already passing — must keep passing.
+test(/((a){2}){2}/, "aaa", null);
+test(/((a){2}){2}/, "aaaa", ["aaaa", "aa", "a"]);
+test(/(?:(?:(?:a){2}){2}){2}/, "aaaaa", null);
+test(/(?:(?:(?:a){2}){2}){2}/, "aaaaaaaa", ["aaaaaaaa"]);
+test(/(((?:a){2}){2}){2}/, "aaaaa", null);
+test(/(((?:a){2}){2}){2}/, "aaaaaaaa", ["aaaaaaaa", "aaaa", "aa"]);

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -4897,7 +4897,7 @@ class YarrGenerator final : public YarrJITInfo {
                 // For FixedCount, we need to handle inter-iteration backtracking.
                 // Check if the current ParenContext is "incomplete" (iteration failed before END).
                 // An incomplete context has matchAmount == -1 (marker stored at BEGIN).
-                // If incomplete, free it and try the previous iteration's context.
+                // If incomplete, skip it and try the previous iteration's context.
                 // If complete, restore from it and retry the iteration's content.
                 if (term->quantityType == QuantifierType::FixedCount) {
                     // First, skip any incomplete contexts (failed iterations that never reached END).
@@ -4913,11 +4913,12 @@ class YarrGenerator final : public YarrJITInfo {
                         MacroAssembler::Address(currParenContextReg, ParenContext::matchAmountOffset()),
                         MacroAssembler::TrustedImm32(-1));
 
-                    // Incomplete context: free this context and try the previous one
-                    m_jit.loadPtr(MacroAssembler::Address(currParenContextReg, ParenContext::nextOffset()), newParenContextReg);
-                    freeParenContext(currParenContextReg);
-                    storeToFrame(newParenContextReg, parenthesesFrameLocation + BackTrackInfoParentheses::parenContextHeadIndex());
-                    m_jit.move(newParenContextReg, currParenContextReg);
+                    // Incomplete context: advance past it without freeing. Outer
+                    // FixedCount layers may hold snapshots of this chain in their
+                    // own ParenContexts; freeing here would leave those snapshots
+                    // pointing into the freelist.
+                    m_jit.loadPtr(MacroAssembler::Address(currParenContextReg, ParenContext::nextOffset()), currParenContextReg);
+                    storeToFrame(currParenContextReg, parenthesesFrameLocation + BackTrackInfoParentheses::parenContextHeadIndex());
                     m_jit.jump(checkContext);
 
                     // Complete context found - restore from it
@@ -4958,29 +4959,19 @@ class YarrGenerator final : public YarrJITInfo {
 
                         // Load the END position from the context. Content's backtrack expects
                         // index at where the iteration ended.
-                        // Must load before freeParenContext since we need currParenContextReg.
                         m_jit.load32(MacroAssembler::Address(currParenContextReg, ParenContext::endOffset()), m_regs.index);
 
-                        // Pop the context from list
-                        m_jit.loadPtr(MacroAssembler::Address(currParenContextReg, ParenContext::nextOffset()), newParenContextReg);
-                        freeParenContext(currParenContextReg);
-                        storeToFrame(newParenContextReg, parenthesesFrameLocation + BackTrackInfoParentheses::parenContextHeadIndex());
+                        // Reuse this context in-place for the retry: mark it incomplete.
+                        // If content-backtrack succeeds, END.forward's saveParenContext
+                        // overwrites the marker. If it fails, next Begin.bt skips it.
+                        // Not freeing keeps outer layers' chain snapshots valid.
+                        m_jit.store32(MacroAssembler::TrustedImm32(-1), MacroAssembler::Address(currParenContextReg, ParenContext::matchAmountOffset()));
 
                         // Decrement matchAmount (we're retrying the previous iteration)
-                        // Use regT2 for count, NOT regT1, because newParenContextReg is regT1
-                        // and we need it later when allocating fresh context.
                         const MacroAssembler::RegisterID countTemporary = m_regs.regT2;
                         loadFromFrame(parenthesesFrameLocation + BackTrackInfoParentheses::matchAmountIndex(), countTemporary);
                         m_jit.sub32(MacroAssembler::TrustedImm32(1), countTemporary);
                         storeToFrame(countTemporary, parenthesesFrameLocation + BackTrackInfoParentheses::matchAmountIndex());
-
-                        // Allocate a fresh context for the retry attempt. This context starts
-                        // as "incomplete" and will be marked complete by END.forward if the
-                        // retried iteration succeeds.
-                        allocateParenContext(currParenContextReg);
-                        m_jit.storePtr(newParenContextReg, MacroAssembler::Address(currParenContextReg, ParenContext::nextOffset()));
-                        storeToFrame(currParenContextReg, parenthesesFrameLocation + BackTrackInfoParentheses::parenContextHeadIndex());
-                        m_jit.store32(MacroAssembler::TrustedImm32(-1), MacroAssembler::Address(currParenContextReg, ParenContext::matchAmountOffset()));
 
                         // Jump to content's backtrack entry point.
                         // We can't use fallthrough() here because backtrack generation runs in
@@ -5025,22 +5016,14 @@ class YarrGenerator final : public YarrJITInfo {
                         // Restore endIndex for content backtracking (where the iteration ended)
                         m_jit.load32(MacroAssembler::Address(currParenContextReg, ParenContext::endOffset()), m_regs.index);
 
-                        // Pop the context from list
-                        m_jit.loadPtr(MacroAssembler::Address(currParenContextReg, ParenContext::nextOffset()), newParenContextReg);
-                        freeParenContext(currParenContextReg);
-                        storeToFrame(newParenContextReg, parenthesesFrameLocation + BackTrackInfoParentheses::parenContextHeadIndex());
+                        // Reuse this context in-place for the retry (see single-alt path above).
+                        m_jit.store32(MacroAssembler::TrustedImm32(-1), MacroAssembler::Address(currParenContextReg, ParenContext::matchAmountOffset()));
 
                         // Decrement matchAmount (we're retrying the previous iteration)
                         const MacroAssembler::RegisterID countTemporary = m_regs.regT2;
                         loadFromFrame(parenthesesFrameLocation + BackTrackInfoParentheses::matchAmountIndex(), countTemporary);
                         m_jit.sub32(MacroAssembler::TrustedImm32(1), countTemporary);
                         storeToFrame(countTemporary, parenthesesFrameLocation + BackTrackInfoParentheses::matchAmountIndex());
-
-                        // Allocate fresh context for the retry attempt (starts as incomplete)
-                        allocateParenContext(currParenContextReg);
-                        m_jit.storePtr(newParenContextReg, MacroAssembler::Address(currParenContextReg, ParenContext::nextOffset()));
-                        storeToFrame(currParenContextReg, parenthesesFrameLocation + BackTrackInfoParentheses::parenContextHeadIndex());
-                        m_jit.store32(MacroAssembler::TrustedImm32(-1), MacroAssembler::Address(currParenContextReg, ParenContext::matchAmountOffset()));
 
                         // Jump to the stored address (content backtrack entry of current alternative)
                         loadFromFrameAndJump(parenthesesFrameLocation + BackTrackInfoParentheses::returnAddressIndex());


### PR DESCRIPTION
#### 569dc9473449a89e25a8b5d8de2cb87620b37ec0
<pre>
[YARR] Fix infinite loop in nested FixedCount ParenContext backtrack
<a href="https://bugs.webkit.org/show_bug.cgi?id=311057">https://bugs.webkit.org/show_bug.cgi?id=311057</a>

Reviewed by Yusuke Suzuki.

Three or more nested capturing FixedCount parentheses (e.g.
/(((a){2}){2}){2}/) would hang in the JIT when backtracking. The
outer and middle layers&apos; ParenContext snapshots both capture the
same inner parenContextHead pointer; the inner layer&apos;s Begin.bt
freed that chain, then the middle layer restored a pointer that
now sat on the freelist, sending the incomplete-skip loop into
an infinite traversal.

Instead of freeing the context and allocating a fresh one for
each retry, reuse the existing context in place: mark it with
matchAmount = -1 so the next Begin.bt skips it, and END.forward
overwrites the marker if the retry succeeds. No context is ever
freed during FixedCount backtracking, so all outer snapshots stay
valid. This also makes the clearInnerParenContextHeadSlots comment
about FixedCount contexts &quot;never freed&quot; actually true.

* JSTests/stress/regexp-nested-fixedcount-paren-context-backtrack.js: Added.
* Source/JavaScriptCore/yarr/YarrJIT.cpp:

Canonical link: <a href="https://commits.webkit.org/310288@main">https://commits.webkit.org/310288@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c67f45ad5753591495624fe9bf18c9a43a9907e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153369 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26153 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19752 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162114 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26679 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26473 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118567 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156328 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20807 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137690 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99279 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/19884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9949 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/145382 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/129531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/15560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164588 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/14189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/7724 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17154 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126628 "Passed tests") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25949 "Failed to checkout and rebase branch from PR 61650") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/21866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126785 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34393 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25952 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137356 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/82619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21723 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14134 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/185004 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25569 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89855 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47379 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25260 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/25419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/25320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->