### PR TITLE
Extract TransformPaintScope RAII helper from RenderLayer::paintLayerByApplyingTransform

### DIFF
--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -155,6 +155,7 @@
 #include "StyleTranslateTransformFunction.h"
 #include "Styleable.h"
 #include "TransformOperationData.h"
+#include "TransformPaintScope.h"
 #include "TransformationMatrix.h"
 #include "ViewTransition.h"
 #include "WheelEventTestMonitor.h"
@@ -4036,14 +4037,6 @@ void RenderLayer::paintLayerByApplyingTransform(GraphicsContext& context, const 
     // all we need to do is add the delta to the accumulated pixels coming from ancestor layers.
     // Translate the graphics context to the snapping position to avoid off-device-pixel positing.
     transform.translateRight(alignedOffsetForThisLayer.width(), alignedOffsetForThisLayer.height());
-    // Apply the transform.
-    auto oldTransform = context.getCTM();
-    auto affineTransform = transform.toAffineTransform();
-    context.concatCTM(affineTransform);
-
-    if (paintingInfo.regionContext)
-        paintingInfo.regionContext->pushTransform(affineTransform);
-
     // Only propagate the subpixel offsets to the descendant layers, if we're not the root
     // of a SVG subtree, where no pixel snapping is applied -- only the outermost <svg> layer
     // is pixel-snapped "as whole", if it's part of a compound document, e.g. inline SVG in HTML.
@@ -4051,21 +4044,10 @@ void RenderLayer::paintLayerByApplyingTransform(GraphicsContext& context, const 
     if (rendererNeedsPixelSnapping(renderer()) && !renderer().isRenderSVGRoot())
         adjustedSubpixelOffset = offsetForThisLayer - LayoutSize(alignedOffsetForThisLayer);
 
-    // Now do a paint with the root layer shifted to be us.
-    LayerPaintingInfo transformedPaintingInfo(paintingInfo);
-    transformedPaintingInfo.rootLayer = this;
-    if (!transformedPaintingInfo.paintDirtyRect.isInfinite())
-        transformedPaintingInfo.paintDirtyRect = LayoutRect(encloseRectToDevicePixels(valueOrDefault(transform.inverse()).mapRect(paintingInfo.paintDirtyRect), deviceScaleFactor));
+    TransformPaintScope scope(context, paintingInfo, transform, deviceScaleFactor, adjustedSubpixelOffset, this);
 
     paintFlags.remove(PaintLayerFlag::PaintingOverflowContents);
-
-    transformedPaintingInfo.subpixelOffset = adjustedSubpixelOffset;
-    paintLayerContentsAndReflection(context, transformedPaintingInfo, paintFlags);
-
-    if (paintingInfo.regionContext)
-        paintingInfo.regionContext->popTransform();
-
-    context.setCTM(oldTransform);
+    paintLayerContentsAndReflection(context, scope.transformedPaintingInfo(), paintFlags);
 }
 
 void RenderLayer::paintList(LayerList layerIterator, GraphicsContext& context, const LayerPaintingInfo& paintingInfo, OptionSet<PaintLayerFlag> paintFlags)

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -981,6 +981,27 @@ public:
 
     bool ancestorLayerIsDOMParent(const RenderLayer* ancestor) const;
 
+    struct LayerPaintingInfo {
+        LayerPaintingInfo(RenderLayer* inRootLayer, const LayoutRect& inDirtyRect, OptionSet<PaintBehavior> inPaintBehavior, const LayoutSize& inSubpixelOffset, RenderObject* inSubtreePaintRoot = nullptr, OverlapTestRequestMap* inOverlapTestRequests = nullptr, bool inRequireSecurityOriginAccessForWidgets = false)
+            : rootLayer(inRootLayer)
+            , subtreePaintRoot(inSubtreePaintRoot)
+            , paintDirtyRect(inDirtyRect)
+            , subpixelOffset(inSubpixelOffset)
+            , overlapTestRequests(inOverlapTestRequests)
+            , paintBehavior(inPaintBehavior)
+            , requireSecurityOriginAccessForWidgets(inRequireSecurityOriginAccessForWidgets)
+        { }
+
+        RenderLayer* rootLayer { nullptr };
+        RenderObject* subtreePaintRoot { nullptr }; // Only paint descendants of this object.
+        LayoutRect paintDirtyRect; // Relative to rootLayer;
+        LayoutSize subpixelOffset;
+        OverlapTestRequestMap* overlapTestRequests { nullptr }; // May be null.
+        OptionSet<PaintBehavior> paintBehavior;
+        bool requireSecurityOriginAccessForWidgets { false };
+        CheckedPtr<RegionContext> regionContext;
+    };
+
 private:
 
     void setNextSibling(RenderLayer* next) { m_next = next; }
@@ -1013,27 +1034,6 @@ private:
     void clearZOrderLists();
 
     void updateNormalFlowList();
-
-    struct LayerPaintingInfo {
-        LayerPaintingInfo(RenderLayer* inRootLayer, const LayoutRect& inDirtyRect, OptionSet<PaintBehavior> inPaintBehavior, const LayoutSize& inSubpixelOffset, RenderObject* inSubtreePaintRoot = nullptr, OverlapTestRequestMap* inOverlapTestRequests = nullptr, bool inRequireSecurityOriginAccessForWidgets = false)
-            : rootLayer(inRootLayer)
-            , subtreePaintRoot(inSubtreePaintRoot)
-            , paintDirtyRect(inDirtyRect)
-            , subpixelOffset(inSubpixelOffset)
-            , overlapTestRequests(inOverlapTestRequests)
-            , paintBehavior(inPaintBehavior)
-            , requireSecurityOriginAccessForWidgets(inRequireSecurityOriginAccessForWidgets)
-        { }
-
-        RenderLayer* rootLayer;
-        RenderObject* subtreePaintRoot; // Only paint descendants of this object.
-        LayoutRect paintDirtyRect; // Relative to rootLayer;
-        LayoutSize subpixelOffset;
-        OverlapTestRequestMap* overlapTestRequests; // May be null.
-        OptionSet<PaintBehavior> paintBehavior;
-        bool requireSecurityOriginAccessForWidgets;
-        RegionContext* regionContext { nullptr };
-    };
 
     LayoutPoint paintOffsetForRenderer(const LayerFragment& fragment, const LayerPaintingInfo& paintingInfo) const
     {

--- a/Source/WebCore/rendering/TransformPaintScope.h
+++ b/Source/WebCore/rendering/TransformPaintScope.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2006-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2014 Google Inc. All rights reserved.
+ * Copyright (C) 2019 Adobe. All rights reserved.
+ * Copyright (c) 2020, 2021, 2022, 2026 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#pragma once
+
+#include "GraphicsContext.h"
+#include "RenderLayer.h"
+
+namespace WebCore {
+
+class TransformPaintScope {
+    WTF_MAKE_NONCOPYABLE(TransformPaintScope);
+public:
+    TransformPaintScope(GraphicsContext& context, const RenderLayer::LayerPaintingInfo& paintingInfo, const TransformationMatrix& transform, float deviceScaleFactor, const LayoutSize& adjustedSubpixelOffset, CheckedPtr<RenderLayer> newRootLayer = nullptr)
+        : m_context(context)
+        , m_oldTransform(context.getCTM())
+        , m_affineTransform(transform.toAffineTransform())
+        , m_transformedPaintingInfo(paintingInfo)
+    {
+        m_context.concatCTM(m_affineTransform);
+
+        if (CheckedPtr regionContext = m_transformedPaintingInfo.regionContext)
+            regionContext->pushTransform(m_affineTransform);
+
+        if (newRootLayer)
+            m_transformedPaintingInfo.rootLayer = newRootLayer.get();
+
+        if (!m_transformedPaintingInfo.paintDirtyRect.isInfinite())
+            m_transformedPaintingInfo.paintDirtyRect = LayoutRect(encloseRectToDevicePixels(valueOrDefault(transform.inverse()).mapRect(paintingInfo.paintDirtyRect), deviceScaleFactor));
+
+        m_transformedPaintingInfo.subpixelOffset = adjustedSubpixelOffset;
+    }
+
+    ~TransformPaintScope()
+    {
+        if (CheckedPtr regionContext = m_transformedPaintingInfo.regionContext)
+            regionContext->popTransform();
+
+        m_context.setCTM(m_oldTransform);
+    }
+
+    const RenderLayer::LayerPaintingInfo& transformedPaintingInfo() const { return m_transformedPaintingInfo; }
+    const AffineTransform& appliedTransform() const { return m_affineTransform; }
+
+private:
+    GraphicsContext& m_context;
+    AffineTransform m_oldTransform;
+    AffineTransform m_affineTransform;
+    RenderLayer::LayerPaintingInfo m_transformedPaintingInfo;
+};
+
+} // namespace WebCore


### PR DESCRIPTION
#### 696e158cf31bfa17dba5a15c7f8010aa85bb6930
<pre>
Extract TransformPaintScope RAII helper from RenderLayer::paintLayerByApplyingTransform
<a href="https://bugs.webkit.org/show_bug.cgi?id=311092">https://bugs.webkit.org/show_bug.cgi?id=311092</a>

Reviewed by Simon Fraser.

Refactor the inline transform setup/teardown logic (CTM save/restore,
RegionContext push/pop, dirty rect inverse-mapping, rootLayer and
subpixelOffset updates) into a reusable TransformPaintScope class.

Move LayerPaintingInfo from private to public in RenderLayer so that
TransformPaintScope can access it without a friend declaration.

Covered by existing tests.

* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::paintLayerByApplyingTransform):
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/TransformPaintScope.h: Added.
(WebCore::TransformPaintScope::TransformPaintScope):
(WebCore::TransformPaintScope::~TransformPaintScope):
(WebCore::TransformPaintScope::transformedPaintingInfo const):
(WebCore::TransformPaintScope::appliedTransform const):

Canonical link: <a href="https://commits.webkit.org/310302@main">https://commits.webkit.org/310302@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6f7f2cbc34af7bfc4f574fe452667aaf036e931

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153408 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26192 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19792 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162153 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155281 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26718 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26512 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118600 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156367 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20845 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137726 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99311 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19923 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9988 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/129570 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15596 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164627 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7763 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17190 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126662 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25989 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21901 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126826 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34403 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25991 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137392 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/82658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21759 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14172 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25608 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89894 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25299 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25458 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/25359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->