### PR TITLE
REGRESSION(309965@main?): JSC-Tests-O3-Debug-arm64 intermittently hitting buildbot step timeout (testwasmdebugger hang?)

### DIFF
--- a/Source/JavaScriptCore/runtime/VMTraps.cpp
+++ b/Source/JavaScriptCore/runtime/VMTraps.cpp
@@ -303,18 +303,23 @@ private:
 
         auto optionalOwnerThread = vm.ownerThread();
         if (optionalOwnerThread) {
+            auto expectedUID = optionalOwnerThread.value()->uid();
             ThreadSuspendLocker locker;
             sendMessage(locker, *optionalOwnerThread.value().get(), [&] (PlatformRegisters& registers) -> void {
                 auto signalContext = SignalContext::tryCreate(registers);
                 if (!signalContext)
                     return;
 
-                auto ownerThread = vm.apiLock().ownerThread();
                 // We can't mess with a thread unless it's the one we suspended.
-                if (!ownerThread || ownerThread != optionalOwnerThread)
+                // Use ownerThreadUID() instead of ownerThread() to avoid creating a temporary
+                // RefPtr<Thread> copy, which would acquire the Thread control block WordLock.
+                // If the suspended thread was frozen mid-unlock of that same WordLock,
+                // calling ownerThread() here would deadlock.
+                auto currentUID = vm.ownerThreadUID();
+                if (!currentUID || *currentUID != expectedUID)
                     return;
 
-                Thread& thread = *ownerThread->get();
+                Thread& thread = *optionalOwnerThread->get();
                 vm.traps().tryInstallTrapBreakpoints(*signalContext, thread.stack());
             });
         }


### PR DESCRIPTION
#### 82fbab56eb7983bbcd10ef29c673754b2bf46b43
<pre>
REGRESSION(309965@main?): JSC-Tests-O3-Debug-arm64 intermittently hitting buildbot step timeout (testwasmdebugger hang?)
<a href="https://bugs.webkit.org/show_bug.cgi?id=311122">https://bugs.webkit.org/show_bug.cgi?id=311122</a>
<a href="https://rdar.apple.com/173709402">rdar://173709402</a>

Reviewed by Yusuke Suzuki.

VMTraps::SignalSender::work() calls vm.apiLock().ownerThread() inside
the sendMessage lambda, which runs while the target VM thread is
suspended via mach thread_suspend(). ownerThread() returns
Optional&lt;RefPtr&lt;Thread&gt;&gt;, and constructing that RefPtr copy calls
strongRef() on the Thread&apos;s ThreadSafeWeakPtrControlBlock, which
acquires a WordLock. If the target thread was suspended mid-strongDeref(),
holding that same WordLock between its acquisition and the Locker
destructor running, the lambda deadlocks trying to acquire it.

The deadlock sequence:
  - T1 (main) calls executionHandler-&gt;interrupt(), which calls
    VMManager::requestStopAll(), firing NeedStopTheWorld traps on all
    active VMs and scheduling each VM&apos;s SignalSender::work() on the
    global serial WorkQueue
  - T5 (cycling VM) is mid JSGlobalObject::create() -&gt; RegExpConstructor::create()
    -&gt; BlockDirectory::assertIsMutatorOrMutatorIsStopped() -&gt;
    JSLock::ownerThread() -&gt; strongDeref(), holding the WordLock inside
    Locker locker { m_lock } before Locker::~Locker() runs
  - T2 (Signal Sender) picks up T5&apos;s work() task, calls thread_suspend()
    on T5 — freezing T5 mid-strongDeref() before Locker::~Locker() runs,
    WordLock never released
  - T2&apos;s lambda calls vm.apiLock().ownerThread(), creating a RefPtr&lt;Thread&gt;
    copy which triggers strongRef() -&gt; tries to acquire the same WordLock
    held by suspended T5 -&gt; T2 blocks forever in WordLock::lockSlow()
  - T3/T4 (anchor and cycling VMs) finish their JS, hit VM::~VM() -&gt;
    VMTraps::willDestroyVM(), waiting for their own SignalSender work()
    tasks to complete — those tasks are queued behind T2&apos;s deadlocked
    task on the serial WorkQueue and never run
  - T1 calls waitForCompletion() on T3 -&gt; blocked; full cascade hang

Fix: replace ownerThread() inside the lambda with ownerThreadUID(),
which reads the thread UID directly from the stored pointer with no
RefPtr copy and no WordLock acquisition. The UID to compare against is
captured before sendMessage() while the target is not yet suspended.

Tests: Already covered by existing ExecutionHandlerVMLifecycleTest.cpp.
Canonical link: <a href="https://commits.webkit.org/310315@main">https://commits.webkit.org/310315@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/781aabe636ced3ce99cad0d0d7024e2a3cf65fd9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153463 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/26247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/19847 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162212 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/26773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26567 "Failed to checkout and rebase branch from PR 61719") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/118644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156422 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/26773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/137770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/99355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/26773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/26567 "Failed to checkout and rebase branch from PR 61719") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/10046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/145476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/26773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/15640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164684 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/14285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/7818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/17234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/126708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/26044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/26567 "Failed to checkout and rebase branch from PR 61719") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/126873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26046 "Failed to checkout and rebase branch from PR 61719") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/137436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/82713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23466 "Built successfully and passed tests") | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/26046 "Failed to checkout and rebase branch from PR 61719") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/14216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/185099 "Built successfully") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/25663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/89949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/47467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/25354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/25513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/25414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->