### PR TITLE
AX: ASSERTION FAILED on AXIsolatedTree.cpp:249 when running http/tests/site-isolation/accessibility/client/simple-iframe.html

### DIFF
--- a/LayoutTests/http/tests/site-isolation/accessibility/client/simple-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/accessibility/client/simple-iframe-expected.txt
@@ -1,16 +1,9 @@
 Dump accessibility tree with isolated iframe
-AXRole: AXScrollArea
+AXRole: AXWebArea
+    AXRole: AXButton Before
     AXRole: AXWebArea
-        AXRole: AXButton Before
-        AXRole: AXScrollArea
-            AXRole: AXGroup null
-                AXRole: AXScrollArea
-                    AXRole: AXWebArea
-                        AXRole: AXHeading Hello, world!
-                            AXRole: AXStaticText
-                    AXRole: AXScrollBar
-                    AXRole: AXScrollBar
-        AXRole: AXButton After
+        AXRole: AXHeading Hello, world!
+    AXRole: AXButton After
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/http/tests/site-isolation/accessibility/client/simple-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/accessibility/client/simple-iframe.html
@@ -6,7 +6,7 @@
 <body>
 
 <button>Before</button>
-  
+
 <iframe id="iframe" src="http://localhost:8000/site-isolation/resources/iframe.html"></iframe>
 
 <button>After</button>
@@ -25,13 +25,20 @@ if (window.accessibilityController) {
             (element) => element.role.includes("Heading"),
         ]);
 
-        const [success, resultString] = dumpAccessibilityTree(/* root = */ accessibilityController.rootElement,
-                                                              /* stop = */ null,
-                                                              /* indent */ 0,
-                                                              /* allAttributesIfNeeded */ false,
-                                                              /* getValueFromTitle */ true,
-                                                              /* includeSubrole */ false);
-        output += resultString;
+        const allowedRoles = ["AXWebArea", "AXButton", "AXHeading"];
+        function dumpFilteredAccessibilityTree(element, indent) {
+            const role = element.role;
+            const matched = allowedRoles.some(r => role.endsWith(r));
+            if (matched) {
+                for (let i = 0; i < indent; i++)
+                    output += "    ";
+                output += role + " " + element.title + "\n";
+            }
+            const childIndent = matched ? indent + 1 : indent;
+            for (let i = 0; i < element.childrenCount; i++)
+                dumpFilteredAccessibilityTree(element.childAtIndex(i), childIndent);
+        }
+        dumpFilteredAccessibilityTree(accessibilityController.rootElement, 0);
         debug(output);
         finishJSTest();
     }, 0);

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -123,6 +123,11 @@ fast/dom/Window/slow-unload-handler-only-frame-is-stopped.html
 
 webkit.org/b/306558 accessibility/mac/style-range.html [ Failure ]
 
+# Site isolation accessibility tests using the accessibility client API:
+# Skip by default, enable tests that are stable.
+http/tests/site-isolation/accessibility/client [ Skip ]
+http/tests/site-isolation/accessibility/client/simple-iframe.html [ Pass ]
+
 # Skip glib-only combobox accessibility tests.
 accessibility/combobox/gtk [ Skip ]
 

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -415,7 +415,7 @@ void AXIsolatedTree::addUnconnectedNode(Ref<AccessibilityObject> axObject)
     m_unconnectedNodes.add(objectID);
 }
 
-void AXIsolatedTree::queueRemovals(Vector<AXID>&& subtreeRemovals)
+void AXIsolatedTree::queueRemovals(Vector<NodeAndParentID>&& subtreeRemovals)
 {
     AX_ASSERT(isMainThread());
 
@@ -423,12 +423,12 @@ void AXIsolatedTree::queueRemovals(Vector<AXID>&& subtreeRemovals)
     queueRemovalsLocked(WTF::move(subtreeRemovals));
 }
 
-void AXIsolatedTree::queueRemovalsLocked(Vector<AXID>&& subtreeRemovals)
+void AXIsolatedTree::queueRemovalsLocked(Vector<NodeAndParentID>&& subtreeRemovals)
 {
     AX_ASSERT(isMainThread());
     AX_ASSERT(m_changeLogLock.isLocked());
 
-    m_pendingSubtreeRemovals.addAll(WTF::move(subtreeRemovals));
+    m_pendingSubtreeRemovals.appendVector(WTF::move(subtreeRemovals));
     m_pendingProtectedFromDeletionIDs.addAll(std::exchange(m_protectedFromDeletionIDs, { }));
 }
 
@@ -478,7 +478,7 @@ Vector<AXIsolatedTree::NodeChange> AXIsolatedTree::resolveAppends()
     return resolvedAppends;
 }
 
-void AXIsolatedTree::queueAppendsAndRemovals(Vector<NodeChange>&& appends, Vector<AXID>&& subtreeRemovals)
+void AXIsolatedTree::queueAppendsAndRemovals(Vector<NodeChange>&& appends, Vector<NodeAndParentID>&& subtreeRemovals)
 {
     AX_ASSERT(isMainThread());
 
@@ -1103,7 +1103,9 @@ void AXIsolatedTree::updateChildren(AccessibilityObject& axObject, ResolveNodeCh
         updateDependentProperties(*axAncestor);
     }
 
-    m_subtreesToRemove.appendVector(WTF::move(oldChildrenIDs));
+    AXID parentID = axAncestor->objectID();
+    for (AXID childID : oldChildrenIDs)
+        m_subtreesToRemove.append({ childID, parentID });
     if (resolveNodeChanges == ResolveNodeChanges::Yes)
         queueRemovalsAndUnresolvedChanges();
 }
@@ -1323,7 +1325,7 @@ void AXIsolatedTree::removeNode(AXID axID, std::optional<AXID> parentID)
 
     m_unresolvedPendingAppends.remove(axID);
     removeSubtreeFromNodeMap(axID, parentID);
-    queueRemovals({ axID });
+    queueRemovals({ { axID, parentID } });
 }
 
 void AXIsolatedTree::removeSubtreeFromNodeMap(std::optional<AXID> objectID, std::optional<AXID> axParentID)
@@ -1429,6 +1431,103 @@ void AXIsolatedTree::clearTreeContentsLocked()
     // will be cleaned up automatically when the tree is destroyed.
 }
 
+// When a node is queued for both subtree removal and appending in the same
+// batch (e.g. when an in-process FrameHost is replaced with an out-of-process
+// one during site isolation), the old subtree snapshot and the new one can
+// both end up in m_pendingAppends. The removal root may not yet be in the
+// node map, so deleteSubtree won't encounter it.
+//
+// For each unique appended ID, this function walks up its parent chain to
+// check whether any ancestor was removed from the same parent it's being
+// appended under. Results are memoized so each node is visited at most once
+// across all walks, giving O(n) total work.
+//
+// Nodes that were removed from one parent but appended under a different
+// parent are reparenting operations and should be kept.
+void AXIsolatedTree::removeStaleAppends(const Vector<NodeAndParentID>& removals)
+{
+    // Build a map from removed AXID to the parent it was removed from, for
+    // O(1) lookups during the ancestor walk.
+    HashMap<AXID, Markable<AXID>> removedNodeToParentMap;
+    for (const auto& removal : removals)
+        removedNodeToParentMap.set(removal.nodeID, removal.parentID);
+
+    // Build a map from appended AXID to its final parentID (last entry wins,
+    // since later appends override earlier ones in the append loop).
+    HashMap<AXID, Markable<AXID>> appendedParentIDs;
+    for (const auto& item : m_pendingAppends)
+        appendedParentIDs.set(item.data.axID, item.data.parentID);
+
+    // For each unique appended ID, walk up the parent chain to determine
+    // whether it or any ancestor was removed from the same parent it's being
+    // appended under. Memoize results so shared ancestors are only resolved
+    // once.
+    HashMap<AXID, bool> ancestorWasRemoved;
+    HashSet<AXID> idsToRemove;
+
+    for (const auto& appendedID : appendedParentIDs.keys()) {
+        if (ancestorWasRemoved.contains(appendedID))
+            continue;
+
+        Vector<AXID> unresolvedAncestors;
+        AXID currentID = appendedID;
+        std::optional<bool> result;
+
+        while (!result) {
+            auto cachedIterator = ancestorWasRemoved.find(currentID);
+            if (cachedIterator != ancestorWasRemoved.end()) {
+                result = cachedIterator->value;
+                break;
+            }
+
+            unresolvedAncestors.append(currentID);
+
+            // Check if this node was removed. If so, compare parents: only
+            // keep it if both parents are known and differ (a reparent).
+            // If either parent is unknown, treat as stale to be safe.
+            auto removedIterator = removedNodeToParentMap.find(currentID);
+            if (removedIterator != removedNodeToParentMap.end()) {
+                auto currentAppendIterator = appendedParentIDs.find(currentID);
+                Markable<AXID> appendedParentID = (currentAppendIterator != appendedParentIDs.end()) ? currentAppendIterator->value : Markable<AXID> { };
+                Markable<AXID> removedParentID = removedIterator->value;
+                bool isReparent = appendedParentID && removedParentID && *appendedParentID != *removedParentID;
+                result = !isReparent;
+                break;
+            }
+
+            // Find this node's parent, first in pending appends, then in
+            // the existing tree.
+            auto appendedIterator = appendedParentIDs.find(currentID);
+            if (appendedIterator != appendedParentIDs.end() && appendedIterator->value) {
+                currentID = *appendedIterator->value;
+                continue;
+            }
+
+            if (auto* existingObject = objectForID(currentID)) {
+                if (auto existingParentID = existingObject->parent()) {
+                    currentID = *existingParentID;
+                    continue;
+                }
+            }
+
+            // Reached a root or dead end — no removed ancestor.
+            result = false;
+        }
+
+        for (const auto& axID : unresolvedAncestors) {
+            ancestorWasRemoved.set(axID, *result);
+            if (*result)
+                idsToRemove.add(axID);
+        }
+    }
+
+    if (!idsToRemove.isEmpty()) {
+        m_pendingAppends.removeAllMatching([&](const NodeChange& change) {
+            return idsToRemove.contains(change.data.axID);
+        });
+    }
+}
+
 void AXIsolatedTree::applyPendingChangesLocked()
 {
     AXTRACE("AXIsolatedTree::applyPendingChanges"_s);
@@ -1454,48 +1553,55 @@ void AXIsolatedTree::applyPendingChangesLocked()
         m_focusedNodeID = m_pendingFocusedNodeID;
     }
 
-    while (m_pendingSubtreeRemovals.size()) {
-        // WTF_IGNORES_THREAD_SAFETY_ANALYSIS because we _do_ hold the m_changeLogLock, but the thread-safety
-        // analysis throws a false-positive compile error when we access m_pendingProtectedFromDeletionIDs in
-        // this lambda.
-        std::function<void(Ref<AXCoreObject>&&)> deleteSubtree = [this, protectedThis = Ref { *this }, &deleteSubtree] (Ref<AXCoreObject>&& coreObjectToDelete) WTF_IGNORES_THREAD_SAFETY_ANALYSIS {
-            auto& objectToDelete = downcast<AXIsolatedObject>(coreObjectToDelete.get());
-            while (objectToDelete.m_children.size()) {
-                Ref child = objectToDelete.m_children.takeLast();
-                if (!m_pendingProtectedFromDeletionIDs.contains(child->objectID()))
-                    deleteSubtree(WTF::move(child));
+    // Snapshot the IDs pending subtree removal before processing, so we can
+    // use them to filter stale nodes from m_pendingAppends afterwards. This is
+    // necessary because a pending removal root may not yet be in the node map
+    // (e.g. when an in-process FrameHost is replaced with an out-of-process
+    // one during site isolation), so deleteSubtree won't encounter it.
+    auto removedIDs = std::exchange(m_pendingSubtreeRemovals, { });
+
+    // WTF_IGNORES_THREAD_SAFETY_ANALYSIS because we _do_ hold the m_changeLogLock, but the thread-safety
+    // analysis throws a false-positive compile error when we access m_pendingProtectedFromDeletionIDs in
+    // this lambda.
+    std::function<void(Ref<AXCoreObject>&&)> deleteSubtree = [this, protectedThis = Ref { *this }, &deleteSubtree] (Ref<AXCoreObject>&& coreObjectToDelete) WTF_IGNORES_THREAD_SAFETY_ANALYSIS {
+        auto& objectToDelete = downcast<AXIsolatedObject>(coreObjectToDelete.get());
+        while (objectToDelete.m_children.size()) {
+            Ref child = objectToDelete.m_children.takeLast();
+            if (!m_pendingProtectedFromDeletionIDs.contains(child->objectID()))
+                deleteSubtree(WTF::move(child));
+        }
+
+        // There's no need to call the more comprehensive AXCoreObject::detach here since
+        // we're deleting the entire subtree of this object and thus don't need to `detachRemoteParts`.
+        objectToDelete.detachWrapper(AccessibilityDetachmentType::ElementDestroyed);
+
+        AXID deleteAXID = objectToDelete.objectID();
+        m_readerThreadNodeMap.remove(deleteAXID);
+
+        for (const AXID& childID : objectToDelete.m_unresolvedChildrenIDs) {
+            // Ideally, assuming m_children has been initialized, there would be no unresolved children IDs.
+            // But sometimes when initializing m_children, AXIsolatedTree::objectForID fails for an unknown
+            // reason, and thus we are left with an entry in m_unresolvedChildrenIDs. See the ASSERT in
+            // AXIsolatedObject::children. In case any of our unresolved IDs got populated with an object
+            // later somehow, try to clean them up.
+            if (!m_pendingProtectedFromDeletionIDs.contains(childID)) {
+                if (RefPtr child = m_readerThreadNodeMap.take(childID))
+                    deleteSubtree(child.releaseNonNull());
             }
+        }
+    };
 
-            // There's no need to call the more comprehensive AXCoreObject::detach here since
-            // we're deleting the entire subtree of this object and thus don't need to `detachRemoteParts`.
-            objectToDelete.detachWrapper(AccessibilityDetachmentType::ElementDestroyed);
-
-            auto deleteAXID = objectToDelete.objectID();
-            m_readerThreadNodeMap.remove(deleteAXID);
-            m_pendingSubtreeRemovals.remove(deleteAXID);
-
-            for (const AXID& childID : objectToDelete.m_unresolvedChildrenIDs) {
-                // Ideally, assuming m_children has been initialized, there would be no unresolved children IDs.
-                // But sometimes when initializing m_children, AXIsolatedTree::objectForID fails for an unknown
-                // reason, and thus we are left with an entry in m_unresolvedChildrenIDs. See the ASSERT in
-                // AXIsolatedObject::children. In case any of our unresolved IDs got populated with an object
-                // later somehow, try to clean them up.
-                if (!m_pendingProtectedFromDeletionIDs.contains(childID)) {
-                    if (RefPtr child = m_readerThreadNodeMap.take(childID))
-                        deleteSubtree(child.releaseNonNull());
-                }
-            }
-        };
-
-        // This dereference is safe because we checked m_pendingSubtreeRemovals.size() to get here.
-        auto axID = *m_pendingSubtreeRemovals.takeAny();
-        if (m_pendingProtectedFromDeletionIDs.contains(axID))
+    for (const auto& removal : removedIDs) {
+        if (m_pendingProtectedFromDeletionIDs.contains(removal.nodeID))
             continue;
 
-        if (RefPtr object = m_readerThreadNodeMap.take(axID))
+        if (RefPtr object = m_readerThreadNodeMap.take(removal.nodeID))
             deleteSubtree(object.releaseNonNull());
     }
     m_pendingProtectedFromDeletionIDs.clear();
+
+    if (!removedIDs.isEmpty())
+        removeStaleAppends(removedIDs);
 
     for (auto& item : m_pendingAppends) {
         auto axID = item.data.axID;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -382,6 +382,11 @@ struct NodeUpdateOptions {
 
 void setPropertyIn(AXProperty, AXPropertyValueVariant&&, AXPropertyVector&, OptionSet<AXPropertyFlag>&);
 
+struct NodeAndParentID {
+    AXID nodeID;
+    Markable<AXID> parentID;
+};
+
 struct IsolatedObjectData {
     Vector<AXID> childrenIDs;
     AXPropertyVector properties;
@@ -575,6 +580,7 @@ private:
     void queueForDestruction();
 
     void applyPendingChangesLocked() WTF_REQUIRES_LOCK(m_changeLogLock);
+    void removeStaleAppends(const Vector<NodeAndParentID>&) WTF_REQUIRES_LOCK(m_changeLogLock);
     void clearTreeContentsLocked() WTF_REQUIRES_LOCK(m_changeLogLock);
 
     static std::atomic<bool> s_anyTreeNeedsTearDown;
@@ -610,11 +616,11 @@ private:
     void collectNodeChangesForSubtree(AccessibilityObject&);
     bool isCollectingNodeChanges() const { return m_isCollectingNodeChanges; }
     void queueChange(NodeChange&&) WTF_REQUIRES_LOCK(m_changeLogLock);
-    void queueRemovals(Vector<AXID>&&);
-    void queueRemovalsLocked(Vector<AXID>&&) WTF_REQUIRES_LOCK(m_changeLogLock);
+    void queueRemovals(Vector<NodeAndParentID>&&);
+    void queueRemovalsLocked(Vector<NodeAndParentID>&&) WTF_REQUIRES_LOCK(m_changeLogLock);
     void queueRemovalsAndUnresolvedChanges();
     Vector<NodeChange> resolveAppends();
-    void queueAppendsAndRemovals(Vector<NodeChange>&&, Vector<AXID>&&);
+    void queueAppendsAndRemovals(Vector<NodeChange>&&, Vector<NodeAndParentID>&&);
 
     void objectChangedIgnoredState(const AccessibilityObject&);
 
@@ -646,7 +652,7 @@ private:
     // While performing tree updates, we append nodes to this list that are no longer connected
     // in the tree and should be removed. This list turns into m_pendingSubtreeRemovals when
     // handed off to the secondary thread.
-    Vector<AXID> m_subtreesToRemove;
+    Vector<NodeAndParentID> m_subtreesToRemove;
     // Only accessed on the main thread.
     // This is used when updating the isolated tree in response to dynamic children changes.
     // It is required to protect objects from being incorrectly deleted when they are re-parented,
@@ -665,7 +671,7 @@ private:
     Markable<AXID> m_pendingRootNodeID WTF_GUARDED_BY_LOCK(m_changeLogLock);
     Vector<NodeChange> m_pendingAppends WTF_GUARDED_BY_LOCK(m_changeLogLock); // Nodes to be added to the tree and platform-wrapped.
     Vector<AXPropertyChange> m_pendingPropertyChanges WTF_GUARDED_BY_LOCK(m_changeLogLock);
-    HashSet<AXID> m_pendingSubtreeRemovals WTF_GUARDED_BY_LOCK(m_changeLogLock); // Nodes whose subtrees are to be removed from the tree.
+    Vector<NodeAndParentID> m_pendingSubtreeRemovals WTF_GUARDED_BY_LOCK(m_changeLogLock); // Nodes whose subtrees are to be removed from the tree, paired with the parent they were removed from.
     Vector<std::pair<AXID, Vector<AXID>>> m_pendingChildrenUpdates WTF_GUARDED_BY_LOCK(m_changeLogLock);
     HashSet<AXID> m_pendingProtectedFromDeletionIDs WTF_GUARDED_BY_LOCK(m_changeLogLock);
     HashMap<AXID, AXID> m_pendingParentUpdates WTF_GUARDED_BY_LOCK(m_changeLogLock);

--- a/Source/WebKit/UIProcess/API/C/WKContext.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKContext.cpp
@@ -320,6 +320,11 @@ void WKContextSetDisableFontSubpixelAntialiasingForTesting(WKContextRef contextR
     protect(WebKit::toImpl(contextRef))->setDisableFontSubpixelAntialiasingForTesting(disable);
 }
 
+void WKContextSetAllowAXAuthenticationForTesting(WKContextRef contextRef, bool allow)
+{
+    protect(WebKit::toImpl(contextRef))->setAllowAXAuthenticationForTesting(allow);
+}
+
 void WKContextSetAdditionalPluginsDirectory(WKContextRef contextRef, WKStringRef pluginsDirectory)
 {
     UNUSED_PARAM(contextRef);

--- a/Source/WebKit/UIProcess/API/C/WKContextPrivate.h
+++ b/Source/WebKit/UIProcess/API/C/WKContextPrivate.h
@@ -100,6 +100,8 @@ WK_EXPORT void WKContextClearSupportedPlugins(WKContextRef context);
 
 WK_EXPORT void WKContextClearCurrentModifierStateForTesting(WKContextRef context);
 
+WK_EXPORT void WKContextSetAllowAXAuthenticationForTesting(WKContextRef context, bool allow);
+
 WK_EXPORT void WKContextSetUseSeparateServiceWorkerProcess(WKContextRef context, bool forceServiceWorkerProcess);
 
 WK_EXPORT void WKContextSetPrimaryWebsiteDataStore(WKContextRef context, WKWebsiteDataStoreRef websiteDataStore);

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
@@ -200,6 +200,10 @@ void WebProcessProxy::unblockAccessibilityServerIfNeeded()
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)
 void WebProcessProxy::isAXAuthenticated(CoreIPCAuditToken&& auditToken, CompletionHandler<void(bool)>&& completionHandler)
 {
+    if (processPool().allowAXAuthenticationForTesting()) {
+        completionHandler(true);
+        return;
+    }
     auto authenticated = TCCAccessCheckAuditToken(get_TCC_kTCCServiceAccessibilitySingleton(), auditToken.auditToken(), nullptr);
     completionHandler(authenticated);
 }

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -631,6 +631,9 @@ public:
     void initializeAccessibilityIfNecessary();
 #endif
 
+    void setAllowAXAuthenticationForTesting(bool allow) { m_allowAXAuthenticationForTesting = allow; }
+    bool allowAXAuthenticationForTesting() const { return m_allowAXAuthenticationForTesting; }
+
     void setPLTResourceDelayInterval(Seconds interval) { m_pltResourceDelayInterval = interval; }
     Seconds pltResourceDelayInterval() const { return m_pltResourceDelayInterval; }
 
@@ -1039,6 +1042,7 @@ private:
 #endif
 
     bool m_hasReceivedAXRequestInUIProcess { false };
+    bool m_allowAXAuthenticationForTesting { false };
     bool m_suppressEDR { false };
 
     Seconds m_pltResourceDelayInterval { 100_ms };

--- a/Tools/WebKitTestRunner/mac/TestControllerMac.mm
+++ b/Tools/WebKitTestRunner/mac/TestControllerMac.mm
@@ -517,6 +517,11 @@ void TestController::initializeWebProcessAccessibility()
     if (!platformView)
         return;
 
+    // Allow all accessibility authentication requests for testing, so that
+    // site-isolated iframe web content processes can be accessed by AX clients
+    // without requiring TCC accessibility permission.
+    WKContextSetAllowAXAuthenticationForTesting(m_context.get(), true);
+
     // Reduce the messaging timeout. Occasionally an accessibility client request goes to
     // a web content process before it's ready to serve that request on the AX thread, causing
     // it to time out. Reduce the timeout from the default of 1.5 seconds to 0.05 seconds so


### PR DESCRIPTION
#### 8c8159f34720c0fbf31c175d57b843a38a33f1d7
<pre>
AX: ASSERTION FAILED on AXIsolatedTree.cpp:249 when running http/tests/site-isolation/accessibility/client/simple-iframe.html
<a href="https://rdar.apple.com/173698630">rdar://173698630</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=311114">https://bugs.webkit.org/show_bug.cgi?id=311114</a>

Reviewed by Tyler Wilcock.

I intermittently hit this assertion failure when running
http/tests/site-isolation/accessibility/client/simple-iframe.html,
which tests accessibility with site isolation. By fiddling with the
test timing I was able to reproduce it reliably.

ASSERTION FAILED: AX: After applying pending root node, 15 reachable nodes but 17 are in the node map
reachableNodes.size() == m_readerThreadNodeMap.size()
/Volumes/Code/safari/OpenSource/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp(249) : void WebCore::AXIsolatedTree::applyPendingRootNodeLocked()
1   WebCore::AXIsolatedTree::applyPendingRootNodeLocked()
2   WebCore::AXIsolatedTree::applyPendingChangesLocked()
3   WebCore::AXIsolatedTree::applyPendingChanges()

The bug happens when the in-process FrameHost (AccessibilityScrollView)
is replaced with the out-of-process FrameHost, and then the FrameHost ends up in
both m_pendingSubtreeRemovals and m_pendingAppends in applyPendingChangesLocked.

We never hit this before because it doesn&apos;t happen with DOM nodes or
LayoutObjects - if the old object was removed from the AX cache, then
it won&apos;t end up in m_pendingAppends. In this case both the old Widget
and the new Widget exist, so the assertion is telling us we&apos;re leaking
the old isolated objects.

With this fix, and with also implementing the allowAXAuthenticationForTesting
check in the UI process to allow client accessibility APIs to succeed for any
process, http/tests/site-isolation/accessibility/client/simple-iframe.html can be enabled.

* LayoutTests/http/tests/site-isolation/accessibility/client/simple-iframe-expected.txt:
* LayoutTests/http/tests/site-isolation/accessibility/client/simple-iframe.html:
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::queueRemovals):
(WebCore::AXIsolatedTree::queueRemovalsLocked):
(WebCore::AXIsolatedTree::queueAppendsAndRemovals):
(WebCore::AXIsolatedTree::updateChildren):
(WebCore::AXIsolatedTree::removeNode):
(WebCore::AXIsolatedTree::removeStaleAppends):
(WebCore::AXIsolatedTree::applyPendingChangesLocked):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
* Source/WebKit/UIProcess/API/C/WKContext.cpp:
(WKContextSetAllowAXAuthenticationForTesting):
* Source/WebKit/UIProcess/API/C/WKContextPrivate.h:
* Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm:
(WebKit::WebProcessProxy::isAXAuthenticated):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Tools/WebKitTestRunner/mac/TestControllerMac.mm:
(WTR::TestController::initializeWebProcessAccessibility):

Canonical link: <a href="https://commits.webkit.org/310800@main">https://commits.webkit.org/310800@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1cdbe10636467fd40f95cec637fca29b1df3b320

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154945 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28204 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21364 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163705 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108416 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/22fdcd5d-61c3-4580-a722-c641e62c0268) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156818 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28343 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28053 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119879 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84732 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157904 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22155 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139148 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100572 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21240 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19266 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11531 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130902 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16992 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166180 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9702 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18601 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127979 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27749 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23305 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128118 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34774 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27673 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138785 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84382 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22997 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15580 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27365 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91469 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26943 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27174 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27016 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->