### PR TITLE
[Site Isolation] Fix block-top-level-navigation-via-redirect-by-third-party-iframes

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6994,8 +6994,6 @@ webkit.org/b/245032 imported/w3c/web-platform-tests/css/compositing/root-element
 
 webkit.org/b/261916 media/video-pause-while-seeking.html [ Pass Failure ]
 
-webkit.org/b/263233 http/tests/security/block-top-level-navigation-via-redirect-by-third-party-iframes.html [ Failure Pass ]
-
 webkit.org/b/263434 imported/w3c/web-platform-tests/uievents/order-of-events/mouse-events/wheel-basic.html [ Skip ]
 
 webkit.org/b/261810 imported/w3c/web-platform-tests/css/css-scroll-snap/input/mouse-wheel.html [ Skip ]

--- a/LayoutTests/http/tests/security/block-top-level-navigation-via-redirect-by-third-party-iframes.html
+++ b/LayoutTests/http/tests/security/block-top-level-navigation-via-redirect-by-third-party-iframes.html
@@ -11,7 +11,7 @@ onload = () => {
         setTimeout(() => {
             testPassed("All navigations by subframes have been blocked");
             finishJSTest();
-        }, 100);
+        }, 1000);
     }, 10);
 }
 </script>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -205,6 +205,7 @@
 #include "Navigation.h"
 #include "NavigationActivation.h"
 #include "NavigationDisabler.h"
+#include "NavigationRequester.h"
 #include "NavigationScheduler.h"
 #include "Navigator.h"
 #include "NavigatorMediaSession.h"
@@ -5018,7 +5019,7 @@ CanNavigateState Document::canNavigate(Frame* targetFrame, const URL& destinatio
     if (!canNavigateInternal(*targetFrame))
         return CanNavigateState::Unable;
 
-    if (isNavigationBlockedByThirdPartyIFrameRedirectBlocking(*targetFrame, destinationURL)) {
+    if (isNavigationBlockedByThirdPartyIFrameRedirectBlocking(NavigationRequester::from(*this), *targetFrame, destinationURL)) {
         printNavigationErrorMessage(*this, *targetFrame, url(), "The frame attempting navigation of the top-level window is cross-origin or untrusted and the user has never interacted with the frame."_s);
         DOCUMENT_RELEASE_LOG_ERROR(Loading, "Navigation was prevented because it was triggered by a cross-origin or untrusted iframe");
         return CanNavigateState::Unable;
@@ -5125,32 +5126,30 @@ void Document::willLoadFrameElement(const URL& frameURL)
 }
 
 // Prevent cross-site top-level redirects from third-party iframes unless the user has ever interacted with the frame.
-bool Document::isNavigationBlockedByThirdPartyIFrameRedirectBlocking(Frame& targetFrame, const URL& destinationURL)
+bool Document::isNavigationBlockedByThirdPartyIFrameRedirectBlocking(const NavigationRequester& requester, Frame& targetFrame, const URL& destinationURL)
 {
     // Only prevent top frame navigations by subframes.
-    if (m_frame == &targetFrame || &targetFrame != &m_frame->tree().top())
+    if (requester.frameID == targetFrame.frameID() || requester.topFrameID != targetFrame.frameID())
         return false;
 
     // Only prevent navigations by subframes that the user has not interacted with.
-    if (m_frame->hasHadUserInteraction())
+    if (requester.hasHadUserInteraction)
         return false;
 
     // Only prevent navigations by unsandboxed iframes. Sandboxed iframes would have already been blocked
     // unless "allow-top-navigation" was explicitly set via the element's sandbox attribute (not CSP).
     // Also require the parent that set the sandbox to be same-origin with the target.
-    bool sandboxIsFromElementAttribute = !sandboxFlags().isEmpty() && m_frame->sandboxFlagsFromSandboxAttributeNotCSP() == sandboxFlags();
+    bool sandboxIsFromElementAttribute = !requester.sandboxFlags.isEmpty() && requester.frameSandboxFlags == requester.sandboxFlags;
     if (sandboxIsFromElementAttribute) {
-        RefPtr parentFrame = m_frame->tree().parent();
-        RefPtr parentOrigin = parentFrame ? parentFrame->frameDocumentSecurityOrigin() : nullptr;
         RefPtr targetOrigin = targetFrame.frameDocumentSecurityOrigin();
-        bool parentIsFirstParty = parentOrigin && targetOrigin && parentOrigin->isSameOriginDomain(*targetOrigin);
+        bool parentIsFirstParty = requester.parentFrameSecurityOrigin && targetOrigin && requester.parentFrameSecurityOrigin->isSameOriginDomain(*targetOrigin);
         if (parentIsFirstParty)
             return false;
     }
 
     // Only prevent navigations by third-party iframes or untrusted first-party iframes.
-    bool isUntrustedIframe = m_hasLoadedThirdPartyScript && m_hasLoadedThirdPartyFrame;
-    if (canAccessAncestor(securityOrigin(), &targetFrame) && !isUntrustedIframe)
+    bool isUntrustedIframe = requester.hasLoadedThirdPartyScript && requester.hasLoadedThirdPartyFrame;
+    if (canAccessAncestor(requester.securityOrigin, &targetFrame) && !isUntrustedIframe)
         return false;
 
     // Only prevent cross-site navigations.

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1673,6 +1673,8 @@ public:
 
     void willLoadScriptElement(const URL&);
     void willLoadFrameElement(const URL&);
+    bool hasLoadedThirdPartyScript() const { return m_hasLoadedThirdPartyScript; }
+    bool hasLoadedThirdPartyFrame() const { return m_hasLoadedThirdPartyFrame; }
 
     Ref<FontFaceSet> fonts();
 
@@ -2039,7 +2041,7 @@ public:
     String httpUserAgent() const final;
 
     virtual void didChangeViewSize() { }
-    bool isNavigationBlockedByThirdPartyIFrameRedirectBlocking(Frame& targetFrame, const URL& destinationURL);
+    static bool isNavigationBlockedByThirdPartyIFrameRedirectBlocking(const NavigationRequester&, Frame& targetFrame, const URL& destinationURL);
 
     enum UpdateLayoutIfContentVisibilityChanged : bool { No, Yes };
     DidUpdateAnyContentRelevancy updateRelevancyOfContentVisibilityElements(UpdateLayoutIfContentVisibilityChanged = UpdateLayoutIfContentVisibilityChanged::Yes);

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -83,6 +83,7 @@
 #include "MemoryCache.h"
 #include "MixedContentChecker.h"
 #include "NavigationNavigationType.h"
+#include "NavigationRequester.h"
 #include "NavigationScheduler.h"
 #include "NetworkLoadMetrics.h"
 #include "NetworkStorageSession.h"
@@ -677,20 +678,17 @@ void DocumentLoader::willSendRequest(ResourceRequest&& newRequest, const Resourc
 
     RefPtr frame = m_frame.get();
     if (auto requester = m_triggeringAction.requester(); requester && requester->documentIdentifier) {
-        if (RefPtr requestingDocument = Document::allDocumentsMap().get(requester->documentIdentifier); requestingDocument && requestingDocument->frame()) {
-            if (frame && requestingDocument->isNavigationBlockedByThirdPartyIFrameRedirectBlocking(*frame, newRequest.url())) {
-                DOCUMENTLOADER_RELEASE_LOG("willSendRequest: canceling - cross-site redirect of top frame triggered by third-party iframe");
-                if (RefPtr document = frame->document()) {
-                    auto message = makeString("Unsafe JavaScript attempt to initiate navigation for frame with URL '"_s
-                        , document->url().string()
-                        , "' from frame with URL '"_s
-                        , requestingDocument->url().string()
-                        , "'. The frame attempting navigation of the top-level window is cross-origin or untrusted and the user has never interacted with the frame."_s);
-                    document->addConsoleMessage(MessageSource::Security, MessageLevel::Error, message);
-                }
-                cancelMainResourceLoad(protect(frameLoader())->cancelledError(newRequest));
-                return completionHandler(WTF::move(newRequest));
+        if (frame && Document::isNavigationBlockedByThirdPartyIFrameRedirectBlocking(*requester, *frame, newRequest.url())) {
+            if (RefPtr document = frame->document()) {
+                auto message = makeString("Unsafe JavaScript attempt to initiate navigation for frame with URL '"_s
+                    , document->url().string()
+                    , "' from frame with URL '"_s
+                    , requester->url.string()
+                    , "'. The frame attempting navigation of the top-level window is cross-origin or untrusted and the user has never interacted with the frame."_s);
+                document->addConsoleMessage(MessageSource::Security, MessageLevel::Error, message);
             }
+            cancelMainResourceLoad(protect(frameLoader())->cancelledError(newRequest));
+            return completionHandler(WTF::move(newRequest));
         }
     }
 

--- a/Source/WebCore/loader/NavigationRequester.cpp
+++ b/Source/WebCore/loader/NavigationRequester.cpp
@@ -27,20 +27,31 @@
 #include "NavigationRequester.h"
 
 #include "Document.h"
+#include "FrameDestructionObserverInlines.h"
+#include "LocalFrame.h"
 
 namespace WebCore {
 
 NavigationRequester NavigationRequester::from(Document& document)
 {
+    RefPtr frame = document.frame();
+    RefPtr parentFrame = frame ? frame->tree().parent() : nullptr;
+
     return {
         document.url(),
         document.securityOrigin(),
         document.topOrigin(),
         document.policyContainer(),
         document.frameID(),
+        frame ? std::make_optional(frame->tree().top().frameID()) : std::nullopt,
         document.pageID(),
         document.identifier(),
-        document.sandboxFlags()
+        document.sandboxFlags(),
+        frame ? frame->sandboxFlagsFromSandboxAttributeNotCSP() : SandboxFlags { },
+        document.hasLoadedThirdPartyScript(),
+        document.hasLoadedThirdPartyFrame(),
+        frame ? frame->hasHadUserInteraction() : false,
+        parentFrame ? parentFrame->frameDocumentSecurityOrigin() : nullptr
     };
 }
 

--- a/Source/WebCore/loader/NavigationRequester.h
+++ b/Source/WebCore/loader/NavigationRequester.h
@@ -43,9 +43,15 @@ struct NavigationRequester {
     Ref<SecurityOrigin> topOrigin;
     PolicyContainer policyContainer;
     std::optional<FrameIdentifier> frameID;
+    std::optional<FrameIdentifier> topFrameID;
     std::optional<PageIdentifier> pageID;
     ScriptExecutionContextIdentifier documentIdentifier;
     SandboxFlags sandboxFlags;
+    SandboxFlags frameSandboxFlags;
+    bool hasLoadedThirdPartyScript { false };
+    bool hasLoadedThirdPartyFrame { false };
+    bool hasHadUserInteraction { false };
+    RefPtr<SecurityOrigin> parentFrameSecurityOrigin;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4794,9 +4794,15 @@ struct WebCore::NavigationRequester {
     Ref<WebCore::SecurityOrigin> topOrigin;
     WebCore::PolicyContainer policyContainer;
     std::optional<WebCore::FrameIdentifier> frameID;
+    std::optional<WebCore::FrameIdentifier> topFrameID;
     std::optional<WebCore::PageIdentifier> pageID;
     WebCore::ScriptExecutionContextIdentifier documentIdentifier;
     WebCore::SandboxFlags sandboxFlags;
+    WebCore::SandboxFlags frameSandboxFlags;
+    bool hasLoadedThirdPartyScript;
+    bool hasLoadedThirdPartyFrame;
+    bool hasHadUserInteraction;
+    RefPtr<WebCore::SecurityOrigin> parentFrameSecurityOrigin;
 };
 
 struct WebCore::PolicyContainer {


### PR DESCRIPTION
#### b9f789219c6581462af54ae1afbfd95da752ee9c
<pre>
[Site Isolation] Fix block-top-level-navigation-via-redirect-by-third-party-iframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=311128">https://bugs.webkit.org/show_bug.cgi?id=311128</a>
<a href="https://rdar.apple.com/173717035">rdar://173717035</a>

Reviewed by Sihui Liu.

Handles the case when site isolation is enabled and a cross origin iframe
tries to navigate the top frame (by setting top.location) to
a same origin site which has a cross origin redirect.

Example:
Top frame&apos;s origin is <a href="https://a.com">https://a.com</a>
Cross-origin iframe&apos;s origin is <a href="https://b.com">https://b.com</a>

The cross origin iframe attempts to navigate the top frame
to a same origin site (<a href="https://a.com)">https://a.com)</a> which has a cross-origin
redirect (to <a href="https://b.com)">https://b.com)</a> via the following JavaScript:

        top.location = &quot;<a href="https://a.com?url=https">https://a.com?url=https</a>://b.com&quot;

If the server hosting a.com responds with a redirect (302 status code)
then WebKit will inspect the validity of the redirect.

In this case, while the initial navigation is same origin and should
be allowed, the redirect goes to a cross-origin site relative to the
top frame. Since the requesting frame is cross-origin, this redirect
should be blocked.

In DocumentLoader::willSendRequest, WebKit inspects the redirect request
and determines if it should be allowed or blocked.
When Site Isolation was enabled, Document::allDocumentsMap().get(requester-&gt;documentIdentifier)
would return null since the requestingDocument was in a cross-origin
RemoteFrame from another process. As a result, the log that reads
&quot;Unsafe JavaScript attempt to initiate navigation for frame ...&quot;
was never logged.

This patch updates DocumentLoader::willSendRequest for site isolation
when requestingDocument is null. Instead, isNavigationBlockedByThirdPartyIFrameRedirectBlocking
has been updated to be a static method which doesn&apos;t depend on Document.
Instead, it takes a NavigationRequester.  The Document fields which
isNavigationBlockedByThirdPartyIFrameRedirectBlocking
uses normally have been populated as new fields in NavigationRequester.

The test was also flaky because it only waited 100ms for the cross-site
redirect to be processed and blocked. This was often not enough time,
causing the test to finish before the redirect was handled and the
&quot;Unsafe JavaScript attempt to initiate navigation for frame ...&quot;
console message was generated. This patch also increases the
timeout to 1000ms.

* LayoutTests/TestExpectations:
* LayoutTests/http/tests/security/block-top-level-navigation-via-redirect-by-third-party-iframes.html:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::canNavigate):
(WebCore::Document::isNavigationBlockedByThirdPartyIFrameRedirectBlocking):
* Source/WebCore/dom/Document.h:
(WebCore::Document::hasLoadedThirdPartyScript const):
(WebCore::Document::hasLoadedThirdPartyFrame const):
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::willSendRequest):
* Source/WebCore/loader/NavigationRequester.cpp:
(WebCore::NavigationRequester::from):
* Source/WebCore/loader/NavigationRequester.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/311805@main">https://commits.webkit.org/311805@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36db0960a9be36e2e3a5928447a444cac42d700d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155321 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28581 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21740 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164082 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109118 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157194 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28959 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28431 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120206 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84857 "1 flakes 2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158280 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22579 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139496 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100895 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21665 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19587 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11915 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131334 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17328 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166560 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/10723 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18938 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128493 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28125 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23621 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128445 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28049 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139121 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/85434 "Build was cancelled. Recent messages:Printed configuration") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24028 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23298 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15918 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27743 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91846 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27320 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27550 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27393 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->