### PR TITLE
Collapse acquire load + release store into a single acq_rel fetch_sub in decrementCheckedPtrCount

### DIFF
--- a/Source/WTF/wtf/CheckedRef.h
+++ b/Source/WTF/wtf/CheckedRef.h
@@ -382,13 +382,17 @@ public:
     {
         // In normal execution, a CheckedPtr always points to an object with a non-zero checkedPtrCount().
         // When it detects a dangling pointer, WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR scribbles an object with zeroes and then leaks it.
-        // When we check checkedPtrCountWithoutThreadCheck() here, we're checking for a scribbled object.
-        if (!checkedPtrCountWithoutThreadCheck()) [[unlikely]]
-            crashDueToCheckedPtrToDeadObject();
-        if constexpr (AtomicLike<StorageType>)
-            m_checkedPtrCount.fetch_sub(1, std::memory_order_release);
-        else
+        // When we check the count here, we're checking for a scribbled object.
+        if constexpr (AtomicLike<StorageType>) {
+            // Combine the acquire load (zombie check) with the release decrement into a
+            // single acq_rel fetch_sub. The returned old value lets us detect a zero count.
+            if (!m_checkedPtrCount.fetch_sub(1, std::memory_order_acq_rel)) [[unlikely]]
+                crashDueToCheckedPtrToDeadObject();
+        } else {
+            if (!m_checkedPtrCount.valueWithoutThreadCheck()) [[unlikely]]
+                crashDueToCheckedPtrToDeadObject();
             --m_checkedPtrCount;
+        }
     }
 
     ALWAYS_INLINE PtrCounterType checkedPtrCountWithoutThreadCheck() const


### PR DESCRIPTION
#### b45d18960b605987bac45f669344f17483d82be0
<pre>
Collapse acquire load + release store into a single acq_rel fetch_sub in decrementCheckedPtrCount
<a href="https://bugs.webkit.org/show_bug.cgi?id=311152">https://bugs.webkit.org/show_bug.cgi?id=311152</a>

Reviewed by Geoffrey Garen.

Follow-up to 310266@main. The atomic path in decrementCheckedPtrCount previously
performed two separate atomic operations: an acquire load (via
checkedPtrCountWithoutThreadCheck) to check for a zombie object, followed by
a release fetch_sub to decrement. These can be collapsed into a single
fetch_sub with acq_rel ordering by checking the old value it returns.

This is safe because:
- fetch_sub returns the value before subtraction, so a return value of 0
  indicates a zombie (same check as before).
- In the zombie case, the fetch_sub underflows the counter to UINT32_MAX, but
  this is harmless: the object&apos;s memory has already been scribbled with zeroes
  and leaked by WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR, and we CRASH()
  immediately afterward.

On ARM64, this replaces a separate ldar (acquire load) + stlr/ldaddl (release
fetch_sub) sequence with a single ldaddal (acq_rel fetch_sub), eliminating one
atomic instruction from every CheckedPtr/CheckedRef destruction.

* Source/WTF/wtf/CheckedRef.h:
(WTF::CanMakeCheckedPtrBase::decrementCheckedPtrCount const):

Canonical link: <a href="https://commits.webkit.org/310338@main">https://commits.webkit.org/310338@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2549e1f665710611f4997b6d53ed571219d55806

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153344 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26128 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19727 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162089 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106802 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4e59c3f1-b69f-41fd-9ecb-6a7d09b4fc3e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26654 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26448 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118548 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83942 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d204ddad-2aa5-457d-a1c1-558bbaa0c3c7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156303 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20790 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137667 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99260 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/02448330-3ac2-4c6b-82b7-fbe1e323be89) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19867 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17812 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9924 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/145357 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129514 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15537 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164563 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/14164 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7699 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17131 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126606 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25924 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21845 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126764 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34426 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25927 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137333 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82594 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21705 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14111 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184979 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25544 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89830 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47370 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25235 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25394 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25295 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->