### PR TITLE
OptionSet: Clean up Iterator template, use std::has_single_bit, and make all() constexpr

### DIFF
--- a/Source/WTF/wtf/OptionSet.h
+++ b/Source/WTF/wtf/OptionSet.h
@@ -35,7 +35,6 @@
 #include <wtf/EnumTraits.h>
 #include <wtf/FastMalloc.h>
 #include <wtf/Forward.h>
-#include <wtf/MathExtras.h>
 #include <wtf/StdLibExtras.h>
 
 namespace WTF {
@@ -53,7 +52,7 @@ template<typename E, ConcurrencyTag concurrency> class OptionSet {
 public:
     using StorageType = std::make_unsigned_t<std::underlying_type_t<E>>;
 
-    template<typename StorageType> class Iterator {
+    class Iterator {
         WTF_DEPRECATED_MAKE_FAST_ALLOCATED(Iterator);
     public:
         // Isolate the rightmost set bit.
@@ -77,7 +76,7 @@ public:
         StorageType m_value;
     };
 
-    using iterator = Iterator<StorageType>;
+    using iterator = Iterator;
 
     static constexpr OptionSet fromRaw(StorageType rawValue)
     {
@@ -89,13 +88,13 @@ public:
     constexpr OptionSet(E e)
         : m_storage(static_cast<StorageType>(e))
     {
-        ASSERT(!m_storage || hasOneBitSet(static_cast<StorageType>(e)));
+        ASSERT(!m_storage || std::has_single_bit(static_cast<StorageType>(e)));
     }
 
     constexpr OptionSet(std::initializer_list<E> initializerList)
     {
         for (auto& option : initializerList) {
-            ASSERT(hasOneBitSet(static_cast<StorageType>(option)));
+            ASSERT(std::has_single_bit(static_cast<StorageType>(option)));
             m_storage |= static_cast<StorageType>(option);
         }
     }
@@ -165,7 +164,7 @@ public:
     constexpr bool hasExactlyOneBitSet() const
     {
         auto storage = m_storage; // Make a local copy for the evaluation so that it is consistent even with concurrency.
-        return storage && !(storage & (storage - 1));
+        return std::has_single_bit(storage);
     }
 
     constexpr std::optional<E> toSingleValue() const
@@ -205,7 +204,7 @@ public:
         return fromRaw(lhs.m_storage ^ rhs.m_storage);
     }
 
-    static OptionSet all() { return fromRaw(-1); }
+    static constexpr OptionSet all() { return fromRaw(-1); }
 
 private:
     enum InitializationTag { FromRawValue };


### PR DESCRIPTION
#### b06c55277c0b6c908a85d9e34106a7b230bede5d
<pre>
OptionSet: Clean up Iterator template, use std::has_single_bit, and make all() constexpr
<a href="https://bugs.webkit.org/show_bug.cgi?id=311097">https://bugs.webkit.org/show_bug.cgi?id=311097</a>

Reviewed by Darin Adler.

- Remove unnecessary template parameter from Iterator that shadowed the
  outer StorageType type alias. Iterator is only ever instantiated with
  the enclosing class&apos;s StorageType.
- Replace hand-rolled bit-twiddling in hasExactlyOneBitSet() and
  hasOneBitSet() assertions with std::has_single_bit() from &lt;bit&gt;,
  which is already included and used elsewhere in WTF.
- Make all() constexpr, consistent with every other method on OptionSet.
- Drop the now-unused MathExtras.h include.

* Source/WTF/wtf/OptionSet.h:
(WTF::OptionSet::OptionSet):
(WTF::OptionSet::hasExactlyOneBitSet const):
(WTF::OptionSet::all):

Canonical link: <a href="https://commits.webkit.org/310271@main">https://commits.webkit.org/310271@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f642f6e5501bb16e011c2a68936aa77cefb033b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153187 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25969 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19567 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161931 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106645 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e14f599b-29fc-4daa-8881-aab81ab5a2e9) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26496 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26274 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118430 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83863 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/32a27c3f-5be6-458c-a700-5edcfe555d5b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156146 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20673 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137541 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99143 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ca974d00-288f-4ab8-b145-03c5a65e3ea0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19749 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17706 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9767 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/145199 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129399 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15414 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164405 "Built successfully") | | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/14002 "Found unexpected failure with change (failure)") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7541 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17008 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126495 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25766 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21715 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126653 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34380 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25768 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137210 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82437 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21596 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13989 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184822 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25384 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89671 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47332 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25077 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25235 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25136 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->