### PR TITLE
RTCRtpSender.setParameters should clear parameters that were unset by the web app

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpParameters-maxFramerate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpParameters-maxFramerate-expected.txt
@@ -8,8 +8,8 @@ PASS setParameters() with maxFramerate 24->16 should succeed with RTCRtpTranscei
 PASS setParameters() with maxFramerate 24->16 should succeed without RTCRtpTransceiverInit
 PASS setParameters() with maxFramerate undefined->16 should succeed with RTCRtpTransceiverInit
 PASS setParameters() with maxFramerate undefined->16 should succeed without RTCRtpTransceiverInit
-FAIL setParameters() with maxFramerate 24->undefined should succeed with RTCRtpTransceiverInit assert_equals: expected (undefined) undefined but got (number) 24
-FAIL setParameters() with maxFramerate 24->undefined should succeed without RTCRtpTransceiverInit assert_equals: expected (undefined) undefined but got (number) 24
+PASS setParameters() with maxFramerate 24->undefined should succeed with RTCRtpTransceiverInit
+PASS setParameters() with maxFramerate 24->undefined should succeed without RTCRtpTransceiverInit
 PASS setParameters() with maxFramerate 0->16 should succeed with RTCRtpTransceiverInit
 PASS setParameters() with maxFramerate 0->16 should succeed without RTCRtpTransceiverInit
 PASS setParameters() with maxFramerate 24->0 should succeed with RTCRtpTransceiverInit

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCUtils.cpp
@@ -310,10 +310,16 @@ void updateRTCRtpSendParameters(const RTCRtpSendParameters& parameters, webrtc::
         rtcParameters.encodings[i].active = parameters.encodings[i].active;
         if (parameters.encodings[i].maxBitrate)
             rtcParameters.encodings[i].max_bitrate_bps = *parameters.encodings[i].maxBitrate;
+        else
+            rtcParameters.encodings[i].max_bitrate_bps = std::nullopt;
         if (parameters.encodings[i].maxFramerate)
             rtcParameters.encodings[i].max_framerate = *parameters.encodings[i].maxFramerate;
+        else
+            rtcParameters.encodings[i].max_framerate = std::nullopt;
         if (parameters.encodings[i].scaleResolutionDownBy)
             rtcParameters.encodings[i].scale_resolution_down_by = *parameters.encodings[i].scaleResolutionDownBy;
+        else
+            rtcParameters.encodings[i].scale_resolution_down_by = std::nullopt;
         rtcParameters.encodings[i].bitrate_priority = toWebRTCBitRatePriority(parameters.encodings[i].priority);
         if (parameters.encodings[i].networkPriority)
             rtcParameters.encodings[i].network_priority = fromRTCPriorityType(*parameters.encodings[i].networkPriority);


### PR DESCRIPTION
#### 9261d55f2589b06a53761dfd696068fb8d394a70
<pre>
RTCRtpSender.setParameters should clear parameters that were unset by the web app
<a href="https://rdar.apple.com/173678165">rdar://173678165</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=311085">https://bugs.webkit.org/show_bug.cgi?id=311085</a>

Reviewed by Eric Carlson.

Previously, we were updating the rtc parameters based on WebCore parameters if a WebCore parameter is defined.
We add the ability to unset the rtc parameter fields for which WebCore parameter fields have been unset.

Covered by rebased WPT test.
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCUtils.cpp:
(WebCore::updateRTCRtpSendParameters):

Canonical link: <a href="https://commits.webkit.org/310286@main">https://commits.webkit.org/310286@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce1fcf15b252c48d833ea2b18184ed577ac5bb57

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153199 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25981 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19579 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161943 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106657 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1d82d3e5-050b-424f-aaf7-8b3210b45f94) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155072 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26508 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26286 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118432 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83870 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c57ab50a-a06b-4a90-8196-6ed6c2f8a777) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156158 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20667 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137533 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99145 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d758b27d-c83a-401b-957f-7fea5508f537) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19743 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17698 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9779 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129393 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15406 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164417 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7553 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17000 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126491 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25778 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21727 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126649 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34390 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25780 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137202 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82449 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21599 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13981 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25396 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89683 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25089 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25247 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25148 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->