### PR TITLE
Simplify fractional seconds parsing in SMIL clock values

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/smil-clock-value-out-of-range-minutes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/smil-clock-value-out-of-range-minutes-expected.txt
@@ -1,3 +1,0 @@
-
-PASS SMIL clock values with out-of-range minutes or seconds should be treated as invalid
-

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/smil-clock-value-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/smil-clock-value-parsing-expected.txt
@@ -1,0 +1,3 @@
+
+PASS SMIL clock values: out-of-range minutes/seconds validation and fractional seconds support
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/smil-clock-value-parsing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/smil-clock-value-parsing.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>SMIL clock values with out-of-range minutes or seconds should be treated as invalid</title>
+<title>SMIL clock values: out-of-range minutes/seconds validation and fractional seconds support</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <link rel="help" href="https://www.w3.org/TR/SMIL/smil-timing.html#q22">
@@ -21,6 +21,22 @@
   </rect>
   <rect id="boundaryValid" fill="green" width="20" height="20">
     <animate attributeName="x" from="0" to="200" begin="0s" dur="00:59:59" fill="freeze"/>
+  </rect>
+  <!-- Fractional seconds: dur="00:00:01.50" is 1.5s, so at t=1s animation should be partway through -->
+  <rect id="fractionalSecHHMMSS" fill="green" width="20" height="20">
+    <animate attributeName="x" from="0" to="200" begin="0s" dur="00:00:01.50" fill="freeze"/>
+  </rect>
+  <!-- Fractional seconds in MM:SS form: dur="00:01.50" is 1.5s -->
+  <rect id="fractionalSecMMSS" fill="green" width="20" height="20">
+    <animate attributeName="x" from="0" to="200" begin="0s" dur="00:01.50" fill="freeze"/>
+  </rect>
+  <!-- Fractional seconds near 60 boundary: dur="00:00:59.50" should be valid (59.5s < 60) -->
+  <rect id="fractionalSecBoundaryHHMMSS" fill="green" width="20" height="20">
+    <animate attributeName="x" from="0" to="200" begin="0s" dur="00:00:59.50" fill="freeze"/>
+  </rect>
+  <!-- Fractional seconds near 60 boundary in MM:SS: dur="00:59.50" should be valid (59.5s < 60) -->
+  <rect id="fractionalSecBoundaryMMSS" fill="green" width="20" height="20">
+    <animate attributeName="x" from="0" to="200" begin="0s" dur="00:59.50" fill="freeze"/>
   </rect>
 </svg>
 <script>
@@ -54,6 +70,23 @@ async_test(t => {
       // Valid boundary dur="00:59:59". Should animate.
       assert_not_equals(document.getElementById("boundaryValid").x.animVal.value, 0,
         'dur="00:59:59" should be valid and animate');
+
+      // Fractional seconds in HH:MM:SS form: dur="00:00:01.50" is 1.5s.
+      // At t=60s, animation should be fully done (fill="freeze" at to=200).
+      assert_equals(document.getElementById("fractionalSecHHMMSS").x.animVal.value, 200,
+        'dur="00:00:01.50" should be valid and include fractional seconds');
+
+      // Fractional seconds in MM:SS form: dur="00:01.50" is 1.5s.
+      assert_equals(document.getElementById("fractionalSecMMSS").x.animVal.value, 200,
+        'dur="00:01.50" should be valid and include fractional seconds');
+
+      // Fractional seconds near 60 boundary in HH:MM:SS form: dur="00:00:59.50" is 59.5s.
+      assert_equals(document.getElementById("fractionalSecBoundaryHHMMSS").x.animVal.value, 200,
+        'dur="00:00:59.50" should be valid (59.5 < 60)');
+
+      // Fractional seconds near 60 boundary in MM:SS form: dur="00:59.50" is 59.5s.
+      assert_equals(document.getElementById("fractionalSecBoundaryMMSS").x.animVal.value, 200,
+        'dur="00:59.50" should be valid (59.5 < 60)');
     }));
   });
 });

--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -344,25 +344,24 @@ SMILTime SVGSMILElement::parseClockValue(StringView data)
         return SMILTime::indefinite();
 
     double result = 0;
-    bool ok;
     size_t doublePointOne = parse.find(':');
     size_t doublePointTwo = parse.find(':', doublePointOne + 1);
     if (doublePointOne == 2 && doublePointTwo == 5 && parse.length() >= 8) {
-        auto hour = parseInteger<uint8_t>(parse.left(2));
-        auto minute = parseInteger<uint8_t>(parse.substring(3, 2));
-        auto seconds = parseInteger<uint8_t>(parse.substring(6, 2));
-        if (!hour || !minute || *minute > 59 || !seconds || *seconds > 59)
+        auto hours = parseInteger<uint8_t>(parse.left(2));
+        auto minutes = parseInteger<uint8_t>(parse.substring(3, 2));
+        auto seconds = parseNumber(parse.substring(6));
+        if (!hours || !minutes || *minutes > 59 || !seconds || *seconds >= 60)
             return SMILTime::unresolved();
-        result = *hour * 60 * 60 + *minute * 60 + parse.substring(6).toDouble(ok);
+        result = *hours * 60 * 60 + *minutes * 60 + *seconds;
     } else if (doublePointOne == 2 && doublePointTwo == notFound && parse.length() >= 5) {
-        auto minute = parseInteger<uint8_t>(parse.left(2));
-        auto seconds = parseInteger<uint8_t>(parse.substring(3, 2));
-        if (!minute || *minute > 59 || !seconds || *seconds > 59)
+        auto minutes = parseInteger<uint8_t>(parse.left(2));
+        auto seconds = parseNumber(parse.substring(3));
+        if (!minutes || *minutes > 59 || !seconds || *seconds >= 60)
             return SMILTime::unresolved();
-        result = *minute * 60 + parse.substring(3).toDouble(ok);
+        result = *minutes * 60 + *seconds;
     } else
         return parseOffsetValue(parse);
-    if (!ok || !SMILTime(result).isFinite())
+    if (!SMILTime(result).isFinite())
         return SMILTime::unresolved();
     return result;
 }


### PR DESCRIPTION
#### a014f760776814fbbd71f03ef9c75c74c6b45318
<pre>
Simplify fractional seconds parsing in SMIL clock values
<a href="https://bugs.webkit.org/show_bug.cgi?id=311149">https://bugs.webkit.org/show_bug.cgi?id=311149</a>
<a href="https://rdar.apple.com/173736238">rdar://173736238</a>

Reviewed by Said Abou-Hallawa.

Simplify parseClockValue by using the result of parseNumber directly in the
calculation instead of re-parsing the substring with toDouble. Fix the seconds
boundary check to use &gt;= 60 instead of &gt; 59, so fractional values like 59.5
are not incorrectly rejected. Add test cases for fractional seconds
(e.g., &quot;00:00:01.50&quot;, &quot;00:01.50&quot;, &quot;00:00:59.50&quot;, &quot;00:59.50&quot;) to verify that
parseClockValue correctly preserves the fractional part. While here, this
also updates all words to plural (i.e., minute -&gt; minutes).

Thanks Said for suggesting this.

* LayoutTests/imported/w3c/web-platform-tests/svg/animations/smil-clock-value-out-of-range-minutes-expected.txt: Removed.
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/smil-clock-value-parsing-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/smil-clock-value-parsing.html: Renamed from LayoutTests/imported/w3c/web-platform-tests/svg/animations/smil-clock-value-out-of-range-minutes.html.
* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(WebCore::SVGSMILElement::parseClockValue):

Canonical link: <a href="https://commits.webkit.org/310472@main">https://commits.webkit.org/310472@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97ccc656e7bf867da51c1ba021a4d50d0bac562c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153945 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26729 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20361 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162695 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107411 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/14d9d7a1-622d-4b8e-b0e9-80c91609d43b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155818 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27260 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27051 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119051 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/84172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3103bb83-841b-43bc-8a33-4f50986df3d9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156904 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21311 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138250 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99752 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cbefc37d-78a4-44ff-be44-2899e7e62ca2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20400 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18365 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10527 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130056 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/16102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165168 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8317 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17703 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127140 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26532 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22399 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127291 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34527 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26538 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137896 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83247 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22191 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14684 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26145 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90454 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25836 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26003 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25896 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->