### PR TITLE
AX: enable Mac client accessibility tests

### DIFF
--- a/LayoutTests/accessibility/mac/client/absolute-position-iframe.html
+++ b/LayoutTests/accessibility/mac/client/absolute-position-iframe.html
@@ -34,7 +34,10 @@ if (window.accessibilityController) {
         });
 
         // Web area -> iframe -> paragraph -> static text.
-        var text = webArea.childAtIndex(0).childAtIndex(0).childAtIndex(0);
+        await waitFor(() => {
+            text = webArea.childAtIndex(0).childAtIndex(0).childAtIndex(0);
+            return text;
+        });
 
         var pageOrigin = { x: webArea.x, y: webArea.y };
 

--- a/LayoutTests/accessibility/mac/client/div-bounds.html
+++ b/LayoutTests/accessibility/mac/client/div-bounds.html
@@ -51,6 +51,8 @@ if (window.accessibilityController) {
         var div2 = webArea.childAtIndex(1);
         output += `div2 role: ${div2.role}\n`;
 
+        await waitForFrameGeometryReady();
+
         // Check exact sizes
         output += `div1 width: ${div1.width}\n`;
         output += `div1 height: ${div1.height}\n`;

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -123,11 +123,6 @@ fast/dom/Window/slow-unload-handler-only-frame-is-stopped.html
 
 webkit.org/b/306558 accessibility/mac/style-range.html [ Failure ]
 
-# Skip accessibility tests that use the accessibility client API on most builders;
-# requires an extra permission for WKTR
-accessibility/mac/client [ Skip ]
-accessibility/mac/client/button.html [ Pass ]
-
 # Skip glib-only combobox accessibility tests.
 accessibility/combobox/gtk [ Skip ]
 

--- a/Tools/WebKitTestRunner/mac/TestControllerMac.mm
+++ b/Tools/WebKitTestRunner/mac/TestControllerMac.mm
@@ -517,6 +517,13 @@ void TestController::initializeWebProcessAccessibility()
     if (!platformView)
         return;
 
+    // Reduce the messaging timeout. Occasionally an accessibility client request goes to
+    // a web content process before it's ready to serve that request on the AX thread, causing
+    // it to time out. Reduce the timeout from the default of 1.5 seconds to 0.05 seconds so
+    // that it retries quickly and doesn't slow down the test.
+    auto systemWide = adoptCF(AXUIElementCreateSystemWide());
+    AXUIElementSetMessagingTimeout(systemWide.get(), 0.05);
+
     // Trigger accessibility initialization by accessing an accessibility attribute.
     // This will call WebViewImpl::enableAccessibilityIfNecessary() which then calls
     // WebProcessPool::initializeAccessibilityIfNecessary() to send the InitializeAccessibility


### PR DESCRIPTION
#### a166853fded9a3e48c484ed0a8ec91da0c16a770
<pre>
AX: enable Mac client accessibility tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=311031">https://bugs.webkit.org/show_bug.cgi?id=311031</a>
<a href="https://rdar.apple.com/173641509">rdar://173641509</a>

Reviewed by Tyler Wilcock.

Re-enable all of the client accessibility tests in
LayoutTests/accessibility/mac/client now that there are no
roadblocks to them running on EWS.

Two tweaks that improve robustness of the tests:

The div-bounds test just needed an additional waitFor at the
top until all objects have received geometry.

Finally, a new call to AXUIElementSetMessagingTimeout speeds up all of
these tests by reducing the global AX IPC timeout; it turns out that
in many tests, a client AX call was coming in before the AX thread
was ready in the web content process, and the default IPC timeout
was 1.5 seconds, which significantly delayed the test. By reducing
the timeout, it retries quickly and the test passes in much less time.

* LayoutTests/accessibility/mac/client/absolute-position-iframe.html:
* LayoutTests/accessibility/mac/client/div-bounds.html:
* LayoutTests/platform/mac/TestExpectations:
* Tools/WebKitTestRunner/mac/TestControllerMac.mm:
(WTR::TestController::initializeWebProcessAccessibility):

Canonical link: <a href="https://commits.webkit.org/310314@main">https://commits.webkit.org/310314@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7d7fd416b6575adf2a77753baebe79626573c03

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153353 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26137 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19736 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162098 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106811 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155226 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26663 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26457 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118552 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83946 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156312 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20795 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137674 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99264 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19872 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17817 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9933 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129519 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15544 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164572 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17138 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126612 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25933 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21850 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/semantics/structured-clone/shared.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126770 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34408 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25936 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137340 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82603 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21713 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14118 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25553 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25244 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25403 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25304 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->