### PR TITLE
REGRESSION: [GStreamer] glib/gobject/gsignal.c:2684: instance '0x7fa458075f30' has no handler with id '2246' in WebCore::TrackDataHolder::disconnect

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp
@@ -168,6 +168,8 @@ void TrackDataHolder::setPad(GRefPtr<GstPad>&& pad)
     if (m_bestUpstreamPad && m_eventProbe)
         gst_pad_remove_probe(m_bestUpstreamPad.get(), m_eventProbe);
 
+    g_clear_signal_handler(&m_padTagsNotifyHandlerId, m_pad.get());
+    g_clear_signal_handler(&m_padCapsNotifyHandlerId, m_pad.get());
     m_pad = WTF::move(pad);
     m_bestUpstreamPad = findBestUpstreamPad(m_pad);
     m_gstStreamId = byteCast<Latin1Character>(unsafeSpan(gst_pad_get_stream_id(m_pad.get())));
@@ -217,14 +219,8 @@ void TrackDataHolder::setPad(GRefPtr<GstPad>&& pad)
 
 void TrackDataHolder::setStream(GRefPtr<GstStream>&& stream)
 {
-    if (m_streamTagsNotifyHandlerId) {
-        g_signal_handler_disconnect(m_stream.get(), m_streamTagsNotifyHandlerId);
-        m_streamTagsNotifyHandlerId = 0;
-    }
-    if (m_streamCapsNotifyHandlerId) {
-        g_signal_handler_disconnect(m_stream.get(), m_streamCapsNotifyHandlerId);
-        m_streamCapsNotifyHandlerId = 0;
-    }
+    g_clear_signal_handler(&m_streamTagsNotifyHandlerId, m_stream.get());
+    g_clear_signal_handler(&m_streamCapsNotifyHandlerId, m_stream.get());
     m_stream = WTF::move(stream);
     m_streamTagsNotifyHandlerId = g_signal_connect_data(m_stream.get(), "notify::tags", G_CALLBACK(+[](GstStream*, GParamSpec*, gpointer userData) {
         RefPtr holder = reinterpret_cast<ThreadSafeWeakPtr<TrackDataHolder>*>(userData)->get();
@@ -301,8 +297,8 @@ void TrackDataHolder::disconnect()
     m_taskQueue.startAborting();
 
     if (m_stream) {
-        g_signal_handler_disconnect(m_stream.get(), m_streamTagsNotifyHandlerId);
-        g_signal_handler_disconnect(m_stream.get(), m_streamCapsNotifyHandlerId);
+        g_clear_signal_handler(&m_streamTagsNotifyHandlerId, m_stream.get());
+        g_clear_signal_handler(&m_streamCapsNotifyHandlerId, m_stream.get());
         m_stream.clear();
     }
 
@@ -317,8 +313,8 @@ void TrackDataHolder::disconnect()
     }
 
     if (m_pad) {
-        g_signal_handler_disconnect(m_pad.get(), m_padTagsNotifyHandlerId);
-        g_signal_handler_disconnect(m_pad.get(), m_padCapsNotifyHandlerId);
+        g_clear_signal_handler(&m_padTagsNotifyHandlerId, m_pad.get());
+        g_clear_signal_handler(&m_padCapsNotifyHandlerId, m_pad.get());
         m_pad.clear();
     }
 


### PR DESCRIPTION
#### d85dc04a2794bc0932fdf29d08442ffe50e6b8b7
<pre>
REGRESSION: [GStreamer] glib/gobject/gsignal.c:2684: instance &apos;0x7fa458075f30&apos; has no handler with id &apos;2246&apos; in WebCore::TrackDataHolder::disconnect
<a href="https://bugs.webkit.org/show_bug.cgi?id=311071">https://bugs.webkit.org/show_bug.cgi?id=311071</a>

Reviewed by Adrian Perez de Castro.

I wasn&apos;t able to reproduce this issue, but I think that the crashes were happening due to this
sequence of events:

1. Track created, a pad (A) is associated to it
2. GObject signals connected to pad A
3. setPad() is called with pad (B)
4. disconnect is called, attempting to disconnect GObject signal handlers associated to pad A, but
on pad B actually

Proposed solution is to clear signal handlers before setting a new pad. This is done already for
GstStreams.

* Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp:
(WebCore::TrackDataHolder::setPad):
(WebCore::TrackDataHolder::setStream):
(WebCore::TrackDataHolder::disconnect):

Canonical link: <a href="https://commits.webkit.org/310226@main">https://commits.webkit.org/310226@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a7ba302fedd8a6734cabab88565827eacfca1cd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153163 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25945 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19543 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161907 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106621 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155036 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26472 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26250 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118399 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156122 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20636 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137505 "Found 1 new API test failure: TestWebKitAPI.ScrollbarWidthCrash.DynamicallyChangeScrollbarWidth (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99112 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19711 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9743 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129362 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15378 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164381 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7517 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16972 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126459 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25742 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21691 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126617 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34345 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25744 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137174 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82410 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21575 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13953 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25360 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89647 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25053 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25211 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25112 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->