### PR TITLE
[GTK][WPE] Fix GL state restoration bugs in BitmapTexture

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
@@ -101,6 +101,10 @@ BitmapTexture::BitmapTexture(const IntSize& size, OptionSet<Flags> flags)
     , m_pixelFormat(flags.contains(Flags::UseBGRALayout) ? PixelFormat::BGRA8 : PixelFormat::RGBA8)
 {
     determineRenderTargetAndBinding();
+
+    GLint boundTexture = 0;
+    glGetIntegerv(m_binding, &boundTexture);
+
 #if USE(GBM)
     if (m_flags.contains(Flags::BackedByDMABuf)) {
         OptionSet<MemoryMappedGPUBuffer::BufferFlag> bufferFlags;
@@ -122,15 +126,14 @@ BitmapTexture::BitmapTexture(const IntSize& size, OptionSet<Flags> flags)
         // Proceed as usual with GL texture creation if the dma-buf creation failed.
         // as we only want to allocate the dma-buf, but neither map it, nor create a texture now - but when we
         // need it (from the thread that needs it!).
-        if (allocateTextureFromMemoryMappedGPUBuffer())
+        if (allocateTextureFromMemoryMappedGPUBuffer()) {
+            glBindTexture(m_renderTarget, boundTexture);
             return;
+        }
 
         m_flags.remove(Flags::BackedByDMABuf);
     }
 #endif
-
-    GLint boundTexture = 0;
-    glGetIntegerv(m_binding, &boundTexture);
 
     allocateTexture();
 
@@ -218,9 +221,11 @@ void BitmapTexture::swapTexture(BitmapTexture& other)
     std::swap(m_flags, other.m_flags);
     std::swap(m_id, other.m_id);
 
-    // This texture needs to be in the same pixel format as the 'other'
-    // texture, before the reset above. The 'other' texture should be
-    // reset to RGBA default pixel format.
+    determineRenderTargetAndBinding();
+    other.determineRenderTargetAndBinding();
+
+    // Take the pixel format from the source texture. The source texture
+    // (going back to the pool) is reset to the default pixel format.
     m_pixelFormat = other.m_pixelFormat;
     other.m_pixelFormat = PixelFormat::RGBA8;
 }
@@ -311,8 +316,6 @@ void BitmapTexture::updateContents(const void* srcData, const IntRect& targetRec
         CRASH();
     }
 #endif
-
-    glBindTexture(m_renderTarget, m_id);
 
     const unsigned bytesPerPixel = 4;
     auto data = static_cast<const uint8_t*>(srcData);
@@ -516,15 +519,15 @@ void BitmapTexture::copyFromExternalTexture(GLuint sourceTextureID, const IntRec
         m_pixelFormat = PixelFormat::RGBA8;
     }
 
-    GLint boundTexture = 0;
     GLint boundFramebuffer = 0;
     GLint boundActiveTexture = 0;
+    GLint boundTextureOnOriginalUnit = 0;
 
     determineRenderTargetAndBinding();
 
-    glGetIntegerv(m_binding, &boundTexture);
     glGetIntegerv(GL_FRAMEBUFFER_BINDING, &boundFramebuffer);
     glGetIntegerv(GL_ACTIVE_TEXTURE, &boundActiveTexture);
+    glGetIntegerv(m_binding, &boundTextureOnOriginalUnit);
 
     glBindTexture(m_renderTarget, sourceTextureID);
 
@@ -534,13 +537,21 @@ void BitmapTexture::copyFromExternalTexture(GLuint sourceTextureID, const IntRec
     glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, m_renderTarget, sourceTextureID, 0);
 
     glActiveTexture(GL_TEXTURE0);
+
+    // Save GL_TEXTURE0's binding separately when switching away from a different unit.
+    GLint boundTextureOnUnit0 = 0;
+    if (static_cast<GLenum>(boundActiveTexture) != GL_TEXTURE0)
+        glGetIntegerv(m_binding, &boundTextureOnUnit0);
+
     glBindTexture(m_renderTarget, id());
     glCopyTexSubImage2D(m_renderTarget, 0, targetRect.x(), targetRect.y(), sourceOffset.width(), sourceOffset.height(), targetRect.width(), targetRect.height());
 
-    glBindTexture(m_renderTarget, boundTexture);
+    if (static_cast<GLenum>(boundActiveTexture) != GL_TEXTURE0)
+        glBindTexture(m_renderTarget, boundTextureOnUnit0);
+
     glBindFramebuffer(GL_FRAMEBUFFER, boundFramebuffer);
-    glBindTexture(m_renderTarget, boundTexture);
     glActiveTexture(boundActiveTexture);
+    glBindTexture(m_renderTarget, boundTextureOnOriginalUnit);
     glDeleteFramebuffers(1, &copyFbo);
 }
 


### PR DESCRIPTION
#### fd8dfbafeb2edf271522def5bcc56ce2cf639ffe
<pre>
[GTK][WPE] Fix GL state restoration bugs in BitmapTexture
<a href="https://bugs.webkit.org/show_bug.cgi?id=311086">https://bugs.webkit.org/show_bug.cgi?id=311086</a>

Reviewed by Miguel Gomez.

Various BitmapTexture methods induced side-effects to the GL state.
In certain cases that lead to a mismatch between the GL state assumed
by Skia and the actual GL state leading to rendering artifacts, at least
for some GPU drivers/configurations.

1. copyFromExternalTexture(): Texture binding was saved from the original
   active texture unit but restored to GL_TEXTURE0 (wrong unit).
   -&gt; Save/restore both units correctly, restore active unit before
      restoring its texture binding.

2. BitmapTexture(size, flags) constructor: The GBM/dma-buf early-return path
   called createTexture() which binds the new texture, then returned without
   restoring the previous texture binding.
   -&gt; Move the binding save before the GBM block and restore on early return.

3. swapTexture(): After swapping m_flags between two textures,
   m_renderTarget/m_binding were not recalculated for either texture.
   If the ExternalOESRenderTarget flag differed between the two textures,
   subsequent GL operations would use the wrong texture target/binding
   query. Not something I could reproduce, but worhth fixing nontheless.
   -&gt; Call determineRenderTargetAndBinding() on both textures after the swap.

4. updateContents(data): Redundant glBindTexture(m_renderTarget, m_id) call
   before the subimage buffer preparation - the same bind is done again
   after preparation -- fix that.

Covered by existing tests.

Canonical link: <a href="https://commits.webkit.org/310220@main">https://commits.webkit.org/310220@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/863510fd5583f3199685b2b2cda1fb750752e02f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153180 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25962 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19560 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161924 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106638 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155053 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26489 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26267 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118414 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156139 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20655 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137521 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99127 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/19731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9760 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129381 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15394 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164398 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7534 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16988 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126475 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25759 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21705 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126633 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34342 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25761 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137190 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82430 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21583 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13969 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25377 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89664 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25070 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25228 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25129 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->