### PR TITLE
Implement RTCRtpReceiver.jitterBufferTarget

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-audio-jitterBufferTarget-stats.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-audio-jitterBufferTarget-stats.https-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL measure raising and lowering audio jitterBufferTarget assert_equals: jitterBufferTarget supported for audio expected (object) null but got (undefined) undefined
+PASS measure raising and lowering audio jitterBufferTarget
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-jitterBufferTarget-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-jitterBufferTarget-expected.txt
@@ -1,14 +1,14 @@
 
-FAIL audio jitterBufferTarget is null by default assert_equals: expected (object) null but got (undefined) undefined
-FAIL audio jitterBufferTarget accepts posititve values assert_equals: expected (object) null but got (undefined) undefined
-FAIL audio jitterBufferTarget accepts values up to 4000 milliseconds assert_equals: expected (object) null but got (undefined) undefined
-FAIL audio jitterBufferTarget returns last valid value on throw assert_equals: expected (object) null but got (undefined) undefined
-FAIL audio jitterBufferTarget allows zero value assert_equals: expected (object) null but got (undefined) undefined
-FAIL audio jitterBufferTarget allows to reset value to null assert_equals: expected (object) null but got (undefined) undefined
-FAIL video jitterBufferTarget is null by default assert_equals: expected (object) null but got (undefined) undefined
-FAIL video jitterBufferTarget accepts posititve values assert_equals: expected (object) null but got (undefined) undefined
-FAIL video jitterBufferTarget accepts values up to 4000 milliseconds assert_equals: expected (object) null but got (undefined) undefined
-FAIL video jitterBufferTarget returns last valid value assert_equals: expected (object) null but got (undefined) undefined
-FAIL video jitterBufferTarget allows zero value assert_equals: expected (object) null but got (undefined) undefined
-FAIL video jitterBufferTarget allows to reset value to null assert_equals: expected (object) null but got (undefined) undefined
+PASS audio jitterBufferTarget is null by default
+PASS audio jitterBufferTarget accepts posititve values
+PASS audio jitterBufferTarget accepts values up to 4000 milliseconds
+PASS audio jitterBufferTarget returns last valid value on throw
+PASS audio jitterBufferTarget allows zero value
+PASS audio jitterBufferTarget allows to reset value to null
+PASS video jitterBufferTarget is null by default
+PASS video jitterBufferTarget accepts posititve values
+PASS video jitterBufferTarget accepts values up to 4000 milliseconds
+PASS video jitterBufferTarget returns last valid value
+PASS video jitterBufferTarget allows zero value
+PASS video jitterBufferTarget allows to reset value to null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-video-jitterBufferTarget-stats-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-video-jitterBufferTarget-stats-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL measure raising and lowering video jitterBufferTarget assert_equals: jitterBufferTarget supported for video expected (object) null but got (undefined) undefined
+PASS measure raising and lowering video jitterBufferTarget
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/idlharness.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/idlharness.https.window-expected.txt
@@ -272,7 +272,7 @@ PASS RTCRtpReceiver interface: operation getParameters()
 PASS RTCRtpReceiver interface: operation getContributingSources()
 PASS RTCRtpReceiver interface: operation getSynchronizationSources()
 PASS RTCRtpReceiver interface: operation getStats()
-FAIL RTCRtpReceiver interface: attribute jitterBufferTarget assert_true: The prototype object must have a property "jitterBufferTarget" expected true got false
+PASS RTCRtpReceiver interface: attribute jitterBufferTarget
 PASS RTCRtpReceiver must be primary interface of new RTCPeerConnection().addTransceiver('audio').receiver
 PASS Stringification of new RTCPeerConnection().addTransceiver('audio').receiver
 PASS RTCRtpReceiver interface: new RTCPeerConnection().addTransceiver('audio').receiver must inherit property "track" with the proper type
@@ -283,7 +283,7 @@ PASS RTCRtpReceiver interface: new RTCPeerConnection().addTransceiver('audio').r
 PASS RTCRtpReceiver interface: new RTCPeerConnection().addTransceiver('audio').receiver must inherit property "getContributingSources()" with the proper type
 PASS RTCRtpReceiver interface: new RTCPeerConnection().addTransceiver('audio').receiver must inherit property "getSynchronizationSources()" with the proper type
 PASS RTCRtpReceiver interface: new RTCPeerConnection().addTransceiver('audio').receiver must inherit property "getStats()" with the proper type
-FAIL RTCRtpReceiver interface: new RTCPeerConnection().addTransceiver('audio').receiver must inherit property "jitterBufferTarget" with the proper type assert_inherits: property "jitterBufferTarget" not found in prototype chain
+FAIL RTCRtpReceiver interface: new RTCPeerConnection().addTransceiver('audio').receiver must inherit property "jitterBufferTarget" with the proper type assert_equals: expected "number" but got "object"
 PASS RTCRtpTransceiver interface: existence and properties of interface object
 PASS RTCRtpTransceiver interface object length
 PASS RTCRtpTransceiver interface object name

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1624,6 +1624,9 @@ webkit.org/b/182103 fast/forms/focus-selection-textarea.html [ Failure ]
 webkit.org/b/308037 imported/w3c/web-platform-tests/webrtc/simulcast/vp8.https.html [ Failure Pass ]
 webkit.org/b/308037 imported/w3c/web-platform-tests/webrtc/simulcast/vp9.https.html [ Failure Pass ]
 
+imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-audio-jitterBufferTarget-stats.https.html [ Failure ]
+imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-video-jitterBufferTarget-stats.html [ Failure ]
+
 webkit.org/b/307144 media/video-restricted-invisible-autoplay-not-allowed.html [ Timeout Pass ]
 
 webkit.org/b/254520 media/video-ended-event-negative-playback.html [ Failure Timeout Pass ]
@@ -2988,7 +2991,6 @@ imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-videoDetectorTest.html 
 imported/w3c/web-platform-tests/webrtc/RTCRtpParameters-encodings.html [ Pass ]
 imported/w3c/web-platform-tests/webrtc/RTCRtpParameters-headerExtensions.html [ Pass ]
 imported/w3c/web-platform-tests/webrtc/RTCRtpParameters-rtcp.html [ Pass ]
-imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-audio-jitterBufferTarget-stats.https.html [ Pass ]
 imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-getCapabilities.html [ Pass ]
 imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-getContributingSources.https.html [ Pass ]
 imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-getParameters.html [ Failure ]
@@ -2996,7 +2998,6 @@ imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-getStats.https.html [ Fail
 imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-jitterBufferTarget.html [ Pass ]
 imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-track-settings.tentative.html [ Failure ]
 imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-video-anyCodec.html [ Failure ]
-imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-video-jitterBufferTarget-stats.html [ Pass ]
 imported/w3c/web-platform-tests/webrtc/RTCRtpSender-encode-same-track-twice.https.html [ Pass ]
 imported/w3c/web-platform-tests/webrtc/RTCRtpSender-getCapabilities.html [ Pass ]
 imported/w3c/web-platform-tests/webrtc/RTCRtpSender-getParameters.html [ Failure ]

--- a/Source/WebCore/Modules/mediastream/RTCRtpReceiver.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpReceiver.cpp
@@ -152,6 +152,16 @@ Ref<RTCRtpTransformBackend> RTCRtpReceiver::rtcRtpTransformBackend()
     return m_backend->rtcRtpTransformBackend();
 }
 
+ExceptionOr<void> RTCRtpReceiver::setJitterBufferTarget(std::optional<double> valueInMillisecond)
+{
+    if (valueInMillisecond && (*valueInMillisecond < 0 || *valueInMillisecond > 4000))
+        return Exception { ExceptionCode::RangeError, "jitterBufferTarget is invalid"_s };
+
+    m_jitterBufferTarget = valueInMillisecond;
+    m_backend->setJitterBufferTarget(valueInMillisecond);
+    return { };
+}
+
 #if !RELEASE_LOG_DISABLED
 WTFLogChannel& RTCRtpReceiver::logChannel() const
 {

--- a/Source/WebCore/Modules/mediastream/RTCRtpReceiver.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpReceiver.h
@@ -89,6 +89,10 @@ public:
 
     const Vector<WeakPtr<MediaStream>>& associatedStreams() const LIFETIME_BOUND { return m_associatedStreams; }
     void setAssociatedStreams(Vector<WeakPtr<MediaStream>>&& streams) { m_associatedStreams = WTF::move(streams); }
+
+    std::optional<double> jitterBufferTarget() const { return m_jitterBufferTarget; }
+    ExceptionOr<void> setJitterBufferTarget(std::optional<double>);
+
 private:
     RTCRtpReceiver(PeerConnectionBackend&, Ref<MediaStreamTrack>&&, UniqueRef<RTCRtpReceiverBackend>&&);
 
@@ -107,6 +111,7 @@ private:
     std::unique_ptr<RTCRtpTransform> m_transform;
     const RefPtr<RTCEncodedStreamProducer> m_encodedStreamProducer;
     Vector<WeakPtr<MediaStream>> m_associatedStreams;
+    std::optional<double> m_jitterBufferTarget;
 #if !RELEASE_LOG_DISABLED
     const Ref<const Logger> m_logger;
     uint64_t m_logIdentifier { 0 };

--- a/Source/WebCore/Modules/mediastream/RTCRtpReceiver.idl
+++ b/Source/WebCore/Modules/mediastream/RTCRtpReceiver.idl
@@ -29,6 +29,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+typedef double DOMHighResTimeStamp;
+
 [
     Conditional=WEB_RTC,
     EnabledBySetting=PeerConnectionEnabled,
@@ -42,6 +44,7 @@
     sequence<RTCRtpContributingSource> getContributingSources();
     sequence<RTCRtpSynchronizationSource> getSynchronizationSources();
     Promise<RTCStatsReport> getStats();
+    attribute DOMHighResTimeStamp? jitterBufferTarget;
 
     [CallWith=CurrentScriptExecutionContext, EnabledByQuirk=shouldEnableRTCEncodedStreams] RTCEncodedStreams createEncodedStreams();
 };

--- a/Source/WebCore/Modules/mediastream/RTCRtpReceiverBackend.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpReceiverBackend.h
@@ -42,6 +42,7 @@ public:
     virtual Vector<RTCRtpSynchronizationSource> getSynchronizationSources() const { return { }; }
     virtual Ref<RTCRtpTransformBackend> rtcRtpTransformBackend() = 0;
     virtual std::unique_ptr<RTCDtlsTransportBackend> dtlsTransportBackend() = 0;
+    virtual void setJitterBufferTarget(std::optional<double> /* valueInMillisecond */) { }
 
     virtual bool isLibWebRTCRtpReceiverBackend() const { return false; }
 };

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.cpp
@@ -172,6 +172,11 @@ std::unique_ptr<RTCDtlsTransportBackend> LibWebRTCRtpReceiverBackend::dtlsTransp
     return backend ? makeUnique<LibWebRTCDtlsTransportBackend>(backend.releaseNonNull()) : nullptr;
 }
 
+void LibWebRTCRtpReceiverBackend::setJitterBufferTarget(std::optional<double> valueInMillisecond)
+{
+    m_rtcReceiver->SetJitterBufferMinimumDelay(valueInMillisecond ? std::make_optional(*valueInMillisecond / 1000.0) : std::nullopt);
+}
+
 void LibWebRTCRtpReceiverBackend::OnFirstPacketReceivedAfterReceptiveChange(webrtc::MediaType)
 {
     callOnMainThread([source = m_source] {

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.h
@@ -63,6 +63,7 @@ private:
     Vector<RTCRtpSynchronizationSource> getSynchronizationSources() const final;
     Ref<RTCRtpTransformBackend> rtcRtpTransformBackend() final;
     std::unique_ptr<RTCDtlsTransportBackend> dtlsTransportBackend() final;
+    void setJitterBufferTarget(std::optional<double>) final;
 
     // webrtc::RtpReceiverObserverInterface
     void OnFirstPacketReceived(webrtc::MediaType) final { }


### PR DESCRIPTION
#### 724785790c29d92e97c83afb66753e8d7e671e71
<pre>
Implement RTCRtpReceiver.jitterBufferTarget
<a href="https://rdar.apple.com/173676035">rdar://173676035</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=311079">https://bugs.webkit.org/show_bug.cgi?id=311079</a>

Reviewed by Eric Carlson.

We expose jitterBufferTarget on webIDL and implement it as per <a href="https://w3c.github.io/webrtc-pc/#dom-rtcrtpreceiver-jitterbuffertarget.">https://w3c.github.io/webrtc-pc/#dom-rtcrtpreceiver-jitterbuffertarget.</a>
We pipe the value up to libwebrtc via the provided API.
We mark the test as failing in glib since we do not implement the GStreamer specific binding code.

Covered by rebased WPT tests.

Canonical link: <a href="https://commits.webkit.org/310285@main">https://commits.webkit.org/310285@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2968219ac9b081d66a82cdf7f2db78fce364b2ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153209 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25991 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19589 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161954 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106667 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cfe0cc3b-2615-417e-b0ea-f74dd9e3cc1d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155082 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26518 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26296 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118443 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83876 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7bb3085a-570f-465d-8dee-1b919dd14e0d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156168 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20684 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137551 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99156 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/19775656-9307-4cb8-9124-a83d3eb84777) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19760 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17704 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9789 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129410 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15424 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164427 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7563 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17018 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126501 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25788 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21733 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126659 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34389 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25790 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137220 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82459 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21608 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13999 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25406 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89693 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25099 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25257 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25158 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->