### PR TITLE
REGRESSION(310087@main): [GStreamer] Introduced 3 new layout test failures/timeouts

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1651,6 +1651,8 @@ webkit.org/b/306457 http/wpt/mediarecorder/MediaRecorder-audio-bitrate-webm.html
 webkit.org/b/213699 http/wpt/mediarecorder/MediaRecorder-AV-audio-video-dataavailable.html [ Crash Timeout Failure ]
 webkit.org/b/213699 http/wpt/mediarecorder/MediaRecorder-first-frame.html [ Failure Pass ]
 
+webkit.org/b/307032 imported/w3c/web-platform-tests/mediacapture-streams/MediaStream-removetrack.https.html [ Pass Failure ]
+
 # No support for Matroska container in GStreamer port.
 http/wpt/mediarecorder/MediaRecorder-matroska-AV-audio-video-dataavailable.html
 
@@ -5431,10 +5433,6 @@ webkit.org/b/309872 imported/w3c/web-platform-tests/permissions-policy/experimen
 webkit.org/b/309872 imported/w3c/web-platform-tests/permissions-policy/experimental-features/vertical-scroll-scrollintoview.tentative.html [ Skip ]
 webkit.org/b/309872 imported/w3c/web-platform-tests/permissions-policy/reporting/xr-report-only.https.html [ Skip ]
 webkit.org/b/309872 imported/w3c/web-platform-tests/permissions-policy/reporting/xr-reporting.https.html [ Skip ]
-
-webkit.org/b/311032 imported/w3c/web-platform-tests/mediacapture-streams/MediaStream-removetrack.https.html [ Failure Timeout Pass ]
-webkit.org/b/311032 media/media-fragments/TC0009.html [ Timeout ]
-webkit.org/b/311032 media/media-fragments/TC0014.html [ Timeout ]
 
 imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-root.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-root-both-edges.html [ ImageOnlyFailure ]

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -1147,8 +1147,10 @@ MediaPlayerPrivateGStreamer::ChangePipelineStateResult MediaPlayerPrivateGStream
     auto& quirksManager = GStreamerQuirksManager::singleton();
     auto eosState = quirksManager.eosMediaPlayerState();
 
-    // Create a timer when entering the READY state so that we can free resources if we stay for too long on READY.
-    // Also lets remove the timer if we request a state change for any state other than READY. See also https://bugs.webkit.org/show_bug.cgi?id=117354
+    // Create a timer when entering the EOS state (which depending on quirks can be either READY or
+    // PAUSED) so that we can free resources if we stay for too long in EOS state. Also lets remove
+    // the timer if we request a state change for any state other than EOS state. See also
+    // https://bugs.webkit.org/show_bug.cgi?id=117354
     if (RefPtr player = m_player.get(); newState == eosState && m_isEndReached && player && !player->isLooping()
         && !isMediaSource() && !m_eosTimerHandler.isActive()) {
         // Max interval in seconds to stay in the eos state after video finished on manual state change requests.
@@ -2899,6 +2901,9 @@ void MediaPlayerPrivateGStreamer::updateStates()
     // updateBufferingStatus() must have been called at some point before updateStates() and have set m_wasBuffering, m_isBuffering,
     // m_previousBufferingPercentage and m_bufferingPercentage. We take decisions here based on their values.
 
+    auto& quirksManager = GStreamerQuirksManager::singleton();
+    auto eosState = quirksManager.eosMediaPlayerState();
+
     bool shouldUpdatePlaybackState = false;
     switch (getStateResult) {
     case GST_STATE_CHANGE_SUCCESS: {
@@ -2906,7 +2911,7 @@ void MediaPlayerPrivateGStreamer::updateStates()
 
         // Do nothing if on EOS and state changed to READY to avoid recreating the player
         // on HTMLMediaElement and properly generate the video 'ended' event.
-        if (m_isEndReached && m_currentState == GST_STATE_READY)
+        if (m_isEndReached && m_currentState == GST_STATE_READY && eosState != GST_STATE_READY)
             break;
 
         m_shouldResetPipeline = m_currentState <= GST_STATE_READY;
@@ -2918,8 +2923,13 @@ void MediaPlayerPrivateGStreamer::updateStates()
             m_networkState = MediaPlayer::NetworkState::Empty;
             break;
         case GST_STATE_READY:
-            m_readyState = MediaPlayer::ReadyState::HaveMetadata;
-            m_networkState = MediaPlayer::NetworkState::Empty;
+            if (m_isEndReached && eosState == GST_STATE_READY) {
+                m_readyState = MediaPlayer::ReadyState::HaveEnoughData;
+                m_networkState = MediaPlayer::NetworkState::Loaded;
+            } else {
+                m_readyState = MediaPlayer::ReadyState::HaveMetadata;
+                m_networkState = MediaPlayer::NetworkState::Empty;
+            }
             break;
         case GST_STATE_PAUSED:
             [[fallthrough]];


### PR DESCRIPTION
#### 84afeac1a2e5a259b53884a8ec4c8fd1368e2b6c
<pre>
REGRESSION(310087@main): [GStreamer] Introduced 3 new layout test failures/timeouts
<a href="https://bugs.webkit.org/show_bug.cgi?id=311032">https://bugs.webkit.org/show_bug.cgi?id=311032</a>

Reviewed by Alicia Boya Garcia.

The tests were timing out since 310087@main because the ready and network states were no longer
properly updated once EOS state has been reached.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::MediaPlayerPrivateGStreamer):
(WebCore::MediaPlayerPrivateGStreamer::changePipelineState):
(WebCore::MediaPlayerPrivateGStreamer::updateStates):
(WebCore::MediaPlayerPrivateGStreamer::didEnd):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/310318@main">https://commits.webkit.org/310318@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91860e3586449e913ec1025a18d1889d7fd6c100

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153387 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26171 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19770 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162132 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106845 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155260 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26697 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26491 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118583 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156346 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20830 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137706 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99295 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19907 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17850 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9967 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129555 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15576 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164606 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7742 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17170 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126645 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25968 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21883 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/semantics/structured-clone/shared.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126802 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34410 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25970 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137372 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82637 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21741 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14152 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25587 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89873 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25278 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25437 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25338 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->