### PR TITLE
Resync `html/webappapis/structured-clone` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any-expected.txt
@@ -131,6 +131,12 @@ FAIL ObjectPrototype must lose its exotic-ness when cloned promise_test: Unhandl
 PASS Serializing a non-serializable platform object fails
 PASS An object whose interface is deleted from the global must still deserialize
 PASS A subclass instance will deserialize as its closest serializable superclass
+PASS Resizable ArrayBuffer
+FAIL Growable SharedArrayBuffer promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: createBuffer"
+PASS Length-tracking TypedArray
+PASS Length-tracking DataView
+PASS Serializing OOB TypedArray throws
+PASS Serializing OOB DataView throws
 PASS ArrayBuffer
 PASS MessagePort
 PASS A detached ArrayBuffer cannot be transferred
@@ -138,4 +144,9 @@ PASS A detached platform object cannot be transferred
 PASS Transferring a non-transferable platform object fails
 PASS An object whose interface is deleted from the global object must still be received
 PASS A subclass instance will be received as its closest transferable superclass
+PASS Resizable ArrayBuffer is transferable
+PASS Length-tracking TypedArray is transferable
+PASS Length-tracking DataView is transferable
+PASS Transferring OOB TypedArray throws
+PASS Transferring OOB DataView throws
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.serviceworker-expected.txt
@@ -116,6 +116,12 @@ FAIL ObjectPrototype must lose its exotic-ness when cloned promise_test: Unhandl
 PASS Serializing a non-serializable platform object fails
 PASS An object whose interface is deleted from the global must still deserialize
 PASS A subclass instance will deserialize as its closest serializable superclass
+PASS Resizable ArrayBuffer
+FAIL Growable SharedArrayBuffer promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: createBuffer"
+PASS Length-tracking TypedArray
+PASS Length-tracking DataView
+PASS Serializing OOB TypedArray throws
+PASS Serializing OOB DataView throws
 PASS ArrayBuffer
 PASS MessagePort
 PASS A detached ArrayBuffer cannot be transferred
@@ -123,4 +129,9 @@ PASS A detached platform object cannot be transferred
 PASS Transferring a non-transferable platform object fails
 PASS An object whose interface is deleted from the global object must still be received
 PASS A subclass instance will be received as its closest transferable superclass
+PASS Resizable ArrayBuffer is transferable
+PASS Length-tracking TypedArray is transferable
+PASS Length-tracking DataView is transferable
+PASS Transferring OOB TypedArray throws
+PASS Transferring OOB DataView throws
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.sharedworker-expected.txt
@@ -116,6 +116,12 @@ FAIL ObjectPrototype must lose its exotic-ness when cloned promise_test: Unhandl
 PASS Serializing a non-serializable platform object fails
 PASS An object whose interface is deleted from the global must still deserialize
 PASS A subclass instance will deserialize as its closest serializable superclass
+PASS Resizable ArrayBuffer
+FAIL Growable SharedArrayBuffer promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: createBuffer"
+PASS Length-tracking TypedArray
+PASS Length-tracking DataView
+PASS Serializing OOB TypedArray throws
+PASS Serializing OOB DataView throws
 PASS ArrayBuffer
 PASS MessagePort
 PASS A detached ArrayBuffer cannot be transferred
@@ -123,4 +129,9 @@ PASS A detached platform object cannot be transferred
 PASS Transferring a non-transferable platform object fails
 PASS An object whose interface is deleted from the global object must still be received
 PASS A subclass instance will be received as its closest transferable superclass
+PASS Resizable ArrayBuffer is transferable
+PASS Length-tracking TypedArray is transferable
+PASS Length-tracking DataView is transferable
+PASS Transferring OOB TypedArray throws
+PASS Transferring OOB DataView throws
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.worker-expected.txt
@@ -116,6 +116,12 @@ FAIL ObjectPrototype must lose its exotic-ness when cloned promise_test: Unhandl
 PASS Serializing a non-serializable platform object fails
 PASS An object whose interface is deleted from the global must still deserialize
 PASS A subclass instance will deserialize as its closest serializable superclass
+PASS Resizable ArrayBuffer
+FAIL Growable SharedArrayBuffer promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: createBuffer"
+PASS Length-tracking TypedArray
+PASS Length-tracking DataView
+PASS Serializing OOB TypedArray throws
+PASS Serializing OOB DataView throws
 PASS ArrayBuffer
 PASS MessagePort
 PASS A detached ArrayBuffer cannot be transferred
@@ -123,4 +129,9 @@ PASS A detached platform object cannot be transferred
 PASS Transferring a non-transferable platform object fails
 PASS An object whose interface is deleted from the global object must still be received
 PASS A subclass instance will be received as its closest transferable superclass
+PASS Resizable ArrayBuffer is transferable
+PASS Length-tracking TypedArray is transferable
+PASS Length-tracking DataView is transferable
+PASS Transferring OOB TypedArray throws
+PASS Transferring OOB DataView throws
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/window-postmessage.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/window-postmessage.window-expected.txt
@@ -131,6 +131,12 @@ FAIL ObjectPrototype must lose its exotic-ness when cloned promise_test: Unhandl
 PASS Serializing a non-serializable platform object fails
 PASS An object whose interface is deleted from the global must still deserialize
 PASS A subclass instance will deserialize as its closest serializable superclass
+PASS Resizable ArrayBuffer
+FAIL Growable SharedArrayBuffer promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: createBuffer"
+PASS Length-tracking TypedArray
+PASS Length-tracking DataView
+PASS Serializing OOB TypedArray throws
+PASS Serializing OOB DataView throws
 PASS ArrayBuffer
 PASS MessagePort
 PASS A detached ArrayBuffer cannot be transferred
@@ -138,4 +144,9 @@ PASS A detached platform object cannot be transferred
 PASS Transferring a non-transferable platform object fails
 PASS An object whose interface is deleted from the global object must still be received
 PASS A subclass instance will be received as its closest transferable superclass
+PASS Resizable ArrayBuffer is transferable
+PASS Length-tracking TypedArray is transferable
+PASS Length-tracking DataView is transferable
+PASS Transferring OOB TypedArray throws
+PASS Transferring OOB DataView throws
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: structured-clone
+  files: "**"

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone-battery-of-tests.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone-battery-of-tests.js
@@ -380,6 +380,14 @@ check('FileList empty', func_FileList_empty, compare_FileList, true);
 check('Array FileList object, FileList empty', () => ([func_FileList_empty()]), compare_Array(enumerate_props(compare_FileList)), true);
 check('Object FileList object, FileList empty', () => ({'x':func_FileList_empty()}), compare_Object(enumerate_props(compare_FileList)), true);
 
+function compare_ArrayBuffer(actual, input) {
+  assert_true(actual instanceof ArrayBuffer, 'instanceof ArrayBuffer');
+  assert_equals(actual.byteLength, input.byteLength, 'byteLength');
+  assert_equals(actual.maxByteLength, input.maxByteLength, 'maxByteLength');
+  assert_equals(actual.resizable, input.resizable, 'resizable');
+  assert_equals(actual.growable, input.growable, 'growable');
+}
+
 function compare_ArrayBufferView(view) {
   const Type = self[view];
   return function(actual, input) {
@@ -387,6 +395,8 @@ function compare_ArrayBufferView(view) {
       assert_unreached(actual);
     assert_true(actual instanceof Type, 'instanceof '+view);
     assert_equals(actual.length, input.length, 'length');
+    assert_equals(actual.byteLength, input.byteLength, 'byteLength');
+    assert_equals(actual.byteOffset, input.byteOffset, 'byteOffset');
     assert_not_equals(actual.buffer, input.buffer, 'buffer');
     for (let i = 0; i < actual.length; ++i) {
       assert_equals(actual[i], input[i], 'actual['+i+']');
@@ -668,3 +678,77 @@ check(
     assert_equals(Object.getPrototypeOf(copy), File.prototype);
   }
 );
+
+check(
+  'Resizable ArrayBuffer',
+  () => {
+    const ab = new ArrayBuffer(16, { maxByteLength: 1024 });
+    assert_true(ab.resizable);
+    return ab;
+  },
+  compare_ArrayBuffer);
+
+structuredCloneBatteryOfTests.push({
+  description: 'Growable SharedArrayBuffer',
+  async f(runner) {
+    const sab = createBuffer('SharedArrayBuffer', 16, { maxByteLength: 1024 });
+    assert_true(sab.growable);
+    try {
+      const copy = await runner.structuredClone(sab);
+      compare_ArrayBuffer(sab, copy);
+    } catch (e) {
+      // If we're cross-origin isolated, cloning SABs should not fail.
+      if (e instanceof DOMException && e.code === DOMException.DATA_CLONE_ERR) {
+        assert_false(self.crossOriginIsolated);
+      } else {
+        throw e;
+      }
+    }
+  }
+});
+
+check(
+  'Length-tracking TypedArray',
+  () => {
+    const ab = new ArrayBuffer(16, { maxByteLength: 1024 });
+    assert_true(ab.resizable);
+    return new Uint8Array(ab);
+  },
+  compare_ArrayBufferView('Uint8Array'));
+
+check(
+  'Length-tracking DataView',
+  () => {
+    const ab = new ArrayBuffer(16, { maxByteLength: 1024 });
+    assert_true(ab.resizable);
+    return new DataView(ab);
+  },
+  compare_ArrayBufferView('DataView'));
+
+structuredCloneBatteryOfTests.push({
+  description: 'Serializing OOB TypedArray throws',
+  async f(runner, t) {
+    const ab = new ArrayBuffer(16, { maxByteLength: 1024 });
+    const ta = new Uint8Array(ab, 8);
+    ab.resize(0);
+    await promise_rejects_dom(
+      t,
+      "DataCloneError",
+      runner.structuredClone(ta)
+    );
+  }
+});
+
+structuredCloneBatteryOfTests.push({
+  description: 'Serializing OOB DataView throws',
+  async f(runner, t) {
+    const ab = new ArrayBuffer(16, { maxByteLength: 1024 });
+    const dv = new DataView(ab, 8);
+    ab.resize(0);
+    await promise_rejects_dom(
+      t,
+      "DataCloneError",
+      runner.structuredClone(dv)
+    );
+  }
+});

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone-detached-window-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone-detached-window-crash.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<title>window.structuredClone() doesn't crash when window is detached</title>
+<link rel="help" href="https://crbug.com/1445375">
+<body>
+<script>
+let i = document.createElement("iframe");
+document.body.appendChild(i);
+let i_win = i.contentWindow;
+i.remove();
+i_win.structuredClone("some data");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone.any-expected.txt
@@ -131,6 +131,12 @@ FAIL ObjectPrototype must lose its exotic-ness when cloned promise_test: Unhandl
 PASS Serializing a non-serializable platform object fails
 PASS An object whose interface is deleted from the global must still deserialize
 PASS A subclass instance will deserialize as its closest serializable superclass
+PASS Resizable ArrayBuffer
+FAIL Growable SharedArrayBuffer assert_true: instanceof ArrayBuffer expected true got false
+PASS Length-tracking TypedArray
+PASS Length-tracking DataView
+PASS Serializing OOB TypedArray throws
+PASS Serializing OOB DataView throws
 PASS ArrayBuffer
 PASS MessagePort
 PASS A detached ArrayBuffer cannot be transferred
@@ -138,4 +144,9 @@ PASS A detached platform object cannot be transferred
 PASS Transferring a non-transferable platform object fails
 PASS An object whose interface is deleted from the global object must still be received
 PASS A subclass instance will be received as its closest transferable superclass
+PASS Resizable ArrayBuffer is transferable
+PASS Length-tracking TypedArray is transferable
+PASS Length-tracking DataView is transferable
+PASS Transferring OOB TypedArray throws
+PASS Transferring OOB DataView throws
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone.any.js
@@ -1,4 +1,5 @@
 // META: title=structuredClone() tests
+// META: script=/common/sab.js
 // META: script=/html/webappapis/structured-clone/structured-clone-battery-of-tests.js
 // META: script=/html/webappapis/structured-clone/structured-clone-battery-of-tests-with-transferables.js
 // META: script=/html/webappapis/structured-clone/structured-clone-battery-of-tests-harness.js

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone.any.worker-expected.txt
@@ -116,6 +116,12 @@ FAIL ObjectPrototype must lose its exotic-ness when cloned promise_test: Unhandl
 PASS Serializing a non-serializable platform object fails
 PASS An object whose interface is deleted from the global must still deserialize
 PASS A subclass instance will deserialize as its closest serializable superclass
+PASS Resizable ArrayBuffer
+FAIL Growable SharedArrayBuffer assert_true: instanceof ArrayBuffer expected true got false
+PASS Length-tracking TypedArray
+PASS Length-tracking DataView
+PASS Serializing OOB TypedArray throws
+PASS Serializing OOB DataView throws
 PASS ArrayBuffer
 PASS MessagePort
 PASS A detached ArrayBuffer cannot be transferred
@@ -123,4 +129,9 @@ PASS A detached platform object cannot be transferred
 PASS Transferring a non-transferable platform object fails
 PASS An object whose interface is deleted from the global object must still be received
 PASS A subclass instance will be received as its closest transferable superclass
+PASS Resizable ArrayBuffer is transferable
+PASS Length-tracking TypedArray is transferable
+PASS Length-tracking DataView is transferable
+PASS Transferring OOB TypedArray throws
+PASS Transferring OOB DataView throws
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/w3c-import.log
@@ -14,8 +14,10 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone-battery-of-tests-harness.js
 /LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone-battery-of-tests-with-transferables.js
 /LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone-battery-of-tests.js
 /LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone-cross-realm-method.html
+/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone-detached-window-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone.any.js

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/semantics/structured-clone/dedicated-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/semantics/structured-clone/dedicated-expected.txt
@@ -131,6 +131,12 @@ FAIL ObjectPrototype must lose its exotic-ness when cloned promise_test: Unhandl
 PASS Serializing a non-serializable platform object fails
 PASS An object whose interface is deleted from the global must still deserialize
 PASS A subclass instance will deserialize as its closest serializable superclass
+PASS Resizable ArrayBuffer
+FAIL Growable SharedArrayBuffer assert_true: instanceof ArrayBuffer expected true got false
+PASS Length-tracking TypedArray
+PASS Length-tracking DataView
+PASS Serializing OOB TypedArray throws
+PASS Serializing OOB DataView throws
 PASS ArrayBuffer
 PASS MessagePort
 PASS A detached ArrayBuffer cannot be transferred
@@ -138,4 +144,9 @@ PASS A detached platform object cannot be transferred
 PASS Transferring a non-transferable platform object fails
 PASS An object whose interface is deleted from the global object must still be received
 PASS A subclass instance will be received as its closest transferable superclass
+PASS Resizable ArrayBuffer is transferable
+PASS Length-tracking TypedArray is transferable
+PASS Length-tracking DataView is transferable
+PASS Transferring OOB TypedArray throws
+PASS Transferring OOB DataView throws
 

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/semantics/structured-clone/shared-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/semantics/structured-clone/shared-expected.txt
@@ -131,6 +131,12 @@ FAIL ObjectPrototype must lose its exotic-ness when cloned promise_test: Unhandl
 PASS Serializing a non-serializable platform object fails
 PASS An object whose interface is deleted from the global must still deserialize
 PASS A subclass instance will deserialize as its closest serializable superclass
+PASS Resizable ArrayBuffer
+FAIL Growable SharedArrayBuffer assert_true: instanceof ArrayBuffer expected true got false
+PASS Length-tracking TypedArray
+PASS Length-tracking DataView
+PASS Serializing OOB TypedArray throws
+PASS Serializing OOB DataView throws
 PASS ArrayBuffer
 PASS MessagePort
 PASS A detached ArrayBuffer cannot be transferred
@@ -138,4 +144,9 @@ PASS A detached platform object cannot be transferred
 PASS Transferring a non-transferable platform object fails
 PASS An object whose interface is deleted from the global object must still be received
 PASS A subclass instance will be received as its closest transferable superclass
+PASS Resizable ArrayBuffer is transferable
+PASS Length-tracking TypedArray is transferable
+PASS Length-tracking DataView is transferable
+PASS Transferring OOB TypedArray throws
+PASS Transferring OOB DataView throws
 


### PR DESCRIPTION
#### 9422f754ef9e9c4940730567be486d0856476d0c
<pre>
Resync `html/webappapis/structured-clone` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=311069">https://bugs.webkit.org/show_bug.cgi?id=311069</a>
<a href="https://rdar.apple.com/173670677">rdar://173670677</a>

Reviewed by Simon Fraser.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/d61231d9ceef372cc66d64ac19c467c2506a8814">https://github.com/web-platform-tests/wpt/commit/d61231d9ceef372cc66d64ac19c467c2506a8814</a>

* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/window-postmessage.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone-battery-of-tests-with-transferables.js:
(structuredCloneBatteryOfTests.push.async f):
* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone-battery-of-tests.js:
(compare_ArrayBufferView):
* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone-detached-window-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone.any.js:
* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/workers/semantics/structured-clone/dedicated-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/semantics/structured-clone/shared-expected.txt:

Canonical link: <a href="https://commits.webkit.org/310230@main">https://commits.webkit.org/310230@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc24f79fa779288c8cd05de99a829b1ea47b573a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153153 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25935 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19533 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161897 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106611 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/03af9d7c-2605-408d-a080-c899ac78c3ab) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26462 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26240 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118393 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83835 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fd4a535e-2276-4624-9398-af6c978a1e96) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156112 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20629 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137497 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99106 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b9105db1-d1b3-4f7a-8191-9f445c112770) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19704 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9733 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129355 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15370 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164371 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16964 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126453 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25732 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21684 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126611 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34349 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25734 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137166 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82399 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21563 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13945 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25350 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25043 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25201 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25102 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->