### PR TITLE
Fix wrong static_cast in lvalue dynamicOSObjectCast overloads and add test coverage

### DIFF
--- a/Source/WTF/wtf/darwin/TypeCastsOSObject.h
+++ b/Source/WTF/wtf/darwin/TypeCastsOSObject.h
@@ -107,7 +107,7 @@ inline OSObjectPtr<T> dynamicOSObjectCast(const OSObjectPtr<U>& object)
     if (!isOSObject<typename OSObjectTypeCastTraits<T>::BaseType>(object.get()))
         return nullptr;
 
-    return static_cast<T*>(object.get());
+    return static_cast<T>(object.get());
 }
 
 template<typename T> inline T dynamicOSObjectCast(id object)
@@ -167,7 +167,7 @@ inline OSObjectPtr<T> dynamicOSObjectCast(const OSObjectPtr<U>& object)
     if (!isOSObject<typename OSObjectTypeCastTraits<T>::BaseType>(object.get()))
         return nullptr;
 
-    return static_cast<T*>(object.get());
+    return static_cast<T>(object.get());
 }
 
 #endif // !defined(__OBJC__)

--- a/Tools/TestWebKitAPI/Tests/WTF/darwin/TypeCastsOSObjectCF.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/darwin/TypeCastsOSObjectCF.cpp
@@ -163,7 +163,64 @@ TEST(TypeCastsOSObjectCF, dynamicOSObjectCast_OSObjectPtr)
         EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
 
         OSObjectPtr<dispatch_queue_global_t> objectCastBad = dynamicOSObjectCast<dispatch_queue_global_t>(WTF::move(object));
-        EXPECT_EQ(NULL, objectCastBad.get());
+        EXPECT_TRUE(!objectCastBad);
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
+    }
+}
+
+TEST(TypeCastsOSObjectCF, dynamicOSObjectCast_const_OSObjectPtr)
+{
+    // Null cast.
+    {
+        OSObjectPtr<dispatch_object_t> object;
+        auto objectCast = dynamicOSObjectCast<dispatch_group_t>(object);
+        EXPECT_TRUE(!object);
+        EXPECT_TRUE(!objectCast);
+    }
+
+    // Down cast / bad cast.
+    {
+        auto object = adoptOSObject<dispatch_object_t>(dispatch_group_create());
+        uintptr_t objectPtr = reinterpret_cast<uintptr_t>(object.get());
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
+
+        OSObjectPtr<dispatch_group_t> objectCast = dynamicOSObjectCast<dispatch_group_t>(object);
+        uintptr_t objectCastPtr = reinterpret_cast<uintptr_t>(objectCast.get());
+        EXPECT_NE(nullptr, object.get()); // Source should be unchanged.
+        EXPECT_EQ(objectPtr, objectCastPtr);
+        EXPECT_EQ(2L, CFGetRetainCount((CFTypeRef)objectCastPtr)); // Both object and objectCast retain it.
+
+        auto object2 = adoptOSObject<dispatch_object_t>(dispatch_group_create());
+        uintptr_t objectPtr2 = reinterpret_cast<uintptr_t>(object2.get());
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr2));
+
+        OSObjectPtr<dispatch_source_t> objectCastBad = dynamicOSObjectCast<dispatch_source_t>(object2);
+        EXPECT_NE(nullptr, object2.get()); // Source should be unchanged.
+        EXPECT_TRUE(!objectCastBad);
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr2));
+    }
+
+    // Up cast.
+    {
+        auto object = adoptOSObject(dispatch_group_create());
+        uintptr_t objectPtr = reinterpret_cast<uintptr_t>(object.get());
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
+
+        auto objectCast = dynamicOSObjectCast<dispatch_object_t>(object);
+        uintptr_t objectCastPtr = reinterpret_cast<uintptr_t>(objectCast.get());
+        EXPECT_NE(nullptr, object.get()); // Source should be unchanged.
+        EXPECT_EQ(objectPtr, objectCastPtr);
+        EXPECT_EQ(2L, CFGetRetainCount((CFTypeRef)objectCastPtr)); // Both object and objectCast retain it.
+    }
+
+    // Bad up cast (excluding dispatch_object_t).
+    {
+        auto object = adoptOSObject(dispatch_queue_create("testQueue", nullptr));
+        uintptr_t objectPtr = reinterpret_cast<uintptr_t>(object.get());
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
+
+        OSObjectPtr<dispatch_queue_global_t> objectCastBad = dynamicOSObjectCast<dispatch_queue_global_t>(object);
+        EXPECT_TRUE(!objectCastBad);
         EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
     }
 }

--- a/Tools/TestWebKitAPI/Tests/WTF/darwin/TypeCastsOSObjectCocoa.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/darwin/TypeCastsOSObjectCocoa.mm
@@ -190,6 +190,96 @@ TEST(TYPE_CASTS_OSOBJECT_PTR_TEST_NAME, dynamicOSObjectCast_from_OSObjectPtr)
     }
 }
 
+TEST(TYPE_CASTS_OSOBJECT_PTR_TEST_NAME, dynamicOSObjectCast_from_const_OSObjectPtr)
+{
+    // Null cast.
+    @autoreleasepool {
+        OSObjectPtr<dispatch_object_t> object;
+        auto objectCast = dynamicOSObjectCast<dispatch_group_t>(object);
+        EXPECT_EQ(NULL, object.get());
+        EXPECT_EQ(NULL, objectCast.get());
+    }
+
+    // Down cast.
+    @autoreleasepool {
+        OSObjectPtr<dispatch_object_t> object;
+        uintptr_t objectPtr = 0;
+        AUTORELEASEPOOL_FOR_ARC_DEBUG {
+            object = adoptOSObject<dispatch_object_t>(dispatch_group_create());
+            objectPtr = reinterpret_cast<uintptr_t>(object.get());
+        }
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
+
+        OSObjectPtr<dispatch_group_t> objectCast;
+        uintptr_t objectCastPtr = 0;
+        AUTORELEASEPOOL_FOR_ARC_DEBUG {
+            objectCast = dynamicOSObjectCast<dispatch_group_t>(object);
+            objectCastPtr = reinterpret_cast<uintptr_t>(objectCast.get());
+            EXPECT_NE(nullptr, object.get()); // Source should be unchanged.
+            EXPECT_EQ(objectPtr, objectCastPtr);
+        }
+        EXPECT_EQ(2L, CFGetRetainCount((CFTypeRef)objectCastPtr)); // Both object and objectCast retain it.
+    }
+
+    // Invalid down cast.
+    @autoreleasepool {
+        OSObjectPtr<dispatch_object_t> object;
+        uintptr_t objectPtr = 0;
+        AUTORELEASEPOOL_FOR_ARC_DEBUG {
+            object = adoptOSObject<dispatch_object_t>(dispatch_group_create());
+            objectPtr = reinterpret_cast<uintptr_t>(object.get());
+        }
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
+
+        OSObjectPtr<dispatch_source_t> objectCastBad;
+        AUTORELEASEPOOL_FOR_ARC_DEBUG {
+            objectCastBad = dynamicOSObjectCast<dispatch_source_t>(object);
+            EXPECT_NE(nullptr, object.get()); // Source should be unchanged.
+            EXPECT_EQ(NULL, objectCastBad.get());
+        }
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
+    }
+
+    // Up cast.
+    @autoreleasepool {
+        OSObjectPtr<dispatch_group_t> object;
+        uintptr_t objectPtr = 0;
+        AUTORELEASEPOOL_FOR_ARC_DEBUG {
+            object = adoptOSObject(dispatch_group_create());
+            objectPtr = reinterpret_cast<uintptr_t>(object.get());
+        }
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
+
+        OSObjectPtr<dispatch_object_t> objectCast;
+        uintptr_t objectCastPtr = 0;
+        AUTORELEASEPOOL_FOR_ARC_DEBUG {
+            objectCast = dynamicOSObjectCast<dispatch_object_t>(object);
+            objectCastPtr = reinterpret_cast<uintptr_t>(objectCast.get());
+            EXPECT_NE(nullptr, object.get()); // Source should be unchanged.
+            EXPECT_EQ(objectPtr, objectCastPtr);
+        }
+        EXPECT_EQ(2L, CFGetRetainCount((CFTypeRef)objectCastPtr)); // Both object and objectCast retain it.
+    }
+
+    // Bad up cast (excluding dispatch_object_t).
+    @autoreleasepool {
+        OSObjectPtr<dispatch_queue_t> object;
+        uintptr_t objectPtr = 0;
+        AUTORELEASEPOOL_FOR_ARC_DEBUG {
+            object = adoptOSObject(dispatch_queue_create("testQueue", NULL));
+            objectPtr = reinterpret_cast<uintptr_t>(object.get());
+        }
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
+
+        OSObjectPtr<dispatch_queue_global_t> objectCastBad;
+        AUTORELEASEPOOL_FOR_ARC_DEBUG {
+            objectCastBad = dynamicOSObjectCast<dispatch_queue_global_t>(object);
+            EXPECT_EQ(NULL, objectCastBad.get());
+        }
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
+    }
+}
+
 TEST(TYPE_CASTS_OSOBJECT_PTR_TEST_NAME, dynamicOSObjectCast_from_id)
 {
     // Null cast.


### PR DESCRIPTION
#### 1846b8e3c9d7c722dcc5d5f3948f059ce7f08593
<pre>
Fix wrong static_cast in lvalue dynamicOSObjectCast overloads and add test coverage
<a href="https://bugs.webkit.org/show_bug.cgi?id=311098">https://bugs.webkit.org/show_bug.cgi?id=311098</a>

Reviewed by Darin Adler.

The lvalue (const OSObjectPtr&lt;U&gt;&amp;) overloads of dynamicOSObjectCast used
static_cast&lt;T*&gt; instead of static_cast&lt;T&gt;. Since T is already a pointer type
(e.g. dispatch_queue_t = dispatch_queue_s*), T* produces a pointer-to-pointer,
which is incorrect. The rvalue overloads correctly used static_cast&lt;T&gt;.

The bug was latent because all existing callers used WTF::move() (hitting the
rvalue overload), and the existing tests only covered that path. Added tests
for dynamicOSObjectCast from const OSObjectPtr&amp; in both the ObjC and C++ test
files to prevent regression.

Tests: Tools/TestWebKitAPI/Tests/WTF/darwin/TypeCastsOSObjectCF.cpp
       Tools/TestWebKitAPI/Tests/WTF/darwin/TypeCastsOSObjectCocoa.mm

* Source/WTF/wtf/darwin/TypeCastsOSObject.h:
(WTF::dynamicOSObjectCast):
* Tools/TestWebKitAPI/Tests/WTF/darwin/TypeCastsOSObjectCF.cpp:
(TestWebKitAPI::TEST(TypeCastsOSObjectCF, dynamicOSObjectCast_const_OSObjectPtr)):
* Tools/TestWebKitAPI/Tests/WTF/darwin/TypeCastsOSObjectCocoa.mm:
(TestWebKitAPI::TEST(TYPE_CASTS_OSOBJECT_PTR_TEST_NAME, dynamicOSObjectCast_from_OSObjectPtr)):
(TestWebKitAPI::TEST(TYPE_CASTS_OSOBJECT_PTR_TEST_NAME, dynamicOSObjectCast_from_const_OSObjectPtr)):

Canonical link: <a href="https://commits.webkit.org/310272@main">https://commits.webkit.org/310272@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21b650ac3dcecbf2a40934035d512169c393e91f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153190 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25972 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19570 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161934 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106648 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e72c459f-001a-4c61-9606-247376d231a1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155063 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26499 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26277 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118423 "Found 1 new test failure: fast/forms/textarea/textarea-placeholder-paint-order-2.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83865 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/61ed5ded-0c7b-4bbe-a33a-0e8976c591ec) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156149 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20674 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137543 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99136 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c3868d07-a7ad-40cf-811a-d6302a469274) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19750 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17692 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9770 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/145202 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129400 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15416 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164408 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/14005 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7544 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17010 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126483 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25769 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21721 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126641 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34381 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25771 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137212 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82440 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21597 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13991 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184825 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25387 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89674 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47334 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25080 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25238 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25139 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->