### PR TITLE
Resync `html/browsers/the-window-object` from WPT Upstream

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -8347,3 +8347,5 @@ imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-eleme
 imported/w3c/web-platform-tests/css/selectors/media/media-loading-state.sub.html [ Skip ] # timeout, passes first subtest
 imported/w3c/web-platform-tests/css/selectors/media/media-loading-state-timing.sub.html [ Skip ] # timeout
 imported/w3c/web-platform-tests/css/selectors/invalidation/media-loading-pseudo-classes-in-has.sub.html [ Skip ] # timeout
+
+imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open_fires_resize.tentative.html [ Skip ] # timeout

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/WEB_FEATURES.yml
@@ -1,0 +1,10 @@
+features:
+- name: window
+  files:
+  - '*'
+  - '!BarProp.window.js'
+  - '!noopener-noreferrer-BarProp.window.js'
+- name: barprop
+  files:
+  - BarProp.window.js
+  - noopener-noreferrer-BarProp.window.js

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/accessing-other-browsing-contexts/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/accessing-other-browsing-contexts/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: window
+  files: '**'

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/accessing-other-browsing-contexts/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/accessing-other-browsing-contexts/w3c-import.log
@@ -14,6 +14,7 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/accessing-other-browsing-contexts/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/accessing-other-browsing-contexts/indexed-browsing-contexts-01.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/accessing-other-browsing-contexts/indexed-browsing-contexts-02.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/accessing-other-browsing-contexts/indexed-browsing-contexts-03.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/garbage-collection-and-browsing-contexts/discard_iframe_history_1-1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/garbage-collection-and-browsing-contexts/discard_iframe_history_1-1.html
@@ -8,9 +8,9 @@ onload = t.step_func(function() {
      var history_length = history.length;
      var iframe = document.getElementsByTagName("iframe")[0];
      iframe.onload = t.step_func(function() {
-       opener.assert_equals(history.length, history_length + 1);
+       opener.assert_equals(history.length, history_length, "History length before iframe removal");
        iframe.parentNode.removeChild(iframe);
-       opener.assert_equals(history.length, history_length);
+       opener.assert_equals(history.length, history_length, "History length after iframe removal");
        t.done();
        window.close();
      });

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/garbage-collection-and-browsing-contexts/discard_iframe_history_1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/garbage-collection-and-browsing-contexts/discard_iframe_history_1-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Removing iframe from document removes it from history assert_equals: expected 2 but got 1
+PASS Removing iframe from document removes it from history
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/garbage-collection-and-browsing-contexts/discard_iframe_history_2-1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/garbage-collection-and-browsing-contexts/discard_iframe_history_2-1.html
@@ -9,7 +9,7 @@ onload = t.step_func(function() {
      var iframe = document.getElementsByTagName("iframe")[0];
      iframe.onload = t.step_func(function() {
        setTimeout(t.step_func(function() {
-         opener.assert_equals(history.length, history_length + 1, "History length before iframe removal");
+         opener.assert_equals(history.length, history_length, "History length before iframe removal");
          document.body.innerHTML = "";
          opener.assert_equals(history.length, history_length, "History length after iframe removal");
          t.done();

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/garbage-collection-and-browsing-contexts/discard_iframe_history_2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/garbage-collection-and-browsing-contexts/discard_iframe_history_2-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Removing iframe from document via innerHTML removes it from history assert_equals: History length before iframe removal expected 2 but got 1
+PASS Removing iframe from document via innerHTML removes it from history
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/named-access-on-the-window-object/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/named-access-on-the-window-object/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: window
+  files: '**'

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/named-access-on-the-window-object/cross-origin-named-access.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/named-access-on-the-window-object/cross-origin-named-access.sub-expected.txt
@@ -1,0 +1,5 @@
+
+FAIL Accessing a cross-origin child global by name returns undefined assert_equals: window.frame1 should be undefined for cross-origin iframes expected (undefined) undefined but got (object) [stringifying object threw SecurityError: Blocked a frame with origin "http://web-platform.test:8800" from accessing a cross-origin frame. Protocols, domains, and ports must match. with type object]
+FAIL Child accessing its own global through a cross-origin parent's WindowProxy throws an exception assert_equals: Accessing `window.parent.frame1` from the child throws a SecurityError expected "SecurityError" but got "No exception"
+FAIL Child accessing its own global (through a changed name) on the cross-origin parent's WindowProxy throws an exception assert_equals: window.new_name should be undefined for cross-origin iframes expected (undefined) undefined but got (object) [stringifying object threw SecurityError: Blocked a frame with origin "http://web-platform.test:8800" from accessing a cross-origin frame. Protocols, domains, and ports must match. with type object]
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/named-access-on-the-window-object/cross-origin-named-access.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/named-access-on-the-window-object/cross-origin-named-access.sub.html
@@ -1,0 +1,101 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Named access on the Window object across origins</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<body>
+<script>
+
+async function setup_and_load_iframe(t) {
+  const host_info = get_host_info();
+  const iframe = document.createElement("iframe");
+  t.add_cleanup(() => iframe.remove());
+
+  iframe.name = "frame1";
+  iframe.src = host_info.HTTP_REMOTE_ORIGIN + "/html/browsers/the-window-object/named-access-on-the-window-object/resources/cross-origin-named-access-child.html";
+
+  // Wait for child to load.
+  let p = new Promise(resolve => {
+    window.addEventListener("message", e => {
+      if (e.data === "child_loaded") {
+        resolve();
+      }
+    }, {once: true});
+  });
+  document.body.append(iframe);
+  await p;
+  return iframe;
+}
+
+promise_test(async t => {
+  const iframe = await setup_and_load_iframe(t);
+
+  // Access of the cross-origin Window by name `window.frame1` should return
+  // undefined, per `[[GetOwnProperty]] (P)` [1]. The access enters [1], where
+  // `IsPlatformObjectSameOrigin()` is true, so we never consult [2] the
+  // document-tree child navigable target name property set [3].
+  //
+  // (But even if we did consult that set directly, no frame by the name
+  // `frame1` would be there, since that set excludes cross-origin globals).
+  //
+  // [1]: https://html.spec.whatwg.org/#windowproxy-getownproperty
+  // [2]: https://html.spec.whatwg.org/#named-access-on-the-window-object:document-tree-child-navigable-target-name-property-set
+  // [3]: https://html.spec.whatwg.org/#document-tree-child-navigable-target-name-property-set
+  assert_equals(window.frame1, undefined, "window.frame1 should be undefined for cross-origin iframes");
+}, "Accessing a cross-origin child global by name returns undefined");
+
+promise_test(async t => {
+  const iframe = await setup_and_load_iframe(t);
+
+  // Ask the child to check `window.parent.frame1` (as well as arbitrary name
+  // access), from its script. This enters `[[GetOwnProperty]] (P)` [1], where
+  // `IsPlatformObjectSameOrigin()` is false since `W` is a WindowProxy object
+  // representing the cross-origin parent. This results in us consulting [2]
+  // the document-tree child navigable target name property set [3], which does
+  // not contain `frame1` (the child's `window.name`), because the frame with
+  // that name is cross-origin to the parent `W`.
+  //
+  // This drops us into `CrossOriginPropertyFallback()` [4] which throws an
+  // exception in the child, which the child will report to us here.
+  //
+  // [1]: https://html.spec.whatwg.org/#windowproxy-getownproperty
+  // [2]: https://html.spec.whatwg.org/#named-access-on-the-window-object:document-tree-child-navigable-target-name-property-set
+  // [3]: https://html.spec.whatwg.org/#document-tree-child-navigable-target-name-property-set
+  // [4]: https://html.spec.whatwg.org/#crossoriginpropertyfallback-(-p-)
+  p = new Promise(resolve => {
+    window.addEventListener("message", e => {
+      if (e.data && e.data.type === "parent_frame1_result") {
+        resolve(e.data);
+      }
+    }, {once: true});
+  });
+  iframe.contentWindow.postMessage("check_parent_frame1", "*");
+  let result = await p;
+
+  assert_equals(result.frame1_result, "SecurityError", "Accessing `window.parent.frame1` from the child throws a SecurityError");
+  // This just indicates that the exception is not specific to the accessing of
+  // frame names that the initiating process "knows about" in its frame tree;
+  // rather, exceptions are thrown for all generic cross-origin property access.
+  assert_equals(result.anythingHere_result, "SecurityError", "Accessing `window.parent.anythingHere` from the child throws a SecurityError");
+}, "Child accessing its own global through a cross-origin parent's WindowProxy throws an exception");
+
+promise_test(async t => {
+  const iframe = await setup_and_load_iframe(t);
+
+  // Ask the child to change its name and check again. The result should be the same.
+  p = new Promise(resolve => {
+    window.addEventListener("message", function handler(e) {
+      if (e.data && e.data.type === "parent_new_name_result") {
+        resolve(e.data);
+      }
+    }, {once: true});
+  });
+  iframe.contentWindow.postMessage("change_name_and_check", "*");
+  let result = await p;
+
+  assert_equals(window.new_name, undefined, "window.new_name should be undefined for cross-origin iframes");
+  assert_equals(result.new_name_result, "SecurityError", "Accessing window.parent.new_name should throw SecurityError");
+}, "Child accessing its own global (through a changed name) on the cross-origin parent's WindowProxy throws an exception");
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/named-access-on-the-window-object/resources/cross-origin-named-access-child.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/named-access-on-the-window-object/resources/cross-origin-named-access-child.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<meta charset=utf-8>
+<script>
+window.addEventListener("message", e => {
+  if (e.data === "check_parent_frame1") {
+    let frame1_result, anythingHere_result;
+
+    try {
+      let x = window.parent.frame1;
+      frame1_result = "No exception";
+    } catch (err) {
+      frame1_result = err.name;
+    }
+
+    try {
+      let x = window.parent.anythingHere;
+      anythingHere_result = "No exception";
+    } catch (err) {
+      anythingHere_result = err.name;
+    }
+
+    window.parent.postMessage({
+      type: "parent_frame1_result",
+      frame1_result,
+      anythingHere_result
+    }, "*");
+  } else if (e.data === "change_name_and_check") {
+    window.name = "new_name";
+
+    let new_name_result;
+    try {
+      let x = window.parent.new_name;
+      new_name_result = "No exception";
+    } catch (err) {
+      new_name_result = err.name;
+    }
+
+    window.parent.postMessage({
+      type: "parent_new_name_result",
+      new_name_result
+    }, "*");
+  }
+});
+
+// Signal to the parent that the cross-origin frame is loaded and ready.
+window.parent.postMessage("child_loaded", "*");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/named-access-on-the-window-object/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/named-access-on-the-window-object/resources/w3c-import.log
@@ -14,5 +14,4 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
-/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/security-window/WEB_FEATURES.yml
-/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/security-window/window-security.https.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/named-access-on-the-window-object/resources/cross-origin-named-access-child.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/named-access-on-the-window-object/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/named-access-on-the-window-object/w3c-import.log
@@ -14,10 +14,12 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/named-access-on-the-window-object/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/named-access-on-the-window-object/basics.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/named-access-on-the-window-object/changing.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/named-access-on-the-window-object/cross-global-npo.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/named-access-on-the-window-object/cross-global-support.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/named-access-on-the-window-object/cross-origin-named-access.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/named-access-on-the-window-object/doc-no-window.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/named-access-on-the-window-object/existing-prop.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/named-access-on-the-window-object/multi-match.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: window
+  files: '**'

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open_fires_resize.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open_fires_resize.tentative.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Test that a resize event is fired on newly opened windows</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+
+promise_test(async t => {
+  popup = window.open("about:blank", "_blank", "width=500,height=500");
+  await new Promise(resolve => popup.onresize = resolve);
+  assert_true(true, "Got resize event");
+}, "Opening a popup with specified size fires a resize event");
+
+promise_test(async t => {
+  popup = window.open("about:blank", "_blank", "popup");
+  await new Promise(resolve => popup.onresize = resolve);
+  assert_true(true, "Got resize event");
+}, "Opening a popup fires a resize event");
+
+promise_test(async t => {
+  popup = window.open("about:blank");
+  await new Promise(resolve => popup.onresize = resolve);
+  assert_true(true, "Got resize event");
+}, "Opening a window fires a resize event");
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/self-close.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/self-close.html
@@ -2,7 +2,7 @@
 <p>self-close.html?navs=n&channel;=name will navigate n times, then close and notify the channel.</p>
 
 <script>
-window.onload = setTimeout(() => {
+window.onload = () => setTimeout(() => {
   const urlParams = new URLSearchParams(window.location.search);
   let n = parseInt(urlParams.get('navs')) || 0;
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/w3c-import.log
@@ -14,6 +14,7 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/callback.js
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/close_beforeunload-1.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/close_beforeunload.html
@@ -45,6 +46,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-screenx-screeny.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-top-left.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-width-height.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open_fires_resize.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open_initial_size.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/script-closable.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/self-close.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/security-window/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/security-window/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: window
+  files: '**'

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/w3c-import.log
@@ -16,6 +16,7 @@ None
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/BarProp.window.js
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/Document-defaultView.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/Window-document.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/close-method.window.js
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/closed-attribute.window.js
@@ -45,3 +46,4 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/window-properties.https.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/window-prototype-chain.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/window-reuse-in-nested-browsing-contexts.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/window-reuse.tentative.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/window-reuse-in-nested-browsing-contexts.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/window-reuse-in-nested-browsing-contexts.tentative.html
@@ -14,6 +14,9 @@ const setupIframe = (t, attrs) => {
   return {iframe, watcher};
 };
 
+// This test is outdated, see
+// https://github.com/whatwg/html/issues/3267#issuecomment-2788132131
+
 promise_test(async t => {
   const {iframe, watcher} = setupIframe(t, {});
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/window-reuse.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/window-reuse.tentative-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Initially navigating window to non-about:blank page should reuse synchonously available window
+PASS synchronously navigating window away from initial about:blank should not reuse window
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/window-reuse.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/window-reuse.tentative.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Test window reuse on initial navigation away from about:blank</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id=log></div>
+<script>
+promise_test(async t => {
+  const w = window.open("/common/blank.html");
+  t.add_cleanup(() => w.close());
+
+  assert_equals(w.location.href, 'about:blank', 'window initially on a transient about:blank');
+  w.foo = 'bar';
+
+  await new Promise(res => w.onload = res);
+  assert_true(w.location.href.endsWith('/common/blank.html'), 'loaded initial navigation target');
+  assert_equals(w.foo, 'bar', 'did reuse window');
+}, 'Initially navigating window to non-about:blank page should reuse synchonously available window');
+
+promise_test(async t => {
+  const name = 'unique-name-11sep25';
+  const channel = new BroadcastChannel(name);
+  const w = window.open("about:blank", name);
+  t.add_cleanup(() => w.close());
+
+  assert_equals(w.location.href, 'about:blank', 'loaded about:blank');
+  w.foo = 'bar';
+
+  w.location.href = 'support/window-open-popup-target.html';
+  await new Promise(res => channel.onmessage = res);
+  assert_true(true, 'completed non-initial load onto initial about:blank');
+  assert_equals(w.foo, undefined, 'did reuse window');
+}, 'synchronously navigating window away from initial about:blank should not reuse window');
+</script>


### PR DESCRIPTION
#### 811cb3694dc1f11065a20a06dae9da695c070ee6
<pre>
Resync `html/browsers/the-window-object` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=311068">https://bugs.webkit.org/show_bug.cgi?id=311068</a>
<a href="https://rdar.apple.com/173669704">rdar://173669704</a>

Reviewed by Simon Fraser.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/d61231d9ceef372cc66d64ac19c467c2506a8814">https://github.com/web-platform-tests/wpt/commit/d61231d9ceef372cc66d64ac19c467c2506a8814</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/accessing-other-browsing-contexts/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/accessing-other-browsing-contexts/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/garbage-collection-and-browsing-contexts/discard_iframe_history_1-1.html:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/garbage-collection-and-browsing-contexts/discard_iframe_history_1-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/garbage-collection-and-browsing-contexts/discard_iframe_history_2-1.html:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/garbage-collection-and-browsing-contexts/discard_iframe_history_2-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/named-access-on-the-window-object/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/named-access-on-the-window-object/cross-origin-named-access.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/named-access-on-the-window-object/cross-origin-named-access.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/named-access-on-the-window-object/resources/cross-origin-named-access-child.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/named-access-on-the-window-object/resources/w3c-import.log: Copied from LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/security-window/w3c-import.log.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/named-access-on-the-window-object/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open_fires_resize.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/self-close.html:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/security-window/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/security-window/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/window-reuse-in-nested-browsing-contexts.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/window-reuse.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/window-reuse.tentative.html: Added.

Canonical link: <a href="https://commits.webkit.org/310231@main">https://commits.webkit.org/310231@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e08af5fd5d24d6f98ec5550267b96189a06b83ad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153148 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25930 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19528 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161892 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106606 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f34e61a6-2a36-405e-9333-2c62c3abadcc) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26457 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26235 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118388 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83830 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/45d2b787-f875-4bca-a4dc-534720f35347) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156107 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20628 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137490 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99101 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ddd8ecaa-dd3b-4884-ab37-efce0051cc9b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19703 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17644 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9728 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129354 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15363 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164366 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16957 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126448 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25727 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21679 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126606 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34350 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25729 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137159 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82393 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21558 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13938 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25345 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25038 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25196 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25097 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->