### PR TITLE
Fix incorrect assertion in PackedAlignedPtr::set()

### DIFF
--- a/Source/WTF/wtf/Packed.h
+++ b/Source/WTF/wtf/Packed.h
@@ -180,7 +180,7 @@ public:
 #else
         memcpySpan(std::span { m_storage }, asByteSpan(value).last(storageSize));
 #endif
-        ASSERT(std::bit_cast<uintptr_t>(get()) == value);
+        ASSERT(get() == passedValue);
     }
 
     void clear()

--- a/Tools/TestWebKitAPI/Tests/WTF/Packed.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Packed.cpp
@@ -109,6 +109,22 @@ TEST(WTF_Packed, PackedAlignedPtr)
     }
 }
 
+TEST(WTF_Packed, PackedAlignedPtrSetNonNull)
+{
+    {
+        PackedAlignedPtr<PackableUint8, 256> ptr;
+        auto* testValue = std::bit_cast<PackableUint8*>(static_cast<uintptr_t>(256));
+        ptr.set(testValue);
+        EXPECT_EQ(ptr.get(), testValue);
+    }
+    {
+        PackedAlignedPtr<PackableUint8, 256> ptr;
+        auto* testValue = std::bit_cast<PackableUint8*>(static_cast<uintptr_t>(256 * 1024));
+        ptr.set(testValue);
+        EXPECT_EQ(ptr.get(), testValue);
+    }
+}
+
 struct PackingTarget {
     WTF_ALLOW_STRUCT_COMPACT_POINTERS;
     unsigned m_value { 0 };


### PR DESCRIPTION
#### 7950fcce4298d4a21cb4eb6abcf5b1eb8870db17
<pre>
Fix incorrect assertion in PackedAlignedPtr::set()
<a href="https://bugs.webkit.org/show_bug.cgi?id=311158">https://bugs.webkit.org/show_bug.cgi?id=311158</a>

Reviewed by Geoffrey Garen.

The ASSERT in set() compared the round-tripped pointer from get() against
the locally shifted value, which is always wrong when the alignment shift
is profitable and the pointer is non-null. For example, with alignment=256
and pointer 0x1000, it compared get()&apos;s result 0x1000 against the shifted
value 0x10.

This hasn&apos;t been caught because the only production use of PackedAlignedPtr
with an explicit alignment is PackedCellPtr&lt;T, 8&gt;, where the 3-bit shift
never reduces storage size on current platforms, so isAlignmentShiftProfitable
is false and the shift codepath is dead. Existing tests only use nullptr with
high-alignment PackedAlignedPtrs.

Fix by comparing get() against the original passedValue, and add a test
exercising set()/get() with non-null pointers on a PackedAlignedPtr with
a profitable alignment shift.

Test: Tools/TestWebKitAPI/Tests/WTF/Packed.cpp

* Source/WTF/wtf/Packed.h:
(WTF::PackedAlignedPtr::set):
* Tools/TestWebKitAPI/Tests/WTF/Packed.cpp:
(TestWebKitAPI::TEST(WTF_Packed, PackedAlignedPtrSetNonNull)):

Canonical link: <a href="https://commits.webkit.org/310340@main">https://commits.webkit.org/310340@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1619e546f868d428c9535aec0d206a2386339590

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153361 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26145 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19744 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162106 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106819 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155234 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26671 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26465 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118561 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83952 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156320 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20804 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137682 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99273 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19881 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17827 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9941 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/145374 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129528 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15552 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164580 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/14181 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7716 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17146 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126623 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25941 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21860 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/semantics/structured-clone/shared.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126780 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34427 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25944 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137348 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82611 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21718 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14126 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184996 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25561 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89847 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47376 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25252 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25411 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25312 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->