### PR TITLE
[Site Isolation] Add API tests for UIProcess back/forward navigation with cross-origin iframes

### DIFF
--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestUIDelegate.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestUIDelegate.h
@@ -65,6 +65,7 @@
 
 @interface WKWebView (TestUIDelegateExtras)
 - (NSString *)_test_waitForAlert;
+- (NSString *)_test_waitForAlertAndSubframeLoads:(int)expectedSubframeCount;
 - (NSString *)_test_waitForConfirm;
 - (NSString *)_test_waitForPromptWithReply:(NSString *)reply;
 - (void)_test_waitForInspectorToShow;

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestUIDelegate.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestUIDelegate.mm
@@ -27,6 +27,7 @@
 #import "Helpers/cocoa/TestUIDelegate.h"
 
 #import "Helpers/Utilities.h"
+#import "Helpers/cocoa/TestNavigationDelegate.h"
 #import <WebKit/WKWebViewPrivateForTesting.h>
 #import <wtf/RetainPtr.h>
 
@@ -269,6 +270,27 @@
     self.UIDelegate = uiDelegate.get();
     NSString *alert = [uiDelegate waitForAlert];
     self.UIDelegate = nil;
+    return alert;
+}
+
+- (NSString *)_test_waitForAlertAndSubframeLoads:(int)expectedSubframeCount
+{
+    EXPECT_TRUE([self.navigationDelegate isKindOfClass:[TestNavigationDelegate class]]);
+    auto navigationDelegate = (TestNavigationDelegate *)self.navigationDelegate;
+    EXPECT_FALSE(navigationDelegate.didFinishLoadWithRequestInFrame);
+
+    __block int subframeLoadCount = 0;
+    __block bool subframesReady = (expectedSubframeCount <= 0);
+    navigationDelegate.didFinishLoadWithRequestInFrame = ^(WKWebView *, NSURLRequest *, WKFrameInfo *frame) {
+        if (!frame.isMainFrame && ++subframeLoadCount >= expectedSubframeCount)
+            subframesReady = true;
+    };
+
+    NSString *alert = [self _test_waitForAlert];
+
+    if (!subframesReady)
+        TestWebKitAPI::Util::run(&subframesReady);
+    navigationDelegate.didFinishLoadWithRequestInFrame = nil;
     return alert;
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -4533,6 +4533,102 @@ TEST(SiteIsolation, GoBackToNestedIframeCreatedAfterNavigatingSibling)
     EXPECT_WK_STREQ([webView _test_waitForAlert], "c");
 }
 
+TEST(SiteIsolation, MultipleIframeBackForwardAfterSessionRestore)
+{
+    HTTPServer server({
+        { "/example"_s, { "<iframe src='https://webkit.org/source'></iframe><iframe src='https://apple.com/other'></iframe>"_s } },
+        { "/source"_s, { "<script> alert('source'); </script>"_s } },
+        { "/destination"_s, { "<script> alert('destination'); </script>"_s } },
+        { "/other"_s, { "other frame"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server);
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "source");
+
+    // Navigate first iframe to /destination.
+    RetainPtr childFrame = [webView firstChildFrame];
+    [webView evaluateJavaScript:@"location.href = 'https://webkit.org/destination'" inFrame:childFrame.get() completionHandler:nil];
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "destination");
+
+    // Session restore to a new web view.
+    RetainPtr sessionState = [webView _sessionState];
+    auto [newWebView, newNavigationDelegate] = siteIsolatedViewAndDelegate(server);
+    [newWebView _restoreSessionState:sessionState.get() andNavigate:YES];
+    EXPECT_WK_STREQ([newWebView _test_waitForAlert], "destination");
+
+    // Go back — first iframe should go back to 'source', second iframe stays at 'other'.
+    // Wait for both the alert from the 'source' iframe and the silent 'other' iframe to load.
+    [newWebView goBack];
+    EXPECT_WK_STREQ([newWebView _test_waitForAlertAndSubframeLoads:2], "source");
+
+    // After session restore, child frame ordering may differ from HTML source order.
+    // Verify both iframes have the expected URLs regardless of order.
+    NSString *url1 = [newWebView objectByEvaluatingJavaScript:@"location.href" inFrame:[newWebView firstChildFrame]];
+    NSString *url2 = [newWebView objectByEvaluatingJavaScript:@"location.href" inFrame:[newWebView secondChildFrame]];
+    if ([url1 isEqualToString:@"https://webkit.org/source"])
+        EXPECT_WK_STREQ("https://apple.com/other", url2);
+    else {
+        EXPECT_WK_STREQ("https://apple.com/other", url1);
+        EXPECT_WK_STREQ("https://webkit.org/source", url2);
+    }
+
+    // Go forward — first iframe should go forward to 'destination'.
+    [newWebView goForward];
+    EXPECT_WK_STREQ([newWebView _test_waitForAlert], "destination");
+}
+
+TEST(SiteIsolation, BackAndForwardNavigationWithCrossOriginIframe)
+{
+    HTTPServer server({
+        { "/a"_s, { "<iframe src='https://frame.com/frame'></iframe>"_s } },
+        { "/b"_s, { "page b"_s } },
+        { "/c"_s, { "page c"_s } },
+        { "/frame"_s, { "frame content"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server);
+
+    // Build history: A (with cross-origin iframe) → B → C
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://b.com/b"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://c.com/c"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // Go back: C → B.
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigation];
+    EXPECT_WK_STREQ("https://b.com/b", [webView objectByEvaluatingJavaScript:@"location.href"]);
+
+    // Go back: B → A (page A has cross-origin iframe, exercises frame tree rebuild).
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigation];
+    [navigationDelegate waitForDidFinishLoadInSubframe];
+
+    // Should be at page A with its cross-origin iframe.
+    EXPECT_WK_STREQ("https://a.com/a", [webView objectByEvaluatingJavaScript:@"location.href"]);
+    checkFrameTreesInProcesses(webView.get(), {
+        { "https://a.com"_s,
+            { { RemoteFrame } }
+        }, { RemoteFrame,
+            { { "https://frame.com"_s } }
+        },
+    });
+
+    // Go forward: A → B.
+    [webView goForward];
+    [navigationDelegate waitForDidFinishNavigation];
+    EXPECT_WK_STREQ("https://b.com/b", [webView objectByEvaluatingJavaScript:@"location.href"]);
+
+    // Go forward: B → C.
+    [webView goForward];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    EXPECT_WK_STREQ("https://c.com/c", [webView objectByEvaluatingJavaScript:@"location.href"]);
+}
+
 TEST(SiteIsolation, AdvancedPrivacyProtectionsHideScreenMetricsFromBindings)
 {
     auto frameHTML = [NSString stringWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"simple" ofType:@"html"] encoding:NSUTF8StringEncoding error:NULL];


### PR DESCRIPTION
#### e7c5d311aa28a841317df7e04cad996a1c818b2f
<pre>
[Site Isolation] Add API tests for UIProcess back/forward navigation with cross-origin iframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=311059">https://bugs.webkit.org/show_bug.cgi?id=311059</a>
<a href="https://rdar.apple.com/173643670">rdar://173643670</a>

Reviewed by NOBODY (OOPS!).

Add two API tests covering session restore and back/forward navigation
with cross-origin iframes.

MultipleIframeBackForwardAfterSessionRestore verifies that goBack and
goForward correctly restore iframe state after session restore to a new
WebView, with order-independent frame URL verification since child frame
ordering may differ from HTML source order after restore.

BackAndForwardNavigationWithCrossOriginIframe exercises frame tree rebuild
by navigating back through multiple pages to one containing a cross-origin
iframe, then forward again, verifying the frame tree structure and URLs
at each step.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, MultipleIframeBackForwardAfterSessionRestore)):
(TestWebKitAPI::TEST(SiteIsolation, BackAndForwardNavigationWithCrossOriginIframe)):
* Tools/TestWebKitAPI/cocoa/TestUIDelegate.h:
* Tools/TestWebKitAPI/cocoa/TestUIDelegate.mm:
(-[WKWebView _test_waitForAlertAndSubframeLoads:]):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/410206d607664bcfd06b4a0e95303141a8b7b527

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169425 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43347 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36638 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178782 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127137 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7870297b-018c-423b-bf67-ff391f913e87) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171291 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43728 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42975 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131978 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92912 "9 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4e5e48df-c9ab-4a13-a9e8-ba7d79daa4e8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172384 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34779 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152291 "Found 3 new API test failures: TestWebKitAPI.SiteIsolation.MultipleIframeBackForwardAfterSessionRestore, TestWebKitAPI.SiteIsolation.BackAndForwardNavigationWithCrossOriginIframe, TestWebKitAPI.SiteIsolation.NavigateFrameWithSiblingsBackForward (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112482 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6fe45d1f-be29-4182-bfbe-91b990633d11) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33761 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32118 "Found 3 new API test failures: TestWebKitAPI.SiteIsolation.MultipleIframeBackForwardAfterSessionRestore, TestWebKitAPI.SiteIsolation.BackAndForwardNavigationWithCrossOriginIframe, TestWebKitAPI.SiteIsolation.NavigateFrameWithSiblingsBackForward (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27481 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143751 "Found 2 new API test failures: TestWebKitAPI.SiteIsolation.MultipleIframeBackForwardAfterSessionRestore, TestWebKitAPI.SiteIsolation.BackAndForwardNavigationWithCrossOriginIframe (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31691 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181382 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36286 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140429 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43003 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140265 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43692 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28667 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107784 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35539 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42202 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6756 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41595 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41850 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41738 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->