### PR TITLE
HTMLMediaElement preservesPitch=true does not work when using AudioContext

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6498,7 +6498,6 @@ imported/w3c/web-platform-tests/html/dom/render-blocking/remove-attr-unblocks-re
 imported/w3c/web-platform-tests/html/dom/self-origin.sub.html [ Skip ]
 imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-failure.https.html [ Skip ]
 imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/structured-cloning-error-extra.html [ Skip ]
-imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/preserves-pitch.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_navigation_download_allow_downloads.sub.tentative.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/delay-load-event-until-move-to-empty-source.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-move-into-script-disabled-iframe.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/preserves-pitch-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/preserves-pitch-expected.txt
@@ -6,6 +6,6 @@ PASS The default playbackRate should not affect pitch
 PASS The default playbackRate should not affect pitch, even with preservesPitch=false
 PASS Speed-ups should not change the pitch when preservesPitch=true
 PASS Slow-downs should not change the pitch when preservesPitch=true
-FAIL Speed-ups should change the pitch when preservesPitch=false assert_approx_equals: The actual pitch should be close to the expected pitch. expected 880 +/- 21.55425219941349 but got 452.63929618768327
-FAIL Slow-downs should change the pitch when preservesPitch=false assert_approx_equals: The actual pitch should be close to the expected pitch. expected 220 +/- 21.55425219941349 but got 0
+PASS Speed-ups should change the pitch when preservesPitch=false
+PASS Slow-downs should change the pitch when preservesPitch=false
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1919,6 +1919,7 @@ webkit.org/b/298269 imported/w3c/web-platform-tests/html/anonymous-iframe/sessio
 webkit.org/b/305509 imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cues-pause-on-exit.html [ Failure Pass ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/played-loop.html [ Skip ] # timeout
 imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/playing-the-media-resource/fragmented-mp4-end.html [ Skip ] # timeout
+imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/preserves-pitch.html [ Skip ]
 
 imported/w3c/web-platform-tests/html/anonymous-iframe/local-storage.tentative.https.window.html [ Failure Pass ]
 
@@ -2569,6 +2570,8 @@ webaudio/crashtest/audioworklet-concurrent-resampler-crash.html [ Timeout Pass ]
 webkit.org/b/309202 webaudio/audiomix-bufferingpolicy.html [ Pass Timeout Crash ]
 webkit.org/b/307727 webaudio/decode-audio-data-aac.html [ Failure ]
 webkit.org/b/307727 webaudio/decode-audio-data-mp3-8000.html [ Failure ]
+
+webaudio/MediaElementAudioSource/mediaelementaudiosourcenode-playbackrate.html [ Skip ]
 
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of WebAudio-related bugs

--- a/Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.cpp
@@ -69,7 +69,6 @@ ExceptionOr<Ref<MediaElementAudioSourceNode>> MediaElementAudioSourceNode::creat
 MediaElementAudioSourceNode::MediaElementAudioSourceNode(BaseAudioContext& context, Ref<HTMLMediaElement>&& mediaElement)
     : AudioNode(context, NodeTypeMediaElementAudioSource)
     , m_mediaElement(WTF::move(mediaElement))
-    , m_playbackRate { abs(m_mediaElement->reportedPlaybackRate()) }
 {
     // Default to stereo. This could change depending on what the media element .src is set to.
     addOutput(2);
@@ -116,24 +115,10 @@ void MediaElementAudioSourceNode::setFormat(size_t numberOfChannels, float sourc
     }
 }
 
-void MediaElementAudioSourceNode::setPlaybackRate(double playbackRate)
-{
-    playbackRate = abs(playbackRate);
-    if (!playbackRate || playbackRate == m_playbackRate)
-        return;
-
-    Locker locker { m_processLock };
-    m_playbackRate = playbackRate;
-    updateResamplerIfNeeded();
-}
-
 void MediaElementAudioSourceNode::updateResamplerIfNeeded()
 {
-    // Account for both sample rate conversion and playback rate
-    double effectiveSampleRate = m_sourceSampleRate * m_playbackRate;
-
-    if (effectiveSampleRate != sampleRate()) {
-        double scaleFactor = effectiveSampleRate / sampleRate();
+    if (m_sourceSampleRate != sampleRate()) {
+        double scaleFactor = m_sourceSampleRate / sampleRate();
         m_multiChannelResampler = makeUnique<MultiChannelResampler>(scaleFactor, m_sourceNumberOfChannels, AudioUtilities::renderQuantumSize, std::bind(&MediaElementAudioSourceNode::provideInput, this, std::placeholders::_1, std::placeholders::_2));
     } else {
         // Bypass resampling.

--- a/Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.h
+++ b/Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.h
@@ -56,7 +56,6 @@ public:
     
     // AudioSourceProviderClient
     void setFormat(size_t numberOfChannels, float sampleRate) final;
-    void setPlaybackRate(double);
     void ref() const final { AudioNode::ref(); }
     void deref() const final { AudioNode::deref(); }
 
@@ -81,7 +80,6 @@ private:
 
     unsigned m_sourceNumberOfChannels WTF_GUARDED_BY_LOCK(m_processLock) { 0 };
     double m_sourceSampleRate WTF_GUARDED_BY_LOCK(m_processLock) { 0 };
-    std::atomic<double> m_playbackRate { 1.0 };
     bool m_muted WTF_GUARDED_BY_LOCK(m_processLock) { false };
 
     std::unique_ptr<MultiChannelResampler> m_multiChannelResampler WTF_GUARDED_BY_LOCK(m_processLock);

--- a/Source/WebCore/PAL/pal/cf/AudioToolboxSoftLink.cpp
+++ b/Source/WebCore/PAL/pal/cf/AudioToolboxSoftLink.cpp
@@ -76,6 +76,7 @@ SOFT_LINK_FUNCTION_FOR_SOURCE(PAL, AudioToolbox, AudioComponentInstanceNew, OSSt
 SOFT_LINK_FUNCTION_FOR_SOURCE(PAL, AudioToolbox, AudioUnitGetProperty, OSStatus, (AudioUnit inUnit, AudioUnitPropertyID inID, AudioUnitScope inScope, AudioUnitElement inElement, void* outData, UInt32* ioDataSize), (inUnit, inID, inScope, inElement, outData, ioDataSize))
 SOFT_LINK_FUNCTION_FOR_SOURCE(PAL, AudioToolbox, AudioUnitInitialize, OSStatus, (AudioUnit inUnit), (inUnit))
 SOFT_LINK_FUNCTION_FOR_SOURCE(PAL, AudioToolbox, AudioUnitSetProperty, OSStatus, (AudioUnit inUnit, AudioUnitPropertyID inID, AudioUnitScope inScope, AudioUnitElement inElement, const void* inData, UInt32 inDataSize), (inUnit, inID, inScope, inElement, inData, inDataSize))
+SOFT_LINK_FUNCTION_FOR_SOURCE(PAL, AudioToolbox, AudioUnitSetParameter, OSStatus, (AudioUnit inUnit, AudioUnitParameterID inID, AudioUnitScope inScope, AudioUnitElement inElement, AudioUnitParameterValue inValue, UInt32 inBufferOffsetInFrames), (inUnit, inID, inScope, inElement, inValue, inBufferOffsetInFrames))
 SOFT_LINK_FUNCTION_FOR_SOURCE(PAL, AudioToolbox, AudioUnitRender, OSStatus, (AudioUnit inUnit, AudioUnitRenderActionFlags* ioActionFlags, const AudioTimeStamp* inTimeStamp, UInt32 inOutputBusNumber, UInt32 inNumberFrames, AudioBufferList* ioData), (inUnit, ioActionFlags, inTimeStamp, inOutputBusNumber, inNumberFrames, ioData))
 SOFT_LINK_FUNCTION_FOR_SOURCE(PAL, AudioToolbox, AudioUnitUninitialize, OSStatus, (AudioUnit inUnit), (inUnit))
 

--- a/Source/WebCore/PAL/pal/cf/AudioToolboxSoftLink.h
+++ b/Source/WebCore/PAL/pal/cf/AudioToolboxSoftLink.h
@@ -77,6 +77,8 @@ typedef struct AudioComponentDescription AudioComponentDescription;
 typedef UInt32 AudioUnitPropertyID;
 typedef UInt32 AudioUnitScope;
 typedef UInt32 AudioUnitElement;
+typedef UInt32 AudioUnitParameterID;
+typedef Float32 AudioUnitParameterValue;
 
 enum SpatialContentTypeID : UInt32;
 struct SpatialAudioPreferences;
@@ -152,6 +154,8 @@ SOFT_LINK_FUNCTION_FOR_HEADER(PAL, AudioToolbox, AudioUnitInitialize, OSStatus, 
 #define AudioUnitInitialize softLink_AudioToolbox_AudioUnitInitialize
 SOFT_LINK_FUNCTION_FOR_HEADER(PAL, AudioToolbox, AudioUnitSetProperty, OSStatus, (AudioUnit inUnit, AudioUnitPropertyID inID, AudioUnitScope inScope, AudioUnitElement inElement, const void* inData, UInt32 inDataSize), (inUnit, inID, inScope, inElement, inData, inDataSize))
 #define AudioUnitSetProperty softLink_AudioToolbox_AudioUnitSetProperty
+SOFT_LINK_FUNCTION_FOR_HEADER(PAL, AudioToolbox, AudioUnitSetParameter, OSStatus, (AudioUnit inUnit, AudioUnitParameterID inID, AudioUnitScope inScope, AudioUnitElement inElement, AudioUnitParameterValue inValue, UInt32 inBufferOffsetInFrames), (inUnit, inID, inScope, inElement, inValue, inBufferOffsetInFrames))
+#define AudioUnitSetParameter softLink_AudioToolbox_AudioUnitSetParameter
 SOFT_LINK_FUNCTION_FOR_HEADER(PAL, AudioToolbox, AudioUnitRender, OSStatus, (AudioUnit inUnit, AudioUnitRenderActionFlags* ioActionFlags, const AudioTimeStamp* inTimeStamp, UInt32 inOutputBusNumber, UInt32 inNumberFrames, AudioBufferList* ioData), (inUnit, ioActionFlags, inTimeStamp, inOutputBusNumber, inNumberFrames, ioData))
 #define AudioUnitRender softLink_AudioToolbox_AudioUnitRender
 SOFT_LINK_FUNCTION_FOR_HEADER(PAL, AudioToolbox, AudioUnitUninitialize, OSStatus, (AudioUnit inUnit), (inUnit))

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -283,6 +283,7 @@ platform/audio/cocoa/CARingBuffer.cpp
 platform/audio/cocoa/FFTFrameCocoa.cpp
 platform/audio/cocoa/MediaSessionManagerCocoa.mm @nonARC
 platform/audio/cocoa/PlatformRawAudioDataCocoa.cpp
+platform/audio/cocoa/PitchShiftAudioUnit.mm @nonARC
 platform/audio/cocoa/SpatialAudioExperienceHelper.mm @nonARC
 platform/audio/cocoa/WebAudioBufferList.cpp
 platform/audio/ios/AudioOutputUnitAdaptorIOS.cpp @no-unify

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -6087,12 +6087,6 @@ void HTMLMediaElement::mediaPlayerRateChanged()
 
     updateSleepDisabling();
 
-#if ENABLE(WEB_AUDIO)
-    // Notify the audio source node if playback rate changed
-    if (RefPtr audioSourceNode = m_audioSourceNode)
-        audioSourceNode->setPlaybackRate(m_reportedPlaybackRate);
-#endif
-
     endProcessingMediaPlayerCallback();
 }
 

--- a/Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.mm
+++ b/Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.mm
@@ -214,7 +214,7 @@ bool AudioSampleDataSource::pullSamples(AudioBufferList& buffer, size_t sampleCo
     if (seekTo != NoSeek)
         m_readCount = seekTo;
 
-    auto [startFrame, endFrame] = m_ringBuffer->getFetchTimeBounds();
+    auto [startFrame, endFrame, writeAhead] = m_ringBuffer->getFetchTimeBounds();
     startFrame = std::max(m_readCount, startFrame);
 
     ASSERT(m_waitToStartForPushCount);
@@ -303,7 +303,7 @@ bool AudioSampleDataSource::pullAvailableSamplesAsChunks(AudioBufferList& buffer
     if (buffer.mNumberBuffers != m_ringBuffer->channelCount())
         return false;
 
-    auto [startFrame, endFrame] = m_ringBuffer->getFetchTimeBounds();
+    auto [startFrame, endFrame, writeAhead] = m_ringBuffer->getFetchTimeBounds();
     if (m_shouldComputeOutputSampleOffset) {
         m_outputSampleOffset = timeStamp + (endFrame - sampleCountPerChunk);
         m_shouldComputeOutputSampleOffset = false;

--- a/Source/WebCore/platform/audio/cocoa/CARingBuffer.cpp
+++ b/Source/WebCore/platform/audio/cocoa/CARingBuffer.cpp
@@ -176,7 +176,7 @@ CARingBuffer::TimeBounds CARingBuffer::getStoreTimeBounds()
     return m_storeBounds;
 }
 
-CARingBuffer::Error CARingBuffer::store(const AudioBufferList* list, size_t framesToWrite, uint64_t startFrame)
+CARingBuffer::Error CARingBuffer::store(const AudioBufferList* list, size_t framesToWrite, uint64_t startFrame, uint64_t writeAhead)
 {
     if (!framesToWrite)
         return Ok;
@@ -228,7 +228,7 @@ CARingBuffer::Error CARingBuffer::store(const AudioBufferList* list, size_t fram
     }
 
     // Now update the end time.
-    setTimeBounds({ m_storeBounds.startFrame, endFrame });
+    setTimeBounds({ m_storeBounds.startFrame, endFrame, writeAhead });
 
     return Ok;
 }

--- a/Source/WebCore/platform/audio/cocoa/CARingBuffer.h
+++ b/Source/WebCore/platform/audio/cocoa/CARingBuffer.h
@@ -55,10 +55,11 @@ public:
     struct TimeBounds {
         uint64_t startFrame { 0 };
         uint64_t endFrame { 0 };
+        uint64_t writeAhead { 0 };
         bool operator<=>(const TimeBounds&) const = default;
     };
     WEBCORE_EXPORT TimeBounds NODELETE getStoreTimeBounds();
-    WEBCORE_EXPORT Error store(const AudioBufferList*, size_t frameCount, uint64_t startFrame);
+    WEBCORE_EXPORT Error store(const AudioBufferList*, size_t frameCount, uint64_t startFrame, uint64_t writeAhead = 0);
 
     enum FetchMode { Copy, MixInt16, MixInt32, MixFloat32, MixFloat64 };
     static FetchMode fetchModeForMixing(AudioStreamDescription::PCMFormat);

--- a/Source/WebCore/platform/audio/cocoa/PitchShiftAudioUnit.h
+++ b/Source/WebCore/platform/audio/cocoa/PitchShiftAudioUnit.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEB_AUDIO) && USE(MEDIATOOLBOX)
+
+#include <wtf/Forward.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/SystemFree.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/UniqueRef.h>
+
+#if TARGET_OS_IPHONE || (defined(AUDIOCOMPONENT_NOCARBONINSTANCES) && AUDIOCOMPONENT_NOCARBONINSTANCES)
+typedef struct OpaqueAudioComponentInstance* AudioComponentInstance;
+#else
+typedef struct ComponentInstanceRecord* AudioComponentInstance;
+#endif
+
+typedef AudioComponentInstance AudioUnit;
+typedef UInt32 AudioUnitRenderActionFlags;
+typedef struct AudioTimeStamp AudioTimeStamp;
+typedef struct AudioBufferList AudioBufferList;
+
+namespace WebCore {
+
+class AudioBus;
+class CAAudioStreamDescription;
+class WebAudioBufferList;
+
+class PitchShiftAudioUnit {
+    WTF_MAKE_NONCOPYABLE(PitchShiftAudioUnit);
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(PitchShiftAudioUnit, WEBCORE_EXPORT);
+public:
+    WEBCORE_EXPORT explicit PitchShiftAudioUnit(const CAAudioStreamDescription&);
+    WEBCORE_EXPORT ~PitchShiftAudioUnit();
+
+    WEBCORE_EXPORT void setRate(double);
+    double rate() const { return m_rate; }
+    WEBCORE_EXPORT void setPitch(double);
+    double pitch() const { return m_pitch; }
+
+    using InputCallback = Function<bool(AudioBus&, size_t numberOfFrames)>;
+    WEBCORE_EXPORT void setInputCallback(InputCallback&&);
+
+    WEBCORE_EXPORT bool render(AudioBus& destinationBus, size_t numberOfFrames);
+
+private:
+    static OSStatus renderCallback(void* inRefCon, AudioUnitRenderActionFlags* ioActionFlags, const AudioTimeStamp* inTimeStamp, UInt32 inBusNumber, UInt32 inNumberFrames, AudioBufferList* ioData);
+
+    AudioUnit m_audioUnit { nullptr };
+    const std::unique_ptr<AudioBufferList, WTF::SystemFree<AudioBufferList>> m_renderBuffer;
+    const Ref<AudioBus> m_renderBus;
+    InputCallback m_inputCallback;
+    double m_rate { 1.0 };
+    double m_pitch { 0. };
+    double m_framesSoFar { 0. };
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_AUDIO) && USE(MEDIATOOLBOX)

--- a/Source/WebCore/platform/audio/cocoa/PitchShiftAudioUnit.mm
+++ b/Source/WebCore/platform/audio/cocoa/PitchShiftAudioUnit.mm
@@ -1,0 +1,181 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "PitchShiftAudioUnit.h"
+
+#if ENABLE(WEB_AUDIO) && USE(MEDIATOOLBOX)
+
+#include "AudioBus.h"
+#include "CAAudioStreamDescription.h"
+#include "Logging.h"
+#include <AudioToolbox/AudioComponent.h>
+#include <AudioToolbox/AudioUnit.h>
+#include <AudioToolbox/AudioUnitParameters.h>
+#include <AudioToolbox/AudioUnitProperties.h>
+#include <pal/cf/CoreAudioExtras.h>
+#include <wtf/StdLibExtras.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PitchShiftAudioUnit);
+
+PitchShiftAudioUnit::PitchShiftAudioUnit(const CAAudioStreamDescription& format)
+    : m_renderBuffer { PAL::createAudioBufferList(format.numberOfChannelStreams(), PAL::ShouldZeroMemory::Yes) }
+    , m_renderBus { AudioBus::create(format.numberOfChannelStreams(), 0, false) }
+{
+    AudioComponentDescription acd {
+        kAudioUnitType_FormatConverter,
+        kAudioUnitSubType_NewTimePitch,
+        kAudioUnitManufacturer_Apple,
+        0,
+        0
+    };
+
+    AudioComponent component = PAL::AudioComponentFindNext(nullptr, &acd);
+    if (!component)
+        return;
+
+    OSStatus status = PAL::AudioComponentInstanceNew(component, &m_audioUnit);
+    if (status != noErr || !m_audioUnit)
+        return;
+
+    AudioStreamBasicDescription asbd = format.streamDescription();
+    PAL::AudioUnitSetProperty(m_audioUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input, 0, &asbd, sizeof(AudioStreamBasicDescription));
+
+    PAL::AudioUnitSetProperty(m_audioUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Output, 0, &asbd, sizeof(AudioStreamBasicDescription));
+
+    AURenderCallbackStruct callbackStruct;
+    callbackStruct.inputProc = renderCallback;
+    callbackStruct.inputProcRefCon = this;
+    PAL::AudioUnitSetProperty(m_audioUnit, kAudioUnitProperty_SetRenderCallback, kAudioUnitScope_Input, 0, &callbackStruct, sizeof(callbackStruct));
+
+    PAL::AudioUnitInitialize(m_audioUnit);
+}
+
+PitchShiftAudioUnit::~PitchShiftAudioUnit()
+{
+    if (m_audioUnit) {
+        PAL::AudioUnitUninitialize(m_audioUnit);
+        PAL::AudioComponentInstanceDispose(m_audioUnit);
+    }
+}
+
+void PitchShiftAudioUnit::setRate(double rate)
+{
+    if (m_rate == rate)
+        return;
+
+    m_rate = rate;
+
+    if (!m_audioUnit)
+        return;
+
+    Float32 rateFloat = rate;
+    PAL::AudioUnitSetParameter(m_audioUnit, kNewTimePitchParam_Rate, kAudioUnitScope_Global, 0, rateFloat, 0);
+}
+
+void PitchShiftAudioUnit::setPitch(double pitch)
+{
+    if (m_pitch == pitch)
+        return;
+
+    m_pitch = pitch;
+
+    if (!m_audioUnit)
+        return;
+
+    Float32 pitchFloat = pitch;
+    PAL::AudioUnitSetParameter(m_audioUnit, kNewTimePitchParam_Pitch, kAudioUnitScope_Global, 0, pitchFloat, 0);
+}
+
+void PitchShiftAudioUnit::setInputCallback(InputCallback&& callback)
+{
+    m_inputCallback = WTF::move(callback);
+}
+
+bool PitchShiftAudioUnit::render(AudioBus& bus, size_t numberOfFrames)
+{
+    if (!m_audioUnit || !m_renderBuffer)
+        return false;
+
+    auto renderBuffers = span(*m_renderBuffer);
+    for (unsigned i = 0; i < bus.numberOfChannels() && i < renderBuffers.size(); ++i) {
+        AudioChannel* channel = bus.channel(i);
+        renderBuffers[i].mNumberChannels = 1;
+        renderBuffers[i].mDataByteSize = numberOfFrames * sizeof(float);
+        renderBuffers[i].mData = channel->mutableData();
+    }
+
+    AudioTimeStamp timeStamp { };
+    FillOutAudioTimeStampWithSampleTime(timeStamp, m_framesSoFar);
+    m_framesSoFar += numberOfFrames;
+
+    AudioUnitRenderActionFlags flags = 0;
+    OSStatus status = PAL::AudioUnitRender(m_audioUnit, &flags, &timeStamp, 0, numberOfFrames, m_renderBuffer.get());
+
+    for (unsigned i = 0; i < renderBuffers.size(); ++i) {
+        renderBuffers[i].mDataByteSize = 0;
+        renderBuffers[i].mData = nullptr;
+    }
+
+    if (status != noErr) {
+        bus.zero();
+        return false;
+    }
+
+    return true;
+}
+
+OSStatus PitchShiftAudioUnit::renderCallback(void* inRefCon, AudioUnitRenderActionFlags* ioActionFlags, const AudioTimeStamp* inTimeStamp, UInt32 inBusNumber, UInt32 inNumberFrames, AudioBufferList* ioData)
+{
+    UNUSED_PARAM(ioActionFlags);
+    UNUSED_PARAM(inTimeStamp);
+    UNUSED_PARAM(inBusNumber);
+
+    auto* self = static_cast<PitchShiftAudioUnit*>(inRefCon);
+    if (!self)
+        return kAudioUnitErr_NoConnection;
+
+    if (!self->m_inputCallback)
+        return kAudioUnitErr_NoConnection;
+
+    auto ioDataBuffers = span(*ioData);
+
+    for (unsigned i = 0; i < ioDataBuffers.size(); ++i) {
+        auto channelData = mutableSpan<float>(ioDataBuffers[i]);
+        self->m_renderBus->setChannelMemory(i, channelData.first(inNumberFrames));
+    }
+    self->m_renderBus->setLength(inNumberFrames);
+
+    if (!self->m_inputCallback(self->m_renderBus, inNumberFrames))
+        return kAudioUnitErr_TooManyFramesToProcess;
+
+    return noErr;
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_AUDIO) && USE(MEDIATOOLBOX)

--- a/Source/WebCore/platform/cocoa/NetworkExtensionContentFilter.mm
+++ b/Source/WebCore/platform/cocoa/NetworkExtensionContentFilter.mm
@@ -35,6 +35,7 @@
 #import "SharedBuffer.h"
 #import <objc/runtime.h>
 #import <pal/spi/cocoa/NEFilterSourceSPI.h>
+#import <wtf/BlockPtr.h>
 #import <wtf/CompletionHandler.h>
 #import <wtf/CrossThreadCopier.h>
 #import <wtf/RunLoop.h>
@@ -42,6 +43,7 @@
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/URL.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/threads/BinarySemaphore.h>
 
 static inline NSData *replacementDataFromDecisionInfo(NSDictionary *decisionInfo)

--- a/Source/WebCore/platform/cocoa/PowerSourceNotifier.h
+++ b/Source/WebCore/platform/cocoa/PowerSourceNotifier.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <wtf/CheckedPtr.h>
 #include <wtf/Function.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>

--- a/Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.h
@@ -52,7 +52,10 @@ namespace WebCore {
 class AudioStreamDescription;
 class CAAudioStreamDescription;
 class CARingBuffer;
+class MultiChannelResampler;
+class PitchShiftAudioUnit;
 class PlatformAudioData;
+class WebAudioBufferList;
 
 class AudioSourceProviderAVFObjC : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<AudioSourceProviderAVFObjC>, public AudioSourceProvider {
 public:
@@ -63,6 +66,7 @@ public:
     void setPlayerItem(AVPlayerItem *);
     void setAudioTrack(AVAssetTrack *);
     void setPlaybackRate(double);
+    void setPreservesPitch(bool);
 
     using AudioCallback = Function<void(uint64_t startFrame, uint64_t numberOfFrames, bool needFlush)>;
     WEBCORE_EXPORT void setAudioCallback(AudioCallback&&);
@@ -79,6 +83,7 @@ private:
 
     // AudioSourceProvider
     void provideInput(AudioBus&, size_t framesToProcess) override;
+    bool provideInputInternal(AudioBus&, size_t framesToProcess);
     void setClient(WeakPtr<AudioSourceProviderClient>&&) override;
     bool isHandlingAVPlayer() const final { return true; }
 
@@ -96,7 +101,9 @@ private:
     RetainPtr<AVAssetTrack> m_avAssetTrack;
     RetainPtr<AVMutableAudioMix> m_avAudioMix;
     RetainPtr<MTAudioProcessingTapRef> m_tap;
-    RetainPtr<AudioConverterRef> m_converter;
+    AudioConverterRef m_converter;
+    std::unique_ptr<PitchShiftAudioUnit> m_pitchShifter;
+    std::unique_ptr<MultiChannelResampler> m_multiChannelResampler;
     std::unique_ptr<AudioBufferList, WTF::SystemFree<AudioBufferList>> m_list;
     std::unique_ptr<AudioStreamBasicDescription> m_tapDescription;
     std::unique_ptr<AudioStreamBasicDescription> m_outputDescription;
@@ -104,11 +111,11 @@ private:
 
     MediaTime m_startTimeAtLastProcess;
     MediaTime m_endTimeAtLastProcess;
-    uint64_t m_writeAheadCount { 0 };
     uint64_t m_readCount { 0 };
     enum { NoSeek = std::numeric_limits<uint64_t>::max() };
     uint64_t m_seekTo { NoSeek };
     bool m_paused { true };
+    bool m_preservesPitch { true };
     double m_playbackRate { 1. };
     WeakPtr<AudioSourceProviderClient> m_client;
     WeakPtrFactory<AudioSourceProviderAVFObjC> m_weakFactory;

--- a/Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
@@ -31,19 +31,25 @@
 #import "AudioBus.h"
 #import "AudioChannel.h"
 #import "AudioSourceProviderClient.h"
+#import "AudioUtilities.h"
 #import "CAAudioStreamDescription.h"
 #import "CARingBuffer.h"
 #import "Logging.h"
+#import "MultiChannelResampler.h"
+#import "PitchShiftAudioUnit.h"
+#import "WebAudioBufferList.h"
 #import <AVFoundation/AVAssetTrack.h>
 #import <AVFoundation/AVAudioMix.h>
 #import <AVFoundation/AVMediaFormat.h>
 #import <AVFoundation/AVPlayerItem.h>
+#import <cmath>
 #import <objc/runtime.h>
 #import <pal/avfoundation/MediaTimeAVFoundation.h>
 #import <pal/cf/CoreAudioExtras.h>
 #import <wtf/IndexedRange.h>
 #import <wtf/Lock.h>
 #import <wtf/MainThread.h>
+#import <wtf/StdLibExtras.h>
 
 #if !LOG_DISABLED
 #import <wtf/StringPrintStream.h>
@@ -86,27 +92,48 @@ AudioSourceProviderAVFObjC::~AudioSourceProviderAVFObjC()
     // to the destructor and a member function. This undefined behavior will be addressed in the future
     // commits. https://bugs.webkit.org/show_bug.cgi?id=224480
     setClient(nullptr);
+
+    if (m_converter) {
+        PAL::AudioConverterDispose(m_converter);
+        m_converter = nullptr;
+    }
 }
 
 void AudioSourceProviderAVFObjC::provideInput(AudioBus& bus, size_t framesToProcess)
+{
+    if (m_pitchShifter && m_preservesPitch && m_playbackRate != 1.0) {
+        if (!m_pitchShifter->render(bus, framesToProcess))
+            bus.zero();
+        return;
+    }
+
+    if (m_multiChannelResampler && !m_preservesPitch && m_playbackRate != 1.0) {
+        m_multiChannelResampler->process(bus, framesToProcess);
+        return;
+    }
+
+    provideInputInternal(bus, framesToProcess);
+}
+
+bool AudioSourceProviderAVFObjC::provideInputInternal(AudioBus& bus, size_t framesToProcess)
 {
     // Protect access to m_ringBuffer by using tryLock(). If we failed
     // to aquire, a re-configure is underway, and m_ringBuffer is unsafe to access.
     // Emit silence.
     if (!m_tapStorage) {
         bus.zero();
-        return;
+        return false;
     }
 
     if (!m_tapStorage->lock.tryLock()) {
         bus.zero();
-        return;
+        return false;
     }
     Locker locker { AdoptLock, m_tapStorage->lock };
 
     if (!m_ringBuffer) {
         bus.zero();
-        return;
+        return false;
     }
 
 
@@ -114,14 +141,14 @@ void AudioSourceProviderAVFObjC::provideInput(AudioBus& bus, size_t framesToProc
     if (seekTo != NoSeek)
         m_readCount = seekTo;
 
-    auto [startFrame, endFrame] = m_ringBuffer->getFetchTimeBounds();
+    auto [startFrame, endFrame, writeAhead] = m_ringBuffer->getFetchTimeBounds();
 
     if (!m_readCount || m_readCount == seekTo) {
         // We have not started rendering yet. If there aren't enough frames in the buffer, then output
         // silence until there is.
-        if (endFrame <= m_readCount + m_writeAheadCount + framesToProcess) {
+        if (endFrame <= m_readCount + writeAhead + framesToProcess) {
             bus.zero();
-            return;
+            return false;
         }
     } else {
         // We've started rendering. Don't output silence unless we really have to.
@@ -129,7 +156,7 @@ void AudioSourceProviderAVFObjC::provideInput(AudioBus& bus, size_t framesToProc
         if (framesAvailable < framesToProcess) {
             bus.zero();
             if (!framesAvailable)
-                return;
+                return false;
             framesToProcess = framesAvailable;
         }
     }
@@ -147,7 +174,9 @@ void AudioSourceProviderAVFObjC::provideInput(AudioBus& bus, size_t framesToProc
     m_readCount += framesToProcess;
 
     if (m_converter)
-        PAL::AudioConverterConvertComplexBuffer(m_converter.get(), framesToProcess, m_list.get(), m_list.get());
+        PAL::AudioConverterConvertComplexBuffer(m_converter, framesToProcess, m_list.get(), m_list.get());
+
+    return true;
 }
 
 void AudioSourceProviderAVFObjC::setClient(WeakPtr<AudioSourceProviderClient>&& client)
@@ -183,7 +212,17 @@ void AudioSourceProviderAVFObjC::setPlaybackRate(double rate)
     if (m_playbackRate == rate)
         return;
 
+    destroyMixIfNeeded();
     m_playbackRate = rate;
+    createMixIfNeeded();
+}
+
+void AudioSourceProviderAVFObjC::setPreservesPitch(bool preservesPitch)
+{
+    if (m_preservesPitch == preservesPitch)
+        return;
+
+    m_preservesPitch = preservesPitch;
 }
 
 void AudioSourceProviderAVFObjC::recreateAudioMixIfNeeded()
@@ -329,10 +368,26 @@ void AudioSourceProviderAVFObjC::prepare(CMItemCount maxFrames, const AudioStrea
     m_outputDescription->mFormatFlags |= kAudioFormatFlagIsNonInterleaved;
 
     if (*m_tapDescription != *m_outputDescription) {
-        AudioConverterRef outConverter = nullptr;
-        PAL::AudioConverterNew(m_tapDescription.get(), m_outputDescription.get(), &outConverter);
-        m_converter = outConverter;
+        if (m_converter) {
+            PAL::AudioConverterDispose(m_converter);
+            m_converter = nullptr;
+        }
+        PAL::AudioConverterNew(m_tapDescription.get(), m_outputDescription.get(), &m_converter);
     }
+
+    // Create the pitch shifter for when preservesPitch is enabled
+    m_pitchShifter = makeUnique<PitchShiftAudioUnit>(CAAudioStreamDescription(*m_outputDescription));
+    m_pitchShifter->setRate(m_playbackRate);
+    m_pitchShifter->setInputCallback([weakThis = ThreadSafeWeakPtr { *this }](AudioBus& inputBus, size_t numberOfFrames) {
+        if (RefPtr protectedThis = weakThis.get())
+            return protectedThis->provideInputInternal(inputBus, numberOfFrames);
+        return false;
+    });
+
+    m_multiChannelResampler = makeUnique<MultiChannelResampler>(m_playbackRate, numberOfChannels, AudioUtilities::renderQuantumSize, [weakThis = ThreadSafeWeakPtr { *this }](AudioBus& inputBus, size_t numberOfFrames) {
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->provideInputInternal(inputBus, numberOfFrames);
+    });
 
     // Make the ringbuffer large enough to store at least two callbacks worth of audio, or 1s, whichever is larger.
     size_t capacity = std::max(static_cast<size_t>(2 * maxFrames), static_cast<size_t>(kRingBufferDuration * sampleRate));
@@ -351,6 +406,8 @@ void AudioSourceProviderAVFObjC::prepare(CMItemCount maxFrames, const AudioStrea
 
 void AudioSourceProviderAVFObjC::unprepare()
 {
+    m_pitchShifter = nullptr;
+    m_multiChannelResampler = nullptr;
     m_tapDescription = nullptr;
     m_outputDescription = nullptr;
     m_ringBuffer = nullptr;
@@ -386,14 +443,14 @@ void AudioSourceProviderAVFObjC::process(MTAudioProcessingTapRef tap, CMItemCoun
         return;
     }
 
+    auto [startFrame, endFrame, writeAhead] = m_ringBuffer->getStoreTimeBounds();
+
     if (m_paused) {
         // Only check the write-ahead time when playback begins.
         m_paused = false;
         MediaTime earlyBy = rangeStart - currentTime;
-        m_writeAheadCount = m_tapDescription->mSampleRate * m_playbackRate * earlyBy.toDouble();
+        writeAhead = m_tapDescription->mSampleRate * m_playbackRate * earlyBy.toDouble();
     }
-
-    auto [startFrame, endFrame] = m_ringBuffer->getStoreTimeBounds();
 
     bool needsFlush = false;
 
@@ -413,7 +470,7 @@ void AudioSourceProviderAVFObjC::process(MTAudioProcessingTapRef tap, CMItemCoun
     if (needsFlush)
         m_seekTo = endFrame;
 
-    m_ringBuffer->store(bufferListInOut, itemCount, endFrame);
+    m_ringBuffer->store(bufferListInOut, itemCount, endFrame, writeAhead);
 
     // Mute the default audio playback by zeroing the tap-owned buffers.
     for (auto& buffer : span(*bufferListInOut))

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -517,6 +517,7 @@ private:
     mutable std::optional<bool> m_cachedAssetIsHLS;
     bool m_volumeLocked { false };
     bool m_muted { false };
+    bool m_preservesPitch { true };
     bool m_shouldObserveTimeControlStatus { false };
     mutable std::optional<bool> m_tracksArePlayable;
     bool m_automaticallyWaitsToMinimizeStalling { false };

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -1218,6 +1218,8 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     if (RefPtr provider = m_provider) {
         provider->setPlayerItem(m_avPlayerItem.get());
         provider->setAudioTrack(firstEnabledAudibleTrack());
+        if (auto player = this->player())
+            provider->setPreservesPitch(player->preservesPitch());
     }
 #endif
 
@@ -1752,6 +1754,10 @@ void MediaPlayerPrivateAVFoundationObjC::setPreservesPitch(bool preservesPitch)
     auto player = this->player();
     if (m_avPlayerItem && player)
         [m_avPlayerItem setAudioTimePitchAlgorithm:MediaSessionManagerCocoa::audioTimePitchAlgorithmForMediaPlayerPitchCorrectionAlgorithm(player->pitchCorrectionAlgorithm(), preservesPitch, m_requestedRate).createNSString().get()];
+#if ENABLE(WEB_AUDIO) && USE(MEDIATOOLBOX)
+    if (RefPtr provider = m_provider)
+        provider->setPreservesPitch(preservesPitch);
+#endif
 }
 
 void MediaPlayerPrivateAVFoundationObjC::setPitchCorrectionAlgorithm(MediaPlayer::PitchCorrectionAlgorithm pitchCorrectionAlgorithm)

--- a/Source/WebCore/platform/mediastream/WebAudioSourceProvider.h
+++ b/Source/WebCore/platform/mediastream/WebAudioSourceProvider.h
@@ -28,11 +28,11 @@
 #if ENABLE(WEB_AUDIO)
 
 #include <WebCore/AudioSourceProvider.h>
-#include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 
 namespace WebCore {
 
-class WebAudioSourceProvider : public ThreadSafeRefCounted<WebAudioSourceProvider, WTF::DestructionThread::Main>, public AudioSourceProvider {
+class WebAudioSourceProvider : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WebAudioSourceProvider, WTF::DestructionThread::Main>, public AudioSourceProvider {
 };
 
 }

--- a/Source/WebCore/platform/mediastream/cocoa/MediaStreamTrackAudioSourceProviderCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/MediaStreamTrackAudioSourceProviderCocoa.cpp
@@ -28,10 +28,26 @@
 
 #if ENABLE(WEB_AUDIO) && ENABLE(MEDIA_STREAM)
 
+#import "AudioBus.h"
+#import "AudioChannel.h"
+#import "AudioSourceProviderClient.h"
+#import "CAAudioStreamDescription.h"
 #import "LibWebRTCAudioModule.h"
+#import "Logging.h"
+#import "WebAudioBufferList.h"
+#import <objc/runtime.h>
+#import <wtf/MainThread.h>
 #import <wtf/TZoneMallocInlines.h>
 
+#if !LOG_DISABLED
+#import <wtf/StringPrintStream.h>
+#endif
+
+#import <pal/cf/CoreMediaSoftLink.h>
+
 namespace WebCore {
+
+static const double kRingBufferDuration = 1;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaStreamTrackAudioSourceProviderCocoa);
 
@@ -54,6 +70,14 @@ MediaStreamTrackAudioSourceProviderCocoa::~MediaStreamTrackAudioSourceProviderCo
 {
     ASSERT(!m_connected);
     m_source->removeAudioSampleObserver(*this);
+}
+
+void MediaStreamTrackAudioSourceProviderCocoa::setClient(WeakPtr<AudioSourceProviderClient>&& client)
+{
+    if (m_client == client)
+        return;
+    m_client = WTF::move(client);
+    hasNewClient(m_client.get());
 }
 
 void MediaStreamTrackAudioSourceProviderCocoa::hasNewClient(AudioSourceProviderClient* client)
@@ -80,13 +104,96 @@ void MediaStreamTrackAudioSourceProviderCocoa::trackEnabledChanged(MediaStreamTr
     m_enabled = track.enabled();
 }
 
+void MediaStreamTrackAudioSourceProviderCocoa::provideInput(AudioBus& bus, size_t framesToProcess)
+{
+    if (!m_lock.tryLock()) {
+        bus.zero();
+        return;
+    }
+    Locker locker { AdoptLock, m_lock };
+    if (!m_dataSource || !m_audioBufferList) {
+        bus.zero();
+        return;
+    }
+
+    if (m_writeCount <= m_readCount) {
+        bus.zero();
+        return;
+    }
+
+    if (bus.numberOfChannels() < m_audioBufferList->bufferCount()) {
+        bus.zero();
+        return;
+    }
+
+    for (unsigned i = 0; i < bus.numberOfChannels(); ++i) {
+        auto& channel = *bus.channel(i);
+        if (i >= m_audioBufferList->bufferCount()) {
+            channel.zero();
+            continue;
+        }
+        auto* buffer = m_audioBufferList->buffer(i);
+        buffer->mNumberChannels = 1;
+        buffer->mData = channel.mutableData();
+        buffer->mDataByteSize = channel.length() * sizeof(float);
+    }
+
+    ASSERT(framesToProcess <= bus.length());
+    m_dataSource->pullSamples(*m_audioBufferList->list(), framesToProcess, m_readCount, 0, AudioSampleDataSource::Copy);
+    m_readCount += framesToProcess;
+}
+
+void MediaStreamTrackAudioSourceProviderCocoa::prepare(const AudioStreamBasicDescription& format)
+{
+    DisableMallocRestrictionsForCurrentThreadScope scope;
+
+    Locker locker { m_lock };
+
+    LOG(Media, "MediaStreamTrackAudioSourceProviderCocoa::prepare(%p)", this);
+
+    m_inputDescription = CAAudioStreamDescription(format);
+    int numberOfChannels = format.mChannelsPerFrame;
+    double sampleRate = format.mSampleRate;
+    ASSERT(sampleRate >= 0);
+
+    const int bytesPerFloat = sizeof(Float32);
+    const int bitsPerByte = 8;
+    const bool isFloat = true;
+    const bool isBigEndian = false;
+    const bool isNonInterleaved = true;
+    AudioStreamBasicDescription outputDescription { };
+    FillOutASBDForLPCM(outputDescription, sampleRate, numberOfChannels, bitsPerByte * bytesPerFloat, bitsPerByte * bytesPerFloat, isFloat, isBigEndian, isNonInterleaved);
+    m_outputDescription = CAAudioStreamDescription(outputDescription);
+    m_audioBufferList = makeUnique<WebAudioBufferList>(m_outputDescription.value());
+
+    if (!m_dataSource)
+        m_dataSource = AudioSampleDataSource::create(kRingBufferDuration * sampleRate, loggerHelper(), m_pollSamplesCount);
+    m_dataSource->setInputFormat(m_inputDescription.value());
+    m_dataSource->setOutputFormat(m_outputDescription.value());
+
+    callOnMainThread([protectedThis = Ref { *this }, numberOfChannels, sampleRate] {
+        if (protectedThis->m_client)
+            protectedThis->m_client->setFormat(numberOfChannels, sampleRate);
+    });
+}
+
 // May get called on a background thread.
 void MediaStreamTrackAudioSourceProviderCocoa::audioSamplesAvailable(const WTF::MediaTime&, const PlatformAudioData& data, const AudioStreamDescription& description, size_t frameCount)
 {
     if (!m_enabled)
         return;
 
-    receivedNewAudioSamples(data, description, frameCount);
+    ASSERT(description.platformDescription().type == PlatformDescription::CAAudioStreamBasicType);
+    auto& basicDescription = *std::get<const AudioStreamBasicDescription*>(description.platformDescription().description);
+    if (!m_inputDescription || m_inputDescription->streamDescription() != basicDescription)
+        prepare(basicDescription);
+
+    if (!m_dataSource)
+        return;
+
+    m_dataSource->pushSamples(MediaTime(m_writeCount, m_inputDescription->sampleRate()), data, frameCount);
+
+    m_writeCount += frameCount;
 }
 
 }

--- a/Source/WebCore/platform/mediastream/cocoa/MediaStreamTrackAudioSourceProviderCocoa.h
+++ b/Source/WebCore/platform/mediastream/cocoa/MediaStreamTrackAudioSourceProviderCocoa.h
@@ -27,17 +27,29 @@
 
 #if ENABLE(WEB_AUDIO) && ENABLE(MEDIA_STREAM)
 
+#include "AudioSampleDataSource.h"
 #include "MediaStreamTrackPrivate.h"
 #include "RealtimeMediaSource.h"
-#include "WebAudioSourceProviderCocoa.h"
+#include "WebAudioSourceProvider.h"
+#include <CoreAudio/CoreAudioTypes.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/MediaTime.h>
 #include <wtf/TZoneMalloc.h>
 
+typedef struct AudioBufferList AudioBufferList;
+typedef struct OpaqueAudioConverter* AudioConverterRef;
+typedef struct AudioStreamBasicDescription AudioStreamBasicDescription;
+typedef const struct opaqueCMFormatDescription *CMFormatDescriptionRef;
+typedef struct opaqueCMSampleBuffer *CMSampleBufferRef;
+
 namespace WebCore {
 
+class CAAudioStreamDescription;
+class PlatformAudioData;
+class WebAudioBufferList;
+
 class MediaStreamTrackAudioSourceProviderCocoa final
-    : public WebAudioSourceProviderCocoa
+    : public WebAudioSourceProvider
     , MediaStreamTrackPrivateObserver
     , RealtimeMediaSource::AudioSampleObserver
     , public CanMakeCheckedPtr<MediaStreamTrackAudioSourceProviderCocoa> {
@@ -47,8 +59,8 @@ public:
     static Ref<MediaStreamTrackAudioSourceProviderCocoa> create(MediaStreamTrackPrivate&);
     ~MediaStreamTrackAudioSourceProviderCocoa();
 
-    void ref() const final { WebAudioSourceProviderCocoa::ref(); }
-    void deref() const final { WebAudioSourceProviderCocoa::deref(); }
+    void ref() const final { WebAudioSourceProvider::ref(); }
+    void deref() const final { WebAudioSourceProvider::deref(); }
 
 private:
     explicit MediaStreamTrackAudioSourceProviderCocoa(MediaStreamTrackPrivate&);
@@ -60,10 +72,16 @@ private:
     void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
     void setDidBeginCheckedPtrDeletion() final { CanMakeCheckedPtr::setDidBeginCheckedPtrDeletion(); }
 
-    // WebAudioSourceProviderCocoa
-    void hasNewClient(AudioSourceProviderClient*) final;
+    void setPollSamplesCount(size_t);
+
+    void hasNewClient(AudioSourceProviderClient*);
+
+    // AudioSourceProvider
+    void provideInput(AudioBus&, size_t) final;
+    void setClient(WeakPtr<AudioSourceProviderClient>&&) final;
+    void prepare(const AudioStreamBasicDescription&);
 #if !RELEASE_LOG_DISABLED
-    WTF::LoggerHelper& loggerHelper() final { return m_source.get(); }
+    WTF::LoggerHelper& loggerHelper() { return m_source.get(); }
 #endif
 
     // MediaStreamTrackPrivateObserver
@@ -75,11 +93,27 @@ private:
     // RealtimeMediaSource::AudioSampleObserver
     void audioSamplesAvailable(const WTF::MediaTime&, const PlatformAudioData&, const AudioStreamDescription&, size_t) final;
 
+    Lock m_lock;
+    WeakPtr<AudioSourceProviderClient> m_client;
+
+    std::optional<CAAudioStreamDescription> m_inputDescription;
+    std::optional<CAAudioStreamDescription> m_outputDescription;
+    std::unique_ptr<WebAudioBufferList> m_audioBufferList;
+    RefPtr<AudioSampleDataSource> m_dataSource;
+
+    size_t m_pollSamplesCount { 3 };
+    uint64_t m_writeCount { 0 };
+    uint64_t m_readCount { 0 };
     WeakPtr<MediaStreamTrackPrivate> m_captureSource;
     const Ref<RealtimeMediaSource> m_source;
     bool m_enabled { true };
     bool m_connected { false };
 };
+
+inline void MediaStreamTrackAudioSourceProviderCocoa::setPollSamplesCount(size_t count)
+{
+    m_pollSamplesCount = count;
+}
 
 }
 

--- a/Source/WebCore/platform/mediastream/cocoa/WebAudioSourceProviderCocoa.h
+++ b/Source/WebCore/platform/mediastream/cocoa/WebAudioSourceProviderCocoa.h
@@ -34,6 +34,8 @@
 #include <wtf/Lock.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
+#include <wtf/RetainPtr.h>
+#include <wtf/SystemFree.h>
 
 typedef struct AudioBufferList AudioBufferList;
 typedef struct OpaqueAudioConverter* AudioConverterRef;
@@ -48,19 +50,30 @@ class LoggerHelper;
 namespace WebCore {
 
 class CAAudioStreamDescription;
+class MultiChannelResampler;
+class PitchShiftAudioUnit;
 class PlatformAudioData;
 class WebAudioBufferList;
 
-class WEBCORE_EXPORT WebAudioSourceProviderCocoa
+class WebAudioSourceProviderCocoa
     : public WebAudioSourceProvider {
 public:
-    WebAudioSourceProviderCocoa();
-    ~WebAudioSourceProviderCocoa();
+    WEBCORE_EXPORT WebAudioSourceProviderCocoa();
+    WEBCORE_EXPORT ~WebAudioSourceProviderCocoa();
+
+    CARingBuffer* ringBuffer() const { return m_ringBuffer.get(); }
+
+    WEBCORE_EXPORT void setPlaybackRate(double);
+    double playbackRate() const { return m_playbackRate; }
+
+    WEBCORE_EXPORT void setPreservesPitch(bool);
+    bool preservesPitch() const { return m_preservesPitch; }
+
+    WEBCORE_EXPORT void audioStorageChanged(std::unique_ptr<CARingBuffer>&&, const AudioStreamDescription&);
+    WEBCORE_EXPORT void receivedNewAudioSamples(const PlatformAudioData&, const AudioStreamDescription&, size_t);
+    WEBCORE_EXPORT void setNeedsFlush();
 
 protected:
-    using NeedsFlush = AudioSampleDataSource::NeedsFlush;
-    void receivedNewAudioSamples(const PlatformAudioData&, const AudioStreamDescription&, size_t, NeedsFlush = NeedsFlush::No);
-
     void setPollSamplesCount(size_t);
 
 private:
@@ -70,22 +83,28 @@ private:
 #endif
 
     // AudioSourceProvider
-    void provideInput(AudioBus&, size_t) final;
-    void setClient(WeakPtr<AudioSourceProviderClient>&&) final;
+    WEBCORE_EXPORT void provideInput(AudioBus&, size_t) final;
+    bool provideInputInternal(AudioBus&, size_t);
+    WEBCORE_EXPORT void setClient(WeakPtr<AudioSourceProviderClient>&&) final;
 
     void prepare(const AudioStreamBasicDescription&);
 
     Lock m_lock;
     WeakPtr<AudioSourceProviderClient> m_client;
 
+    std::unique_ptr<PitchShiftAudioUnit> m_pitchShifter;
+    std::unique_ptr<MultiChannelResampler> m_multiChannelResampler;
     std::optional<CAAudioStreamDescription> m_inputDescription;
     std::optional<CAAudioStreamDescription> m_outputDescription;
-    std::unique_ptr<WebAudioBufferList> m_audioBufferList;
-    RefPtr<AudioSampleDataSource> m_dataSource;
+    std::unique_ptr<AudioBufferList, WTF::SystemFree<AudioBufferList>> m_list;
+    AudioConverterRef m_converter;
+    std::unique_ptr<CARingBuffer> m_ringBuffer;
 
+    double m_playbackRate { 1 };
+    bool m_preservesPitch { true };
     size_t m_pollSamplesCount { 3 };
-    uint64_t m_writeCount { 0 };
     uint64_t m_readCount { 0 };
+    bool m_underflowed { true };
 };
 
 inline void WebAudioSourceProviderCocoa::setPollSamplesCount(size_t count)

--- a/Source/WebCore/platform/mediastream/cocoa/WebAudioSourceProviderCocoa.mm
+++ b/Source/WebCore/platform/mediastream/cocoa/WebAudioSourceProviderCocoa.mm
@@ -31,20 +31,23 @@
 #import "AudioBus.h"
 #import "AudioChannel.h"
 #import "AudioSourceProviderClient.h"
+#import "AudioUtilities.h"
 #import "Logging.h"
+#import "MultiChannelResampler.h"
+#import "PitchShiftAudioUnit.h"
 #import "WebAudioBufferList.h"
 #import <objc/runtime.h>
+#import <wtf/IndexedRange.h>
 #import <wtf/MainThread.h>
 
 #if !LOG_DISABLED
 #import <wtf/StringPrintStream.h>
 #endif
 
+#import <pal/cf/AudioToolboxSoftLink.h>
 #import <pal/cf/CoreMediaSoftLink.h>
 
 namespace WebCore {
-
-static const double kRingBufferDuration = 1;
 
 WebAudioSourceProviderCocoa::WebAudioSourceProviderCocoa()
 {
@@ -52,6 +55,10 @@ WebAudioSourceProviderCocoa::WebAudioSourceProviderCocoa()
 
 WebAudioSourceProviderCocoa::~WebAudioSourceProviderCocoa()
 {
+    if (m_converter) {
+        PAL::AudioConverterDispose(m_converter);
+        m_converter = nullptr;
+    }
 }
 
 void WebAudioSourceProviderCocoa::setClient(WeakPtr<AudioSourceProviderClient>&& client)
@@ -59,7 +66,48 @@ void WebAudioSourceProviderCocoa::setClient(WeakPtr<AudioSourceProviderClient>&&
     if (m_client == client)
         return;
     m_client = WTF::move(client);
+
     hasNewClient(m_client.get());
+}
+
+void WebAudioSourceProviderCocoa::setPlaybackRate(double playbackRate)
+{
+    if (m_playbackRate == playbackRate)
+        return;
+
+    Locker locker { m_lock };
+    m_playbackRate = playbackRate;
+
+    if (!m_outputDescription)
+        return;
+
+    if (m_pitchShifter)
+        m_pitchShifter->setRate(m_playbackRate);
+    m_multiChannelResampler = makeUnique<MultiChannelResampler>(m_playbackRate, m_outputDescription->numberOfChannels(), AudioUtilities::renderQuantumSize, [weakThis = ThreadSafeWeakPtr { *this }](AudioBus& inputBus, size_t numberOfFrames) {
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->provideInputInternal(inputBus, numberOfFrames);
+    });
+
+}
+
+void WebAudioSourceProviderCocoa::setPreservesPitch(bool preservesPitch)
+{
+    if (m_preservesPitch == preservesPitch)
+        return;
+
+    Locker locker { m_lock };
+    m_preservesPitch = preservesPitch;
+}
+
+void WebAudioSourceProviderCocoa::audioStorageChanged(std::unique_ptr<CARingBuffer>&& ringBuffer, const AudioStreamDescription& description)
+{
+    Locker locker { m_lock };
+    m_ringBuffer = WTF::move(ringBuffer);
+
+    ASSERT(description.platformDescription().type == PlatformDescription::CAAudioStreamBasicType);
+    auto& basicDescription = *std::get<const AudioStreamBasicDescription*>(description.platformDescription().description);
+    if (!m_inputDescription || m_inputDescription->streamDescription() != basicDescription)
+        prepare(basicDescription);
 }
 
 void WebAudioSourceProviderCocoa::provideInput(AudioBus& bus, size_t framesToProcess)
@@ -69,45 +117,80 @@ void WebAudioSourceProviderCocoa::provideInput(AudioBus& bus, size_t framesToPro
         return;
     }
     Locker locker { AdoptLock, m_lock };
-    if (!m_dataSource || !m_audioBufferList) {
+
+    if (!m_playbackRate) {
         bus.zero();
         return;
     }
 
-    if (m_writeCount <= m_readCount) {
-        bus.zero();
+    if (m_pitchShifter && m_preservesPitch && m_playbackRate != 1.0) {
+        m_pitchShifter->render(bus, framesToProcess);
         return;
     }
 
-    if (bus.numberOfChannels() < m_audioBufferList->bufferCount()) {
-        bus.zero();
+    if (m_multiChannelResampler && !m_preservesPitch && m_playbackRate != 1.0) {
+        m_multiChannelResampler->process(bus, framesToProcess);
         return;
     }
 
-    for (unsigned i = 0; i < bus.numberOfChannels(); ++i) {
-        auto& channel = *bus.channel(i);
-        if (i >= m_audioBufferList->bufferCount()) {
-            channel.zero();
-            continue;
+    provideInputInternal(bus, framesToProcess);
+}
+
+bool WebAudioSourceProviderCocoa::provideInputInternal(AudioBus& bus, size_t framesToProcess)
+{
+    if (!m_ringBuffer) {
+        bus.zero();
+        return false;
+    }
+
+    auto [startFrame, endFrame, writeAhead] = m_ringBuffer->getFetchTimeBounds();
+
+    if (m_readCount >= endFrame) {
+        bus.zero();
+        m_underflowed = true;
+        return false;
+    }
+
+    size_t framesAvailable = static_cast<size_t>(endFrame - m_readCount);
+    if (framesAvailable < framesToProcess) {
+        bus.zero();
+        framesToProcess = framesAvailable;
+    }
+
+    if (m_underflowed) {
+        // Wait for enough future data to be written before restarting:
+        if (framesAvailable < writeAhead) {
+            bus.zero();
+            return false;
         }
-        auto* buffer = m_audioBufferList->buffer(i);
-        buffer->mNumberChannels = 1;
-        buffer->mData = channel.mutableData();
-        buffer->mDataByteSize = channel.length() * sizeof(float);
+        m_underflowed = false;
     }
 
-    ASSERT(framesToProcess <= bus.length());
-    m_dataSource->pullSamples(*m_audioBufferList->list(), framesToProcess, m_readCount, 0, AudioSampleDataSource::Copy);
+    ASSERT(bus.numberOfChannels() == m_ringBuffer->channelCount());
+    if (bus.numberOfChannels() != m_ringBuffer->channelCount()) {
+        bus.zero();
+        return false;
+    }
+
+    for (auto [i, buffer] : indexedRange(span(*m_list))) {
+        AudioChannel* channel = bus.channel(i);
+        buffer.mNumberChannels = 1;
+        buffer.mData = channel->mutableData();
+        buffer.mDataByteSize = channel->length() * sizeof(float);
+    }
+
+    m_ringBuffer->fetch(m_list.get(), framesToProcess, m_readCount);
     m_readCount += framesToProcess;
+
+    if (m_converter)
+        PAL::AudioConverterConvertComplexBuffer(m_converter, framesToProcess, m_list.get(), m_list.get());
+
+    return true;
 }
 
 void WebAudioSourceProviderCocoa::prepare(const AudioStreamBasicDescription& format)
 {
     DisableMallocRestrictionsForCurrentThreadScope scope;
-
-    Locker locker { m_lock };
-
-    LOG(Media, "WebAudioSourceProviderCocoa::prepare(%p)", this);
 
     m_inputDescription = CAAudioStreamDescription(format);
     int numberOfChannels = format.mChannelsPerFrame;
@@ -122,12 +205,28 @@ void WebAudioSourceProviderCocoa::prepare(const AudioStreamBasicDescription& for
     AudioStreamBasicDescription outputDescription { };
     FillOutASBDForLPCM(outputDescription, sampleRate, numberOfChannels, bitsPerByte * bytesPerFloat, bitsPerByte * bytesPerFloat, isFloat, isBigEndian, isNonInterleaved);
     m_outputDescription = CAAudioStreamDescription(outputDescription);
-    m_audioBufferList = makeUnique<WebAudioBufferList>(m_outputDescription.value());
+    m_list = PAL::createAudioBufferList(numberOfChannels, PAL::ShouldZeroMemory::Yes);
 
-    if (!m_dataSource)
-        m_dataSource = AudioSampleDataSource::create(kRingBufferDuration * sampleRate, loggerHelper(), m_pollSamplesCount);
-    m_dataSource->setInputFormat(m_inputDescription.value());
-    m_dataSource->setOutputFormat(m_outputDescription.value());
+    m_pitchShifter = makeUnique<PitchShiftAudioUnit>(CAAudioStreamDescription(*m_outputDescription));
+    m_pitchShifter->setRate(m_playbackRate);
+    m_pitchShifter->setInputCallback([weakThis = ThreadSafeWeakPtr { *this }](AudioBus& inputBus, size_t numberOfFrames) {
+        if (RefPtr protectedThis = weakThis.get())
+            return protectedThis->provideInputInternal(inputBus, numberOfFrames);
+        return false;
+    });
+
+    m_multiChannelResampler = makeUnique<MultiChannelResampler>(m_playbackRate, numberOfChannels, AudioUtilities::renderQuantumSize, [weakThis = ThreadSafeWeakPtr { *this }](AudioBus& inputBus, size_t numberOfFrames) {
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->provideInputInternal(inputBus, numberOfFrames);
+    });
+
+    if (*m_inputDescription != *m_outputDescription) {
+        if (m_converter) {
+            PAL::AudioConverterDispose(m_converter);
+            m_converter = nullptr;
+        }
+        PAL::AudioConverterNew(&m_inputDescription->streamDescription(), &m_outputDescription->streamDescription(), &m_converter);
+    }
 
     callOnMainThread([protectedThis = Ref { *this }, numberOfChannels, sampleRate] {
         if (protectedThis->m_client)
@@ -136,19 +235,22 @@ void WebAudioSourceProviderCocoa::prepare(const AudioStreamBasicDescription& for
 }
 
 // May get called on a background thread.
-void WebAudioSourceProviderCocoa::receivedNewAudioSamples(const PlatformAudioData& data, const AudioStreamDescription& description, size_t frameCount, NeedsFlush needsFlush)
+void WebAudioSourceProviderCocoa::receivedNewAudioSamples(const PlatformAudioData& data, const AudioStreamDescription&, size_t frameCount)
 {
-    ASSERT(description.platformDescription().type == PlatformDescription::CAAudioStreamBasicType);
-    auto& basicDescription = *std::get<const AudioStreamBasicDescription*>(description.platformDescription().description);
-    if (!m_inputDescription || m_inputDescription->streamDescription() != basicDescription)
-        prepare(basicDescription);
-
-    if (!m_dataSource)
+    if (!m_ringBuffer)
         return;
 
-    m_dataSource->pushSamples(MediaTime(m_writeCount, m_inputDescription->sampleRate()), data, frameCount, needsFlush);
+    auto [startFrame, endFrame, writeAhead] = m_ringBuffer->getStoreTimeBounds();
+    m_ringBuffer->store(downcast<WebAudioBufferList>(data).list(), frameCount, endFrame, writeAhead);
+}
 
-    m_writeCount += frameCount;
+void WebAudioSourceProviderCocoa::setNeedsFlush()
+{
+    if (!m_ringBuffer)
+        return;
+    auto [startFrame, endFrame, writeAhead] = m_ringBuffer->getFetchTimeBounds();
+    m_readCount = startFrame;
+    m_underflowed = true;
 }
 
 }

--- a/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTB.mm
+++ b/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTB.mm
@@ -30,6 +30,7 @@
 
 #import "MediaReorderQueue.h"
 #import <WebCore/CMUtilities.h>
+#import <wtf/cf/TypeCastsCF.h>
 
 #import "CoreVideoSoftLink.h"
 #import "VideoToolboxSoftLink.h"

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.cpp
@@ -66,9 +66,20 @@ std::unique_ptr<WebCore::CARingBuffer> RemoteAudioSourceProviderProxy::configure
     return caRingBuffer;
 }
 
-void RemoteAudioSourceProviderProxy::newAudioSamples(uint64_t startFrame, uint64_t numberOfFrames, bool needsFlush)
+void RemoteAudioSourceProviderProxy::newAudioSamples(uint64_t, uint64_t, bool needsFlush)
 {
-    m_connection->send(Messages::RemoteAudioSourceProviderManager::AudioSamplesAvailable { m_identifier, startFrame, numberOfFrames, needsFlush }, 0);
+    if (needsFlush)
+        m_connection->send(Messages::RemoteAudioSourceProviderManager::SetNeedsFlush { m_identifier }, 0);
+}
+
+void RemoteAudioSourceProviderProxy::setPlaybackRate(double playbackRate)
+{
+    m_connection->send(Messages::RemoteAudioSourceProviderManager::SetPlaybackRate { m_identifier, playbackRate }, 0);
+}
+
+void RemoteAudioSourceProviderProxy::setPreservesPitch(bool preservesPitch)
+{
+    m_connection->send(Messages::RemoteAudioSourceProviderManager::SetPreservesPitch { m_identifier, preservesPitch }, 0);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.h
@@ -48,6 +48,8 @@ public:
     ~RemoteAudioSourceProviderProxy();
 
     void newAudioSamples(uint64_t startFrame, uint64_t endFrame, bool);
+    void setPlaybackRate(double);
+    void setPreservesPitch(bool);
 
     void ref() const final { ThreadSafeRefCounted::ref(); }
     void deref() const final { ThreadSafeRefCounted::deref(); }

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -313,6 +313,10 @@ void RemoteMediaPlayerProxy::setPrivateBrowsingMode(bool privateMode)
 void RemoteMediaPlayerProxy::setPreservesPitch(bool preservesPitch)
 {
     protect(m_player)->setPreservesPitch(preservesPitch);
+#if ENABLE(WEB_AUDIO) && PLATFORM(COCOA)
+    if (RefPtr provider = m_remoteAudioSourceProvider)
+        provider->setPreservesPitch(preservesPitch);
+#endif
 }
 
 void RemoteMediaPlayerProxy::setPitchCorrectionAlgorithm(WebCore::MediaPlayer::PitchCorrectionAlgorithm algorithm)
@@ -504,7 +508,17 @@ void RemoteMediaPlayerProxy::mediaPlayerRateChanged()
     sendCachedState();
 
     RefPtr player = m_player;
-    protect(m_webProcessConnection)->send(Messages::MediaPlayerPrivateRemote::RateChanged(player->effectiveRate(), timeUpdateData(*player, player->currentTime())), m_id);
+    if (!player)
+        return;
+
+    auto effectiveRate = player->effectiveRate();
+
+#if ENABLE(WEB_AUDIO) && PLATFORM(COCOA)
+    if (RefPtr provider = m_remoteAudioSourceProvider)
+        provider->setPlaybackRate(effectiveRate);
+#endif
+
+    protect(m_webProcessConnection)->send(Messages::MediaPlayerPrivateRemote::RateChanged(effectiveRate, timeUpdateData(*player, player->currentTime())), m_id);
 }
 
 void RemoteMediaPlayerProxy::mediaPlayerEngineFailedToLoad()
@@ -1252,7 +1266,10 @@ void RemoteMediaPlayerProxy::createAudioSourceProvider()
     if (!provider)
         return;
 
-    m_remoteAudioSourceProvider = RemoteAudioSourceProviderProxy::create(m_id, m_webProcessConnection.copyRef(), *provider);
+    Ref proxy = RemoteAudioSourceProviderProxy::create(m_id, m_webProcessConnection.copyRef(), *provider);
+    proxy->setPlaybackRate(player->effectiveRate());
+    proxy->setPreservesPitch(player->preservesPitch());
+    m_remoteAudioSourceProvider = WTF::move(proxy);
 #endif
 }
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -8489,6 +8489,9 @@
 		CDF1B914266F395F0007EC10 /* GroupActivitiesSessionNotifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GroupActivitiesSessionNotifier.h; sourceTree = "<group>"; };
 		CDF1B919267021D60007EC10 /* WebKitSwiftSoftLink.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebKitSwiftSoftLink.h; sourceTree = "<group>"; };
 		CDF1B91A267021D60007EC10 /* WebKitSwiftSoftLink.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebKitSwiftSoftLink.mm; sourceTree = "<group>"; };
+		CDFE82BA2F7DE9C300547599 /* RemoteAudioDestinationManagerMessageReceiver.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = RemoteAudioDestinationManagerMessageReceiver.cpp; path = /Volumes/WebKitBuild/Debug/DerivedSources/WebKit/IPC/RemoteAudioDestinationManagerMessageReceiver.cpp; sourceTree = "<absolute>"; };
+		CDFE82BB2F7DE9C300547599 /* RemoteAudioSourceProviderManagerMessageReceiver.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = RemoteAudioSourceProviderManagerMessageReceiver.cpp; path = /Volumes/WebKitBuild/Debug/DerivedSources/WebKit/IPC/RemoteAudioSourceProviderManagerMessageReceiver.cpp; sourceTree = "<absolute>"; };
+		CDFE82BC2F7DE9C300547599 /* RemoteAudioSourceProviderManagerMessages.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RemoteAudioSourceProviderManagerMessages.h; path = /Volumes/WebKitBuild/Debug/DerivedSources/WebKit/IPC/RemoteAudioSourceProviderManagerMessages.h; sourceTree = "<absolute>"; };
 		CDFF2D082EAB3CAA00899478 /* _WKCaptionStyleMenuControllerIOS.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKCaptionStyleMenuControllerIOS.mm; sourceTree = "<group>"; };
 		CE11AD4F1CBC47F800681EE5 /* CodeSigning.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CodeSigning.mm; sourceTree = "<group>"; };
 		CE11AD511CBC482F00681EE5 /* CodeSigning.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CodeSigning.h; sourceTree = "<group>"; };
@@ -13486,12 +13489,15 @@
 				51EE7B5A2A95B5820016FF78 /* PushClientConnectionMessages.h */,
 				1C55A593275457C900EB7E95 /* RemoteAdapterMessageReceiver.cpp */,
 				1C55A5B1275457CD00EB7E95 /* RemoteAdapterMessages.h */,
+				CDFE82BA2F7DE9C300547599 /* RemoteAudioDestinationManagerMessageReceiver.cpp */,
 				CD20CE7725CD2B9D0069B542 /* RemoteAudioHardwareListenerMessageReceiver.cpp */,
 				CD20CE7925CD2B9E0069B542 /* RemoteAudioHardwareListenerMessages.h */,
 				CDD53576240DDE0700F7B8C4 /* RemoteAudioSessionMessageReceiver.cpp */,
 				CDD53575240DDE0700F7B8C4 /* RemoteAudioSessionMessages.h */,
 				CDD53571240DDE0600F7B8C4 /* RemoteAudioSessionProxyMessageReceiver.cpp */,
 				CDD53572240DDE0600F7B8C4 /* RemoteAudioSessionProxyMessages.h */,
+				CDFE82BB2F7DE9C300547599 /* RemoteAudioSourceProviderManagerMessageReceiver.cpp */,
+				CDFE82BC2F7DE9C300547599 /* RemoteAudioSourceProviderManagerMessages.h */,
 				5132290C2E77A368009E1992 /* RemoteAudioVideoRendererProxyManagerMessageReceiver.cpp */,
 				5132290D2E77A368009E1992 /* RemoteAudioVideoRendererProxyManagerMessages.h */,
 				1C55A582275457C600EB7E95 /* RemoteBindGroupLayoutMessageReceiver.cpp */,

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
@@ -41,6 +41,7 @@
 #include "MediaSourcePrivateRemoteMessageReceiverMessages.h"
 #include "RemoteAudioHardwareListenerMessages.h"
 #include "RemoteAudioSourceProviderManager.h"
+#include "RemoteAudioSourceProviderManagerMessages.h"
 #include "RemoteCDMFactory.h"
 #include "RemoteCDMProxy.h"
 #include "RemoteMediaEngineConfigurationFactory.h"
@@ -225,7 +226,7 @@ RemoteMediaPlayerManager& GPUProcessConnection::mediaPlayerManager()
 RemoteAudioSourceProviderManager& GPUProcessConnection::audioSourceProviderManager()
 {
     if (!m_audioSourceProviderManager)
-        m_audioSourceProviderManager = RemoteAudioSourceProviderManager::create();
+        m_audioSourceProviderManager = RemoteAudioSourceProviderManager::create(m_connection);
     return *m_audioSourceProviderManager;
 }
 #endif

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProvider.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProvider.cpp
@@ -81,9 +81,10 @@ void RemoteAudioSourceProvider::hasNewClient(AudioSourceProviderClient* client)
         gpuProcessConnection->connection().send(Messages::RemoteMediaPlayerProxy::SetShouldEnableAudioSourceProvider { !!client }, m_identifier);
 }
 
-void RemoteAudioSourceProvider::audioSamplesAvailable(const PlatformAudioData& data, const AudioStreamDescription& description, size_t size, bool needsFlush)
+void RemoteAudioSourceProvider::audioSamplesAvailable(const AudioStreamDescription& description, bool needsFlush)
 {
-    receivedNewAudioSamples(data, description, size, needsFlush ? NeedsFlush::Yes : NeedsFlush::No);
+    if (needsFlush)
+        setNeedsFlush();
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProvider.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProvider.h
@@ -44,7 +44,7 @@ public:
     static Ref<RemoteAudioSourceProvider> create(WebCore::MediaPlayerIdentifier, WTF::LoggerHelper&);
     ~RemoteAudioSourceProvider();
 
-    void audioSamplesAvailable(const WebCore::PlatformAudioData&, const WebCore::AudioStreamDescription&, size_t, bool);
+    void audioSamplesAvailable(const WebCore::AudioStreamDescription&, bool);
     void close();
 
     WebCore::MediaPlayerIdentifier identifier() const { return m_identifier; }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.cpp
@@ -26,12 +26,16 @@
 #include "config.h"
 #include "RemoteAudioSourceProviderManager.h"
 
+#include "Connection.h"
 #include "GPUProcessConnection.h"
 #include "Logging.h"
 #include "RemoteAudioSourceProvider.h"
 #include "RemoteAudioSourceProviderManagerMessages.h"
 #include "SharedCARingBuffer.h"
 #include "WebProcess.h"
+#include <WebCore/CAAudioStreamDescription.h>
+#include <WebCore/SharedMemory.h>
+#include <WebCore/WebAudioBufferList.h>
 #include <wtf/TZoneMallocInlines.h>
 
 #if PLATFORM(COCOA) && ENABLE(GPU_PROCESS)
@@ -39,117 +43,105 @@
 namespace WebKit {
 using namespace WebCore;
 
-RemoteAudioSourceProviderManager::RemoteAudioSourceProviderManager()
-    : m_queue(WorkQueue::create("RemoteAudioSourceProviderManager"_s, WorkQueue::QOS::UserInteractive))
+RemoteAudioSourceProviderManager::RemoteAudioSourceProviderManager(IPC::Connection& connection)
+    : m_connection { connection }
+    , m_queue { WorkQueue::create("RemoteAudioSourceProviderManager"_s, WorkQueue::QOS::UserInteractive) }
 {
+    connection.addWorkQueueMessageReceiver(Messages::RemoteAudioSourceProviderManager::messageReceiverName(), m_queue, *this);
 }
 
 RemoteAudioSourceProviderManager::~RemoteAudioSourceProviderManager()
 {
-    ASSERT(!m_connection);
+    ASSERT(!m_connection.get());
 }
 
 void RemoteAudioSourceProviderManager::stopListeningForIPC()
 {
-    setConnection(nullptr);
-}
-
-void RemoteAudioSourceProviderManager::setConnection(RefPtr<IPC::Connection>&& connection)
-{
-    if (m_connection == connection)
-        return;
-
-    if (RefPtr previousConnection = m_connection)
-        previousConnection->removeWorkQueueMessageReceiver(Messages::RemoteAudioSourceProviderManager::messageReceiverName());
-
-    m_connection = connection.copyRef();
-
-    if (connection)
-        connection->addWorkQueueMessageReceiver(Messages::RemoteAudioSourceProviderManager::messageReceiverName(), m_queue, *this);
+    if (RefPtr connection = m_connection.get()) {
+        connection->removeWorkQueueMessageReceiver(Messages::RemoteAudioSourceProviderManager::messageReceiverName());
+        m_connection = nullptr;
+    }
 }
 
 void RemoteAudioSourceProviderManager::addProvider(Ref<RemoteAudioSourceProvider>&& provider)
 {
-    ASSERT(WTF::isMainRunLoop());
-    setConnection(WebProcess::singleton().ensureGPUProcessConnection().connection());
-
     m_queue->dispatch([this, protectedThis = Ref { *this }, provider = WTF::move(provider)]() mutable {
         auto identifier = provider->identifier();
 
         ASSERT(!m_providers.contains(identifier));
-        m_providers.add(identifier, makeUnique<RemoteAudio>(WTF::move(provider)));
+        m_providers.add(identifier, WTF::move(provider));
     });
 }
 
 void RemoteAudioSourceProviderManager::removeProvider(MediaPlayerIdentifier identifier)
 {
-    ASSERT(WTF::isMainRunLoop());
-
     m_queue->dispatch([this, protectedThis = Ref { *this }, identifier] {
         ASSERT(m_providers.contains(identifier));
         m_providers.remove(identifier);
     });
 }
 
-void RemoteAudioSourceProviderManager::audioStorageChanged(MediaPlayerIdentifier identifier, ConsumerSharedCARingBuffer::Handle&& handle, const WebCore::CAAudioStreamDescription& description)
+RefPtr<RemoteAudioSourceProvider> RemoteAudioSourceProviderManager::providerFor(MediaPlayerIdentifier identifier)
 {
-    ASSERT(!WTF::isMainRunLoop());
+    assertIsCurrent(m_queue);
 
     auto iterator = m_providers.find(identifier);
-    if (iterator == m_providers.end()) {
+    if (iterator == m_providers.end())
+        return nullptr;
+    return iterator->value.ptr();
+}
+
+void RemoteAudioSourceProviderManager::audioStorageChanged(MediaPlayerIdentifier identifier, ConsumerSharedCARingBuffer::Handle&& handle, const WebCore::CAAudioStreamDescription& description)
+{
+    assertIsCurrent(m_queue);
+
+    RefPtr provider = providerFor(identifier);
+    if (!provider) {
         RELEASE_LOG_ERROR(Media, "Unable to find provider %llu for storageChanged", identifier.toUInt64());
         return;
     }
-    iterator->value->setStorage(WTF::move(handle), description);
-}
-
-void RemoteAudioSourceProviderManager::audioSamplesAvailable(MediaPlayerIdentifier identifier, uint64_t startFrame, uint64_t numberOfFrames, bool needsFlush)
-{
-    ASSERT(!WTF::isMainRunLoop());
-
-    auto iterator = m_providers.find(identifier);
-    if (iterator == m_providers.end()) {
-        RELEASE_LOG_ERROR(Media, "Unable to find provider %llu for audioSamplesAvailable", identifier.toUInt64());
-        return;
-    }
-    iterator->value->audioSamplesAvailable(startFrame, numberOfFrames, needsFlush);
-}
-
-WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteAudioSourceProviderManager::RemoteAudio);
-
-RemoteAudioSourceProviderManager::RemoteAudio::RemoteAudio(Ref<RemoteAudioSourceProvider>&& provider)
-    : m_provider(WTF::move(provider))
-{
-}
-
-void RemoteAudioSourceProviderManager::RemoteAudio::setStorage(ConsumerSharedCARingBuffer::Handle&& handle, const WebCore::CAAudioStreamDescription& description)
-{
-    m_buffer = nullptr;
     handle.takeOwnershipOfMemory(MemoryLedger::Media);
-    m_ringBuffer = ConsumerSharedCARingBuffer::map(description, WTF::move(handle));
-    if (!m_ringBuffer)
+    auto ringBuffer = ConsumerSharedCARingBuffer::map(description, WTF::move(handle));
+    if (!ringBuffer)
         return;
-    m_description = description;
-    m_buffer = makeUnique<WebAudioBufferList>(description);
+
+    provider->audioStorageChanged(WTF::move(ringBuffer), description);
 }
 
-void RemoteAudioSourceProviderManager::RemoteAudio::audioSamplesAvailable(uint64_t startFrame, uint64_t numberOfFrames, bool needsFlush)
+void RemoteAudioSourceProviderManager::setNeedsFlush(WebCore::MediaPlayerIdentifier identifier)
 {
-    if (!m_buffer) {
-        RELEASE_LOG_ERROR(Media, "buffer for audio provider %llu is null", m_provider->identifier().toUInt64());
+    assertIsCurrent(m_queue);
+
+    if (RefPtr provider = providerFor(identifier)) {
+        provider->setNeedsFlush();
         return;
     }
 
-    if (!WebAudioBufferList::isSupportedDescription(*m_description, numberOfFrames)) {
-        RELEASE_LOG_ERROR(Media, "Unable to support description with given number of frames for audio provider %llu", m_provider->identifier().toUInt64());
+    RELEASE_LOG_ERROR(Media, "Unable to find provider %llu for setNeedsFlush", identifier.toUInt64());
+}
+
+void RemoteAudioSourceProviderManager::setPlaybackRate(WebCore::MediaPlayerIdentifier identifier, double playbackRate)
+{
+    assertIsCurrent(m_queue);
+
+    if (RefPtr provider = providerFor(identifier)) {
+        provider->setPlaybackRate(playbackRate);
         return;
     }
 
-    m_buffer->setSampleCount(numberOfFrames);
+    RELEASE_LOG_ERROR(Media, "Unable to find provider %llu for setPlaybackRate", identifier.toUInt64());
+}
 
-    m_ringBuffer->fetch(m_buffer->list(), numberOfFrames, startFrame);
+void RemoteAudioSourceProviderManager::setPreservesPitch(WebCore::MediaPlayerIdentifier identifier, bool preservesPitch)
+{
+    assertIsCurrent(m_queue);
 
-    m_provider->audioSamplesAvailable(*m_buffer, *m_description, numberOfFrames, needsFlush);
+    if (RefPtr provider = providerFor(identifier)) {
+        provider->setPreservesPitch(preservesPitch);
+        return;
+    }
+
+    RELEASE_LOG_ERROR(Media, "Unable to find provider %llu for setPreservesPitch", identifier.toUInt64());
 }
 
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.h
@@ -27,15 +27,20 @@
 
 #if PLATFORM(COCOA) && ENABLE(GPU_PROCESS)
 
-#include "Connection.h"
 #include "SharedCARingBuffer.h"
-#include "WebProcess.h"
 #include "WorkQueueMessageReceiver.h"
-#include <WebCore/CAAudioStreamDescription.h>
 #include <WebCore/MediaPlayerIdentifier.h>
-#include <WebCore/SharedMemory.h>
-#include <WebCore/WebAudioBufferList.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/ThreadSafeWeakPtr.h>
+
+namespace WebCore {
+class CAAudioStreamDescription;
+class WebAudioBufferList;
+}
+
+namespace IPC {
+class Connection;
+}
 
 namespace WebKit {
 
@@ -43,7 +48,7 @@ class RemoteAudioSourceProvider;
 
 class RemoteAudioSourceProviderManager : public IPC::WorkQueueMessageReceiver<WTF::DestructionThread::Any> {
 public:
-    static Ref<RemoteAudioSourceProviderManager> create() { return adoptRef(*new RemoteAudioSourceProviderManager()); }
+    static Ref<RemoteAudioSourceProviderManager> create(IPC::Connection& connection) { return adoptRef(*new RemoteAudioSourceProviderManager(connection)); }
     ~RemoteAudioSourceProviderManager();
     void stopListeningForIPC();
 
@@ -53,34 +58,19 @@ public:
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
 
 private:
-    RemoteAudioSourceProviderManager();
+    RemoteAudioSourceProviderManager(IPC::Connection&);
 
     // Messages
     void audioStorageChanged(WebCore::MediaPlayerIdentifier, ConsumerSharedCARingBuffer::Handle&&, const WebCore::CAAudioStreamDescription&);
-    void audioSamplesAvailable(WebCore::MediaPlayerIdentifier, uint64_t startFrame, uint64_t numberOfFrames, bool needsFlush);
+    void setNeedsFlush(WebCore::MediaPlayerIdentifier);
+    void setPlaybackRate(WebCore::MediaPlayerIdentifier, double);
+    void setPreservesPitch(WebCore::MediaPlayerIdentifier, bool);
 
-    void setConnection(RefPtr<IPC::Connection>&&);
+    RefPtr<RemoteAudioSourceProvider> providerFor(WebCore::MediaPlayerIdentifier);
 
-    class RemoteAudio {
-        WTF_MAKE_TZONE_ALLOCATED(RemoteAudio);
-    public:
-        explicit RemoteAudio(Ref<RemoteAudioSourceProvider>&&);
-
-        void setStorage(ConsumerSharedCARingBuffer::Handle&&, const WebCore::CAAudioStreamDescription&);
-        void audioSamplesAvailable(uint64_t startFrame, uint64_t numberOfFrames, bool needsFlush);
-
-    private:
-        const Ref<RemoteAudioSourceProvider> m_provider;
-        std::optional<WebCore::CAAudioStreamDescription> m_description;
-        std::unique_ptr<ConsumerSharedCARingBuffer> m_ringBuffer;
-        std::unique_ptr<WebCore::WebAudioBufferList> m_buffer;
-    };
-
+    ThreadSafeWeakPtr<IPC::Connection> m_connection;
     const Ref<WorkQueue> m_queue;
-    RefPtr<IPC::Connection> m_connection;
-
-    // background thread member
-    HashMap<WebCore::MediaPlayerIdentifier, std::unique_ptr<RemoteAudio>> m_providers;
+    HashMap<WebCore::MediaPlayerIdentifier, Ref<RemoteAudioSourceProvider>> m_providers;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.messages.in
@@ -31,7 +31,9 @@
 ]
 messages -> RemoteAudioSourceProviderManager {
     AudioStorageChanged(WebCore::MediaPlayerIdentifier id, struct WebKit::ConsumerSharedCARingBufferHandle storageHandle, WebCore::CAAudioStreamDescription description)
-    AudioSamplesAvailable(WebCore::MediaPlayerIdentifier id, uint64_t startFrame, uint64_t numberOfFrames, bool needsFlush)
+    SetNeedsFlush(WebCore::MediaPlayerIdentifier id)
+    SetPlaybackRate(WebCore::MediaPlayerIdentifier id, double playbackRate)
+    SetPreservesPitch(WebCore::MediaPlayerIdentifier id, bool preservesPitch)
 }
 
 #endif

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -230,6 +230,7 @@ Tests/WebKitCocoa/PasteRTFD.mm @nonARC
 Tests/WebKitCocoa/PasteWebArchive.mm @nonARC
 Tests/WebKitCocoa/PermissionsAPI.mm @nonARC
 Tests/WebKitCocoa/PictureInPictureDelegate.mm @nonARC
+Tests/WebKitCocoa/PitchShiftAudioUnitTests.cpp
 Tests/WebKitCocoa/Preconnect.mm @nonARC
 Tests/WebKitCocoa/Preferences.mm @nonARC
 Tests/WebKitCocoa/PreferredAudioBufferSize.mm @nonARC

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -98,6 +98,7 @@
 		115EB3431EE0BA03003C2C0A /* ViewportSizeForViewportUnits.mm in Sources */ = {isa = PBXBuildFile; fileRef = 115EB3421EE0B720003C2C0A /* ViewportSizeForViewportUnits.mm */; };
 		1171B24F219F49CD00CB897D /* FirstMeaningfulPaintMilestone_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 11B7FD21219F46DD0069B27F /* FirstMeaningfulPaintMilestone_Bundle.cpp */; };
 		11B7FD28219F47110069B27F /* FirstMeaningfulPaintMilestone.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 11B7FD22219F46DD0069B27F /* FirstMeaningfulPaintMilestone.cpp */; };
+		13A9FF1D120B98579E9E28F3 /* StaticRangeValidity.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 62C480C646AE2D4CB5936315 /* StaticRangeValidity.cpp */; };
 		143DDE9820C9018B007F76FA /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 574F55D0204D471C002948C6 /* Security.framework */; };
 		14CC42E624B8D8FA00E64F48 /* JSRunLoopTimer.mm in Sources */ = {isa = PBXBuildFile; fileRef = 14CC42E524B8D8FA00E64F48 /* JSRunLoopTimer.mm */; };
 		155B87332BF55D7800D93968 /* TextBoundaries.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 155B872B2BF55D7800D93968 /* TextBoundaries.cpp */; };
@@ -667,6 +668,7 @@
 		83BC5AC020E6C0DF00F5879F /* StartLoadInDidFailProvisionalLoad.mm in Sources */ = {isa = PBXBuildFile; fileRef = 83BC5ABF20E6C0D300F5879F /* StartLoadInDidFailProvisionalLoad.mm */; };
 		83F22C6420B355F80034277E /* NoPolicyDelegateResponse.mm in Sources */ = {isa = PBXBuildFile; fileRef = 83F22C6320B355EB0034277E /* NoPolicyDelegateResponse.mm */; };
 		86AF7A742F11406800EC5DB2 /* ShareableBitmap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86AF7A722F11406800EC5DB2 /* ShareableBitmap.cpp */; };
+		8CC128AB2E904F3449BED524 /* BitVector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8CC128AA2E904F3449BED524 /* BitVector.cpp */; };
 		8E4A85371E1D1AB200F53B0F /* GridPosition.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8E4A85361E1D1AA100F53B0F /* GridPosition.cpp */; };
 		919B50762C177055009FE7B0 /* Base64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 919B506E2C177055009FE7B0 /* Base64.cpp */; };
 		9310CD381EF708FB0050FFE0 /* Function.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9310CD361EF708FB0050FFE0 /* Function.cpp */; };
@@ -675,7 +677,6 @@
 		933D631D1FCB76200032ECD6 /* Hasher.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 933D631B1FCB76180032ECD6 /* Hasher.cpp */; };
 		936E4AE42821BB6D00208654 /* SuspendableWorkQueueTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 936E4AE32821BB6D00208654 /* SuspendableWorkQueueTests.cpp */; };
 		93915A1724DB66C70019FF43 /* DocumentOrder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93915A1624DB66C70019FF43 /* DocumentOrder.cpp */; };
-		13A9FF1D120B98579E9E28F3 /* StaticRangeValidity.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 62C480C646AE2D4CB5936315 /* StaticRangeValidity.cpp */; };
 		93AF4ECE1506F064007FD57E /* NewFirstVisuallyNonEmptyLayoutForImages_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93AF4ECD1506F064007FD57E /* NewFirstVisuallyNonEmptyLayoutForImages_Bundle.cpp */; };
 		93C3647B2BDD8800006D8B55 /* UTF8Conversion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93C3647A2BDD8800006D8B55 /* UTF8Conversion.cpp */; };
 		93E2C5551FD3204100E1DF6A /* LineEnding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93E2C5541FD3204100E1DF6A /* LineEnding.cpp */; };
@@ -1548,7 +1549,6 @@
 		FF41AC702A79CAA000AC0FA5 /* WYHash.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FF41AC682A79CAA000AC0FA5 /* WYHash.cpp */; };
 		FF5D0CB4283221AD00F3278A /* CompactRefPtr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FF5D0CB3283221AD00F3278A /* CompactRefPtr.cpp */; };
 		FF8CB40C2A88C152004AF498 /* SuperFastHash.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FF8CB4042A88C152004AF498 /* SuperFastHash.cpp */; };
-		8CC128AB2E904F3449BED524 /* BitVector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8CC128AA2E904F3449BED524 /* BitVector.cpp */; };
 		FF910EA5297A0D1100D1A24D /* FixedBitVector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FF910E9D297A0D1100D1A24D /* FixedBitVector.cpp */; };
 		FFD3FF372AF9BD8F0057C508 /* DragonBoxTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FFD3FF2F2AF9BD8F0057C508 /* DragonBoxTest.cpp */; };
 /* End PBXBuildFile section */
@@ -3392,6 +3392,7 @@
 		5CFACF62226F73C60056C7D0 /* libboringssl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libboringssl.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		5CFACF64226FD1FB0056C7D0 /* Proxy.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = Proxy.mm; sourceTree = "<group>"; };
 		5E4B1D2C1D404C6100053621 /* WKScrollViewDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = WKScrollViewDelegate.mm; path = ../ios/WKScrollViewDelegate.mm; sourceTree = "<group>"; };
+		62C480C646AE2D4CB5936315 /* StaticRangeValidity.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StaticRangeValidity.cpp; sourceTree = "<group>"; };
 		631EFFF51E7B5E8D00D2EBB8 /* Geolocation.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = Geolocation.mm; sourceTree = "<group>"; };
 		634910DF1E9D3FF300880309 /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
 		634E44892DB770CA00793399 /* WebContentRestrictions.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebContentRestrictions.mm; sourceTree = "<group>"; };
@@ -3585,6 +3586,7 @@
 		8AA28C1916D2FA7B002FF4DB /* LoadPageOnCrash.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LoadPageOnCrash.cpp; sourceTree = "<group>"; };
 		8C10AF96206467770018FD90 /* LocalStoragePersistence.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = LocalStoragePersistence.mm; sourceTree = "<group>"; };
 		8C10AF97206467830018FD90 /* localstorage-empty-string-value.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "localstorage-empty-string-value.html"; sourceTree = "<group>"; };
+		8CC128AA2E904F3449BED524 /* BitVector.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BitVector.cpp; sourceTree = "<group>"; };
 		8DD76FA10486AA7600D96B5E /* TestWebKitAPI */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = TestWebKitAPI; sourceTree = BUILT_PRODUCTS_DIR; };
 		8E4A85361E1D1AA100F53B0F /* GridPosition.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GridPosition.cpp; sourceTree = "<group>"; };
 		919B506E2C177055009FE7B0 /* Base64.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Base64.cpp; sourceTree = "<group>"; };
@@ -3617,7 +3619,6 @@
 		937A6C8824357BF300C3A6B0 /* KillWebProcessWithOpenConnection-1.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "KillWebProcessWithOpenConnection-1.html"; sourceTree = "<group>"; };
 		937A6C8924357BF300C3A6B0 /* KillWebProcessWithOpenConnection-2.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "KillWebProcessWithOpenConnection-2.html"; sourceTree = "<group>"; };
 		93915A1624DB66C70019FF43 /* DocumentOrder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DocumentOrder.cpp; sourceTree = "<group>"; };
-		62C480C646AE2D4CB5936315 /* StaticRangeValidity.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StaticRangeValidity.cpp; sourceTree = "<group>"; };
 		9399BA01237110AE008392BF /* IndexedDBInPageCache.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = IndexedDBInPageCache.mm; sourceTree = "<group>"; };
 		9399BA02237110BF008392BF /* IndexedDBInPageCache.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = IndexedDBInPageCache.html; sourceTree = "<group>"; };
 		9399BA03237110BF008392BF /* IndexedDBNotInPageCache.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = IndexedDBNotInPageCache.html; sourceTree = "<group>"; };
@@ -4157,6 +4158,7 @@
 		CDEEC7CF2DBC6B7200F5B8EB /* spatial-audio-experience-with-video.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "spatial-audio-experience-with-video.html"; sourceTree = "<group>"; };
 		CDF0B789216D484300421ECC /* CloseWebViewDuringEnterFullscreen.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CloseWebViewDuringEnterFullscreen.mm; sourceTree = "<group>"; };
 		CDF92236216D186400647AA7 /* CloseWebViewAfterEnterFullscreen.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CloseWebViewAfterEnterFullscreen.mm; sourceTree = "<group>"; };
+		CDFCFC5B2F7C6B89003C3B03 /* PitchShiftAudioUnitTests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PitchShiftAudioUnitTests.cpp; sourceTree = "<group>"; };
 		CE06DF9A1E1851F200E570C9 /* SecurityOrigin.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SecurityOrigin.cpp; sourceTree = "<group>"; };
 		CE0947362063223B003C9BA0 /* SchemeRegistry.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = SchemeRegistry.mm; sourceTree = "<group>"; };
 		CE14F1A2181873B0001C2705 /* WillPerformClientRedirectToURLCrash.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = WillPerformClientRedirectToURLCrash.html; sourceTree = "<group>"; };
@@ -4561,7 +4563,6 @@
 		FF41AC682A79CAA000AC0FA5 /* WYHash.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WYHash.cpp; sourceTree = "<group>"; };
 		FF5D0CB3283221AD00F3278A /* CompactRefPtr.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CompactRefPtr.cpp; sourceTree = "<group>"; };
 		FF8CB4042A88C152004AF498 /* SuperFastHash.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SuperFastHash.cpp; sourceTree = "<group>"; };
-		8CC128AA2E904F3449BED524 /* BitVector.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BitVector.cpp; sourceTree = "<group>"; };
 		FF910E9D297A0D1100D1A24D /* FixedBitVector.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FixedBitVector.cpp; sourceTree = "<group>"; };
 		FFD3FF2F2AF9BD8F0057C508 /* DragonBoxTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DragonBoxTest.cpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -5142,6 +5143,7 @@
 				33FFFC442CBA079500248AC3 /* PDFTestHelpers.mm */,
 				41E9EE1A28B4DBF8006A2298 /* PermissionsAPI.mm */,
 				3FCC4FE41EC4E8520076E37C /* PictureInPictureDelegate.mm */,
+				CDFCFC5B2F7C6B89003C3B03 /* PitchShiftAudioUnitTests.cpp */,
 				DFB8FF312492F51A00F00B0D /* Preconnect.mm */,
 				C95501BE19AD2FAF0049BE3E /* Preferences.mm */,
 				CD227E43211A4D5D00D285AF /* PreferredAudioBufferSize.mm */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PitchShiftAudioUnitTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PitchShiftAudioUnitTests.cpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#import "PlatformUtilities.h"
+#import <WebCore/AudioBus.h>
+#import <WebCore/CAAudioStreamDescription.h>
+#import <WebCore/PitchShiftAudioUnit.h>
+#import <cmath>
+#import <pal/cf/CoreAudioExtras.h>
+
+using namespace WebCore;
+
+static constexpr size_t kSampleRate = 44100;
+static constexpr size_t kNumChannels = 1;
+static constexpr size_t kFrameCount = 1024;
+static constexpr double kTestFrequency = 440.0; // A4 note
+
+// Helper to generate a sine wave at a given frequency
+static void generateSineWave(AudioBus& bus, size_t numFrames, double frequency, double sampleRate, size_t startingFrame)
+{
+    for (unsigned channel = 0; channel < bus.numberOfChannels(); ++channel) {
+        auto* channelData = bus.channel(channel)->mutableData();
+        for (size_t frame = 0; frame < numFrames; ++frame) {
+            auto currentFrame = frame + startingFrame;
+            double phase = 2.0 * M_PI * frequency * currentFrame / sampleRate;
+            channelData[frame] = static_cast<Float32>(std::sin(phase));
+        }
+    }
+}
+
+// Helper to count zero crossings (approximates frequency)
+static size_t countZeroCrossings(std::span<const Float32> buffer)
+{
+    size_t crossings = 0;
+    for (size_t i = 1; i < buffer.size(); ++i) {
+        if ((buffer[i - 1] < 0.0f && buffer[i] >= 0.0f) || (buffer[i - 1] >= 0.0f && buffer[i] < 0.0f))
+            ++crossings;
+    }
+    return crossings;
+}
+
+static AudioStreamBasicDescription audioFormat()
+{
+    return {
+        .mSampleRate = kSampleRate,
+        .mFormatID = kAudioFormatLinearPCM,
+        .mFormatFlags = static_cast<AudioFormatFlags>(kAudioFormatFlagsNativeFloatPacked) | static_cast<AudioFormatFlags>(kAudioFormatFlagIsNonInterleaved),
+        .mBytesPerPacket = sizeof(Float32),
+        .mFramesPerPacket = 1,
+        .mBytesPerFrame = sizeof(Float32),
+        .mChannelsPerFrame = kNumChannels,
+        .mBitsPerChannel = 8 * sizeof(Float32),
+        .mReserved = 0,
+    };
+}
+
+TEST(PitchShiftAudioUnit, BasicProcessing)
+{
+    // Create pitch shifter
+    auto pitchShifter = makeUnique<PitchShiftAudioUnit>(audioFormat());
+    ASSERT_TRUE(pitchShifter);
+
+    pitchShifter->setRate(2);
+
+    // Set up input callback to generate 440Hz sine wave
+    size_t frameCounter = 0;
+    pitchShifter->setInputCallback([&frameCounter](AudioBus& bus, size_t numberOfFrames) {
+        generateSineWave(bus, numberOfFrames, kTestFrequency, kSampleRate, frameCounter);
+        frameCounter += numberOfFrames;
+        return true;
+    });
+
+    // Allocate output AudioBus
+    auto outputBus = AudioBus::create(kNumChannels, kFrameCount);
+
+    // Process audio through pitch shifter
+    for (int i = 0; i < 10; ++i) {
+        bool success = pitchShifter->render(outputBus, kFrameCount);
+        ASSERT_TRUE(success);
+    }
+
+    // Verify output is not silent (has some energy)
+    auto* outputData = outputBus->channel(0)->data();
+    float sumSquares = 0.0f;
+    for (size_t i = 0; i < kFrameCount; ++i)
+        sumSquares += outputData[i] * outputData[i];
+
+    float rms = std::sqrt(sumSquares / kFrameCount);
+    EXPECT_GT(rms, 0.1f); // Should have significant energy
+
+    // Verify the output has approximately the same frequency as input
+    // (pitch shifting should have preserved the 440Hz frequency)
+    auto outputSpan = std::span<const Float32>(outputData, kFrameCount);
+    size_t outputCrossings = countZeroCrossings(outputSpan);
+
+    // Expected zero crossings for 440Hz at 44.1kHz over 1024 samples
+    // = 2 * 440 * 1024 / 44100 ≈ 20.4 crossings
+    // Allow 20% tolerance
+    size_t expectedCrossings = static_cast<size_t>(2.0 * kTestFrequency * kFrameCount / kSampleRate);
+    double ratio = static_cast<double>(outputCrossings) / static_cast<double>(expectedCrossings);
+    EXPECT_GT(ratio, 0.8);
+    EXPECT_LT(ratio, 1.2);
+}


### PR DESCRIPTION
#### 1774dbef65c9c409eb4a1c61b476033c6255e601
<pre>
HTMLMediaElement preservesPitch=true does not work when using AudioContext
<a href="https://rdar.apple.com/173727365">rdar://173727365</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=311000">https://bugs.webkit.org/show_bug.cgi?id=311000</a>

Reviewed by Eric Carlson.

Add support for playing HTMLMediaElements at non-1x rates with `preservesPitch=true` through
MediaElementSourceNode. Due to the nature of AVAudioMix, this requires pitch correction to be
applied after the tap emits audio samples.

When an AVPlayer is configured to use &quot;varispeed&quot; and plays at a rate of (e.g.) 2x, the tap will
emit 88,200 samples per second for content encoded at 44.1khz. This is essentially a sample rate
conversion, and the output can be converted by MultiChannelSampleRateConverter to 44.1khz, with the
side effect of pitch shifting upwards by (e.g., again) one octave. To counteract this pitch change
and simultaneously resample the content, a new class PitchShiftAudioNode is added, which wraps an
AudioUnit provided by CoreAudio. This new class operates very similarly to the
MultiChannelSampleRateConverter, insofar as it uses a callback to request more data from the
caller, then writes the output data to a AudioBus provided by the caller.

Two concrete classes were modified to incorporate this new PitchShiftAudioNode: AudioSourceProviderAVFObjC
and WebAudioSourceProviderCocoa. These two classes are now very similar, and are targets for merging
together in the future. The MultiChannelSampleRateConverter was removed from MediaElementSourceNode
and added to those same two classes, to handle the case where the connected audio element had
`preservesPitch=false`.

Both playbackRate and preservesPitch were piped through from the GPU process to the WebContent
process so that both ends of the audio provider could be configured correctly.

With this change, two subtests in imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/preserves-pitch.html
now pass.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/PitchShiftAudioUnitTests.cpp

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/preserves-pitch-expected.txt:
* Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.cpp:
(WebCore::MediaElementAudioSourceNode::MediaElementAudioSourceNode):
(WebCore::MediaElementAudioSourceNode::updateResamplerIfNeeded):
(WebCore::MediaElementAudioSourceNode::setPlaybackRate): Deleted.
* Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.h:
* Source/WebCore/PAL/pal/cf/AudioToolboxSoftLink.cpp:
* Source/WebCore/PAL/pal/cf/AudioToolboxSoftLink.h:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::mediaPlayerRateChanged):
* Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.mm:
(WebCore::AudioSampleDataSource::pullSamples):
(WebCore::AudioSampleDataSource::pullAvailableSamplesAsChunks):
* Source/WebCore/platform/audio/cocoa/CARingBuffer.cpp:
(WebCore::CARingBuffer::store):
* Source/WebCore/platform/audio/cocoa/CARingBuffer.h:
* Source/WebCore/platform/audio/cocoa/PitchShiftAudioUnit.h: Added.
(WebCore::PitchShiftAudioUnit::rate const):
(WebCore::PitchShiftAudioUnit::pitch const):
* Source/WebCore/platform/audio/cocoa/PitchShiftAudioUnit.mm: Added.
(WebCore::PitchShiftAudioUnit::PitchShiftAudioUnit):
(WebCore::PitchShiftAudioUnit::~PitchShiftAudioUnit):
(WebCore::PitchShiftAudioUnit::setRate):
(WebCore::PitchShiftAudioUnit::setPitch):
(WebCore::PitchShiftAudioUnit::setInputCallback):
(WebCore::PitchShiftAudioUnit::render):
(WebCore::PitchShiftAudioUnit::renderCallback):
* Source/WebCore/platform/cocoa/NetworkExtensionContentFilter.mm:
* Source/WebCore/platform/cocoa/PowerSourceNotifier.h:
* Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm:
(WebCore::AudioSourceProviderAVFObjC::provideInput):
(WebCore::AudioSourceProviderAVFObjC::provideInputInternal):
(WebCore::AudioSourceProviderAVFObjC::setPlaybackRate):
(WebCore::AudioSourceProviderAVFObjC::setPreservesPitch):
(WebCore::AudioSourceProviderAVFObjC::prepare):
(WebCore::AudioSourceProviderAVFObjC::unprepare):
(WebCore::AudioSourceProviderAVFObjC::process):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::createAVPlayerItem):
(WebCore::MediaPlayerPrivateAVFoundationObjC::setPreservesPitch):
* Source/WebCore/platform/mediastream/cocoa/MediaStreamTrackAudioSourceProviderCocoa.cpp:
(WebCore::MediaStreamTrackAudioSourceProviderCocoa::audioSamplesAvailable):
* Source/WebCore/platform/mediastream/cocoa/WebAudioSourceProviderCocoa.h:
* Source/WebCore/platform/mediastream/cocoa/WebAudioSourceProviderCocoa.mm:
(WebCore::WebAudioSourceProviderCocoa::setClient):
(WebCore::WebAudioSourceProviderCocoa::setPlaybackRate):
(WebCore::WebAudioSourceProviderCocoa::setPreservesPitch):
(WebCore::WebAudioSourceProviderCocoa::audioStorageChanged):
(WebCore::WebAudioSourceProviderCocoa::provideInput):
(WebCore::WebAudioSourceProviderCocoa::provideInputInternal):
(WebCore::WebAudioSourceProviderCocoa::prepare):
(WebCore::WebAudioSourceProviderCocoa::receivedNewAudioSamples):
(WebCore::WebAudioSourceProviderCocoa::setNeedsFlush):
* Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTB.mm:
* Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.cpp:
(WebKit::RemoteAudioSourceProviderProxy::newAudioSamples):
(WebKit::RemoteAudioSourceProviderProxy::setPlaybackRate):
(WebKit::RemoteAudioSourceProviderProxy::setPreservesPitch):
* Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::setPreservesPitch):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerRateChanged):
(WebKit::RemoteMediaPlayerProxy::createAudioSourceProvider):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp:
(WebKit::GPUProcessConnection::audioSourceProviderManager):
(WebKit::GPUProcessConnection::dispatchMessage):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProvider.cpp:
(WebKit::RemoteAudioSourceProvider::audioSamplesAvailable):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProvider.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.cpp:
(WebKit::RemoteAudioSourceProviderManager::RemoteAudioSourceProviderManager):
(WebKit::m_queue):
(WebKit::RemoteAudioSourceProviderManager::~RemoteAudioSourceProviderManager):
(WebKit::RemoteAudioSourceProviderManager::stopListeningForIPC):
(WebKit::RemoteAudioSourceProviderManager::addProvider):
(WebKit::RemoteAudioSourceProviderManager::removeProvider):
(WebKit::RemoteAudioSourceProviderManager::providerFor):
(WebKit::RemoteAudioSourceProviderManager::audioStorageChanged):
(WebKit::RemoteAudioSourceProviderManager::setNeedsFlush):
(WebKit::RemoteAudioSourceProviderManager::setPlaybackRate):
(WebKit::RemoteAudioSourceProviderManager::setPreservesPitch):
(WebKit::RemoteAudioSourceProviderManager::setConnection): Deleted.
(WebKit::RemoteAudioSourceProviderManager::audioSamplesAvailable): Deleted.
(WebKit::RemoteAudioSourceProviderManager::RemoteAudio::RemoteAudio): Deleted.
(WebKit::RemoteAudioSourceProviderManager::RemoteAudio::setStorage): Deleted.
(WebKit::RemoteAudioSourceProviderManager::RemoteAudio::audioSamplesAvailable): Deleted.
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.h:
(WebKit::RemoteAudioSourceProviderManager::create):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.messages.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PitchShiftAudioUnitTests.cpp: Added.
(generateSineWave):
(countZeroCrossings):
(audioFormat):
(TEST(PitchShiftAudioUnit, BasicProcessing)):

Canonical link: <a href="https://commits.webkit.org/310521@main">https://commits.webkit.org/310521@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ddef78d75e971f5775141e38630919a49ff085e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154098 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27355 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20513 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162850 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107564 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8d8e6aa0-990b-4942-bd33-714f2fc8f713) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155971 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27487 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27206 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119175 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84254 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/02484c37-0365-4f2f-819b-df2311cec49c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157057 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21412 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138375 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99875 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cc986651-e31c-40eb-8341-24b3a300ed04) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/20508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18501 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10683 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/130170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16226 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165323 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8523 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17827 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127269 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26901 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22539 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127420 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34567 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26824 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138020 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83411 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22286 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14808 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26516 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90607 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26096 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26326 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26168 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->