### PR TITLE
`HashCountedSet::add(value, count)` should ASSERT that `count` is non-zero

### DIFF
--- a/Source/WTF/wtf/HashCountedSet.h
+++ b/Source/WTF/wtf/HashCountedSet.h
@@ -239,6 +239,7 @@ inline auto HashCountedSet<Value, HashFunctions, Traits>::add(ValueType&& value)
 template<typename Value, typename HashFunctions, typename Traits>
 inline auto HashCountedSet<Value, HashFunctions, Traits>::add(const ValueType& value, unsigned count) LIFETIME_BOUND -> AddResult
 {
+    ASSERT(count);
     auto result = m_impl.add(value, 0);
     result.iterator->value += count;
     return result;
@@ -247,6 +248,7 @@ inline auto HashCountedSet<Value, HashFunctions, Traits>::add(const ValueType& v
 template<typename Value, typename HashFunctions, typename Traits>
 inline auto HashCountedSet<Value, HashFunctions, Traits>::add(ValueType&& value, unsigned count) LIFETIME_BOUND -> AddResult
 {
+    ASSERT(count);
     auto result = m_impl.add(std::forward<Value>(value), 0);
     result.iterator->value += count;
     return result;


### PR DESCRIPTION
#### 083052704679ec1d2bf18c1d4391e249ca9ab164
<pre>
`HashCountedSet::add(value, count)` should ASSERT that `count` is non-zero
<a href="https://bugs.webkit.org/show_bug.cgi?id=311061">https://bugs.webkit.org/show_bug.cgi?id=311061</a>

Reviewed by NOBODY (OOPS!).

`HashCountedSet::add(value, count)` with `count == 0` creates an entry
with a zero count in the underlying HashMap, violating the class
invariant that all entries have count &gt;= 1. This leads to
contradictory behavior where `contains()` returns true but `count()`
returns 0, and a subsequent `remove()` triggers `ASSERT(oldVal)` or,
in release builds, wraps unsigned 0 - 1 to UINT_MAX.

Add `ASSERT(count)` to both overloads of `add(value, count)`.

* Source/WTF/wtf/HashCountedSet.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/083052704679ec1d2bf18c1d4391e249ca9ab164

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153122 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25904 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19502 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161866 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106580 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f46dec52-961b-424a-9035-f6179001b968) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26431 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26209 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118365 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c08dbf0b-0ef4-4b1a-add2-e5fbad468679) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156081 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20599 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137469 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99078 "Found 1 new API test failure: TestWTF:WTF_HashCountedSet.DoubleHashCollisionsInitialCount (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/57e7408c-608d-4236-a3ae-e0302113293b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19672 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9702 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/145134 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129325 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15342 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164340 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/13936 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7476 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16936 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126423 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25701 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21654 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126581 "Found 1 new API test failure: TestWTF:WTF_HashCountedSet.DoubleHashCollisionsInitialCount (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25703 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137138 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82360 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21536 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13917 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184757 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25319 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89606 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47237 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25012 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25170 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25071 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->