### PR TITLE
AX: Implement accessibility for base-appearance selects on macOS

### DIFF
--- a/LayoutTests/accessibility/base-select-basic-expected.txt
+++ b/LayoutTests/accessibility/base-select-basic-expected.txt
@@ -1,0 +1,40 @@
+This test verifies basic accessibility properties of base-appearance selects (appearance: base-select).
+
+--- Select role and value ---
+PASS: select.role.toLowerCase().includes('popup') === true
+PASS: select.stringValue.includes('Banana') === true
+PASS: select.isExpanded === false
+PASS: select.isExpanded === true
+PASS: select.childrenCount === 1
+PASS: menu.role.toLowerCase().includes('menu') === true
+PASS: menu.childrenCount === 3
+PASS: (menu.childAtIndex(0)).role.toLowerCase().includes('menuitem') === true
+	AXTitle: Apple
+	AXDescription:
+	AXHelp:
+PASS: _menuItemText.includes('Apple') === true
+PASS: (menu.childAtIndex(1)).role.toLowerCase().includes('menuitem') === true
+	AXTitle: Banana
+	AXDescription:
+	AXHelp:
+PASS: _menuItemText.includes('Banana') === true
+PASS: (menu.childAtIndex(2)).role.toLowerCase().includes('menuitem') === true
+	AXTitle: Cherry
+	AXDescription:
+	AXHelp:
+PASS: _menuItemText.includes('Cherry') === true
+PASS: menu.childAtIndex(0).isSelected === false
+PASS: menu.childAtIndex(1).isSelected === true
+PASS: menu.childAtIndex(2).isSelected === false
+PASS: menu.selectedChildrenCount === 1
+PASS: (menu.selectedChildAtIndex(0)).role.toLowerCase().includes('menuitem') === true
+	AXTitle: Banana
+	AXDescription:
+	AXHelp:
+PASS: _menuItemText.includes('Banana') === true
+PASS: select.isExpanded === false
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/base-select-basic.html
+++ b/LayoutTests/accessibility/base-select-basic.html
@@ -1,0 +1,73 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+<style>
+select, select::picker(select) {
+    appearance: base-select;
+}
+</style>
+</head>
+<body>
+
+<select id="select">
+    <option id="option1">Apple</option>
+    <option id="option2" selected>Banana</option>
+    <option id="option3">Cherry</option>
+</select>
+
+<script>
+var output = "This test verifies basic accessibility properties of base-appearance selects (appearance: base-select).\n\n";
+
+function expectMenuItem(axElement, expectedText) {
+    var result = "";
+    result += expect("(" + axElement + ").role.toLowerCase().includes('menuitem')", "true");
+    window._menuItemText = platformTextAlternatives(eval(axElement));
+    result += _menuItemText + "\n";
+    result += expect("_menuItemText.includes('" + expectedText + "')", "true");
+    return result;
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var select = accessibilityController.accessibleElementById("select");
+
+    output += "--- Select role and value ---\n";
+    output += expect("select.role.toLowerCase().includes('popup')", "true");
+    output += expect("select.stringValue.includes('Banana')", "true");
+    output += expect("select.isExpanded", "false");
+
+    setTimeout(async function() {
+        select.press();
+        output += await expectAsync("select.isExpanded", "true");
+
+        // The select should contain a Menu which wraps the MenuItems.
+        output += expect("select.childrenCount", "1");
+        window.menu = select.childAtIndex(0);
+        output += expect("menu.role.toLowerCase().includes('menu')", "true");
+        output += expect("menu.childrenCount", "3");
+
+        output += expectMenuItem("menu.childAtIndex(0)", "Apple");
+        output += expectMenuItem("menu.childAtIndex(1)", "Banana");
+        output += expectMenuItem("menu.childAtIndex(2)", "Cherry");
+
+        output += expect("menu.childAtIndex(0).isSelected", "false");
+        output += expect("menu.childAtIndex(1).isSelected", "true");
+        output += expect("menu.childAtIndex(2).isSelected", "false");
+
+        output += expect("menu.selectedChildrenCount", "1");
+        output += expectMenuItem("menu.selectedChildAtIndex(0)", "Banana");
+
+        // Press to close the picker.
+        select.press();
+        output += await expectAsync("select.isExpanded", "false");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/base-select-complex-options-expected.txt
+++ b/LayoutTests/accessibility/base-select-complex-options-expected.txt
@@ -1,0 +1,40 @@
+This test verifies that text nodes inside complex base-appearance select options are exposed as accessible elements (e.g. for VoiceOver navigation), but only when the option has non-text descendants.
+
+PASS: select.isExpanded === true
+PASS: menu.role.toLowerCase().includes('menu') === true
+
+--- Simple option: text is NOT exposed as a StaticText child ---
+PASS: (menu.childAtIndex(0)).role.toLowerCase().includes('menuitem') === true
+	AXTitle: Apple
+	AXDescription:
+	AXHelp:
+PASS: _menuItemText.includes('Apple') === true
+PASS: appleItem.childrenCount === 0
+
+--- Complex option text includes all descendant text ---
+PASS: bananaItem.role.toLowerCase().includes('menuitem') === true
+	AXTitle: Banana Foo Bar
+	AXDescription:
+	AXHelp:
+PASS: bananaText.includes('Banana') === true
+PASS: bananaText.includes('Foo') === true
+PASS: bananaText.includes('Bar') === true
+PASS: bananaHasStaticText === true
+
+--- Option with only a span wrapper: text is NOT exposed ---
+PASS: (menu.childAtIndex(2)).role.toLowerCase().includes('menuitem') === true
+	AXTitle: Cherry
+	AXDescription:
+	AXHelp:
+PASS: _menuItemText.includes('Cherry') === true
+PASS: cherryItem.childrenCount === 0
+PASS: cherryHasStaticTextAfterAdd === true
+
+--- Dynamic: remove the button from the option ---
+PASS: cherryHasStaticTextAfterRemove === false
+PASS: select.isExpanded === false
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/base-select-complex-options.html
+++ b/LayoutTests/accessibility/base-select-complex-options.html
@@ -1,0 +1,110 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+<style>
+select, select::picker(select) {
+    appearance: base-select;
+}
+</style>
+</head>
+<body>
+
+<select id="select">
+    <option id="option1">Apple</option>
+    <option id="option2" selected>
+        Banana
+        <button id="foo">Foo</button>
+        <a href="#url">Bar</a>
+    </option>
+    <option id="option3"><span>Cherry</span></option>
+</select>
+
+<script>
+var output = "This test verifies that text nodes inside complex base-appearance select options are exposed as accessible elements (e.g. for VoiceOver navigation), but only when the option has non-text descendants.\n\n";
+
+function expectMenuItem(axElement, expectedText) {
+    var result = "";
+    result += expect("(" + axElement + ").role.toLowerCase().includes('menuitem')", "true");
+    window._menuItemText = platformTextAlternatives(eval(axElement));
+    result += _menuItemText + "\n";
+    result += expect("_menuItemText.includes('" + expectedText + "')", "true");
+    return result;
+}
+
+function hasStaticTextChild(axElement, text) {
+    for (var i = 0; i < axElement.childrenCount; i++) {
+        var child = axElement.childAtIndex(i);
+        if (child.role.toLowerCase().includes("statictext") && child.stringValue.includes(text))
+            return true;
+    }
+    return false;
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var select = accessibilityController.accessibleElementById("select");
+
+    setTimeout(async function() {
+        select.press();
+        output += await expectAsync("select.isExpanded", "true");
+
+        window.menu = select.childAtIndex(0);
+        output += expect("menu.role.toLowerCase().includes('menu')", "true");
+
+        output += "\n--- Simple option: text is NOT exposed as a StaticText child ---\n";
+        window.appleItem = menu.childAtIndex(0);
+        output += expectMenuItem("menu.childAtIndex(0)", "Apple");
+        output += expect("appleItem.childrenCount", "0");
+
+        output += "\n--- Complex option text includes all descendant text ---\n";
+        window.bananaItem = menu.childAtIndex(1);
+        output += expect("bananaItem.role.toLowerCase().includes('menuitem')", "true");
+        window.bananaText = platformTextAlternatives(bananaItem);
+        output += bananaText + "\n";
+        output += expect("bananaText.includes('Banana')", "true");
+        output += expect("bananaText.includes('Foo')", "true");
+        output += expect("bananaText.includes('Bar')", "true");
+        window.bananaHasStaticText = hasStaticTextChild(bananaItem, "Banana");
+        output += expect("bananaHasStaticText", "true");
+
+        output += "\n--- Option with only a span wrapper: text is NOT exposed ---\n";
+        window.cherryItem = menu.childAtIndex(2);
+        output += expectMenuItem("menu.childAtIndex(2)", "Cherry");
+        output += expect("cherryItem.childrenCount", "0");
+
+        // Add a button to the span-wrapped option and verify we update the accessibility tree correctly.
+        var option3 = document.getElementById("option3");
+        var button = document.createElement("button");
+        button.textContent = "New";
+        option3.appendChild(button);
+        document.body.offsetWidth;
+
+        await waitFor(() => {
+            return hasStaticTextChild(menu.childAtIndex(2), "Cherry");
+        });
+        window.cherryHasStaticTextAfterAdd = hasStaticTextChild(menu.childAtIndex(2), "Cherry");
+        output += expect("cherryHasStaticTextAfterAdd", "true");
+
+        output += "\n--- Dynamic: remove the button from the option ---\n";
+        option3.removeChild(button);
+        document.body.offsetWidth;
+
+        await waitFor(() => {
+            return !hasStaticTextChild(menu.childAtIndex(2), "Cherry");
+        });
+        window.cherryHasStaticTextAfterRemove = hasStaticTextChild(menu.childAtIndex(2), "Cherry");
+        output += expect("cherryHasStaticTextAfterRemove", "false");
+
+        select.press();
+        output += await expectAsync("select.isExpanded", "false");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/base-select-focus-on-open-expected.txt
+++ b/LayoutTests/accessibility/base-select-focus-on-open-expected.txt
@@ -1,0 +1,20 @@
+This test verifies that when a base-appearance select opens, VoiceOver's focused element is the selected option.
+
+PASS: select.isExpanded === true
+PASS: window.focusedRoleAtNotificationTime != null === true
+
+--- Focused element at notification time should be the selected menu item ---
+PASS: window.focusedRoleAtNotificationTime.toLowerCase().includes('menuitem') === true
+	AXTitle: Bravo
+	AXDescription:
+	AXHelp:
+PASS: window.focusedTextAtNotificationTime.includes('Bravo') === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+Alpha
+Bravo
+Charlie
+

--- a/LayoutTests/accessibility/base-select-focus-on-open.html
+++ b/LayoutTests/accessibility/base-select-focus-on-open.html
@@ -1,0 +1,64 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+<style>
+select, select::picker(select) {
+    appearance: base-select;
+}
+</style>
+</head>
+<body>
+
+<select id="select">
+    <option>Alpha</option>
+    <option selected>Bravo</option>
+    <option>Charlie</option>
+</select>
+
+<script>
+var output = "This test verifies that when a base-appearance select opens, VoiceOver's focused element is the selected option.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var select = accessibilityController.accessibleElementById("select");
+
+    var focusedElement;
+    setTimeout(async function() {
+        document.getElementById("select").focus();
+        await waitFor(() => {
+            focusedElement = accessibilityController.focusedElement;
+            return focusedElement && focusedElement.role.toLowerCase().includes("popup");
+        });
+
+        // Listen for FocusedUIElementChanged. When it fires, immediately query
+        // the focused element — this is exactly what VoiceOver does.
+        window.focusedRoleAtNotificationTime = null;
+        window.focusedTextAtNotificationTime = null;
+        accessibilityController.addNotificationListener(function(element, notification) {
+            if (notification === "AXFocusedUIElementChanged") {
+                var focused = accessibilityController.focusedElement;
+                window.focusedRoleAtNotificationTime = focused.role;
+                window.focusedTextAtNotificationTime = platformTextAlternatives(focused);
+            }
+        });
+
+        select.press();
+        output += await expectAsync("select.isExpanded", "true");
+        output += await expectAsync("window.focusedRoleAtNotificationTime != null", "true");
+
+        output += "\n--- Focused element at notification time should be the selected menu item ---\n";
+        output += expect("window.focusedRoleAtNotificationTime.toLowerCase().includes('menuitem')", "true");
+        output += focusedTextAtNotificationTime + "\n";
+        output += expect("window.focusedTextAtNotificationTime.includes('Bravo')", "true");
+
+        accessibilityController.removeNotificationListener();
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/base-select-notifications-expected.txt
+++ b/LayoutTests/accessibility/base-select-notifications-expected.txt
@@ -1,0 +1,12 @@
+This test verifies accessibility notifications for base-appearance selects (appearance: base-select).
+
+PASS: select.isExpanded === true
+PASS: select.isExpanded === false
+PASS: select.stringValue.includes('Bravo') === true
+PASS: window.receivedNotification === true
+PASS: select.stringValue.includes('Charlie') === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/base-select-notifications.html
+++ b/LayoutTests/accessibility/base-select-notifications.html
@@ -1,0 +1,58 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+<style>
+select, select::picker(select) {
+    appearance: base-select;
+}
+</style>
+</head>
+<body>
+
+<select id="select">
+    <option>Alpha</option>
+    <option selected>Bravo</option>
+    <option>Charlie</option>
+</select>
+
+<script>
+var output = "This test verifies accessibility notifications for base-appearance selects (appearance: base-select).\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var select = accessibilityController.accessibleElementById("select");
+
+    setTimeout(async function() {
+        select.press();
+        output += await expectAsync("select.isExpanded", "true");
+        select.press();
+        output += await expectAsync("select.isExpanded", "false");
+
+        output += expect("select.stringValue.includes('Bravo')", "true");
+
+        // Verify we post a notification when the selected item changes.
+        window.receivedNotification = false;
+        function listener(notification) {
+            if (notification == "AXMenuItemSelected")
+                window.receivedNotification = true;
+        }
+        select.addNotificationListener(listener);
+
+        document.getElementById("select").selectedIndex = 2;
+
+        output += await expectAsync("window.receivedNotification", "true");
+        // We should not have to await this change -- the stringValue should be right at notification time.
+        output += expect("select.stringValue.includes('Charlie')", "true");
+
+        select.removeNotificationListener(listener);
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/base-select-search-predicate-expected.txt
+++ b/LayoutTests/accessibility/base-select-search-predicate-expected.txt
@@ -1,0 +1,27 @@
+This test verifies that base-appearance select menu items are discoverable via the accessibility search predicate API (used by Voice Control to generate numbered overlays).
+
+PASS: select.isExpanded === true
+
+--- Search for controls should find the select and its menu items ---
+PASS: foundMenuItems.length === 3
+PASS: (foundMenuItems[0]).role.toLowerCase().includes('menuitem') === true
+	AXTitle: Alpha
+	AXDescription:
+	AXHelp:
+PASS: _menuItemText.includes('Alpha') === true
+PASS: (foundMenuItems[1]).role.toLowerCase().includes('menuitem') === true
+	AXTitle: Bravo
+	AXDescription:
+	AXHelp:
+PASS: _menuItemText.includes('Bravo') === true
+PASS: (foundMenuItems[2]).role.toLowerCase().includes('menuitem') === true
+	AXTitle: Charlie
+	AXDescription:
+	AXHelp:
+PASS: _menuItemText.includes('Charlie') === true
+PASS: select.isExpanded === false
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/base-select-search-predicate.html
+++ b/LayoutTests/accessibility/base-select-search-predicate.html
@@ -1,0 +1,80 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+<style>
+select, select::picker(select) {
+    appearance: base-select;
+}
+</style>
+</head>
+<body>
+
+<select id="select">
+    <option id="option1">Alpha</option>
+    <option id="option2" selected>Bravo</option>
+    <option id="option3">Charlie</option>
+</select>
+
+<script>
+var output = "This test verifies that base-appearance select menu items are discoverable via the accessibility search predicate API (used by Voice Control to generate numbered overlays).\n\n";
+
+function expectMenuItem(axElement, expectedText) {
+    var result = "";
+    result += expect("(" + axElement + ").role.toLowerCase().includes('menuitem')", "true");
+    window._menuItemText = platformTextAlternatives(eval(axElement));
+    result += _menuItemText + "\n";
+    result += expect("_menuItemText.includes('" + expectedText + "')", "true");
+    return result;
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var select = accessibilityController.accessibleElementById("select");
+
+    setTimeout(async function() {
+        // Open the picker so menu items are on screen.
+        select.press();
+        output += await expectAsync("select.isExpanded", "true");
+
+        var webArea = accessibilityController.rootElement.childAtIndex(0);
+
+        // Search for controls with visibleOnly=true, mimicking what Voice Control does.
+        output += "\n--- Search for controls should find the select and its menu items ---\n";
+        var controls = [];
+        var result = null;
+        for (var i = 0; i < 20; i++) {
+            result = webArea.uiElementForSearchPredicate(
+                result,
+                /* isDirectionNext */ true,
+                "AXControlSearchKey",
+                /* searchText */ "",
+                /* visibleOnly */ true,
+                /* immediateDescendantsOnly */ false
+            );
+            if (!result)
+                break;
+            controls.push(result);
+        }
+
+        window.foundMenuItems = controls.filter(function(element) {
+            return element.role.toLowerCase().includes("menuitem");
+        });
+        output += expect("foundMenuItems.length", "3");
+        output += expectMenuItem("foundMenuItems[0]", "Alpha");
+        output += expectMenuItem("foundMenuItems[1]", "Bravo");
+        output += expectMenuItem("foundMenuItems[2]", "Charlie");
+
+        // Close the picker.
+        select.press();
+        output += await expectAsync("select.isExpanded", "false");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -845,6 +845,16 @@ accessibility/dynamic-content-visibility.html [ Skip ]
 accessibility/dynamic-selected-radio-button.html [ Skip ]
 accessibility/password-notifications-timing.html [ Skip ]
 
+# appearance: base-select failures. These need investigation, but it's possible they can be made to pass if the tests
+# are restructured to be more platform-agnostic.
+accessibility/base-select-basic.html [ Skip ]
+accessibility/base-select-complex-options.html [ Skip ]
+accessibility/base-select-focus-on-open.html [ Skip ]
+accessibility/base-select-notifications.html [ Skip ]
+# This one fails because it leans on a Cocoa-specific API (AccessibilityUIElement::uiElementForSearchPredicate), so
+# may be a true skip.
+accessibility/base-select-search-predicate.html [ Skip ]
+
 # Failing because the mtable cannot be found as an accessible element.
 accessibility/table-row-bounding-boxes.html [ Skip ]
 

--- a/LayoutTests/platform/gtk/inspector/dom/getAccessibilityPropertiesForNode-expected.txt
+++ b/LayoutTests/platform/gtk/inspector/dom/getAccessibilityPropertiesForNode-expected.txt
@@ -291,6 +291,7 @@ Total elements to be tested: 126.
     label:
     role: button
     childNodeIds.length: 1
+    expanded: false
     focused: false
     required: false
     isPopUpButton: true

--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -36,6 +36,8 @@
 #include "AXUtilities.h"
 #include "DocumentView.h"
 #include "HTMLAreaElement.h"
+#include "HTMLOptionElement.h"
+#include "HTMLSelectElement.h"
 #include "LocalFrameView.h"
 #include "Logging.h"
 #include "RenderObjectStyle.h"
@@ -104,6 +106,9 @@ bool AXCoreObject::isControl() const
     case AccessibilityRole::DateTime:
     case AccessibilityRole::LandmarkSearch:
     case AccessibilityRole::ListBox:
+    // FIXME: MenuItemCheckbox and MenuItemRadio should also be considered controls.
+    // Without this, Voice Control won't generate numbered overlays for them.
+    case AccessibilityRole::MenuItem:
     case AccessibilityRole::PopUpButton:
     case AccessibilityRole::RadioButton:
     case AccessibilityRole::SearchField:
@@ -923,6 +928,15 @@ AXCoreObject::AccessibilityChildrenVector AXCoreObject::selectedChildren()
         return selectedListItems();
     case AccessibilityRole::Menu:
     case AccessibilityRole::MenuBar:
+        if (Accessibility::findAncestor(*this, /* includeSelf */ false, [] (const auto& ancestor) {
+            return ancestor.isPopUpButton();
+        })) {
+            for (const auto& child : unignoredChildren()) {
+                if (child->isSelected())
+                    return { { child } };
+            }
+            break;
+        }
         if (RefPtr descendant = activeDescendant())
             return { { descendant.releaseNonNull() } };
         if (RefPtr focusedElement = focusedUIElement())

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -126,6 +126,7 @@
 #include "SVGElement.h"
 #include "ScriptDisallowedScope.h"
 #include "ScrollView.h"
+#include "SelectPopoverElement.h"
 #include "Settings.h"
 #include "ShadowRoot.h"
 #include "TextBoundaries.h"
@@ -861,7 +862,7 @@ Ref<AccessibilityRenderObject> AXObjectCache::createObjectFromRenderer(RenderObj
         return AccessibilityMathMLElement::create(AXID::generate(), renderer, *this, isAnonymousOperator);
 #endif
 
-    if (RefPtr select = dynamicDowncast<HTMLSelectElement>(node); select && select->usesMenuList())
+    if (RefPtr select = dynamicDowncast<HTMLSelectElement>(node); select && select->usesMenuList() && !select->usesBaseAppearancePicker())
         return AccessibilityMenuList::create(AXID::generate(), renderer, *this);
 
     // Progress indicator.
@@ -987,7 +988,7 @@ AccessibilityObject* AXObjectCache::getOrCreateSlow(Node& node, IsPartOfRelation
         if (!select)
             return nullptr;
         RefPtr<AccessibilityObject> object;
-        if (select->usesMenuList()) {
+        if (select->usesMenuList() && !select->usesBaseAppearancePicker()) {
             if (!optionElement || !select->renderer())
                 return nullptr;
             object = AccessibilityMenuListOption::create(AXID::generate(), *optionElement, *this);
@@ -1611,6 +1612,17 @@ void AXObjectCache::handleChildrenChanged(AccessibilityObject& object)
     object.setNeedsToUpdateSubtree();
 
     object.recomputeIsIgnored();
+
+    if (auto* optionElement = dynamicDowncast<HTMLOptionElement>(object.node()); optionElement && optionElement->belongsToBaseAppearancePicker()) {
+        // When a base-appearance select option's children change, its text descendants may need to
+        // change their is-ignored state. Text is only exposed when the option has complex content
+        // (non-text descendants like buttons or links), so adding or removing such elements
+        // toggles can change whether text nodes are ignored.
+        Accessibility::enumerateDescendantsIncludingIgnored<AXCoreObject>(object, /* includeSelf */ false, [] (auto& descendant) {
+            if (descendant.isStaticText())
+                downcast<AccessibilityObject>(descendant).recomputeIsIgnored();
+        });
+    }
 
     // Go up the existing ancestors chain and fire the appropriate notifications.
     bool shouldUpdateParent = true;
@@ -2374,8 +2386,14 @@ void AXObjectCache::onSelectedOptionChanged(Element& element)
 
 void AXObjectCache::onSelectedOptionChanged(HTMLSelectElement& select, int optionIndex)
 {
-    if (RefPtr axMenuList = dynamicDowncast<AccessibilityMenuList>(get(select)))
+    if (RefPtr axMenuList = dynamicDowncast<AccessibilityMenuList>(get(select))) {
         axMenuList->didUpdateActiveOption(optionIndex);
+        return;
+    }
+
+    // Base-appearance selects don't use AccessibilityMenuList (which normally handles this),
+    // so post the value change notification directly.
+    deferMenuListValueChange(&select);
 }
 
 void AXObjectCache::onSlottedContentChange(const HTMLSlotElement& slot)
@@ -5289,6 +5307,31 @@ void AXObjectCache::performDeferredCacheUpdate(ForceLayout forceLayout)
 
 void AXObjectCache::handleDeferredPopoverToggle(AccessibilityObject& axPopover)
 {
+    if (RefPtr popoverElement = dynamicDowncast<SelectPopoverElement>(axPopover.element())) {
+        // When a base-appearance select's popover toggles, post ExpandedChanged on the
+        // select element itself, since the popover is opened programmatically (not
+        // via popovertarget/commandfor) so controllers() would be empty.
+        if (RefPtr selectElement = popoverElement->selectElement()) {
+            if (RefPtr axSelect = get(selectElement.get()))
+                postNotification(axSelect.get(), document(), AXNotification::ExpandedChanged);
+
+            bool isOpening = popoverElement->isPopoverShowing();
+            if (isOpening) {
+                RefPtr option = selectElement->selectedOption();
+                if (option && (selectElement->focused() || option->focused())) {
+                    // This notification isn't strictly necessary, as when handling press() via the
+                    // accessibility API, the DOM will naturally move focus to the selected option.
+                    // However, in practice, I've found a notification here to make VoiceOver's focus
+                    // movement significantly more snappy and consistent.
+                    if (RefPtr axOption = getOrCreate(*option))
+                        postNotification(axOption.get(), document(), AXNotification::FocusedUIElementChanged);
+                }
+            }
+        }
+
+        return;
+    }
+
     // There may be multiple elements with popovertarget or commandfor attributes that point at this popover.
     for (const auto& invoker : axPopover.controllers())
         postNotification(&downcast<AccessibilityObject>(invoker.get()), document(), AXNotification::ExpandedChanged);
@@ -5430,6 +5473,16 @@ void AXObjectCache::updateIsolatedTree(const Vector<std::pair<Ref<AccessibilityO
         case AXNotification::ExpandedChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::IsExpanded });
             break;
+        case AXNotification::FocusedUIElementChanged: {
+            // If we're going to inform ATs that the focus has changed, use the handling
+            // of this notification to ensure the isolated tree has the latest focused node.
+            // This is especially important for ATs like VoiceOver who immediately respond
+            // to this notification with a request for the currenly focused object. If we
+            // serve stale data in this scenario, VoiceOver will never move its cursor.
+            RefPtr focus = focusedObjectForLocalFrame();
+            tree->setFocusedNodeID(focus ? std::optional { focus->objectID() } : std::nullopt);
+            break;
+        }
         case AXNotification::ExtendedDescriptionChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { { AXProperty::AccessibilityText, AXProperty::ExtendedDescription } });
             break;

--- a/Source/WebCore/accessibility/AccessibilityMenuList.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMenuList.cpp
@@ -64,10 +64,12 @@ bool AccessibilityMenuList::press()
     RefPtr selectElement = dynamicDowncast<HTMLSelectElement>(element());
     auto notification = AXNotification::PressDidFail;
     if (selectElement && !selectElement->isDisabledFormControl()) {
+        // Note that hiding or showing the popup could trigger JS.
         if (selectElement->popupIsVisible())
             selectElement->hidePopup();
         else
             selectElement->showPopup();
+
         notification = AXNotification::PressDidSucceed;
     }
     if (CheckedPtr cache = axObjectCache())

--- a/Source/WebCore/accessibility/AccessibilityMenuListOption.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMenuListOption.cpp
@@ -109,6 +109,12 @@ bool AccessibilityMenuListOption::computeIsIgnored() const
 
 LayoutRect AccessibilityMenuListOption::elementRect() const
 {
+    if (renderer()) {
+        // When the option has a renderer (as for base-appearance selects),
+        // use the renderer's bounding box.
+        return boundingBoxRect();
+    }
+
     RefPtr parent = parentObject();
     // Our parent should've been set to be a menu-list popup before this method is called.
     AX_ASSERT(parent && parent->isMenuListPopup());

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -895,6 +895,12 @@ bool AccessibilityNodeObject::canHaveChildren() const
     case AccessibilityRole::MenuItemRadio:
     case AccessibilityRole::Splitter:
     case AccessibilityRole::Meter:
+        // Base-appearance selects expose their popover and options as real
+        // AX children, so the PopUpButton must be able to have children.
+        if (role() == AccessibilityRole::PopUpButton) {
+            if (RefPtr select = dynamicDowncast<HTMLSelectElement>(node()))
+                return select->usesBaseAppearancePicker();
+        }
         return false;
     default:
         return true;
@@ -3492,6 +3498,11 @@ void AccessibilityNodeObject::visibleText(Vector<AccessibilityText>& textOrder) 
         if (isHeading())
             mode.includeFocusableContent = true;
 
+        // Base-appearance select options can have interactive content (buttons, links) whose text
+        // should be included in the menu item's title for VoiceOver to read.
+        if (RefPtr optionElement = dynamicDowncast<HTMLOptionElement>(node.get()); optionElement && optionElement->belongsToBaseAppearancePicker())
+            mode.includeFocusableContent = true;
+
         // Track nodes referenced via aria-labelledby to avoid double-counting them
         // when they're encountered again in the tree.
         HashSet<const Node*> nodesReferencedViaLabeledby;
@@ -4249,14 +4260,10 @@ String AccessibilityNodeObject::stringValue() const
     }
 
     if (RefPtr selectElement = dynamicDowncast<HTMLSelectElement>(*node)) {
-        int selectedIndex = selectElement->selectedIndex();
-        auto& listItems = selectElement->listItems();
-        if (selectedIndex >= 0 && static_cast<size_t>(selectedIndex) < listItems.size()) {
-            if (RefPtr selectedItem = listItems[selectedIndex].get()) {
-                auto overriddenDescription = selectedItem->attributeTrimmedWithDefaultARIA(aria_labelAttr);
-                if (!overriddenDescription.isEmpty())
-                    return overriddenDescription;
-            }
+        if (RefPtr option = selectElement->selectedOption()) {
+            auto overriddenDescription = option->attributeTrimmedWithDefaultARIA(aria_labelAttr);
+            if (!overriddenDescription.isEmpty())
+                return overriddenDescription;
         }
         if (!selectElement->multiple())
             return selectElement->value();

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -71,7 +71,9 @@
 #include "HTMLInputElement.h"
 #include "HTMLModelElement.h"
 #include "HTMLNames.h"
+#include "HTMLOptionElement.h"
 #include "HTMLParserIdioms.h"
+#include "HTMLSelectElement.h"
 #include "HTMLSlotElement.h"
 #include "HTMLTableSectionElement.h"
 #include "HTMLTextAreaElement.h"
@@ -3055,7 +3057,12 @@ bool AccessibilityObject::isSelected() const
     if (isTabItem() && isTabItemSelected())
         return true;
 
-    // Menu items are considered selectable by assistive technologies
+    if (RefPtr option = dynamicDowncast<HTMLOptionElement>(node())) {
+        // Non-base-appearance select options are handled by AccessibilityMenuListOption
+        // or AccessibilityListBoxOption, so only base-appearance options reach here.
+        return option->selected();
+    }
+
     if (isMenuItem()) {
         if (isFocused())
             return true;
@@ -3437,6 +3444,9 @@ bool AccessibilityObject::supportsExpanded() const
     if (isColumnHeader() || isRowHeader())
         return hasValidAriaExpandedValue();
 
+    if (RefPtr select = dynamicDowncast<HTMLSelectElement>(node()); select && select->usesMenuList())
+        return true;
+
     switch (role()) {
     case AccessibilityRole::Details:
         return true;
@@ -3485,6 +3495,8 @@ bool AccessibilityObject::isExpanded() const
     }
 
     if (supportsExpanded()) {
+        if (RefPtr select = dynamicDowncast<HTMLSelectElement>(node()); select && select->usesMenuList())
+            return select->popupIsVisible();
         if (RefPtr commandForElement = this->commandForElement())
             return commandForElement->isPopoverShowing();
         if (RefPtr popoverTargetElement = this->popoverTargetElement())

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -72,6 +72,7 @@
 #include "HTMLMediaElement.h"
 #include "HTMLMeterElement.h"
 #include "HTMLNames.h"
+#include "HTMLOptGroupElement.h"
 #include "HTMLOptionElement.h"
 #include "HTMLOptionsCollection.h"
 #include "HTMLSelectElement.h"
@@ -132,6 +133,7 @@
 #include "SVGElementTypeHelpers.h"
 #include "SVGImage.h"
 #include "SVGSVGElement.h"
+#include "SelectPopoverElement.h"
 #include "ShadowRootMode.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
 #include "Text.h"
@@ -562,17 +564,12 @@ String AccessibilityRenderObject::stringValue() const
 
     // For menu list select elements, get the selected option's aria-label or label.
     if (RefPtr selectElement = dynamicDowncast<HTMLSelectElement>(node()); selectElement && selectElement->usesMenuList()) {
-        int selectedIndex = selectElement->selectedIndex();
-        const auto& listItems = selectElement->listItems();
-        if (selectedIndex >= 0 && static_cast<size_t>(selectedIndex) < listItems.size()) {
-            if (RefPtr selectedItem = listItems[selectedIndex].get()) {
-                auto overriddenDescription = selectedItem->attributeTrimmedWithDefaultARIA(aria_labelAttr);
-                if (!overriddenDescription.isEmpty())
-                    return overriddenDescription;
-            }
-        }
-        if (RefPtr option = selectElement->item(selectedIndex))
+        if (RefPtr option = selectElement->selectedOption()) {
+            auto overriddenDescription = option->attributeTrimmedWithDefaultARIA(aria_labelAttr);
+            if (!overriddenDescription.isEmpty())
+                return overriddenDescription;
             return option->label();
+        }
         return String();
     }
 
@@ -945,6 +942,13 @@ bool AccessibilityRenderObject::computeIsIgnored() const
     AX_ASSERT(m_initialized);
 #endif
 
+    if (is<SelectPopoverElement>(node())) {
+        // The base-appearance select popover (Menu) must always be included so that it
+        // properly wraps the menu items. Check before the !m_renderer bailout
+        // because the popover has display:contents (no renderer) when closed.
+        return false;
+    }
+
     if (!m_renderer)
         return AccessibilityNodeObject::computeIsIgnored();
 
@@ -1008,10 +1012,19 @@ bool AccessibilityRenderObject::computeIsIgnored() const
     if (isExposableTable())
         return false;
 
-    // Ignore popup menu items because AppKit does.
     if (RefPtr node = this->node()) {
+        if (node->isInUserAgentShadowTree()) {
+            // Non-base-appearance selects delegate popup rendering to AppKit and use mock AX
+            // objects for their options, so ignore real DOM descendants to avoid duplication.
+            // Base-appearance selects render their own popover and expose real elements, so
+            // their descendants must not be ignored.
+            RefPtr select = dynamicDowncast<HTMLSelectElement>(node->shadowHost());
+            if (select && (!select->usesBaseAppearancePicker() || !is<SelectPopoverElement>(*node)))
+                return true;
+        }
+
         for (Ref ancestor : ancestorsOfType<HTMLSelectElement>(*node)) {
-            if (ancestor->usesMenuList())
+            if (ancestor->usesMenuList() && !ancestor->usesBaseAppearancePicker())
                 return true;
         }
     }
@@ -1061,8 +1074,24 @@ bool AccessibilityRenderObject::computeIsIgnored() const
             if (checkForIgnored && !ancestor->isIgnored()) {
                 checkForIgnored = false;
                 // Static text beneath MenuItems are just reported along with the menu item, so it's ignored on an individual level.
-                if (ancestor->isMenuItem())
+                if (ancestor->isMenuItem()) {
+                    // For base-appearance selects, option elements can have complex content (e.g.
+                    // text alongside buttons and links). When the option has interactive
+                    // content, expose text nodes so VoiceOver can navigate to them.
+                    // Presentational wrappers like <span> don't count.
+                    if (auto* optionElement = dynamicDowncast<HTMLOptionElement>(ancestor->node()); optionElement && optionElement->belongsToBaseAppearancePicker()) {
+                        bool hasInteractiveContent = false;
+                        for (Ref descendant : descendantsOfType<HTMLElement>(*optionElement)) {
+                            if (descendant->isInteractiveContent()) {
+                                hasInteractiveContent = true;
+                                break;
+                            }
+                        }
+                        if (hasInteractiveContent)
+                            break;
+                    }
                     return true;
+                }
             }
         }
 
@@ -1695,6 +1724,21 @@ bool AccessibilityRenderObject::press()
         return AccessibilityMediaHelpers::press(*mediaElement);
     }
 #endif
+
+    if (RefPtr selectElement = dynamicDowncast<HTMLSelectElement>(element()); selectElement && selectElement->usesBaseAppearancePicker()) {
+        // Base-appearance selects need explicit picker toggling since they no longer use
+        // AccessibilityMenuList which had its own press() override.
+        if (selectElement->isDisabledFormControl())
+            return false;
+        if (selectElement->popupIsVisible())
+            selectElement->hidePickerPopoverElement();
+        else
+            selectElement->openPickerForUserInteraction();
+        if (CheckedPtr cache = axObjectCache())
+            cache->postNotification(selectElement.get(), AXNotification::PressDidSucceed);
+        return true;
+    }
+
     return AccessibilityObject::press();
 }
 
@@ -2228,6 +2272,9 @@ AccessibilityRole AccessibilityRenderObject::determineAccessibilityRole()
     if (hasTreeRole())
         return isValidTree() ? AccessibilityRole::Tree : AccessibilityRole::Generic;
 
+    if (is<SelectPopoverElement>(node()))
+        return AccessibilityRole::Menu;
+
     if (!m_renderer)
         return AccessibilityNodeObject::determineAccessibilityRole();
 
@@ -2294,6 +2341,16 @@ AccessibilityRole AccessibilityRenderObject::determineAccessibilityRole()
         if (selectElement->usesMenuList())
             return selectElement->multiple() ? AccessibilityRole::ListBox : AccessibilityRole::PopUpButton;
         return AccessibilityRole::ListBox;
+    }
+
+    // Options inside base-appearance selects are menu items.
+    if (RefPtr option = dynamicDowncast<HTMLOptionElement>(node)) {
+        if (RefPtr select = option->ownerSelectElement(); select && select->usesBaseAppearancePicker())
+            return AccessibilityRole::MenuItem;
+    }
+    if (RefPtr optGroup = dynamicDowncast<HTMLOptGroupElement>(node)) {
+        if (RefPtr select = optGroup->ownerSelectElement(); select && select->usesBaseAppearancePicker())
+            return AccessibilityRole::Group;
     }
 
     if (m_renderer->isRenderOrLegacyRenderSVGRoot())

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -220,10 +220,7 @@ void HTMLOptionElement::finishParsingChildren()
 
 bool HTMLOptionElement::supportsFocus() const
 {
-    if (HTMLElement::supportsFocus())
-        return true;
-    RefPtr select = ownerSelectElement();
-    return select && select->usesBaseAppearancePicker();
+    return HTMLElement::supportsFocus() || belongsToBaseAppearancePicker();
 }
 
 bool HTMLOptionElement::isFocusable() const
@@ -475,6 +472,12 @@ HTMLSelectElement* HTMLOptionElement::ownerSelectElement() const
             return optGroup->ownerSelectElement();
     }
     return nullptr;
+}
+
+bool HTMLOptionElement::belongsToBaseAppearancePicker() const
+{
+    RefPtr select = ownerSelectElement();
+    return select && select->usesBaseAppearancePicker();
 }
 
 String HTMLOptionElement::label() const

--- a/Source/WebCore/html/HTMLOptionElement.h
+++ b/Source/WebCore/html/HTMLOptionElement.h
@@ -58,6 +58,7 @@ public:
     WEBCORE_EXPORT void setSelected(bool);
 
     WEBCORE_EXPORT HTMLSelectElement* NODELETE ownerSelectElement() const;
+    bool belongsToBaseAppearancePicker() const;
 
     WEBCORE_EXPORT String label() const;
     WEBCORE_EXPORT String displayLabel() const;

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -1238,6 +1238,12 @@ int HTMLSelectElement::selectedIndex() const
     return -1;
 }
 
+HTMLOptionElement* HTMLSelectElement::selectedOption()
+{
+    int index = selectedIndex();
+    return index >= 0 ? item(index) : nullptr;
+}
+
 void HTMLSelectElement::setSelectedIndex(int index)
 {
     selectOption(index, SelectOptionFlag::DeselectOtherOptions);

--- a/Source/WebCore/html/HTMLSelectElement.h
+++ b/Source/WebCore/html/HTMLSelectElement.h
@@ -67,6 +67,7 @@ public:
     static HTMLSelectElement* NODELETE findOwnerSelect(ContainerNode*, ExcludeOptGroup);
 
     WEBCORE_EXPORT int selectedIndex() const;
+    HTMLOptionElement* selectedOption();
     WEBCORE_EXPORT void setSelectedIndex(int);
 
     WEBCORE_EXPORT void optionSelectedByUser(int index, bool dispatchChangeEvent, bool allowMultipleSelection = false);
@@ -187,6 +188,7 @@ public:
 
     WEBCORE_EXPORT bool usesBaseAppearancePicker() const;
     SelectPopoverElement* NODELETE pickerPopoverElement() const;
+    void openPickerForUserInteraction(std::optional<bool> focusVisible = std::nullopt);
     void hidePickerPopoverElement();
     void queuePickerCloseForAppearanceChange();
 
@@ -285,7 +287,6 @@ private:
     void didAddUserAgentShadowRoot(ShadowRoot&) final;
 
     void showPickerInternal();
-    void openPickerForUserInteraction(std::optional<bool> focusVisible = std::nullopt);
 
     // TypeAheadDataSource functions.
     int indexOfSelectedOption() const final;


### PR DESCRIPTION
#### 17d031e1620afbe35bdeb7d0b1593dd64a7b07d8
<pre>
AX: Implement accessibility for base-appearance selects on macOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=311111">https://bugs.webkit.org/show_bug.cgi?id=311111</a>
<a href="https://rdar.apple.com/173696010">rdar://173696010</a>

Reviewed by Joshua Hoffman.

Base-appearance selects render their own popover and options as real DOM elements,
unlike traditional selects which delegate popup rendering to AppKit and are thus
modeled by WebKit as mock objects.

This commit implements accessibility for base-appearance selects on macOS, tested
with VoiceOver, Voice Control, and Hover Text.

Multiple tests are added to exercise the various APIs and markup variations.

* LayoutTests/accessibility/base-select-basic-expected.txt: Added.
* LayoutTests/accessibility/base-select-basic.html: Added.
* LayoutTests/accessibility/base-select-complex-options-expected.txt: Added.
* LayoutTests/accessibility/base-select-complex-options.html: Added.
* LayoutTests/accessibility/base-select-focus-on-open-expected.txt: Added.
* LayoutTests/accessibility/base-select-focus-on-open.html: Added.
* LayoutTests/accessibility/base-select-notifications-expected.txt: Added.
* LayoutTests/accessibility/base-select-notifications.html: Added.
* LayoutTests/accessibility/base-select-search-predicate-expected.txt: Added.
* LayoutTests/accessibility/base-select-search-predicate.html: Added.
* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::isControl const):
(WebCore::AXCoreObject::selectedChildren):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::createObjectFromRenderer):
(WebCore::AXObjectCache::getOrCreateSlow):
(WebCore::AXObjectCache::handleChildrenChanged):
(WebCore::AXObjectCache::onSelectedOptionChanged):
(WebCore::AXObjectCache::handleDeferredPopoverToggle):
(WebCore::AXObjectCache::updateIsolatedTree):
* Source/WebCore/accessibility/AccessibilityMenuList.cpp:
(WebCore::AccessibilityMenuList::press):
* Source/WebCore/accessibility/AccessibilityMenuListOption.cpp:
(WebCore::AccessibilityMenuListOption::elementRect const):
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::canHaveChildren const):
(WebCore::AccessibilityNodeObject::visibleText const):
(WebCore::AccessibilityNodeObject::stringValue const):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::isSelected const):
(WebCore::AccessibilityObject::supportsExpanded const):
(WebCore::AccessibilityObject::isExpanded const):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::stringValue const):
(WebCore::AccessibilityRenderObject::computeIsIgnored const):
(WebCore::AccessibilityRenderObject::press):
(WebCore::AccessibilityRenderObject::determineAccessibilityRole):
* Source/WebCore/html/HTMLOptionElement.cpp:
(WebCore::HTMLOptionElement::belongsToBaseAppearancePicker const):
* Source/WebCore/html/HTMLOptionElement.h:
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::selectedOption):
* Source/WebCore/html/HTMLSelectElement.h:

Canonical link: <a href="https://commits.webkit.org/310441@main">https://commits.webkit.org/310441@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85dc3aeab84796e60084015ea21f4c665b67b471

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153724 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26508 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20125 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162474 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107182 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eac7a8a4-b435-4463-a7bd-3a8d4171d677) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155597 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27036 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26830 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118857 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/107182 "An unexpected error occured. Recent messages:Printed configuration") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156683 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21117 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138032 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99567 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b29a691c-701a-46f1-b6fe-3494da69ab29) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20196 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18151 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10307 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129845 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15891 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164945 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8079 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17485 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126933 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26305 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22182 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127100 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34512 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26307 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137686 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82985 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22006 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14468 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25924 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90212 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25615 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25775 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25675 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->