### PR TITLE
RTC stats should support video source width and height

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-mandatory-getStats.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-mandatory-getStats.https-expected.txt
@@ -42,8 +42,8 @@ PASS RTCMediaSourceStats's trackIdentifier
 PASS RTCMediaSourceStats's kind
 PASS RTCAudioSourceStats's totalAudioEnergy
 PASS RTCAudioSourceStats's totalSamplesDuration
-FAIL RTCVideoSourceStats's width assert_true: Is width present expected true got false
-FAIL RTCVideoSourceStats's height assert_true: Is height present expected true got false
+PASS RTCVideoSourceStats's width
+PASS RTCVideoSourceStats's height
 PASS RTCVideoSourceStats's framesPerSecond
 PASS RTCCodecStats's payloadType
 PASS RTCCodecStats's mimeType

--- a/Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.cpp
@@ -124,6 +124,8 @@ void RealtimeOutgoingVideoSource::updateFramesSending()
 {
     double videoFrameScaling = 1.0;
     if (m_maxPixelCount && *m_maxPixelCount > 0) {
+        Locker lock(m_frameSizeLock);
+
         int counter = 0;
         while (videoFrameScaling * m_width * m_height > *m_maxPixelCount) {
             if (++counter % 2)
@@ -174,8 +176,11 @@ void RealtimeOutgoingVideoSource::sourceEnabledChanged()
 void RealtimeOutgoingVideoSource::initializeFromSource()
 {
     const auto& settings = m_videoSource->source().settings();
-    m_width = settings.width();
-    m_height = settings.height();
+    {
+        Locker lock(m_frameSizeLock);
+        m_width = settings.width();
+        m_height = settings.height();
+    }
 
     m_muted = m_videoSource->muted();
     m_enabled = m_videoSource->enabled();
@@ -226,10 +231,15 @@ void RealtimeOutgoingVideoSource::sendBlackFramesIfNeeded()
     if (!m_muted && m_enabled)
         return;
 
-    if (!m_width || !m_height)
-        return;
+    {
+        Locker locker(m_frameSizeLock);
+        if (!m_width || !m_height)
+            return;
+    }
 
     if (!m_blackFrame) {
+        Locker lock(m_frameSizeLock);
+
         auto width = m_width;
         auto height = m_height;
         if (!m_isApplyingRotation && (m_currentRotation == webrtc::kVideoRotation_270 || m_currentRotation == webrtc::kVideoRotation_90))
@@ -273,6 +283,16 @@ void RealtimeOutgoingVideoSource::sendFrame(webrtc::scoped_refptr<webrtc::VideoF
     Locker locker { m_sinksLock };
     for (auto* sink : m_sinks)
         sink->OnFrame(frame);
+}
+
+bool RealtimeOutgoingVideoSource::GetStats(Stats* stats)
+{
+    Locker lock(m_frameSizeLock);
+    if (!stats || !m_width || !m_height)
+        return false;
+
+    *stats = { static_cast<int>(m_width), static_cast<int>(m_height) };
+    return true;
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.h
@@ -110,7 +110,7 @@ private:
     // VideoTrackSourceInterface API
     bool is_screencast() const final { return false; }
     std::optional<bool> needs_denoising() const final { return std::optional<bool>(); }
-    bool GetStats(Stats*) final { return false; };
+    bool GetStats(Stats*) final;
     bool SupportsEncodedOutput() const final { return false; }
     void GenerateKeyFrame() final { }
     void AddEncodedSink(webrtc::VideoSinkInterface<webrtc::RecordableEncodedFrame>*) final { }
@@ -147,8 +147,9 @@ private:
 
     bool m_enabled { true };
     bool m_muted { false };
-    uint32_t m_width { 0 };
-    uint32_t m_height { 0 };
+    Lock m_frameSizeLock;
+    uint32_t m_width WTF_GUARDED_BY_LOCK(m_frameSizeLock) { 0 };
+    uint32_t m_height WTF_GUARDED_BY_LOCK(m_frameSizeLock) { 0 };
     std::optional<double> m_maxFrameRate;
     std::optional<double> m_maxPixelCount;
     std::atomic<double> m_videoFrameScaling { 1.0 };


### PR DESCRIPTION
#### b096c504cd11c41d9f16a80cfd53a2e6727edd79
<pre>
RTC stats should support video source width and height
<a href="https://rdar.apple.com/173677615">rdar://173677615</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=311084">https://bugs.webkit.org/show_bug.cgi?id=311084</a>

Reviewed by Eric Carlson.

We implement VideoTrackSourceInterface GetStats in RealtimeOutgoingVideoSource by filling Stats with m_width and m_height.
Given this might be in different threads, we use a lock.

Covered by rebased test.

Canonical link: <a href="https://commits.webkit.org/310295@main">https://commits.webkit.org/310295@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f41b1d4260cc46479eccbecd6c7a6fec07c53a22

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153169 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25951 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19549 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161913 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106627 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d3131ab5-17f5-4ae5-bc82-119f946952c0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155042 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26478 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26256 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118404 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83847 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0019e62b-e4b1-4d3a-87b4-e61638f39a2e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156128 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20644 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137508 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99117 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5bec7666-5e3e-4507-9fd1-07256002c086) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19719 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17668 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9749 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129370 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15381 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164387 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7523 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16975 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126464 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25748 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21697 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126622 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34398 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25750 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137177 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82416 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21576 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13956 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25366 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89653 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25059 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25217 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25118 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->