### PR TITLE
Allow Object.prototype to be serialized by structuredClone

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any-expected.txt
@@ -127,7 +127,7 @@ PASS Array ImageBitmap object, ImageBitmap 1x1 transparent black
 PASS Array ImageBitmap object, ImageBitmap 1x1 transparent non-black
 PASS Object ImageBitmap object, ImageBitmap 1x1 transparent black
 PASS Object ImageBitmap object, ImageBitmap 1x1 transparent non-black
-FAIL ObjectPrototype must lose its exotic-ness when cloned promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
+PASS ObjectPrototype must lose its exotic-ness when cloned
 PASS Serializing a non-serializable platform object fails
 PASS An object whose interface is deleted from the global must still deserialize
 PASS A subclass instance will deserialize as its closest serializable superclass

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.serviceworker-expected.txt
@@ -112,7 +112,7 @@ PASS Object with non-enumerable property
 PASS Object with non-writable property
 PASS Object with non-configurable property
 PASS Object with a getter that throws
-FAIL ObjectPrototype must lose its exotic-ness when cloned promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
+PASS ObjectPrototype must lose its exotic-ness when cloned
 PASS Serializing a non-serializable platform object fails
 PASS An object whose interface is deleted from the global must still deserialize
 PASS A subclass instance will deserialize as its closest serializable superclass

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.sharedworker-expected.txt
@@ -112,7 +112,7 @@ PASS Object with non-enumerable property
 PASS Object with non-writable property
 PASS Object with non-configurable property
 PASS Object with a getter that throws
-FAIL ObjectPrototype must lose its exotic-ness when cloned promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
+PASS ObjectPrototype must lose its exotic-ness when cloned
 PASS Serializing a non-serializable platform object fails
 PASS An object whose interface is deleted from the global must still deserialize
 PASS A subclass instance will deserialize as its closest serializable superclass

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.worker-expected.txt
@@ -112,7 +112,7 @@ PASS Object with non-enumerable property
 PASS Object with non-writable property
 PASS Object with non-configurable property
 PASS Object with a getter that throws
-FAIL ObjectPrototype must lose its exotic-ness when cloned promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
+PASS ObjectPrototype must lose its exotic-ness when cloned
 PASS Serializing a non-serializable platform object fails
 PASS An object whose interface is deleted from the global must still deserialize
 PASS A subclass instance will deserialize as its closest serializable superclass

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/window-postmessage.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/window-postmessage.window-expected.txt
@@ -127,7 +127,7 @@ PASS Array ImageBitmap object, ImageBitmap 1x1 transparent black
 PASS Array ImageBitmap object, ImageBitmap 1x1 transparent non-black
 PASS Object ImageBitmap object, ImageBitmap 1x1 transparent black
 PASS Object ImageBitmap object, ImageBitmap 1x1 transparent non-black
-FAIL ObjectPrototype must lose its exotic-ness when cloned promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
+PASS ObjectPrototype must lose its exotic-ness when cloned
 PASS Serializing a non-serializable platform object fails
 PASS An object whose interface is deleted from the global must still deserialize
 PASS A subclass instance will deserialize as its closest serializable superclass

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone.any-expected.txt
@@ -127,7 +127,7 @@ PASS Array ImageBitmap object, ImageBitmap 1x1 transparent black
 PASS Array ImageBitmap object, ImageBitmap 1x1 transparent non-black
 PASS Object ImageBitmap object, ImageBitmap 1x1 transparent black
 PASS Object ImageBitmap object, ImageBitmap 1x1 transparent non-black
-FAIL ObjectPrototype must lose its exotic-ness when cloned promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
+PASS ObjectPrototype must lose its exotic-ness when cloned
 PASS Serializing a non-serializable platform object fails
 PASS An object whose interface is deleted from the global must still deserialize
 PASS A subclass instance will deserialize as its closest serializable superclass

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone.any.worker-expected.txt
@@ -112,7 +112,7 @@ PASS Object with non-enumerable property
 PASS Object with non-writable property
 PASS Object with non-configurable property
 PASS Object with a getter that throws
-FAIL ObjectPrototype must lose its exotic-ness when cloned promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
+PASS ObjectPrototype must lose its exotic-ness when cloned
 PASS Serializing a non-serializable platform object fails
 PASS An object whose interface is deleted from the global must still deserialize
 PASS A subclass instance will deserialize as its closest serializable superclass

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/semantics/structured-clone/dedicated-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/semantics/structured-clone/dedicated-expected.txt
@@ -127,7 +127,7 @@ PASS Array ImageBitmap object, ImageBitmap 1x1 transparent black
 PASS Array ImageBitmap object, ImageBitmap 1x1 transparent non-black
 PASS Object ImageBitmap object, ImageBitmap 1x1 transparent black
 PASS Object ImageBitmap object, ImageBitmap 1x1 transparent non-black
-FAIL ObjectPrototype must lose its exotic-ness when cloned promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
+PASS ObjectPrototype must lose its exotic-ness when cloned
 PASS Serializing a non-serializable platform object fails
 PASS An object whose interface is deleted from the global must still deserialize
 PASS A subclass instance will deserialize as its closest serializable superclass

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/semantics/structured-clone/shared-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/semantics/structured-clone/shared-expected.txt
@@ -127,7 +127,7 @@ PASS Array ImageBitmap object, ImageBitmap 1x1 transparent black
 PASS Array ImageBitmap object, ImageBitmap 1x1 transparent non-black
 PASS Object ImageBitmap object, ImageBitmap 1x1 transparent black
 PASS Object ImageBitmap object, ImageBitmap 1x1 transparent non-black
-FAIL ObjectPrototype must lose its exotic-ness when cloned promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
+PASS ObjectPrototype must lose its exotic-ness when cloned
 PASS Serializing a non-serializable platform object fails
 PASS An object whose interface is deleted from the global must still deserialize
 PASS A subclass instance will deserialize as its closest serializable superclass

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -99,6 +99,7 @@
 #include <JavaScriptCore/JSWebAssemblyModule.h>
 #include <JavaScriptCore/NumberObject.h>
 #include <JavaScriptCore/ObjectConstructor.h>
+#include <JavaScriptCore/ObjectPrototype.h>
 #include <JavaScriptCore/Options.h>
 #include <JavaScriptCore/PropertyNameArray.h>
 #include <JavaScriptCore/RegExp.h>
@@ -3006,7 +3007,7 @@ SerializationReturnCode CloneSerializer::serialize(JSValue in)
                 // objects have been handled. If we reach this point and
                 // the input is not an Object object then we should throw
                 // a DataCloneError.
-                if (inObject->classInfo() != JSFinalObject::info())
+                if (inObject->classInfo() != JSFinalObject::info() && inObject->classInfo() != ObjectPrototype::info())
                     return SerializationReturnCode::DataCloneError;
                 inputObjectStack.append(inObject);
                 indexStack.append(0);


### PR DESCRIPTION
#### b271e70e72920454d9760f6e340ff265f4df7501
<pre>
Allow Object.prototype to be serialized by structuredClone
<a href="https://bugs.webkit.org/show_bug.cgi?id=311143">https://bugs.webkit.org/show_bug.cgi?id=311143</a>
<a href="https://rdar.apple.com/173728983">rdar://173728983</a>

Reviewed by Yusuke Suzuki.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

The structured clone serializer rejected Object.prototype because it
checks for JSFinalObject exactly, but ObjectPrototype is a
JSNonFinalObject subclass. Widen the check to also accept
ObjectPrototype so it serializes as a plain object, naturally losing
its immutable-prototype exotic-ness on deserialization.

Per the StructuredSerializeInternal algorithm step 23:

&quot;Otherwise, if value is an exotic object and value is not the
 %Object.prototype% intrinsic object associated with any realm,
 then throw a DataCloneError DOMException.&quot;

This explicitly carves out %Object.prototype% from the exotic object
rejection, meaning it should be cloneable.

Specification: <a href="https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal">https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal</a>

* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/window-postmessage.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/semantics/structured-clone/dedicated-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/semantics/structured-clone/shared-expected.txt:
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneSerializer::serialize):

Canonical link: <a href="https://commits.webkit.org/310363@main">https://commits.webkit.org/310363@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e66b2498f1f80782627256ed595f33b684e82d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153311 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26095 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19694 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162056 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106769 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7a930ab6-f19b-4ad9-9c16-59bc23836bf4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155184 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26621 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26415 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118525 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83927 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0c731461-eb65-4dc7-9292-c5dbd4dc5dbe) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156270 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20764 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137638 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99237 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9fb9aee2-142f-4034-9f6f-ac2f745dd0fe) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19841 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17790 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9891 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129488 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15508 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164530 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7666 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17102 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126584 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25891 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21823 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/semantics/structured-clone/shared.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126742 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34445 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25894 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137304 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82561 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21685 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14082 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25511 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89797 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25202 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25361 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25262 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->