### PR TITLE
[JSC] Refine clobberize rules for `CheckPrivateBrand` and `SetPrivateBrand`

### DIFF
--- a/JSTests/microbenchmarks/check-private-brand-polymorphic.js
+++ b/JSTests/microbenchmarks/check-private-brand-polymorphic.js
@@ -1,0 +1,19 @@
+function makeClasses(n) {
+    const classes = [];
+    for (let i = 0; i < n; i++)
+        classes.push(class { #m() { return i; } go() { return this.#m() + this.#m(); } });
+    return classes;
+}
+
+const objs = makeClasses(8).map(C => new C());
+
+function test(objs) {
+    let sum = 0;
+    for (let j = 0; j < objs.length; j++)
+        sum += objs[j].go();
+    return sum;
+}
+noInline(test);
+
+for (let i = 0; i < 1e6; ++i)
+    test(objs);

--- a/JSTests/stress/check-private-brand-clobberize.js
+++ b/JSTests/stress/check-private-brand-clobberize.js
@@ -1,0 +1,144 @@
+//@ requireOptions("--useConcurrentJIT=0")
+
+function assert(b, msg) {
+    if (!b)
+        throw new Error("FAIL: " + msg);
+}
+
+function assertThrows(fn, msg) {
+    let threw = false;
+    try { fn(); } catch (e) { threw = e instanceof TypeError; }
+    assert(threw, msg);
+}
+
+// Test 1: CSE of redundant CheckPrivateBrand in polymorphic case.
+// With 8 classes, ByteCodeParser keeps the raw CheckPrivateBrand node
+// instead of lowering to CheckStructure, so the new clobberize rule
+// and def(HeapLocation) are exercised.
+(function testPolymorphicCSE() {
+    function factory(v) {
+        return class {
+            #m() { return v; }
+            go() { return this.#m() + this.#m() + this.#m(); }
+        };
+    }
+    const objs = [];
+    for (let i = 0; i < 8; i++)
+        objs.push(new (factory(i))());
+
+    function run(objs) {
+        let sum = 0;
+        for (let j = 0; j < objs.length; j++)
+            sum += objs[j].go();
+        return sum;
+    }
+    noInline(run);
+
+    for (let i = 0; i < testLoopCount; i++)
+        assert(run(objs) === 84, "polymorphic CSE sum");
+})();
+
+// Test 2: CellUse speculation must preserve TypeError for non-cell bases.
+// After CellUse OSR exit, baseline must still throw.
+(function testCellUseThrow() {
+    class C {
+        #m() { return 1; }
+        static call(o) { return o.#m(); }
+    }
+    noInline(C.call);
+
+    const c = new C();
+    for (let i = 0; i < testLoopCount; i++)
+        assert(C.call(c) === 1, "warmup");
+
+    assertThrows(() => C.call(42), "number base must throw");
+    assertThrows(() => C.call("str"), "string base must throw");
+    assertThrows(() => C.call(true), "boolean base must throw");
+    assertThrows(() => C.call(null), "null base must throw");
+    assertThrows(() => C.call(undefined), "undefined base must throw");
+    assertThrows(() => C.call(Symbol()), "symbol base must throw");
+})();
+
+// Test 3: CheckPrivateBrand must NOT be CSE'd across a structure transition.
+// The clobberize rule read(JSCell_structureID) means a write to structureID
+// in between should invalidate CSE. A property store transitions the structure.
+(function testNoStaleCSEAcrossTransition() {
+    function factory() {
+        return class {
+            #m() { return this.x || 0; }
+            go() {
+                let a = this.#m();
+                this.x = 42;
+                let b = this.#m();
+                return a + b;
+            }
+        };
+    }
+    const objs = [];
+    for (let i = 0; i < 8; i++)
+        objs.push(new (factory())());
+
+    function run(objs) {
+        let sum = 0;
+        for (let j = 0; j < objs.length; j++) {
+            delete objs[j].x;
+            sum += objs[j].go();
+        }
+        return sum;
+    }
+    noInline(run);
+
+    for (let i = 0; i < testLoopCount; i++)
+        assert(run(objs) === 336, "brand check across transition");
+})();
+
+// Test 4: Brand check must still fail for wrong-class objects after CSE warmup.
+(function testWrongBrandAfterCSE() {
+    function factory() {
+        return class {
+            #m() { return 1; }
+            go(other) { return this.#m() + other.#m(); }
+        };
+    }
+    const A = factory();
+    const B = factory();
+    const a = new A();
+    const b = new B();
+
+    function run(x, y) { return x.go(y); }
+    noInline(run);
+
+    for (let i = 0; i < testLoopCount; i++)
+        assert(run(a, a) === 2, "same brand warmup");
+
+    assertThrows(() => run(a, b), "cross-brand must throw after CSE warmup");
+})();
+
+// Test 5: LICM safety - brand check hoisted out of loop must still be correct.
+(function testLICM() {
+    function factory(v) {
+        return class {
+            #m() { return v; }
+            sum(n) {
+                let s = 0;
+                for (let i = 0; i < n; i++)
+                    s += this.#m();
+                return s;
+            }
+        };
+    }
+    const objs = [];
+    for (let i = 0; i < 8; i++)
+        objs.push(new (factory(i + 1))());
+
+    function run(objs) {
+        let sum = 0;
+        for (let j = 0; j < objs.length; j++)
+            sum += objs[j].sum(10);
+        return sum;
+    }
+    noInline(run);
+
+    for (let i = 0; i < testLoopCount; i++)
+        assert(run(objs) === 360, "LICM sum");
+})();

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -5254,7 +5254,13 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
     }
 
     case CheckPrivateBrand:
-    case SetPrivateBrand:
+        break;
+
+    case SetPrivateBrand: {
+        clobberStructures();
+        break;
+    }
+
     case PutPrivateName: {
         clobberWorld();
         break;

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -763,10 +763,6 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
     case PutPrivateNameById:
     case GetPrivateName:
     case GetPrivateNameById:
-    // FIXME: We should have a better cloberize rule for both CheckPrivateBrand and SetPrivateBrand
-    // https://bugs.webkit.org/show_bug.cgi?id=221571
-    case CheckPrivateBrand:
-    case SetPrivateBrand:
     case DefineDataProperty:
     case DefineAccessorProperty:
     case ObjectDefineProperty:
@@ -1449,6 +1445,16 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
     case CheckStructureOrEmpty:
     case CheckStructure:
         read(JSCell_structureID);
+        return;
+
+    case CheckPrivateBrand:
+        read(JSCell_structureID);
+        def(HeapLocation(CheckPrivateBrandLoc, JSCell_structureID, node->child1(), node->child2()), LazyNode(node));
+        return;
+
+    case SetPrivateBrand:
+        read(JSCell_structureID);
+        write(JSCell_structureID);
         return;
 
     case CheckArrayOrEmpty:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -2377,6 +2377,7 @@ private:
         }
 
         case CheckPrivateBrand: {
+            fixEdge<CellUse>(node->child1());
             fixEdge<SymbolUse>(node->child2());
             break;
         }

--- a/Source/JavaScriptCore/dfg/DFGHeapLocation.h
+++ b/Source/JavaScriptCore/dfg/DFGHeapLocation.h
@@ -43,6 +43,7 @@ enum LocationKind {
     DataViewByteLengthLoc,
     DataViewByteLengthAsInt52Loc,
     CheckTypeInfoFlagsLoc,
+    CheckPrivateBrandLoc,
     OverridesHasInstanceLoc,
     ClosureVariableLoc,
     ClosureVariableDoubleLoc,

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -7706,10 +7706,11 @@ void SpeculativeJIT::compilePutPrivateName(Node* node)
 
 void SpeculativeJIT::compileCheckPrivateBrand(Node* node)
 {
-    JSValueOperand base(this, node->child1());
+    ASSERT(node->child1().useKind() == CellUse);
+    SpeculateCellOperand base(this, node->child1());
     SpeculateCellOperand brandValue(this, node->child2());
 
-    JSValueRegs baseRegs = base.jsValueRegs();
+    GPRReg baseGPR = base.gpr();
     GPRReg brandGPR = brandValue.gpr();
 
     speculateSymbol(node->child2(), brandGPR);
@@ -7723,7 +7724,7 @@ void SpeculativeJIT::compileCheckPrivateBrand(Node* node)
     auto [ propertyCache, propertyCacheConstant ] = addPropertyInlineCache();
     shuffleRegisters<GPRReg, 2>(
         {
-            baseRegs.payloadGPR(),
+            baseGPR,
             brandGPR,
         },
         {
@@ -7734,8 +7735,6 @@ void SpeculativeJIT::compileCheckPrivateBrand(Node* node)
         codeBlock(), propertyCache, JITType::DFGJIT, codeOrigin, callSite, AccessType::CheckPrivateBrand, usedRegisters,
         BaselineJITRegisters::PrivateBrand::baseJSR, BaselineJITRegisters::PrivateBrand::propertyJSR, BaselineJITRegisters::PrivateBrand::propertyCacheGPR);
     JumpList slowCases;
-    if (needsTypeCheck(node->child1(), SpecCell))
-        slowCases.append(branchIfNotCell(BaselineJITRegisters::PrivateBrand::baseJSR));
 
     WTF::visit([&](auto* propertyCache) {
         propertyCache->propertyIsSymbol = true;

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -5051,7 +5051,8 @@ private:
 
     void compileCheckPrivateBrand()
     {
-        compilePrivateBrandAccess(lowJSValue(m_node->child1()), lowSymbol(m_node->child2()), AccessType::CheckPrivateBrand);
+        DFG_ASSERT(m_graph, m_node, m_node->child1().useKind() == CellUse, m_node->child1().useKind());
+        compilePrivateBrandAccess(lowCell(m_node->child1()), lowSymbol(m_node->child2()), AccessType::CheckPrivateBrand);
     }
 
     void compileSetPrivateBrand()


### PR DESCRIPTION
#### f977b7aa6f769b2fa944b306bdde40e365388e53
<pre>
[JSC] Refine clobberize rules for `CheckPrivateBrand` and `SetPrivateBrand`
<a href="https://bugs.webkit.org/show_bug.cgi?id=311058">https://bugs.webkit.org/show_bug.cgi?id=311058</a>

Reviewed by Yusuke Suzuki.

CheckPrivateBrand and SetPrivateBrand were falling through to clobberWorld(),
preventing CSE and LICM. This patch gives them precise rules: CheckPrivateBrand
only reads JSCell_structureID (BrandedStructure::checkBrand traverses immutable
m_brand/m_parentBrand after reading the base&apos;s structure, same category as
CheckStructure), and SetPrivateBrand reads/writes it like PutStructure. A new
CheckPrivateBrandLoc heap location enables CSE of redundant brand checks on the
same base and symbol.

This patch also adds CellUse to CheckPrivateBrand&apos;s base operand in FixupPhase,
matching SetPrivateBrand&apos;s existing handling. On speculation failure, OSR exit
falls back to baseline where toObject throws, preserving semantics. This lets us
drop branchIfNotCell in the DFG fast path and use lowCell in FTL.

Polymorphic private method calls (&gt;4 classes, where the raw CheckPrivateBrand
node survives instead of being lowered to CheckStructure) show ~1.5x improvement.
JetStream3 raytrace-private-class-fields is neutral as its monomorphic call
sites are already lowered.

                                         TipOfTree                  Patched

check-private-brand-polymorphic       54.1080+-3.8215     ^     36.2630+-3.5408        ^ definitely 1.4921x faster

Tests: JSTests/microbenchmarks/check-private-brand-polymorphic.js
       JSTests/stress/check-private-brand-clobberize.js

* JSTests/microbenchmarks/check-private-brand-polymorphic.js: Added.
* JSTests/stress/check-private-brand-clobberize.js: Added.
(assert):
(assertThrows):
(testPolymorphicCSE.factory.return.prototype.m):
(testPolymorphicCSE.factory.return.prototype.go):
(testPolymorphicCSE.run):
(testCellUseThrow.C.prototype.m):
(testCellUseThrow.C.call):
(testCellUseThrow.C):
(testNoStaleCSEAcrossTransition.factory.return.prototype.m):
(testNoStaleCSEAcrossTransition.factory.return.prototype.go):
(testNoStaleCSEAcrossTransition.run):
(testWrongBrandAfterCSE.factory.return.prototype.m):
(testWrongBrandAfterCSE.factory.return.prototype.go):
(testWrongBrandAfterCSE.run):
(testLICM.factory.return.prototype.m):
(testLICM.factory.return.prototype.sum):
(testLICM.run):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGHeapLocation.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compileCheckPrivateBrand):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCheckPrivateBrand):

Canonical link: <a href="https://commits.webkit.org/310775@main">https://commits.webkit.org/310775@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b019ddf0bb5e68e4a50d2338c7c0879813d51984

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153118 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25900 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19498 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161862 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106576 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26427 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26205 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118358 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83808 "4 flakes 6 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156077 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20593 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137462 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99071 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19667 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17614 "Found 4 new API test failures: TestWebKitAPI.WKWebExtensionAPIExtension.GetViewsExcludesServiceWorkerBackground, TestWebKitAPI.WKWebExtension.ContentScriptImport, TestWebKitAPI.RunScriptAfterDocumentLoad.ExecutionOrderOfScriptsInDocument, TestWebKitAPI.WKWebExtensionAPICommands.ExecuteActionCommand (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9698 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/145130 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129320 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15335 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164336 "Built successfully") | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13932 "Found unexpected failure with change (failure)") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7472 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16929 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126418 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25697 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21650 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126576 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34753 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25699 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137131 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82356 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21528 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13910 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184753 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25315 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89602 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47236 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25008 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25166 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25067 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->