### PR TITLE
roundUpToPowerOfTwo() truncates its return value to uint32_t

### DIFF
--- a/Source/WTF/wtf/MathExtras.h
+++ b/Source/WTF/wtf/MathExtras.h
@@ -456,7 +456,7 @@ inline void doubleToInteger(double d, unsigned long long& value)
 
 namespace WTF {
 
-constexpr uint32_t roundUpToPowerOfTwo(auto v)
+constexpr auto roundUpToPowerOfTwo(auto v)
 {
     return std::bit_ceil(v);
 }

--- a/Source/WebKit/Shared/Cocoa/SharedCARingBuffer.cpp
+++ b/Source/WebKit/Shared/Cocoa/SharedCARingBuffer.cpp
@@ -30,6 +30,7 @@
 
 #include "Logging.h"
 #include <WebCore/CARingBuffer.h>
+#include <utility>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
@@ -46,7 +47,12 @@ SharedCARingBufferBase::SharedCARingBufferBase(size_t bytesPerFrame, size_t fram
 
 std::unique_ptr<ConsumerSharedCARingBuffer> ConsumerSharedCARingBuffer::map(uint32_t bytesPerFrame, uint32_t numChannelStreams, ConsumerSharedCARingBuffer::Handle&& handle)
 {
-    auto frameCount = roundUpToPowerOfTwo(handle.frameCount);
+    if (!std::in_range<size_t>(handle.frameCount)) {
+        RELEASE_LOG_FAULT(Media, "ConsumerSharedCARingBuffer::map: handle.frameCount doesn't fit in a size_t");
+        return nullptr;
+    }
+
+    auto frameCount = roundUpToPowerOfTwo(static_cast<size_t>(handle.frameCount));
 
     // Validate the parameters as they may be coming from an untrusted process.
     auto expectedStorageSize = computeSizeForBuffers(bytesPerFrame, frameCount, numChannelStreams) + sizeof(TimeBoundsBuffer);

--- a/Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp
@@ -489,6 +489,24 @@ TEST(WTF, roundUpToPowerOfTwo)
     EXPECT_EQ(roundUpToPowerOfTwo(1U << 31), (1U << 31));
 }
 
+TEST(WTF, roundUpToPowerOfTwoSizeT)
+{
+    // Values that fit in 32 bits should still work.
+    EXPECT_EQ(roundUpToPowerOfTwo(static_cast<size_t>(1)), static_cast<size_t>(1));
+    EXPECT_EQ(roundUpToPowerOfTwo(static_cast<size_t>(120)), static_cast<size_t>(128));
+
+    // Values beyond 32 bits should not be truncated.
+#if CPU(ADDRESS64)
+    constexpr size_t twoTo33 = static_cast<size_t>(1) << 33;
+    EXPECT_EQ(roundUpToPowerOfTwo(twoTo33), twoTo33);
+    EXPECT_EQ(roundUpToPowerOfTwo(twoTo33 + 1), twoTo33 << 1);
+    EXPECT_EQ(roundUpToPowerOfTwo(twoTo33 - 1), twoTo33);
+
+    constexpr size_t twoTo63 = static_cast<size_t>(1) << 63;
+    EXPECT_EQ(roundUpToPowerOfTwo(twoTo63), twoTo63);
+#endif
+}
+
 TEST(WTF, clz)
 {
     EXPECT_EQ(WTF::clz<int32_t>(1), 31U);


### PR DESCRIPTION
#### 3242d3d821c50563fbbd9899575fb10b1f208db4
<pre>
roundUpToPowerOfTwo() truncates its return value to uint32_t
<a href="https://bugs.webkit.org/show_bug.cgi?id=311090">https://bugs.webkit.org/show_bug.cgi?id=311090</a>

Reviewed by Darin Adler.

use `auto` for the return type so that the return type gets deduced from
whatever std::bit_ceil() returns.

Test: Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp

* Source/WTF/wtf/MathExtras.h:
(WTF::roundUpToPowerOfTwo):
* Source/WebKit/Shared/Cocoa/SharedCARingBuffer.cpp:
(WebKit::ConsumerSharedCARingBuffer::map):
* Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp:
(TestWebKitAPI::TEST(WTF, roundUpToPowerOfTwoSizeT)):

Canonical link: <a href="https://commits.webkit.org/310337@main">https://commits.webkit.org/310337@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ea42f925c1735709c5ccf72d721462441d54c89

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153388 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26172 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19771 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162133 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106846 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155261 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26698 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26492 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118591 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83965 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156347 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20834 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137711 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99303 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19912 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17854 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9968 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/145401 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129559 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15581 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164607 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/14209 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7743 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17175 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126654 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25969 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21887 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126813 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34424 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25971 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137377 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82638 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21748 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14157 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/185024 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25588 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89874 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47457 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25279 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25438 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25339 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->