### PR TITLE
[JSC] Fix custom key trait treatment in InlineMap and add .take()

### DIFF
--- a/Source/WTF/wtf/InlineMap.h
+++ b/Source/WTF/wtf/InlineMap.h
@@ -62,6 +62,7 @@ public:
     using MappedTraits = MappedTraitsArg;
     using Entry = KeyValuePair<KeyType, MappedType>;
     using EntryTraits = KeyValuePairHashTraits<KeyTraits, MappedTraits>;
+    using MappedTakeType = typename MappedTraits::TakeType;
 
     InlineMap()
         : m_size(0)
@@ -147,6 +148,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     class ValuesIterator;
 
     class iterator {
+        friend class InlineMap;
         friend class ValuesIterator;
     public:
         iterator() = default;
@@ -323,7 +325,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
                     if (i != m_size) {
                         // Move last entry to fill the gap
                         std::construct_at(&entryStorage[i], WTF::move(entryStorage[m_size]));
-                        // Assuming the moved-from entry is trivially destructible
+                        std::destroy_at(&entryStorage[m_size]);
                     }
                     return true;
                 }
@@ -345,6 +347,51 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
             shrink();
 
         return true;
+    }
+
+    bool remove(iterator it)
+    {
+        if (it == end())
+            return false;
+
+        Entry* slot = it.m_current;
+
+        if (isInline()) {
+            std::destroy_at(slot);
+            --m_size;
+            Entry* lastEntry = &inlineStorage()[m_size];
+            if (slot != lastEntry) {
+                std::construct_at(slot, WTF::move(*lastEntry));
+                std::destroy_at(lastEntry);
+            }
+            return true;
+        }
+
+        std::destroy_at(slot);
+        constructDeletedEntry(*slot);
+        incrementDeletedCount();
+        --m_size;
+
+        if (shouldShrink())
+            shrink();
+
+        return true;
+    }
+
+    template<typename K>
+    MappedTakeType take(const K& key)
+    {
+        return take(find(key));
+    }
+
+    MappedTakeType take(iterator it)
+    {
+        if (it == end())
+            return emptyTakeResult();
+
+        auto result = MappedTraits::take(WTF::move(it->value));
+        remove(it);
+        return result;
     }
 
     iterator begin() LIFETIME_BOUND
@@ -480,7 +527,7 @@ private:
 
     ALWAYS_INLINE static bool isEmptyKey(const KeyType& key)
     {
-        return isHashTraitsEmptyValue<HashTraits<KeyType>>(key);
+        return isHashTraitsEmptyValue<KeyTraits>(key);
     }
 
     ALWAYS_INLINE static bool isEmptyEntry(const Entry& entry)
@@ -490,7 +537,7 @@ private:
 
     ALWAYS_INLINE static bool isDeletedEntry(const Entry& entry)
     {
-        return HashTraits<KeyType>::isDeletedValue(entry.key);
+        return KeyTraits::isDeletedValue(entry.key);
     }
 
     ALWAYS_INLINE static bool isEmptyOrDeletedEntry(const Entry& entry)
@@ -526,6 +573,14 @@ private:
     static constexpr unsigned loadFactorNumerator = 3;
     static constexpr unsigned loadFactorDenominator = 4;
     static constexpr unsigned minLoadInverse = 6;
+
+    ALWAYS_INLINE static MappedTakeType emptyTakeResult()
+    {
+        if constexpr (requires { MappedTraits::emptyTakeValue(); })
+            return MappedTraits::emptyTakeValue();
+        else
+            return MappedTraits::take(MappedTraits::emptyValue());
+    }
 
     ALWAYS_INLINE unsigned deletedCount() const
     {

--- a/Tools/TestWebKitAPI/Tests/WTF/InlineMap.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/InlineMap.cpp
@@ -2575,4 +2575,671 @@ TEST(WTF_InlineMap, MustRehashInPlacePathDirect)
     }
 }
 
+TEST(WTF_InlineMap, CustomKeyTraitsTransitionToHashed)
+{
+    // Regression test: InlineMap with custom key traits (where emptyValue != 0)
+    // must use those traits for empty/deleted checks, not the default HashTraits.
+    // Previously, isEmptyKey() used HashTraits<KeyType> instead of the passed-in
+    // KeyTraits, causing an infinite loop during transitionToHashed() when
+    // UnsignedWithZeroKeyHashTraits was used (empty = INT_MAX, not 0).
+    InlineMap<int, int, 4, IntHash<int>, WTF::UnsignedWithZeroKeyHashTraits<int>> map;
+
+    // Fill inline capacity (4 entries, including key 0 which is allowed)
+    map.add(0, 100);
+    map.add(1, 200);
+    map.add(2, 300);
+    map.add(3, 400);
+    EXPECT_EQ(map.size(), 4u);
+
+    // This add triggers transitionToHashed(). With the bug, it would loop forever
+    // because the hashed storage was initialized with empty key = INT_MAX but
+    // isEmptyKey() checked for key == 0 (default HashTraits<int>).
+    map.add(4, 500);
+    EXPECT_EQ(map.size(), 5u);
+
+    // Verify all entries survived the transition
+    EXPECT_EQ(map.find(0)->value, 100);
+    EXPECT_EQ(map.find(1)->value, 200);
+    EXPECT_EQ(map.find(2)->value, 300);
+    EXPECT_EQ(map.find(3)->value, 400);
+    EXPECT_EQ(map.find(4)->value, 500);
+
+    // Verify remove works correctly in hashed mode with custom traits
+    EXPECT_TRUE(map.remove(2));
+    EXPECT_EQ(map.size(), 4u);
+    EXPECT_FALSE(map.contains(2));
+    EXPECT_TRUE(map.contains(0));
+    EXPECT_TRUE(map.contains(3));
+}
+
+// --- take() tests ---
+
+TEST(WTF_InlineMap, TakeExistingKeyInline)
+{
+    // take() on an existing key in inline mode returns the value and removes the entry.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    map.add(1, 100);
+    map.add(2, 200);
+    map.add(3, 300);
+
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+    EXPECT_EQ(map.size(), 3u);
+
+    unsigned value = map.take(2);
+    EXPECT_EQ(value, 200u);
+    EXPECT_EQ(map.size(), 2u);
+    EXPECT_FALSE(map.contains(2));
+
+    // Other entries unaffected
+    EXPECT_TRUE(map.contains(1));
+    EXPECT_EQ(map.find(1)->value, 100u);
+    EXPECT_TRUE(map.contains(3));
+    EXPECT_EQ(map.find(3)->value, 300u);
+
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+}
+
+TEST(WTF_InlineMap, TakeNonExistingKeyReturnsDefault)
+{
+    // take() on a non-existing key returns the empty/default value.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    map.add(1, 100);
+    map.add(2, 200);
+
+    // Take a key that does not exist (inline mode)
+    unsigned value = map.take(99);
+    EXPECT_EQ(value, 0u);
+    EXPECT_EQ(map.size(), 2u);
+
+    // Take from an empty map
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> emptyMap;
+    value = emptyMap.take(1);
+    EXPECT_EQ(value, 0u);
+    EXPECT_EQ(emptyMap.size(), 0u);
+}
+
+TEST(WTF_InlineMap, TakeExistingKeyHashed)
+{
+    // take() on an existing key in hashed mode returns the value and removes the entry.
+    InlineMap<unsigned, unsigned, 3, IntHash<unsigned>> map;
+
+    for (unsigned i = 1; i <= 10; ++i)
+        map.add(i, i * 10);
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+    EXPECT_EQ(map.size(), 10u);
+
+    unsigned value = map.take(5);
+    EXPECT_EQ(value, 50u);
+    EXPECT_EQ(map.size(), 9u);
+    EXPECT_FALSE(map.contains(5));
+
+    // Other entries unaffected
+    for (unsigned i = 1; i <= 10; ++i) {
+        if (i == 5)
+            continue;
+        EXPECT_TRUE(map.contains(i));
+        EXPECT_EQ(map.find(i)->value, i * 10);
+    }
+
+    // Take a non-existing key in hashed mode
+    value = map.take(99);
+    EXPECT_EQ(value, 0u);
+    EXPECT_EQ(map.size(), 9u);
+}
+
+TEST(WTF_InlineMap, TakeWithMoveOnlyValues)
+{
+    // take() works correctly with move-only value types.
+    InlineMap<unsigned, MoveOnly, 5, IntHash<unsigned>> map;
+
+    map.add(1, MoveOnly(10));
+    map.add(2, MoveOnly(20));
+    map.add(3, MoveOnly(30));
+
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    MoveOnly taken = map.take(2);
+    EXPECT_EQ(taken.value(), 20u);
+    EXPECT_EQ(map.size(), 2u);
+    EXPECT_FALSE(map.contains(2));
+
+    // Remaining entries intact
+    EXPECT_EQ(map.find(1)->value.value(), 10u);
+    EXPECT_EQ(map.find(3)->value.value(), 30u);
+
+    // Take non-existing key returns default (value 0)
+    MoveOnly missing = map.take(99);
+    EXPECT_EQ(missing.value(), 0u);
+    EXPECT_EQ(map.size(), 2u);
+}
+
+TEST(WTF_InlineMap, TakeAfterTransitionToHashed)
+{
+    // take() works on entries that were originally added in inline mode but are now
+    // in hashed mode after the transition.
+    InlineMap<unsigned, unsigned, 3, IntHash<unsigned>> map;
+
+    // Add entries in inline mode
+    map.add(1, 100);
+    map.add(2, 200);
+    map.add(3, 300);
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    // Trigger transition to hashed
+    map.add(4, 400);
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    // Take an entry that was added while inline
+    unsigned value = map.take(2);
+    EXPECT_EQ(value, 200u);
+    EXPECT_EQ(map.size(), 3u);
+    EXPECT_FALSE(map.contains(2));
+
+    // Take an entry that was added while hashed
+    value = map.take(4);
+    EXPECT_EQ(value, 400u);
+    EXPECT_EQ(map.size(), 2u);
+    EXPECT_FALSE(map.contains(4));
+
+    // Remaining entries
+    EXPECT_TRUE(map.contains(1));
+    EXPECT_EQ(map.find(1)->value, 100u);
+    EXPECT_TRUE(map.contains(3));
+    EXPECT_EQ(map.find(3)->value, 300u);
+}
+
+TEST(WTF_InlineMap, TakeTriggersShrinkToInline)
+{
+    // Repeatedly calling take() on a hashed map can trigger shrink back to inline.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    for (unsigned i = 1; i <= 20; ++i)
+        map.add(i, i * 10);
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+    EXPECT_EQ(map.size(), 20u);
+
+    // Take entries one by one. At some point the map should shrink back to inline.
+    bool becameInline = false;
+    for (unsigned i = 1; i <= 15; ++i) {
+        unsigned value = map.take(i);
+        EXPECT_EQ(value, i * 10);
+        if (!becameInline && WTF::InlineMapAccessForTesting::isInline(map))
+            becameInline = true;
+    }
+
+    EXPECT_TRUE(becameInline);
+    EXPECT_EQ(map.size(), 5u);
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    // Remaining entries (16-20) are accessible
+    for (unsigned i = 16; i <= 20; ++i) {
+        EXPECT_TRUE(map.contains(i));
+        EXPECT_EQ(map.find(i)->value, i * 10);
+    }
+
+    // Taken entries are gone
+    for (unsigned i = 1; i <= 15; ++i)
+        EXPECT_FALSE(map.contains(i));
+}
+
+TEST(WTF_InlineMap, TakeWithMoveOnlyInHashedMode)
+{
+    // take() works with move-only values in hashed mode.
+    InlineMap<unsigned, MoveOnly, 3, IntHash<unsigned>> map;
+
+    for (unsigned i = 1; i <= 10; ++i)
+        map.add(i, MoveOnly(i * 100));
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    MoveOnly taken = map.take(7);
+    EXPECT_EQ(taken.value(), 700u);
+    EXPECT_EQ(map.size(), 9u);
+    EXPECT_FALSE(map.contains(7));
+
+    // Take all remaining entries, verifying each
+    for (unsigned i = 1; i <= 10; ++i) {
+        if (i == 7)
+            continue;
+        MoveOnly v = map.take(i);
+        EXPECT_EQ(v.value(), i * 100);
+    }
+
+    EXPECT_TRUE(map.isEmpty());
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+}
+
+// --- remove(iterator) tests ---
+
+TEST(WTF_InlineMap, RemoveIteratorInlineMode)
+{
+    // Removing via iterator in inline mode removes the entry and keeps others intact.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    map.add(1, 100);
+    map.add(2, 200);
+    map.add(3, 300);
+
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    auto it = map.find(2);
+    EXPECT_FALSE(it == map.end());
+    EXPECT_TRUE(map.remove(it));
+
+    EXPECT_EQ(map.size(), 2u);
+    EXPECT_FALSE(map.contains(2));
+    EXPECT_TRUE(map.contains(1));
+    EXPECT_EQ(map.find(1)->value, 100u);
+    EXPECT_TRUE(map.contains(3));
+    EXPECT_EQ(map.find(3)->value, 300u);
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+}
+
+TEST(WTF_InlineMap, RemoveIteratorHashedMode)
+{
+    // Removing via iterator in hashed mode removes the entry and keeps others intact.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    for (unsigned i = 1; i <= 20; ++i)
+        map.add(i, i * 10);
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+    EXPECT_EQ(map.size(), 20u);
+
+    auto it = map.find(10);
+    EXPECT_FALSE(it == map.end());
+    EXPECT_TRUE(map.remove(it));
+
+    EXPECT_EQ(map.size(), 19u);
+    EXPECT_FALSE(map.contains(10));
+
+    // Other entries unaffected
+    for (unsigned i = 1; i <= 20; ++i) {
+        if (i == 10)
+            continue;
+        EXPECT_TRUE(map.contains(i));
+        EXPECT_EQ(map.find(i)->value, i * 10);
+    }
+}
+
+TEST(WTF_InlineMap, RemoveEndIteratorReturnsFalse)
+{
+    // Removing via end() iterator returns false and does not modify the map.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    map.add(1, 100);
+    map.add(2, 200);
+
+    EXPECT_FALSE(map.remove(map.end()));
+    EXPECT_EQ(map.size(), 2u);
+    EXPECT_TRUE(map.contains(1));
+    EXPECT_TRUE(map.contains(2));
+
+    // Also test with an empty map
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> emptyMap;
+    EXPECT_FALSE(emptyMap.remove(emptyMap.end()));
+    EXPECT_TRUE(emptyMap.isEmpty());
+}
+
+TEST(WTF_InlineMap, RemoveIteratorFirstEntryInline)
+{
+    // Removing the first entry via iterator in inline mode uses swap-with-last compaction.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    map.add(1, 100);
+    map.add(2, 200);
+    map.add(3, 300);
+
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    // Find and remove the first entry (key 1)
+    auto it = map.find(1);
+    EXPECT_FALSE(it == map.end());
+    EXPECT_TRUE(map.remove(it));
+
+    EXPECT_EQ(map.size(), 2u);
+    EXPECT_FALSE(map.contains(1));
+    EXPECT_TRUE(map.contains(2));
+    EXPECT_EQ(map.find(2)->value, 200u);
+    EXPECT_TRUE(map.contains(3));
+    EXPECT_EQ(map.find(3)->value, 300u);
+}
+
+TEST(WTF_InlineMap, RemoveIteratorLastEntryInline)
+{
+    // Removing the last entry via iterator in inline mode works without swap.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    map.add(1, 100);
+    map.add(2, 200);
+    map.add(3, 300);
+
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    // Remove the last inline entry (key 3, which is at index 2)
+    auto it = map.find(3);
+    EXPECT_FALSE(it == map.end());
+    EXPECT_TRUE(map.remove(it));
+
+    EXPECT_EQ(map.size(), 2u);
+    EXPECT_FALSE(map.contains(3));
+    EXPECT_TRUE(map.contains(1));
+    EXPECT_EQ(map.find(1)->value, 100u);
+    EXPECT_TRUE(map.contains(2));
+    EXPECT_EQ(map.find(2)->value, 200u);
+}
+
+TEST(WTF_InlineMap, RemoveIteratorMiddleEntryInline)
+{
+    // Removing a middle entry via iterator in inline mode compacts correctly.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    map.add(10, 1000);
+    map.add(20, 2000);
+    map.add(30, 3000);
+    map.add(40, 4000);
+    map.add(50, 5000);
+
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    // Remove the middle entry (key 30)
+    auto it = map.find(30);
+    EXPECT_FALSE(it == map.end());
+    EXPECT_TRUE(map.remove(it));
+
+    EXPECT_EQ(map.size(), 4u);
+    EXPECT_FALSE(map.contains(30));
+    EXPECT_TRUE(map.contains(10));
+    EXPECT_EQ(map.find(10)->value, 1000u);
+    EXPECT_TRUE(map.contains(20));
+    EXPECT_EQ(map.find(20)->value, 2000u);
+    EXPECT_TRUE(map.contains(40));
+    EXPECT_EQ(map.find(40)->value, 4000u);
+    EXPECT_TRUE(map.contains(50));
+    EXPECT_EQ(map.find(50)->value, 5000u);
+}
+
+TEST(WTF_InlineMap, RemoveIteratorSoleEntryInline)
+{
+    // Removing the sole entry via iterator leaves the map empty and still usable.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    map.add(42, 420);
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    auto it = map.find(42);
+    EXPECT_FALSE(it == map.end());
+    EXPECT_TRUE(map.remove(it));
+
+    EXPECT_TRUE(map.isEmpty());
+    EXPECT_EQ(map.size(), 0u);
+    EXPECT_FALSE(map.contains(42));
+
+    // Map should still be usable
+    map.add(99, 990);
+    EXPECT_EQ(map.size(), 1u);
+    EXPECT_TRUE(map.contains(99));
+}
+
+// --- take(iterator) tests ---
+
+TEST(WTF_InlineMap, TakeIteratorInlineMode)
+{
+    // take(iterator) in inline mode returns the value and removes the entry.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    map.add(1, 100);
+    map.add(2, 200);
+    map.add(3, 300);
+
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    auto it = map.find(2);
+    EXPECT_FALSE(it == map.end());
+    unsigned value = map.take(it);
+
+    EXPECT_EQ(value, 200u);
+    EXPECT_EQ(map.size(), 2u);
+    EXPECT_FALSE(map.contains(2));
+    EXPECT_TRUE(map.contains(1));
+    EXPECT_EQ(map.find(1)->value, 100u);
+    EXPECT_TRUE(map.contains(3));
+    EXPECT_EQ(map.find(3)->value, 300u);
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+}
+
+TEST(WTF_InlineMap, TakeIteratorHashedMode)
+{
+    // take(iterator) in hashed mode returns the value and removes the entry.
+    InlineMap<unsigned, unsigned, 3, IntHash<unsigned>> map;
+
+    for (unsigned i = 1; i <= 10; ++i)
+        map.add(i, i * 10);
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    auto it = map.find(7);
+    EXPECT_FALSE(it == map.end());
+    unsigned value = map.take(it);
+
+    EXPECT_EQ(value, 70u);
+    EXPECT_EQ(map.size(), 9u);
+    EXPECT_FALSE(map.contains(7));
+
+    // Other entries unaffected
+    for (unsigned i = 1; i <= 10; ++i) {
+        if (i == 7)
+            continue;
+        EXPECT_TRUE(map.contains(i));
+        EXPECT_EQ(map.find(i)->value, i * 10);
+    }
+}
+
+TEST(WTF_InlineMap, TakeEndIteratorReturnsDefault)
+{
+    // take(end()) returns the default/empty value and does not modify the map.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    map.add(1, 100);
+    map.add(2, 200);
+
+    unsigned value = map.take(map.end());
+    EXPECT_EQ(value, 0u);
+    EXPECT_EQ(map.size(), 2u);
+    EXPECT_TRUE(map.contains(1));
+    EXPECT_TRUE(map.contains(2));
+
+    // Also test with an empty map
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> emptyMap;
+    value = emptyMap.take(emptyMap.end());
+    EXPECT_EQ(value, 0u);
+    EXPECT_TRUE(emptyMap.isEmpty());
+}
+
+TEST(WTF_InlineMap, TakeIteratorWithMoveOnlyValues)
+{
+    // take(iterator) works correctly with move-only value types.
+    InlineMap<unsigned, MoveOnly, 5, IntHash<unsigned>> map;
+
+    map.add(1, MoveOnly(10));
+    map.add(2, MoveOnly(20));
+    map.add(3, MoveOnly(30));
+
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    auto it = map.find(2);
+    EXPECT_FALSE(it == map.end());
+    MoveOnly taken = map.take(it);
+
+    EXPECT_EQ(taken.value(), 20u);
+    EXPECT_EQ(map.size(), 2u);
+    EXPECT_FALSE(map.contains(2));
+    EXPECT_EQ(map.find(1)->value.value(), 10u);
+    EXPECT_EQ(map.find(3)->value.value(), 30u);
+
+    // take(end()) returns default MoveOnly (value 0)
+    MoveOnly missing = map.take(map.end());
+    EXPECT_EQ(missing.value(), 0u);
+    EXPECT_EQ(map.size(), 2u);
+}
+
+TEST(WTF_InlineMap, TakeIteratorTriggersShrinkToInline)
+{
+    // Repeatedly calling take(iterator) on a hashed map can trigger shrink back to inline.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    for (unsigned i = 1; i <= 20; ++i)
+        map.add(i, i * 10);
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+    EXPECT_EQ(map.size(), 20u);
+
+    // Take entries one by one via iterator until the map shrinks to inline.
+    bool becameInline = false;
+    for (unsigned i = 1; i <= 15; ++i) {
+        auto it = map.find(i);
+        EXPECT_FALSE(it == map.end());
+        unsigned value = map.take(it);
+        EXPECT_EQ(value, i * 10);
+        if (!becameInline && WTF::InlineMapAccessForTesting::isInline(map))
+            becameInline = true;
+    }
+
+    EXPECT_TRUE(becameInline);
+    EXPECT_EQ(map.size(), 5u);
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    // Remaining entries (16-20) are accessible
+    for (unsigned i = 16; i <= 20; ++i) {
+        EXPECT_TRUE(map.contains(i));
+        EXPECT_EQ(map.find(i)->value, i * 10);
+    }
+
+    // Taken entries are gone
+    for (unsigned i = 1; i <= 15; ++i)
+        EXPECT_FALSE(map.contains(i));
+}
+
+TEST(WTF_InlineMap, TakeIteratorWithMoveOnlyInHashedMode)
+{
+    // take(iterator) works with move-only values in hashed mode.
+    InlineMap<unsigned, MoveOnly, 3, IntHash<unsigned>> map;
+
+    for (unsigned i = 1; i <= 10; ++i)
+        map.add(i, MoveOnly(i * 100));
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    auto it = map.find(5);
+    EXPECT_FALSE(it == map.end());
+    MoveOnly taken = map.take(it);
+    EXPECT_EQ(taken.value(), 500u);
+    EXPECT_EQ(map.size(), 9u);
+    EXPECT_FALSE(map.contains(5));
+
+    // Take all remaining entries via iterator
+    for (unsigned i = 1; i <= 10; ++i) {
+        if (i == 5)
+            continue;
+        it = map.find(i);
+        EXPECT_FALSE(it == map.end());
+        MoveOnly v = map.take(it);
+        EXPECT_EQ(v.value(), i * 100);
+    }
+
+    EXPECT_TRUE(map.isEmpty());
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+}
+
+TEST(WTF_InlineMap, TakeIteratorLastEntryInline)
+{
+    // Taking the last inline entry (slot == lastEntry) exercises the no-swap path.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    map.add(1, 100);
+    map.add(2, 200);
+    map.add(3, 300);
+
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    // Key 3 is the last entry in inline storage (index 2)
+    auto it = map.find(3);
+    EXPECT_FALSE(it == map.end());
+    unsigned value = map.take(it);
+
+    EXPECT_EQ(value, 300u);
+    EXPECT_EQ(map.size(), 2u);
+    EXPECT_FALSE(map.contains(3));
+    EXPECT_TRUE(map.contains(1));
+    EXPECT_EQ(map.find(1)->value, 100u);
+    EXPECT_TRUE(map.contains(2));
+    EXPECT_EQ(map.find(2)->value, 200u);
+}
+
+TEST(WTF_InlineMap, TakeIteratorSoleEntryInline)
+{
+    // Taking the only entry leaves the map empty and still usable.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    map.add(42, 420);
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    auto it = map.find(42);
+    EXPECT_FALSE(it == map.end());
+    unsigned value = map.take(it);
+
+    EXPECT_EQ(value, 420u);
+    EXPECT_TRUE(map.isEmpty());
+    EXPECT_EQ(map.size(), 0u);
+    EXPECT_FALSE(map.contains(42));
+
+    // Map should still be usable after being emptied
+    map.add(99, 990);
+    EXPECT_EQ(map.size(), 1u);
+    EXPECT_EQ(map.find(99)->value, 990u);
+}
+
+TEST(WTF_InlineMap, TakeIteratorExactTransitionToInline)
+{
+    // A single take(iterator) crosses the shrink threshold and transitions
+    // the map from hashed back to inline. Verify all surviving entries.
+    // With InlineCapacity=4, 5 entries transition to hashed capacity 16.
+    // shouldShrink() fires when m_size * 6 < 16, i.e. m_size <= 2.
+    InlineMap<unsigned, unsigned, 4, IntHash<unsigned>> map;
+
+    for (unsigned i = 1; i <= 5; ++i)
+        map.add(i, i * 10);
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+    EXPECT_EQ(map.size(), 5u);
+
+    // Remove entries until one more take will cross the shrink threshold
+    map.remove(1); // size -> 4
+    map.remove(2); // size -> 3
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    // This take brings size to 2; 2*6=12 < 16 triggers shrink,
+    // and 2 <= InlineCapacity=4 triggers transition to inline
+    auto it = map.find(3);
+    EXPECT_FALSE(it == map.end());
+    unsigned value = map.take(it);
+
+    EXPECT_EQ(value, 30u);
+    EXPECT_EQ(map.size(), 2u);
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    // All surviving entries accessible
+    EXPECT_FALSE(map.contains(1));
+    EXPECT_FALSE(map.contains(2));
+    EXPECT_FALSE(map.contains(3));
+    EXPECT_TRUE(map.contains(4));
+    EXPECT_EQ(map.find(4)->value, 40u);
+    EXPECT_TRUE(map.contains(5));
+    EXPECT_EQ(map.find(5)->value, 50u);
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### d8d5cb3aaebdc83bf0fc8831c00f92d4a09a9e2e
<pre>
[JSC] Fix custom key trait treatment in InlineMap and add .take()
<a href="https://bugs.webkit.org/show_bug.cgi?id=311155">https://bugs.webkit.org/show_bug.cgi?id=311155</a>
<a href="https://rdar.apple.com/173741706">rdar://173741706</a>

Reviewed by Yusuke Suzuki.

The existing implementation of InlineMap uses HashTraits&lt;KeyType&gt; instead of KeyTraits in
isEmptyKey() and isDeletedEntry() methods. That is in general incorrect when KeyTraitsArg
has a non-default value. This bug is not an immediate problem because the only existing
usage of InlineMap in VariableEnvironment uses the default KeyTraits, but it should be
fixed.

This patch changes the methods to use the correct type parameter. It also adds
InlineMap::take() to make it a little more like UncheckedKeyHashMap, and
iterator-accepting overloads of .take() and .remove().

Tests: Tools/TestWebKitAPI/Tests/WTF/InlineMap.cpp -- a regression test for the trait
issue and unit tests for the added APIs.

* Source/WTF/wtf/InlineMap.h:
* Tools/TestWebKitAPI/Tests/WTF/InlineMap.cpp:

Canonical link: <a href="https://commits.webkit.org/310324@main">https://commits.webkit.org/310324@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32d3598ea2128ab51a7f174f2c01092a4e59ffd1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153354 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26138 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19737 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162099 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106812 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f93f39e7-6ac6-4790-891a-b736233d2ebe) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155227 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26664 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26458 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118559 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83950 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9b8a1b90-57ed-44db-b873-37116e5eea4b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156313 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20798 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137675 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99271 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/259ea87b-6798-484b-b9b9-a0ccdaf167f5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19875 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17820 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9934 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/145367 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129522 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15545 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164573 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/14174 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7709 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17139 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126619 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25934 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21853 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126776 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34414 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25937 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137341 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82604 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21715 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14119 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184989 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25554 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89840 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47374 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25245 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25404 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25305 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->