### PR TITLE
Fixed boxes anchored to children of sticky boxes should stick

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-to-sticky-005-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-to-sticky-005-expected.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html class='reftest-wait'>
+<title>Reference: Fixed box anchors to sticky child while scrolling</title>
+<link rel="author" title="Elika J. Etemad" href="https://fantasai.inkedblade.net/contact">
+
+<style>
+#sticky {
+  background: teal;
+  border: 10px solid aqua;
+  color: white;
+  anchor-name: --sticky;
+}
+
+#child {
+  anchor-name: --sticky-child;
+  background: blue;
+  border: 5px solid navy;
+  margin-inline: 25%;
+}
+
+.anchored {
+  position: absolute;
+  background: fuchsia;
+  padding: 4px;
+}
+.anchored.positionArea {
+  position-area: bottom span-right;
+}
+.anchored.anchorFunction {
+  top: anchor(outside);
+  right: anchor(inside);
+ }
+
+.anchored.sticky {
+  position-anchor: --sticky;
+}
+.anchored.sticky-child {
+  position-anchor: --sticky-child;
+}
+
+:root {
+  padding: 40px;
+  block-size: 200%;
+}
+body {
+  border: 2px dashed;
+  height: 100%;
+}
+</style>
+
+<div style="position: fixed; top: 0; width: calc(100% - 100px); height: 100vh">
+<div id="sticky">Sticky
+  <div id="child">Sticky Child</div>
+</div>
+<div class="anchored sticky positionArea">Anchored to Sticky</div>
+<div class="anchored sticky-child positionArea">Anchored to Child</div>
+<div class="anchored sticky anchorFunction">Anchored to Sticky</div>
+<div class="anchored sticky-child anchorFunction">Anchored to Child</div>
+</div>
+
+<script>
+window.scrollBy(0, 100);
+document.documentElement.removeAttribute('class');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-to-sticky-005-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-to-sticky-005-ref.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html class='reftest-wait'>
+<title>Reference: Fixed box anchors to sticky child while scrolling</title>
+<link rel="author" title="Elika J. Etemad" href="https://fantasai.inkedblade.net/contact">
+
+<style>
+#sticky {
+  background: teal;
+  border: 10px solid aqua;
+  color: white;
+  anchor-name: --sticky;
+}
+
+#child {
+  anchor-name: --sticky-child;
+  background: blue;
+  border: 5px solid navy;
+  margin-inline: 25%;
+}
+
+.anchored {
+  position: absolute;
+  background: fuchsia;
+  padding: 4px;
+}
+.anchored.positionArea {
+  position-area: bottom span-right;
+}
+.anchored.anchorFunction {
+  top: anchor(outside);
+  right: anchor(inside);
+ }
+
+.anchored.sticky {
+  position-anchor: --sticky;
+}
+.anchored.sticky-child {
+  position-anchor: --sticky-child;
+}
+
+:root {
+  padding: 40px;
+  block-size: 200%;
+}
+body {
+  border: 2px dashed;
+  height: 100%;
+}
+</style>
+
+<div style="position: fixed; top: 0; width: calc(100% - 100px); height: 100vh">
+<div id="sticky">Sticky
+  <div id="child">Sticky Child</div>
+</div>
+<div class="anchored sticky positionArea">Anchored to Sticky</div>
+<div class="anchored sticky-child positionArea">Anchored to Child</div>
+<div class="anchored sticky anchorFunction">Anchored to Sticky</div>
+<div class="anchored sticky-child anchorFunction">Anchored to Child</div>
+</div>
+
+<script>
+window.scrollBy(0, 100);
+document.documentElement.removeAttribute('class');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-to-sticky-005.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-to-sticky-005.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html class='reftest-wait'>
+<title>Test: Fixed box anchors to sticky child while scrolling</title>
+<link rel="author" title="Elika J. Etemad" href="https://fantasai.inkedblade.net/contact">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-1/">
+<link rel="match" href="anchor-scroll-to-sticky-005.html">
+
+<style>
+#sticky {
+  position: sticky;
+  inset-block-start: 0;
+  background: teal;
+  border: 10px solid aqua;
+  color: white;
+  anchor-name: --sticky;
+}
+
+#child {
+  anchor-name: --sticky-child;
+  background: blue;
+  border: 5px solid navy;
+  margin-inline: 25%;
+}
+
+.anchored {
+  position: absolute;
+  background: fuchsia;
+  padding: 4px;
+}
+.anchored.positionArea {
+  position-area: bottom span-right;
+}
+.anchored.anchorFunction {
+  top: anchor(outside);
+  right: anchor(inside);
+ }
+
+.anchored.sticky {
+  position-anchor: --sticky;
+}
+.anchored.sticky-child {
+  position-anchor: --sticky-child;
+}
+
+:root {
+  padding: 40px;
+  block-size: 200%;
+}
+body {
+  border: 2px dashed;
+  height: 100%;
+}
+</style>
+
+<div id="sticky">Sticky
+  <div id="child">Sticky Child</div>
+</div>
+<div class="anchored sticky positionArea">Anchored to Sticky</div>
+<div class="anchored sticky-child positionArea">Anchored to Child</div>
+<div class="anchored sticky anchorFunction">Anchored to Sticky</div>
+<div class="anchored sticky-child anchorFunction">Anchored to Child</div>
+
+<script>
+window.scrollBy(0, 100);
+document.documentElement.removeAttribute('class');
+</script>

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -71,9 +71,22 @@ inline LayoutSize AnchorScrollSnapshot::adjustmentForCurrentScrollPosition() con
     return { };
 }
 
+AnchorStickySnapshot::AnchorStickySnapshot(const RenderBoxModelObject& sticky, LayoutSize snapshot)
+    : m_sticky(sticky)
+    , m_stickySnapshot(snapshot)
+{ }
+
+inline LayoutSize AnchorStickySnapshot::adjustmentForCurrentScrollPosition() const
+{
+    if (m_sticky && m_sticky->isStickilyPositioned())
+        return m_sticky->stickyPositionOffset() - m_stickySnapshot;
+    // If the box is no longer sticky positioned, just compensate for the snapshotted value against zero.
+    return -m_stickySnapshot;
+}
+
 inline bool AnchorScrollAdjuster::isEmpty() const
 {
-    return !m_scrollSnapshots.size() && !(m_hasChainedAnchor | m_hasStickyAnchor);
+    return !m_scrollSnapshots.size() && !m_hasChainedAnchor && !m_stickySnapshots.size();
 }
 
 AnchorScrollAdjuster::AnchorScrollAdjuster(RenderBox& anchored, const RenderBoxModelObject& defaultAnchor)
@@ -124,9 +137,6 @@ AnchorScrollAdjuster::AnchorScrollAdjuster(RenderBox& anchored, const RenderBoxM
 
     m_isHidden = style.isForceHidden();
 
-    if ((m_hasStickyAnchor = defaultAnchor.isStickilyPositioned()))
-        m_stickySnapshot = defaultAnchor.stickyPositionOffset();
-
     if (auto anchorBox = dynamicDowncast<RenderBox>(defaultAnchor)) {
         if (CheckedPtr chainedAnchor = Style::AnchorPositionEvaluator::defaultAnchorForBox(*anchorBox))
             m_hasChainedAnchor = true;
@@ -142,11 +152,11 @@ bool AnchorScrollAdjuster::recaptureDiffers(const AnchorScrollAdjuster& other) c
 {
     bool same = m_anchored.ptr() == other.m_anchored.ptr()
         && m_scrollSnapshots == other.m_scrollSnapshots
-        && m_stickySnapshot == other.m_stickySnapshot;
+        && m_stickySnapshots == other.m_stickySnapshots;
     return !same;
 }
 
-void AnchorScrollAdjuster::addSnapshot(const RenderBox& scroller)
+void AnchorScrollAdjuster::addScrollSnapshot(const RenderBox& scroller)
 {
     ASSERT(scroller.hasPotentiallyScrollableOverflow() && !is<RenderView>(scroller));
     m_scrollSnapshots.constructAndAppend(scroller, scroller.constrainedScrollPosition());
@@ -172,12 +182,18 @@ LayoutSize AnchorScrollAdjuster::adjustmentForViewport(const RenderView& renderV
     return { };
 }
 
+void AnchorScrollAdjuster::addStickySnapshot(const RenderBoxModelObject& sticky)
+{
+    ASSERT(sticky.isStickilyPositioned());
+    m_stickySnapshots.constructAndAppend(sticky, sticky.stickyPositionOffset());
+}
+
 LayoutSize AnchorScrollAdjuster::accumulateAdjustments(const RenderView& renderView, const RenderBox& anchored) const
 {
     ASSERT(m_anchored.ptr() == &anchored);
     LayoutSize scrollAdjustment;
 
-    if (m_hasChainedAnchor || m_hasStickyAnchor) {
+    if (m_hasChainedAnchor) {
         if (CheckedPtr defaultAnchor = Style::AnchorPositionEvaluator::defaultAnchorForBox(anchored)) {
             auto defaultAnchorBox = dynamicDowncast<RenderBox>(defaultAnchor.get());
             ASSERT(defaultAnchorBox); // We shouldn't exist if there's no default anchor.
@@ -185,9 +201,6 @@ LayoutSize AnchorScrollAdjuster::accumulateAdjustments(const RenderView& renderV
                 // The anchor may itself be scroll-compensated. Recurse if needed.
                 if (auto chainedAdjuster = renderView.layoutContext().anchorScrollAdjusterFor(*defaultAnchorBox))
                     scrollAdjustment += chainedAdjuster->accumulateAdjustments(renderView, *defaultAnchorBox);
-                // Compensate for sticky adjustments.
-                if (m_hasStickyAnchor)
-                    scrollAdjustment += defaultAnchorBox->stickyPositionOffset() - m_stickySnapshot;
             }
         }
     }
@@ -195,6 +208,9 @@ LayoutSize AnchorScrollAdjuster::accumulateAdjustments(const RenderView& renderV
     for (auto snapshot : m_scrollSnapshots)
         scrollAdjustment += snapshot.adjustmentForCurrentScrollPosition();
     scrollAdjustment += adjustmentForViewport(renderView);
+
+    for (auto snapshot : m_stickySnapshots)
+        scrollAdjustment += snapshot.adjustmentForCurrentScrollPosition();
 
     if (!m_needsXAdjustment)
         scrollAdjustment.setWidth(0);
@@ -249,6 +265,11 @@ static inline void clearAnchorScrollSnapshots(RenderBox& anchored)
     anchored.layoutContext().unregisterAnchorScrollAdjusterFor(anchored);
 }
 
+static inline bool isFixed(const RenderBoxModelObject& box)
+{
+    return box.layer() && box.layer()->behavesAsFixed();
+}
+
 void AnchorPositionEvaluator::captureScrollSnapshots(RenderBox& anchored, bool invalidateStyleForScrollPositionChanges)
 {
     if (!anchored.layer())
@@ -265,17 +286,21 @@ void AnchorPositionEvaluator::captureScrollSnapshots(RenderBox& anchored, bool i
     CheckedPtr containingBlock = anchored.containingBlock();
     ASSERT(defaultAnchor->isDescendantOf(containingBlock.get()));
 
-    bool isFixedAnchor = defaultAnchor->layer() && defaultAnchor->layer()->behavesAsFixed();
+    bool isFixedAnchor = isFixed(*defaultAnchor);
+    if (defaultAnchor->isStickilyPositioned())
+        adjuster.addStickySnapshot(*defaultAnchor);
     for (auto* ancestor = defaultAnchor->container(); ancestor && ancestor != containingBlock; ancestor = ancestor->container()) {
         if (auto* box = dynamicDowncast<RenderBox>(ancestor)) {
             if (box->hasPotentiallyScrollableOverflow())
-                adjuster.addSnapshot(*box);
-            if (box->layer() && box->layer()->behavesAsFixed())
+                adjuster.addScrollSnapshot(*box);
+            if (isFixed(*box))
                 isFixedAnchor = true;
+            if (box->isStickilyPositioned())
+                adjuster.addStickySnapshot(*box);
         }
     }
 
-    if (anchored.layer() && anchored.layer()->behavesAsFixed() && !isFixedAnchor)
+    if (isFixed(anchored) && !isFixedAnchor && !isFixed(*containingBlock))
         adjuster.addViewportSnapshot(anchored.view());
 
     if (adjuster.isEmpty())

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -66,6 +66,15 @@ struct AnchorScrollSnapshot {
     bool operator==(const AnchorScrollSnapshot&) const = default;
 };
 
+class AnchorStickySnapshot {
+    SingleThreadWeakPtr<const RenderBoxModelObject> m_sticky;
+    LayoutSize m_stickySnapshot { };
+public:
+    inline LayoutSize adjustmentForCurrentScrollPosition() const;
+    AnchorStickySnapshot(const RenderBoxModelObject& sticky, LayoutSize snapshot);
+    bool operator==(const AnchorStickySnapshot&) const = default;
+};
+
 class AnchorScrollAdjuster {
 public:
     AnchorScrollAdjuster(RenderBox& anchored, const RenderBoxModelObject& defaultAnchor);
@@ -79,9 +88,11 @@ public:
     bool isHidden() const { return m_isHidden; }
     void setHidden(bool hide) { m_isHidden = hide; }
 
-    inline void addSnapshot(const RenderBox& scroller);
+    inline void addScrollSnapshot(const RenderBox& scroller);
     inline void addViewportSnapshot(const RenderView&);
     bool hasViewportSnapshot() const { return m_adjustForViewport; }
+
+    inline void addStickySnapshot(const RenderBoxModelObject& sticky);
 
     enum Diff : uint8_t { New, SnapshotsDiffer, SnapshotsMatch };
     bool NODELETE recaptureDiffers(const AnchorScrollAdjuster&) const; // Snapshot differences can require invalidation.
@@ -98,14 +109,13 @@ private:
 
     CheckedRef<RenderBox> m_anchored;
     Vector<AnchorScrollSnapshot, 1> m_scrollSnapshots;
+    Vector<AnchorStickySnapshot> m_stickySnapshots;
     bool m_needsXAdjustment : 1 { false };
     bool m_needsYAdjustment : 1 { false };
     bool m_adjustForViewport : 1 { false };
     bool m_hasChainedAnchor : 1 { false };
-    bool m_hasStickyAnchor : 1 { false };
     bool m_isHidden : 1 { false };
     bool m_hasFallback : 1 { false };
-    LayoutSize m_stickySnapshot;
     LayoutSizeLimits m_fallbackLimits;
 };
 


### PR DESCRIPTION
#### 344b0fc11db6bd68cbafaaf0a40fed35cbd86d7b
<pre>
Fixed boxes anchored to children of sticky boxes should stick
<a href="https://bugs.webkit.org/show_bug.cgi?id=310239">https://bugs.webkit.org/show_bug.cgi?id=310239</a>
<a href="https://rdar.apple.com/172884148">rdar://172884148</a>

Reviewed by Antti Koivisto.

We were only tracking the sticky offset of the anchor itself, but not of its
ancestors. Update the AnchorScrollAdjuster to be able to track the ancestor
chain, using a structure analogous to how we manage ancestor scrollers.

While we&apos;re here, also fix the bug where we are incorrectly performing scroll
compensation for absolutely positioned boxes trapped within a fixed-positioned
containing block, so we can write a good reference for the WPT test.

Tests: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-to-sticky-005-ref.html
       imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-to-sticky-005.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-to-sticky-005-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-to-sticky-005-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-to-sticky-005.html: Added.

Add tests.

* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::AnchorStickySnapshot::AnchorStickySnapshot):
(WebCore::AnchorStickySnapshot::adjustmentForCurrentScrollPosition const):

Implement core methods for new AnchorStickySnapshot struct.

(WebCore::AnchorScrollAdjuster::isEmpty const):
(WebCore::AnchorScrollAdjuster::AnchorScrollAdjuster):
(WebCore::AnchorScrollAdjuster::recaptureDiffers const):
(WebCore::AnchorScrollAdjuster::addScrollSnapshot):
(WebCore::AnchorScrollAdjuster::addStickySnapshot):
(WebCore::AnchorScrollAdjuster::accumulateAdjustments const):

Update AnchorScrollAdjuster to manage AnchorStickySnapshots.

(WebCore::Style::isFixed):

Add convenience method, since we&apos;re repeating this pattern multiple times.

(WebCore::Style::AnchorPositionEvaluator::captureScrollSnapshots):

1. Hook up sticky snapshotting to our ancestor walk for scrollers.
2. Also, check for a fixed containing block before creating a viewport snapshot.

(WebCore::AnchorScrollAdjuster::addSnapshot): Deleted.
* Source/WebCore/style/AnchorPositionEvaluator.h:

Create new AnchorStickySnapshot struct parallelling AnchorScrollSnapshot
and hook it up to the AnchorScrollAdjuster.

Canonical link: <a href="https://commits.webkit.org/310255@main">https://commits.webkit.org/310255@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/729b914d3888c702094f5e253353d9b35fa45e98

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153235 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26017 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19615 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161980 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106693 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0312f847-ec5c-41f0-9cc9-a34e42d83ede) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155108 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26544 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26322 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118464 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b9a87793-f12e-48ab-9dde-f562e6daf879) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156194 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20706 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137583 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99177 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/31b5b0a0-1352-4780-9366-0f15f2aa3b94) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19782 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9815 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129432 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15447 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164454 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7589 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17041 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126524 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25814 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21757 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/semantics/structured-clone/shared.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126682 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34366 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25816 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137243 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82485 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21632 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14022 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25433 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89719 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25125 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25283 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25184 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->