### PR TITLE
Generate CoreIPC TypeScript definitions on build

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6210,6 +6210,8 @@ imported/w3c/web-platform-tests/css/motion/offset-path-url-011.html [ ImageOnlyF
 # mac-only IPC test
 ipc/webpageproxy-correctionpanel-no-crash.html [ Skip ]
 
+ipc/validate-coreipc-dts.html
+
 # WebGPU settings need to be exposed through the test runner.
 ipc/restrictedendpoints/allow-access-webGPU.html [ Pass Failure ]
 

--- a/LayoutTests/ipc/validate-coreipc-dts-expected.txt
+++ b/LayoutTests/ipc/validate-coreipc-dts-expected.txt
@@ -1,0 +1,25 @@
+CONSOLE MESSAGE: === Primitives: string, boolean, number ===
+CONSOLE MESSAGE: PASS NetworkConnectionToWebProcess.DeleteCookie
+CONSOLE MESSAGE: === Nested structs, enums, ObjectIdentifiers ===
+CONSOLE MESSAGE: PASS NetworkConnectionToWebProcess.CookiesForDOM
+CONSOLE MESSAGE: === Optionals: present and absent ===
+CONSOLE MESSAGE: PASS struct WebCore::SecurityOriginData
+CONSOLE MESSAGE: PASS struct WebCore::SecurityOriginData
+CONSOLE MESSAGE: === Vectors and nested struct arrays ===
+CONSOLE MESSAGE: PASS struct WebCore::WebTransportOptions
+CONSOLE MESSAGE: === Variant with variantIndex ===
+CONSOLE MESSAGE: PASS struct WebCore::SecurityOriginData
+CONSOLE MESSAGE: === Using alias with ObjectIdentifier target ===
+CONSOLE MESSAGE: PASS struct WebKit::PageData
+CONSOLE MESSAGE: PASS struct WebKit::PageData
+CONSOLE MESSAGE: === Using alias with std::pair target (struct elements) ===
+CONSOLE MESSAGE: PASS struct WebCore::TargetedElementIdentifiers
+CONSOLE MESSAGE: === Using alias with std::pair structure verification ===
+CONSOLE MESSAGE: PASS RootFrameData alias shape: { name: "alias", type: "std::pair<...>" }
+CONSOLE MESSAGE: === Full message: nested variants, structs, optionals ===
+CONSOLE MESSAGE: PASS NetworkConnectionToWebProcess.InitializeWebTransportSession
+CONSOLE MESSAGE: === HashMap via using alias ===
+CONSOLE MESSAGE: PASS struct WebCore::IndexIDToIndexKeyMap
+CONSOLE MESSAGE: PASS struct WebCore::IndexIDToIndexKeyMap
+CONSOLE MESSAGE: === Summary: 13 passed, 0 failed ===
+

--- a/LayoutTests/ipc/validate-coreipc-dts.html
+++ b/LayoutTests/ipc/validate-coreipc-dts.html
@@ -1,0 +1,229 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+window.setTimeout(async () => {
+    if (!window.IPC)
+        return window.testRunner?.notifyDone();
+
+    const { CoreIPC, ArgumentSerializer } = await import('./coreipc.js');
+    let passed = 0;
+    let failed = 0;
+
+    // Helper: try serializing message arguments using the runtime definition
+    function testMessage(process, receiver, message, params) {
+        const key = `${receiver}_${message}`;
+        const def = CoreIPC.messages[key];
+        if (!def) {
+            console.log(`SKIP ${receiver}.${message} — not found in runtime messages`);
+            return;
+        }
+        try {
+            ArgumentSerializer.serializeArguments(def.arguments, params);
+            console.log(`PASS ${receiver}.${message}`);
+            passed++;
+        } catch (e) {
+            console.log(`FAIL ${receiver}.${message}: ${e.message}`);
+            failed++;
+        }
+    }
+
+    // Helper: try serializing a struct value against its typeInfo definition
+    function testStruct(typeName, value) {
+        const def = CoreIPC.typeInfo[typeName];
+        if (!def) {
+            console.log(`SKIP struct ${typeName} — not found in runtime typeInfo`);
+            return;
+        }
+        try {
+            ArgumentSerializer.serializeArguments(def, value);
+            console.log(`PASS struct ${typeName}`);
+            passed++;
+        } catch (e) {
+            console.log(`FAIL struct ${typeName}: ${e.message}`);
+            failed++;
+        }
+    }
+
+    // ---------------------------------------------------------------
+    console.log('=== Primitives: string, boolean, number ===');
+    // .d.ts: DeleteCookie_Params { firstParty: URL; url: URL; cookieName: string; }
+    // .d.ts: URL { string: string; }
+    testMessage('Networking', 'NetworkConnectionToWebProcess', 'DeleteCookie', {
+        firstParty: { string: 'https://example.com' },
+        url: { string: 'https://example.com/page' },
+        cookieName: 'session_id'
+    });
+
+    // ---------------------------------------------------------------
+    console.log('=== Nested structs, enums, ObjectIdentifiers ===');
+    // .d.ts: CookiesForDOM_Params {
+    //   firstParty: URL; sameSiteInfo: WebCore_SameSiteInfo; url: URL;
+    //   frameID: number | bigint; pageID: number | bigint;
+    //   includeSecureCookies: number; webPageProxyID: number | bigint;
+    // }
+    // .d.ts: WebCore_SameSiteInfo { isSameSite: boolean; isTopSite: boolean; isSafeHTTPMethod: boolean; }
+    testMessage('Networking', 'NetworkConnectionToWebProcess', 'CookiesForDOM', {
+        firstParty: { string: 'https://example.com' },
+        sameSiteInfo: { isSameSite: true, isTopSite: true, isSafeHTTPMethod: true },
+        url: { string: 'https://example.com' },
+        frameID: 1,
+        pageID: 1,
+        includeSecureCookies: 0,
+        webPageProxyID: 1
+    });
+
+    // ---------------------------------------------------------------
+    console.log('=== Optionals: present and absent ===');
+    // .d.ts: WebCore_SecurityOriginData { data: variant... }
+    // .d.ts: WebCore_SecurityOriginData_Tuple { protocol: string; host: string; port: { optionalValue: number } | {}; }
+    testStruct('WebCore::SecurityOriginData', {
+        data: {
+            variantType: 'WebCore::SecurityOriginData::Tuple',
+            variant: { protocol: 'https', host: 'example.com', port: { optionalValue: 443 } }
+        }
+    });
+    testStruct('WebCore::SecurityOriginData', {
+        data: {
+            variantType: 'WebCore::SecurityOriginData::Tuple',
+            variant: { protocol: 'https', host: 'example.com', port: {} }
+        }
+    });
+
+    // ---------------------------------------------------------------
+    console.log('=== Vectors and nested struct arrays ===');
+    // .d.ts: WebCore_WebTransportOptions {
+    //   allowPooling: boolean; requireUnreliable: boolean;
+    //   serverCertificateHashes: Array<WebCore_WebTransportHash>;
+    //   congestionControl: number; ...optionals...  protocols: Array<string>; ...
+    // }
+    // .d.ts: WebCore_WebTransportHash { algorithm: string; value: WebCore_BufferSource; }
+    // .d.ts: WebCore_BufferSource { span: Array<number>; }
+    testStruct('WebCore::WebTransportOptions', {
+        allowPooling: false,
+        requireUnreliable: true,
+        serverCertificateHashes: [
+            { algorithm: 'sha-256', value: { span: [1, 2, 3, 4, 5] } },
+            { algorithm: 'sha-256', value: { span: [10, 20, 30] } }
+        ],
+        congestionControl: 0,
+        anticipatedConcurrentIncomingUnidirectionalStreams: { optionalValue: 4 },
+        anticipatedConcurrentIncomingBidirectionalStreams: {},
+        protocols: ['h3'],
+        datagramsReadableMode: {}
+    });
+
+    // ---------------------------------------------------------------
+    console.log('=== Variant with variantIndex ===');
+    testStruct('WebCore::SecurityOriginData', {
+        data: {
+            variantIndex: 0,
+            variant: { protocol: 'http', host: 'localhost', port: { optionalValue: 8080 } }
+        }
+    });
+
+    // ---------------------------------------------------------------
+    console.log('=== Using alias with ObjectIdentifier target ===');
+    // .d.ts: WebKit_PageData { callbackIDs: Array<WebKit_PageData_TransactionCallbackID>; renderTreeSize: number | bigint; }
+    // .d.ts: WebKit_PageData_TransactionCallbackID { alias: number | bigint; }
+    testStruct('WebKit::PageData', {
+        callbackIDs: [{ alias: 100 }, { alias: 200 }],
+        renderTreeSize: 0
+    });
+    testStruct('WebKit::PageData', {
+        callbackIDs: [],
+        renderTreeSize: 42
+    });
+
+    // ---------------------------------------------------------------
+    console.log('=== Using alias with std::pair target (struct elements) ===');
+    // .d.ts: WebCore_TargetedElementIdentifiers {
+    //   alias: [number | bigint, WebCore_ScriptExecutionContextIdentifier];
+    // }
+    // .d.ts: WebCore_ScriptExecutionContextIdentifier {
+    //   object: WTF_UUID;
+    //   processIdentifier: number | bigint;
+    // }
+    // .d.ts: WTF_UUID { high: number | bigint; low: number | bigint; }
+    testStruct('WebCore::TargetedElementIdentifiers', {
+        alias: [
+            1,
+            { object: { high: 0, low: 1 }, processIdentifier: 1 }
+        ]
+    });
+
+    // ---------------------------------------------------------------
+    console.log('=== Using alias with std::pair structure verification ===');
+    const rootFrameDataDef = CoreIPC.typeInfo['WebKit::RemoteLayerTreeCommitBundle::RootFrameData'];
+    if (rootFrameDataDef) {
+        const memberName = rootFrameDataDef[0].name;
+        const memberType = rootFrameDataDef[0].type;
+        if (memberName === 'alias' && memberType.startsWith('std::pair<')) {
+            console.log('PASS RootFrameData alias shape: { name: "alias", type: "std::pair<...>" }');
+            passed++;
+        } else {
+            console.log(`FAIL RootFrameData unexpected shape: ${JSON.stringify(rootFrameDataDef[0])}`);
+            failed++;
+        }
+    } else {
+        console.log('SKIP RootFrameData — not in typeInfo');
+    }
+
+    // ---------------------------------------------------------------
+    console.log('=== Full message: nested variants, structs, optionals ===');
+    // .d.ts: InitializeWebTransportSession_Params {
+    //   identifier: number | bigint; url: URL;
+    //   options: WebCore_WebTransportOptions;
+    //   pageID: number | bigint; clientOrigin: WebCore_ClientOrigin;
+    // }
+    // .d.ts: WebCore_ClientOrigin { topOrigin: WebCore_SecurityOriginData; clientOrigin: WebCore_SecurityOriginData; }
+    testMessage('Networking', 'NetworkConnectionToWebProcess', 'InitializeWebTransportSession', {
+        identifier: 1,
+        url: { string: 'https://example.com:4443/webtransport' },
+        options: {
+            allowPooling: false, requireUnreliable: false,
+            serverCertificateHashes: [],
+            congestionControl: 0,
+            anticipatedConcurrentIncomingUnidirectionalStreams: {},
+            anticipatedConcurrentIncomingBidirectionalStreams: {},
+            protocols: [],
+            datagramsReadableMode: {}
+        },
+        pageID: IPC.pageID,
+        clientOrigin: {
+            topOrigin: {
+                data: { variantType: 'WebCore::SecurityOriginData::Tuple',
+                        variant: { protocol: 'https', host: 'example.com', port: { optionalValue: 4443 } } }
+            },
+            clientOrigin: {
+                data: { variantType: 'WebCore::SecurityOriginData::Tuple',
+                        variant: { protocol: 'https', host: 'example.com', port: { optionalValue: 4443 } } }
+            }
+        }
+    });
+
+    // ---------------------------------------------------------------
+    console.log('=== HashMap via using alias ===');
+    // .d.ts: WebCore_IndexIDToIndexKeyMap {
+    //   alias: Array<{ key: number | bigint; value: WebCore_IndexKey } | [number | bigint, WebCore_IndexKey]>;
+    // }
+    // .d.ts: WebCore_IndexKey {
+    //   data: { variantType: 'std::nullptr_t'; variant: null } | ...
+    // }
+    testStruct('WebCore::IndexIDToIndexKeyMap', {
+        alias: [
+            { key: 1, value: { data: { variantType: 'std::nullptr_t', variant: null } } },
+            [2, { data: { variantType: 'std::nullptr_t', variant: null } }]
+        ]
+    });
+    testStruct('WebCore::IndexIDToIndexKeyMap', { alias: [] });
+
+    // ---------------------------------------------------------------
+    console.log(`=== Summary: ${passed} passed, ${failed} failed ===`);
+
+    globalThis.testRunner?.notifyDone();
+}, 10);
+</script>

--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -2026,6 +2026,337 @@ def generate_webkit_secure_coding_header(serialized_types):
     return '\n'.join(result)
 
 
+# --- CoreIPC.js TypeScript Definition Generation ---
+# Generates a .d.ts file describing the JavaScript parameter shapes
+# accepted by ArgumentSerializer in coreipc.js for IPC testing.
+
+_coreipc_js_type_aliases = {
+    'int': 'uint32_t', 'unsigned': 'uint32_t', 'char': 'uint8_t',
+    'pid_t': 'uint32_t', 'unsigned short': 'uint16_t', 'unsigned char': 'uint8_t',
+    'long long': 'int64_t', 'unsigned long long': 'uint64_t', 'short': 'int16_t',
+    'WebCore::ContextMenuAction': 'uint32_t', 'CGBitmapInfo': 'uint32_t',
+    'UInt32': 'uint32_t', 'CTFontDescriptorOptions': 'uint32_t',
+    'SystemMemoryPressureStatus': 'WTF::SystemMemoryPressureStatus',
+    'GCGLenum': 'uint32_t', 'GCGLint': 'int32_t',
+    'GCGLErrorCodeSet': 'OptionSet<GCGLErrorCode>',
+    'CFTypeRef': 'WebKit::CoreIPCCFType', 'CFDataRef': 'WebKit::CoreIPCData',
+    'CFStringRef': 'String', 'CFArrayRef': 'WebKit::CoreIPCCFArray',
+    'CFDictionaryRef': 'WebKit::CoreIPCCFDictionary', 'CFBooleanRef': 'WebKit::CoreIPCBoolean',
+    'CFNumberRef': 'WebKit::CoreIPCNumber', 'CFDateRef': 'WebKit::CoreIPCDate',
+    'CFURLRef': 'WebKit::CoreIPCCFURL', 'CFNullRef': 'WebKit::CoreIPCNull',
+    'SecAccessControlRef': 'WebKit::CoreIPCSecAccessControl',
+    'SecCertificateRef': 'WebKit::CoreIPCSecCertificate',
+    'SecKeychainItemRef': 'WebKit::CoreIPCSecKeychainItem',
+    'CVPixelBufferRef': 'WebKit::CoreIPCCVPixelBufferRef',
+    'SecTrustRef': 'WebKit::CoreIPCSecTrust',
+    'CFCharacterSetRef': 'WebKit::CoreIPCCFCharacterSet',
+    'CGColorRef': 'WebCore::Color', 'CGColorSpaceRef': 'WebKit::CoreIPCCGColorSpace',
+    'size_t': 'uint64_t', 'CGFloat': 'double',
+}
+
+
+def _dts_resolve_alias(t):
+    if t in _coreipc_js_type_aliases:
+        return _dts_resolve_alias(_coreipc_js_type_aliases[t])
+    return t[len('const '):] if t.startswith('const ') else t
+
+
+def _dts_simplify_name(name):
+    name = name.replace('()', '')
+    while '.' in name:
+        p = name.index('.')
+        name = name[:p] + (name[p + 1].upper() + name[p + 2:] if p + 1 < len(name) else '')
+    return name
+
+
+def _dts_sanitize(name):
+    return name.replace('::', '_').replace('<', '_').replace('>', '').replace(' ', '_').replace(',', '_')
+
+
+def _dts_split_template(s):
+    result, cur, depth = [], '', 0
+    for ch in s:
+        if ch == '>':
+            depth -= 1
+        if ch == '<':
+            depth += 1
+        if depth == 0 and ch == ',':
+            result.append(cur.strip())
+            cur = ''
+        else:
+            cur += ch
+    result.append(cur.strip())
+    return result
+
+
+def _dts_parse_template(name):
+    name = name.strip()
+    if not name.endswith('>'):
+        return None, None
+    start = name.index('<')
+    return (name[:start], name[start + 1:-1]) if start != -1 else (None, None)
+
+
+class _DtsTypeResolver:
+    def __init__(self, type_info, enum_info, identifiers):
+        self.type_info = type_info
+        self.enum_info = enum_info
+        self.identifiers = identifiers
+
+    def resolve(self, cpp_type):
+        cpp_type = _dts_resolve_alias(cpp_type)
+        ts = self._template(cpp_type)
+        if ts is not None:
+            return ts
+        if cpp_type in self.identifiers:
+            return 'number | bigint'
+        if cpp_type in self.enum_info:
+            return 'number'
+        ts = self._primitive(cpp_type)
+        if ts is not None:
+            return ts
+        if cpp_type in self.type_info:
+            return _dts_sanitize(cpp_type)
+        return 'any'
+
+    def _template(self, t):
+        if '<' not in t:
+            return None
+        tpl, inner = _dts_parse_template(t)
+        if tpl is None:
+            return None
+        if tpl in ('RefPtr', 'std::unique_ptr', 'RetainPtr', 'std::optional', 'Optional', 'WTF::Markable', 'Markable'):
+            return f'{{ optionalValue: {self.resolve(inner)} }} | {{}}'
+        if tpl in ('Vector', 'std::vector', 'ArrayReference', 'Span', 'std::span', 'std::array', 'HashSet'):
+            return f'Array<{self.resolve(_dts_split_template(inner)[0])}>'
+        if tpl in ('std::variant', 'Variant'):
+            parts = [f"{{ variantType: '{vt}'; variant: {self.resolve(vt)} }}" for vt in _dts_split_template(inner)]
+            parts.append('{ variantIndex: number; variant: any }')
+            return ' | '.join(parts)
+        if tpl == 'std::pair':
+            ps = _dts_split_template(inner)
+            return f'[{self.resolve(ps[0])}, {self.resolve(ps[1])}]' if len(ps) == 2 else None
+        if tpl == 'OptionSet':
+            return 'number'
+        if tpl in ('HashMap', 'MemoryCompactRobinHoodHashMap'):
+            ps = _dts_split_template(inner)
+            if len(ps) >= 2:
+                k, v = self.resolve(ps[0]), self.resolve(ps[1])
+                return f'Array<{{ key: {k}; value: {v} }} | [{k}, {v}]>'
+        if tpl == 'KeyValuePair':
+            ps = _dts_split_template(inner)
+            if len(ps) == 2:
+                k, v = self.resolve(ps[0]), self.resolve(ps[1])
+                return f'{{ key: {k}; value: {v} }} | [{k}, {v}]'
+        if tpl == 'IPC::ArrayReferenceTuple':
+            return f'[{", ".join(f"Array<{self.resolve(p)}>" for p in _dts_split_template(inner))}]'
+        if tpl == 'OptionalTuple':
+            return 'any'
+        if tpl in ('Ref', 'UniqueRef'):
+            return self.resolve(inner)
+        return None
+
+    @staticmethod
+    def _primitive(t):
+        m = {'uint8_t': 'number', 'int8_t': 'number', 'uint16_t': 'number', 'int16_t': 'number',
+             'uint32_t': 'number', 'int32_t': 'number', 'uint64_t': 'number | bigint', 'int64_t': 'number | bigint',
+             'float': 'number | bigint', 'double': 'number | bigint',
+             'bool': 'boolean', 'String': 'string', 'std::nullptr_t': 'null',
+             'IPC::ConnectionHandle': 'StreamConnection | { open: Function }',
+             'IPC::StreamServerConnectionHandle': 'StreamConnection | { open: Function }',
+             'IPC::Semaphore': '{ signal: Function }'}
+        if t in m:
+            return m[t]
+        if t in ('WebCore::SharedMemory::Handle', 'WebCore::SharedMemoryHandle', 'MachSendRight'):
+            return "{ protection: 'ReadOnly' | 'ReadWrite'; handle: any }"
+        return None
+
+
+def generate_coreipc_dts(serialized_types, serialized_enums, using_statements, output_dir, source_root):
+    from webkit import parser as msg_parser, model as msg_model
+    from webkit.messages import serialized_identifiers
+
+    # Build using alias map
+    using_alias_map = {}
+    for us in using_statements:
+        parts = [line.strip() for line in us.alias_lines if not line.strip().startswith('#')]
+        target = ' '.join(parts).strip().rstrip(';').strip()
+        if target:
+            using_alias_map[us.name] = target
+
+    # Build type_info
+    type_info = {}
+    for st in serialized_types:
+        name = st.name_declaration_for_serialized_type_info()
+        members = []
+        sm = st.members_for_serialized_type_info()
+        parent = st.parent_class
+        while parent is not None:
+            sm = parent.members_for_serialized_type_info() + sm
+            parent = parent.parent_class
+        for m in sm:
+            if m.optional_tuple_bits() or m.optional_tuple_bit():
+                continue
+            members.append((m.type, _dts_simplify_name(m.name)))
+        ot_types, ot_names = [], []
+        for m in sm:
+            if m.optional_tuple_bit():
+                ot_types.append(m.type)
+                ot_names.append(m.name)
+        if ot_types:
+            members.append(('OptionalTuple<' + ', '.join(ot_types) + '>', _dts_simplify_name('OptionalTuple<' + ', '.join(ot_names) + '>')))
+        for m in sm:
+            if 'EncodeRequestBody' in m.attributes:
+                members.append(('IPC::FormDataReference', 'requestBody'))
+        if st.members_are_subclasses:
+            members = [(f'Variant<{", ".join(f"{m.namespace}::{m.name}" for m in st.members)}>', 'subclasses')]
+        if st.cf_type is not None:
+            members = [(st.namespace_if_not_wtf_and_name(), 'wrapper')]
+        type_info[name] = members
+    for us_name, us_target in using_alias_map.items():
+        if us_name not in type_info:
+            type_info[us_name] = [(us_target, 'alias')]
+
+    # Build resolver
+    identifiers = set(serialized_identifiers())
+    identifiers.update(['WebKit::WebPageProxyIdentifier', 'WebCore::ProcessIdentifier', 'WebKit::RemoteCDMIdentifier'])
+    enum_info = {se.namespace_and_name(): se for se in serialized_enums}
+    resolver = _DtsTypeResolver(type_info, enum_info, identifiers)
+
+    # Parse messages
+    receivers = []
+    webkit_dir = os.path.join(source_root, 'Source', 'WebKit')
+    for root, _dirs, files in os.walk(webkit_dir):
+        for f in sorted(files):
+            if f.endswith('.messages.in'):
+                try:
+                    with open(os.path.join(root, f)) as fh:
+                        receivers.append(msg_parser.parse(fh))
+                except Exception:
+                    pass
+    try:
+        receivers = msg_model.generate_global_model(receivers)
+    except Exception:
+        pass
+
+    # Emit
+    L = []
+    L.append('// Auto-generated by generate-serializers.py — do not edit.')
+    L.append('// Describes the JavaScript parameter shapes accepted by ArgumentSerializer in coreipc.js.')
+    L.append('//\n// Usage: Reference for LLMs and developers writing CoreIPC.js layout tests.')
+    L.append('// Messages are accessible as: CoreIPC.<Process>.<ReceiverClass>.<MessageName>(connectionId, params)\n')
+    L.append('// --- Helper Types ---\n')
+    L.append('/** A StreamConnection object created by CoreIPC.newStreamConnection() */')
+    L.append('interface StreamConnection {\n    handle: any;\n    connection: any;')
+    L.append('    newInterface(interfaceName: string, connectionIdentifier: number | bigint): StreamConnectionInterface;\n}\n')
+    L.append('interface StreamConnectionInterface {\n    interfaceName: string;\n    connection: any;\n    [messageName: string]: any;\n}\n')
+
+    L.append('// --- Enum Types ---\n')
+    for se in sorted(serialized_enums, key=lambda e: e.namespace_and_name()):
+        ts = _dts_sanitize(se.namespace_and_name())
+        if se.is_option_set():
+            L.append(f'/** OptionSet */\ntype {ts} = number;\n')
+        elif se.underlying_type == 'bool':
+            L.append(f'type {ts} = 0 | 1;\n')
+        else:
+            names = [vv.name for vv in se.valid_values]
+            if names:
+                L.append(f'/** Valid values: {", ".join(names)} */')
+            L.append(f'type {ts} = number;\n')
+
+    L.append('// --- Struct/Class Interfaces ---\n')
+    for st in sorted(serialized_types, key=lambda t: t.name_declaration_for_serialized_type_info()):
+        name = st.name_declaration_for_serialized_type_info()
+        ts = _dts_sanitize(name)
+        members = type_info.get(name, [])
+        if not members:
+            L.append(f'// {name} — opaque\ntype {ts} = any;\n')
+            continue
+        L.append(f'/** C++ type: {name} */\ninterface {ts} {{')
+        for mt, mn in members:
+            if mt.startswith('OptionalTuple<'):
+                pt, pn = _dts_parse_template(mt), _dts_parse_template(mn)
+                if pt[0] == 'OptionalTuple' and pn[0] == 'OptionalTuple':
+                    tt, tn = _dts_split_template(pt[1]), _dts_split_template(pn[1])
+                    L.append(f'    /** OptionalTuple — each field is independently optional */')
+                    L.append(f'    \'{mn}\': {{')
+                    for i in range(min(len(tt), len(tn))):
+                        L.append(f'        \'{tn[i].strip()}\'?: {resolver.resolve(tt[i])};')
+                    L.append(f'    }};')
+                else:
+                    L.append(f'    \'{mn}\': any;')
+            else:
+                L.append(f'    {mn}: {resolver.resolve(mt)};')
+        L.append('}\n')
+
+    stn = set(st.name_declaration_for_serialized_type_info() for st in serialized_types)
+    for un in sorted(using_alias_map.keys()):
+        if un in stn:
+            continue
+        ms = type_info.get(un, [])
+        if not ms:
+            continue
+        L.append(f'/** C++ using alias: {un} = {using_alias_map[un]} */\ninterface {_dts_sanitize(un)} {{')
+        for mt, mn in ms:
+            L.append(f'    {mn}: {resolver.resolve(mt)};')
+        L.append('}\n')
+
+    L.append('// --- Message Parameter Interfaces ---\n')
+    pm = {'UI': {}, 'GPU': {}, 'Networking': {}}
+    for recv in receivers:
+        if recv.name == 'IPC':
+            continue
+        dt = recv.receiver_dispatched_to
+        if dt not in pm:
+            continue
+        methods = []
+        for msg in recv.messages:
+            if msg.is_async_reply:
+                continue
+            pn = f'{_dts_sanitize(recv.name)}_{msg.name}_Params'
+            hp, hr = len(msg.parameters) > 0, msg.reply_parameters is not None
+            if hp:
+                L.append(f'interface {pn} {{')
+                for p in msg.parameters:
+                    L.append(f'    {p.name}: {resolver.resolve(p.type)};')
+                L.append('}\n')
+            rh = ', replyHandler?: Function' if hr else ''
+            if hp:
+                methods.append(f'    {msg.name}(connectionId: number | bigint, params: {pn}{rh}): void;')
+            else:
+                methods.append(f'    {msg.name}(connectionId: number | bigint, params: {{}}{rh}): void;')
+        if methods:
+            pm[dt][recv.name] = methods
+
+    L.append('// --- Receiver Interfaces ---\n')
+    for proc in ('UI', 'GPU', 'Networking'):
+        for rn in sorted(pm[proc].keys()):
+            L.append(f'interface {_dts_sanitize(rn)}Messages {{')
+            L.extend(pm[proc][rn])
+            L.append('}\n')
+
+    L.append('// --- Process Namespace Interfaces ---\n')
+    for proc in ('UI', 'GPU', 'Networking'):
+        L.append(f'interface {proc}ProcessMessages {{')
+        for rn in sorted(pm[proc].keys()):
+            L.append(f'    {rn}: {_dts_sanitize(rn)}Messages;')
+        L.append('}\n')
+
+    L.append('// --- CoreIPC Top-Level Interface ---\n')
+    L.append('interface CoreIPCType {')
+    L.append('    UI: UIProcessMessages;\n    GPU: GPUProcessMessages;\n    Networking: NetworkingProcessMessages;')
+    L.append('    newStreamConnection(): StreamConnection;\n    messages: Record<string, any>;')
+    L.append('    typeInfo: Record<string, any>;\n    enumInfo: Record<string, any>;')
+    L.append('    objectIdentifiers: string[];\n    messageByName: Record<string, any>;')
+    L.append('    default_timeout: number;\n}\n')
+    L.append('export declare const CoreIPC: CoreIPCType;\nexport { StreamConnection, StreamConnectionInterface };\n')
+
+    output_path = os.path.join(output_dir, 'coreipc.d.ts') if output_dir else 'coreipc.d.ts'
+    with open(output_path, 'w') as f:
+        f.write('\n'.join(L))
+    return output_path
+
+
 def main(argv):
     parser = argparse.ArgumentParser(description='Generate serializers from input files')
     parser.add_argument('file_extension', help='File extension for output files')
@@ -2088,6 +2419,21 @@ def main(argv):
         output.write(generate_webkit_secure_coding_header(serialized_types))
     with open(output_path('GeneratedWebKitSecureCoding.%s' % file_extension), "w+") as output:
         output.write(generate_webkit_secure_coding_impl(serialized_types, headers))
+
+    # Generate CoreIPC.js TypeScript definitions into the output (DerivedSources) directory
+    source_root = None
+    for input_file in input_files:
+        abs_path = os.path.abspath(input_file)
+        idx = abs_path.find(os.sep + 'Source' + os.sep + 'WebKit' + os.sep)
+        if idx != -1:
+            source_root = abs_path[:idx]
+            break
+    if source_root:
+        try:
+            dts_path = generate_coreipc_dts(serialized_types, serialized_enums, using_statements, output_dir, source_root)
+        except Exception as e:
+            sys.stderr.write(f'Warning: Failed to generate CoreIPC.js type definitions: {e}\n')
+
     return 0
 
 


### PR DESCRIPTION
#### 7e7c505f781acc24b30bcdf64a6c4d3793706cbc
<pre>
Generate CoreIPC TypeScript definitions on build
<a href="https://bugs.webkit.org/show_bug.cgi?id=311082">https://bugs.webkit.org/show_bug.cgi?id=311082</a>

Reviewed by NOBODY (OOPS!).

This change adds an additional output for TypeScript definitions, describing how CoreIPC expects the values to each message to be serialised.

The generated file is produced in DerivedSources. It is not directly used by WebKit, but can be useful for LLM and fuzzer generation for CoreIPC.js testcases.

Test: ipc/validate-coreipc-dts.html

* LayoutTests/TestExpectations:
* LayoutTests/ipc/validate-coreipc-dts-expected.txt: Added.
* LayoutTests/ipc/validate-coreipc-dts.html: Added.
* Source/WebKit/Scripts/generate-serializers.py:
(generate_webkit_secure_coding_header):
(_dts_resolve_alias):
(_dts_simplify_name):
(_dts_sanitize):
(_dts_split_template):
(_dts_parse_template):
(_DtsTypeResolver):
(_DtsTypeResolver.__init__):
(_DtsTypeResolver.resolve):
(_DtsTypeResolver._template):
(_DtsTypeResolver._primitive):
(generate_coreipc_dts):
(main):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e7c505f781acc24b30bcdf64a6c4d3793706cbc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153910 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26699 "Hash 7e7c505f for PR 61673 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20311 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162661 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107375 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4e828d36-d1e8-4ef9-83a1-5b970f02b6ca) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27223 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27016 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119012 "Found 2 new test failures: imported/w3c/web-platform-tests/webaudio/the-audio-api/the-mediaelementaudiosourcenode-interface/no-cors.https.html storage/indexeddb/modern/blob-simple-private.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84153 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156869 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21277 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138207 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99717 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/71501bc4-2f70-48bc-b32a-02f07aea3d20) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/153231 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20362 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18334 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10493 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130014 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16061 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165134 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8275 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17659 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127102 "Found 4 new test failures: accessibility/aria-roledescription.html fast/repaint/select-option-background-color.html imported/w3c/web-platform-tests/svg/animations/use-animate-display-none-symbol-2.html inspector/canvas/create-context-2d.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26491 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22357 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127261 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26499 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137855 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83208 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22163 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14641 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26110 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90409 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25801 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25966 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25861 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->