### PR TITLE
Potential bug in table border code caught in code review

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-sideways-rl-rtl-overflow-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-sideways-rl-rtl-overflow-expected.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>Collapsed border overflow in sideways-rl RTL composited table (reference)</title>
+<link rel="help" href="https://drafts.csswg.org/css-tables/#border-collapsing">
+<style>
+body { margin: 60px; }
+div { display: inline-block; }
+table {
+    writing-mode: sideways-rl;
+    direction: rtl;
+    border-collapse: collapse;
+    border: none;
+}
+td {
+    width: 40px;
+    height: 40px;
+    padding: 5px;
+}
+.thin td { border: 2px solid blue; }
+.thick td { border: 40px solid orange; }
+</style>
+<div>
+    <table>
+        <tr class="thin"><td></td><td></td></tr>
+        <tr class="thick"><td></td><td></td></tr>
+    </table>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-sideways-rl-rtl-overflow-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-sideways-rl-rtl-overflow-ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>Collapsed border overflow in sideways-rl RTL composited table (reference)</title>
+<link rel="help" href="https://drafts.csswg.org/css-tables/#border-collapsing">
+<style>
+body { margin: 60px; }
+div { display: inline-block; }
+table {
+    writing-mode: sideways-rl;
+    direction: rtl;
+    border-collapse: collapse;
+    border: none;
+}
+td {
+    width: 40px;
+    height: 40px;
+    padding: 5px;
+}
+.thin td { border: 2px solid blue; }
+.thick td { border: 40px solid orange; }
+</style>
+<div>
+    <table>
+        <tr class="thin"><td></td><td></td></tr>
+        <tr class="thick"><td></td><td></td></tr>
+    </table>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-sideways-rl-rtl-overflow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-sideways-rl-rtl-overflow.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>Collapsed border overflow in sideways-rl RTL composited table</title>
+<link rel="help" href="https://drafts.csswg.org/css-tables/#border-collapsing">
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=311117">
+<link rel="match" href="collapsed-border-sideways-rl-rtl-overflow-ref.html">
+<style>
+body { margin: 60px; }
+div { display: inline-block; }
+table {
+    writing-mode: sideways-rl;
+    direction: rtl;
+    border-collapse: collapse;
+    border: none;
+    will-change: transform;
+}
+td {
+    width: 40px;
+    height: 40px;
+    padding: 5px;
+}
+.thin td { border: 2px solid blue; }
+.thick td { border: 40px solid orange; }
+</style>
+<div>
+    <table>
+        <tr class="thin"><td></td><td></td></tr>
+        <tr class="thick"><td></td><td></td></tr>
+    </table>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-vertical-lr-rtl-overflow-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-vertical-lr-rtl-overflow-expected.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>Collapsed border overflow in vertical-lr RTL composited table (reference)</title>
+<link rel="help" href="https://drafts.csswg.org/css-tables/#border-collapsing">
+<style>
+body { margin: 60px; }
+div { display: inline-block; }
+table {
+    writing-mode: vertical-lr;
+    direction: rtl;
+    border-collapse: collapse;
+    border: none;
+}
+td {
+    width: 40px;
+    height: 40px;
+    padding: 5px;
+}
+.thin td { border: 2px solid blue; }
+.thick td { border: 40px solid orange; }
+</style>
+<div>
+    <table>
+        <tr class="thin"><td></td><td></td></tr>
+        <tr class="thick"><td></td><td></td></tr>
+    </table>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-vertical-lr-rtl-overflow-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-vertical-lr-rtl-overflow-ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>Collapsed border overflow in vertical-lr RTL composited table (reference)</title>
+<link rel="help" href="https://drafts.csswg.org/css-tables/#border-collapsing">
+<style>
+body { margin: 60px; }
+div { display: inline-block; }
+table {
+    writing-mode: vertical-lr;
+    direction: rtl;
+    border-collapse: collapse;
+    border: none;
+}
+td {
+    width: 40px;
+    height: 40px;
+    padding: 5px;
+}
+.thin td { border: 2px solid blue; }
+.thick td { border: 40px solid orange; }
+</style>
+<div>
+    <table>
+        <tr class="thin"><td></td><td></td></tr>
+        <tr class="thick"><td></td><td></td></tr>
+    </table>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-vertical-lr-rtl-overflow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-vertical-lr-rtl-overflow.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>Collapsed border overflow in vertical-lr RTL composited table</title>
+<link rel="help" href="https://drafts.csswg.org/css-tables/#border-collapsing">
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=311117">
+<link rel="match" href="collapsed-border-vertical-lr-rtl-overflow-ref.html">
+<style>
+body { margin: 60px; }
+div { display: inline-block; }
+table {
+    writing-mode: vertical-lr;
+    direction: rtl;
+    border-collapse: collapse;
+    border: none;
+    will-change: transform;
+}
+td {
+    width: 40px;
+    height: 40px;
+    padding: 5px;
+}
+.thin td { border: 2px solid blue; }
+.thick td { border: 40px solid orange; }
+</style>
+<div>
+    <table>
+        <tr class="thin"><td></td><td></td></tr>
+        <tr class="thick"><td></td><td></td></tr>
+    </table>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-vertical-rtl-overflow-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-vertical-rtl-overflow-expected.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>Collapsed border overflow in vertical-rl RTL composited table (reference)</title>
+<link rel="help" href="https://drafts.csswg.org/css-tables/#border-collapsing">
+<style>
+body { margin: 60px; }
+div { display: inline-block; }
+table {
+    writing-mode: vertical-rl;
+    direction: rtl;
+    border-collapse: collapse;
+    border: none;
+}
+td {
+    width: 40px;
+    height: 40px;
+    padding: 5px;
+}
+.thin td { border: 2px solid blue; }
+.thick td { border: 40px solid orange; }
+</style>
+<div>
+    <table>
+        <tr class="thin"><td></td><td></td></tr>
+        <tr class="thick"><td></td><td></td></tr>
+    </table>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-vertical-rtl-overflow-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-vertical-rtl-overflow-ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>Collapsed border overflow in vertical-rl RTL composited table (reference)</title>
+<link rel="help" href="https://drafts.csswg.org/css-tables/#border-collapsing">
+<style>
+body { margin: 60px; }
+div { display: inline-block; }
+table {
+    writing-mode: vertical-rl;
+    direction: rtl;
+    border-collapse: collapse;
+    border: none;
+}
+td {
+    width: 40px;
+    height: 40px;
+    padding: 5px;
+}
+.thin td { border: 2px solid blue; }
+.thick td { border: 40px solid orange; }
+</style>
+<div>
+    <table>
+        <tr class="thin"><td></td><td></td></tr>
+        <tr class="thick"><td></td><td></td></tr>
+    </table>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-vertical-rtl-overflow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-vertical-rtl-overflow.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>Collapsed border overflow in vertical-rl RTL composited table</title>
+<link rel="help" href="https://drafts.csswg.org/css-tables/#border-collapsing">
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=311117">
+<link rel="match" href="collapsed-border-vertical-rtl-overflow-ref.html">
+<style>
+body { margin: 60px; }
+div { display: inline-block; }
+table {
+    writing-mode: vertical-rl;
+    direction: rtl;
+    border-collapse: collapse;
+    border: none;
+    will-change: transform;
+}
+td {
+    width: 40px;
+    height: 40px;
+    padding: 5px;
+}
+.thin td { border: 2px solid blue; }
+.thick td { border: 40px solid orange; }
+</style>
+<div>
+    <table>
+        <tr class="thin"><td></td><td></td></tr>
+        <tr class="thick"><td></td><td></td></tr>
+    </table>
+</div>

--- a/Source/WebCore/rendering/RenderTableInlines.h
+++ b/Source/WebCore/rendering/RenderTableInlines.h
@@ -149,7 +149,7 @@ inline LayoutUnit RenderTable::outerBorderTop() const
 {
     if (writingMode().isHorizontal())
         return writingMode().isBlockTopToBottom() ? outerBorderBefore() : outerBorderAfter();
-    return writingMode().isInlineTopToBottom() ? outerBorderStart() : borderEnd();
+    return writingMode().isInlineTopToBottom() ? outerBorderStart() : outerBorderEnd();
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 6885c2bcb70b722d63467aba2b7ac15b30331f4c
<pre>
Potential bug in table border code caught in code review
<a href="https://bugs.webkit.org/show_bug.cgi?id=311117">https://bugs.webkit.org/show_bug.cgi?id=311117</a>
<a href="https://rdar.apple.com/173742600">rdar://173742600</a>

Reviewed by Brent Fulgham.

In the vertical writing mode path of outerBorderTop(), when
isInlineTopToBottom() is false (vertical-rl + direction:rtl),
borderEnd() was used instead of outerBorderEnd(). This is
inconsistent with outerBorderBottom(), outerBorderLeft(), and
outerBorderRight(), which all exclusively use outerBorder*() calls.

<a href="https://www.w3.org/TR/CSS22/tables.html#collapsing-borders">https://www.w3.org/TR/CSS22/tables.html#collapsing-borders</a>
Per CSS 2.2 §17.6.2, borderEnd() computes the initial inline-end
border width from the first row only. outerBorderEnd() accounts
for subsequent rows with larger borders whose excess &quot;spills into
the margin area of the table&quot; and must be &quot;taken into account when
determining if the table overflows some ancestor.&quot;

borderEnd() = the spec&apos;s &quot;initial left and right border width&quot; computed
from the first row only:
    &quot;UAs must compute an initial left and right border width for the
    table by examining the first and last cells in the first row of
    the table.&quot;

outerBorderEnd() = the full extent including the &quot;spill&quot; from subsequent
rows, needed for overflow:
    &quot;If subsequent rows have larger collapsed left and right borders,
    then any excess spills into the margin area of the table.&quot;

And:
    &quot;Any borders that spill into the margin are taken into account when
    determining if the table overflows some ancestor (see &apos;overflow&apos;).&quot;

Using borderEnd() instead of outerBorderEnd() causes the visual
overflow rect to be too small at the physical top, under-reporting
the border spill from later rows with thicker borders.

Test: css/css-tables/collapsed-border-vertical-rtl-overflow.html
      css/css-tables/collapsed-border-sideways-rl-rtl-overflow.html
      css/css-tables/collapsed-border-vertical-lr-rtl-overflow.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-sideways-rl-rtl-overflow-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-sideways-rl-rtl-overflow-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-sideways-rl-rtl-overflow.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-vertical-lr-rtl-overflow-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-vertical-lr-rtl-overflow-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-vertical-lr-rtl-overflow.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-vertical-rtl-overflow-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-vertical-rtl-overflow-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-vertical-rtl-overflow.html: Added.
* Source/WebCore/rendering/RenderTableInlines.h:
(WebCore::RenderTable::outerBorderTop const):

Canonical link: <a href="https://commits.webkit.org/310404@main">https://commits.webkit.org/310404@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b663de3e27de496eacb0f4b24a648633be0567cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153623 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26407 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20024 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162373 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107081 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0372aca6-a926-42b9-806b-d3ec2f9a9783) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155496 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26935 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26729 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118771 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84022 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/97b52386-d95a-4056-ac9f-3969241fa1f7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156582 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21031 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137934 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99482 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b74381df-b786-445c-928e-c0c965cc574a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20110 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18049 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10206 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129758 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15793 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164844 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7978 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17387 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126847 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26204 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22083 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127017 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26206 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137588 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82874 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23496 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21930 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14369 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25823 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90110 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25514 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25674 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25574 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->