### PR TITLE
Table with fixed-height cells and border-spacing doesn't respect specified height

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/table-height-border-spacing-distribution-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/table-height-border-spacing-distribution-expected.txt
@@ -1,0 +1,5 @@
+Row 1
+Row 2
+
+PASS Table specified height is honored when distributing extra height with border-spacing
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/table-height-border-spacing-distribution.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/table-height-border-spacing-distribution.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>Table specified height with border-spacing and fixed-height cells</title>
+<link rel="help" href="https://drafts.csswg.org/css-tables/#height-distribution">
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+<style>
+  #tabletest {
+    height: 200px;
+    width: 200px;
+    border-spacing: 0 50px;
+    border: none;
+  }
+  #tabletest td {
+    height: 20px;
+    padding: 0;
+  }
+</style>
+<table id="tabletest">
+  <tr><td>Row 1</td></tr>
+  <tr><td>Row 2</td></tr>
+</table>
+<script>
+  test(function() {
+    var table = document.getElementById("tabletest");
+    assert_equals(table.offsetHeight, 200,
+      "Table with fixed-height cells and border-spacing must respect specified height");
+  }, "Table specified height is honored when distributing extra height with border-spacing");
+</script>


### PR DESCRIPTION
#### ef0f700458d3c2427cb111d1bda296caafd78b8a
<pre>
Table with fixed-height cells and border-spacing doesn&apos;t respect specified height
<a href="https://bugs.webkit.org/show_bug.cgi?id=311064">https://bugs.webkit.org/show_bug.cgi?id=311064</a>
<a href="https://rdar.apple.com/173665148">rdar://173665148</a>

Reviewed by NOBODY (OOPS!).

In distributeRemainingExtraLogicalHeight, the denominator for
proportional height distribution included the initial border-spacing
offset (m_rowPos[0]), but the sum of all row-slice numerators in the
loop did not. This caused a fraction of the extra height to go
undistributed, leaving the table shorter than its specified CSS height.

The code had a FIXME acknowledging this:
  // FIXME: m_rowPos[totalRows] - m_rowPos[0] is the total rows&apos; size.
  LayoutUnit totalRowSize = m_rowPos[totalRows];

For a table with height:200px, border-spacing:0 50px, and two
fixed-height cells (td { height:20px }):

  m_rowPos layout:
  [0]=50   [1]=120   [2]=190
    |  50px  | 20px+50px | 20px+50px |
    spacing   row0+gap    row1+gap

  Extra to distribute: 200 - 190 = 10px
  Numerators: (120-50) + (190-120) = 70+70 = 140
  Old denominator: m_rowPos[2]           = 190
  New denominator: m_rowPos[2]-m_rowPos[0] = 140

  Old: 10 * 140/190 = 7px distributed  (table=197px, WRONG)
  New: 10 * 140/140 = 10px distributed (table=200px, CORRECT)

The effect scales with border-spacing: larger spacing causes more
undistributed height. This was most visible with fixed-height cells
(not auto, not percentage) since the entire extra height goes through
distributeRemainingExtraLogicalHeight.

Test: imported/w3c/web-platform-tests/css/css-tables/table-height-border-spacing-distribution.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/table-height-border-spacing-distribution-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/table-height-border-spacing-distribution.html: Added.
* LayoutTests/platform/glib/fast/repaint/table-two-pass-layout-overpaint-expected.txt:
* LayoutTests/platform/glib/tables/mozilla/bugs/bug11944-expected.txt:
* LayoutTests/platform/glib/tables/mozilla/bugs/bug120364-expected.txt:
* LayoutTests/platform/glib/tables/mozilla/core/cell_heights-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/bugs/bug11944-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/bugs/bug120364-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/core/cell_heights-expected.txt:
* LayoutTests/platform/mac/fast/repaint/table-two-pass-layout-overpaint-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug120364-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/core/cell_heights-expected.txt:
* Source/WebCore/rendering/RenderTableSection.cpp:
(WebCore::RenderTableSection::distributeRemainingExtraLogicalHeight):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef0f700458d3c2427cb111d1bda296caafd78b8a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159164 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32592 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25697 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167993 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/113248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32660 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32579 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123308 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/113248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162121 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25580 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/142966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103974 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15766 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/134320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20746 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170488 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22372 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131502 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32281 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/27125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/131616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32225 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142539 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/90286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26310 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19348 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31736 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31256 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31529 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31411 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->