### PR TITLE
[GTK][WPE] Avoid the need for ImageBuffer/NativeImage in scrollbar painting

### DIFF
--- a/Source/WebCore/page/scrolling/coordinated/ScrollerCoordinated.cpp
+++ b/Source/WebCore/page/scrolling/coordinated/ScrollerCoordinated.cpp
@@ -29,10 +29,23 @@
 #include "ScrollerCoordinated.h"
 
 #if USE(COORDINATED_GRAPHICS_ASYNC_SCROLLBAR)
+#include "BitmapTexturePool.h"
 #include "CoordinatedPlatformLayer.h"
-#include "ImageBuffer.h"
-#include "NativeImage.h"
+#include "CoordinatedPlatformLayerBufferRGB.h"
+#include "FontRenderOptions.h"
+#include "GLContext.h"
+#include "GLFence.h"
+#include "GraphicsContextSkia.h"
+#include "PlatformDisplay.h"
 #include "ScrollerImpAdwaita.h"
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkColorSpace.h>
+#include <skia/core/SkImage.h>
+#include <skia/gpu/ganesh/GrBackendSurface.h>
+#include <skia/gpu/ganesh/SkSurfaceGanesh.h>
+#include <skia/gpu/ganesh/gl/GrGLBackendSurface.h>
+#include <skia/gpu/ganesh/gl/GrGLDirectContext.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -78,7 +91,8 @@ void ScrollerCoordinated::updateValues()
 
     if (!scrollerImp) {
         // Custom scrollbars are painted by RenderScrollbar
-        hostLayer->setContentsScrollbarImageForScrolling(nullptr);
+        Locker layerLocker { hostLayer->lock() };
+        hostLayer->setContentsBuffer(nullptr);
         return;
     }
 
@@ -111,14 +125,45 @@ void ScrollerCoordinated::updateValues()
     state.thumbPosition = (values.visibleSize - state.thumbLength) * values.value;
     state.frameRect = rect;
 
-    RefPtr imageBuffer = ImageBuffer::create(state.frameRect.size(), RenderingMode::Accelerated, RenderingPurpose::DOM, 1, DestinationColorSpace::SRGB(), PixelFormat::RGBA8);
-    if (!imageBuffer)
+    auto& display = PlatformDisplay::sharedDisplay();
+    auto* glContext = display.skiaGLContext();
+    if (!glContext)
         return;
-    scrollerImp->paint(imageBuffer->context(), state.frameRect, state);
-    RefPtr nativeImage = ImageBuffer::sinkIntoNativeImage(WTF::move(imageBuffer));
-    if (!nativeImage)
+
+    auto* grContext = display.skiaGrContext();
+    RELEASE_ASSERT(grContext);
+
+    Ref texture = BitmapTexturePool::singleton().acquireTexture(state.frameRect.size(), { BitmapTexture::Flags::SupportsAlpha });
+
+    GLContext::ScopedGLContextCurrent scopedCurrent(*glContext);
+    GrGLTextureInfo externalTexture;
+    externalTexture.fTarget = GL_TEXTURE_2D;
+    externalTexture.fID = texture->id();
+    externalTexture.fFormat = GL_RGBA8;
+    auto backendTexture = GrBackendTextures::MakeGL(state.frameRect.size().width(), state.frameRect.size().height(), skgpu::Mipmapped::kNo, externalTexture);
+    SkSurfaceProps properties = FontRenderOptions::singleton().createSurfaceProps();
+    auto surface = SkSurfaces::WrapBackendTexture(grContext, backendTexture, kTopLeft_GrSurfaceOrigin, 0, kRGBA_8888_SkColorType, SkColorSpace::MakeSRGB(), &properties);
+    if (!surface)
         return;
-    hostLayer->setContentsScrollbarImageForScrolling(WTF::move(nativeImage));
+
+    auto* canvas = surface->getCanvas();
+    if (!canvas)
+        return;
+
+    canvas->clear(SK_ColorTRANSPARENT);
+
+    GraphicsContextSkia context(*canvas, RenderingMode::Accelerated, RenderingPurpose::DOM);
+    scrollerImp->paint(context, state.frameRect, state);
+
+    grContext->flushAndSubmit(surface.get(), GLFence::isSupported(display.glDisplay()) ? GrSyncCpu::kNo : GrSyncCpu::kYes);
+    auto buffer = CoordinatedPlatformLayerBufferRGB::create(WTF::move(texture), { TextureMapperFlags::ShouldBlend }, GLFence::create(display.glDisplay()));
+    if (!buffer)
+        return;
+
+    Locker layerLocker { hostLayer->lock() };
+    hostLayer->setContentsRect(state.frameRect);
+    hostLayer->setContentsClippingRect(FloatRoundedRect(state.frameRect));
+    hostLayer->setContentsBuffer(WTF::move(buffer));
 }
 
 void ScrollerCoordinated::setHoveredAndPressedParts(ScrollbarPart hoveredPart, ScrollbarPart pressedPart)

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -579,20 +579,6 @@ void CoordinatedPlatformLayer::setDirtyRegion(Damage&& damage)
 #endif
 }
 
-#if USE(COORDINATED_GRAPHICS_ASYNC_SCROLLBAR)
-void CoordinatedPlatformLayer::setContentsScrollbarImageForScrolling(NativeImage* image)
-{
-    Locker locker { m_lock };
-    if (image) {
-        setContentsImage(image);
-        IntRect rect { { }, image->size() };
-        setContentsRect(rect);
-        setContentsClippingRect(FloatRoundedRect(rect));
-    } else
-        setContentsImage(nullptr);
-}
-#endif
-
 #if ENABLE(DAMAGE_TRACKING)
 void CoordinatedPlatformLayer::addDamage(Damage&& damage)
 {
@@ -935,11 +921,6 @@ void CoordinatedPlatformLayer::flushCompositingState(const OptionSet<Composition
             layer.setContentsClippingRect(m_contentsClippingRect);
             m_pendingChanges.remove(Change::ContentsClippingRect);
         }
-
-        if (m_pendingChanges.contains(Change::ContentsImage)) {
-            m_imageBackingStore.committed = m_imageBackingStore.current;
-            m_pendingChanges.remove(Change::ContentsImage);
-        }
     }
 
     if (reasons.contains(CompositionReason::RenderingUpdate)) {
@@ -997,6 +978,11 @@ void CoordinatedPlatformLayer::flushCompositingState(const OptionSet<Composition
                 m_backingStore = nullptr;
             }
             m_pendingChanges.remove(Change::BackingStore);
+        }
+
+        if (m_pendingChanges.contains(Change::ContentsImage)) {
+            m_imageBackingStore.committed = m_imageBackingStore.current;
+            m_pendingChanges.remove(Change::ContentsImage);
         }
 
         if (m_pendingChanges.contains(Change::ContentsVisible)) {

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -159,10 +159,6 @@ public:
     void setContentsTilePhase(const FloatSize&);
     void setDirtyRegion(Damage&&);
 
-#if USE(COORDINATED_GRAPHICS_ASYNC_SCROLLBAR)
-    void setContentsScrollbarImageForScrolling(NativeImage*);
-#endif
-
     void setFilters(const FilterOperations&);
     void setMask(CoordinatedPlatformLayer*);
     void setReplica(CoordinatedPlatformLayer*);


### PR DESCRIPTION
#### 6f2a9a7ee4deb21b938eb3d4847ba03f67566971
<pre>
[GTK][WPE] Avoid the need for ImageBuffer/NativeImage in scrollbar painting
<a href="https://bugs.webkit.org/show_bug.cgi?id=311101">https://bugs.webkit.org/show_bug.cgi?id=311101</a>

Reviewed by Adrian Perez de Castro.

Replace ImageBuffer-based scrollbar rendering in ScrollerCoordinated with
direct Skia/GL rendering to BitmapTexturePool textures, producing a
CoordinatedPlatformLayerBufferRGB that is set via setContentsBuffer().

This removes the setContentsScrollbarImageForScrolling() convenience
wrapper from CoordinatedPlatformLayer, which internally used
setContentsImage(NativeImage*), and instead directly manages the
contents rect, clipping rect, and buffer on the host layer.

Also moves the ContentsImage flush from the Composition to the
RenderingUpdate composition reason block.

Co-Authored-By: Carlos Garcia Campos &lt;cgarcia@igalia.com&gt;

* Source/WebCore/page/scrolling/coordinated/ScrollerCoordinated.cpp:
(WebCore::ScrollerCoordinated::updateValues):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
(WebCore::CoordinatedPlatformLayer::flushCompositingState):
(WebCore::CoordinatedPlatformLayer::setContentsScrollbarImageForScrolling): Deleted.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h:

Canonical link: <a href="https://commits.webkit.org/310298@main">https://commits.webkit.org/310298@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c25201555cc044795c784d15c819dc8c8adc4b1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153393 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26177 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19776 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162138 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155266 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26703 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26497 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118586 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156352 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20833 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137712 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99298 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/19911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9973 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/129558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/15582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164612 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/7748 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17176 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126649 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25974 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/21888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126806 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34400 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25976 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137378 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/82643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21744 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14158 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25593 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89879 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25284 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/25443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/25344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->