### PR TITLE
[WIP] GRA: split live ranges around loops

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
@@ -30,10 +30,13 @@
 
 #include "AirArgInlines.h"
 #include "AirCode.h"
+#include "AirDominators.h"
+#include "AirEmitShuffle.h"
 #include "AirFixSpillsAfterTerminals.h"
 #include "AirPhaseInsertionSet.h"
 #include "AirInstInlines.h"
 #include "AirLiveness.h"
+#include "AirNaturalLoops.h"
 #include "AirPadInterference.h"
 #include "AirPhaseScope.h"
 #include "AirRegLiveness.h"
@@ -62,10 +65,16 @@ static_assert(unspillableCost > maxSpillableSpillCost);
 
 // Phase constants used for the PhaseInsertionSet. Ensures that the fixup and spill/fill instructions
 // inserted in a particular gap ends up in the correct order.
-static constexpr unsigned spillStore = 0;
-static constexpr unsigned splitMoveTo = 1;
-static constexpr unsigned splitMoveFrom = 2;
-static constexpr unsigned spillLoad = 3;
+static constexpr unsigned maxLoopSplitDepth = 32;
+
+enum InsertionPhase : unsigned {
+    spillStore,
+    aroundLoopExitFixup,
+    splitMoveTo,
+    splitMoveFrom,
+    aroundLoopEntryFixup,
+    spillLoad,
+};
 
 static bool NODELETE verbose() { return Options::airGreedyRegAllocVerbose(); }
 
@@ -201,6 +210,16 @@ public:
     size_t NODELETE size() const
     {
         return m_size;
+    }
+
+    bool NODELETE contains(Point point) const
+    {
+        for (auto& interval : m_intervals) {
+            if (interval.end() <= point)
+                continue;
+            return interval.begin() <= point;
+        }
+        return false;
     }
 
     bool NODELETE overlaps(LiveRange& other)
@@ -633,7 +652,7 @@ struct TmpData {
     {
         out.print("{stage = ", stage, " liveRange = ", liveRange, ", preferredReg = ", preferredReg,
             ", coalescables = ", coalescables, ", useDefCost = ", useDefCost, ", spillability = ", spillability,
-            ", assigned = ", assigned, ", spillSlot = ", pointerDump(spillSlot), ", splitMetadataIndex = ", splitMetadataIndex, "}");
+            ", assigned = ", assigned, ", spillSlotTableIndex = ", spillSlotTableIndex, ", splitAroundClobbersMetadataIndex = ", splitAroundClobbersMetadataIndex, "}");
     }
 
     float spillCost()
@@ -660,18 +679,16 @@ struct TmpData {
 
     void NODELETE validate()
     {
-        ASSERT(!(spillSlot && assigned));
         ASSERT(!!assigned == (stage == Stage::Assigned));
         ASSERT(liveRange.intervals().isEmpty() == !liveRange.size());
-        ASSERT_IMPLIES(spillSlot, stage == Stage::Spilled);
         ASSERT_IMPLIES(stage == Stage::Spilled, spillCost() != unspillableCost);
     }
 
     LiveRange liveRange;
     Coalescables coalescables;
-    StackSlot* spillSlot { nullptr };
     float useDefCost { 0.0f };
-    uint32_t splitMetadataIndex : 31 { 0 };
+    uint32_t spillSlotTableIndex { 0 };
+    uint32_t splitAroundClobbersMetadataIndex : 31 { 0 };
     uint32_t hasColdUse : 1 { 0 };
     Stage stage { Stage::New };
     Spillability spillability { Spillability::Spillable };
@@ -691,7 +708,12 @@ public:
         }
     }
 
-    const List& NODELETE useDefs() { return m_instPoints; }
+    const List& NODELETE useDefs() const { return m_instPoints; }
+
+    void dump(PrintStream& out) const
+    {
+        out.print(listDump(m_instPoints));
+    }
 
 private:
     List m_instPoints;
@@ -704,6 +726,7 @@ struct SplitMetadata {
         Invalid,
         AroundClobbers,
         IntraBlock,
+        AroundLoop,
     };
 
     struct Split {
@@ -733,6 +756,7 @@ struct SplitMetadata {
     Type type;
     Tmp originalTmp;
     Vector<Split> splits;
+    const NaturalLoop* loop { nullptr }; // Only valid for AroundLoop
 };
 
 class GreedyAllocator {
@@ -744,6 +768,7 @@ public:
         , m_map(code)
         , m_useDefLists()
         , m_splitMetadata(1) // Sacrifice index 0.
+        , m_spillSlotTable(1, nullptr) // Sacrifice index 0.
         , m_regRanges(Reg::maxIndex() + 1)
         , m_insertionSets(code.size())
         , m_useCounts(m_code)
@@ -817,6 +842,8 @@ public:
             out.println("    ", tmp, ": ", m_map[tmp], " useWidth=", m_tmpWidth.useWidth(tmp));
         });
         out.println("Splits:\n", listDump(m_splitMetadata, "\n"));
+        // TODO: dump UseDefLists (needs TmpMap iteration support)
+        out.println("SpillSlotTable: ", pointerListDump(m_spillSlotTable));
         out.println("Stats (GP):", m_stats[GP]);
         out.println("Stats (FP):", m_stats[FP]);
     }
@@ -877,6 +904,21 @@ private:
         m_stats[GP].numInsts += (tailPosition + 1) / PointOffsets::PointsPerInst;
     }
 
+    void forEachBlockInLiveRange(const LiveRange& liveRange, const Invocable<IterationStatus(BasicBlock*)> auto& func)
+    {
+        for (auto& interval : liveRange.intervals()) {
+            BasicBlock* block = findBlockContainingPoint(interval.begin());
+            while (true) {
+                if (func(block) == IterationStatus::Done)
+                    return;
+                Point nextHead = positionOfTail(block) + 1;
+                if (nextHead >= interval.end())
+                    break;
+                block = findBlockContainingPoint(nextHead);
+            };
+        }
+    }
+
     BasicBlock* findBlockContainingPoint(Point point)
     {
         auto iter = std::lower_bound(m_tailPoints.begin(), m_tailPoints.end(), point);
@@ -889,12 +931,16 @@ private:
 
     Point NODELETE positionOfHead(BasicBlock* block) const
     {
-        return m_blockToHeadPoint[block];
+        Point point = m_blockToHeadPoint[block];
+        ASSERT(pointAtOffset(point, PointOffsets::Pre) == point);
+        return point;
     }
 
     Point NODELETE positionOfTail(BasicBlock* block)
     {
-        return positionOfHead(block) + block->size() * PointOffsets::PointsPerInst - 1;
+        Point point = positionOfHead(block) + block->size() * PointOffsets::PointsPerInst - 1;
+        ASSERT(pointAtOffset(point, PointOffsets::Post) == point);
+        return point;
     }
 
     static size_t NODELETE instIndex(Point positionOfHead, Point point)
@@ -975,6 +1021,12 @@ private:
         return Interval();
     }
 
+    template<Bank bank>
+    bool isConstDef(Tmp tmp)
+    {
+        return m_useCounts.isConstDef<bank>(AbsoluteTmpMapper<bank>::absoluteIndex(tmp));
+    }
+
     Reg NODELETE assignedReg(Tmp tmp)
     {
         return m_map[tmp].assigned;
@@ -986,8 +1038,9 @@ private:
     {
         TmpData& tmpData = m_map.get<bank>(tmp);
         if (tmpData.stage == Stage::Spilled) {
-            ASSERT(tmpData.spillSlot);
-            return tmpData.spillSlot;
+            StackSlot* slot = m_spillSlotTable[tmpData.spillSlotTableIndex];
+            ASSERT(slot);
+            return slot;
         }
         return nullptr;
     }
@@ -996,6 +1049,14 @@ private:
     {
         ASSERT(tmp.isGP() || tmp.isFP());
         return tmp.isGP() ? spillSlot<GP>(tmp) : spillSlot<FP>(tmp);
+    }
+
+    void ensureSpillSlotTableEntry(TmpData& tmpData)
+    {
+        if (tmpData.spillSlotTableIndex)
+            return;
+        m_spillSlotTable.append(nullptr);
+        tmpData.spillSlotTableIndex = m_spillSlotTable.size() - 1;
     }
 
     float NODELETE adjustedBlockFrequency(BasicBlock* block)
@@ -1881,8 +1942,7 @@ private:
             bool hasColdUse = false;
             for (Tmp member : group.members()) {
                 m_stats[bank].numGroupTmpsCoalesced++;
-                auto memberIdx = AbsoluteTmpMapper<bank>::absoluteIndex(member);
-                if (m_useCounts.isConstDef<bank>(memberIdx))
+                if (isConstDef<bank>(member))
                     m_stats[bank].numGroupConstDefMerged++;
                 TmpData& memberData = m_map.get<bank>(member);
                 useWidth = std::max(useWidth, m_tmpWidth.useWidth(member));
@@ -2001,16 +2061,17 @@ private:
         });
     }
 
-    // newTmp creates and returns a new tmp that can hold the values of 'from'.
+    // addTmpImpl creates and returns a new tmp that can hold the values of 'from'.
     // Note that all TmpData references invalidated since it may expand/realloc the TmpData map.
-    Tmp newTmp(Tmp from, float useDefCost, Interval interval)
+    Tmp addTmpImpl(Tmp from, float useDefCost, Interval interval)
     {
         Tmp tmp = m_code.newTmp(from.bank());
         m_tmpWidth.setWidths(tmp, m_tmpWidth.useWidth(from), m_tmpWidth.defWidth(from));
 
         m_map.append(tmp, TmpData());
         TmpData& tmpData = m_map[tmp];
-        tmpData.liveRange.prepend(interval);
+        if (interval)
+            tmpData.liveRange.prepend(interval);
         tmpData.useDefCost = useDefCost;
         tmpData.validate();
         return tmp;
@@ -2018,12 +2079,26 @@ private:
 
     Tmp addSpillTmpWithInterval(Tmp spilledTmp, Interval interval)
     {
-        Tmp tmp = newTmp(spilledTmp, 0, interval);
-        m_map[tmp].spillability = TmpData::Spillability::Unspillable;
-        dataLogLnIf(verbose(), "New spill for ", spilledTmp, " tmp: ", tmp, ": ", m_map[tmp]);
-        setStageAndEnqueue(tmp, m_map[tmp], Stage::Unspillable);
+        Tmp tmp = addTmpImpl(spilledTmp, 0, interval);
+        TmpData& tmpData = m_map[tmp];
+        tmpData.spillability = TmpData::Spillability::Unspillable;
+        dataLogLnIf(verbose(), "New spill for ", spilledTmp, " tmp: ", tmp, ": ", tmpData);
+        setStageAndEnqueue(tmp, tmpData, Stage::Unspillable);
         m_stats[tmp.bank()].numSpillTmps++;
         return tmp;
+    }
+
+    Tmp addSplitTmp(Tmp originalTmp, float useDefCost, Interval interval)
+    {
+        Tmp splitTmp = addTmpImpl(originalTmp, useDefCost, interval);
+        // All tmps split from originalTmp share the spill slot to avoid moving between spill slots
+        // unnecessarily if parts of the original live-range spill.
+        TmpData& originalData = m_map[originalTmp];
+        ensureSpillSlotTableEntry(originalData);
+        m_map[splitTmp].spillSlotTableIndex = originalData.spillSlotTableIndex;
+        if (m_hasUseDefLists)
+            m_useDefLists.resize(m_code);
+        return splitTmp;
     }
 
     void setStageAndEnqueue(Tmp tmp, TmpData& tmpData, Stage stage)
@@ -2303,19 +2378,231 @@ private:
         tmpData.validate();
     }
 
+    bool isLiveRangeBlockLocal(const LiveRange& liveRange)
+    {
+        BasicBlock* startBlock = findBlockContainingPoint(liveRange.intervals().first().begin());
+        Point last = liveRange.intervals().last().end() - 1;
+        return last <= positionOfTail(startBlock);
+    }
+
     template<Bank bank>
     bool trySplit(Tmp tmp, TmpData& tmpData)
     {
         ASSERT(tmpData.spillCost() != unspillableCost); // Should have evicted.
-        if (trySplitAroundClobbers<bank>(tmp, tmpData))
+        if (trySplitAroundLoop<bank>(tmp, tmpData))
             return true;
-        return trySplitIntraBlock<bank>(tmp, tmpData);
+        if (trySplitIntraBlock<bank>(tmp, tmpData))
+            return true;
+        return trySplitAroundClobbers<bank>(tmp, tmpData);
+    }
+
+    void analyzeLoop(const NaturalLoop& loop)
+    {
+        // FIXME: skip this for invalid loops once we no longer need the stats.
+        Vector<Interval, 32> loopIntervals;
+        for (unsigned i = 0; i < loop.size(); i++) {
+            auto block = loop.at(i);
+            loopIntervals.constructAndAppend(positionOfHead(block), positionOfTail(block) + 1);
+        }
+        std::ranges::sort(loopIntervals, [](const Interval& a, const Interval& b) {
+            return a.begin() < b.begin();
+        });
+
+        LiveRange loopRange;
+        for (auto& interval : loopIntervals)
+            loopRange.append(interval);
+
+        m_loopRanges.resize(std::max(m_loopRanges.size(), static_cast<size_t>(loop.index() + 1)));
+        ASSERT(!m_loopRanges[loop.index()].size());
+        m_loopRanges[loop.index()] = WTF::move(loopRange);
+
+        // All edges into the loop must be non-critical so that entry fixup can be inserted.
+        // FIXME: break critical edges if stats indicate it's helpful.
+        BasicBlock* header = loop.header();
+        for (BasicBlock* pred : header->predecessors()) {
+            if (m_naturalLoops->belongsTo(pred, loop))
+                continue; // Back-edge predecessor, skip.
+            if (pred->numSuccessors() > 1) {
+                m_invalidLoops.set(loop.index());
+                return;
+            }
+        }
+
+        // All exit successors must have only loop predecessors so that exit fixup can be inserted.
+        // FIXME: break critical edge if stats indicate it's helpful.
+        for (unsigned i = 0; i < loop.size(); i++) {
+            BasicBlock* loopBlock = loop.at(i);
+            for (auto& succ : loopBlock->successors()) {
+                if (m_naturalLoops->belongsTo(succ.block(), loop))
+                    continue;
+                for (BasicBlock* exitPred : succ.block()->predecessors()) {
+                    if (!m_naturalLoops->belongsTo(exitPred, loop)) {
+                        m_invalidLoops.set(loop.index());
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    void ensureLoopAnalysis()
+    {
+        if (m_naturalLoops)
+            return;
+        m_dominators = makeUnique<Dominators>(m_code);
+        m_naturalLoops = makeUnique<NaturalLoops>(m_code, *m_dominators);
+
+        for (unsigned i = 0; i < m_naturalLoops->numLoops(); i++)
+            analyzeLoop(m_naturalLoops->loop(i));
+    }
+
+    template<Bank bank>
+    std::pair<const NaturalLoop*, LiveRange> chooseLoopForSplit(const LiveRange& liveRange) {
+        // Find candidate loops: walk the Tmp's live range intervals to find blocks,
+        // then look up which outermost loop each block belongs to.
+
+        // FIXME: Consider breadth-first search by collecting all candidate loops, sorting by
+        // loopDepth(loop->header()), and picking the shallowest feasible one. Currently this
+        // is depth-first (returns the first outermost feasible loop found).
+        // FIXME: Consider splitting around all loops at the same depth at once, rather than
+        // one loop at a time, to reduce re-splitting rounds.
+        const NaturalLoop* resultLoop = nullptr;
+        LiveRange resultNonLoopRange;
+
+        BitVector visitedLoops;
+        Vector<const NaturalLoop*, 16> nestedLoops;
+        forEachBlockInLiveRange(liveRange, [&](BasicBlock* block) {
+            nestedLoops.shrink(0);
+            for (const NaturalLoop* loop = m_naturalLoops->innerMostLoopOf(block); loop; loop = m_naturalLoops->innerMostOuterLoop(*loop)) {
+                if (visitedLoops.get(loop->index()))
+                    break;
+                nestedLoops.append(loop);
+            }
+
+            // Iterate from outer-most to inner-most
+            for (auto* loop : std::views::reverse(nestedLoops)) {
+                ASSERT(!visitedLoops.get(loop->index()));
+                visitedLoops.set(loop->index());
+                const LiveRange& loopRange = m_loopRanges[loop->index()];
+                LiveRange nonLoopRange = LiveRange::subtract(liveRange, loopRange);
+                if (!nonLoopRange.size())
+                    continue; // liveRange contained entirely within this loop
+                if (m_invalidLoops.get(loop->index())) {
+                    // FIXME: break critical edges during fixup if this case is important
+                    m_stats[bank].numSplitAroundLoopSkipCriticalEdge++;
+                    continue;
+                }
+                resultLoop = loop;
+                resultNonLoopRange = WTF::move(nonLoopRange);
+                return IterationStatus::Done;
+            }
+            return IterationStatus::Continue;
+        });
+        return { resultLoop, WTF::move(resultNonLoopRange) };
+    }
+
+    template<Bank bank>
+    bool trySplitAroundLoop(Tmp tmp, TmpData& tmpData)
+    {
+        if (!Options::airGreedyRegAllocSplitAroundLoops())
+            return false;
+
+        if (isLiveRangeBlockLocal(tmpData.liveRange)) {
+            m_stats[bank].numSplitAroundLoopBailLocalOnly++;
+            return false;
+        }
+
+        ensureLoopAnalysis();
+        if (!m_naturalLoops->numLoops())
+            return false;
+
+        auto [loop, nonLoopRange] = chooseLoopForSplit<bank>(tmpData.liveRange);
+        if (!loop) {
+            m_stats[bank].numSplitAroundLoopBailNoLoop++;
+            return false;
+        }
+
+        if (m_naturalLoops->loopDepth(loop->header()) > maxLoopSplitDepth) {
+            m_stats[bank].numSplitAroundLoopBailTooDeep++;
+            return false;
+        }
+
+        // FIXME: move these earlier after collecting stats.
+        if (tmpData.splitAroundClobbersMetadataIndex) {
+            // Already clobber-split; clobber fixup references originalTmp which would be stale after loop splitting.
+            m_stats[bank].numSplitAroundLoopBailAlreadySplitAroundClobbers++;
+            return false;
+        }
+        if (tmpData.liveRange.size() < splitMinRangeSize) {
+            m_stats[bank].numSplitAroundLoopBailTooSmall++;
+            return false;
+        }
+
+        if (isConstDef<bank>(tmp)) {
+            m_stats[bank].numSplitAroundLoopBailConstDef++;
+            return false; // Constant will be rematerialized
+        }
+
+        ensureUseDefLists();
+
+        Tmp loopTmp = addSplitTmp(tmp, 0, {});
+        // Note: addSplitTmp() may have resized m_map, invalidating the tmpData parameter.
+        TmpData& origData = m_map.get<bank>(tmp);
+        TmpData& loopData = m_map.get<bank>(loopTmp);
+        loopData.liveRange = LiveRange::subtract(origData.liveRange, nonLoopRange);
+        ASSERT(loopData.liveRange.size());
+
+        Point defPoint = 0;
+        size_t cursor = 0;
+        for (Interval interval : loopData.liveRange.intervals()) {
+            do {
+                interval = forEachUseDefWithin(tmp, interval, cursor, [&](Point point, Inst& inst, BasicBlock& block) {
+                    inst.forEachTmp([&](Tmp& t, Arg::Role role, Bank, Width) {
+                        if (t != tmp)
+                            return;
+                        t = loopTmp;
+                        if (Arg::isAnyDef(role))
+                            defPoint = point; // May have multiple defs so can only use this to mean has def within loop
+                        if (Arg::isColdUse(role))
+                            loopData.hasColdUse = true;
+                        else
+                            loopData.useDefCost += block.frequency();
+                        m_useDefLists[loopTmp].add(point);
+                    });
+                });
+            } while (interval);
+        }
+
+        // originalTmp no longer live within the loop.
+        origData.liveRange = WTF::move(nonLoopRange);
+
+        if (std::isinf(loopData.useDefCost))
+            origData.useDefCost = 0; // Exact cost unknown, but favor allocating the loop tmp.
+        else {
+            ASSERT(std::isfinite(origData.useDefCost) && std::isfinite(loopData.useDefCost));
+            origData.useDefCost -= loopData.useDefCost;
+            if (origData.useDefCost < 0)
+                origData.useDefCost = 0;
+        }
+
+        m_splitMetadata.constructAndAppend(SplitMetadata::Type::AroundLoop, tmp);
+        SplitMetadata& metadata = m_splitMetadata.last();
+        metadata.loop = loop;
+        metadata.splits.append({ loopTmp, defPoint });
+
+        // Now try to allocate the non-loop and loop live-ranges independently.
+        setStageAndEnqueue(loopTmp, loopData, Stage::TryAllocate);
+        setStageAndEnqueue(tmp, origData, Stage::TryAllocate);
+
+        m_stats[bank].numSplitAroundLoop++;
+        dataLogLnIf(verbose(), "Split (around loop): ", tmp, " -> loopTmp=", loopTmp, " header=BB", loop->header(), " hasDefInLoop=", !!defPoint);
+        return true;
     }
 
     template<Bank bank>
     bool trySplitAroundClobbers(Tmp tmp, TmpData& tmpData)
     {
-        if (tmpData.splitMetadataIndex)
+        if (tmpData.splitAroundClobbersMetadataIndex)
             return false; // Already split around clobbers
         if (tmpData.liveRange.size() < splitMinRangeSize)
             return false; // Not enough instructions to be worthwhile
@@ -2382,7 +2669,7 @@ private:
             });
 
         tmpData.liveRange = LiveRange::subtract(tmpData.liveRange, holeRange);
-        tmpData.splitMetadataIndex = m_splitMetadata.size();
+        tmpData.splitAroundClobbersMetadataIndex = m_splitMetadata.size();
         setStageAndEnqueue(tmp, tmpData, Stage::TryAllocate);
 
         SplitMetadata metadata(SplitMetadata::Type::AroundClobbers, tmp);
@@ -2402,7 +2689,7 @@ private:
             // rotation of register assignments) but that would trigger an extra liveness
             // analysis (see lowerAfterRegAlloc()), and that's unlikely to be worth it.
             Interval gapInterval = hole | Interval(hole.begin() - 1);
-            Tmp gapTmp = newTmp(tmp, freq, gapInterval);
+            Tmp gapTmp = addSplitTmp(tmp, freq, gapInterval);
             metadata.splits.append({ gapTmp, 0 });
             setStageAndEnqueue(gapTmp, m_map.get<bank>(gapTmp), Stage::TryAllocate);
         }
@@ -2440,7 +2727,7 @@ private:
     // uses or defs the given tmp, up to the end of the basic block.
     // Returns the unprocessed portion of the interval (if interval spans multiple blocks).
     // `cursor` can be used to perform a "sort-merge join" when the caller is making queries over a sorted set of intervals for the same tmp
-    Interval forEachUseDefWithin(Tmp tmp, Interval interval, size_t& cursor, const Invocable<void(Point, Inst&)> auto& func)
+    Interval forEachUseDefWithin(Tmp tmp, Interval interval, size_t& cursor, const Invocable<void(Point, Inst&, BasicBlock&)> auto& func)
     {
         auto& useDefs = m_useDefLists[tmp].useDefs();
 
@@ -2465,7 +2752,7 @@ private:
         Point last = std::min(positionOfTail, end - 1);
 
         do {
-            func(useDefs[i], block->at(instIndex(positionOfHead, useDefs[i])));
+            func(useDefs[i], block->at(instIndex(positionOfHead, useDefs[i])), *block);
             i++;
         } while (i < useDefs.size() && useDefs[i] <= last);
         cursor = i - 1; // i-1 since the next interval may include this final instruction
@@ -2475,19 +2762,16 @@ private:
     template<Bank bank>
     bool trySplitIntraBlock(Tmp tmp, TmpData& tmpData)
     {
-        if (tmpData.splitMetadataIndex)
+        if (tmpData.splitAroundClobbersMetadataIndex)
             return false;
 
-        unsigned tmpIndex = AbsoluteTmpMapper<bank>::absoluteIndex(tmp);
-        if (m_useCounts.isConstDef<bank>(tmpIndex))
+        if (isConstDef<bank>(tmp))
             return false; // Constant will be rematerialized instead
 
         // Don't split an already intra-block tmp. Otherwise, we might recursively try to
         // split a cluster tmp that couldn't be allocated.
-        BasicBlock* startBlock = findBlockContainingPoint(tmpData.liveRange.intervals().first().begin());
-        Point last = tmpData.liveRange.intervals().last().end() - 1;
-        if (last <= positionOfTail(startBlock))
-            return false; // Tmp's live range is already block local
+        if (isLiveRangeBlockLocal(tmpData.liveRange))
+            return false;
 
         ensureUseDefLists();
 
@@ -2508,19 +2792,19 @@ private:
                 tmpPtrs.shrink(0);
                 coldUsePtrs.shrink(0);
 
-                remaining = forEachUseDefWithin(tmp, remaining, cursor, [&](Point point, Inst& inst) {
+                remaining = forEachUseDefWithin(tmp, remaining, cursor, [&](Point point, Inst& inst, BasicBlock&) {
                     inst.forEachTmp([&](Tmp& t, Arg::Role role, Bank, Width) {
-                        if (t == tmp) {
-                            Point early = point + PointOffsets::Early;
-                            Interval timingInterval = intervalForTiming(early, Arg::timing(role));
-                            if (Arg::isColdUse(role))
-                                coldUsePtrs.append({ &t, timingInterval.begin() });
-                            else {
-                                tmpPtrs.append(&t);
-                                if (Arg::isAnyDef(role))
-                                    lastDefPoint = early; // Remember where the fixup store to spill is needed
-                                cluster |= timingInterval;
-                            }
+                        if (t != tmp)
+                            return;
+                        Point early = point + PointOffsets::Early;
+                        Interval timingInterval = intervalForTiming(early, Arg::timing(role));
+                        if (Arg::isColdUse(role))
+                            coldUsePtrs.append({ &t, timingInterval.begin() });
+                        else {
+                            tmpPtrs.append(&t);
+                            if (Arg::isAnyDef(role))
+                                lastDefPoint = early; // Remember where the fixup store to spill is needed
+                            cluster |= timingInterval;
                         }
                     });
                 });
@@ -2528,7 +2812,6 @@ private:
                 if (tmpPtrs.size() > 1) {
                     ASSERT(cluster);
                     if (!metadata) {
-                        m_map.get<bank>(tmp).splitMetadataIndex = m_splitMetadata.size();
                         m_splitMetadata.constructAndAppend(SplitMetadata::Type::IntraBlock, tmp);
                         metadata = &m_splitMetadata.last();
                     }
@@ -2543,7 +2826,7 @@ private:
                         cluster |= Interval(pointAtOffset(lastDefPoint, PointOffsets::Post));
 
                     BasicBlock* block = findBlockContainingPoint(cluster.begin());
-                    Tmp clusterTmp = newTmp(tmp, tmpPtrs.size() * adjustedBlockFrequency(block), cluster);
+                    Tmp clusterTmp = addSplitTmp(tmp, tmpPtrs.size() * adjustedBlockFrequency(block), cluster);
                     TmpData& clusterData = m_map.get<bank>(clusterTmp);
                     m_stats[bank].numSplitIntraBlockClusterTmps++;
                     for (auto& ptr : tmpPtrs)
@@ -2593,20 +2876,19 @@ private:
         m_stats[tmp.bank()].numSpilledTmps++;
         dataLogLnIf(verbose(), "Spilled ", tmp);
 
-        if (tmpData.splitMetadataIndex) {
-            auto& metadata = m_splitMetadata[tmpData.splitMetadataIndex];
-            if (metadata.type == SplitMetadata::Type::AroundClobbers) {
-                // Splitting didn't prevent originalTmp from spilling after all, so no point assigning
-                // registers or stack slots to the gap tmps for this split.
-                dataLogLnIf(verbose(), "   evicting tmps created during split");
-                ASSERT(metadata.originalTmp == tmp);
-                for (auto& split : metadata.splits) {
-                    Tmp gapTmp = split.tmp;
-                    Reg reg = m_map[gapTmp].assigned;
-                    if (reg)
-                        evict(gapTmp, m_map[gapTmp], reg);
-                    m_map[gapTmp].stage = Stage::Replaced;
-                }
+        if (tmpData.splitAroundClobbersMetadataIndex) {
+            auto& metadata = m_splitMetadata[tmpData.splitAroundClobbersMetadataIndex];
+            ASSERT(metadata.type == SplitMetadata::Type::AroundClobbers);
+            // Splitting didn't prevent originalTmp from spilling after all, so no point assigning
+            // registers or stack slots to the gap tmps for this split.
+            dataLogLnIf(verbose(), "   evicting tmps created during split");
+            ASSERT(metadata.originalTmp == tmp);
+            for (auto& split : metadata.splits) {
+                Tmp gapTmp = split.tmp;
+                Reg reg = m_map[gapTmp].assigned;
+                if (reg)
+                    evict(gapTmp, m_map[gapTmp], reg);
+                m_map[gapTmp].stage = Stage::Replaced;
             }
         }
         // Batch the generation of spill/fill tmps so that we can limit traversals of the code while
@@ -2651,28 +2933,16 @@ private:
     {
         m_code.forEachTmp<bank>([&](Tmp tmp) {
             TmpData& tmpData = m_map.get<bank>(tmp);
-            if (tmpData.stage == Stage::Spilled && !tmpData.spillSlot) {
-                if (!tmpData.spillSlot)
-                    tmpData.spillSlot = m_code.addStackSlot(stackSlotMinimumWidth(m_tmpWidth.requiredWidth(tmp)), StackSlotKind::Spill);
-                ASSERT(spillSlot<bank>(tmp));
+            if (tmpData.stage != Stage::Spilled)
+                return;
+
+            ensureSpillSlotTableEntry(tmpData);
+            StackSlot*& slot = m_spillSlotTable[tmpData.spillSlotTableIndex];
+            if (!slot) {
+                slot = m_code.addStackSlot(stackSlotMinimumWidth(m_tmpWidth.requiredWidth(tmp)), StackSlotKind::Spill);
                 m_stats[bank].numSpillStackSlots++;
             }
-            if (tmpData.splitMetadataIndex) {
-                auto& metadata = m_splitMetadata[tmpData.splitMetadataIndex];
-                if (metadata.type == SplitMetadata::Type::IntraBlock) {
-                    // Redirect spilled intra-block cluster tmps to the spill slot of the original tmp.
-                    ASSERT(tmpData.stage == Stage::Spilled && spillSlot<bank>(tmp));
-                    for (auto& split : metadata.splits) {
-                        Tmp clusterTmp = split.tmp;
-                        TmpData& clusterData = m_map.get<bank>(clusterTmp);
-                        if (clusterData.stage == Stage::Spilled) {
-                            if (!clusterData.spillSlot)
-                                clusterData.spillSlot = spillSlot<bank>(tmp);
-                            ASSERT(spillSlot<bank>(clusterTmp) == spillSlot<bank>(tmp));
-                        }
-                    }
-                }
-            }
+            ASSERT(spillSlot<bank>(tmp));
         });
         for (BasicBlock* block : m_code) {
             Point positionOfHead = this->positionOfHead(block);
@@ -2920,6 +3190,18 @@ private:
 
     void insertFixupCode()
     {
+        HashMap<Tmp, Tmp> loopToNonLoopTmp;
+        for (auto& metadata : m_splitMetadata) {
+            if (metadata.type == SplitMetadata::Type::AroundLoop)
+                loopToNonLoopTmp.add(metadata.splits[0].tmp, metadata.originalTmp);
+        }
+
+        // Loop fixups for different Tmps may introduce register cycles.
+        // i.e. Move r1, r2 for tmpA and Move r2, r1 for tmpB. Handle this by accumulating
+        // all fixups and then emitting Shuffle to deal with the potential register cycle.
+        HashMap<BasicBlock*, Vector<ShufflePair>> loopEntryFixups;
+        HashMap<BasicBlock*, Vector<ShufflePair>> loopExitFixups;
+
         for (auto& metadata : m_splitMetadata) {
             switch (metadata.type) {
             case SplitMetadata::Type::Invalid:
@@ -2930,8 +3212,17 @@ private:
             case SplitMetadata::Type::IntraBlock:
                 insertSplitIntraBlockFixupCode(metadata);
                 break;
+            case SplitMetadata::Type::AroundLoop:
+                insertSplitAroundLoopFixupCode(metadata, loopToNonLoopTmp, loopEntryFixups, loopExitFixups);
+                break;
             }
         }
+        for (auto& [block, shufflePairs] : loopEntryFixups) {
+            unsigned termIndex = block->size() - 1;
+            m_insertionSets[block].insertInst(termIndex, aroundLoopEntryFixup, createShuffle(block->at(termIndex).origin, shufflePairs));
+        }
+        for (auto& [block, shufflePairs] : loopExitFixups)
+            m_insertionSets[block].insertInst(0, aroundLoopExitFixup, createShuffle(block->at(0).origin, shufflePairs));
         for (BasicBlock* block : m_code)
             m_insertionSets[block].execute(block);
     }
@@ -3008,6 +3299,95 @@ private:
                 m_stats[bank].numSplitIntraBlockStore++;
             }
         }
+    }
+
+    void insertSplitAroundLoopFixupCode(SplitMetadata& metadata, const HashMap<Tmp, Tmp>& loopToNonLoopTmp, HashMap<BasicBlock*, Vector<ShufflePair>>& entryFixups, HashMap<BasicBlock*, Vector<ShufflePair>>& exitFixups)
+    {
+        ASSERT(metadata.type == SplitMetadata::Type::AroundLoop);
+
+        Tmp nonLoopTmp = metadata.originalTmp;
+        Tmp loopTmp = metadata.splits[0].tmp;
+        const NaturalLoop& loop = *metadata.loop;
+        BasicBlock* header = loop.header();
+
+        Bank bank = nonLoopTmp.bank();
+        if (spillSlot(loopTmp))
+            m_stats[bank].numSplitAroundLoopLoopSpilled++;
+        if (spillSlot(nonLoopTmp))
+            m_stats[bank].numSplitAroundLoopNonLoopSpilled++;
+        if (spillSlot(loopTmp) && spillSlot(nonLoopTmp))
+            m_stats[bank].numSplitAroundLoopBothSpilled++;
+
+        auto argFor = [&](Tmp tmp) -> Arg {
+            StackSlot* spilled = spillSlot(tmp);
+            if (spilled)
+                return Arg::stack(spilled);
+            return tmp;
+        };
+        Arg nonLoopArg = argFor(nonLoopTmp);
+        Arg loopArg = argFor(loopTmp);
+
+        LiveRange& loopLiveRange = m_map[loopTmp].liveRange;
+        Width width = canonicalWidth(m_tmpWidth.requiredWidth(nonLoopTmp));
+
+        // Entry fixup: unless both tmps spilled, if the original tmp was live into the header
+        // block, then need to transfer from nonLoopTmp → loopTmp at end of each entry edge.
+        // Note that analyzeLoop already filtered loops where this is a critical edge.
+        if (nonLoopArg != loopArg && loopLiveRange.contains(positionOfHead(header))) {
+            for (BasicBlock* pred : header->predecessors()) {
+                if (m_naturalLoops->belongsTo(pred, loop))
+                    continue; // Skip back-edge predecessors.
+                ASSERT(pred->numSuccessors() == 1 && pred->successors()[0] == header);
+                ASSERT(!nonLoopArg.isStack() || !loopArg.isStack());
+                entryFixups.ensure(pred, [] { return Vector<ShufflePair>(); }).iterator->value.append(ShufflePair(nonLoopArg, loopArg, width));
+            }
+        }
+
+        // Exit fixup: unless both tmps spilled, on each exit edge, need to transfer from
+        // the inner-most loopTmp to the nonLoopTmp of the exit successor (which can be
+        // different from this split's nonLoopTmp in the case of breaking through multiple
+        // levels of loops).
+        // analyzeLoop() ensured the exit successor has only loop predecessors so
+        // it's safe to emit the fixup code in the successor block.
+
+        // FIXME: can we skip the fixup if the dest is spilled and not def'ed (by any nesting level)?
+
+        // FIXME: revisit this allocation
+        IndexSet<BasicBlock*> visitedExitSuccessors;
+        for (unsigned i = 0; i < loop.size(); i++) {
+            BasicBlock* loopBlock = loop.at(i);
+            for (auto& succ : loopBlock->successors()) {
+                if (m_naturalLoops->belongsTo(succ.block(), loop))
+                    continue;
+                if (!visitedExitSuccessors.add(succ.block()))
+                    continue; // Already inserted fixup for this exit successor.
+                // If loopTmp isn't live at the exiting block then this block is within a nested loop that
+                // was also split. The inner fixup will handle this multi-level loop exit.
+                if (!loopLiveRange.contains(positionOfTail(loopBlock)))
+                    continue;
+                Point exitHead = positionOfHead(succ.block());
+                // Find the nonLoopTmp that carries the value into succ block by traversing splits outward.
+                Tmp destTmp = nonLoopTmp;
+                while (!m_map[destTmp].liveRange.contains(exitHead)) {
+                    auto it = loopToNonLoopTmp.find(destTmp);
+                    if (it == loopToNonLoopTmp.end()) {
+                        destTmp = Tmp();
+                        break;
+                    }
+                    destTmp = it->value;
+                }
+                // There won't be a destTmp if the original range wasn't live out of this loop. In that case,
+                // no exit fixup is needed.
+                if (destTmp) {
+                    Arg destArg = argFor(destTmp);
+                    if (loopArg != destArg) {
+                        ASSERT(!loopArg.isStack() || !destArg.isStack());
+                        exitFixups.ensure(succ.block(), [] { return Vector<ShufflePair>(); }).iterator->value.append(ShufflePair(loopArg, destArg, width));
+                    }
+                }
+            }
+        }
+        dataLogLnIf(verbose(), "AroundLoop fixup: nonLoop=", nonLoopTmp, " loop=", loopTmp, " header=BB", *header);
     }
 
     bool NODELETE mayBeCoalescable(Inst& inst)
@@ -3101,6 +3481,7 @@ private:
     TmpMap<TmpData> m_map;
     TmpMap<UseDefList> m_useDefLists;
     Vector<SplitMetadata> m_splitMetadata;
+    Vector<StackSlot*> m_spillSlotTable;
     IndexMap<Reg, RegisterRange> m_regRanges;
     GenerationalSet<uint8_t, SaVector> m_visited;
     PriorityQueue<TmpPriority, TmpPriority::isHigherPriority> m_queue;
@@ -3112,6 +3493,10 @@ private:
     std::array<bool, numBanks> m_didSpill { };
     bool m_needsEmitSpillCode { false };
     bool m_hasUseDefLists { false };
+    std::unique_ptr<Dominators> m_dominators;
+    std::unique_ptr<NaturalLoops> m_naturalLoops;
+    BitVector m_invalidLoops;
+    Vector<LiveRange> m_loopRanges;
 };
 
 } // namespace JSC::B3::Air::Greedy

--- a/Source/JavaScriptCore/b3/air/AirCode.cpp
+++ b/Source/JavaScriptCore/b3/air/AirCode.cpp
@@ -48,6 +48,8 @@ const char* const tierName = "Air ";
 
 WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED_IMPL(CFG);
 WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED_IMPL(Code);
+WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED_IMPL(Dominators);
+WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED_IMPL(NaturalLoops);
 
 static void defaultPrologueGenerator(CCallHelpers& jit, Code& code)
 {

--- a/Source/JavaScriptCore/b3/air/AirCode.h
+++ b/Source/JavaScriptCore/b3/air/AirCode.h
@@ -310,7 +310,7 @@ public:
     const SparseCollection<Special>& specials() const LIFETIME_BOUND { return m_specials; }
     SparseCollection<Special>& specials() LIFETIME_BOUND { return m_specials; }
 
-    void addFastTmp(Tmp);
+    JS_EXPORT_PRIVATE void addFastTmp(Tmp);
 
     template<typename Functor>
     void forEachFastTmp(const Functor& functor) const

--- a/Source/JavaScriptCore/b3/air/AirRegisterAllocatorStats.h
+++ b/Source/JavaScriptCore/b3/air/AirRegisterAllocatorStats.h
@@ -60,6 +60,17 @@ namespace JSC { namespace B3 { namespace Air {
     macro(numSplitIntraBlockClusterTmpsSpilled) \
     macro(numSplitIntraBlockLoad)               \
     macro(numSplitIntraBlockStore)              \
+    macro(numSplitAroundLoop)                   \
+    macro(numSplitAroundLoopBothSpilled)        \
+    macro(numSplitAroundLoopLoopSpilled)        \
+    macro(numSplitAroundLoopNonLoopSpilled)     \
+    macro(numSplitAroundLoopBailNoLoop)         \
+    macro(numSplitAroundLoopBailAlreadySplitAroundClobbers)   \
+    macro(numSplitAroundLoopBailLocalOnly)      \
+    macro(numSplitAroundLoopBailTooSmall)       \
+    macro(numSplitAroundLoopBailConstDef)       \
+    macro(numSplitAroundLoopBailTooDeep)        \
+    macro(numSplitAroundLoopSkipCriticalEdge)   \
     macro(numGroupTmpsCoalesced)                \
     macro(numGroupsCreated)                     \
     macro(numGroupMovesCoalesced)               \

--- a/Source/JavaScriptCore/b3/air/testair.cpp
+++ b/Source/JavaScriptCore/b3/air/testair.cpp
@@ -2960,6 +2960,380 @@ void testStorePairClobberMemoryLoad()
 #endif
 #endif
 
+// Test loop-aware live range splitting in the greedy register allocator.
+// Template parameters control the allocation outcome and structural properties of across-loop tmps:
+//   nonLoopSpilled: whether the outside-loop portion should end up spilled
+//   loopSpilled: whether the inside-loop portion should end up spilled
+//   hasDef: whether the tmp has a def inside the loop body
+//   liveAtHeader: whether the tmp is live across the loop entry edge
+//   liveAtExit: whether the tmp is live across the loop exit edge
+//
+// The tmp always has three regions of activity:
+//   Pre-loop (root): defined via loadConstant. If !liveAtHeader, also used here (separate range).
+//   Loop (body): read into sum. If hasDef, also modified (tmp += counter).
+//                If !liveAtHeader, fresh def at start of body (range not connected to pre-loop).
+//   Post-loop (exit): If liveAtExit, value flows from loop. If !liveAtExit, redefined here (separate range).
+//
+// 5 bools = 32 combinations. 18 are tested:
+//   - 8 excluded: liveAtHeader=false && hasDef=false is infeasible (no def means no in-loop range).
+//   - 1 excluded: nonLoopSpilled=true && !liveAtHeader && !liveAtExit — tmps are block-local to the
+//     body, nothing crosses loop boundaries, so nonLoopSpilled is meaningless.
+//   - 6 collapsed into 1: nonLoop=spill && loop=spill hits the early-return path regardless of
+//     hasDef/liveAtHeader/liveAtExit, so only one representative is needed.
+//   32 - 8 - 1 - 6 + 1 = 18.
+template<bool nonLoopSpilled, bool loopSpilled, bool hasDef, bool liveAtHeader, bool liveAtExit>
+void testSplitAroundLoop()
+{
+    unsigned numRegs = 8;
+    unsigned numAcrossLoopTmps = 4;
+
+    // Fast tmps consume registers in specific regions to steer which side spills.
+    unsigned numFastTmpsOutsideLoop = 0; // Consume regs in root+exit → nonLoopTmp spills
+    unsigned numFastTmpsInsideLoop = 0;  // Consume regs in loop body → loopTmp spills
+
+    if (nonLoopSpilled)
+        numFastTmpsOutsideLoop = numRegs - 1;
+    if (loopSpilled)
+        numFastTmpsInsideLoop = numRegs - 1;
+
+    B3::Procedure proc;
+    Code& code = proc.code();
+
+    // Pin registers to limit allocatable set.
+    {
+        Vector<Reg> allRegs = code.regsInPriorityOrder(GP);
+        for (size_t i = numRegs; i < allRegs.size(); ++i)
+            code.pinRegister(allRegs[i]);
+    }
+
+    BasicBlock* root = code.addBlock();
+    BasicBlock* header = code.addBlock(10.0);
+    BasicBlock* body = code.addBlock(10.0);
+    BasicBlock* exit = code.addBlock();
+
+    // --- Create tmps ---
+    Vector<Tmp> tmps;
+    for (unsigned i = 0; i < numAcrossLoopTmps; ++i)
+        tmps.append(code.newTmp(GP));
+
+    Vector<Tmp> fastTmpsOutside;
+    for (unsigned i = 0; i < numFastTmpsOutsideLoop; ++i) {
+        Tmp ft = code.newTmp(GP);
+        code.addFastTmp(ft);
+        fastTmpsOutside.append(ft);
+    }
+    Vector<Tmp> fastTmpsInside;
+    for (unsigned i = 0; i < numFastTmpsInsideLoop; ++i) {
+        Tmp ft = code.newTmp(GP);
+        code.addFastTmp(ft);
+        fastTmpsInside.append(ft);
+    }
+
+    Tmp counter = code.newTmp(GP);
+    Tmp sum = code.newTmp(GP);
+
+    // --- Root: define tmps, optional pre-loop use, fast tmps, counter ---
+    root->append(Move, nullptr, Arg::imm(0), sum);
+    for (unsigned i = 0; i < numAcrossLoopTmps; ++i)
+        loadConstant(root, static_cast<intptr_t>(i + 1), tmps[i]);
+    if (!liveAtHeader) {
+        // Pre-loop use: creates a separate pre-loop live range (not connected to loop range).
+        for (unsigned i = 0; i < numAcrossLoopTmps; ++i)
+            root->append(Add64, nullptr, tmps[i], sum);
+    }
+    for (unsigned i = 0; i < numFastTmpsOutsideLoop; ++i)
+        loadConstant(root, static_cast<intptr_t>(100 + i), fastTmpsOutside[i]);
+    for (unsigned i = 0; i < numFastTmpsOutsideLoop; ++i)
+        root->append(Add64, nullptr, fastTmpsOutside[i], sum);
+    loadConstant(root, static_cast<intptr_t>(5), counter);
+    root->append(Jump, nullptr);
+    root->setSuccessors(header);
+
+    // --- Header: branch to body or exit ---
+    header->append(Branch32, nullptr, Arg::relCond(MacroAssembler::GreaterThan), counter, Arg::imm(0));
+    header->setSuccessors(body, exit);
+
+    // --- Body: fast tmps inside, optional fresh def, read tmps, optional modify, decrement ---
+    for (unsigned i = 0; i < numFastTmpsInsideLoop; ++i)
+        body->append(Move, nullptr, counter, fastTmpsInside[i]);
+
+    if (!liveAtHeader) {
+        // Fresh def in body: not connected to pre-loop range.
+        for (unsigned i = 0; i < numAcrossLoopTmps; ++i) {
+            body->append(Move, nullptr, counter, tmps[i]);
+            body->append(Add64, nullptr, Arg::imm(i + 1), tmps[i]);
+        }
+    }
+
+    // Read tmps in body (accumulate into sum).
+    for (unsigned i = 0; i < numAcrossLoopTmps; ++i)
+        body->append(Add64, nullptr, tmps[i], sum);
+
+    if (hasDef) {
+        // Modify tmps in body.
+        for (unsigned i = 0; i < numAcrossLoopTmps; ++i)
+            body->append(Add64, nullptr, counter, tmps[i]);
+    }
+
+    for (unsigned i = 0; i < numFastTmpsInsideLoop; ++i)
+        body->append(Add64, nullptr, fastTmpsInside[i], sum);
+
+    body->append(Sub32, nullptr, Arg::imm(1), counter);
+    body->append(Jump, nullptr);
+    body->setSuccessors(header);
+
+    // --- Exit: optional redef, read tmps, fast tmps, return sum ---
+    if (!liveAtExit) {
+        // Post-loop redef: creates a separate post-loop live range (not connected to loop range).
+        for (unsigned i = 0; i < numAcrossLoopTmps; ++i)
+            loadConstant(exit, static_cast<intptr_t>(i + 1), tmps[i]);
+    }
+    for (unsigned i = 0; i < numAcrossLoopTmps; ++i)
+        exit->append(Add64, nullptr, tmps[i], sum);
+    for (unsigned i = 0; i < numFastTmpsOutsideLoop; ++i)
+        loadConstant(exit, static_cast<intptr_t>(200 + i), fastTmpsOutside[i]);
+    for (unsigned i = 0; i < numFastTmpsOutsideLoop; ++i)
+        exit->append(Add64, nullptr, fastTmpsOutside[i], sum);
+    exit->append(Move, nullptr, sum, Tmp(GPRInfo::returnValueGPR));
+    exit->append(Ret64, nullptr, Tmp(GPRInfo::returnValueGPR));
+
+    // --- Compute expected result ---
+    // sum accumulates contributions from pre-loop, loop body, and post-loop.
+    int64_t expected = 0;
+
+    // Pre-loop fast tmps: 100+101+...+(100+N-1)
+    for (unsigned i = 0; i < numFastTmpsOutsideLoop; ++i)
+        expected += static_cast<int64_t>(100 + i);
+
+    // Pre-loop tmps (only when !liveAtHeader): 1+2+3+4 = 10
+    if (!liveAtHeader) {
+        for (unsigned i = 0; i < numAcrossLoopTmps; ++i)
+            expected += static_cast<int64_t>(i + 1);
+    }
+
+    // Loop body: 5 iterations with counter=5,4,3,2,1.
+    {
+        int64_t tmpVals[4];
+        for (unsigned i = 0; i < numAcrossLoopTmps; ++i)
+            tmpVals[i] = static_cast<int64_t>(i + 1);
+
+        for (int c = 5; c >= 1; --c) {
+            if (!liveAtHeader) {
+                // Fresh def: tmp = counter + (i+1)
+                for (unsigned i = 0; i < numAcrossLoopTmps; ++i)
+                    tmpVals[i] = c + static_cast<int64_t>(i + 1);
+            }
+            // Read: sum += tmp[i]
+            for (unsigned i = 0; i < numAcrossLoopTmps; ++i)
+                expected += tmpVals[i];
+            if (hasDef) {
+                // Modify: tmp[i] += counter
+                for (unsigned i = 0; i < numAcrossLoopTmps; ++i)
+                    tmpVals[i] += c;
+            }
+            // Inside fast tmps: sum += counter (each fast tmp was set to counter)
+            for (unsigned i = 0; i < numFastTmpsInsideLoop; ++i)
+                expected += c;
+        }
+
+        // Post-loop tmps: value at exit.
+        if (liveAtExit) {
+            for (unsigned i = 0; i < numAcrossLoopTmps; ++i)
+                expected += tmpVals[i];
+        }
+    }
+
+    if (!liveAtExit) {
+        // Post-loop redef: 1+2+3+4 = 10
+        for (unsigned i = 0; i < numAcrossLoopTmps; ++i)
+            expected += static_cast<int64_t>(i + 1);
+    }
+
+    // Post-loop fast tmps: 200+201+...+(200+N-1)
+    for (unsigned i = 0; i < numFastTmpsOutsideLoop; ++i)
+        expected += static_cast<int64_t>(200 + i);
+
+    auto runResult = compileAndRun<int64_t>(proc);
+    CHECK(runResult == expected);
+}
+
+void testSplitAroundLoopNoInLoopUses()
+{
+    // Tmps defined before loop, not used/defined inside, used after.
+    // loopTmp has spillCost=0 → spills. Tests the simple case where no
+    // tmp rewrite happens inside the loop (no uses to rename).
+    // Fast tmps inside the loop body create register pressure.
+    B3::Procedure proc;
+    Code& code = proc.code();
+
+    unsigned numRegs = 8;
+    unsigned numAcrossLoopTmps = 4;
+    unsigned numFastTmpsInsideLoop = numRegs - 1;
+
+    // Pin registers to limit allocatable set.
+    {
+        Vector<Reg> allRegs = code.regsInPriorityOrder(GP);
+        for (size_t i = numRegs; i < allRegs.size(); ++i)
+            code.pinRegister(allRegs[i]);
+    }
+
+    BasicBlock* root = code.addBlock();
+    BasicBlock* header = code.addBlock(10.0);
+    BasicBlock* body = code.addBlock(10.0);
+    BasicBlock* exit = code.addBlock();
+
+    // Across-loop tmps: defined in root, used only in exit (no in-loop uses).
+    Vector<Tmp> tmps;
+    for (unsigned i = 0; i < numAcrossLoopTmps; ++i) {
+        Tmp tmp = code.newTmp(GP);
+        tmps.append(tmp);
+        loadConstant(root, static_cast<intptr_t>(i + 1), tmp);
+    }
+
+    // Fast tmps inside loop: consume registers in the body, forcing across-loop tmps out.
+    Vector<Tmp> fastTmpsInside;
+    for (unsigned i = 0; i < numFastTmpsInsideLoop; ++i) {
+        Tmp ft = code.newTmp(GP);
+        code.addFastTmp(ft);
+        fastTmpsInside.append(ft);
+    }
+
+    Tmp counter = code.newTmp(GP);
+    Tmp sum = code.newTmp(GP);
+    root->append(Move, nullptr, Arg::imm(0), sum);
+    loadConstant(root, static_cast<intptr_t>(5), counter);
+    root->append(Jump, nullptr);
+    root->setSuccessors(header);
+
+    header->append(Branch32, nullptr, Arg::relCond(MacroAssembler::GreaterThan), counter, Arg::imm(0));
+    header->setSuccessors(body, exit);
+
+    // Body: fast tmps consume registers, no uses of across-loop tmps.
+    for (unsigned i = 0; i < numFastTmpsInsideLoop; ++i)
+        body->append(Move, nullptr, counter, fastTmpsInside[i]);
+    for (unsigned i = 0; i < numFastTmpsInsideLoop; ++i)
+        body->append(Add64, nullptr, fastTmpsInside[i], sum);
+    body->append(Sub32, nullptr, Arg::imm(1), counter);
+    body->append(Jump, nullptr);
+    body->setSuccessors(header);
+
+    // Exit: sum all across-loop tmps.
+    for (unsigned i = 0; i < numAcrossLoopTmps; ++i)
+        exit->append(Add64, nullptr, tmps[i], sum);
+    exit->append(Move, nullptr, sum, Tmp(GPRInfo::returnValueGPR));
+    exit->append(Ret64, nullptr, Tmp(GPRInfo::returnValueGPR));
+
+    // Expected: fast tmps add counter each iter: 7*(5+4+3+2+1) = 105
+    // Plus across-loop tmps: 1+2+3+4 = 10. Total = 115.
+    CHECK(compileAndRun<int64_t>(proc) == 115);
+}
+
+template<bool criticalEntry>
+void testSplitAroundLoopCriticalEdge()
+{
+    // Tests that loop splitting bails out when there's a critical edge, and code is still correct.
+    // criticalEntry=true: root has two successors (header + altExit) — critical entry edge.
+    // criticalEntry=false: exit has predecessors from both loop and non-loop — critical exit edge.
+    //
+    // Structure: tmps defined → fast tmps consume regs → loop uses tmps → fast tmps again → read tmps.
+    // Loop splitting would help (keep tmps in regs during loop, spill outside), but critical edge prevents it.
+
+    B3::Procedure proc;
+    Code& code = proc.code();
+
+    unsigned numRegs = 8;
+    unsigned numAcrossLoopTmps = 4;
+    unsigned numFastTmps = numRegs - 1;
+
+    {
+        Vector<Reg> allRegs = code.regsInPriorityOrder(GP);
+        for (size_t i = numRegs; i < allRegs.size(); ++i)
+            code.pinRegister(allRegs[i]);
+    }
+
+    BasicBlock* root = code.addBlock();
+    BasicBlock* header = code.addBlock(10.0);
+    BasicBlock* body = code.addBlock(10.0);
+    BasicBlock* exit = code.addBlock();
+
+    // Step 1: Define across-loop tmps.
+    Vector<Tmp> tmps;
+    for (unsigned i = 0; i < numAcrossLoopTmps; ++i) {
+        Tmp tmp = code.newTmp(GP);
+        tmps.append(tmp);
+        loadConstant(root, static_cast<intptr_t>(i + 1), tmp);
+    }
+
+    // Step 2: Fast tmps consume registers in root (pre-loop pressure).
+    // Add them into sum so the optimizer can't eliminate them.
+    Vector<Tmp> fastTmps;
+    for (unsigned i = 0; i < numFastTmps; ++i) {
+        Tmp ft = code.newTmp(GP);
+        code.addFastTmp(ft);
+        fastTmps.append(ft);
+        loadConstant(root, static_cast<intptr_t>(100 + i), ft);
+    }
+
+    Tmp counter = code.newTmp(GP);
+    Tmp arg = code.newTmp(GP);
+    Tmp sum = code.newTmp(GP);
+    root->append(Move, nullptr, Arg::imm(0), sum);
+    for (unsigned i = 0; i < numFastTmps; ++i)
+        root->append(Add64, nullptr, fastTmps[i], sum);
+    root->append(Move, nullptr, Tmp(GPRInfo::argumentGPR0), arg);
+    loadConstant(root, static_cast<intptr_t>(5), counter);
+
+    // CFG wiring: create the critical edge.
+    if (criticalEntry) {
+        // root → header (loop entry) AND root → altExit: critical entry edge.
+        BasicBlock* altExit = code.addBlock();
+        root->append(Branch32, nullptr, Arg::relCond(MacroAssembler::GreaterThan), arg, Arg::imm(0));
+        root->setSuccessors(header, altExit);
+        altExit->append(Move, nullptr, Arg::imm(-1), Tmp(GPRInfo::returnValueGPR));
+        altExit->append(Ret64, nullptr, Tmp(GPRInfo::returnValueGPR));
+    } else {
+        // root → preheader → header, root → exit: exit has non-loop predecessor.
+        BasicBlock* preheader = code.addBlock();
+        root->append(Branch32, nullptr, Arg::relCond(MacroAssembler::GreaterThan), arg, Arg::imm(0));
+        root->setSuccessors(preheader, exit);
+        preheader->append(Jump, nullptr);
+        preheader->setSuccessors(header);
+    }
+
+    // Step 3: Loop reads tmps and accumulates.
+    header->append(Branch32, nullptr, Arg::relCond(MacroAssembler::GreaterThan), counter, Arg::imm(0));
+    header->setSuccessors(body, exit);
+
+    for (unsigned i = 0; i < numAcrossLoopTmps; ++i)
+        body->append(Add64, nullptr, tmps[i], sum);
+    body->append(Sub32, nullptr, Arg::imm(1), counter);
+    body->append(Jump, nullptr);
+    body->setSuccessors(header);
+
+    // Step 4: Fast tmps consume registers in exit (post-loop pressure).
+    // Add them into sum so the optimizer can't eliminate them.
+    for (unsigned i = 0; i < numFastTmps; ++i)
+        loadConstant(exit, static_cast<intptr_t>(200 + i), fastTmps[i]);
+    for (unsigned i = 0; i < numFastTmps; ++i)
+        exit->append(Add64, nullptr, fastTmps[i], sum);
+
+    // Step 5: Read tmps and loop result.
+    for (unsigned i = 0; i < numAcrossLoopTmps; ++i)
+        exit->append(Add64, nullptr, tmps[i], sum);
+    exit->append(Move, nullptr, sum, Tmp(GPRInfo::returnValueGPR));
+    exit->append(Ret64, nullptr, Tmp(GPRInfo::returnValueGPR));
+
+    // Pre-loop fast tmps: 100+101+...+106 = 721
+    // Loop (5 iters): 5 * (1+2+3+4) = 50
+    // Post-loop tmps: 1+2+3+4 = 10
+    // Post-loop fast tmps: 200+201+...+206 = 1421
+    // arg=1 total: 721 + 50 + 10 + 1421 = 2202
+    // arg=0: skip to altExit (-1) or exit (721 + 0 + 10 + 1421 = 2152)
+    auto compilation = compile(proc);
+    CHECK(invoke<int64_t>(*compilation, static_cast<int64_t>(1)) == 2202);
+    CHECK(invoke<int64_t>(*compilation, static_cast<int64_t>(0)) == (criticalEntry ? -1 : 2152));
+}
+
 #define PREFIX "O", Options::defaultB3OptLevel(), ": "
 
 #define RUN(test) do {                                 \
@@ -3087,6 +3461,40 @@ void run(const char* filter)
     RUN(testStorePairClobberMemoryLoad());
 #endif
 #endif
+
+    // Loop-aware splitting tests: parameterized matrix.
+    // testSplitAroundLoop<nonLoopSpilled, loopSpilled, hasDef, liveAtHeader, liveAtExit>()
+    //                                                                        Entry fixup   Exit fixup
+    // FIXME: Cases 5-8 and 15-16 (nonLoopSpilled=false, loopSpilled=false) don't exercise splitting —
+    // there's no register pressure so the allocator never splits. The intended reg→reg fixups never occur.
+    // To induce reg→reg, we'd need the original tmp to fail allocation (no single register free across
+    // its entire range) while both halves succeed with different registers after splitting. This is hard
+    // to achieve because the greedy allocator reuses registers freed by dead fast tmps.
+    // FIXME: Case 18 (nonLoopSpilled=true, liveAtHeader=false, liveAtExit=false) doesn't split because
+    // the tmps are block-local to the loop body — there's nothing across-loop to split.
+    RUN((testSplitAroundLoop<false, true,  false, true,  true>()));  // #1    reg→slot      slot→reg
+    RUN((testSplitAroundLoop<false, true,  true,  true,  true>()));  // #2    reg→slot      slot→reg
+    RUN((testSplitAroundLoop<false, true,  false, true,  false>())); // #3    reg→slot      none
+    RUN((testSplitAroundLoop<false, true,  true,  true,  false>())); // #4    reg→slot      none
+    RUN((testSplitAroundLoop<false, false, false, true,  true>()));  // #5    reg→reg       reg→reg
+    RUN((testSplitAroundLoop<false, false, true,  true,  true>()));  // #6    reg→reg       reg→reg
+    RUN((testSplitAroundLoop<false, false, false, true,  false>())); // #7    reg→reg       none
+    RUN((testSplitAroundLoop<false, false, true,  true,  false>())); // #8    reg→reg       none
+    RUN((testSplitAroundLoop<true,  false, false, true,  true>()));  // #9    slot→reg      none
+    RUN((testSplitAroundLoop<true,  false, true,  true,  true>()));  // #10   slot→reg      reg→slot
+    RUN((testSplitAroundLoop<true,  false, false, true,  false>())); // #11   slot→reg      none
+    RUN((testSplitAroundLoop<true,  false, true,  true,  false>())); // #12   slot→reg      none
+    RUN((testSplitAroundLoop<false, true,  true,  false, true>()));  // #13   none          slot→reg
+    RUN((testSplitAroundLoop<false, true,  true,  false, false>())); // #14   none          none
+    RUN((testSplitAroundLoop<false, false, true,  false, true>()));  // #15   none          reg→reg
+    RUN((testSplitAroundLoop<false, false, true,  false, false>())); // #16   none          none
+    RUN((testSplitAroundLoop<true,  false, true,  false, true>()));  // #17   none          reg→slot
+    RUN((testSplitAroundLoop<true,  true,  true,  true,  true>()));  // #18   none          none
+
+    // Loop-aware splitting: standalone tests.
+    RUN(testSplitAroundLoopNoInLoopUses());
+    RUN((testSplitAroundLoopCriticalEdge<true>()));
+    RUN((testSplitAroundLoopCriticalEdge<false>()));
 
     if (tasks.isEmpty())
         usage();

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -509,6 +509,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, airGreedyRegAllocVerbose, false, Normal, nullptr) \
     v(Bool, airUseGreedyRegAlloc, true, Normal, nullptr) \
     v(Double, airGreedyRegAllocSplitMultiplier, 2.0, Normal, nullptr) \
+    v(Bool, airGreedyRegAllocSplitAroundLoops, true, Normal, nullptr) \
     v(Bool, airGreedyRegAllocSpillsEverything, false, Normal, nullptr) \
     v(Bool, airDumpPhaseStats, false, Normal, nullptr) \
     v(Bool, airValidateGreedRegAlloc, ASSERT_ENABLED, Normal, nullptr) \


### PR DESCRIPTION
#### 795273231e5963e0bed382eb713184a0054d763f
<pre>
[WIP] GRA: split live ranges around loops
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

Test: Source/JavaScriptCore/b3/air/testair.cpp

* Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp:
(JSC::B3::Air::Greedy::LiveRange::contains const):
(JSC::B3::Air::Greedy::TmpData::dump const):
(JSC::B3::Air::Greedy::TmpData::validate):
(JSC::B3::Air::Greedy::UseDefList::useDefs const):
(JSC::B3::Air::Greedy::UseDefList::dump const):
(JSC::B3::Air::Greedy::GreedyAllocator::GreedyAllocator):
(JSC::B3::Air::Greedy::GreedyAllocator::dump const):
(JSC::B3::Air::Greedy::GreedyAllocator::forEachBlockInLiveRange):
(JSC::B3::Air::Greedy::GreedyAllocator::positionOfHead const):
(JSC::B3::Air::Greedy::GreedyAllocator::positionOfTail):
(JSC::B3::Air::Greedy::GreedyAllocator::isConstDef):
(JSC::B3::Air::Greedy::GreedyAllocator::spillSlot):
(JSC::B3::Air::Greedy::GreedyAllocator::ensureSpillSlotTableEntry):
(JSC::B3::Air::Greedy::GreedyAllocator::createGroupRepresentatives):
(JSC::B3::Air::Greedy::GreedyAllocator::addTmpImpl):
(JSC::B3::Air::Greedy::GreedyAllocator::addSpillTmpWithInterval):
(JSC::B3::Air::Greedy::GreedyAllocator::addSplitTmp):
(JSC::B3::Air::Greedy::GreedyAllocator::isLiveRangeBlockLocal):
(JSC::B3::Air::Greedy::GreedyAllocator::trySplit):
(JSC::B3::Air::Greedy::GreedyAllocator::analyzeLoop):
(JSC::B3::Air::Greedy::GreedyAllocator::ensureLoopAnalysis):
(JSC::B3::Air::Greedy::GreedyAllocator::chooseLoopForSplit):
(JSC::B3::Air::Greedy::GreedyAllocator::trySplitAroundLoop):
(JSC::B3::Air::Greedy::GreedyAllocator::trySplitAroundClobbers):
(JSC::B3::Air::Greedy::GreedyAllocator::forEachUseDefWithin):
(JSC::B3::Air::Greedy::GreedyAllocator::trySplitIntraBlock):
(JSC::B3::Air::Greedy::GreedyAllocator::spill):
(JSC::B3::Air::Greedy::GreedyAllocator::emitSpillCodeAndEnqueueNewTmps):
(JSC::B3::Air::Greedy::GreedyAllocator::insertFixupCode):
(JSC::B3::Air::Greedy::GreedyAllocator::insertSplitAroundLoopFixupCode):
(JSC::B3::Air::Greedy::UseDefList::useDefs): Deleted.
(JSC::B3::Air::Greedy::GreedyAllocator::newTmp): Deleted.
* Source/JavaScriptCore/b3/air/AirCode.cpp:
* Source/JavaScriptCore/b3/air/AirCode.h:
* Source/JavaScriptCore/b3/air/AirRegisterAllocatorStats.h:
* Source/JavaScriptCore/b3/air/testair.cpp:
* Source/JavaScriptCore/runtime/OptionsList.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/795273231e5963e0bed382eb713184a0054d763f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153337 "22 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26121 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19720 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162082 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106795 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e49bcc2a-4773-4746-837e-7adc7f9ad5fa) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26647 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26441 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118544 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83938 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/94876ff5-56c0-432d-8447-b30b35e2b8c7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156296 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20783 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137665 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99256 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ffd81266-e5d6-434f-9a9a-52055896afa1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19860 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17807 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9917 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/145350 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129507 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15535 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164556 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/14157 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7692 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17129 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126605 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25917 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21840 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126763 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25920 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137331 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82587 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21699 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14109 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184972 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25537 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89823 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47368 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25228 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25387 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25288 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->