### PR TITLE
Fix url() token serialization

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-security-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-security-expected.txt
@@ -8,7 +8,7 @@ FAIL 'background-image: src("https://does-not-exist.test/404.png")' with data-fo
 PASS '--x: src(string("https://does-not-exist.test" attr(data-foo)))' with data-foo="/404.png"
 PASS 'background-image: src(string("https://does-not-exist.test" attr(data-foo)))' with data-foo="/404.png"
 FAIL 'background-image: src(string("https://does-not-exist.test/""404.png"))' with data-foo="/404.png" assert_equals: expected "src(url(\"https://does-not-exist.test/404.png\"))" but got "none"
-FAIL '--x: attr(data-foo type(<url>))' with data-foo="url(https://does-not-exist.test/404.png)" assert_equals: expected "url(\"https://does-not-exist.test/404.png\")" but got "url(https\\:\\/\\/does-not-exist\\.test\\/404\\.png)"
+PASS '--x: attr(data-foo type(<url>))' with data-foo="url(https://does-not-exist.test/404.png)"
 PASS 'background-image: attr(data-foo type(<url>))' with data-foo="url(https://does-not-exist.test/404.png)"
 PASS 'background-image: url("https://does-not-exist.test/404.png")' with data-foo="url(https://does-not-exist.test/404.png)"
 PASS '--x: image(attr(data-foo))' with data-foo="https://does-not-exist.test/404.png"
@@ -46,8 +46,8 @@ FAIL 'background-image: image-set(if(style(--true): url(https://does-not-exist.t
                             else: url(https://does-not-exist.test/404.png);))' with data-foo="attr(data-foo type(*))" assert_equals: expected "image-set(url(\"https://does-not-exist.test/404.png\") 1dppx)" but got "none"
 PASS 'background-image: image-set(
                 if(style(--condition-val: if(style(--true): attr(data-foo type(*));)): url(https://does-not-exist.test/404.png);))' with data-foo="3"
-FAIL '--x: image-set(if(style(--condition-val: if(style(--true): attr(data-foo type(*));)): url(https://does-not-exist.test/404.png);))' with data-foo="3" assert_equals: expected "image-set(url(https://does-not-exist.test/404.png))" but got "image-set(if(style(--condition-val: if(style(--true): 3;)): url(https\\:\\/\\/does-not-exist\\.test\\/404\\.png);))"
-FAIL '--x: image-set(if(style(--condition-val >= attr(data-foo type(*))): url(https://does-not-exist.test/404.png);))' with data-foo="3" assert_equals: expected "image-set(url(https://does-not-exist.test/404.png))" but got "image-set(if(style(--condition-val >= 3): url(https\\:\\/\\/does-not-exist\\.test\\/404\\.png);))"
+FAIL '--x: image-set(if(style(--condition-val: if(style(--true): attr(data-foo type(*));)): url(https://does-not-exist.test/404.png);))' with data-foo="3" assert_equals: expected "image-set(url(https://does-not-exist.test/404.png))" but got "image-set(if(style(--condition-val: if(style(--true): 3;)): url(\"https://does-not-exist.test/404.png\");))"
+FAIL '--x: image-set(if(style(--condition-val >= attr(data-foo type(*))): url(https://does-not-exist.test/404.png);))' with data-foo="3" assert_equals: expected "image-set(url(https://does-not-exist.test/404.png))" but got "image-set(if(style(--condition-val >= 3): url(\"https://does-not-exist.test/404.png\");))"
 PASS 'background-image: image-set(
                 if(style(--condition-val >= attr(data-foo type(*))): url(https://does-not-exist.test/404.png);))' with data-foo="3"
 PASS 'background-image: image-set(

--- a/Source/WebCore/css/parser/CSSParserToken.cpp
+++ b/Source/WebCore/css/parser/CSSParserToken.cpp
@@ -653,8 +653,9 @@ void CSSParserToken::serialize(StringBuilder& builder, const CSSParserToken* nex
         appendCommentIfNeeded({ IdentToken, FunctionToken, UrlToken, BadUrlToken, NumberToken, PercentageToken, DimensionToken, CDCToken }, '-');
         break;
     case UrlToken:
+        // https://drafts.csswg.org/cssom-1/#serialize-a-url
         builder.append("url("_s);
-        serializeIdentifier(value().toString(), builder);
+        serializeString(value().toString(), builder);
         builder.append(')');
         break;
     case DelimiterToken:


### PR DESCRIPTION
#### 32d097006b6083f93d49f855882a989df90aa711
<pre>
Fix url() token serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=311120">https://bugs.webkit.org/show_bug.cgi?id=311120</a>
<a href="https://rdar.apple.com/173708292">rdar://173708292</a>

Reviewed by NOBODY (OOPS!).

&apos;To serialize a URL means to create a string represented by &quot;url(&quot;, followed by the serialization of the URL as a string, followed by &quot;)&apos;

<a href="https://drafts.csswg.org/cssom-1/#serialize-a-url">https://drafts.csswg.org/cssom-1/#serialize-a-url</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-security-expected.txt:
* Source/WebCore/css/parser/CSSParserToken.cpp:
(WebCore::CSSParserToken::serialize const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32d097006b6083f93d49f855882a989df90aa711

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153254 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26036 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19634 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161999 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106712 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5965b3e4-d2d3-41b5-b34d-a22355d4e76b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155127 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26563 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26341 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118480 "Found 4 new test failures: fast/css/attr-parsing.html imported/w3c/web-platform-tests/css/css-properties-values-api/registered-property-computation.html imported/w3c/web-platform-tests/css/css-syntax/escaped-eof.html imported/w3c/web-platform-tests/css/css-syntax/serialize-consecutive-tokens.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83901 "2 flakes 1 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0196537c-4523-4270-8fae-36363f03dde6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156213 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20716 "Found 1 new test failure: fast/css/attr-parsing.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137593 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99193 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/096e8162-a2c9-4282-b514-c9e316e45754) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19799 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-properties-values-api/registered-property-computation.html imported/w3c/web-platform-tests/css/css-syntax/escaped-eof.html imported/w3c/web-platform-tests/css/css-syntax/serialize-consecutive-tokens.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17743 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9834 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129440 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15462 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164473 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7608 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17056 "Found 4 new test failures: fast/css/attr-parsing.html imported/w3c/web-platform-tests/css/css-properties-values-api/registered-property-computation.html imported/w3c/web-platform-tests/css/css-syntax/escaped-eof.html imported/w3c/web-platform-tests/css/css-syntax/serialize-consecutive-tokens.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126537 "Found 4 new test failures: fast/css/attr-parsing.html imported/w3c/web-platform-tests/css/css-properties-values-api/registered-property-computation.html imported/w3c/web-platform-tests/css/css-syntax/escaped-eof.html imported/w3c/web-platform-tests/css/css-syntax/serialize-consecutive-tokens.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25833 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21770 "Found 5 new test failures: fast/css/attr-parsing.html imported/w3c/web-platform-tests/css/css-properties-values-api/registered-property-computation.html imported/w3c/web-platform-tests/css/css-syntax/escaped-eof.html imported/w3c/web-platform-tests/css/css-syntax/serialize-consecutive-tokens.html imported/w3c/web-platform-tests/workers/semantics/structured-clone/shared.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126695 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25835 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137258 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82504 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21647 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14037 "Found 4 new test failures: fast/css/attr-parsing.html imported/w3c/web-platform-tests/css/css-properties-values-api/registered-property-computation.html imported/w3c/web-platform-tests/css/css-syntax/escaped-eof.html imported/w3c/web-platform-tests/css/css-syntax/serialize-consecutive-tokens.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25453 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89738 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25144 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25303 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25203 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->