### PR TITLE
Add Subgrid and Grid-Lanes badges to Web Inspector Elements panel

### DIFF
--- a/LayoutTests/inspector/css/nodeLayoutContextTypeChanged-expected.txt
+++ b/LayoutTests/inspector/css/nodeLayoutContextTypeChanged-expected.txt
@@ -23,6 +23,20 @@ PASS: Layout context should now be `flex`.
 PASS: Layout context should now be `grid`.
 PASS: Layout context should now be `flex`.
 
+-- Running test case: CSS.nodeLayoutContextTypeChanged.Subgrid
+PASS: Layout context should be `subgrid`.
+
+-- Running test case: CSS.nodeLayoutContextTypeChanged.SubgridToNonGrid
+PASS: Layout context should be `subgrid`.
+PASS: Layout context should now be `null`.
+
+-- Running test case: CSS.nodeLayoutContextTypeChanged.GridLanes
+PASS: Layout context should be `grid-lanes`.
+
+-- Running test case: CSS.nodeLayoutContextTypeChanged.GridLanesToGrid
+PASS: Layout context should be `grid-lanes`.
+PASS: Layout context should now be `grid`.
+
 -- Running test case: CSS.nodeLayoutContextTypeChanged.NotFlex.SubmitInput
 PASS: Layout context should be `null`.
 

--- a/LayoutTests/inspector/css/nodeLayoutContextTypeChanged.html
+++ b/LayoutTests/inspector/css/nodeLayoutContextTypeChanged.html
@@ -126,6 +126,52 @@ function test()
         }
     });
 
+    addEnsureLayoutContextTypeTestCase({
+        name: "CSS.nodeLayoutContextTypeChanged.Subgrid",
+        description: "Make sure a subgrid element is detected as a subgrid.",
+        selector: "#subgridElement",
+        expectedLayoutContextType: WI.DOMNode.LayoutFlag.Subgrid,
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutContextTypeChanged.SubgridToNonGrid",
+        description: "Change a subgrid to a non-grid.",
+        selector: "#subgridToNonGrid",
+        async domNodeHandler(domNode) {
+            InspectorTest.expectEqual(domNode.layoutContextType, WI.DOMNode.LayoutFlag.Subgrid, "Layout context should be `subgrid`.");
+
+            await Promise.all([
+                domNode.awaitEvent(WI.DOMNode.Event.LayoutFlagsChanged),
+                changeElementDisplayValue("subgridToNonGrid", "block"),
+            ]);
+
+            InspectorTest.expectEqual(domNode.layoutContextType, null, "Layout context should now be `null`.");
+        }
+    });
+
+    addEnsureLayoutContextTypeTestCase({
+        name: "CSS.nodeLayoutContextTypeChanged.GridLanes",
+        description: "Make sure a masonry element is detected as grid-lanes.",
+        selector: "#gridLanesElement",
+        expectedLayoutContextType: WI.DOMNode.LayoutFlag.GridLanes,
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutContextTypeChanged.GridLanesToGrid",
+        description: "Change a grid-lanes (masonry) container to a regular grid.",
+        selector: "#gridLanesToGrid",
+        async domNodeHandler(domNode) {
+            InspectorTest.expectEqual(domNode.layoutContextType, WI.DOMNode.LayoutFlag.GridLanes, "Layout context should be `grid-lanes`.");
+
+            await Promise.all([
+                domNode.awaitEvent(WI.DOMNode.Event.LayoutFlagsChanged),
+                changeElementDisplayValue("gridLanesToGrid", "grid"),
+            ]);
+
+            InspectorTest.expectEqual(domNode.layoutContextType, WI.DOMNode.LayoutFlag.Grid, "Layout context should now be `grid`.");
+        }
+    });
+
     function addEnsureLayoutContextTypeTestCase({name, description, selector, expectedLayoutContextType, setup})
     {
         addTestCase({name, description, selector, setup, async domNodeHandler(domNode) {
@@ -179,6 +225,23 @@ function test()
     .flex-container {
         display: flex;
     }
+
+    .subgrid-parent {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        grid-template-rows: auto auto;
+    }
+
+    .subgrid-child {
+        display: grid;
+        grid-column: 1 / -1;
+        grid-template-columns: subgrid;
+    }
+
+    .grid-lanes-container {
+        display: grid-lanes;
+        grid-template-columns: 1fr 1fr;
+    }
 </style>
 </head>
 <body onload="runTest()">
@@ -211,5 +274,29 @@ function test()
     <input type="submit" id="flexSubmitInput" />
     <select id="flexSelect"></select>
     <button id="flexButton"></button>
+
+    <div class="subgrid-parent">
+        <div id="subgridElement" class="subgrid-child">
+            <div></div>
+            <div></div>
+        </div>
+    </div>
+
+    <div class="subgrid-parent">
+        <div id="subgridToNonGrid" class="subgrid-child">
+            <div></div>
+            <div></div>
+        </div>
+    </div>
+
+    <div id="gridLanesElement" class="grid-lanes-container">
+        <div></div>
+        <div></div>
+    </div>
+
+    <div id="gridLanesToGrid" class="grid-lanes-container">
+        <div></div>
+        <div></div>
+    </div>
 </body>
 </html>

--- a/Source/JavaScriptCore/inspector/protocol/CSS.json
+++ b/Source/JavaScriptCore/inspector/protocol/CSS.json
@@ -294,6 +294,8 @@
                 "scrollable",
                 "flex",
                 "grid",
+                "subgrid",
+                "grid-lanes",
                 "event",
                 "slot-assigned",
                 "slot-filled"

--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -662,10 +662,10 @@
 "Finder" = "Finder";
 
 /* Inspector element selection tooltip text for Flexbox containers. */
-"Flex (Inspector Element Selection)" = "Flex";
+"flex (Inspector Element Selection)" = "flex";
 
 /* Inspector element selection tooltip text for items inside a Flexbox Container. */
-"Flex Item (Inspector Element Selection)" = "Flex Item";
+"flex item (Inspector Element Selection)" = "flex item";
 
 /* Font context sub-menu item */
 "Font" = "Font";
@@ -695,10 +695,16 @@
 "Google Safe Browsing" = "Google Safe Browsing";
 
 /* Inspector element selection tooltip text for Grid containers. */
-"Grid (Inspector Element Selection)" = "Grid";
+"grid (Inspector Element Selection)" = "grid";
+
+/* Inspector element selection tooltip text for Grid Lanes containers. */
+"grid lanes (Inspector Element Selection)" = "grid lanes";
 
 /* Inspector element selection tooltip text for items inside a Grid Container. */
-"Grid Item (Inspector Element Selection)" = "Grid Item";
+"grid item (Inspector Element Selection)" = "grid item";
+
+/* Inspector element selection tooltip text for Subgrid containers. */
+"subgrid (Inspector Element Selection)" = "subgrid";
 
 /* Codec Strings */
 "HEVC (Codec String)" = "HEVC";

--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -1212,14 +1212,20 @@ Path InspectorOverlay::drawElementTitle(GraphicsContext& context, Node& node, co
     Vector<String> layoutContextBubbleStrings;
     
     if (rendererIsFlexboxItem(*renderer))
-        layoutContextBubbleStrings.append(WEB_UI_STRING_KEY("Flex Item", "Flex Item (Inspector Element Selection)", "Inspector element selection tooltip text for items inside a Flexbox Container."));
+        layoutContextBubbleStrings.append(WEB_UI_STRING_KEY("flex item", "flex item (Inspector Element Selection)", "Inspector element selection tooltip text for items inside a Flexbox Container."));
     else if (rendererIsGridItem(*renderer))
-        layoutContextBubbleStrings.append(WEB_UI_STRING_KEY("Grid Item", "Grid Item (Inspector Element Selection)", "Inspector element selection tooltip text for items inside a Grid Container."));
+        layoutContextBubbleStrings.append(WEB_UI_STRING_KEY("grid item", "grid item (Inspector Element Selection)", "Inspector element selection tooltip text for items inside a Grid Container."));
 
     if (is<RenderFlexibleBox>(renderer))
-        layoutContextBubbleStrings.append(WEB_UI_STRING_KEY("Flex", "Flex (Inspector Element Selection)", "Inspector element selection tooltip text for Flexbox containers."));
-    else if (is<RenderGrid>(renderer))
-        layoutContextBubbleStrings.append(WEB_UI_STRING_KEY("Grid", "Grid (Inspector Element Selection)", "Inspector element selection tooltip text for Grid containers."));
+        layoutContextBubbleStrings.append(WEB_UI_STRING_KEY("flex", "flex (Inspector Element Selection)", "Inspector element selection tooltip text for Flexbox containers."));
+    else if (CheckedPtr renderGrid = dynamicDowncast<RenderGrid>(renderer)) {
+        if (renderGrid->isSubgrid())
+            layoutContextBubbleStrings.append(WEB_UI_STRING_KEY("subgrid", "subgrid (Inspector Element Selection)", "Inspector element selection tooltip text for Subgrid containers."));
+        else if (renderGrid->isMasonry())
+            layoutContextBubbleStrings.append(WEB_UI_STRING_KEY("grid lanes", "grid lanes (Inspector Element Selection)", "Inspector element selection tooltip text for Grid Lanes containers."));
+        else
+            layoutContextBubbleStrings.append(WEB_UI_STRING_KEY("grid", "grid (Inspector Element Selection)", "Inspector element selection tooltip text for Grid containers."));
+    }
 
     // Need to enable AX to get the computed role.
     WebCore::AXObjectCache::enableAccessibility();

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
@@ -1049,8 +1049,13 @@ static std::optional<InspectorCSSAgent::LayoutFlag> layoutFlagContextType(Render
             return std::nullopt;
         return InspectorCSSAgent::LayoutFlag::Flex;
     }
-    if (is<RenderGrid>(renderer))
+    if (CheckedPtr renderGrid = dynamicDowncast<RenderGrid>(renderer)) {
+        if (renderGrid->isSubgrid())
+            return InspectorCSSAgent::LayoutFlag::Subgrid;
+        if (renderGrid->isMasonry())
+            return InspectorCSSAgent::LayoutFlag::GridLanes;
         return InspectorCSSAgent::LayoutFlag::Grid;
+    }
     return std::nullopt;
 }
 
@@ -1059,6 +1064,8 @@ static bool layoutFlagsContainLayoutContextType(OptionSet<InspectorCSSAgent::Lay
     return layoutFlags.containsAny({
         InspectorCSSAgent::LayoutFlag::Flex,
         InspectorCSSAgent::LayoutFlag::Grid,
+        InspectorCSSAgent::LayoutFlag::Subgrid,
+        InspectorCSSAgent::LayoutFlag::GridLanes,
     });
 }
 
@@ -1140,6 +1147,10 @@ static RefPtr<JSON::ArrayOf<String /* Inspector::Protocol::CSS::LayoutFlag */>> 
         protocolLayoutFlags->addItem(Inspector::Protocol::Helpers::getEnumConstantValue(Inspector::Protocol::CSS::LayoutFlag::Flex));
     if (layoutFlags.contains(InspectorCSSAgent::LayoutFlag::Grid))
         protocolLayoutFlags->addItem(Inspector::Protocol::Helpers::getEnumConstantValue(Inspector::Protocol::CSS::LayoutFlag::Grid));
+    if (layoutFlags.contains(InspectorCSSAgent::LayoutFlag::Subgrid))
+        protocolLayoutFlags->addItem(Inspector::Protocol::Helpers::getEnumConstantValue(Inspector::Protocol::CSS::LayoutFlag::Subgrid));
+    if (layoutFlags.contains(InspectorCSSAgent::LayoutFlag::GridLanes))
+        protocolLayoutFlags->addItem(Inspector::Protocol::Helpers::getEnumConstantValue(Inspector::Protocol::CSS::LayoutFlag::GridLanes));
     if (layoutFlags.contains(InspectorCSSAgent::LayoutFlag::Event))
         protocolLayoutFlags->addItem(Inspector::Protocol::Helpers::getEnumConstantValue(Inspector::Protocol::CSS::LayoutFlag::Event));
     if (layoutFlags.contains(InspectorCSSAgent::LayoutFlag::SlotAssigned))

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.h
@@ -136,14 +136,20 @@ public:
     void didRemoveDOMNode(Node&, Inspector::Protocol::DOM::NodeId);
     void didModifyDOMAttr(Element&);
 
-    enum class LayoutFlag : uint8_t {
+    enum class LayoutFlag : uint16_t {
         Rendered = 1 << 0,
+
+        // Layout context types (mutually exclusive).
         Flex = 1 << 1,
         Grid = 1 << 2,
-        Event = 1 << 3,
-        Scrollable = 1 << 4,
-        SlotAssigned = 1 << 5,
-        SlotFilled = 1 << 6,
+        Subgrid = 1 << 3,
+        GridLanes = 1 << 4,
+
+        // Independent flags.
+        Event = 1 << 5,
+        Scrollable = 1 << 6,
+        SlotAssigned = 1 << 7,
+        SlotFilled = 1 << 8,
     };
     OptionSet<LayoutFlag> layoutFlagsForNode(Node&);
     RefPtr<JSON::ArrayOf<String /* Inspector::Protocol::CSS::LayoutFlag */>> protocolLayoutFlagsForNode(Node&);

--- a/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
+++ b/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
@@ -295,6 +295,8 @@ WI.DOMNode = class DOMNode extends WI.Object
             break;
 
         case WI.DOMNode.LayoutFlag.Grid:
+        case WI.DOMNode.LayoutFlag.Subgrid:
+        case WI.DOMNode.LayoutFlag.GridLanes:
             WI.settings.gridOverlayShowExtendedGridLines.removeEventListener(WI.Setting.Event.Changed, this._handleLayoutOverlaySettingChanged, this);
             WI.settings.gridOverlayShowLineNames.removeEventListener(WI.Setting.Event.Changed, this._handleLayoutOverlaySettingChanged, this);
             WI.settings.gridOverlayShowLineNumbers.removeEventListener(WI.Setting.Event.Changed, this._handleLayoutOverlaySettingChanged, this);
@@ -653,6 +655,8 @@ WI.DOMNode = class DOMNode extends WI.Object
 
         switch (this.layoutContextType) {
         case WI.DOMNode.LayoutFlag.Grid:
+        case WI.DOMNode.LayoutFlag.Subgrid:
+        case WI.DOMNode.LayoutFlag.GridLanes:
             agentCommandArguments.gridOverlayConfig = {
                 gridColor: color.toProtocol(),
                 showLineNames: WI.settings.gridOverlayShowLineNames.value,
@@ -722,6 +726,8 @@ WI.DOMNode = class DOMNode extends WI.Object
 
         switch (this.layoutContextType) {
         case WI.DOMNode.LayoutFlag.Grid:
+        case WI.DOMNode.LayoutFlag.Subgrid:
+        case WI.DOMNode.LayoutFlag.GridLanes:
             WI.settings.gridOverlayShowExtendedGridLines.removeEventListener(WI.Setting.Event.Changed, this._handleLayoutOverlaySettingChanged, this);
             WI.settings.gridOverlayShowLineNames.removeEventListener(WI.Setting.Event.Changed, this._handleLayoutOverlaySettingChanged, this);
             WI.settings.gridOverlayShowLineNumbers.removeEventListener(WI.Setting.Event.Changed, this._handleLayoutOverlaySettingChanged, this);
@@ -1326,6 +1332,8 @@ WI.DOMNode = class DOMNode extends WI.Object
         let nextColorIndex;
         switch (this.layoutContextType) {
         case WI.DOMNode.LayoutFlag.Grid:
+        case WI.DOMNode.LayoutFlag.Subgrid:
+        case WI.DOMNode.LayoutFlag.GridLanes:
             nextColorIndex = defaultConfiguration.nextGridColorIndex;
             defaultConfiguration.nextGridColorIndex = (nextColorIndex + 1) % defaultConfiguration.colors.length;
             break;
@@ -1407,9 +1415,13 @@ WI.DOMNode.LayoutFlag = {
     // These are mutually exclusive.
     Flex: "flex",
     Grid: "grid",
+    Subgrid: "subgrid",
+    GridLanes: "grid-lanes",
 };
 
 WI.DOMNode._LayoutContextTypes = [
     WI.DOMNode.LayoutFlag.Flex,
     WI.DOMNode.LayoutFlag.Grid,
+    WI.DOMNode.LayoutFlag.Subgrid,
+    WI.DOMNode.LayoutFlag.GridLanes,
 ];

--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.js
@@ -518,6 +518,22 @@ WI.DOMTreeContentView = class DOMTreeContentView extends WI.ContentView
             }, WI.settings.enabledDOMTreeBadgeTypes.value.includes(WI.DOMTreeElement.BadgeType.Grid));
         }
 
+        // COMPATIBILITY (macOS X.Y, iOS X.Y): `Subgrid` value for `CSS.LayoutFlag` did not exist yet.
+        if (InspectorBackend.Enum.CSS?.LayoutFlag?.Subgrid) {
+            contextMenu.appendCheckboxItem(WI.unlocalizedString("subgrid"), () => {
+                WI.settings.enabledDOMTreeBadgeTypes.value.toggleIncludes(WI.DOMTreeElement.BadgeType.Subgrid);
+                WI.settings.enabledDOMTreeBadgeTypes.save();
+            }, WI.settings.enabledDOMTreeBadgeTypes.value.includes(WI.DOMTreeElement.BadgeType.Subgrid));
+        }
+
+        // COMPATIBILITY (macOS X.Y, iOS X.Y): `GridLanes` value for `CSS.LayoutFlag` did not exist yet.
+        if (InspectorBackend.Enum.CSS?.LayoutFlag?.GridLanes) {
+            contextMenu.appendCheckboxItem(WI.unlocalizedString("grid-lanes"), () => {
+                WI.settings.enabledDOMTreeBadgeTypes.value.toggleIncludes(WI.DOMTreeElement.BadgeType.GridLanes);
+                WI.settings.enabledDOMTreeBadgeTypes.save();
+            }, WI.settings.enabledDOMTreeBadgeTypes.value.includes(WI.DOMTreeElement.BadgeType.GridLanes));
+        }
+
         // COMPATIBILITY (macOS 13.0, iOS 16.0): `DOM.showFlexOverlay` did not exist yet.
         if (InspectorBackend.hasCommand("DOM.showFlexOverlay")) {
             contextMenu.appendCheckboxItem(WI.unlocalizedString("flex"), () => {

--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js
@@ -72,6 +72,29 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
         }
     }
 
+    static badgeTypeForLayoutFlag(layoutFlag)
+    {
+        switch (layoutFlag) {
+        case WI.DOMNode.LayoutFlag.Scrollable:
+            return WI.DOMTreeElement.BadgeType.Scrollable;
+        case WI.DOMNode.LayoutFlag.Flex:
+            return WI.DOMTreeElement.BadgeType.Flex;
+        case WI.DOMNode.LayoutFlag.Grid:
+            return WI.DOMTreeElement.BadgeType.Grid;
+        case WI.DOMNode.LayoutFlag.Subgrid:
+            return WI.DOMTreeElement.BadgeType.Subgrid;
+        case WI.DOMNode.LayoutFlag.GridLanes:
+            return WI.DOMTreeElement.BadgeType.GridLanes;
+        case WI.DOMNode.LayoutFlag.Event:
+            return WI.DOMTreeElement.BadgeType.Event;
+        case WI.DOMNode.LayoutFlag.SlotAssigned:
+            return WI.DOMTreeElement.BadgeType.SlotAssigned;
+        case WI.DOMNode.LayoutFlag.SlotFilled:
+            return WI.DOMTreeElement.BadgeType.SlotFilled;
+        }
+        console.assert(false, "not reached", layoutFlag);
+    }
+
     // Public
 
     get statusImageElement() { return this._statusImageElement; }
@@ -2103,13 +2126,33 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
 
         case WI.DOMTreeElement.BadgeType.Flex:
             console.assert(!this._elementForBadgeType.has(WI.DOMTreeElement.BadgeType.Grid));
+            console.assert(!this._elementForBadgeType.has(WI.DOMTreeElement.BadgeType.Subgrid));
+            console.assert(!this._elementForBadgeType.has(WI.DOMTreeElement.BadgeType.GridLanes));
             text = WI.unlocalizedString("flex");
             handleClick = this._layoutBadgeClicked.bind(this);
             break;
 
         case WI.DOMTreeElement.BadgeType.Grid:
             console.assert(!this._elementForBadgeType.has(WI.DOMTreeElement.BadgeType.Flex));
+            console.assert(!this._elementForBadgeType.has(WI.DOMTreeElement.BadgeType.Subgrid));
+            console.assert(!this._elementForBadgeType.has(WI.DOMTreeElement.BadgeType.GridLanes));
             text = WI.unlocalizedString("grid");
+            handleClick = this._layoutBadgeClicked.bind(this);
+            break;
+
+        case WI.DOMTreeElement.BadgeType.Subgrid:
+            console.assert(!this._elementForBadgeType.has(WI.DOMTreeElement.BadgeType.Flex));
+            console.assert(!this._elementForBadgeType.has(WI.DOMTreeElement.BadgeType.Grid));
+            console.assert(!this._elementForBadgeType.has(WI.DOMTreeElement.BadgeType.GridLanes));
+            text = WI.unlocalizedString("subgrid");
+            handleClick = this._layoutBadgeClicked.bind(this);
+            break;
+
+        case WI.DOMTreeElement.BadgeType.GridLanes:
+            console.assert(!this._elementForBadgeType.has(WI.DOMTreeElement.BadgeType.Flex));
+            console.assert(!this._elementForBadgeType.has(WI.DOMTreeElement.BadgeType.Grid));
+            console.assert(!this._elementForBadgeType.has(WI.DOMTreeElement.BadgeType.Subgrid));
+            text = WI.unlocalizedString("grid-lanes");
             handleClick = this._layoutBadgeClicked.bind(this);
             break;
 
@@ -2150,33 +2193,8 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
             badgeElement.remove();
         this._elementForBadgeType.clear();
 
-        for (let layoutFlag of this.representedObject.layoutFlags) {
-            switch (layoutFlag) {
-            case WI.DOMNode.LayoutFlag.Scrollable:
-                this._createBadge(WI.DOMTreeElement.BadgeType.Scrollable);
-                break;
-
-            case WI.DOMNode.LayoutFlag.Grid:
-                this._createBadge(WI.DOMTreeElement.BadgeType.Grid);
-                break;
-
-            case WI.DOMNode.LayoutFlag.Flex:
-                this._createBadge(WI.DOMTreeElement.BadgeType.Flex);
-                break;
-
-            case WI.DOMNode.LayoutFlag.Event:
-                this._createBadge(WI.DOMTreeElement.BadgeType.Event);
-                break;
-
-            case WI.DOMNode.LayoutFlag.SlotAssigned:
-                this._createBadge(WI.DOMTreeElement.BadgeType.SlotAssigned);
-                break;
-
-            case WI.DOMNode.LayoutFlag.SlotFilled:
-                this._createBadge(WI.DOMTreeElement.BadgeType.SlotFilled);
-                break;
-            }
-        }
+        for (let layoutFlag of this.representedObject.layoutFlags)
+            this._createBadge(WI.DOMTreeElement.badgeTypeForLayoutFlag(layoutFlag));
 
         if (!this._elementForBadgeType.size) {
             if (hadBadge) {
@@ -2327,6 +2345,8 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
         for (let [badgeType, badgeElement] of this._elementForBadgeType) {
             switch (badgeType) {
             case WI.DOMTreeElement.BadgeType.Grid:
+            case WI.DOMTreeElement.BadgeType.Subgrid:
+            case WI.DOMTreeElement.BadgeType.GridLanes:
             case WI.DOMTreeElement.BadgeType.Flex: {
                 let layoutOverlayShowing = this.representedObject.layoutOverlayShowing;
                 badgeElement.classList.toggle("activated", layoutOverlayShowing);
@@ -2400,6 +2420,8 @@ WI.DOMTreeElement.BadgeType = {
     Scrollable: "scrollable",
     Flex: "flex",
     Grid: "grid",
+    Subgrid: "subgrid",
+    GridLanes: "grid-lanes",
     Event: "event",
     SlotAssigned: "slot-assigned",
     SlotFilled: "slot-filled",

--- a/Source/WebInspectorUI/UserInterface/Views/LayoutDetailsSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/LayoutDetailsSidebarPanel.js
@@ -197,6 +197,8 @@ WI.LayoutDetailsSidebarPanel = class LayoutDetailsSidebarPanel extends WI.DOMDet
         for (let node of WI.domManager.attachedNodes({filter: (node) => node.layoutContextType})) {
             switch (node.layoutContextType) {
             case WI.DOMNode.LayoutFlag.Grid:
+            case WI.DOMNode.LayoutFlag.Subgrid:
+            case WI.DOMNode.LayoutFlag.GridLanes:
                 this._gridNodeSet.add(node);
                 break;
 


### PR DESCRIPTION
#### ab5173660b7bff2925b86a2984d0e964cf9245e5
<pre>
Add Subgrid and Grid-Lanes badges to Web Inspector Elements panel
<a href="https://bugs.webkit.org/show_bug.cgi?id=311089">https://bugs.webkit.org/show_bug.cgi?id=311089</a>
<a href="https://rdar.apple.com/173681497">rdar://173681497</a>

Reviewed by Devin Rousso.

Add two new layout badges (&quot;subgrid&quot; and &quot;grid-lanes&quot;) to the Elements panel DOM tree.
Both are subtypes of RenderGrid, detected via existing isSubgrid() and isMasonry() APIs.
They are mutually exclusive with each other and with the existing flex/grid badges.
Clicking either badge toggles the grid overlay, reusing the existing grid overlay infrastructure.
The element selection overlay tooltip also now shows the correct label for each subtype.

* LayoutTests/inspector/css/nodeLayoutContextTypeChanged-expected.txt:
* LayoutTests/inspector/css/nodeLayoutContextTypeChanged.html:
Add test cases for Subgrid and GridLanes layout context detection and transitions.

* Source/JavaScriptCore/inspector/protocol/CSS.json:
Add &quot;subgrid&quot; and &quot;grid-lanes&quot; to the LayoutFlag enum.

* Source/WebCore/en.lproj/Localizable.strings:
Add localized strings for &quot;Subgrid&quot; and &quot;Grid Lanes&quot; element selection tooltips.

* Source/WebCore/inspector/InspectorOverlay.cpp:
(WebCore::InspectorOverlay::drawElementTitle): Show &quot;Subgrid&quot; or &quot;Grid Lanes&quot; in element
selection tooltip instead of &quot;Grid&quot; for those subtypes.

* Source/WebCore/inspector/agents/InspectorCSSAgent.cpp:
(WebCore::layoutFlagContextType): Downcast to RenderGrid via CheckedPtr and check
isSubgrid()/isMasonry().
(WebCore::layoutFlagsContainLayoutContextType): Include Subgrid and GridLanes.
(WebCore::toProtocol): Convert Subgrid and GridLanes to protocol values.

* Source/WebCore/inspector/agents/InspectorCSSAgent.h:
Reorder LayoutFlag enum to group layout context types (Flex, Grid, Subgrid, GridLanes)
together. Widen to uint16_t to accommodate new flags.

* Source/WebInspectorUI/UserInterface/Models/DOMNode.js:
(WI.DOMNode.prototype.showLayoutOverlay): Handle Subgrid and GridLanes via grid overlay.
(WI.DOMNode.prototype.hideLayoutOverlay): Ditto.
(WI.DOMNode.prototype._createLayoutOverlayColorSettingIfNeeded): Share grid color index
for Subgrid and GridLanes.

* Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.js:
(WI.DOMTreeContentView.prototype._populateConfigureDOMTreeBadgesNavigationItemContextMenu):
Add checkbox items for subgrid and grid-lanes badges, gated on protocol enum support.

* Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js:
(WI.DOMTreeElement.badgeTypeForLayoutFlag): Add static conversion function from LayoutFlag
to BadgeType.
(WI.DOMTreeElement.prototype._createBadge): Handle Subgrid and GridLanes badges with full
mutual exclusivity assertions against all other layout context badge types.
(WI.DOMTreeElement.prototype._createBadges): Use badgeTypeForLayoutFlag conversion function.
(WI.DOMTreeElement.prototype._updateBadges): Include Subgrid and GridLanes for activated
state styling.

* Source/WebInspectorUI/UserInterface/Views/LayoutDetailsSidebarPanel.js:
(WI.LayoutDetailsSidebarPanel.prototype._refreshNodeSets): Add Subgrid and GridLanes nodes
to the grid node set.

Canonical link: <a href="https://commits.webkit.org/310936@main">https://commits.webkit.org/310936@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c019cb2d39342097dbe079d7a5e55da6c9aa810

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155410 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28670 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21829 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164172 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f937a51b-687d-4495-9702-2b71a74c3e97) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157283 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28811 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28520 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120275 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158369 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22464 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139557 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100965 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21550 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19654 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12001 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147460 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131219 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17389 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166650 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/16241 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/10819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18999 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128384 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28214 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23688 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128520 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34864 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28138 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139182 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/85575 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23357 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15979 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/187295 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27832 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91935 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48016 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27409 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27639 "Built successfully") | | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27482 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | | | 
<!--EWS-Status-Bubble-End-->