### PR TITLE
Drop redundant `std::isnan()` checks in MathExtras.h

### DIFF
--- a/Source/WTF/wtf/MathExtras.h
+++ b/Source/WTF/wtf/MathExtras.h
@@ -882,7 +882,7 @@ SUPPRESS_NODELETE ALWAYS_INLINE int32_t NODELETE truncateDoubleToInt32(double nu
 #else
     if (WTF_PROVEN_TRUE(number > -2147483649.0 && number < 2147483648.0))
         return static_cast<int32_t>(number);
-    if (std::isnan(number) || !std::isfinite(number))
+    if (!std::isfinite(number))
         return 0;
     if (number > 0) {
         if (number >= static_cast<double>(INT32_MAX) + 1.0)
@@ -904,7 +904,7 @@ SUPPRESS_NODELETE ALWAYS_INLINE int64_t NODELETE truncateDoubleToInt64(double nu
 #else
     if (WTF_PROVEN_TRUE(number >= -9223372036854775808.0 && number < 9223372036854775808.0))
         return static_cast<int64_t>(number);
-    if (std::isnan(number) || !std::isfinite(number))
+    if (!std::isfinite(number))
         return 0;
     if (number > 0) {
         if (number >= static_cast<double>(INT64_MAX) + 1.0)
@@ -931,7 +931,7 @@ SUPPRESS_NODELETE ALWAYS_INLINE uint32_t NODELETE truncateDoubleToUint32(double 
 #else
     if (WTF_PROVEN_TRUE(number >= 0.0 && number < 4294967296.0))
         return static_cast<uint32_t>(number);
-    if (std::isnan(number) || !std::isfinite(number))
+    if (!std::isfinite(number))
         return 0;
     // Mimic x86_64: cvttsd2si into int64, take low 32 bits.
     int64_t wide = truncateDoubleToInt64(number);
@@ -957,7 +957,7 @@ SUPPRESS_NODELETE ALWAYS_INLINE uint64_t NODELETE truncateDoubleToUint64(double 
 #else
     if (WTF_PROVEN_TRUE(number >= 0.0 && number < 18446744073709551616.0))
         return static_cast<uint64_t>(number);
-    if (std::isnan(number) || !std::isfinite(number))
+    if (!std::isfinite(number))
         return 0;
     if (number < 0.0)
         return 0;
@@ -984,7 +984,7 @@ SUPPRESS_NODELETE ALWAYS_INLINE int32_t NODELETE truncateFloatToInt32(float numb
 #else
     if (WTF_PROVEN_TRUE(number > -2147483649.0f && number < 2147483648.0f))
         return static_cast<int32_t>(number);
-    if (std::isnan(number) || !std::isfinite(number))
+    if (!std::isfinite(number))
         return 0;
     if (number > 0) {
         if (number >= static_cast<float>(INT32_MAX) + 1.0f)
@@ -1011,7 +1011,7 @@ SUPPRESS_NODELETE ALWAYS_INLINE int64_t NODELETE truncateFloatToInt64(float numb
 #else
     if (WTF_PROVEN_TRUE(number >= -9223372036854775808.0f && number < 9223372036854775808.0f))
         return static_cast<int64_t>(number);
-    if (std::isnan(number) || !std::isfinite(number))
+    if (!std::isfinite(number))
         return 0;
     if (number > 0) {
         if (number >= static_cast<float>(INT64_MAX) + 1.0f)
@@ -1033,7 +1033,7 @@ SUPPRESS_NODELETE ALWAYS_INLINE uint32_t NODELETE truncateFloatToUint32(float nu
 #else
     if (WTF_PROVEN_TRUE(number >= 0.0f && number < 4294967296.0f))
         return static_cast<uint32_t>(number);
-    if (std::isnan(number) || !std::isfinite(number))
+    if (!std::isfinite(number))
         return 0;
     int64_t wide = truncateFloatToInt64(number);
     return static_cast<uint32_t>(wide);
@@ -1060,7 +1060,7 @@ SUPPRESS_NODELETE ALWAYS_INLINE uint64_t NODELETE truncateFloatToUint64(float nu
 #else
     if (WTF_PROVEN_TRUE(number >= 0.0f && number < 18446744073709551616.0f))
         return static_cast<uint64_t>(number);
-    if (std::isnan(number) || !std::isfinite(number))
+    if (!std::isfinite(number))
         return 0;
     if (number < 0.0f)
         return 0;


### PR DESCRIPTION
#### dab059cbea788c7283c2592b8c9a44c2e6dd909e
<pre>
Drop redundant `std::isnan()` checks in MathExtras.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=311096">https://bugs.webkit.org/show_bug.cgi?id=311096</a>

Reviewed by Darin Adler.

Drop redundant `std::isnan()` checks in MathExtras.h. `!std::isfinite()`
already covers the NaN case.

* Source/WTF/wtf/MathExtras.h:
(WTF::truncateDoubleToInt32):
(WTF::truncateDoubleToInt64):
(WTF::truncateDoubleToUint32):
(WTF::truncateDoubleToUint64):
(WTF::truncateFloatToInt32):
(WTF::truncateFloatToInt64):
(WTF::truncateFloatToUint32):
(WTF::truncateFloatToUint64):

Canonical link: <a href="https://commits.webkit.org/310270@main">https://commits.webkit.org/310270@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73f9b87d92a2ea974a2fb5735cdb2e3fae5262e1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153186 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25968 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19566 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161930 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106644 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a1049bee-5f79-4c9c-9aad-468c1dad311f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26495 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26273 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118419 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83862 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8e6fbfcb-0eb2-4f81-84a9-88c641162365) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156145 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20660 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137540 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99132 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b1b961bf-96cd-4de5-9094-39f222f95fcd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19736 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17685 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9766 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/145198 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129386 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15413 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164404 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/14001 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7540 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17007 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126479 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25765 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21714 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126637 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34379 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25767 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137209 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82436 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21595 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13988 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184821 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25383 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89670 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47331 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25076 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25234 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25135 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->