### PR TITLE
Scrubbing a YouTube video in full-screen causes it to exit full-screen mode.

### DIFF
--- a/LayoutTests/ipc/serialized-type-info.html
+++ b/LayoutTests/ipc/serialized-type-info.html
@@ -164,7 +164,8 @@
         // add IPC metadata in a *.serialization.in file instead.
         let result = [
             "CTFontDescriptorOptions",
-            "MachSendRight"
+            "MachSendRight",
+            "GenericPromise::Result", // Added to hide the implementation details that simulate an Expected<void, void>
         ];
         if (window.testRunner) {
             if (testRunner.isMac) {

--- a/LayoutTests/media/media-source/media-source-seek-during-pending-seek-expected.txt
+++ b/LayoutTests/media/media-source/media-source-seek-during-pending-seek-expected.txt
@@ -1,0 +1,19 @@
+
+RUN(video.src = URL.createObjectURL(source))
+EVENT(sourceopen)
+RUN(sourceBuffer = source.addSourceBuffer(loader.type()))
+RUN(sourceBuffer.appendBuffer(loader.initSegment()))
+EVENT(update)
+Appended all media segments
+
+Test: Seek during pending seek while paused
+EXPECTED (video.currentTime >= 7 == 'true') OK
+
+Test: Seek during pending seek while playing
+RUN(video.play())
+EVENT(playing)
+EXPECTED (video.currentTime >= 8 == 'true') OK
+EXPECTED (video.paused == 'false') OK
+
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-seek-during-pending-seek.html
+++ b/LayoutTests/media/media-source/media-source-seek-during-pending-seek.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="timeout" content="long">
+    <title>media-source-seek-during-pending-seek</title>
+    <script src="media-source-loader.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    var loader;
+    var source;
+    var sourceBuffer;
+
+    function loaderPromise(loader) {
+        return new Promise((resolve, reject) => {
+            loader.onload = resolve;
+            loader.onerror = reject;
+        });
+    }
+
+    async function start() {
+        findMediaElement();
+
+        loader = new MediaSourceLoader('content/test-fragmented-manifest.json');
+        await loaderPromise(loader);
+
+        source = new MediaSource();
+        run('video.src = URL.createObjectURL(source)');
+        await waitFor(source, 'sourceopen');
+        waitFor(video, 'error').then(failTest);
+
+        run('sourceBuffer = source.addSourceBuffer(loader.type())');
+        run('sourceBuffer.appendBuffer(loader.initSegment())');
+        await waitFor(sourceBuffer, 'update');
+
+        // Append all segments so data is buffered for all seek targets.
+        for (let i = 0; i < loader.mediaSegmentsLength(); i++) {
+            sourceBuffer.appendBuffer(loader.mediaSegment(i));
+            await waitFor(sourceBuffer, 'update', true);
+        }
+        consoleWrite('Appended all media segments');
+
+        // Seek to position A, wait for the seeking event (which confirms
+        // seekTask() has run and seekToTarget was called), then immediately
+        // seek to position B. This exercises the window where waitForTarget's
+        // promise from the first seek may have resolved and be in-flight on
+        // the run loop when the second seek cancels it.
+        consoleWrite('');
+        consoleWrite('Test: Seek during pending seek while paused');
+        for (let i = 0; i < 5; i++) {
+            video.currentTime = 3;
+            await waitFor(video, 'seeking', true);
+            video.currentTime = 7;
+            await waitFor(video, 'seeking', true);
+        }
+        await waitFor(video, 'seeked', true);
+        testExpected('video.currentTime >= 7', true);
+
+        // Same pattern but while playing.
+        consoleWrite('');
+        consoleWrite('Test: Seek during pending seek while playing');
+        run('video.play()');
+        await waitFor(video, 'playing');
+        for (let i = 0; i < 5; i++) {
+            video.currentTime = 2;
+            await waitFor(video, 'seeking', true);
+            video.currentTime = 8;
+            await waitFor(video, 'seeking', true);
+        }
+        await waitFor(video, 'seeked', true);
+        testExpected('video.currentTime >= 8', true);
+        testExpected('video.paused', false);
+
+        consoleWrite('');
+        endTest();
+    }
+    </script>
+</head>
+<body onload="start()">
+    <video></video>
+</body>
+</html>

--- a/Source/WTF/wtf/NativePromise.h
+++ b/Source/WTF/wtf/NativePromise.h
@@ -1593,6 +1593,10 @@ struct LogArgument<GenericPromise> {
     }
 };
 
+struct GenericPromiseConverter {
+    static auto convertError(auto&&) { return makeUnexpected(GenericPromise::RejectValueType { }); }
+};
+
 } // namespace WTF
 
 #undef PROMISE_LOG

--- a/Source/WebCore/platform/PlatformMediaError.cpp
+++ b/Source/WebCore/platform/PlatformMediaError.cpp
@@ -48,7 +48,7 @@ String convertEnumerationToString(PlatformMediaError enumerationValue)
         MAKE_STATIC_STRING_IMPL("NotReady"),
         MAKE_STATIC_STRING_IMPL("AudioDecodingError"),
         MAKE_STATIC_STRING_IMPL("VideoDecodingError"),
-        MAKE_STATIC_STRING_IMPL("RequiresFlushToResume"),
+        MAKE_STATIC_STRING_IMPL("InvalidState"),
         MAKE_STATIC_STRING_IMPL("CDMInstanceKeyNeeded"),
     };
     static_assert(!static_cast<size_t>(PlatformMediaError::AppendError), "PlatformMediaError::AppendError is not 0 as expected");
@@ -66,7 +66,7 @@ String convertEnumerationToString(PlatformMediaError enumerationValue)
     static_assert(static_cast<size_t>(PlatformMediaError::NotReady) == 12, "PlatformMediaError::NotReady is not 12 as expected");
     static_assert(static_cast<size_t>(PlatformMediaError::AudioDecodingError) == 13, "PlatformMediaError::AudioDecodingError is not 13 as expected");
     static_assert(static_cast<size_t>(PlatformMediaError::VideoDecodingError) == 14, "PlatformMediaError::VideoDecodingError is not 14 as expected");
-    static_assert(static_cast<size_t>(PlatformMediaError::RequiresFlushToResume) == 15, "PlatformMediaError::RequiresFlushToResume is not 15 as expected");
+    static_assert(static_cast<size_t>(PlatformMediaError::InvalidState) == 15, "PlatformMediaError::InvalidState is not 15 as expected");
     static_assert(static_cast<size_t>(PlatformMediaError::CDMInstanceKeyNeeded) == 16, "PlatformMediaError::CDMInstanceKeyNeeded is not 16 as expected");
     ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];

--- a/Source/WebCore/platform/PlatformMediaError.h
+++ b/Source/WebCore/platform/PlatformMediaError.h
@@ -46,7 +46,7 @@ enum class PlatformMediaError : uint8_t {
     NotReady,
     AudioDecodingError,
     VideoDecodingError,
-    RequiresFlushToResume,
+    InvalidState,
     CDMInstanceKeyNeeded,
 };
 

--- a/Source/WebCore/platform/graphics/AudioVideoRenderer.h
+++ b/Source/WebCore/platform/graphics/AudioVideoRenderer.h
@@ -125,8 +125,8 @@ public:
     virtual void setRate(double) = 0;
     virtual double effectiveRate() const = 0;
     virtual void stall() { };
-    virtual void prepareToSeek() { }
-    virtual Ref<MediaTimePromise> seekTo(const MediaTime&) = 0;
+    virtual Ref<MediaTimePromise> prepareToSeek(const MediaTime&) = 0;
+    virtual Ref<GenericPromise> finishSeek(const MediaTime&) = 0;
     virtual bool seeking() const = 0;
 };
 

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
@@ -99,21 +99,28 @@ MediaTime MediaSourcePrivate::duration() const
 
 Ref<MediaTimePromise> MediaSourcePrivate::waitForTarget(const SeekTarget& target)
 {
+    assertIsMainThread();
+    m_reenqueuePending = true;
     if (RefPtr client = this->client())
         return client->waitForTarget(target);
     return MediaTimePromise::createAndReject(PlatformMediaError::ClientDisconnected);
 }
 
-void MediaSourcePrivate::seekToTime(const MediaTime& seekTime)
+Ref<GenericPromise> MediaSourcePrivate::reenqueueMediaForTime(const MediaTime& time)
 {
-    ensureOnDispatcher([weakThis = ThreadSafeWeakPtr { *this }, seekTime] {
-        RefPtr protectedThis = weakThis.get();
-        if (!protectedThis)
-            return;
+    assertIsMainThread();
+
+    auto process = [protectedThis = Ref { *this }, time] {
         assertIsCurrent(protectedThis->m_dispatcher.get());
+        protectedThis->m_reenqueuePending = false;
         for (RefPtr sourceBuffer : protectedThis->m_activeSourceBuffers)
-            sourceBuffer->seekToTime(seekTime);
-    });
+            sourceBuffer->reenqueueMediaForTime(time);
+        return GenericPromise::createAndResolve();
+    };
+    if (m_dispatcher->isCurrent())
+        return process();
+
+    return invokeAsync(m_dispatcher, WTF::move(process));
 }
 
 void MediaSourcePrivate::removeSourceBuffer(SourceBufferPrivate& sourceBuffer)

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.h
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.h
@@ -105,7 +105,8 @@ public:
     void clearLiveSeekableRange();
 
     Ref<MediaTimePromise> waitForTarget(const SeekTarget&);
-    void seekToTime(const MediaTime&);
+    Ref<GenericPromise> reenqueueMediaForTime(const MediaTime&);
+    bool isReenqueuePending() const { return m_reenqueuePending; }
 
     virtual void setTimeFudgeFactor(const MediaTime& fudgeFactor) { m_timeFudgeFactor = fudgeFactor; }
     MediaTime timeFudgeFactor() const { return m_timeFudgeFactor; }
@@ -158,6 +159,7 @@ private:
     HashMap<SourceBufferPrivate*, TracksType> m_tracksTypes WTF_GUARDED_BY_CAPABILITY(m_dispatcher.get());
     std::atomic<TracksType> m_tracksCombinedTypes;
     const ThreadSafeWeakPtr<MediaSourcePrivateClient> m_client;
+    std::atomic<bool> m_reenqueuePending { false };
 };
 
 String convertEnumerationToString(MediaSourcePrivate::AddStatus);

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -283,7 +283,7 @@ Ref<SourceBufferPrivate::ComputeSeekPromise> SourceBufferPrivate::computeSeekTim
     });
 }
 
-void SourceBufferPrivate::seekToTime(const MediaTime& time)
+void SourceBufferPrivate::reenqueueMediaForTime(const MediaTime& time)
 {
     assertIsCurrent(m_dispatcher.get());
 
@@ -296,6 +296,13 @@ void SourceBufferPrivate::seekToTime(const MediaTime& time)
     }
 
     computeEvictionData();
+}
+
+bool SourceBufferPrivate::isReenqueuePending() const
+{
+    if (RefPtr mediaSource = m_mediaSource.get())
+        return mediaSource->isReenqueuePending();
+    return false;
 }
 
 void SourceBufferPrivate::clearTrackBuffers(bool shouldReportToClient)
@@ -408,7 +415,7 @@ void SourceBufferPrivate::provideMediaData(TrackID trackID)
 
 void SourceBufferPrivate::provideMediaData(TrackBuffer& trackBuffer, TrackID trackID)
 {
-    if (trackBuffer.needsReenqueueing() || isSeeking())
+    if (trackBuffer.needsReenqueueing() || isReenqueuePending())
         return;
     RefPtr client = this->client();
     if (!client)
@@ -1687,7 +1694,7 @@ void SourceBufferPrivate::attach()
 
             // When a MediaSource is re-attached part of the loading the media resources algorithm (https://html.spec.whatwg.org/multipage/media.html#loading-the-media-resourceas)
             // the playback position is to be set back to 0.
-            protectedThis->seekToTime(MediaTime::zeroTime());
+            protectedThis->reenqueueMediaForTime(MediaTime::zeroTime());
         });
     });
 }

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.h
@@ -122,7 +122,7 @@ public:
 
     using ComputeSeekPromise = MediaTimePromise;
     WEBCORE_EXPORT virtual Ref<ComputeSeekPromise> computeSeekTime(const SeekTarget&);
-    WEBCORE_EXPORT virtual void seekToTime(const MediaTime&);
+    WEBCORE_EXPORT virtual void reenqueueMediaForTime(const MediaTime&);
     WEBCORE_EXPORT virtual void updateTrackIds(Vector<std::pair<TrackID, TrackID>>&& trackIdPairs);
 
     WEBCORE_EXPORT void setClient(SourceBufferPrivateClient&);
@@ -179,7 +179,6 @@ protected:
     virtual Ref<MediaPromise> appendInternal(Ref<SharedBuffer>&&) = 0;
     virtual void resetParserStateInternal() = 0;
     virtual MediaTime timeFudgeFactor() const { return PlatformTimeRanges::timeFudgeFactor(); }
-    virtual bool isSeeking() const { return false; }
     virtual void flush(TrackID) { }
     virtual void enqueueSample(Ref<MediaSample>&&, TrackID) { }
     virtual void allSamplesInTrackEnqueued(TrackID) { }
@@ -241,6 +240,7 @@ private:
     uint64_t totalTrackBufferSizeInBytes() const;
     void iterateTrackBuffers(NOESCAPE const Function<void(TrackBuffer&)>&);
     void iterateTrackBuffers(NOESCAPE const Function<void(const TrackBuffer&)>&) const;
+    bool isReenqueuePending() const;
 
     using OperationPromise = NativePromise<void, PlatformMediaError, WTF::PromiseOption::Default | WTF::PromiseOption::NonExclusive>;
 

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
@@ -101,8 +101,8 @@ public:
     void setRate(double) final;
     double effectiveRate() const final;
     void stall() final;
-    void prepareToSeek() final;
-    Ref<MediaTimePromise> seekTo(const MediaTime&) final;
+    Ref<MediaTimePromise> prepareToSeek(const MediaTime&) final;
+    Ref<GenericPromise> finishSeek(const MediaTime&) final;
     void notifyEffectiveRateChanged(Function<void(double)>&&) final;
     bool seeking() const final;
 
@@ -247,14 +247,13 @@ private:
     WTFLogChannel& logChannel() const final;
 
     enum SeekState {
-        Preparing,
-        RequiresFlush,
         Seeking,
         WaitingForAvailableFame,
         SeekCompleted,
     };
     struct AudioTrackProperties {
         bool hasAudibleSample { false };
+        bool readyToRequestAudioData { true };
         std::unique_ptr<RequestPromise::AutoRejectProducer> requestPromise;
         Function<void(TrackIdentifier, const MediaTime&)> callbackForReenqueuing;
     };
@@ -297,7 +296,7 @@ private:
     // Seek Logic
     MediaTime m_lastSeekTime;
     SeekState m_seekState { SeekCompleted };
-    std::optional<MediaTimePromise::Producer> m_seekPromise;
+    std::optional<GenericPromise::AutoRejectProducer> m_seekPromise;
     RetainPtr<id> m_timeJumpedObserver;
     bool m_isSynchronizerSeeking { false };
     bool m_hasAvailableVideoFrame { false };
@@ -306,7 +305,6 @@ private:
     HashMap<TrackIdentifier, AudioTrackProperties> m_audioTracksMap;
     std::optional<RequestPromise::AutoRejectProducer> m_requestVideoPromise;
     bool m_readyToRequestVideoData { true };
-    bool m_readyToRequestAudioData { true };
 
     HashMap<TrackIdentifier, TrackType> m_trackTypes;
     HashMap<TrackIdentifier, RetainPtr<AVSampleBufferAudioRenderer>> m_audioRenderers;
@@ -374,6 +372,7 @@ private:
     ThreadSafeWeakPtr<CDMSessionAVContentKeySession> m_session;
 #endif
 #endif
+    bool m_keyframeNeeded { true };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
@@ -246,6 +246,12 @@ void AudioVideoRendererAVFObjC::enqueueSample(TrackIdentifier trackId, Ref<Media
         }
 
         ASSERT(m_videoRenderer);
+        if (m_keyframeNeeded && !sample->isSync()) {
+            ALWAYS_LOG(LOGIDENTIFIER, "Keyframe needed: but frame not keyframe");
+            ASSERT_NOT_REACHED();
+            return;
+        }
+        m_keyframeNeeded = false;
         if (RefPtr videoRenderer = m_videoRenderer; videoRenderer && isEnabledVideoTrackId(trackId))
             videoRenderer->enqueueSample(sample, minimumUpcomingTime.value_or(sample->presentationTime()));
         break;
@@ -278,10 +284,8 @@ bool AudioVideoRendererAVFObjC::isReadyForMoreSamples(TrackIdentifier trackId)
     case TrackType::Video:
         return m_readyToRequestVideoData && isEnabledVideoTrackId(trackId) && protect(m_videoRenderer)->isReadyForMoreMediaData();
     case TrackType::Audio:
-        if (!m_readyToRequestAudioData)
-            return false;
         if (RetainPtr audioRenderer = audioRendererFor(trackId))
-            return [audioRenderer isReadyForMoreMediaData];
+            return audioTrackPropertiesFor(trackId).readyToRequestAudioData && [audioRenderer isReadyForMoreMediaData];
         return false;
     default:
         ASSERT_NOT_REACHED();
@@ -307,7 +311,7 @@ Ref<AudioVideoRenderer::RequestPromise> AudioVideoRendererAVFObjC::requestMediaD
                 if (!protectedThis)
                     return;
                 if (!protectedThis->m_readyToRequestVideoData) {
-                        DEBUG_LOG_WITH_THIS(protectedThis, LOGIDENTIFIER_WITH_THIS(protectedThis), "Not ready to request video data, ignoring");
+                    DEBUG_LOG_WITH_THIS(protectedThis, LOGIDENTIFIER_WITH_THIS(protectedThis), "Not ready to request video data, ignoring");
                     return;
                 }
                 if (RefPtr videoRenderer = protectedThis->m_videoRenderer)
@@ -326,16 +330,17 @@ Ref<AudioVideoRenderer::RequestPromise> AudioVideoRendererAVFObjC::requestMediaD
                 RefPtr protectedThis = weakThis.get();
                 if (!protectedThis)
                     return;
-                if (!protectedThis->m_readyToRequestAudioData) {
-                        DEBUG_LOG_WITH_THIS(protectedThis, LOGIDENTIFIER_WITH_THIS(protectedThis), "Not ready to request audio data, ignoring");
-                    return;
-                }
 
                 RetainPtr audioRenderer = protectedThis->audioRendererFor(trackId);
                 if (!audioRenderer)
                     return;
-                [audioRenderer stopRequestingMediaData];
+
                 auto& property = protectedThis->audioTrackPropertiesFor(trackId);
+                if (!property.readyToRequestAudioData) {
+                    DEBUG_LOG_WITH_THIS(protectedThis, LOGIDENTIFIER_WITH_THIS(protectedThis), "Not ready to request audio data, ignoring");
+                    return;
+                }
+                [audioRenderer stopRequestingMediaData];
                 if (auto existingPromise = std::exchange(property.requestPromise, nullptr))
                     existingPromise->resolve(trackId);
             });
@@ -375,12 +380,8 @@ void AudioVideoRendererAVFObjC::flush()
     ALWAYS_LOG(LOGIDENTIFIER);
 
     cancelSeekingPromiseIfNeeded();
-    if (m_seekState == RequiresFlush)
-        m_seekState = Seeking;
-    else {
-        m_seekState = SeekCompleted;
-        m_isSynchronizerSeeking = false;
-    }
+    m_seekState = SeekCompleted;
+    m_isSynchronizerSeeking = false;
 
     flushVideo();
     flushAudio();
@@ -388,7 +389,7 @@ void AudioVideoRendererAVFObjC::flush()
 
 void AudioVideoRendererAVFObjC::flushTrack(TrackIdentifier trackId)
 {
-    DEBUG_LOG(LOGIDENTIFIER, toString(trackId));
+    ALWAYS_LOG(LOGIDENTIFIER, toString(trackId));
 
     auto type = typeOf(trackId);
     if (!type)
@@ -569,6 +570,7 @@ void AudioVideoRendererAVFObjC::setTimeObserver(Seconds interval, Function<void(
                 if (!protectedThis->m_currentTimeDidChangeCallback)
                     return;
 
+                ALWAYS_LOG_WITH_THIS(protectedThis, LOGIDENTIFIER_WITH_THIS(protectedThis), "timeobserver called", PAL::toMediaTime(time));
                 auto clampedTime = CMTIME_IS_NUMERIC(time) ? protectedThis->clampTimeToLastSeekTime(PAL::toMediaTime(time)) : MediaTime::zeroTime();
                 protectedThis->m_currentTimeDidChangeCallback(clampedTime);
             }
@@ -588,24 +590,12 @@ void AudioVideoRendererAVFObjC::cancelPerformTaskAtTimeObserverIfNeeded()
         [m_synchronizer removeTimeObserver:taskObserver.get()];
 }
 
-void AudioVideoRendererAVFObjC::prepareToSeek()
+Ref<MediaTimePromise> AudioVideoRendererAVFObjC::prepareToSeek(const MediaTime& seekTime)
 {
     ALWAYS_LOG(LOGIDENTIFIER, "state: ", toString(m_seekState));
 
     cancelSeekingPromiseIfNeeded();
-    m_seekState = Preparing;
-    stall();
-}
-
-Ref<MediaTimePromise> AudioVideoRendererAVFObjC::seekTo(const MediaTime& seekTime)
-{
-    ALWAYS_LOG(LOGIDENTIFIER, seekTime, "state: ", toString(m_seekState), " m_isSynchronizerSeeking: ", m_isSynchronizerSeeking, " hasAvailableVideoFrame: ", m_videoRenderer && allRenderersHaveAvailableSamples());
-
-    cancelSeekingPromiseIfNeeded();
-    if (m_seekState == RequiresFlush)
-        return MediaTimePromise::createAndReject(PlatformMediaError::RequiresFlushToResume);
-
-    m_lastSeekTime = seekTime;
+    m_seekState = Seeking;
 
     MediaTime synchronizerTime = PAL::toMediaTime([m_synchronizer currentTime]);
 
@@ -616,27 +606,35 @@ Ref<MediaTimePromise> AudioVideoRendererAVFObjC::seekTo(const MediaTime& seekTim
         // In cases where the destination seek time matches too closely the synchronizer's existing time
         // no time jumped notification will be issued. In this case, just notify the MediaPlayer that
         // the seek completed successfully.
-        m_seekPromise.emplace();
-        Ref promise = m_seekPromise->promise();
-        maybeCompleteSeek();
-        return promise;
+        m_lastSeekTime = synchronizerTime;
+        m_seekState = SeekCompleted;
+        return MediaTimePromise::createAndResolve(m_lastSeekTime);
     }
 
+    setHasAvailableVideoFrame(false);
+    m_readyToRequestVideoData = false;
+    for (auto& properties : m_audioTracksMap.values()) {
+        properties.hasAudibleSample = false;
+        properties.readyToRequestAudioData = false;
+    }
+
+    m_lastSeekTime = seekTime;
     m_isSynchronizerSeeking = isSynchronizerSeeking;
     [m_synchronizer setRate:0 time:PAL::toCMTime(seekTime)];
+    return MediaTimePromise::createAndResolve(MediaTime::indefiniteTime());
+}
 
-    if (m_seekState == SeekCompleted || m_seekState == Preparing) {
-        m_seekState = RequiresFlush;
-        m_readyToRequestAudioData = false;
-        m_readyToRequestVideoData = false;
-        ALWAYS_LOG(LOGIDENTIFIER, "Requesting Flush");
-        return MediaTimePromise::createAndReject(PlatformMediaError::RequiresFlushToResume);
-    }
+Ref<GenericPromise> AudioVideoRendererAVFObjC::finishSeek(const MediaTime& seekTime)
+{
+    ALWAYS_LOG(LOGIDENTIFIER, seekTime, "state: ", toString(m_seekState), " m_isSynchronizerSeeking: ", m_isSynchronizerSeeking, " hasAvailableVideoFrame: ", m_videoRenderer && allRenderersHaveAvailableSamples());
 
-    m_seekState = Seeking;
+    if (m_seekState != Seeking)
+        return GenericPromise::createAndReject();
 
     m_seekPromise.emplace();
-    return m_seekPromise->promise();
+    Ref promise = m_seekPromise->promise();
+    maybeCompleteSeek();
+    return promise;
 }
 
 void AudioVideoRendererAVFObjC::notifyEffectiveRateChanged(Function<void(double)>&& callback)
@@ -1018,7 +1016,6 @@ void AudioVideoRendererAVFObjC::maybeCompleteSeek()
         m_seekState = WaitingForAvailableFame;
         return;
     }
-    m_seekState = Seeking;
     if (m_isSynchronizerSeeking) {
         ALWAYS_LOG(LOGIDENTIFIER, "Waiting on synchronizer to complete seeking");
         return;
@@ -1030,7 +1027,7 @@ void AudioVideoRendererAVFObjC::maybeCompleteSeek()
         ALWAYS_LOG(LOGIDENTIFIER, "Not resuming playback, shouldBePlaying:false");
 
     if (auto promise = std::exchange(m_seekPromise, std::nullopt))
-        promise->resolve(m_lastSeekTime);
+        promise->resolve();
     ALWAYS_LOG(LOGIDENTIFIER, "seek completed");
 }
 
@@ -1868,18 +1865,20 @@ void AudioVideoRendererAVFObjC::flushVideo()
     if (RefPtr videoRenderer = m_videoRenderer)
         videoRenderer->flush();
     flushPendingSizeChanges();
+    m_keyframeNeeded = true;
 }
 
 void AudioVideoRendererAVFObjC::flushAudio()
 {
-    for (auto& properties : m_audioTracksMap.values())
+    for (auto& properties : m_audioTracksMap.values()) {
         properties.hasAudibleSample = false;
+        properties.readyToRequestAudioData = true;
+    }
     updateAllRenderersHaveAvailableSamples();
 
     applyOnAudioRenderers([&](auto *renderer) {
         [renderer flush];
     });
-    m_readyToRequestAudioData = true;
 }
 
 void AudioVideoRendererAVFObjC::flushAudioTrack(TrackIdentifier trackId)
@@ -1888,6 +1887,7 @@ void AudioVideoRendererAVFObjC::flushAudioTrack(TrackIdentifier trackId)
     RetainPtr audioRenderer = audioRendererFor(trackId);
     if (!audioRenderer)
         return;
+    audioTrackPropertiesFor(trackId).readyToRequestAudioData = true;
     [audioRenderer flush];
     setHasAvailableAudioSample(trackId, false);
 }
@@ -1903,8 +1903,7 @@ void AudioVideoRendererAVFObjC::notifyRequiresFlushToResume()
 
 void AudioVideoRendererAVFObjC::cancelSeekingPromiseIfNeeded()
 {
-    if (auto promise = std::exchange(m_seekPromise, std::nullopt))
-        promise->reject(PlatformMediaError::Cancelled);
+    m_seekPromise.reset();
 }
 
 WTFLogChannel& AudioVideoRendererAVFObjC::logChannel() const
@@ -1939,10 +1938,6 @@ String AudioVideoRendererAVFObjC::toString(TrackIdentifier trackId) const
 String AudioVideoRendererAVFObjC::toString(SeekState state) const
 {
     switch (state) {
-    case Preparing:
-        return "Preparing"_s;
-    case RequiresFlush:
-        return "RequiresFlush"_s;
     case Seeking:
         return "Seeking"_s;
     case WaitingForAvailableFame:

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -99,10 +99,6 @@ public:
     void setReadyState(MediaPlayer::ReadyState);
     void setNetworkState(MediaPlayer::NetworkState);
 
-    void seekInternal();
-    void startSeek(const MediaTime&);
-    void cancelPendingSeek();
-    void completeSeek(const MediaTime&);
     void NODELETE setLoadingProgresssed(bool);
     void setHasAvailableVideoFrame(bool);
     bool hasAvailableVideoFrame() const override;
@@ -320,9 +316,13 @@ private:
     void timeChanged();
 
     void setLayerRequiresFlush();
-    void flush();
     void flushVideoIfNeeded();
-    void reenqueueMediaForTime(const MediaTime&);
+
+    void seekInternal();
+    void continueSeek(const MediaTime&);
+    void reenqueueMediaForTimeAndFinishSeek(const MediaTime&);
+    void cancelPendingSeek();
+    void completeSeek(const MediaTime&);
 
     // Remote layer support
     WebCore::HostingContext hostingContext() const final;
@@ -345,7 +345,9 @@ private:
     Timer m_seekTimer WTF_GUARDED_BY_CAPABILITY(mainThread);
     bool m_seeking  WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
     std::optional<SeekTarget> m_pendingSeek WTF_GUARDED_BY_CAPABILITY(mainThread);
-    const Ref<NativePromiseRequest> m_rendererSeekRequest WTF_GUARDED_BY_CAPABILITY(mainThread);
+    const Ref<NativePromiseRequest> m_waitForTargetRequest WTF_GUARDED_BY_CAPABILITY(mainThread);
+    const Ref<NativePromiseRequest> m_rendererPrepareSeekRequest WTF_GUARDED_BY_CAPABILITY(mainThread);
+    const Ref<NativePromiseRequest> m_rendererFinishSeekRequest WTF_GUARDED_BY_CAPABILITY(mainThread);
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
     ThreadSafeWeakPtr<CDMSessionAVContentKeySession> m_session;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -104,7 +104,9 @@ Ref<AudioVideoRenderer> MediaPlayerPrivateMediaSourceAVFObjC::createRenderer(Log
 MediaPlayerPrivateMediaSourceAVFObjC::MediaPlayerPrivateMediaSourceAVFObjC(MediaPlayer& player)
     : m_player(player)
     , m_seekTimer(*this, &MediaPlayerPrivateMediaSourceAVFObjC::seekInternal)
-    , m_rendererSeekRequest(NativePromiseRequest::create())
+    , m_waitForTargetRequest(NativePromiseRequest::create())
+    , m_rendererPrepareSeekRequest(NativePromiseRequest::create())
+    , m_rendererFinishSeekRequest(NativePromiseRequest::create())
     , m_networkState(MediaPlayer::NetworkState::Empty)
     , m_logger(player.mediaPlayerLogger())
     , m_logIdentifier(player.mediaPlayerLogIdentifier())
@@ -125,7 +127,6 @@ MediaPlayerPrivateMediaSourceAVFObjC::~MediaPlayerPrivateMediaSourceAVFObjC()
     cancelPendingSeek();
     m_seekTimer.stop();
     m_renderer->pause();
-    m_renderer->flush();
 }
 
 #pragma mark -
@@ -523,52 +524,85 @@ void MediaPlayerPrivateMediaSourceAVFObjC::seekInternal()
     m_seeking = true;
 
     cancelPendingSeek();
-    m_renderer->prepareToSeek();
 
-    mediaSourcePrivate->waitForTarget(pendingSeek)->whenSettled(RunLoop::currentSingleton(), [weakThis = WeakPtr { *this }, seekTime = m_lastSeekTime] (auto&& result) mutable {
+    m_renderer->stall();
+
+    ALWAYS_LOG(LOGIDENTIFIER);
+
+    // Wait until the user agent has established whether or not the
+    // media data for the new playback position is available, and, if it is, until it has decoded enough data
+    // to play back that position" step of the seek algorithm:
+    protect(m_mediaSourcePrivate)->waitForTarget(pendingSeek)->whenSettled(RunLoop::mainSingleton(), [weakThis = WeakPtr { *this }] (auto&& result) {
+        assertIsMainThread();
         RefPtr protectedThis = weakThis.get();
-        if (!protectedThis || !result)
-            return; // seek cancelled;
+        if (!protectedThis)
+            return;
+        protectedThis->m_waitForTargetRequest->complete();
 
-        protectedThis->startSeek(seekTime);
-    });
+        if (!result)
+            return; // seek cancelled;
+        protectedThis->continueSeek(*result);
+    })->track(m_waitForTargetRequest);
 }
 
-void MediaPlayerPrivateMediaSourceAVFObjC::startSeek(const MediaTime& seekTime)
+void MediaPlayerPrivateMediaSourceAVFObjC::continueSeek(const MediaTime& seekTime)
 {
     assertIsMainThread();
-    if (m_rendererSeekRequest->hasCallback()) {
-        ALWAYS_LOG(LOGIDENTIFIER, "Seeking pending, cancel earlier seek");
-        cancelPendingSeek();
-    }
-    m_renderer->seekTo(seekTime)->whenSettled(RunLoop::mainSingleton(), [weakThis = WeakPtr { *this }, seekTime](auto&& result) {
-        assertIsMainThread();
-        if (!result && result.error() != PlatformMediaError::RequiresFlushToResume)
-            return; // cancelled.
+    ALWAYS_LOG(LOGIDENTIFIER, seekTime);
 
+    m_lastSeekTime = seekTime;
+    m_renderer->prepareToSeek(seekTime)->whenSettled(RunLoop::mainSingleton(), [weakThis = WeakPtr { *this }, seekTime] (auto&& result) {
+        assertIsMainThread();
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
 
-        protectedThis->m_rendererSeekRequest->complete();
+        protectedThis->m_rendererPrepareSeekRequest->complete();
 
-        if (!result) {
-            ASSERT(result.error() == PlatformMediaError::RequiresFlushToResume);
-            protectedThis->flush();
-            protectedThis->reenqueueMediaForTime(seekTime);
-            protectedThis->startSeek(seekTime);
+        if (!result)
+            return;
+        if (result->isIndefinite()) {
+            protectedThis->setHasAvailableVideoFrame(false);
+            protectedThis->reenqueueMediaForTimeAndFinishSeek(seekTime);
             return;
         }
         protectedThis->completeSeek(*result);
-    })->track(m_rendererSeekRequest.get());
+    })->track(m_rendererPrepareSeekRequest);
+}
+
+void MediaPlayerPrivateMediaSourceAVFObjC::reenqueueMediaForTimeAndFinishSeek(const MediaTime& seekTime)
+{
+    assertIsMainThread();
+    ALWAYS_LOG(LOGIDENTIFIER, seekTime);
+
+    GenericPromise::all({
+        protect(m_mediaSourcePrivate)->reenqueueMediaForTime(seekTime),
+        m_renderer->finishSeek(seekTime)
+    })->whenSettled(RunLoop::mainSingleton(), [weakThis = WeakPtr { *this }, seekTime](auto&& result) {
+        assertIsMainThread();
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
+            return;
+
+        protectedThis->m_rendererFinishSeekRequest->complete();
+
+        if (!result)
+            return; // cancelled.
+
+        protectedThis->completeSeek(seekTime);
+    })->track(m_rendererFinishSeekRequest);
 }
 
 void MediaPlayerPrivateMediaSourceAVFObjC::cancelPendingSeek()
 {
     assertIsMainThread();
 
-    if (m_rendererSeekRequest->hasCallback())
-        m_rendererSeekRequest->disconnect();
+    if (m_waitForTargetRequest->hasCallback())
+        m_waitForTargetRequest->disconnect();
+    if (m_rendererPrepareSeekRequest->hasCallback())
+        m_rendererPrepareSeekRequest->disconnect();
+    if (m_rendererFinishSeekRequest->hasCallback())
+        m_rendererFinishSeekRequest->disconnect();
 }
 
 void MediaPlayerPrivateMediaSourceAVFObjC::completeSeek(const MediaTime& seekedTime)
@@ -739,20 +773,6 @@ void MediaPlayerPrivateMediaSourceAVFObjC::flushVideoIfNeeded()
         setHasAvailableVideoFrame(false);
         mediaSourcePrivate->flushAndReenqueueActiveVideoSourceBuffers();
     }
-}
-
-void MediaPlayerPrivateMediaSourceAVFObjC::flush()
-{
-    assertIsMainThread();
-    ALWAYS_LOG(LOGIDENTIFIER);
-    m_renderer->flush();
-    setHasAvailableVideoFrame(false);
-}
-
-void MediaPlayerPrivateMediaSourceAVFObjC::reenqueueMediaForTime(const MediaTime& seekTime)
-{
-    if (RefPtr mediaSourcePrivate = m_mediaSourcePrivate)
-        mediaSourcePrivate->seekToTime(seekTime);
 }
 
 bool MediaPlayerPrivateMediaSourceAVFObjC::didLoadingProgress() const

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -373,7 +373,6 @@ private:
     bool seeking() const final;
     void seekInternal();
     void cancelPendingSeek(); // Called from destructor or running queue
-    void startSeek(const MediaTime&);
     void completeSeek(const MediaTime&);
     Ref<GenericPromise> waitForTimeBuffered(const MediaTime&);
     void resolveWaitForTimeBufferedPromiseIfPossible();

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -620,14 +620,31 @@ void MediaPlayerPrivateWebM::seekInternal()
         protectedThis->m_lastSeekTime = seekTime;
         protectedThis->cancelPendingSeek();
         protectedThis->m_seeking = true;
-        protectedThis->m_renderer->prepareToSeek();
-
+        protectedThis->m_renderer->stall();
         protectedThis->waitForTimeBuffered(seekTime)->whenSettled(protectedThis->m_runningQueue, [weakThis, seekTime](auto&& result) {
             RefPtr protectedThis = weakThis.get();
             if (!result || !protectedThis)
-                return; // seek cancelled.
+                return MediaTimePromise::createAndReject(PlatformMediaError::Cancelled); // seek cancelled.
+            return protectedThis->m_renderer->prepareToSeek(seekTime);
+        })->whenSettled(protectedThis->m_runningQueue, [weakThis, seekTime](auto&& result) {
+            RefPtr protectedThis = weakThis.get();
+            if (!result || !protectedThis)
+                return;
+            if (!result->isIndefinite()) {
+                protectedThis->completeSeek(*result);
+                return;
+            }
+            protectedThis->reenqueueMediaForTime(seekTime);
+            protectedThis->m_renderer->finishSeek(seekTime)->whenSettled(protectedThis->m_runningQueue, [weakThis, seekTime](auto&& result) {
+                RefPtr protectedThis = weakThis.get();
+                if (!protectedThis)
+                    return;
+                protect(protectedThis->m_rendererSeekRequest)->complete();
 
-            return protectedThis->startSeek(seekTime);
+                if (!result)
+                    return;
+                protectedThis->completeSeek(seekTime);
+            })->track(protectedThis->m_rendererSeekRequest);
         });
     });
 }
@@ -638,31 +655,6 @@ void MediaPlayerPrivateWebM::cancelPendingSeek()
     if (m_rendererSeekRequest->hasCallback())
         protect(m_rendererSeekRequest)->disconnect();
     m_waitForTimeBufferedPromise.reset();
-}
-
-void MediaPlayerPrivateWebM::startSeek(const MediaTime& seekTime)
-{
-    assertIsCurrent(runningQueue());
-    ALWAYS_LOG(LOGIDENTIFIER, seekTime);
-    m_renderer->seekTo(seekTime)->whenSettled(m_runningQueue, [weakThis = ThreadSafeWeakPtr { *this }, seekTime](auto&& result) {
-        if (!result && result.error() != PlatformMediaError::RequiresFlushToResume)
-            return; // cancelled.
-
-        RefPtr protectedThis = weakThis.get();
-        if (!protectedThis)
-            return;
-
-        protect(protectedThis->m_rendererSeekRequest)->complete();
-
-        if (!result) {
-            ASSERT(result.error() == PlatformMediaError::RequiresFlushToResume);
-            protectedThis->flush();
-            protectedThis->reenqueueMediaForTime(seekTime);
-            // Try seeking again.
-            return protectedThis->startSeek(seekTime);
-        }
-        protectedThis->completeSeek(*result);
-    })->track(m_rendererSeekRequest);
 }
 
 void MediaPlayerPrivateWebM::completeSeek(const MediaTime& seekedTime)
@@ -1219,7 +1211,7 @@ void MediaPlayerPrivateWebM::reenqueueMediaForTime(const MediaTime& time)
     for (auto& trackBufferPair : m_trackBufferMap) {
         TrackBuffer& trackBuffer = trackBufferPair.second;
         auto trackId = trackBufferPair.first;
-        reenqueueMediaForTime(trackBuffer, trackId, time, NeedsFlush::No);
+        reenqueueMediaForTime(trackBuffer, trackId, time);
     }
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -310,14 +310,15 @@ bool MediaPlayerPrivateGStreamerMSE::doSeek(const SeekTarget& target, float rate
     // This will also add support for fastSeek once done (see webkit.org/b/260607)
     if (!m_mediaSourcePrivate)
         return false;
-    m_mediaSourcePrivate->willSeek();
     m_mediaSourcePrivate->waitForTarget(target)->whenSettled(RunLoop::currentSingleton(), [this, weakThis = ThreadSafeWeakPtr { *this }](auto&& result) {
         RefPtr self = weakThis.get();
         if (!self || !result)
             return;
 
+        // FIXME: Should m_mediaSourcePrivate run on its own WorkQueue (e.g. if MSE in a worker is enabled)
+        // this should be changed for the async version of reenqueueMediaForTime.
         if (m_mediaSourcePrivate)
-            m_mediaSourcePrivate->seekToTime(*result);
+            m_mediaSourcePrivate->reenqueueMediaForTime(*result);
 
         auto player = m_player.get();
         if (player && !hasVideo() && m_audioSink) {

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
@@ -297,12 +297,6 @@ MediaSourcePrivateGStreamer::RegisteredTrack MediaSourcePrivateGStreamer::regist
     return info;
 }
 
-void MediaSourcePrivateGStreamer::willSeek()
-{
-    for (auto* sourceBuffer : m_activeSourceBuffers)
-        downcast<SourceBufferPrivateGStreamer>(sourceBuffer)->willSeek();
-}
-
 void MediaSourcePrivateGStreamer::unregisterTrack(TrackID trackId)
 {
     ASSERT(isMainThread());

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h
@@ -105,8 +105,6 @@ public:
     RegisteredTrack registerTrack(TrackID, StreamType);
     void unregisterTrack(TrackID);
 
-    void willSeek();
-
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger; }
     ASCIILiteral logClassName() const override { return "MediaSourcePrivateGStreamer"_s; }

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
@@ -479,24 +479,6 @@ void SourceBufferPrivateGStreamer::detach()
         downcast<MediaSourcePrivateGStreamer>(mediaSource)->detach();
 }
 
-void SourceBufferPrivateGStreamer::willSeek()
-{
-    ALWAYS_LOG(LOGIDENTIFIER);
-    m_seeking = true;
-}
-
-bool SourceBufferPrivateGStreamer::isSeeking() const
-{
-    return m_seeking;
-}
-
-void SourceBufferPrivateGStreamer::seekToTime(const MediaTime& time)
-{
-    m_seeking = false;
-    // WebKit now has the samples to complete the seek and is about to enqueue them.
-    SourceBufferPrivate::seekToTime(time);
-}
-
 #undef GST_CAT_DEFAULT
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
@@ -102,10 +102,6 @@ public:
     size_t platformMaximumBufferSize() const override;
     size_t platformEvictionThreshold() const final;
 
-    void willSeek();
-    bool isSeeking() const final;
-    void seekToTime(const MediaTime&) final;
-
 private:
     friend class AppendPipeline;
 
@@ -123,10 +119,6 @@ private:
     std::optional<MediaPromise::Producer> m_appendPromise;
 
     bool m_pendingInitializationSegmentForChangeType { false };
-
-    // Set while waiting for samples from the multiplatform layer after a seek has initiated.
-    // Unset once the samples are ready for the platform-specific layer.
-    bool m_seeking { false };
 
 #if !RELEASE_LOG_DISABLED
     const Ref<const Logger> m_logger;

--- a/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
@@ -260,20 +260,24 @@ void MockMediaPlayerMediaSource::seekToTarget(const SeekTarget& target)
             return;
 
         const auto seekTime = *result;
-        protect(protectedThis->m_mediaSourcePrivate)->seekToTime(seekTime);
-        protectedThis->m_lastSeekTarget.reset();
-        protectedThis->m_currentTime = seekTime;
+        protect(protectedThis->m_mediaSourcePrivate)->reenqueueMediaForTime(seekTime)->whenSettled(RunLoop::currentSingleton(), [weakThis, seekTime](auto&& result) {
+            RefPtr protectedThis = weakThis.get();
+            if (!protectedThis || !result)
+                return;
+            protectedThis->m_lastSeekTarget.reset();
+            protectedThis->m_currentTime = seekTime;
 
-        if (RefPtr player = protectedThis->m_player.get()) {
-            player->seeked(seekTime);
-            player->timeChanged();
-        }
+            if (RefPtr player = protectedThis->m_player.get()) {
+                player->seeked(seekTime);
+                player->timeChanged();
+            }
 
-        if (protectedThis->m_playing) {
-            callOnMainThread([protectedThis = WTF::move(protectedThis)] {
-                protectedThis->advanceCurrentTime();
-            });
-        }
+            if (protectedThis->m_playing) {
+                callOnMainThread([protectedThis = WTF::move(protectedThis)] {
+                    protectedThis->advanceCurrentTime();
+                });
+            }
+        });
     });
 }
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
@@ -373,21 +373,30 @@ void RemoteAudioVideoRendererProxyManager::stall(RemoteAudioVideoRendererIdentif
         renderer->stall();
 }
 
-void RemoteAudioVideoRendererProxyManager::prepareToSeek(RemoteAudioVideoRendererIdentifier identifier)
-{
-    if (RefPtr renderer = rendererFor(identifier))
-        renderer->prepareToSeek();
-}
-
-void RemoteAudioVideoRendererProxyManager::seekTo(RemoteAudioVideoRendererIdentifier identifier, const MediaTime& time, CompletionHandler<void(WebCore::MediaTimePromise::Result&&)>&& completionHandler)
+void RemoteAudioVideoRendererProxyManager::prepareToSeek(RemoteAudioVideoRendererIdentifier identifier, const MediaTime& seekTime, CompletionHandler<void(WebCore::MediaTimePromise::Result&&)>&& completionHandler)
 {
     RefPtr renderer = rendererFor(identifier);
     if (!renderer) {
         completionHandler(makeUnexpected(PlatformMediaError::NotSupportedError));
         return;
     }
-    renderer->seekTo(time)->whenSettled(RunLoop::mainSingleton(), [protectedThis = Ref { *this }, identifier, completionHandler = WTF::move(completionHandler)](auto&& result) mutable {
-        protectedThis->m_gpuConnectionToWebProcess.get()->connection().send(Messages::AudioVideoRendererRemoteMessageReceiver::StateUpdate(protectedThis->stateFor(identifier)), identifier);
+    renderer->prepareToSeek(seekTime)->whenSettled(RunLoop::mainSingleton(), [weakThis = WeakPtr { *this }, identifier, completionHandler = WTF::move(completionHandler)](auto&& result) mutable {
+        if (RefPtr protectedThis = weakThis.get(); protectedThis && protectedThis->m_renderers.contains(identifier))
+            protectedThis->m_gpuConnectionToWebProcess.get()->connection().send(Messages::AudioVideoRendererRemoteMessageReceiver::StateUpdate(protectedThis->stateFor(identifier)), identifier);
+        completionHandler(WTF::move(result));
+    });
+}
+
+void RemoteAudioVideoRendererProxyManager::finishSeek(RemoteAudioVideoRendererIdentifier identifier, const MediaTime& time, CompletionHandler<void(GenericPromise::Result&&)>&& completionHandler)
+{
+    RefPtr renderer = rendererFor(identifier);
+    if (!renderer) {
+        completionHandler(makeUnexpected(GenericPromise::RejectValueType { }));
+        return;
+    }
+    renderer->finishSeek(time)->whenSettled(RunLoop::mainSingleton(), [weakThis = WeakPtr { *this }, identifier, completionHandler = WTF::move(completionHandler)](auto&& result) mutable {
+        if (RefPtr protectedThis = weakThis.get(); protectedThis && protectedThis->m_renderers.contains(identifier))
+            protectedThis->m_gpuConnectionToWebProcess.get()->connection().send(Messages::AudioVideoRendererRemoteMessageReceiver::StateUpdate(protectedThis->stateFor(identifier)), identifier);
         completionHandler(WTF::move(result));
     });
 }
@@ -558,7 +567,6 @@ RemoteAudioVideoRendererState RemoteAudioVideoRendererProxyManager::stateFor(Rem
     return {
         .currentTime = renderer->currentTime(),
         .paused = renderer->paused(),
-        .seeking = renderer->seeking(),
         .timeIsProgressing = renderer->timeIsProgressing(),
         .effectiveRate = renderer->effectiveRate(),
         .videoPlaybackQualityMetrics = renderer->videoPlaybackQualityMetrics()

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
@@ -117,8 +117,8 @@ private:
     void pause(RemoteAudioVideoRendererIdentifier, std::optional<MonotonicTime>);
     void setRate(RemoteAudioVideoRendererIdentifier, double);
     void stall(RemoteAudioVideoRendererIdentifier);
-    void prepareToSeek(RemoteAudioVideoRendererIdentifier);
-    void seekTo(RemoteAudioVideoRendererIdentifier, const MediaTime&, CompletionHandler<void(WebCore::MediaTimePromise::Result&&)>&&);
+    void prepareToSeek(RemoteAudioVideoRendererIdentifier, const MediaTime&, CompletionHandler<void(WebCore::MediaTimePromise::Result&&)>&&);
+    void finishSeek(RemoteAudioVideoRendererIdentifier, const MediaTime&, CompletionHandler<void(GenericPromise::Result&&)>&&);
 
     // AudioInterface
     void setVolume(RemoteAudioVideoRendererIdentifier, float);

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in
@@ -58,8 +58,8 @@ messages -> RemoteAudioVideoRendererProxyManager {
     Pause(WebKit::RemoteAudioVideoRendererIdentifier identifier, std::optional<MonotonicTime> hostTime)
     SetRate(WebKit::RemoteAudioVideoRendererIdentifier identifier, double rate)
     Stall(WebKit::RemoteAudioVideoRendererIdentifier identifier)
-    PrepareToSeek(WebKit::RemoteAudioVideoRendererIdentifier identifier)
-    SeekTo(WebKit::RemoteAudioVideoRendererIdentifier identifier, MediaTime seekTime) -> (Expected<MediaTime, WebCore::PlatformMediaError> result)
+    PrepareToSeek(WebKit::RemoteAudioVideoRendererIdentifier identifier, MediaTime seekTime) -> (Expected<MediaTime, WebCore::PlatformMediaError> result)
+    FinishSeek(WebKit::RemoteAudioVideoRendererIdentifier identifier, MediaTime seekTime) -> (GenericPromise::Result result)
 
     SetVolume(WebKit::RemoteAudioVideoRendererIdentifier identifier, float volume)
     SetMuted(WebKit::RemoteAudioVideoRendererIdentifier identifier, bool muted)

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -415,15 +415,18 @@ public:
     template<typename PC, typename BasePromise>
     struct ConvertedPromise {
         template <typename T, typename E>
-        struct Promise
-        {
+        struct Promise {
             using Type = NativePromise<T, E>;
         };
 
         template <typename T, typename E>
-        struct Promise<Expected<T, E>, E>
-        {
+        struct Promise<Expected<T, E>, E> {
             using Type = NativePromise<T, E>;
+        };
+
+        template <typename T>
+        struct Promise<Expected<T, GenericPromise::RejectValueType>, GenericPromise::RejectValueType> {
+            using Type = NativePromise<T, void>;
         };
 
         using RejectValueType = std::remove_reference_t<decltype(PC::convertError(std::declval<IPC::Error>()).error())>;

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -570,6 +570,7 @@ def types_that_cannot_be_forward_declared():
     return frozenset([
         'CVPixelBufferRef',
         'GCGLint',
+        'GenericPromise::Result',
         'IPC::AsyncReplyID',
         'IPC::FontReference',
         'IPC::Semaphore',
@@ -1098,6 +1099,7 @@ def headers_for_type(type, for_implementation_file=False):
     special_cases = {
         'CVPixelBufferRef': ['<WebCore/CVUtilities.h>'],
         'GCGLint': ['<WebCore/GraphicsTypesGL.h>'],
+        'GenericPromise::Result': ['<wtf/NativePromise.h>'],
         'Inspector::ExtensionAppearance': ['"InspectorExtensionTypes.h"'],
         'Inspector::ExtensionError': ['"InspectorExtensionTypes.h"'],
         'Inspector::ExtensionTabID': ['"InspectorExtensionTypes.h"'],
@@ -1134,6 +1136,7 @@ def headers_for_type(type, for_implementation_file=False):
         'String': ['<wtf/text/WTFString.h>'],
         'std::monostate': [],
         'URL': ['<wtf/URLHash.h>'],
+        'WTF::GenericPromise::Result': ['<wtf/NativePromise.h>'],
         'WTF::UUID': ['<wtf/UUID.h>'],
         'WallTime': ['<wtf/WallTime.h>'],
         'WebCore::AXDebugInfo': ['<WebCore/AXObjectCache.h>'],
@@ -1309,6 +1312,7 @@ def headers_for_type(type, for_implementation_file=False):
         'WebCore::MediaSettingsRange': ['<WebCore/MediaSettingsRange.h>'],
         'WebCore::MediaSourcePrivateAddStatus': ['<WebCore/MediaSourcePrivate.h>'],
         'WebCore::MediaSourcePrivateEndOfStreamStatus': ['<WebCore/MediaSourcePrivate.h>'],
+        'WebCore::MediaTimePromise::Result': ['<WebCore/MediaPromiseTypes.h>'],
         'WebCore::MessagePortChannelProvider::HasActivity': ['<WebCore/MessagePortChannelProvider.h>'],
         'WebCore::ModalContainerControlType': ['<WebCore/ModalContainerTypes.h>'],
         'WebCore::ModalContainerDecision': ['<WebCore/ModalContainerTypes.h>'],

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -282,3 +282,7 @@ using FileSystem::Salt = std::array<uint8_t, 8>;
     FixedVector<uint8_t> data;
 }
 #endif
+
+header: <wtf/NativePromise.h>
+[CustomHeader] struct WTF::detail::VoidPlaceholder {
+}

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8620,7 +8620,7 @@ enum class WebCore::PlatformMediaError : uint8_t {
     NotReady,
     AudioDecodingError,
     VideoDecodingError,
-    RequiresFlushToResume,
+    InvalidState,
     CDMInstanceKeyNeeded,
 };
 #endif

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
@@ -86,6 +86,8 @@ AudioVideoRendererRemote::AudioVideoRendererRemote(LoggerHelper* loggerHelper, G
     : m_gpuProcessConnection(connection)
     , m_receiver(MessageReceiver::create(*this))
     , m_identifier(identifier)
+    , m_prepareSeekRequest(NativePromiseRequest::create())
+    , m_finishSeekRequest(NativePromiseRequest::create())
 #if PLATFORM(COCOA)
     , m_videoLayerManager(makeUniqueRef<VideoLayerManagerObjC>(loggerHelper->logger(), loggerHelper->logIdentifier()))
 #endif
@@ -106,13 +108,24 @@ AudioVideoRendererRemote::AudioVideoRendererRemote(LoggerHelper* loggerHelper, G
     connection.connection().send(Messages::RemoteAudioVideoRendererProxyManager::Create(identifier, mediaElementIdentifier, playerIdentifier), 0);
 }
 
-AudioVideoRendererRemote::~AudioVideoRendererRemote()
+AudioVideoRendererRemote::~AudioVideoRendererRemote() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
 {
     ALWAYS_LOG(LOGIDENTIFIER);
 
 #if PLATFORM(COCOA)
     m_videoLayerManager->didDestroyVideoLayer();
 #endif
+
+    ensureOnDispatcher([prepareSeekRequest = WTF::move(m_prepareSeekRequest), prepareSeekPromise = WTF::move(m_prepareSeekPromise), finishSeekRequest = WTF::move(m_finishSeekRequest), finishSeekPromise = WTF::move(m_finishSeekPromise)]() mutable {
+        if (prepareSeekRequest->hasCallback())
+            prepareSeekRequest->disconnect();
+        if (auto promise = std::exchange(prepareSeekPromise, std::nullopt))
+            promise->reject(PlatformMediaError::Cancelled);
+        if (finishSeekRequest->hasCallback())
+            finishSeekRequest->disconnect();
+        if (auto promise = std::exchange(finishSeekPromise, std::nullopt))
+            promise->reject();
+    });
 
     if (RefPtr gpuProcessConnection = m_gpuProcessConnection.get(); gpuProcessConnection && !m_shutdown) {
         ensureOnDispatcher([gpuProcessConnection, identifier = m_identifier] {
@@ -425,14 +438,21 @@ void AudioVideoRendererRemote::stall()
     });
 }
 
-void AudioVideoRendererRemote::prepareToSeek()
+void AudioVideoRendererRemote::cancelPendingSeek()
 {
-    ensureOnDispatcherWithConnection([](auto& renderer, auto& connection) {
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::PrepareToSeek(renderer.m_identifier), 0);
-    });
+    assertIsCurrent(queueSingleton());
+
+    if (m_prepareSeekRequest->hasCallback())
+        protect(m_prepareSeekRequest)->disconnect();
+    if (auto promise = std::exchange(m_prepareSeekPromise, std::nullopt))
+        promise->reject(PlatformMediaError::Cancelled);
+    if (m_finishSeekRequest->hasCallback())
+        protect(m_finishSeekRequest)->disconnect();
+    if (auto promise = std::exchange(m_finishSeekPromise, std::nullopt))
+        promise->reject();
 }
 
-Ref<MediaTimePromise> AudioVideoRendererRemote::seekTo(const MediaTime& time)
+Ref<MediaTimePromise> AudioVideoRendererRemote::prepareToSeek(const MediaTime& time)
 {
     {
         Locker locker { m_lock };
@@ -441,22 +461,78 @@ Ref<MediaTimePromise> AudioVideoRendererRemote::seekTo(const MediaTime& time)
     m_seeking = true;
     m_lastSeekTime = time;
     return invokeAsync(queueSingleton(), [protectedThis = Ref { *this }, this, time] -> Ref<MediaTimePromise> {
-        RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
-        if (!isGPURunning() || !gpuProcessConnection)
-            return MediaTimePromise::createAndReject(PlatformMediaError::Cancelled);
+        cancelPendingSeek();
 
-        return gpuProcessConnection->connection().sendWithPromisedReply<MediaPromiseConverter>(Messages::RemoteAudioVideoRendererProxyManager::SeekTo(m_identifier, time), 0)->whenSettled(queueSingleton(), [protectedThis](auto&& result) {
-            if (result)
+        RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+        if (!isGPURunning() || !gpuProcessConnection) {
+            m_seeking = false;
+            return MediaTimePromise::createAndReject(PlatformMediaError::IPCError);
+        }
+
+        assertIsCurrent(queueSingleton());
+        m_prepareSeekPromise.emplace();
+        Ref promise = m_prepareSeekPromise->promise();
+
+        gpuProcessConnection->connection().sendWithPromisedReply<MediaPromiseConverter>(Messages::RemoteAudioVideoRendererProxyManager::PrepareToSeek(m_identifier, time), 0)->whenSettled(queueSingleton(), [weakThis = ThreadSafeWeakPtr { *this }](auto&& result) {
+            RefPtr protectedThis = weakThis.get();
+            if (!protectedThis)
+                return;
+
+            assertIsCurrent(queueSingleton());
+            protect(protectedThis->m_prepareSeekRequest)->complete();
+
+            if (result && !result->isIndefinite())
                 protectedThis->m_seeking = false;
-            return MediaTimePromise::createAndSettle(WTF::move(result));
-        });
+
+            if (auto producer = std::exchange(protectedThis->m_prepareSeekPromise, std::nullopt))
+                producer->settle(WTF::move(result));
+        })->track(m_prepareSeekRequest);
+
+        return promise;
+    });
+}
+
+Ref<GenericPromise> AudioVideoRendererRemote::finishSeek(const MediaTime& time)
+{
+    {
+        Locker locker { m_lock };
+        m_state.currentTime = time;
+    }
+    ASSERT(m_seeking, "Invalid seeking state, bad API usage");
+    return invokeAsync(queueSingleton(), [protectedThis = Ref { *this }, this, time] -> Ref<GenericPromise> {
+        cancelPendingSeek();
+
+        RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+        if (!isGPURunning() || !gpuProcessConnection) {
+            m_seeking = false;
+            return GenericPromise::createAndReject();
+        }
+
+        assertIsCurrent(queueSingleton());
+        m_finishSeekPromise.emplace();
+        Ref promise = m_finishSeekPromise->promise();
+
+        gpuProcessConnection->connection().sendWithPromisedReply<WTF::GenericPromiseConverter>(Messages::RemoteAudioVideoRendererProxyManager::FinishSeek(m_identifier, time), 0)->whenSettled(queueSingleton(), [weakThis = ThreadSafeWeakPtr { *this }](auto&& result) {
+            RefPtr protectedThis = weakThis.get();
+            if (!protectedThis)
+                return;
+
+            assertIsCurrent(queueSingleton());
+            protect(protectedThis->m_finishSeekRequest)->complete();
+
+            protectedThis->m_seeking = false;
+
+            if (auto producer = std::exchange(protectedThis->m_finishSeekPromise, std::nullopt))
+                producer->settle(WTF::move(result));
+        })->track(m_finishSeekRequest);
+
+        return promise;
     });
 }
 
 bool AudioVideoRendererRemote::seeking() const
 {
-    Locker locker { m_lock };
-    return m_state.seeking;
+    return m_seeking;
 }
 
 void AudioVideoRendererRemote::setPreferences(VideoRendererPreferences preferences)
@@ -515,6 +591,14 @@ void AudioVideoRendererRemote::enqueueSample(TrackIdentifier trackIdentifier, Re
         auto block = addResult.iterator->value.convert(sample, MediaSampleConverter::SetTrackInfo::No);
         if (formatChanged)
             connection.send(Messages::RemoteAudioVideoRendererProxyManager::NewTrackInfoForTrack(renderer.m_identifier, trackIdentifier, Ref { const_cast<WebCore::TrackInfo&>(*addResult.iterator->value.currentTrackInfo()) }), 0);
+        if (addResult.iterator->value.currentTrackInfo()->isVideo()) {
+            if (renderer.m_keyframeNeeded && !sample->isSync()) {
+                ALWAYS_LOG_WITH_THIS(&renderer, LOGIDENTIFIER_WITH_THIS(&renderer), "Keyframe needed: but frame not keyframe");
+                ASSERT_NOT_REACHED();
+                return;
+            }
+            renderer.m_keyframeNeeded = false;
+        }
         connection.sendWithAsyncReplyOnDispatcher(Messages::RemoteAudioVideoRendererProxyManager::EnqueueSample(renderer.m_identifier, trackIdentifier, WTF::move(block), expectedMinimum), queueSingleton(), [weakThis = ThreadSafeWeakPtr { renderer }, trackIdentifier](bool readyForMoreData) {
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis)
@@ -621,7 +705,10 @@ void AudioVideoRendererRemote::performTaskAtTime(const MediaTime& time, Function
 
 void AudioVideoRendererRemote::flush()
 {
+    ALWAYS_LOG(LOGIDENTIFIER, "seeking:", m_seeking.load());
+    m_seeking = false;
     ensureOnDispatcherWithConnection([](auto& renderer, auto& connection) {
+        renderer.m_keyframeNeeded = true;
         connection.send(Messages::RemoteAudioVideoRendererProxyManager::Flush(renderer.m_identifier), 0);
     });
 }

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
@@ -147,8 +147,8 @@ private:
     void setRate(double) final;
     double effectiveRate() const final;
     void stall() final;
-    void prepareToSeek() final;
-    Ref<WebCore::MediaTimePromise> seekTo(const MediaTime&) final;
+    Ref<WebCore::MediaTimePromise> prepareToSeek(const MediaTime&) final;
+    Ref<GenericPromise> finishSeek(const MediaTime&) final;
     bool seeking() const final;
 
     void setPreferences(WebCore::VideoRendererPreferences) final;
@@ -235,6 +235,8 @@ private:
     ReadyForMoreDataState& readyForMoreDataState(TrackIdentifier);
     void resolveRequestMediaDataWhenReadyIfNeeded(TrackIdentifier);
 
+    void cancelPendingSeek();
+
     const ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
     const Ref<MessageReceiver> m_receiver;
     const RemoteAudioVideoRendererIdentifier m_identifier;
@@ -265,8 +267,15 @@ private:
     Vector<LayerHostingContextCallback> m_layerHostingContextRequests WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     WebCore::HostingContext m_layerHostingContext WTF_GUARDED_BY_LOCK(m_lock);
     WebCore::FloatSize m_naturalSize WTF_GUARDED_BY_LOCK(m_lock);
+
+    // Seek Tracking
+    Ref<NativePromiseRequest> m_prepareSeekRequest WTF_GUARDED_BY_CAPABILITY(queueSingleton());
+    std::optional<WebCore::MediaTimePromise::Producer> m_prepareSeekPromise WTF_GUARDED_BY_CAPABILITY(queueSingleton());
+    Ref<NativePromiseRequest> m_finishSeekRequest WTF_GUARDED_BY_CAPABILITY(queueSingleton());
+    std::optional<GenericPromise::Producer> m_finishSeekPromise WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     std::atomic<bool> m_seeking { false };
-    MediaTime m_lastSeekTime; // Always call on the renderer's client thread.
+    MediaTime m_lastSeekTime; // Always called on the renderer's client thread.
+
 #if PLATFORM(COCOA)
     const UniqueRef<WebCore::VideoLayerManager> m_videoLayerManager WTF_GUARDED_BY_LOCK(m_lock);
     mutable PlatformLayerContainer m_videoLayer WTF_GUARDED_BY_LOCK(m_lock);
@@ -276,6 +285,7 @@ private:
     const Ref<const Logger> m_logger;
     const uint64_t m_logIdentifier;
 #endif
+    bool m_keyframeNeeded { true };
 };
 
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioVideoRendererState.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioVideoRendererState.h
@@ -34,7 +34,6 @@ namespace WebKit {
 struct RemoteAudioVideoRendererState {
     MediaTime currentTime { MediaTime::zeroTime() };
     bool paused { false };
-    bool seeking { false };
     bool timeIsProgressing { false };
     double effectiveRate { 0 };
     std::optional<WebCore::VideoPlaybackQualityMetrics> videoPlaybackQualityMetrics { };

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioVideoRendererState.serialization.in
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioVideoRendererState.serialization.in
@@ -24,7 +24,6 @@
 struct WebKit::RemoteAudioVideoRendererState {
     MediaTime currentTime;
     bool paused;
-    bool seeking;
     bool timeIsProgressing;
     double effectiveRate;
     std::optional<WebCore::VideoPlaybackQualityMetrics> videoPlaybackQualityMetrics;

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
@@ -357,7 +357,7 @@ Ref<SourceBufferPrivate::ComputeSeekPromise> SourceBufferPrivateRemote::computeS
     });
 }
 
-void SourceBufferPrivateRemote::seekToTime(const MediaTime& time)
+void SourceBufferPrivateRemote::reenqueueMediaForTime(const MediaTime& time)
 {
     ASSERT_NOT_REACHED();
 }

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
@@ -125,7 +125,7 @@ private:
     Ref<GenericPromise> setMaximumBufferSize(size_t) final;
 
     Ref<ComputeSeekPromise> computeSeekTime(const WebCore::SeekTarget&) final;
-    void seekToTime(const MediaTime&) final;
+    void reenqueueMediaForTime(const MediaTime&) final;
 
     void updateTrackIds(Vector<std::pair<TrackID, TrackID>>&&) final;
 


### PR DESCRIPTION
#### 2fcceeb9c6b0ef543e182c5dc28e64dae6281314
<pre>
Scrubbing a YouTube video in full-screen causes it to exit full-screen mode.
<a href="https://bugs.webkit.org/show_bug.cgi?id=311100">https://bugs.webkit.org/show_bug.cgi?id=311100</a>
<a href="https://rdar.apple.com/172682230">rdar://172682230</a>

Reviewed by Jer Noble.

There were two issues at play:
1- The seeking code relied on a key assumption ; the AudioVideoRenderer will
be flushed and then new samples will be enqueued serially during a seeking operation:
 - No new flush will be issued while samples are being enqueued.
This guarantees that after a flush, the first sample enqueued to the renderer
will always be a keyframe.

When a new seek is started before the prior one completed, it was assumed that the second time
MediaSourcePrivate::waitForTarget was called, any pending promise would be rejected by the MediaSource
which would stop the processing flow of the first seek.
However, the MediaSourcePrivate::waitForTarget isn&apos;t synchronous and isn&apos;t atomic; it will always
take at least two event loop to complete.
It was possible when the new seek came, that the previous waitForTarget promise had been resolved
and was already in-flight. Once received by the MediaPlayerPrivateMediaSourceAVFObjC
it would then seek the AudioVideoRenderer and then enqueue new frames on the SourceBuffer&apos;s workqueue.
The 2nd call to MediaSourcePrivate::waitForTarget would then resolve, and also start
seeking the renderer and once again flush the renderer; all while the SourceBuffer is in the
process on enqueueing new samples.

We properly cancel the MediaSourcePrivate::waitForTarget current operation by using
a NativePromiseRequest to track the completion, and disconnect is as needed.

2- The flush operation was started on the main thread while the samples re-enqueueing was occurring
on the SourceBuffer, the tasks dispatched to flush the renderer and re-enqueue the content could run
out of order.

We restructure the seek operations and MediaPlayerPrivateMediaSourceAVFObjC::startSeek() was restructured
to not require the inner promise resolver to call back into startSeek() again.
AudioVideoRenderer prepareToSeek(MediaTime) , now takes the seek time and
return a MediaTimePromise.
If no seeking is required by the AudioVideoRenderer&apos;s synchronizer, then the promise
is resolved with the current time value to indicate the caller can short circuit and finish the seek early.
Otherwise the promise is resolved with MediaTime::isIndefinite() which indicates that samples need
to be re-enqueued following a flush on their respective tracks.

The AudioVideoRenderer no longer needs to be fully flushed; instead all current tracks
much be individually flushed for the seek operation to continue.

The new flow is more asynchronous and parallelise two tasks:
 - m_mediaSourcePrivate)-&gt;reenqueueMediaForTime(seekTime),
 - m_renderer-&gt;finishSeek(seekTime)
so that the renderer can start waiting for the first sample decoding to complete before all frames have been enqueued.

It also allows the seek to be more easily interrupted and another seek started.

We now track the seek state from within AudioVideoRendereRemote as AudioVideoRendererRemote::seeking() could
have returned a stale value. It also allows to better assert that the API usage of seeking with the AudioVideoRenderer
is correct.

Fly-By: the m_rendererSeekRequest wasn&apos;t always disconnected/completed should an error occur
(such as the GPU process crashing), which would have caused an assertion on debug build.

We add some assertions and logging to more easily detect should the first frame
received after a flush not be a keyframe.

Added test.

* LayoutTests/ipc/serialized-type-info.html:
* LayoutTests/media/media-source/media-source-seek-during-pending-seek-expected.txt: Added.
* LayoutTests/media/media-source/media-source-seek-during-pending-seek.html: Added.
* Source/WTF/wtf/NativePromise.h:
(WTF::GenericPromiseConverter::convertError): Add converter to send a GenericPromise over IPC.
* Source/WebCore/platform/PlatformMediaError.cpp:
(WebCore::convertEnumerationToString):
* Source/WebCore/platform/PlatformMediaError.h:
* Source/WebCore/platform/graphics/AudioVideoRenderer.h:
(WebCore::SynchronizerInterface::prepareToSeek): Deleted.
* Source/WebCore/platform/graphics/MediaSourcePrivate.cpp:
(WebCore::MediaSourcePrivate::waitForTarget):
(WebCore::MediaSourcePrivate::reenqueueMediaForTime):
(WebCore::MediaSourcePrivate::seekToTime): Deleted.
* Source/WebCore/platform/graphics/MediaSourcePrivate.h:
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::reenqueueMediaForTime):
(WebCore::SourceBufferPrivate::isReenqueuePending const):
(WebCore::SourceBufferPrivate::provideMediaData):
(WebCore::SourceBufferPrivate::attach):
(WebCore::SourceBufferPrivate::seekToTime): Deleted.
* Source/WebCore/platform/graphics/SourceBufferPrivate.h:
(WebCore::SourceBufferPrivate::timeFudgeFactor const):
(WebCore::SourceBufferPrivate::isSeeking const): Deleted.
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::enqueueSample):
(WebCore::AudioVideoRendererAVFObjC::isReadyForMoreSamples):
(WebCore::AudioVideoRendererAVFObjC::requestMediaDataWhenReady):
(WebCore::AudioVideoRendererAVFObjC::flush):
(WebCore::AudioVideoRendererAVFObjC::flushTrack):
(WebCore::AudioVideoRendererAVFObjC::setTimeObserver):
(WebCore::AudioVideoRendererAVFObjC::prepareToSeek):
(WebCore::AudioVideoRendererAVFObjC::finishSeek):
(WebCore::AudioVideoRendererAVFObjC::maybeCompleteSeek):
(WebCore::AudioVideoRendererAVFObjC::flushVideo):
(WebCore::AudioVideoRendererAVFObjC::flushAudio):
(WebCore::AudioVideoRendererAVFObjC::flushAudioTrack):
(WebCore::AudioVideoRendererAVFObjC::cancelSeekingPromiseIfNeeded):
(WebCore::AudioVideoRendererAVFObjC::toString const):
(WebCore::AudioVideoRendererAVFObjC::seekTo): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::MediaPlayerPrivateMediaSourceAVFObjC):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::~MediaPlayerPrivateMediaSourceAVFObjC):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::seekInternal):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::continueSeek):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::reenqueueMediaForTimeAndFinishSeek):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::cancelPendingSeek):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::startSeek):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::flush): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::reenqueueMediaForTime): Deleted.
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::seekInternal):
(WebCore::MediaPlayerPrivateWebM::reenqueueMediaForTime):
(WebCore::MediaPlayerPrivateWebM::startSeek): Deleted.
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:
(WebCore::MediaPlayerPrivateGStreamerMSE::doSeek):
* Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp:
(WebCore::MediaSourcePrivateGStreamer::willSeek): Deleted.
* Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp:
(WebCore::SourceBufferPrivateGStreamer::willSeek): Deleted.
(WebCore::SourceBufferPrivateGStreamer::isSeeking const): Deleted.
(WebCore::SourceBufferPrivateGStreamer::seekToTime): Deleted.
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h:
* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp:
(WebCore::MockMediaPlayerMediaSource::seekToTarget):
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp:
(WebKit::RemoteAudioVideoRendererProxyManager::prepareToSeek):
(WebKit::RemoteAudioVideoRendererProxyManager::finishSeek):
(WebKit::RemoteAudioVideoRendererProxyManager::stateFor const):
(WebKit::RemoteAudioVideoRendererProxyManager::seekTo): Deleted.
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h:
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in:
* Source/WebKit/Platform/IPC/Connection.h:
* Source/WebKit/Scripts/webkit/messages.py:
(types_that_cannot_be_forward_declared):
(headers_for_type):
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp:
(WebKit::AudioVideoRendererRemote::AudioVideoRendererRemote):
(WebKit::AudioVideoRendererRemote::cancelPendingSeek):
(WebKit::AudioVideoRendererRemote::prepareToSeek):
(WebKit::AudioVideoRendererRemote::finishSeek):
(WebKit::AudioVideoRendererRemote::seeking const):
(WebKit::AudioVideoRendererRemote::enqueueSample):
(WebKit::AudioVideoRendererRemote::flush):
(WebKit::AudioVideoRendererRemote::~AudioVideoRendererRemote): Deleted.
(WebKit::AudioVideoRendererRemote::seekTo): Deleted.
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioVideoRendererState.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioVideoRendererState.serialization.in:
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp:
(WebKit::SourceBufferPrivateRemote::reenqueueMediaForTime):
(WebKit::SourceBufferPrivateRemote::seekToTime): Deleted.
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h:

Canonical link: <a href="https://commits.webkit.org/310415@main">https://commits.webkit.org/310415@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/00c0e6e9976cde529984bd74194959874c74345b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153626 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26410 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20027 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162376 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107084 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f262fd25-4a4c-4d41-8723-48425f984887) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155499 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26938 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26732 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118779 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84023 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/16da8374-cddc-4b0f-b9f5-c4e18aea88be) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156585 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21028 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137937 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99490 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2d6b8873-0076-43fb-80c4-94a6b176687d) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/152947 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20107 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18054 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10209 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/145639 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129755 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15796 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164847 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/14450 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7981 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17390 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126850 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26207 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22088 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127014 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34487 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26209 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137591 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82877 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21927 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14535 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/185262 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25826 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90113 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47517 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25517 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25677 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25577 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->