### PR TITLE
Split "flags" structs out of Style::ComputedStyleBase

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3118,11 +3118,13 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/computed/data/StyleGridData.h
     style/computed/data/StyleGridItemData.h
     style/computed/data/StyleInheritedData.h
+    style/computed/data/StyleInheritedFlags.h
     style/computed/data/StyleInheritedRareData.h
     style/computed/data/StyleMarqueeData.h
     style/computed/data/StyleMaskBorderData.h
     style/computed/data/StyleMultiColumnData.h
     style/computed/data/StyleNonInheritedData.h
+    style/computed/data/StyleNonInheritedFlags.h
     style/computed/data/StyleNonInheritedMiscData.h
     style/computed/data/StyleNonInheritedRareData.h
     style/computed/data/StyleSurroundData.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3199,11 +3199,13 @@ style/computed/data/StyleFontData.cpp
 style/computed/data/StyleGridData.cpp
 style/computed/data/StyleGridItemData.cpp
 style/computed/data/StyleInheritedData.cpp
+style/computed/data/StyleInheritedFlags.cpp
 style/computed/data/StyleInheritedRareData.cpp
 style/computed/data/StyleMarqueeData.cpp
 style/computed/data/StyleMaskBorderData.cpp
 style/computed/data/StyleMultiColumnData.cpp
 style/computed/data/StyleNonInheritedData.cpp
+style/computed/data/StyleNonInheritedFlags.cpp
 style/computed/data/StyleNonInheritedMiscData.cpp
 style/computed/data/StyleNonInheritedRareData.cpp
 style/computed/data/StyleSVGData.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -5026,6 +5026,8 @@
 		BC2B41192732F42900A2D191 /* ModelPlayerClient.h in Headers */ = {isa = PBXBuildFile; fileRef = BC2B410E2732EFE400A2D191 /* ModelPlayerClient.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC2B41252733600500A2D191 /* DummyModelPlayer.h in Headers */ = {isa = PBXBuildFile; fileRef = BC2B412327335E1F00A2D191 /* DummyModelPlayer.h */; };
 		BC2B41312734A08600A2D191 /* DummyModelPlayerProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = BC2B412027335CB900A2D191 /* DummyModelPlayerProvider.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BC2C010A2F7AE1B800F65FC9 /* StyleInheritedFlags.h in Headers */ = {isa = PBXBuildFile; fileRef = BC2C01062F7AE0A700F65FC9 /* StyleInheritedFlags.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BC2C010B2F7AE1B800F65FC9 /* StyleNonInheritedFlags.h in Headers */ = {isa = PBXBuildFile; fileRef = BC2C01082F7AE0AF00F65FC9 /* StyleNonInheritedFlags.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC2C0BEC2D284F7B00FCFBA0 /* CSSValueConcepts.h in Headers */ = {isa = PBXBuildFile; fileRef = BC2C0BEB2D284F7B00FCFBA0 /* CSSValueConcepts.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC2C0C2B2D2C6A4700FCFBA0 /* StyleScrollPadding.h in Headers */ = {isa = PBXBuildFile; fileRef = BC2C0C242D2C5D2B00FCFBA0 /* StyleScrollPadding.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC2C0C2C2D2C6A5600FCFBA0 /* StyleScrollMargin.h in Headers */ = {isa = PBXBuildFile; fileRef = BC2C0C222D2C5D2B00FCFBA0 /* StyleScrollMargin.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -18788,6 +18790,10 @@
 		BC2B412127335CB900A2D191 /* DummyModelPlayerProvider.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = DummyModelPlayerProvider.cpp; sourceTree = "<group>"; };
 		BC2B412327335E1F00A2D191 /* DummyModelPlayer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DummyModelPlayer.h; sourceTree = "<group>"; };
 		BC2B412427335E1F00A2D191 /* DummyModelPlayer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = DummyModelPlayer.cpp; sourceTree = "<group>"; };
+		BC2C01062F7AE0A700F65FC9 /* StyleInheritedFlags.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleInheritedFlags.h; sourceTree = "<group>"; };
+		BC2C01072F7AE0A700F65FC9 /* StyleInheritedFlags.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleInheritedFlags.cpp; sourceTree = "<group>"; };
+		BC2C01082F7AE0AF00F65FC9 /* StyleNonInheritedFlags.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleNonInheritedFlags.h; sourceTree = "<group>"; };
+		BC2C01092F7AE0AF00F65FC9 /* StyleNonInheritedFlags.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleNonInheritedFlags.cpp; sourceTree = "<group>"; };
 		BC2C0BEB2D284F7B00FCFBA0 /* CSSValueConcepts.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CSSValueConcepts.h; sourceTree = "<group>"; };
 		BC2C0C222D2C5D2B00FCFBA0 /* StyleScrollMargin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleScrollMargin.h; sourceTree = "<group>"; };
 		BC2C0C232D2C5D2B00FCFBA0 /* StyleScrollMargin.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleScrollMargin.cpp; sourceTree = "<group>"; };
@@ -37163,6 +37169,8 @@
 				BC63ACE62F08340A007B62C4 /* StyleGridItemData.h */,
 				BC63ACE92F08340A007B62C4 /* StyleInheritedData.cpp */,
 				BC63ACE82F08340A007B62C4 /* StyleInheritedData.h */,
+				BC2C01072F7AE0A700F65FC9 /* StyleInheritedFlags.cpp */,
+				BC2C01062F7AE0A700F65FC9 /* StyleInheritedFlags.h */,
 				BC63AD502F085657007B62C4 /* StyleInheritedRareData.cpp */,
 				BC63AD4F2F085657007B62C4 /* StyleInheritedRareData.h */,
 				BC63ACFA2F083F79007B62C4 /* StyleMarqueeData.cpp */,
@@ -37173,6 +37181,8 @@
 				BC63AD012F084141007B62C4 /* StyleMultiColumnData.h */,
 				BC63ACEB2F08340A007B62C4 /* StyleNonInheritedData.cpp */,
 				BC63ACEA2F08340A007B62C4 /* StyleNonInheritedData.h */,
+				BC2C01092F7AE0AF00F65FC9 /* StyleNonInheritedFlags.cpp */,
+				BC2C01082F7AE0AF00F65FC9 /* StyleNonInheritedFlags.h */,
 				BC63AD4A2F08561F007B62C4 /* StyleNonInheritedMiscData.cpp */,
 				BC63AD492F08561F007B62C4 /* StyleNonInheritedMiscData.h */,
 				BC63AD4C2F08561F007B62C4 /* StyleNonInheritedRareData.cpp */,
@@ -47824,6 +47834,7 @@
 				BC731E752E636D8700A6584F /* StyleImageOrNone.h in Headers */,
 				BC22AA9E2E36A2BD009AC0C3 /* StyleImageWrapper.h in Headers */,
 				BC63AD3E2F084C2F007B62C4 /* StyleInheritedData.h in Headers */,
+				BC2C010A2F7AE1B800F65FC9 /* StyleInheritedFlags.h in Headers */,
 				BC63AD512F08565F007B62C4 /* StyleInheritedRareData.h in Headers */,
 				BC9ABA192DED227400F7E52D /* StyleInset.h in Headers */,
 				BCB272092CC1F1DB00265123 /* StyleInsetFunction.h in Headers */,
@@ -47867,6 +47878,7 @@
 				BC63AD312F084C2F007B62C4 /* StyleMultiColumnData.h in Headers */,
 				BC452A6F2ED0FF4700FD066C /* StyleNameScope.h in Headers */,
 				BC63AD362F084C2F007B62C4 /* StyleNonInheritedData.h in Headers */,
+				BC2C010B2F7AE1B800F65FC9 /* StyleNonInheritedFlags.h in Headers */,
 				BC63AD4D2F085646007B62C4 /* StyleNonInheritedMiscData.h in Headers */,
 				BC63AD4E2F085646007B62C4 /* StyleNonInheritedRareData.h in Headers */,
 				BCD9F1752E203A0200D1C3DF /* StyleObjectPosition.h in Headers */,

--- a/Source/WebCore/css/scripts/process-css-properties.py
+++ b/Source/WebCore/css/scripts/process-css-properties.py
@@ -6384,6 +6384,7 @@ class GenerateStyleComputedStyleProperties:
             self.generation_context.generate_includes(
                 to=writer,
                 system_headers=[
+                    "<WebCore/CSSPropertyNames.h>",
                     "<WebCore/StyleComputedStyleBase.h>",
                 ]
             )

--- a/Source/WebCore/css/scripts/test/TestCSSPropertiesResults/StyleComputedStyleProperties.h
+++ b/Source/WebCore/css/scripts/test/TestCSSPropertiesResults/StyleComputedStyleProperties.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <WebCore/CSSPropertyNames.h>
 #include <WebCore/StyleComputedStyleBase.h>
 
 namespace WebCore {

--- a/Source/WebCore/css/scripts/test/TestCSSPropertiesResults/StyleExtractorGenerated.cpp
+++ b/Source/WebCore/css/scripts/test/TestCSSPropertiesResults/StyleExtractorGenerated.cpp
@@ -16,82 +16,82 @@ namespace Style {
 
 class ExtractorFunctions {
 public:
-    static RefPtr<CSSValue> NODELETE extractBackgroundCoordinatedValueListPropertyTestDiscrete(ExtractorState& extractorState)
+    static RefPtr<CSSValue> extractBackgroundCoordinatedValueListPropertyTestDiscrete(ExtractorState& extractorState)
     {
         auto mapper = [](auto& extractorState, const auto& value, const std::optional<BackgroundLayers::value_type>&, const auto&) -> Ref<CSSValue> {
             return createCSSValue(extractorState.pool, extractorState.style, value);
         };
         return extractCoordinatedValueListValue<CSSPropertyID::CSSPropertyBackgroundCoordinatedValueListPropertyTestDiscrete>(extractorState, extractorState.style.computedStyle().backgroundLayers(), mapper);
     }
-    static void NODELETE extractBackgroundCoordinatedValueListPropertyTestDiscreteSerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
+    static void extractBackgroundCoordinatedValueListPropertyTestDiscreteSerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
     {
         auto mapper = [](auto& extractorState, auto& builder, const auto& context, const auto& value, const std::optional<BackgroundLayers::value_type>&, const auto&) {
             serializationForCSS(builder, context, extractorState.style, value);
         };
         extractCoordinatedValueListSerialization<CSSPropertyID::CSSPropertyBackgroundCoordinatedValueListPropertyTestDiscrete>(extractorState, builder, context, extractorState.style.computedStyle().backgroundLayers(), mapper);
     }
-    static RefPtr<CSSValue> NODELETE extractBackgroundCoordinatedValueListPropertyTestTwo(ExtractorState& extractorState)
+    static RefPtr<CSSValue> extractBackgroundCoordinatedValueListPropertyTestTwo(ExtractorState& extractorState)
     {
         auto mapper = [](auto& extractorState, const auto& value, const std::optional<BackgroundLayers::value_type>&, const auto&) -> Ref<CSSValue> {
             return createCSSValue(extractorState.pool, extractorState.style, value);
         };
         return extractCoordinatedValueListValue<CSSPropertyID::CSSPropertyBackgroundCoordinatedValueListPropertyTestTwo>(extractorState, extractorState.style.computedStyle().backgroundLayers(), mapper);
     }
-    static void NODELETE extractBackgroundCoordinatedValueListPropertyTestTwoSerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
+    static void extractBackgroundCoordinatedValueListPropertyTestTwoSerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
     {
         auto mapper = [](auto& extractorState, auto& builder, const auto& context, const auto& value, const std::optional<BackgroundLayers::value_type>&, const auto&) {
             serializationForCSS(builder, context, extractorState.style, value);
         };
         extractCoordinatedValueListSerialization<CSSPropertyID::CSSPropertyBackgroundCoordinatedValueListPropertyTestTwo>(extractorState, builder, context, extractorState.style.computedStyle().backgroundLayers(), mapper);
     }
-    static RefPtr<CSSValue> NODELETE extractTestAnimationWrapper(ExtractorState& extractorState)
+    static RefPtr<CSSValue> extractTestAnimationWrapper(ExtractorState& extractorState)
     {
         return createCSSValue(extractorState.pool, extractorState.style, extractorState.style.computedStyle().testAnimationWrapper());
     }
-    static void NODELETE extractTestAnimationWrapperSerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
+    static void extractTestAnimationWrapperSerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
     {
         serializationForCSS(builder, context, extractorState.style, extractorState.style.computedStyle().testAnimationWrapper());
     }
-    static RefPtr<CSSValue> NODELETE extractTestAnimationWrapperAccelerationAlways(ExtractorState& extractorState)
+    static RefPtr<CSSValue> extractTestAnimationWrapperAccelerationAlways(ExtractorState& extractorState)
     {
         return createCSSValue(extractorState.pool, extractorState.style, extractorState.style.computedStyle().testAnimationWrapperAccelerationAlways());
     }
-    static void NODELETE extractTestAnimationWrapperAccelerationAlwaysSerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
+    static void extractTestAnimationWrapperAccelerationAlwaysSerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
     {
         serializationForCSS(builder, context, extractorState.style, extractorState.style.computedStyle().testAnimationWrapperAccelerationAlways());
     }
-    static RefPtr<CSSValue> NODELETE extractTestAnimationWrapperAccelerationThreadedOnly(ExtractorState& extractorState)
+    static RefPtr<CSSValue> extractTestAnimationWrapperAccelerationThreadedOnly(ExtractorState& extractorState)
     {
         return createCSSValue(extractorState.pool, extractorState.style, extractorState.style.computedStyle().testAnimationWrapperAccelerationThreadedOnly());
     }
-    static void NODELETE extractTestAnimationWrapperAccelerationThreadedOnlySerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
+    static void extractTestAnimationWrapperAccelerationThreadedOnlySerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
     {
         serializationForCSS(builder, context, extractorState.style, extractorState.style.computedStyle().testAnimationWrapperAccelerationThreadedOnly());
     }
-    static RefPtr<CSSValue> NODELETE extractTestColor(ExtractorState& extractorState)
+    static RefPtr<CSSValue> extractTestColor(ExtractorState& extractorState)
     {
         return createCSSValue(extractorState.pool, extractorState.style, extractorState.style.computedStyle().testColor());
     }
-    static void NODELETE extractTestColorSerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
+    static void extractTestColorSerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
     {
         serializationForCSS(builder, context, extractorState.style, extractorState.style.computedStyle().testColor());
     }
-    static RefPtr<CSSValue> NODELETE extractTestColorAllowsTypesAbsolute(ExtractorState& extractorState)
+    static RefPtr<CSSValue> extractTestColorAllowsTypesAbsolute(ExtractorState& extractorState)
     {
         return createCSSValue(extractorState.pool, extractorState.style, extractorState.style.computedStyle().testColorAllowsTypesAbsolute());
     }
-    static void NODELETE extractTestColorAllowsTypesAbsoluteSerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
+    static void extractTestColorAllowsTypesAbsoluteSerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
     {
         serializationForCSS(builder, context, extractorState.style, extractorState.style.computedStyle().testColorAllowsTypesAbsolute());
     }
-    static RefPtr<CSSValue> NODELETE extractTestColorPropertyWithVisitedLinkSupport(ExtractorState& extractorState)
+    static RefPtr<CSSValue> extractTestColorPropertyWithVisitedLinkSupport(ExtractorState& extractorState)
     {
         if (extractorState.allowVisitedStyle) {
             return extractorState.pool.createColorValue(extractorState.style.visitedDependentTestColorPropertyWithVisitedLinkSupport());
         }
         return createCSSValue(extractorState.pool, extractorState.style, extractorState.style.computedStyle().testColorPropertyWithVisitedLinkSupport());
     }
-    static void NODELETE extractTestColorPropertyWithVisitedLinkSupportSerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
+    static void extractTestColorPropertyWithVisitedLinkSupportSerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
     {
         if (extractorState.allowVisitedStyle) {
             builder.append(WebCore::serializationForCSS(extractorState.style.visitedDependentTestColorPropertyWithVisitedLinkSupport()));
@@ -99,107 +99,107 @@ public:
         }
         serializationForCSS(builder, context, extractorState.style, extractorState.style.computedStyle().testColorPropertyWithVisitedLinkSupport());
     }
-    static RefPtr<CSSValue> NODELETE extractTestRenderStyleHasExplicitlySetPolicyAllAuthorOrigin(ExtractorState& extractorState)
+    static RefPtr<CSSValue> extractTestRenderStyleHasExplicitlySetPolicyAllAuthorOrigin(ExtractorState& extractorState)
     {
         return createCSSValue(extractorState.pool, extractorState.style, extractorState.style.computedStyle().testRenderStyleHasExplicitlySetPolicyAllAuthorOrigin());
     }
-    static void NODELETE extractTestRenderStyleHasExplicitlySetPolicyAllAuthorOriginSerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
+    static void extractTestRenderStyleHasExplicitlySetPolicyAllAuthorOriginSerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
     {
         serializationForCSS(builder, context, extractorState.style, extractorState.style.computedStyle().testRenderStyleHasExplicitlySetPolicyAllAuthorOrigin());
     }
-    static RefPtr<CSSValue> NODELETE extractTestRenderStyleHasExplicitlySetPolicyAllBorderRadius(ExtractorState& extractorState)
+    static RefPtr<CSSValue> extractTestRenderStyleHasExplicitlySetPolicyAllBorderRadius(ExtractorState& extractorState)
     {
         return createCSSValue(extractorState.pool, extractorState.style, extractorState.style.computedStyle().testRenderStyleHasExplicitlySetPolicyAllBorderRadius());
     }
-    static void NODELETE extractTestRenderStyleHasExplicitlySetPolicyAllBorderRadiusSerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
+    static void extractTestRenderStyleHasExplicitlySetPolicyAllBorderRadiusSerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
     {
         serializationForCSS(builder, context, extractorState.style, extractorState.style.computedStyle().testRenderStyleHasExplicitlySetPolicyAllBorderRadius());
     }
-    static RefPtr<CSSValue> NODELETE extractTestRenderStyleHasExplicitlySetPolicyValueOnly(ExtractorState& extractorState)
+    static RefPtr<CSSValue> extractTestRenderStyleHasExplicitlySetPolicyValueOnly(ExtractorState& extractorState)
     {
         return createCSSValue(extractorState.pool, extractorState.style, extractorState.style.computedStyle().testRenderStyleHasExplicitlySetPolicyValueOnly());
     }
-    static void NODELETE extractTestRenderStyleHasExplicitlySetPolicyValueOnlySerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
+    static void extractTestRenderStyleHasExplicitlySetPolicyValueOnlySerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
     {
         serializationForCSS(builder, context, extractorState.style, extractorState.style.computedStyle().testRenderStyleHasExplicitlySetPolicyValueOnly());
     }
-    static RefPtr<CSSValue> NODELETE extractTestRenderStyleStorageOneLevelEnum(ExtractorState& extractorState)
+    static RefPtr<CSSValue> extractTestRenderStyleStorageOneLevelEnum(ExtractorState& extractorState)
     {
         return createCSSValue(extractorState.pool, extractorState.style, extractorState.style.computedStyle().testRenderStyleStorageOneLevelEnum());
     }
-    static void NODELETE extractTestRenderStyleStorageOneLevelEnumSerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
+    static void extractTestRenderStyleStorageOneLevelEnumSerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
     {
         serializationForCSS(builder, context, extractorState.style, extractorState.style.computedStyle().testRenderStyleStorageOneLevelEnum());
     }
-    static RefPtr<CSSValue> NODELETE extractTestRenderStyleStorageOneLevelRaw(ExtractorState& extractorState)
+    static RefPtr<CSSValue> extractTestRenderStyleStorageOneLevelRaw(ExtractorState& extractorState)
     {
         return createCSSValue(extractorState.pool, extractorState.style, extractorState.style.computedStyle().testRenderStyleStorageOneLevelRaw());
     }
-    static void NODELETE extractTestRenderStyleStorageOneLevelRawSerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
+    static void extractTestRenderStyleStorageOneLevelRawSerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
     {
         serializationForCSS(builder, context, extractorState.style, extractorState.style.computedStyle().testRenderStyleStorageOneLevelRaw());
     }
-    static RefPtr<CSSValue> NODELETE extractTestRenderStyleStorageOneLevelReference(ExtractorState& extractorState)
+    static RefPtr<CSSValue> extractTestRenderStyleStorageOneLevelReference(ExtractorState& extractorState)
     {
         return createCSSValue(extractorState.pool, extractorState.style, extractorState.style.computedStyle().testRenderStyleStorageOneLevelReference());
     }
-    static void NODELETE extractTestRenderStyleStorageOneLevelReferenceSerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
+    static void extractTestRenderStyleStorageOneLevelReferenceSerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
     {
         serializationForCSS(builder, context, extractorState.style, extractorState.style.computedStyle().testRenderStyleStorageOneLevelReference());
     }
-    static RefPtr<CSSValue> NODELETE extractTestRenderStyleStorageOneLevelValue(ExtractorState& extractorState)
+    static RefPtr<CSSValue> extractTestRenderStyleStorageOneLevelValue(ExtractorState& extractorState)
     {
         return createCSSValue(extractorState.pool, extractorState.style, extractorState.style.computedStyle().testRenderStyleStorageOneLevelValue());
     }
-    static void NODELETE extractTestRenderStyleStorageOneLevelValueSerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
+    static void extractTestRenderStyleStorageOneLevelValueSerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
     {
         serializationForCSS(builder, context, extractorState.style, extractorState.style.computedStyle().testRenderStyleStorageOneLevelValue());
     }
-    static RefPtr<CSSValue> NODELETE extractTestRenderStyleStorageTwoLevelEnum(ExtractorState& extractorState)
+    static RefPtr<CSSValue> extractTestRenderStyleStorageTwoLevelEnum(ExtractorState& extractorState)
     {
         return createCSSValue(extractorState.pool, extractorState.style, extractorState.style.computedStyle().testRenderStyleStorageTwoLevelEnum());
     }
-    static void NODELETE extractTestRenderStyleStorageTwoLevelEnumSerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
+    static void extractTestRenderStyleStorageTwoLevelEnumSerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
     {
         serializationForCSS(builder, context, extractorState.style, extractorState.style.computedStyle().testRenderStyleStorageTwoLevelEnum());
     }
-    static RefPtr<CSSValue> NODELETE extractTestRenderStyleStorageTwoLevelRaw(ExtractorState& extractorState)
+    static RefPtr<CSSValue> extractTestRenderStyleStorageTwoLevelRaw(ExtractorState& extractorState)
     {
         return createCSSValue(extractorState.pool, extractorState.style, extractorState.style.computedStyle().testRenderStyleStorageTwoLevelRaw());
     }
-    static void NODELETE extractTestRenderStyleStorageTwoLevelRawSerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
+    static void extractTestRenderStyleStorageTwoLevelRawSerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
     {
         serializationForCSS(builder, context, extractorState.style, extractorState.style.computedStyle().testRenderStyleStorageTwoLevelRaw());
     }
-    static RefPtr<CSSValue> NODELETE extractTestRenderStyleStorageTwoLevelReference(ExtractorState& extractorState)
+    static RefPtr<CSSValue> extractTestRenderStyleStorageTwoLevelReference(ExtractorState& extractorState)
     {
         return createCSSValue(extractorState.pool, extractorState.style, extractorState.style.computedStyle().testRenderStyleStorageTwoLevelReference());
     }
-    static void NODELETE extractTestRenderStyleStorageTwoLevelReferenceSerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
+    static void extractTestRenderStyleStorageTwoLevelReferenceSerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
     {
         serializationForCSS(builder, context, extractorState.style, extractorState.style.computedStyle().testRenderStyleStorageTwoLevelReference());
     }
-    static RefPtr<CSSValue> NODELETE extractTestRenderStyleStorageTwoLevelValue(ExtractorState& extractorState)
+    static RefPtr<CSSValue> extractTestRenderStyleStorageTwoLevelValue(ExtractorState& extractorState)
     {
         return createCSSValue(extractorState.pool, extractorState.style, extractorState.style.computedStyle().testRenderStyleStorageTwoLevelValue());
     }
-    static void NODELETE extractTestRenderStyleStorageTwoLevelValueSerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
+    static void extractTestRenderStyleStorageTwoLevelValueSerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
     {
         serializationForCSS(builder, context, extractorState.style, extractorState.style.computedStyle().testRenderStyleStorageTwoLevelValue());
     }
-    static RefPtr<CSSValue> NODELETE extractTestSettingsOne(ExtractorState& extractorState)
+    static RefPtr<CSSValue> extractTestSettingsOne(ExtractorState& extractorState)
     {
         return createCSSValue(extractorState.pool, extractorState.style, extractorState.style.computedStyle().testSettingsOne());
     }
-    static void NODELETE extractTestSettingsOneSerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
+    static void extractTestSettingsOneSerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
     {
         serializationForCSS(builder, context, extractorState.style, extractorState.style.computedStyle().testSettingsOne());
     }
-    static RefPtr<CSSValue> NODELETE extractTestLogicalPropertyGroupPhysicalVertical(ExtractorState& extractorState)
+    static RefPtr<CSSValue> extractTestLogicalPropertyGroupPhysicalVertical(ExtractorState& extractorState)
     {
         return createCSSValue(extractorState.pool, extractorState.style, extractorState.style.computedStyle().testLogicalPropertyGroupPhysicalVertical());
     }
-    static void NODELETE extractTestLogicalPropertyGroupPhysicalVerticalSerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
+    static void extractTestLogicalPropertyGroupPhysicalVerticalSerialization(ExtractorState& extractorState, StringBuilder& builder, const CSS::SerializationContext& context)
     {
         serializationForCSS(builder, context, extractorState.style, extractorState.style.computedStyle().testLogicalPropertyGroupPhysicalVertical());
     }

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -496,10 +496,10 @@ private:
     RenderStyle(RenderStyle&, RenderStyle&&);
 
     const Style::NonInheritedData& nonInheritedData() const LIFETIME_BOUND { return computedStyle().nonInheritedData(); }
-    const Style::ComputedStyle::NonInheritedFlags& nonInheritedFlags() const LIFETIME_BOUND { return computedStyle().nonInheritedFlags(); }
+    const Style::NonInheritedFlags& nonInheritedFlags() const LIFETIME_BOUND { return computedStyle().nonInheritedFlags(); }
     const Style::InheritedRareData& inheritedRareData() const LIFETIME_BOUND { return computedStyle().inheritedRareData(); }
     const Style::InheritedData& inheritedData() const LIFETIME_BOUND { return computedStyle().inheritedData(); }
-    const Style::ComputedStyle::InheritedFlags& inheritedFlags() const LIFETIME_BOUND { return computedStyle().inheritedFlags(); }
+    const Style::InheritedFlags& inheritedFlags() const LIFETIME_BOUND { return computedStyle().inheritedFlags(); }
     const Style::SVGData& svgData() const LIFETIME_BOUND { return computedStyle().svgData(); }
 };
 

--- a/Source/WebCore/style/StyleChangedAnimatablePropertiesCustom.h
+++ b/Source/WebCore/style/StyleChangedAnimatablePropertiesCustom.h
@@ -33,12 +33,12 @@ namespace Style {
 
 class ChangedAnimatablePropertiesCustom final {
 public:
-    static void conservativelyCollectChangedAnimatablePropertiesForCursor(const ComputedStyle::InheritedFlags&, const ComputedStyle::InheritedFlags&, CSSPropertiesBitSet&);
+    static void conservativelyCollectChangedAnimatablePropertiesForCursor(const InheritedFlags&, const InheritedFlags&, CSSPropertiesBitSet&);
     static void conservativelyCollectChangedAnimatablePropertiesForZIndex(const BoxData&, const BoxData&, CSSPropertiesBitSet&);
     static void conservativelyCollectChangedAnimatablePropertiesForCaretColor(const InheritedRareData&, const InheritedRareData&, CSSPropertiesBitSet&);
 };
 
-inline void ChangedAnimatablePropertiesCustom::conservativelyCollectChangedAnimatablePropertiesForCursor(const ComputedStyle::InheritedFlags& a, const ComputedStyle::InheritedFlags& b, CSSPropertiesBitSet& changingProperties)
+inline void ChangedAnimatablePropertiesCustom::conservativelyCollectChangedAnimatablePropertiesForCursor(const InheritedFlags& a, const InheritedFlags& b, CSSPropertiesBitSet& changingProperties)
 {
     if (a.cursorType != b.cursorType)
         changingProperties.m_properties.set(CSSPropertyCursor);

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+ConstructionInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+ConstructionInlines.h
@@ -113,24 +113,5 @@ inline ComputedStyleBase::ComputedStyleBase(ComputedStyleBase& a, ComputedStyleB
 {
 }
 
-inline void ComputedStyleBase::NonInheritedFlags::copyNonInheritedFrom(const NonInheritedFlags& other)
-{
-    // Only some flags are copied because NonInheritedFlags contains things that are not actually style data.
-    display = other.display;
-    originalDisplay = other.originalDisplay;
-    overflowX = other.overflowX;
-    overflowY = other.overflowY;
-    clear = other.clear;
-    position = other.position;
-    unicodeBidi = other.unicodeBidi;
-    floating = other.floating;
-    textDecorationLine = other.textDecorationLine;
-    usesViewportUnits = other.usesViewportUnits;
-    usesContainerUnits = other.usesContainerUnits;
-    useTreeCountingFunctions = other.useTreeCountingFunctions;
-    hasExplicitlyInheritedProperties = other.hasExplicitlyInheritedProperties;
-    disallowsFastPathInheritance = other.disallowsFastPathInheritance;
-}
-
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
@@ -84,19 +84,6 @@
 namespace WebCore {
 namespace Style {
 
-// MARK: - ComputedStyleBase::NonInheritedFlags
-
-inline bool ComputedStyleBase::NonInheritedFlags::hasPseudoStyle(PseudoElementType pseudo) const
-{
-    ASSERT(allPublicPseudoElementTypes.contains(pseudo));
-    return EnumSet<PseudoElementType>::fromRaw(pseudoBits).contains(pseudo);
-}
-
-inline bool ComputedStyleBase::NonInheritedFlags::hasAnyPublicPseudoStyles() const
-{
-    return !!pseudoBits;
-}
-
 // MARK: - Non-property getters
 
 inline bool ComputedStyleBase::usesViewportUnits() const
@@ -275,12 +262,13 @@ inline const AtomString& ComputedStyleBase::pseudoElementNameArgument() const
 
 inline bool ComputedStyleBase::hasPseudoStyle(PseudoElementType pseudo) const
 {
-    return m_nonInheritedFlags.hasPseudoStyle(pseudo);
+    ASSERT(allPublicPseudoElementTypes.contains(pseudo));
+    return EnumSet<PseudoElementType>::fromRaw(m_nonInheritedFlags.pseudoBits).contains(pseudo);
 }
 
 inline bool ComputedStyleBase::hasAnyPublicPseudoStyles() const
 {
-    return m_nonInheritedFlags.hasAnyPublicPseudoStyles();
+    return !!m_nonInheritedFlags.pseudoBits;
 }
 
 // MARK: - Custom properties

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
@@ -47,15 +47,6 @@ template<typename T, typename U> inline bool compareEqual(const T& a, const U& b
      return a == b;
 }
 
-// MARK: - ComputedStyleBase::NonInheritedFlags
-
-inline void ComputedStyleBase::NonInheritedFlags::setHasPseudoStyles(EnumSet<PseudoElementType> pseudoElementSet)
-{
-    ASSERT(pseudoElementSet);
-    ASSERT(pseudoElementSet.containsOnly(allPublicPseudoElementTypes));
-    pseudoBits = pseudoElementSet.toRaw();
-}
-
 // MARK: - Non-property setters
 
 inline void ComputedStyleBase::setUsesViewportUnits()
@@ -221,7 +212,9 @@ inline void ComputedStyleBase::setUsedAppleVisualEffectForSubtree(AppleVisualEff
 
 inline void ComputedStyleBase::setHasPseudoStyles(EnumSet<PseudoElementType> set)
 {
-    m_nonInheritedFlags.setHasPseudoStyles(set);
+    ASSERT(set);
+    ASSERT(set.containsOnly(allPublicPseudoElementTypes));
+    m_nonInheritedFlags.pseudoBits = set.toRaw();
 }
 
 inline void ComputedStyleBase::setPseudoElementIdentifier(std::optional<PseudoElementIdentifier>&& identifier)

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.cpp
@@ -55,12 +55,6 @@
 namespace WebCore {
 namespace Style {
 
-static_assert(PublicPseudoIDBits == allPublicPseudoElementTypes.size());
-static_assert(!(static_cast<unsigned>(maxTextTransformValue) >> TextTransformBits));
-
-// Value zero is used to indicate no pseudo-element.
-static_assert(!((std::to_underlying(PseudoElementType::HighestEnumValue) + 1) >> PseudoElementTypeBits));
-
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(ComputedStyleBase);
 
 ComputedStyleBase::~ComputedStyleBase()
@@ -402,80 +396,6 @@ void ComputedStyleBase::updateUsedCounterSetDirectives()
         directives.setValue = counterSetValue.value.value;
     }
 }
-
-// MARK: - Flags Diffing
-
-#if !LOG_DISABLED
-void ComputedStyleBase::NonInheritedFlags::dumpDifferences(TextStream& ts, const NonInheritedFlags& other) const
-{
-    if (*this == other)
-        return;
-
-    LOG_IF_DIFFERENT_WITH_CAST(Style::DisplayType, display);
-    LOG_IF_DIFFERENT_WITH_CAST(Style::DisplayType, originalDisplay);
-    LOG_IF_DIFFERENT_WITH_CAST(Overflow, overflowX);
-    LOG_IF_DIFFERENT_WITH_CAST(Overflow, overflowY);
-    LOG_IF_DIFFERENT_WITH_CAST(Clear, clear);
-    LOG_IF_DIFFERENT_WITH_CAST(PositionType, position);
-    LOG_IF_DIFFERENT_WITH_CAST(UnicodeBidi, unicodeBidi);
-    LOG_IF_DIFFERENT_WITH_CAST(Float, floating);
-
-    LOG_IF_DIFFERENT(usesViewportUnits);
-    LOG_IF_DIFFERENT(usesContainerUnits);
-    LOG_IF_DIFFERENT(useTreeCountingFunctions);
-
-    LOG_IF_DIFFERENT_WITH_FROM_RAW(TextDecorationLine, textDecorationLine);
-
-    LOG_IF_DIFFERENT(hasExplicitlyInheritedProperties);
-    LOG_IF_DIFFERENT(disallowsFastPathInheritance);
-
-    LOG_IF_DIFFERENT(emptyState);
-    LOG_IF_DIFFERENT(firstChildState);
-    LOG_IF_DIFFERENT(lastChildState);
-    LOG_IF_DIFFERENT(isLink);
-
-    LOG_IF_DIFFERENT_WITH_CAST(PseudoId, pseudoElementType);
-    LOG_IF_DIFFERENT_WITH_CAST(unsigned, pseudoBits);
-}
-
-void ComputedStyleBase::InheritedFlags::dumpDifferences(TextStream& ts, const InheritedFlags& other) const
-{
-    if (*this == other)
-        return;
-
-    LOG_IF_DIFFERENT(writingMode);
-
-    LOG_IF_DIFFERENT_WITH_CAST(WhiteSpaceCollapse, whiteSpaceCollapse);
-    LOG_IF_DIFFERENT_WITH_CAST(TextWrapMode, textWrapMode);
-    LOG_IF_DIFFERENT_WITH_CAST(TextAlign, textAlign);
-    LOG_IF_DIFFERENT_WITH_CAST(TextWrapStyle, textWrapStyle);
-
-    LOG_IF_DIFFERENT_WITH_FROM_RAW(TextTransform, textTransform);
-    LOG_IF_DIFFERENT_WITH_FROM_RAW(TextDecorationLine, textDecorationLineInEffect);
-
-    LOG_IF_DIFFERENT_WITH_CAST(PointerEvents, pointerEvents);
-    LOG_IF_DIFFERENT_WITH_CAST(Visibility, visibility);
-    LOG_IF_DIFFERENT_WITH_CAST(CursorType, cursorType);
-
-#if ENABLE(CURSOR_VISIBILITY)
-    LOG_IF_DIFFERENT_WITH_CAST(CursorVisibility, cursorVisibility);
-#endif
-
-    LOG_IF_DIFFERENT_WITH_CAST(ListStylePosition, listStylePosition);
-    LOG_IF_DIFFERENT_WITH_CAST(EmptyCell, emptyCells);
-    LOG_IF_DIFFERENT_WITH_CAST(BorderCollapse, borderCollapse);
-    LOG_IF_DIFFERENT_WITH_CAST(CaptionSide, captionSide);
-    LOG_IF_DIFFERENT_WITH_CAST(BoxDirection, boxDirection);
-    LOG_IF_DIFFERENT_WITH_CAST(Order, rtlOrdering);
-    LOG_IF_DIFFERENT_WITH_CAST(bool, hasExplicitlySetColor);
-    LOG_IF_DIFFERENT_WITH_CAST(PrintColorAdjust, printColorAdjust);
-    LOG_IF_DIFFERENT_WITH_CAST(InsideLink, insideLink);
-
-#if ENABLE(TEXT_AUTOSIZING)
-    LOG_IF_DIFFERENT_WITH_CAST(unsigned, autosizeStatus);
-#endif
-}
-#endif
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.h
@@ -28,15 +28,14 @@
 
 #include <WebCore/BoxExtents.h>
 #include <WebCore/PseudoElementIdentifier.h>
-#include <WebCore/StyleGridAutoFlow.h>
+#include <WebCore/StyleInheritedFlags.h>
+#include <WebCore/StyleNonInheritedFlags.h>
 #include <WebCore/StylePrimitiveNumeric+Forward.h>
-#include <WebCore/WritingMode.h>
 #include <unicode/utypes.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/DataRef.h>
-#include <wtf/FixedVector.h>
+#include <wtf/HashMap.h>
 #include <wtf/OptionSet.h>
-#include <wtf/Vector.h>
 
 namespace WebCore {
 
@@ -269,6 +268,7 @@ struct FontVariationSettings;
 struct FontWeight;
 struct FontWidth;
 struct GapGutter;
+struct GridAutoFlow;
 struct GridPosition;
 struct GridTemplateAreas;
 struct GridTemplateList;
@@ -438,11 +438,6 @@ using WebkitBorderSpacing = Length<CSS::NonnegativeUnzoomed>;
 using WebkitBoxFlex = Number<CSS::All, float>;
 using WebkitBoxFlexGroup = Integer<CSS::Nonnegative>;
 using WebkitBoxOrdinalGroup = Integer<CSS::Positive>;
-
-constexpr auto PublicPseudoIDBits = 19;
-constexpr auto TextDecorationLineBits = 5;
-constexpr auto TextTransformBits = 6;
-constexpr auto PseudoElementTypeBits = 5;
 
 using PseudoStyleCache = HashMap<PseudoElementIdentifier, std::unique_ptr<RenderStyle>>;
 
@@ -721,96 +716,6 @@ public:
     // `@page size`
     inline const PageSize& pageSize() const LIFETIME_BOUND;
     inline void setPageSize(PageSize&&);
-
-    struct NonInheritedFlags {
-        bool operator==(const NonInheritedFlags&) const = default;
-
-        inline void copyNonInheritedFrom(const NonInheritedFlags&);
-
-        inline bool hasAnyPublicPseudoStyles() const;
-        bool hasPseudoStyle(PseudoElementType) const;
-        void setHasPseudoStyles(EnumSet<PseudoElementType>);
-
-#if !LOG_DISABLED
-        void dumpDifferences(TextStream&, const NonInheritedFlags&) const;
-#endif
-
-        PREFERRED_TYPE(Style::DisplayType) unsigned display : 5;
-        PREFERRED_TYPE(Style::DisplayType) unsigned originalDisplay : 5;
-        PREFERRED_TYPE(Overflow) unsigned overflowX : 3;
-        PREFERRED_TYPE(Overflow) unsigned overflowY : 3;
-        PREFERRED_TYPE(Clear) unsigned clear : 3;
-        PREFERRED_TYPE(PositionType) unsigned position : 3;
-        PREFERRED_TYPE(UnicodeBidi) unsigned unicodeBidi : 3;
-        PREFERRED_TYPE(Float) unsigned floating : 3;
-
-        PREFERRED_TYPE(bool) unsigned usesViewportUnits : 1;
-        PREFERRED_TYPE(bool) unsigned usesContainerUnits : 1;
-        PREFERRED_TYPE(bool) unsigned useTreeCountingFunctions : 1;
-        PREFERRED_TYPE(bool) unsigned hasExplicitlyInheritedProperties : 1; // Explicitly inherits a non-inherited property.
-        PREFERRED_TYPE(bool) unsigned disallowsFastPathInheritance : 1;
-
-        // Non-property related state bits.
-        PREFERRED_TYPE(bool) unsigned emptyState : 1;
-        PREFERRED_TYPE(bool) unsigned firstChildState : 1;
-        PREFERRED_TYPE(bool) unsigned lastChildState : 1;
-        PREFERRED_TYPE(bool) unsigned isLink : 1;
-        PREFERRED_TYPE(PseudoElementType) unsigned pseudoElementType : PseudoElementTypeBits;
-        unsigned pseudoBits : PublicPseudoIDBits;
-        unsigned textDecorationLine : TextDecorationLineBits; // Text decorations defined *only* by this element. PREFERRED_TYPE elided to avoid header inclusion.
-
-        // If you add more style bits here, you will also need to update ComputedStyleBase::NonInheritedFlags::copyNonInheritedFrom().
-    };
-
-    struct InheritedFlags {
-        bool operator==(const InheritedFlags&) const = default;
-
-#if !LOG_DISABLED
-        void dumpDifferences(TextStream&, const InheritedFlags&) const;
-#endif
-
-        // Writing Mode = 8 bits (can be packed into 6 if needed)
-        WritingMode writingMode;
-
-        // Text Formatting = 19 bits aligned onto 2 bytes + 4 trailing bits
-        PREFERRED_TYPE(WhiteSpaceCollapse) unsigned char whiteSpaceCollapse : 3;
-        PREFERRED_TYPE(TextWrapMode) unsigned char textWrapMode : 1;
-        PREFERRED_TYPE(TextAlign) unsigned char textAlign : 4;
-        PREFERRED_TYPE(TextWrapStyle) unsigned char textWrapStyle : 2;
-        unsigned char textTransform : TextTransformBits; // PREFERRED_TYPE elided to avoid header inclusion.
-        unsigned char : 1; // byte alignment
-        unsigned char textDecorationLineInEffect : TextDecorationLineBits; // PREFERRED_TYPE elided to avoid header inclusion.
-
-        // Cursors and Visibility = 13 bits aligned onto 4 bits + 1 byte + 1 bit
-        PREFERRED_TYPE(PointerEvents) unsigned char pointerEvents : 4;
-        PREFERRED_TYPE(Visibility) unsigned char visibility : 2;
-        PREFERRED_TYPE(CursorType) unsigned char cursorType : 6;
-#if ENABLE(CURSOR_VISIBILITY)
-        PREFERRED_TYPE(CursorVisibility) unsigned char cursorVisibility : 1;
-#endif
-
-        // Display Type-Specific = 5 bits
-        PREFERRED_TYPE(ListStylePosition) unsigned char listStylePosition : 1;
-        PREFERRED_TYPE(EmptyCell) unsigned char emptyCells : 1;
-        PREFERRED_TYPE(BorderCollapse) unsigned char borderCollapse : 1;
-        PREFERRED_TYPE(CaptionSide) unsigned char captionSide : 2;
-
-        // -webkit- Stuff = 2 bits
-        PREFERRED_TYPE(BoxDirection) unsigned char boxDirection : 1;
-        PREFERRED_TYPE(WebCore::Order) unsigned char rtlOrdering : 1;
-
-        // Color Stuff = 4 bits
-        PREFERRED_TYPE(bool) unsigned char hasExplicitlySetColor : 1;
-        PREFERRED_TYPE(PrintColorAdjust) unsigned char printColorAdjust : 1;
-        PREFERRED_TYPE(InsideLink) unsigned char insideLink : 2;
-
-        PREFERRED_TYPE(bool) unsigned char isZoomed : 1;
-
-#if ENABLE(TEXT_AUTOSIZING)
-        unsigned autosizeStatus : 5;
-#endif
-        // Total = 63 bits (fits in 8 bytes)
-    };
 
 protected:
     friend class Adjuster;

--- a/Source/WebCore/style/computed/data/StyleInheritedFlags.cpp
+++ b/Source/WebCore/style/computed/data/StyleInheritedFlags.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleInheritedFlags.h"
+
+#include "StyleComputedStyle+DifferenceLogging.h"
+#include "StyleComputedStyle+InitialInlines.h"
+#include "StylePrimitiveKeyword+Logging.h"
+#include "StylePrimitiveNumericTypes+Logging.h"
+
+namespace WebCore {
+namespace Style {
+
+static_assert(!(static_cast<unsigned>(maxTextTransformValue) >> TextTransformBits));
+
+#if !LOG_DISABLED
+void InheritedFlags::dumpDifferences(TextStream& ts, const InheritedFlags& other) const
+{
+    if (*this == other)
+        return;
+
+    LOG_IF_DIFFERENT(writingMode);
+
+    LOG_IF_DIFFERENT_WITH_CAST(WhiteSpaceCollapse, whiteSpaceCollapse);
+    LOG_IF_DIFFERENT_WITH_CAST(TextWrapMode, textWrapMode);
+    LOG_IF_DIFFERENT_WITH_CAST(TextAlign, textAlign);
+    LOG_IF_DIFFERENT_WITH_CAST(TextWrapStyle, textWrapStyle);
+
+    LOG_IF_DIFFERENT_WITH_FROM_RAW(TextTransform, textTransform);
+    LOG_IF_DIFFERENT_WITH_FROM_RAW(TextDecorationLine, textDecorationLineInEffect);
+
+    LOG_IF_DIFFERENT_WITH_CAST(PointerEvents, pointerEvents);
+    LOG_IF_DIFFERENT_WITH_CAST(Visibility, visibility);
+    LOG_IF_DIFFERENT_WITH_CAST(CursorType, cursorType);
+
+#if ENABLE(CURSOR_VISIBILITY)
+    LOG_IF_DIFFERENT_WITH_CAST(CursorVisibility, cursorVisibility);
+#endif
+
+    LOG_IF_DIFFERENT_WITH_CAST(ListStylePosition, listStylePosition);
+    LOG_IF_DIFFERENT_WITH_CAST(EmptyCell, emptyCells);
+    LOG_IF_DIFFERENT_WITH_CAST(BorderCollapse, borderCollapse);
+    LOG_IF_DIFFERENT_WITH_CAST(CaptionSide, captionSide);
+    LOG_IF_DIFFERENT_WITH_CAST(BoxDirection, boxDirection);
+    LOG_IF_DIFFERENT_WITH_CAST(Order, rtlOrdering);
+    LOG_IF_DIFFERENT_WITH_CAST(bool, hasExplicitlySetColor);
+    LOG_IF_DIFFERENT_WITH_CAST(PrintColorAdjust, printColorAdjust);
+    LOG_IF_DIFFERENT_WITH_CAST(InsideLink, insideLink);
+
+#if ENABLE(TEXT_AUTOSIZING)
+    LOG_IF_DIFFERENT_WITH_CAST(unsigned, autosizeStatus);
+#endif
+}
+#endif
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/computed/data/StyleInheritedFlags.h
+++ b/Source/WebCore/style/computed/data/StyleInheritedFlags.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2000 Lars Knoll (knoll@kde.org)
+ *           (C) 2000 Antti Koivisto (koivisto@kde.org)
+ *           (C) 2000 Dirk Mueller (mueller@kde.org)
+ * Copyright (C) 2003-2026 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2021 Google Inc. All rights reserved.
+ * Copyright (C) 2006 Graham Dennis (graham.dennis@gmail.com)
+ * Copyright (C) 2025-2026 Samuel Weinig <sam@webkit.org>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ *
+ */
+
+#pragma once
+
+#include <WebCore/StyleNonInheritedFlags.h>
+#include <WebCore/WritingMode.h>
+
+namespace WebCore {
+
+enum class BorderCollapse : bool;
+enum class BoxDirection : bool;
+enum class CaptionSide : uint8_t;
+enum class CursorType : uint8_t;
+enum class CursorVisibility : bool;
+enum class EmptyCell : bool;
+enum class InsideLink : uint8_t;
+enum class ListStylePosition : bool;
+enum class Order : bool;
+enum class PointerEvents : uint8_t;
+enum class PrintColorAdjust : bool;
+enum class TextWrapMode : bool;
+enum class TextWrapStyle : uint8_t;
+enum class Visibility : uint8_t;
+enum class WhiteSpaceCollapse : uint8_t;
+
+namespace Style {
+
+enum class TextAlign : uint8_t;
+
+constexpr auto TextTransformBits = 6;
+
+struct InheritedFlags {
+    bool operator==(const InheritedFlags&) const = default;
+
+#if !LOG_DISABLED
+    void dumpDifferences(TextStream&, const InheritedFlags&) const;
+#endif
+
+    // Writing Mode = 8 bits (can be packed into 6 if needed)
+    WritingMode writingMode;
+
+    // Text Formatting = 19 bits aligned onto 2 bytes + 4 trailing bits
+    PREFERRED_TYPE(WhiteSpaceCollapse) unsigned char whiteSpaceCollapse : 3;
+    PREFERRED_TYPE(TextWrapMode) unsigned char textWrapMode : 1;
+    PREFERRED_TYPE(TextAlign) unsigned char textAlign : 4;
+    PREFERRED_TYPE(TextWrapStyle) unsigned char textWrapStyle : 2;
+    unsigned char textTransform : TextTransformBits; // PREFERRED_TYPE elided to avoid header inclusion.
+    unsigned char : 1; // byte alignment
+    unsigned char textDecorationLineInEffect : TextDecorationLineBits; // PREFERRED_TYPE elided to avoid header inclusion.
+
+    // Cursors and Visibility = 13 bits aligned onto 4 bits + 1 byte + 1 bit
+    PREFERRED_TYPE(PointerEvents) unsigned char pointerEvents : 4;
+    PREFERRED_TYPE(Visibility) unsigned char visibility : 2;
+    PREFERRED_TYPE(CursorType) unsigned char cursorType : 6;
+#if ENABLE(CURSOR_VISIBILITY)
+    PREFERRED_TYPE(CursorVisibility) unsigned char cursorVisibility : 1;
+#endif
+
+    // Display Type-Specific = 5 bits
+    PREFERRED_TYPE(ListStylePosition) unsigned char listStylePosition : 1;
+    PREFERRED_TYPE(EmptyCell) unsigned char emptyCells : 1;
+    PREFERRED_TYPE(BorderCollapse) unsigned char borderCollapse : 1;
+    PREFERRED_TYPE(CaptionSide) unsigned char captionSide : 2;
+
+    // -webkit- Stuff = 2 bits
+    PREFERRED_TYPE(BoxDirection) unsigned char boxDirection : 1;
+    PREFERRED_TYPE(WebCore::Order) unsigned char rtlOrdering : 1;
+
+    // Color Stuff = 4 bits
+    PREFERRED_TYPE(bool) unsigned char hasExplicitlySetColor : 1;
+    PREFERRED_TYPE(PrintColorAdjust) unsigned char printColorAdjust : 1;
+    PREFERRED_TYPE(InsideLink) unsigned char insideLink : 2;
+
+    PREFERRED_TYPE(bool) unsigned char isZoomed : 1;
+
+#if ENABLE(TEXT_AUTOSIZING)
+    unsigned autosizeStatus : 5;
+#endif
+    // Total = 63 bits (fits in 8 bytes)
+};
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/computed/data/StyleNonInheritedFlags.cpp
+++ b/Source/WebCore/style/computed/data/StyleNonInheritedFlags.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleNonInheritedFlags.h"
+
+#include "StyleComputedStyle+DifferenceLogging.h"
+#include "StyleComputedStyle+InitialInlines.h"
+#include "StylePrimitiveKeyword+Logging.h"
+#include "StylePrimitiveNumericTypes+Logging.h"
+
+namespace WebCore {
+namespace Style {
+
+static_assert(PublicPseudoIDBits == allPublicPseudoElementTypes.size());
+// Value zero is used to indicate no pseudo-element.
+static_assert(!((std::to_underlying(PseudoElementType::HighestEnumValue) + 1) >> PseudoElementTypeBits));
+
+#if !LOG_DISABLED
+void NonInheritedFlags::dumpDifferences(TextStream& ts, const NonInheritedFlags& other) const
+{
+    if (*this == other)
+        return;
+
+    LOG_IF_DIFFERENT_WITH_CAST(Style::DisplayType, display);
+    LOG_IF_DIFFERENT_WITH_CAST(Style::DisplayType, originalDisplay);
+    LOG_IF_DIFFERENT_WITH_CAST(Overflow, overflowX);
+    LOG_IF_DIFFERENT_WITH_CAST(Overflow, overflowY);
+    LOG_IF_DIFFERENT_WITH_CAST(Clear, clear);
+    LOG_IF_DIFFERENT_WITH_CAST(PositionType, position);
+    LOG_IF_DIFFERENT_WITH_CAST(UnicodeBidi, unicodeBidi);
+    LOG_IF_DIFFERENT_WITH_CAST(Float, floating);
+
+    LOG_IF_DIFFERENT(usesViewportUnits);
+    LOG_IF_DIFFERENT(usesContainerUnits);
+    LOG_IF_DIFFERENT(useTreeCountingFunctions);
+
+    LOG_IF_DIFFERENT_WITH_FROM_RAW(TextDecorationLine, textDecorationLine);
+
+    LOG_IF_DIFFERENT(hasExplicitlyInheritedProperties);
+    LOG_IF_DIFFERENT(disallowsFastPathInheritance);
+
+    LOG_IF_DIFFERENT(emptyState);
+    LOG_IF_DIFFERENT(firstChildState);
+    LOG_IF_DIFFERENT(lastChildState);
+    LOG_IF_DIFFERENT(isLink);
+
+    LOG_IF_DIFFERENT_WITH_CAST(PseudoId, pseudoElementType);
+    LOG_IF_DIFFERENT_WITH_CAST(unsigned, pseudoBits);
+}
+#endif
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/computed/data/StyleNonInheritedFlags.h
+++ b/Source/WebCore/style/computed/data/StyleNonInheritedFlags.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2000 Lars Knoll (knoll@kde.org)
+ *           (C) 2000 Antti Koivisto (koivisto@kde.org)
+ *           (C) 2000 Dirk Mueller (mueller@kde.org)
+ * Copyright (C) 2003-2026 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2021 Google Inc. All rights reserved.
+ * Copyright (C) 2006 Graham Dennis (graham.dennis@gmail.com)
+ * Copyright (C) 2025-2026 Samuel Weinig <sam@webkit.org>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ *
+ */
+
+#pragma once
+
+#include <wtf/Forward.h>
+
+namespace WebCore {
+
+enum class Clear : uint8_t;
+enum class Float : uint8_t;
+enum class Overflow : uint8_t;
+enum class PositionType : uint8_t;
+enum class PseudoElementType : uint8_t;
+enum class UnicodeBidi : uint8_t;
+
+namespace Style {
+
+enum class DisplayType : uint8_t;
+
+constexpr auto PseudoElementTypeBits = 5;
+constexpr auto PublicPseudoIDBits = 19;
+constexpr auto TextDecorationLineBits = 5;
+
+struct NonInheritedFlags {
+    bool operator==(const NonInheritedFlags&) const = default;
+
+    inline void copyNonInheritedFrom(const NonInheritedFlags&);
+
+#if !LOG_DISABLED
+    void dumpDifferences(TextStream&, const NonInheritedFlags&) const;
+#endif
+
+    PREFERRED_TYPE(Style::DisplayType) unsigned display : 5;
+    PREFERRED_TYPE(Style::DisplayType) unsigned originalDisplay : 5;
+    PREFERRED_TYPE(Overflow) unsigned overflowX : 3;
+    PREFERRED_TYPE(Overflow) unsigned overflowY : 3;
+    PREFERRED_TYPE(Clear) unsigned clear : 3;
+    PREFERRED_TYPE(PositionType) unsigned position : 3;
+    PREFERRED_TYPE(UnicodeBidi) unsigned unicodeBidi : 3;
+    PREFERRED_TYPE(Float) unsigned floating : 3;
+
+    PREFERRED_TYPE(bool) unsigned usesViewportUnits : 1;
+    PREFERRED_TYPE(bool) unsigned usesContainerUnits : 1;
+    PREFERRED_TYPE(bool) unsigned useTreeCountingFunctions : 1;
+    PREFERRED_TYPE(bool) unsigned hasExplicitlyInheritedProperties : 1; // Explicitly inherits a non-inherited property.
+    PREFERRED_TYPE(bool) unsigned disallowsFastPathInheritance : 1;
+
+    // Non-property related state bits.
+    PREFERRED_TYPE(bool) unsigned emptyState : 1;
+    PREFERRED_TYPE(bool) unsigned firstChildState : 1;
+    PREFERRED_TYPE(bool) unsigned lastChildState : 1;
+    PREFERRED_TYPE(bool) unsigned isLink : 1;
+    PREFERRED_TYPE(PseudoElementType) unsigned pseudoElementType : PseudoElementTypeBits;
+    unsigned pseudoBits : PublicPseudoIDBits;
+    unsigned textDecorationLine : TextDecorationLineBits; // Text decorations defined *only* by this element. PREFERRED_TYPE elided to avoid header inclusion.
+
+    // If you add more style bits here, you will also need to update NonInheritedFlags::copyNonInheritedFrom().
+};
+
+inline void NonInheritedFlags::copyNonInheritedFrom(const NonInheritedFlags& other)
+{
+    // Only some flags are copied because NonInheritedFlags contains things that are not actually style data.
+    display = other.display;
+    originalDisplay = other.originalDisplay;
+    overflowX = other.overflowX;
+    overflowY = other.overflowY;
+    clear = other.clear;
+    position = other.position;
+    unicodeBidi = other.unicodeBidi;
+    floating = other.floating;
+    textDecorationLine = other.textDecorationLine;
+    usesViewportUnits = other.usesViewportUnits;
+    usesContainerUnits = other.usesContainerUnits;
+    useTreeCountingFunctions = other.useTreeCountingFunctions;
+    hasExplicitlyInheritedProperties = other.hasExplicitlyInheritedProperties;
+    disallowsFastPathInheritance = other.disallowsFastPathInheritance;
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/shapes/StyleShapeFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StyleShapeFunction.cpp
@@ -38,6 +38,7 @@
 #include "StylePathFunction.h"
 #include "StylePrimitiveNumericTypes+Blending.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
+#include "TransformOperationData.h"
 
 namespace WebCore {
 namespace Style {


### PR DESCRIPTION
#### eaeeb7dfa0552226370925f19705ba5c337cb5ec
<pre>
Split &quot;flags&quot; structs out of Style::ComputedStyleBase
<a href="https://bugs.webkit.org/show_bug.cgi?id=311119">https://bugs.webkit.org/show_bug.cgi?id=311119</a>

Reviewed by NOBODY (OOPS!).

Makes Style::ComputedStyleBase a bit less big by splitting out
the nested &quot;flags&quot; structs.

Remove some unnecessary includes and addressed fallout, including
updating the results of `run-css-property-code-generation-tests`.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/scripts/process-css-properties.py:
* Source/WebCore/css/scripts/test/TestCSSPropertiesResults/StyleComputedStyleProperties.h:
* Source/WebCore/css/scripts/test/TestCSSPropertiesResults/StyleExtractorGenerated.cpp:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/style/StyleChangedAnimatablePropertiesCustom.h:
* Source/WebCore/style/computed/StyleComputedStyleBase+ConstructionInlines.h:
* Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h:
* Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h:
* Source/WebCore/style/computed/StyleComputedStyleBase.cpp:
* Source/WebCore/style/computed/StyleComputedStyleBase.h:
* Source/WebCore/style/computed/data/StyleInheritedFlags.cpp: Added.
* Source/WebCore/style/computed/data/StyleInheritedFlags.h: Added.
* Source/WebCore/style/computed/data/StyleNonInheritedFlags.cpp: Added.
* Source/WebCore/style/computed/data/StyleNonInheritedFlags.h: Added.
* Source/WebCore/style/values/shapes/StyleShapeFunction.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eaeeb7dfa0552226370925f19705ba5c337cb5ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153250 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26032 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19630 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161995 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106708 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155123 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26559 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26337 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118481 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83899 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156209 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20717 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137591 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99194 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19791 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17741 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9830 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129441 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15460 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164469 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7604 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17054 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126538 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25829 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21768 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/semantics/structured-clone/shared.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126696 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25831 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137256 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82500 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21644 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14035 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25449 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89734 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25140 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25299 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25199 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->