### PR TITLE
[WPE][Qt] Crash on wpeViewQtQuickDispose

### DIFF
--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.cpp
@@ -97,6 +97,8 @@ void WPEQtView::configureWindow()
 
     win->setSurfaceType(QWindow::OpenGLSurface);
 
+    connect(win, &QQuickWindow::sceneGraphInvalidated, this, &WPEQtView::invalidateSceneGraph);
+
     if (win->isSceneGraphInitialized())
         createWebView();
     else
@@ -590,6 +592,16 @@ void WPEQtView::touchEvent(QTouchEvent* event)
         return;
     auto* wpeView = webkit_web_view_get_wpe_view(d->m_webView.get());
     wpe_view_dispatch_touch_event(WPE_VIEW_QTQUICK(wpeView), event);
+}
+
+void WPEQtView::invalidateSceneGraph()
+{
+    Q_D(WPEQtView);
+    if (!d->m_webView)
+        return;
+
+    auto* wpeView = webkit_web_view_get_wpe_view(d->m_webView.get());
+    wpe_view_qtquick_invalidate_rendering(WPE_VIEW_QTQUICK(wpeView));
 }
 
 WebKitWebView* WPEQtView::webView() const

--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.h
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.h
@@ -109,6 +109,7 @@ private Q_SLOTS:
     void configureWindow();
     void createWebView();
     void didUpdateScene();
+    void invalidateSceneGraph();
 
 private:
     QSGNode* updatePaintNode(QSGNode*, UpdatePaintNodeData*) final;

--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEViewQtQuick.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEViewQtQuick.cpp
@@ -64,13 +64,7 @@ static PFNGLEGLIMAGETARGETTEXTURE2DOESPROC imageTargetTexture2DOES;
 
 static void wpeViewQtQuickDispose(GObject* object)
 {
-    auto* priv = WPE_VIEW_QTQUICK(object)->priv;
-    if (priv->textureId) {
-        if (auto* glFunctions = priv->context ? priv->context->functions() : nullptr)
-            glFunctions->glDeleteTextures(1, &priv->textureId);
-        priv->textureId = 0;
-    }
-
+    wpe_view_qtquick_invalidate_rendering(WPE_VIEW_QTQUICK(object));
     G_OBJECT_CLASS(wpe_view_qtquick_parent_class)->dispose(object);
 }
 
@@ -161,6 +155,17 @@ gboolean wpe_view_qtquick_initialize_rendering(WPEViewQtQuick* view, WPEQtView* 
     priv->surface.create();
 
     return TRUE;
+}
+
+void wpe_view_qtquick_invalidate_rendering(WPEViewQtQuick* view)
+{
+    auto* priv = view->priv;
+    if (priv->textureId && priv->context) {
+        if (auto* glFunctions = priv->context->functions())
+            glFunctions->glDeleteTextures(1, &priv->textureId);
+        priv->textureId = 0;
+    }
+    priv->context = nullptr;
 }
 
 QSGTexture* wpe_view_qtquick_render_buffer_to_texture(WPEViewQtQuick* view, QSize size, GError** error)

--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEViewQtQuick.h
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEViewQtQuick.h
@@ -45,6 +45,7 @@ G_DECLARE_FINAL_TYPE (WPEViewQtQuick, wpe_view_qtquick, WPE, VIEW_QTQUICK, WPEVi
 WPEView *wpe_view_qtquick_new                              (WPEDisplayQtQuick *display);
 gboolean         wpe_view_qtquick_initialize_rendering     (WPEViewQtQuick    *view, WPEQtView   *wpeQtView, GError **error);
 
+void             wpe_view_qtquick_invalidate_rendering     (WPEViewQtQuick    *view);
 QSGTexture*      wpe_view_qtquick_render_buffer_to_texture (WPEViewQtQuick    *view, QSize             size, GError **error);
 void             wpe_view_qtquick_did_update_scene         (WPEViewQtQuick    *view);
 


### PR DESCRIPTION
#### 7bd4877673012f0980daf481a4d2674e736e6fec
<pre>
[WPE][Qt] Crash on wpeViewQtQuickDispose
<a href="https://bugs.webkit.org/show_bug.cgi?id=311129">https://bugs.webkit.org/show_bug.cgi?id=311129</a>

Reviewed by Adrian Perez de Castro.

wpeViewQtQuickDispose was previously attempting to dispose of the GL
resources. However, by the time this was called, these resources might
already be unavailable.

This subscribes to QQuickWindow::sceneGraphInvalidated() and disposes of
the GL resources there. Since it sets textureId to 0, this slot can be
safely invoked from wpeViewQtQuickDispose, too.

Closing Qt MiniBrowser after having loaded a site would result in a
crash. After this fix, the crash is gone.

* Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.cpp:
(WPEQtView::configureWindow):
(WPEQtView::invalidateSceneGraph):
* Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.h:
* Source/WebKit/UIProcess/API/wpe/qt6/WPEViewQtQuick.cpp:
(wpeViewQtQuickDispose):
(wpe_view_qtquick_invalidate_rendering):
* Source/WebKit/UIProcess/API/wpe/qt6/WPEViewQtQuick.h:

Canonical link: <a href="https://commits.webkit.org/310287@main">https://commits.webkit.org/310287@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f7c7f9828b41077da8f092fe10457db14714fcb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153275 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26059 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19657 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162020 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106733 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26585 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26362 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118500 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83908 "12 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156234 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20749 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137615 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99213 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19826 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17766 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9855 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129473 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164494 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7629 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17079 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126560 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25855 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21799 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/semantics/structured-clone/shared.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126718 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34392 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25856 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137281 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82525 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21663 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14059 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25474 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89772 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25165 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25325 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25226 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->