### PR TITLE
[JSC][WASM][Debugger] Extend WASM debugger trap interception to all IPInt exception sites

### DIFF
--- a/JSTests/wasm/debugger/lib/core/base.py
+++ b/JSTests/wasm/debugger/lib/core/base.py
@@ -233,12 +233,13 @@ class BaseTestCase:
         self._process_tracker = tracker
         self._worker_tid = worker_tid
 
-    def start_debugger(self, test_file: str) -> bool:
+    def start_debugger(self, test_file: str, extra_jsc_options: List[str] = None) -> bool:
         """
         Start the WebAssembly debugger server
 
         Args:
             test_file: Path to the test file (JavaScript or WebAssembly) to debug
+            extra_jsc_options: Optional list of additional JSC options (e.g. ["--maxPerThreadStackUsage=524288"])
 
         Returns:
             True if debugger started successfully, False otherwise
@@ -252,12 +253,16 @@ class BaseTestCase:
         if not jsc_path:
             raise Exception("JSC executable not found")
 
-        cmd = [jsc_path, f"--wasm-debugger={self.current_port}"]
+        def build_cmd(filename):
+            cmd = [jsc_path, f"--wasm-debugger={self.current_port}"]
+            if self._verbose_wasm_debugger:
+                cmd.append("--verboseWasmDebugger=1")
+            if extra_jsc_options:
+                cmd.extend(extra_jsc_options)
+            cmd.append(filename)
+            return cmd
 
-        if self._verbose_wasm_debugger:
-            cmd.append("--verboseWasmDebugger=1")
-
-        cmd.append(test_file)
+        cmd = build_cmd(test_file)
 
         self.logger.verbose(f"Starting debugger on port {self.current_port}")
         self.logger.verbose(f"Command: {' '.join(cmd)}")
@@ -272,14 +277,7 @@ class BaseTestCase:
             if "/" in test_file:
                 test_subdir = os.path.dirname(test_file)
                 working_dir = os.path.join(test_dir, test_subdir)
-                # Update the command to use just the filename
-                test_filename = os.path.basename(test_file)
-                cmd = [jsc_path, f"--wasm-debugger={self.current_port}"]
-
-                if self._verbose_wasm_debugger:
-                    cmd.append("--verboseWasmDebugger=1")
-
-                cmd.append(test_filename)
+                cmd = build_cmd(os.path.basename(test_file))
             else:
                 working_dir = test_dir
 
@@ -415,12 +413,13 @@ class BaseTestCase:
                 self.lldb_process = None
             return False
 
-    def setup_debugging_session(self, test_file: str) -> bool:
+    def setup_debugging_session(self, test_file: str, extra_jsc_options: List[str] = None) -> bool:
         """
         Setup complete debugging session (debugger + LLDB)
 
         Args:
             test_file: Path to the test file (JavaScript or WebAssembly) to debug
+            extra_jsc_options: Optional list of additional JSC options
 
         Returns:
             True if both debugger and LLDB started successfully, False otherwise
@@ -428,7 +427,7 @@ class BaseTestCase:
         self.logger.header(f"Setting up debugging session for {self.name}")
 
         # Start debugger
-        if not self.start_debugger(test_file):
+        if not self.start_debugger(test_file, extra_jsc_options):
             return False
 
         if not self.start_lldb(connection_timeout=60.0):
@@ -497,9 +496,9 @@ class BaseTestCase:
             raise Exception(f"Command '{command}' failed: {result.error}")
         return result
 
-    def setup_debugging_session_or_raise(self, test_file: str):
+    def setup_debugging_session_or_raise(self, test_file: str, extra_jsc_options: List[str] = None):
         """Setup complete debugging session and raise exception on failure"""
-        if not self.setup_debugging_session(test_file):
+        if not self.setup_debugging_session(test_file, extra_jsc_options):
             raise Exception("Session setup failed")
 
     def wait_for_lldb_stop(self, timeout: float = 10.0) -> bool:

--- a/JSTests/wasm/debugger/resources/wasm/trap-div-by-zero.js
+++ b/JSTests/wasm/debugger/resources/wasm/trap-div-by-zero.js
@@ -1,0 +1,40 @@
+var wasm = new Uint8Array([
+    // [0x00] WASM header
+    0x00, 0x61, 0x73, 0x6d, // magic: \0asm
+    0x01, 0x00, 0x00, 0x00, // version: 1
+
+    // [0x08] Type section: 1 type, func () -> i32
+    0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7f,
+
+    // [0x0f] Function section: 1 function, type index 0
+    0x03, 0x02, 0x01, 0x00,
+
+    // [0x13] Export section: export function 0 as "triggerTrap"
+    0x07, 0x0f, 0x01, 0x0b, 0x74, 0x72, 0x69, 0x67, 0x67, 0x65, 0x72, 0x54, 0x72, 0x61, 0x70, 0x00, 0x00,
+
+    // [0x24] Code section
+    0x0a,       // section id = 10
+    0x09,       // section size = 9
+    0x01,       // 1 function body
+    0x07,       // body size = 7
+    0x00,       // 0 local declarations
+    0x41, 0x0a, // [0x29][0x2a] i32.const 10
+    0x41, 0x00, // [0x2b][0x2c] i32.const 0
+    0x6d,       // [0x2d] i32.div_s  <- DivisionByZero trap
+    0x0b        // [0x2e] end
+]);
+
+var module = new WebAssembly.Module(wasm);
+var instance = new WebAssembly.Instance(module);
+let triggerTrap = instance.exports.triggerTrap;
+
+let iteration = 0;
+for (;;) {
+    try {
+        triggerTrap();
+    } catch (e) {
+    }
+    iteration += 1;
+    if (iteration % 1e5 == 0)
+        print("iteration=", iteration);
+}

--- a/JSTests/wasm/debugger/resources/wasm/trap-oob-memory.js
+++ b/JSTests/wasm/debugger/resources/wasm/trap-oob-memory.js
@@ -1,0 +1,42 @@
+var wasm = new Uint8Array([
+    // [0x00] WASM header
+    0x00, 0x61, 0x73, 0x6d, // magic: \0asm
+    0x01, 0x00, 0x00, 0x00, // version: 1
+
+    // [0x08] Type section: 1 type, func () -> i32
+    0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7f,
+
+    // [0x0f] Function section: 1 function, type index 0
+    0x03, 0x02, 0x01, 0x00,
+
+    // [0x13] Memory section: 1 memory, min=1 page (64KB), no max
+    0x05, 0x03, 0x01, 0x00, 0x01,
+
+    // [0x18] Export section: export function 0 as "triggerTrap"
+    0x07, 0x0f, 0x01, 0x0b, 0x74, 0x72, 0x69, 0x67, 0x67, 0x65, 0x72, 0x54, 0x72, 0x61, 0x70, 0x00, 0x00,
+
+    // [0x29] Code section
+    0x0a,               // section id = 10
+    0x0b,               // section size = 11
+    0x01,               // 1 function body
+    0x09,               // body size = 9
+    0x00,               // 0 local declarations
+    0x41, 0x80, 0x80, 0x04, // [0x2e][0x2f][0x30][0x31] i32.const 65536 (1 page = 64KB, so OOB)
+    0x28, 0x02, 0x00,   // [0x32] i32.load align=2 offset=0  <- OutOfBoundsMemoryAccess trap
+    0x0b                // [0x35] end
+]);
+
+var module = new WebAssembly.Module(wasm);
+var instance = new WebAssembly.Instance(module);
+let triggerTrap = instance.exports.triggerTrap;
+
+let iteration = 0;
+for (;;) {
+    try {
+        triggerTrap();
+    } catch (e) {
+    }
+    iteration += 1;
+    if (iteration % 1e5 == 0)
+        print("iteration=", iteration);
+}

--- a/JSTests/wasm/debugger/resources/wasm/trap-out-of-bounds-call-indirect.js
+++ b/JSTests/wasm/debugger/resources/wasm/trap-out-of-bounds-call-indirect.js
@@ -1,0 +1,45 @@
+var wasm = new Uint8Array([
+    // [0x00] WASM header
+    0x00, 0x61, 0x73, 0x6d, // magic: \0asm
+    0x01, 0x00, 0x00, 0x00, // version: 1
+
+    // [0x08] Type section: 1 type, func () -> i32
+    0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7f,
+
+    // [0x0f] Function section: 1 function, type index 0
+    0x03, 0x02, 0x01, 0x00,
+
+    // [0x13] Table section: 1 table, funcref, min=0 (empty)
+    0x04, 0x04, 0x01, 0x70, 0x00, 0x00,
+
+    // [0x19] Export section: export function 0 as "triggerTrap"
+    0x07, 0x0f, 0x01, 0x0b, 0x74, 0x72, 0x69, 0x67, 0x67, 0x65, 0x72, 0x54, 0x72, 0x61, 0x70, 0x00, 0x00,
+
+    // [0x2a] Code section
+    0x0a,       // section id = 10
+    0x0c,       // section size = 12
+    0x01,       // 1 function body
+    0x0a,       // body size = 10
+    0x00,       // 0 local declarations
+    0x41, 0x00, // [0x2f][0x30] i32.const 0  (call index)
+    0x11, 0x00, 0x00, // [0x31][0x32][0x33] call_indirect type=0 table=0  <- OutOfBoundsCallIndirect
+                      //   PC advanced past 3-byte instruction; trap handler sees PC=[0x34]
+    0x1a,       // [0x34] drop  <- PC visible in debugger
+    0x41, 0x00, // [0x35][0x36] i32.const 0  (return value, never reached)
+    0x0b,       // [0x37] end
+]);
+
+var module = new WebAssembly.Module(wasm);
+var instance = new WebAssembly.Instance(module);
+let triggerTrap = instance.exports.triggerTrap;
+
+let iteration = 0;
+for (;;) {
+    try {
+        triggerTrap();
+    } catch (e) {
+    }
+    iteration += 1;
+    if (iteration % 1e5 == 0)
+        print("iteration=", iteration);
+}

--- a/JSTests/wasm/debugger/resources/wasm/trap-stack-overflow.js
+++ b/JSTests/wasm/debugger/resources/wasm/trap-stack-overflow.js
@@ -1,0 +1,38 @@
+var wasm = new Uint8Array([
+    // [0x00] WASM header
+    0x00, 0x61, 0x73, 0x6d, // magic: \0asm
+    0x01, 0x00, 0x00, 0x00, // version: 1
+
+    // [0x08] Type section: 1 type, func () -> ()
+    0x01, 0x04, 0x01, 0x60, 0x00, 0x00,
+
+    // [0x0e] Function section: 1 function, type index 0
+    0x03, 0x02, 0x01, 0x00,
+
+    // [0x12] Export section: export function 0 as "triggerTrap"
+    0x07, 0x0f, 0x01, 0x0b, 0x74, 0x72, 0x69, 0x67, 0x67, 0x65, 0x72, 0x54, 0x72, 0x61, 0x70, 0x00, 0x00,
+
+    // [0x23] Code section
+    0x0a,       // section id = 10
+    0x06,       // section size = 6
+    0x01,       // 1 function body
+    0x04,       // body size = 4
+    0x00,       // 0 local declarations
+    0x10, 0x00, // [0x28][0x29] call func 0  <- infinite recursion, StackOverflow trap
+    0x0b,       // [0x2a] end
+]);
+
+var module = new WebAssembly.Module(wasm);
+var instance = new WebAssembly.Instance(module);
+let triggerTrap = instance.exports.triggerTrap;
+
+let iteration = 0;
+for (;;) {
+    try {
+        triggerTrap();
+    } catch (e) {
+    }
+    iteration += 1;
+    if (iteration % 1e5 == 0)
+        print("iteration=", iteration);
+}

--- a/JSTests/wasm/debugger/tests/tests.py
+++ b/JSTests/wasm/debugger/tests/tests.py
@@ -1851,3 +1851,120 @@ class WasmUnreachableFaultTestCase(BaseTestCase):
                 "frame #1: 0xc000000000000000",
             ]
         )
+
+
+class WasmDivByZeroTrapTestCase(BaseTestCase):
+
+    def __init__(self, build_config: str = None, port: int = None):
+        super().__init__(build_config, port)
+
+    def execute(self):
+        self.setup_debugging_session_or_raise("resources/wasm/trap-div-by-zero.js")
+
+        try:
+            for _ in range(1):
+                self.faultTest()
+
+        except Exception as e:
+            raise Exception(f"Test failed: {e}")
+
+    def faultTest(self):
+        for _ in range(10):
+            self.send_lldb_command_or_raise("c", patterns=["Process 1 stopped", "Division by zero"])
+            self.send_lldb_command_or_raise("dis", patterns=["->  0x400000000000002d: i32.div_s"])
+
+        self.send_lldb_command_or_raise(
+            "bt",
+            patterns=[
+                "frame #0: 0x400000000000002d",
+                "frame #1: 0xc000000000000000",
+            ]
+        )
+
+
+class WasmOutOfBoundsCallIndirectTrapTestCase(BaseTestCase):
+
+    def __init__(self, build_config: str = None, port: int = None):
+        super().__init__(build_config, port)
+
+    def execute(self):
+        self.setup_debugging_session_or_raise("resources/wasm/trap-out-of-bounds-call-indirect.js")
+
+        try:
+            for _ in range(1):
+                self.faultTest()
+
+        except Exception as e:
+            raise Exception(f"Test failed: {e}")
+
+    def faultTest(self):
+        for _ in range(10):
+            self.send_lldb_command_or_raise("c", patterns=["Process 1 stopped", "Out of bounds call_indirect"])
+            self.send_lldb_command_or_raise("dis", patterns=["->  0x4000000000000034: drop"])
+
+        self.send_lldb_command_or_raise(
+            "bt",
+            patterns=[
+                "frame #0: 0x4000000000000034",
+                "frame #1: 0xc000000000000000",
+            ]
+        )
+
+
+class WasmStackOverflowTrapTestCase(BaseTestCase):
+
+    def __init__(self, build_config: str = None, port: int = None):
+        super().__init__(build_config, port)
+
+    def execute(self):
+        self.setup_debugging_session_or_raise("resources/wasm/trap-stack-overflow.js", extra_jsc_options=["--maxPerThreadStackUsage=524288"])
+
+        try:
+            for _ in range(1):
+                self.faultTest()
+
+        except Exception as e:
+            raise Exception(f"Test failed: {e}")
+
+    def faultTest(self):
+        for _ in range(10):
+            self.send_lldb_command_or_raise("c", patterns=["Process 1 stopped", "Stack overflow"])
+            self.send_lldb_command_or_raise("dis", patterns=["->  0x4000000000000028: call"])
+
+        self.send_lldb_command_or_raise(
+            "bt",
+            patterns=[
+                "frame #0: 0x4000000000000028",
+                "frame #1: 0x400000000000002a",
+                "frame #99: 0x400000000000002a",
+            ]
+        )
+
+
+class WasmOobMemoryTrapTestCase(BaseTestCase):
+
+    def __init__(self, build_config: str = None, port: int = None):
+        super().__init__(build_config, port)
+
+    def execute(self):
+        self.setup_debugging_session_or_raise("resources/wasm/trap-oob-memory.js")
+
+        try:
+            for _ in range(1):
+                self.faultTest()
+
+        except Exception as e:
+            raise Exception(f"Test failed: {e}")
+
+    def faultTest(self):
+        for _ in range(10):
+            self.send_lldb_command_or_raise("c", patterns=["Process 1 stopped", "Out of bounds memory access"])
+            self.send_lldb_command_or_raise("dis", patterns=["->  0x4000000000000032: i32.load"])
+
+        self.send_lldb_command_or_raise(
+            "bt",
+            patterns=[
+                "frame #0: 0x4000000000000032",
+                "frame #1: 0xc000000000000000",
+            ]
+        )

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
@@ -270,7 +270,7 @@ macro checkStackOverflow(callee, scratch)
 
 if not ADDRESS64
     bpbeq scratch, cfr, .checkTrapAwareSoftStackLimit
-    ipintException(StackOverflow)
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(StackOverflow)
 .checkTrapAwareSoftStackLimit:
 end
     bpbeq JSWebAssemblyInstance::m_stackMirror + StackManager::Mirror::m_trapAwareSoftStackLimit[wasmInstance], scratch, .stackHeightOK
@@ -284,7 +284,8 @@ if X86_64
 else
         move callee, a2
 end
-        cCall3(_ipint_extern_check_stack_and_vm_traps)
+        move cfr, a3
+        cCall4(_ipint_extern_check_stack_and_vm_traps)
     end)
 
 .stackHeightOK:
@@ -391,6 +392,11 @@ macro operationCallMayThrowImpl(fn, sizeOfExtraRegistersPreserved)
     bpneq r1, (constexpr JSC::IPInt::SlowPathExceptionTag), .continuation
 
     storei r0, ArgumentCountIncludingThis + PayloadOffset[cfr]
+    if ARM64 or ARM64E
+        move cfr, a1
+        move sp, a2
+        operationCall(macro() cCall3(_ipint_extern_handle_debugger_trap_if_needed) end)
+    end
     addp sizeOfExtraRegistersPreserved + (4 * MachineRegisterSize), sp
     jmp _wasm_throw_from_slow_path_trampoline
 .continuation:
@@ -414,9 +420,16 @@ macro operationCallMayThrowPreservingVolatileRegisters(fn)
 end
 
 # Exception handling
-macro ipintException(exception)
+#
+# debugger-aware trap. 2 instructions; heavy logic in _wasm_ipint_check_debugger_hook_and_throw_trap due to fixed-size IPInt dispatch slots.
+macro handleDebuggerTrapIfNeededAndThrowWasmTrap(exception)
     storei constexpr Wasm::ExceptionType::%exception%, ArgumentCountIncludingThis + PayloadOffset[cfr]
+if ADDRESS64 and (ARM64 or ARM64E)
+   # Currently, only ARM64 and ARM64E with ADDRESS64 platforms support the WasmDebugger.
+    jmp _wasm_ipint_check_debugger_hook_and_throw_trap
+else
     jmp _wasm_throw_from_slow_path_trampoline
+end
 end
 
 # OSR
@@ -1166,6 +1179,27 @@ macro jumpToException()
     end
 end
 
+macro handleDebuggerTrapIfNeeded()
+    push PC, MC
+    push PL, ws0    # sp[0]=PL, sp[1]=ws0 (IPIntCallee*), sp[2]=PC, sp[3]=MC
+    move cfr, a1
+    move sp, a2     # a2 = pointer to saved [PL, ws0, PC, MC]
+    operationCall(macro() cCall3(_ipint_extern_handle_debugger_trap_if_needed) end)
+    addp 4 * MachineRegisterSize, sp
+end
+
+op(wasm_ipint_check_debugger_hook_and_throw_trap, macro ()
+    handleDebuggerTrapIfNeeded()
+    # r0 == 0 i.e. DebuggerTrapStatus::ResolvedByDebugger i.e. this was purely a debugger trap / breakpoint,
+    #              and has been handled.  We should continue executing because it's not a Wasm trap.
+    # r0 == 1 i.e. DebuggerTrapStatus::NotResolvedByDebugger i.e. this was a fatal Wasm trap.  We should
+    #              throw it to terminate Wasm execution.
+    btpz r0, .continue
+    jmp _wasm_throw_from_slow_path_trampoline
+.continue:
+    nextIPIntInstruction()
+end)
+
 op(wasm_throw_from_slow_path_trampoline, macro ()
     validateOpcodeConfig(t5)
     loadp JSWebAssemblyInstance::m_vm[wasmInstance], t5
@@ -1196,6 +1230,14 @@ op(wasm_unwind_from_slow_path_trampoline, macro()
 end)
 
 op(wasm_throw_from_fault_handler_trampoline_reg_instance, macro ()
+    # enableWasmDebugger disables BBQ/OMG, so this trampoline is only
+    # reached from IPInt when the debugger is active. The signal handler only patches
+    # the machine PC, so IPInt registers (PC, MC, PL, ws0, cfr) are still live.
+    # Exception type comes from instance->m_exception; copy to CFR slot for handle_debugger_trap_if_needed.
+    loadi JSWebAssemblyInstance::m_exception[wasmInstance], t0
+    storei t0, ArgumentCountIncludingThis + PayloadOffset[cfr]
+    handleDebuggerTrapIfNeeded()
+
     move wasmInstance, a2
     loadp JSWebAssemblyInstance::m_vm[a2], a0
     loadp VM::topEntryFrame[a0], a0

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -235,26 +235,7 @@ end
     #############################
 
 ipintOp(_unreachable, macro()
-    # unreachable
-
-    # Push to stack for the handler
-    push PC, MC
-    push PL, ws0
-
-    move cfr, a1
-    move sp, a2
-    operationCall(macro() cCall3(_ipint_extern_unreachable_handler) end)
-
-    # Remove pushed values
-    addq 4 * SlotSize, sp
-
-    bqeq r0, 0, .exception
-
-.continue:
-    nextIPIntInstruction()
-
-.exception:
-    ipintException(Unreachable)
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(Unreachable)
 end)
 
 ipintOp(_nop, macro()
@@ -396,7 +377,7 @@ ipintOp(_throw_ref, macro()
     jumpToException()
 
 .throw_null_ref:
-    throwException(NullExnrefReference)
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(NullExnrefReference)
 end)
 
 macro uintDispatch()
@@ -927,7 +908,7 @@ macro ipintCheckMemoryBound(mem, scratch, size)
     # Memory indices are 32 bit
     leap size - 1[mem], scratch
     bpb scratch, boundsCheckingSize, .continuation
-    ipintException(OutOfBoundsMemoryAccess)
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(OutOfBoundsMemoryAccess)
 .continuation:
 end
 
@@ -994,7 +975,7 @@ macro loadStoreAdvanceMCAndMakePointer(instrLenReg, wasmAddrReg, size, scratch, 
     jmp .done
 
 .outOfBounds:
-    ipintException(OutOfBoundsMemoryAccess)
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(OutOfBoundsMemoryAccess)
 .done:
 end
 
@@ -1845,10 +1826,10 @@ ipintOp(_i32_div_s, macro()
     nextIPIntInstruction()
 
 .ipint_i32_div_s_throwDivisionByZero:
-    ipintException(DivisionByZero)
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(DivisionByZero)
 
 .ipint_i32_div_s_throwIntegerOverflow:
-    ipintException(IntegerOverflow)
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(IntegerOverflow)
 end)
 
 ipintOp(_i32_div_u, macro()
@@ -1870,7 +1851,7 @@ ipintOp(_i32_div_u, macro()
     nextIPIntInstruction()
 
 .ipint_i32_div_u_throwDivisionByZero:
-    ipintException(DivisionByZero)
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(DivisionByZero)
 end)
 
 ipintOp(_i32_rem_s, macro()
@@ -1908,7 +1889,7 @@ ipintOp(_i32_rem_s, macro()
     nextIPIntInstruction()
 
 .ipint_i32_rem_s_throwDivisionByZero:
-    ipintException(DivisionByZero)
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(DivisionByZero)
 end)
 
 ipintOp(_i32_rem_u, macro()
@@ -1934,7 +1915,7 @@ ipintOp(_i32_rem_u, macro()
     nextIPIntInstruction()
 
 .ipint_i32_rem_u_throwDivisionByZero:
-    ipintException(DivisionByZero)
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(DivisionByZero)
 end)
 
 ipintOp(_i32_and, macro()
@@ -2117,10 +2098,10 @@ ipintOp(_i64_div_s, macro()
     nextIPIntInstruction()
 
 .ipint_i64_div_s_throwDivisionByZero:
-    ipintException(DivisionByZero)
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(DivisionByZero)
 
 .ipint_i64_div_s_throwIntegerOverflow:
-    ipintException(IntegerOverflow)
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(IntegerOverflow)
 end)
 
 ipintOp(_i64_div_u, macro()
@@ -2142,7 +2123,7 @@ ipintOp(_i64_div_u, macro()
     nextIPIntInstruction()
 
 .ipint_i64_div_u_throwDivisionByZero:
-    ipintException(DivisionByZero)
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(DivisionByZero)
 end)
 
 ipintOp(_i64_rem_s, macro()
@@ -2180,7 +2161,7 @@ ipintOp(_i64_rem_s, macro()
     nextIPIntInstruction()
 
 .ipint_i64_rem_s_throwDivisionByZero:
-    ipintException(DivisionByZero)
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(DivisionByZero)
 end)
 
 ipintOp(_i64_rem_u, macro()
@@ -2206,7 +2187,7 @@ ipintOp(_i64_rem_u, macro()
     nextIPIntInstruction()
 
 .ipint_i64_rem_u_throwDivisionByZero:
-    ipintException(DivisionByZero)
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(DivisionByZero)
 end)
 
 ipintOp(_i64_and, macro()
@@ -2734,7 +2715,7 @@ ipintOp(_i32_trunc_f32_s, macro()
     nextIPIntInstruction()
 
 .ipint_trunc_i32_f32_s_outOfBoundsTrunc:
-    ipintException(OutOfBoundsTrunc)
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(OutOfBoundsTrunc)
 end)
 
 ipintOp(_i32_trunc_f32_u, macro()
@@ -2753,7 +2734,7 @@ ipintOp(_i32_trunc_f32_u, macro()
     nextIPIntInstruction()
 
 .ipint_trunc_i32_f32_u_outOfBoundsTrunc:
-    ipintException(OutOfBoundsTrunc)
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(OutOfBoundsTrunc)
 end)
 
 ipintOp(_i32_trunc_f64_s, macro()
@@ -2772,7 +2753,7 @@ ipintOp(_i32_trunc_f64_s, macro()
     nextIPIntInstruction()
 
 .ipint_trunc_i32_f64_s_outOfBoundsTrunc:
-    ipintException(OutOfBoundsTrunc)
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(OutOfBoundsTrunc)
 end)
 
 ipintOp(_i32_trunc_f64_u, macro()
@@ -2791,7 +2772,7 @@ ipintOp(_i32_trunc_f64_u, macro()
     nextIPIntInstruction()
 
 .ipint_trunc_i32_f64_u_outOfBoundsTrunc:
-    ipintException(OutOfBoundsTrunc)
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(OutOfBoundsTrunc)
 end)
 
 ipintOp(_i64_extend_i32_s, macro()
@@ -2828,7 +2809,7 @@ ipintOp(_i64_trunc_f32_s, macro()
     nextIPIntInstruction()
 
 .ipint_trunc_i64_f32_s_outOfBoundsTrunc:
-    ipintException(OutOfBoundsTrunc)
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(OutOfBoundsTrunc)
 end)
 
 ipintOp(_i64_trunc_f32_u, macro()
@@ -2847,7 +2828,7 @@ ipintOp(_i64_trunc_f32_u, macro()
     nextIPIntInstruction()
 
 .ipint_i64_f32_u_outOfBoundsTrunc:
-    ipintException(OutOfBoundsTrunc)
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(OutOfBoundsTrunc)
 end)
 
 ipintOp(_i64_trunc_f64_s, macro()
@@ -2866,7 +2847,7 @@ ipintOp(_i64_trunc_f64_s, macro()
     nextIPIntInstruction()
 
 .ipint_i64_f64_s_outOfBoundsTrunc:
-    ipintException(OutOfBoundsTrunc)
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(OutOfBoundsTrunc)
 end)
 
 ipintOp(_i64_trunc_f64_u, macro()
@@ -2885,7 +2866,7 @@ ipintOp(_i64_trunc_f64_u, macro()
     nextIPIntInstruction()
 
 .ipint_i64_f64_u_outOfBoundsTrunc:
-    ipintException(OutOfBoundsTrunc)
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(OutOfBoundsTrunc)
 end)
 
 ipintOp(_f32_convert_i32_s, macro()
@@ -3111,7 +3092,7 @@ ipintOp(_ref_as_non_null, macro()
     advancePC(1)
     nextIPIntInstruction()
 .ref_as_non_null_nullRef:
-    throwException(NullRefAsNonNull)
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(NullRefAsNonNull)
 end)
 
 ipintOp(_br_on_null, macro()
@@ -3477,7 +3458,7 @@ ipintOp(_array_len, macro()
     nextIPIntInstruction()
 
 .nullArray:
-    throwException(NullAccess)
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(NullAccess)
 end)
 
 ipintOp(_array_fill, macro()
@@ -3663,7 +3644,7 @@ ipintOp(_i31_get_s, macro()
     advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 .i31_get_throw:
-    throwException(NullI31Get)
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(NullI31Get)
 end)
 
 ipintOp(_i31_get_u, macro()
@@ -3677,7 +3658,7 @@ ipintOp(_i31_get_u, macro()
     advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 .i31_get_throw:
-    throwException(NullI31Get)
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(NullI31Get)
 end)
 
     #############################
@@ -9080,11 +9061,11 @@ macro ipintCheckMemoryBoundWithAlignmentCheck(mem, scratch, size)
     leap size - 1[mem], scratch
     bpb scratch, boundsCheckingSize, .continuationInBounds
 .throwOOB:
-    ipintException(OutOfBoundsMemoryAccess)
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(OutOfBoundsMemoryAccess)
 .continuationInBounds:
     btpz mem, (size - 1), .continuationAligned
 .throwUnaligned:
-    throwException(UnalignedMemoryAccess)
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 .continuationAligned:
 end
 
@@ -9122,7 +9103,7 @@ ipintOp(_memory_atomic_notify, macro()
     nextIPIntInstruction()
 
 .atomic_notify_throw:
-    ipintException(OutOfBoundsMemoryAccess)
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(OutOfBoundsMemoryAccess)
 end)
 
 ipintOp(_memory_atomic_wait32, macro()
@@ -9147,7 +9128,7 @@ ipintOp(_memory_atomic_wait32, macro()
     nextIPIntInstruction()
 
 .atomic_wait32_throw:
-    ipintException(OutOfBoundsMemoryAccess)
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(OutOfBoundsMemoryAccess)
 end)
 
 ipintOp(_memory_atomic_wait64, macro()
@@ -9172,7 +9153,7 @@ ipintOp(_memory_atomic_wait64, macro()
     nextIPIntInstruction()
 
 .atomic_wait64_throw:
-    ipintException(OutOfBoundsMemoryAccess)
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(OutOfBoundsMemoryAccess)
 end)
 
 ipintOp(_atomic_fence, macro()

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -31,6 +31,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #if ENABLE(WEBASSEMBLY)
 
 #include "BytecodeStructs.h"
+#include "CallFrame.h"
 #include "FrameTracers.h"
 #include "JITExceptions.h"
 #include "JSWebAssemblyArrayInlines.h"
@@ -1274,15 +1275,16 @@ extern "C" UGPRPair SYSV_ABI slow_path_wasm_popcountll(const void* pc, uint64_t 
     WASM_RETURN_TWO(pc, result);
 }
 
-WASM_IPINT_EXTERN_CPP_DECL(check_stack_and_vm_traps, void* candidateNewStackPointer, Wasm::IPIntCallee* callee)
+WASM_IPINT_EXTERN_CPP_DECL(check_stack_and_vm_traps, void* candidateNewStackPointer, Wasm::IPIntCallee* callee, CallFrame* callFrame)
 {
     VM& vm = instance->vm();
 
 #if ENABLE(WEBASSEMBLY_DEBUGGER)
     if (Options::enableWasmDebugger()) [[unlikely]]
-        vm.debugState()->setPrologueStopData(instance, callee);
+        vm.debugState()->setPrologueStopData(instance, callee, callFrame);
 #else
     UNUSED_PARAM(callee);
+    UNUSED_PARAM(callFrame);
 #endif
 
     if (vm.traps().handleTrapsIfNeeded()) {
@@ -1327,23 +1329,26 @@ static UNUSED_FUNCTION void displayWasmDebugState(JSWebAssemblyInstance* instanc
 }
 #endif
 
-WASM_IPINT_EXTERN_CPP_DECL(unreachable_handler, CallFrame* callFrame, Register* sp)
+WASM_IPINT_EXTERN_CPP_DECL(handle_debugger_trap_if_needed, CallFrame* callFrame, Register* sp)
 {
-    bool breakpointHandled = false;
+    // By default, the trap is a fatal Wasm trap and must propagate (shouldThrow = true).
+    // If the debugger is connected and determines this was solely a debugger trap (e.g. a
+    // breakpoint on unreachable), it sets shouldThrow = false and execution resumes.
+    bool shouldThrow = true;
 #if ENABLE(WEBASSEMBLY_DEBUGGER)
     if (Options::enableWasmDebugger()) [[unlikely]] {
         Wasm::DebugServer& debugServer = Wasm::DebugServer::singleton();
-        if (debugServer.shouldHandleUnreachable()) {
+        if (debugServer.isConnected()) {
             uint8_t* pc = static_cast<uint8_t*>(sp[2].pointer());
             uint8_t* mc = static_cast<uint8_t*>(sp[3].pointer());
             IPIntLocal* pl = static_cast<IPIntLocal*>(sp[0].pointer());
-            Wasm::IPIntCallee* callee = static_cast<Wasm::IPIntCallee*>(sp[1].pointer());
-
-            IPIntStackEntry* stackPointer = std::bit_cast<IPIntStackEntry*>(sp + 4);
-            if (Options::verboseWasmDebugger())
-                displayWasmDebugState(instance, callee, stackPointer, pl);
-
-            breakpointHandled = debugServer.execution().handleUnreachable(callFrame, instance, callee, pc, mc, pl, stackPointer);
+            auto* callee = static_cast<Wasm::IPIntCallee*>(sp[1].pointer());
+            auto* stack = std::bit_cast<IPIntStackEntry*>(sp + 4);
+            auto exceptionType = static_cast<Wasm::ExceptionType>(callFrame->argumentCountIncludingThis());
+            if (Options::verboseWasmDebugger() && exceptionType == Wasm::ExceptionType::Unreachable)
+                displayWasmDebugState(instance, callee, stack, pl);
+            auto trapStatus = debugServer.execution().handleDebuggerTrapIfNeeded(callFrame, instance, callee, pc, mc, pl, stack, exceptionType);
+            shouldThrow = trapStatus == Wasm::DebuggerTrapStatus::NotResolvedByDebugger;
         }
     }
 #else
@@ -1351,7 +1356,7 @@ WASM_IPINT_EXTERN_CPP_DECL(unreachable_handler, CallFrame* callFrame, Register* 
     UNUSED_PARAM(callFrame);
     UNUSED_PARAM(sp);
 #endif
-    IPINT_RETURN(static_cast<EncodedJSValue>(static_cast<int32_t>(breakpointHandled)));
+    IPINT_RETURN(static_cast<EncodedJSValue>(static_cast<int32_t>(shouldThrow)));
 }
 
 } } // namespace JSC::IPInt

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h
@@ -140,8 +140,8 @@ WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_atomic_wait32, uint64_t, uint32_t, uint
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_atomic_wait64, uint64_t, uint64_t, uint64_t);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_atomic_notify, unsigned, unsigned, int32_t);
 
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(check_stack_and_vm_traps, void* candidateNewStackPointer, Wasm::IPIntCallee*);
-WASM_IPINT_EXTERN_CPP_DECL(unreachable_handler, CallFrame*, Register*);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(check_stack_and_vm_traps, void* candidateNewStackPointer, Wasm::IPIntCallee*, CallFrame*);
+WASM_IPINT_EXTERN_CPP_DECL(handle_debugger_trap_if_needed, CallFrame*, Register*);
 
 } } // namespace JSC::IPInt
 

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.cpp
@@ -439,9 +439,9 @@ void DebugServer::handlePacket(StringView packet)
         dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Routing halt reason query to ExecutionHandler");
         m_executionHandler->interrupt();
         // After the initial interrupt is handled and the stop reply is sent, the debugger has
-        // established a known VM state. Any unreachable trap encountered in future execution
+        // established a known VM state. Any trap encountered in future execution
         // (after the user sends 'c') will be properly intercepted.
-        m_executionHandler->setUnreachableHandlingEnabled(true);
+        m_executionHandler->setTrapHandlingEnabled(true);
         break;
     case 'k':
         dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Kill request");
@@ -573,11 +573,6 @@ bool DebugServer::isConnected() const
         return true;
 #endif
     return isSocketValid(m_clientSocket);
-}
-
-bool DebugServer::shouldHandleUnreachable() const
-{
-    return isConnected() && m_executionHandler->isUnreachableHandlingEnabled();
 }
 
 }

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.h
@@ -117,7 +117,6 @@ public:
     void setPort(uint64_t port) { m_port = port; }
 
     JS_EXPORT_PRIVATE bool NODELETE isConnected() const;
-    bool shouldHandleUnreachable() const;
 
     JS_EXPORT_PRIVATE void handlePacket(StringView packet);
 

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.cpp
@@ -339,12 +339,13 @@ Vector<FrameInfo> collectCallStack(VirtualAddress stopAddress, CallFrame* startF
     return frames;
 }
 
-StopData::StopData(IPIntCallee* callee, JSWebAssemblyInstance* instance)
+StopData::StopData(IPIntCallee* callee, JSWebAssemblyInstance* instance, CallFrame* callFrame)
     : code(Code::Stop)
     , location(Location::Prologue)
     , address(VirtualAddress::toVirtual(instance, callee->functionIndex(), callee->bytecode()))
     , callee(callee)
     , instance(instance)
+    , callFrame(callFrame)
 {
 }
 
@@ -382,9 +383,10 @@ StopData::StopData(Breakpoint::Type type, VirtualAddress address, uint8_t origin
 {
 }
 
-StopData::StopData(IPIntCallee* callee, JSWebAssemblyInstance* instance, CallFrame* callFrame, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal* locals, IPInt::IPIntStackEntry* stack)
+StopData::StopData(IPIntCallee* callee, JSWebAssemblyInstance* instance, CallFrame* callFrame, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal* locals, IPInt::IPIntStackEntry* stack, Wasm::ExceptionType type)
     : StopData(Location::Trap, Code::Trap, VirtualAddress::toVirtual(instance, callee->functionIndex(), pc), 0, pc, mc, locals, stack, callee, instance, callFrame)
 {
+    wasmTrapType = type;
 }
 
 StopData::~StopData() = default;

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.h
@@ -34,6 +34,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 #include <JavaScriptCore/CallFrame.h>
 #include <JavaScriptCore/JSWebAssemblyInstance.h>
+#include <JavaScriptCore/WasmExceptionType.h>
 #include <JavaScriptCore/WasmIPIntGenerator.h>
 #include <JavaScriptCore/WasmVirtualAddress.h>
 #include <memory>
@@ -155,9 +156,9 @@ struct StopData {
 
     StopData(Breakpoint::Type, VirtualAddress, uint8_t originalBytecode, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal*, IPInt::IPIntStackEntry*, IPIntCallee*, JSWebAssemblyInstance*, CallFrame*);
 
-    StopData(IPIntCallee*, JSWebAssemblyInstance*);
+    StopData(IPIntCallee*, JSWebAssemblyInstance*, CallFrame*);
 
-    StopData(IPIntCallee*, JSWebAssemblyInstance*, CallFrame*, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal*, IPInt::IPIntStackEntry*);
+    StopData(IPIntCallee*, JSWebAssemblyInstance*, CallFrame*, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal*, IPInt::IPIntStackEntry*, Wasm::ExceptionType);
 
     ~StopData();
 
@@ -174,6 +175,7 @@ struct StopData {
     RefPtr<IPIntCallee> callee;
     JSWebAssemblyInstance* instance { nullptr };
     CallFrame* callFrame { nullptr };
+    std::optional<Wasm::ExceptionType> wasmTrapType;
 
 private:
     StopData(Location, Code, VirtualAddress, uint8_t originalBytecode, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal*, IPInt::IPIntStackEntry*, IPIntCallee*, JSWebAssemblyInstance*, CallFrame*);
@@ -192,9 +194,9 @@ struct DebugState {
 
     DebugState() = default;
 
-    void setPrologueStopData(JSWebAssemblyInstance* instance, IPIntCallee* callee)
+    void setPrologueStopData(JSWebAssemblyInstance* instance, IPIntCallee* callee, CallFrame* callFrame)
     {
-        stopData = makeUnique<StopData>(callee, instance);
+        stopData = makeUnique<StopData>(callee, instance, callFrame);
     }
 
     void setBreakpointStopData(Breakpoint::Type type, VirtualAddress address, uint8_t originalBytecode, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal* locals, IPInt::IPIntStackEntry* stack, IPIntCallee* callee, JSWebAssemblyInstance* instance, CallFrame* callFrame)
@@ -202,16 +204,15 @@ struct DebugState {
         stopData = makeUnique<StopData>(type, address, originalBytecode, pc, mc, locals, stack, callee, instance, callFrame);
     }
 
-    void setTrapStopData(IPIntCallee* callee, JSWebAssemblyInstance* instance, CallFrame* callFrame, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal* locals, IPInt::IPIntStackEntry* stack)
+    void setTrapStopData(IPIntCallee* callee, JSWebAssemblyInstance* instance, CallFrame* callFrame, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal* locals, IPInt::IPIntStackEntry* stack, Wasm::ExceptionType wasmTrapType)
     {
-        stopData = makeUnique<StopData>(callee, instance, callFrame, pc, mc, locals, stack);
+        stopData = makeUnique<StopData>(callee, instance, callFrame, pc, mc, locals, stack, wasmTrapType);
     }
 
     bool atSystemCall() const { return !stopData; }
     bool atPrologue() const { return !!stopData && stopData->location == StopData::Location::Prologue; }
     bool atBreakpoint() const { return !!stopData && stopData->location == StopData::Location::Breakpoint; }
-    bool atTrap() const { return !!stopData && stopData->location == StopData::Location::Trap; }
-    bool atBreakpointOrTrap() const { return atBreakpoint() || atTrap(); }
+    bool isWasmTrap() const { return !!stopData && stopData->wasmTrapType.has_value(); }
 
     void clearStop()
     {
@@ -230,7 +231,7 @@ struct DebugState {
     bool takeStepIntoThrow() { return stepIntoEvent.take(StepIntoEvent::StepIntoThrow); }
 
     State state { State::Running };
-    std::unique_ptr<const StopData> stopData { nullptr };
+    std::unique_ptr<StopData> stopData { nullptr };
 
     // Step-into tracking (for step debugging behavior)
     StepIntoEvent stepIntoEvent;
@@ -290,6 +291,11 @@ inline StringView getErrorReply(ProtocolError error)
         return "E00"_s;
     }
 }
+
+enum class DebuggerTrapStatus : uint8_t {
+    ResolvedByDebugger,
+    NotResolvedByDebugger,
+};
 
 } // namespace Wasm
 } // namespace JSC

--- a/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.cpp
@@ -40,6 +40,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include "WasmCallee.h"
 #include "WasmDebugServer.h"
 #include "WasmDebugServerUtilities.h"
+#include "WasmExceptionType.h"
 #include "WasmIPIntGenerator.h"
 #include "WasmIPIntSlowPaths.h"
 #include "WasmModuleManager.h"
@@ -133,23 +134,31 @@ void ExecutionHandler::stopTheWorld(VM& debuggee, StopTheWorldEvent event)
     VMManager::singleton().notifyVMStop(debuggee, event);
 }
 
-bool ExecutionHandler::handleUnreachable(CallFrame* callFrame, JSWebAssemblyInstance* instance, IPIntCallee* callee, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal* locals, IPInt::IPIntStackEntry* stack)
+DebuggerTrapStatus ExecutionHandler::handleDebuggerTrapIfNeeded(CallFrame* callFrame, JSWebAssemblyInstance* instance, IPIntCallee* callee, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal* locals, IPInt::IPIntStackEntry* stack, Wasm::ExceptionType exceptionType)
 {
-    if (hasBreakpoints()) {
+    VM& debuggee = instance->vm();
+    if (exceptionType == Wasm::ExceptionType::Unreachable && hasBreakpoints()) {
         VirtualAddress address = VirtualAddress::toVirtual(instance, callee->functionIndex(), pc);
         if (auto* breakpoint = m_breakpointManager->findBreakpoint(address)) {
-            VM& debuggee = instance->vm();
             debuggee.debugState()->setBreakpointStopData(breakpoint->type, address, breakpoint->originalBytecode, pc, mc, locals, stack, callee, instance, callFrame);
-            dataLogLnIf(Options::verboseWasmDebugger(), "[Code][handleUnreachable] Breakpoint at ", *breakpoint, " with ", *debuggee.debugState()->stopData);
+            dataLogLnIf(Options::verboseWasmDebugger(), "[Code][handleDebuggerTrapIfNeeded] Breakpoint at ", *breakpoint, " with ", *debuggee.debugState()->stopData);
             stopTheWorld(debuggee, StopTheWorldEvent::BreakpointHit);
-            return true;
+            return DebuggerTrapStatus::ResolvedByDebugger; // Don't throw; resume execution at this breakpoint
         }
     }
-    VM& debuggee = instance->vm();
-    debuggee.debugState()->setTrapStopData(callee, instance, callFrame, pc, mc, locals, stack);
-    dataLogLnIf(Options::verboseWasmDebugger(), "[Code][handleUnreachable] Wasm unreachable trap at ", *debuggee.debugState()->stopData);
+
+    if (!isTrapHandlingEnabled())
+        return DebuggerTrapStatus::NotResolvedByDebugger; // Throw; no debugger connected
+
+    if (exceptionType == Wasm::ExceptionType::StackOverflow || exceptionType == Wasm::ExceptionType::Termination) {
+        RELEASE_ASSERT(debuggee.debugState()->atPrologue());
+        debuggee.debugState()->stopData->code = StopData::Code::Trap;
+        debuggee.debugState()->stopData->wasmTrapType = exceptionType;
+    } else
+        debuggee.debugState()->setTrapStopData(callee, instance, callFrame, pc, mc, locals, stack, exceptionType);
+    dataLogLnIf(Options::verboseWasmDebugger(), "[Code][handleDebuggerTrapIfNeeded] Wasm trap at ", *debuggee.debugState()->stopData);
     stopTheWorld(debuggee, StopTheWorldEvent::TrapHit);
-    return false;
+    return DebuggerTrapStatus::NotResolvedByDebugger; // Throw; trap was reported, now propagate it
 }
 
 ExecutionHandler::ResumeMode ExecutionHandler::stopCode(Locker<Lock>& locker, StopTheWorldEvent event)
@@ -391,10 +400,10 @@ void ExecutionHandler::step()
     RELEASE_ASSERT(m_debuggerState == DebuggerState::Replied && state->isStopped());
 
     bool resumeAll = false;
-    if (state->atSystemCall() || state->atTrap()) {
+    if (state->atSystemCall() || state->isWasmTrap()) {
         // There is no valid next WASM instruction to step to in either case.
-        // For traps, unreachable throws a WebAssembly.RuntimeError back to JS — equivalent
-        // to returning from WASM — so resuming all is the right behavior.
+        // For traps (including StackOverflow at prologue), execution unwinds back to JS —
+        // resuming all is the right behavior.
         resumeAll = true;
     }
     else if (state->atBreakpoint())
@@ -705,18 +714,19 @@ void ExecutionHandler::handleThreadStopInfo(StringView packet)
 
 static uint64_t NODELETE getStopPC(const DebugState& state)
 {
-    if (state.atBreakpointOrTrap() || state.atPrologue())
-        return state.stopData->address;
-    return VirtualAddress(VirtualAddress::INVALID_BASE).value();
+    if (state.atSystemCall())
+        return VirtualAddress(VirtualAddress::INVALID_BASE).value();
+    RELEASE_ASSERT(state.stopData);
+    return state.stopData->address;
 }
 
 static String getThreadName(const DebugState& state, uint64_t threadId)
 {
     StringView stateName;
-    if (state.atBreakpointOrTrap())
-        stateName = "wasm-call"_s;
-    else if (state.atPrologue())
+    if (state.atPrologue())
         stateName = "wasm-prologue"_s;
+    else if (state.atBreakpoint() || state.isWasmTrap())
+        stateName = "wasm-call"_s;
     else {
         RELEASE_ASSERT(state.atSystemCall());
         stateName = "system-call"_s;
@@ -769,7 +779,7 @@ void ExecutionHandler::sendStopReplyForThread(AbstractLocker& locker, uint64_t t
     Vector<ThreadInfo> allThreads = collectAllStoppedThreads();
 
     // FIXME: Report different stop reasons for active vs passive threads (currently all use same code).
-    StopData::Code code = state->atBreakpointOrTrap() ? state->stopData->code : StopData::Code::Stop;
+    StopData::Code code = state->atSystemCall() ? StopData::Code::Stop : state->stopData->code;
     auto stopInfo = stopReasonCodeToInfo(code);
 
     // Build packet with target thread
@@ -799,11 +809,11 @@ void ExecutionHandler::sendStopReplyForThread(AbstractLocker& locker, uint64_t t
     reply.append("00:"_s, toNativeEndianHex(getStopPC(*state)), ';');
     reply.append("reason:"_s, stopInfo.reasonSuffix, ';');
 
-    // For trap stops, include a hex-encoded description of the exception message
-    // matching WAMR convention so LLDB can display it to the user.
+    // For trap stops, include a hex-encoded description matching WAMR convention so LLDB
+    // can display the trap reason to the user.
     if (code == StopData::Code::Trap) {
         reply.append("description:"_s);
-        for (UChar c : StringView("unreachable hit"_s).codeUnits())
+        for (UChar c : StringView(Wasm::errorMessageForExceptionType(*state->stopData->wasmTrapType)).codeUnits())
             reply.append(hex(static_cast<uint8_t>(c), 2, Lowercase));
         reply.append(';');
     }
@@ -858,7 +868,7 @@ void ExecutionHandler::reset()
 
     m_breakpointManager->clearAllBreakpoints();
     m_debuggerState = DebuggerState::Replied;
-    setUnreachableHandlingEnabled(false);
+    setTrapHandlingEnabled(false);
     takeAwaitingResumeNotification();
     m_debuggee = nullptr;
 }
@@ -903,8 +913,7 @@ String ExecutionHandler::callStackStringFor(uint64_t threadId)
     auto* state = targetVM->debugState();
     RELEASE_ASSERT(state->isStopped());
 
-    // For threads stopped at breakpoint or trap with full call stack, walk the stack
-    if (state->atBreakpointOrTrap()) {
+    if (state->stopData) {
         auto& stopData = *state->stopData;
         RELEASE_ASSERT(stopData.callFrame);
 

--- a/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.h
@@ -77,7 +77,8 @@ public:
     };
 
     ResumeMode stopCode(Locker<Lock>&, StopTheWorldEvent) WTF_REQUIRES_LOCK(m_lock);
-    bool handleUnreachable(CallFrame*, JSWebAssemblyInstance*, IPIntCallee*, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal* = nullptr, IPInt::IPIntStackEntry* = nullptr);
+
+    DebuggerTrapStatus handleDebuggerTrapIfNeeded(CallFrame*, JSWebAssemblyInstance*, IPIntCallee*, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal*, IPInt::IPIntStackEntry*, Wasm::ExceptionType);
 
     JS_EXPORT_PRIVATE void resume();
     JS_EXPORT_PRIVATE void step();
@@ -126,8 +127,7 @@ public:
     StopTheWorldStatus handleStopTheWorld(VM&, StopTheWorldEvent);
     void handlePostResume();
     bool takeAwaitingResumeNotification() WTF_REQUIRES_LOCK(m_lock) { return std::exchange(m_awaitingResumeNotification, false); }
-    void setUnreachableHandlingEnabled(bool enabled) { m_unreachableHandlingEnabled.store(enabled, std::memory_order_release); }
-    bool isUnreachableHandlingEnabled() const { return m_unreachableHandlingEnabled.load(std::memory_order_acquire); }
+    void setTrapHandlingEnabled(bool enabled) { m_trapHandlingEnabled.store(enabled, std::memory_order_release); }
 
 private:
     friend class DebugServer;
@@ -148,6 +148,8 @@ private:
     void sendErrorReply(ProtocolError);
 
     void selectDebuggeeIfNeeded(VM& fallbackVM) WTF_REQUIRES_LOCK(m_lock);
+
+    bool isTrapHandlingEnabled() const { return m_trapHandlingEnabled.load(std::memory_order_acquire); }
 
     bool requiresStopConfirmation() const WTF_REQUIRES_LOCK(m_lock)
     {
@@ -170,7 +172,7 @@ private:
     Condition m_debuggeeContinue;
     DebuggerState m_debuggerState WTF_GUARDED_BY_LOCK(m_lock) { DebuggerState::Replied };
     bool m_awaitingResumeNotification WTF_GUARDED_BY_LOCK(m_lock) { false };
-    std::atomic<bool> m_unreachableHandlingEnabled { false };
+    std::atomic<bool> m_trapHandlingEnabled { false };
     VM* m_debuggee WTF_GUARDED_BY_LOCK(m_lock) { nullptr };
     std::optional<uint64_t> m_debugServerThreadId;
 };

--- a/Source/JavaScriptCore/wasm/debugger/WasmQueryHandler.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmQueryHandler.cpp
@@ -210,29 +210,6 @@ bool QueryHandler::handleChunkedLibrariesResponse(size_t offset, size_t maxSize,
     return true;
 }
 
-String QueryHandler::buildWasmCallStackResponse()
-{
-    auto* state = m_debugServer.execution().debuggeeStateSafe();
-    if (!state->atBreakpointOrTrap()) {
-        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] buildWasmCallStackResponse: not stopped at breakpoint or trap, returning empty");
-        return String();
-    }
-
-    auto& stopData = *state->stopData;
-    RELEASE_ASSERT(stopData.callFrame);
-    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] buildWasmCallStackResponse: walking call stack from CallFrame ", RawPointer(stopData.callFrame));
-
-    Vector<FrameInfo> frames = collectCallStack(stopData.address, stopData.callFrame, stopData.instance->vm());
-
-    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] buildWasmCallStackResponse: finished walking, ", frames.size(), " frames");
-
-    StringBuilder result;
-    for (const auto& frame : frames)
-        result.append(toNativeEndianHex(frame.address));
-    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] buildWasmCallStackResponse: response length: ", result.length());
-    return result.toString();
-}
-
 void QueryHandler::handleStartNoAckMode()
 {
     // Format: QStartNoAckMode
@@ -378,7 +355,7 @@ void QueryHandler::handleWasmLocal(StringView packet)
     dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] qWasmLocal frame=", frameIndex, ", variable=", localIndex);
 
     auto* state = m_debugServer.execution().debuggeeStateSafe();
-    if (!state->atBreakpointOrTrap()) {
+    if (state->atSystemCall() || state->atPrologue()) {
         m_debugServer.sendErrorReply(ProtocolError::UnknownCommand);
         return;
     }
@@ -460,7 +437,7 @@ void QueryHandler::handleWasmGlobal(StringView packet)
     dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] qWasmGlobal frame=", frameIndex, ", global=", globalIndex);
 
     auto* state = m_debugServer.execution().debuggeeStateSafe();
-    if (!state->atBreakpointOrTrap()) {
+    if (state->atSystemCall()) {
         m_debugServer.sendErrorReply(ProtocolError::UnknownCommand);
         return;
     }

--- a/Source/JavaScriptCore/wasm/debugger/WasmQueryHandler.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmQueryHandler.h
@@ -63,7 +63,6 @@ private:
 
     bool parseLibrariesReadPacket(StringView packet, size_t& offset, size_t& maxSize);
     bool handleChunkedLibrariesResponse(size_t offset, size_t maxSize, String& response);
-    String buildWasmCallStackResponse();
 };
 
 } // namespace Wasm

--- a/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTest.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTest.cpp
@@ -379,7 +379,6 @@ static void cleanupAfterScript(const TestScript& script, RefPtr<Thread>& workerT
     doneTesting = true;
     workerThread->waitForCompletion();
     executionHandler->reset();
-    executionHandler->setUnreachableHandlingEnabled(true);
     doneTesting = false;
 }
 

--- a/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTestSupport.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTestSupport.cpp
@@ -276,7 +276,6 @@ void setupTestEnvironment(DebugServer*& debugServer, ExecutionHandler*& executio
 
     executionHandler = &debugServer->execution();
     executionHandler->setDebugServerThreadId(Thread::currentSingleton().uid());
-    executionHandler->setUnreachableHandlingEnabled(true);
 
     dataLogLnIf(verboseLogging, "DebugServer setup complete in RWI mode");
 }


### PR DESCRIPTION
#### 6fa604090d4e14d47b354c9572006eeed49bcb7b
<pre>
[JSC][WASM][Debugger] Extend WASM debugger trap interception to all IPInt exception sites
<a href="https://bugs.webkit.org/show_bug.cgi?id=311138">https://bugs.webkit.org/show_bug.cgi?id=311138</a>
<a href="https://rdar.apple.com/173723442">rdar://173723442</a>

Reviewed by Mark Lam.

Previously the WASM debugger only intercepted the unreachable opcode.
This patch extends interception to all IPInt-dispatched traps (division
by zero, integer overflow, out-of-bounds memory, null reference, bad
signature, stack overflow, etc.) by routing all exception paths through
a single C++ handler, ipint_extern_handle_debugger_trap_if_needed.

Inline trap sites use the handleDebuggerTrapIfNeededAndThrowWasmTrap macro,
which remains 2 instructions (store + jmp) to avoid overflowing fixed-size
IPInt dispatch slots. On ARM64/ARM64E it jumps to the shared
_wasm_ipint_check_debugger_hook_and_throw_trap trampoline which saves IPInt
registers and calls the handler; on other platforms it jumps directly to
_wasm_throw_from_slow_path_trampoline since the WASM debugger is not supported there.

The operationCallMayThrowImpl exception path calls
ipint_extern_handle_debugger_trap_if_needed directly, using the IPInt
registers already on the stack from operationCallMayThrowImpl&apos;s own save sequence.

Stack-overflow and Termination traps go through
operationCallMayThrowPreservingVolatileRegisters, which takes the same
operationCallMayThrowImpl exception path with volatile registers preserved.

The fault-handler path (wasm_throw_from_fault_handler_trampoline_reg_instance)
copies instance-&gt;m_exception into the CFR ArgumentCountIncludingThis slot
before calling handleDebuggerTrapIfNeeded(), since IPInt registers remain
live when the Mach exception handler redirects the machine PC to the trampoline.

Four new tests cover one representative trap per execution path:
WasmDivByZeroTrapTestCase (inline asm trap)
WasmOutOfBoundsCallIndirectTrapTestCase (C++ slow-path trap)
WasmStackOverflowTrapTestCase (prologue/volatile-preserved trap)
WasmOobMemoryTrapTestCase (fault-handler path)

Canonical link: <a href="https://commits.webkit.org/310417@main">https://commits.webkit.org/310417@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc947a43f978cc6938c2ec47a0cc911d37b15841

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153780 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26564 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20181 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162531 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107241 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fc71b0f4-cddb-41b0-9ee3-ab49bc938184) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27092 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26886 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118893 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/84072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6f5acc01-03fe-4aa4-be38-1bf8f51dd777) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156739 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21159 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138083 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99603 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a41d014e-fac6-49bb-9fc5-f0304c973576) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20239 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18197 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10363 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/145793 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129887 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15942 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165001 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/14604 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8135 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17536 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126981 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26361 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22228 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127148 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34489 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26363 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137737 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83041 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22047 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14520 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/185416 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25980 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90268 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47559 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25671 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25831 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25731 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->