### PR TITLE
[Accessibility] Remove overly strict AX_ASSERT in WebPage::inheritAccessibilityMode

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2849,13 +2849,11 @@ void WebPage::accessibilitySettingsDidChange()
 void WebPage::inheritAccessibilityMode(WebCore::AccessibilityMode mode)
 {
     if (WebCore::isAccessibilityModeOff(mode)) {
-        // The only time we disable accessibility is for testing, and
-        // that should request to disable accessibility should not sync
-        // to other processes. If we hit this assert, it means we
-        // turned accessibility on in this process, and then something
-        // tried to sync an Off-state to us, which should never happen.
-        AX_ASSERT(!WebCore::AXObjectCache::accessibilityEnabled());
-
+        // Accessibility may already be enabled process-wide (e.g. a prior
+        // WebPage in this process received a non-Off mode, or
+        // shouldForceAccessibilityEnabled() triggered enableAccessibility).
+        // Receiving Off for a new page is normal in that case — just no-op.
+        //
         // In the future, we may add a way to disable accessibility in
         // production (i.e. the user turns off their AT), in which case
         // this function will need to change.


### PR DESCRIPTION
#### 038aac1ed9186c24d78f37a5ff5abd169acba344
<pre>
[Accessibility] Remove overly strict AX_ASSERT in WebPage::inheritAccessibilityMode
<a href="https://bugs.webkit.org/show_bug.cgi?id=311126">https://bugs.webkit.org/show_bug.cgi?id=311126</a>
<a href="https://rdar.apple.com/173716198">rdar://173716198</a>

Reviewed by BJ Burg and Tyler Wilcock.

Running the css/css-grid WPT tests in debug mode was causing numerous crashes.

The assertion assumed that if the UIProcess sends an Off accessibility mode during WebPage creation,
accessibility must not already be enabled in the WebContent process. This doesn&apos;t hold when multiple
WebPages share a process: an earlier page may have enabled accessibility process-wide via a non-Off mode,
and a subsequent page receiving Off is normal.

The function already handles this correctly by returning early (no-op). The assertion was purely defensive
and the crash it caused was worse than the silent no-op.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::inheritAccessibilityMode):

Canonical link: <a href="https://commits.webkit.org/310276@main">https://commits.webkit.org/310276@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e390a7c850ccd7414bbd1dddc507efe220da68f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153266 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26050 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19648 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162011 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106724 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d0874ef9-a623-4525-afb4-ec9b16ad4495) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26576 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26353 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118493 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ae1d35c5-e573-44dc-9e44-756cc7c77968) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156225 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20731 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137609 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99206 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b3ef5ea4-c959-4006-b826-e85ab488c35e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19808 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17758 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9846 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129454 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164485 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7620 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17073 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126552 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25845 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21791 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126710 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34383 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25847 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137275 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82516 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21656 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14053 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25465 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89750 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25156 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25316 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25217 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->