### PR TITLE
Resync `html/infrastructure/safe-passing-of-structured-data` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/WEB_FEATURES.yml
@@ -1,0 +1,12 @@
+features:
+- name: channel-messaging
+  files:
+  - messagechannel.any.js
+  - transfer-errors.window.js
+- name: postmessage
+  files:
+  - cross-origin-transfer-resizable-arraybuffer.html
+  - structured-cloning-error-extra.html
+  - structured-cloning-error-stack-optional.sub.window.js
+  - structuredclone_0.html
+  - window-postmessage.window.js

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/cross-origin-transfer-resizable-arraybuffer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/cross-origin-transfer-resizable-arraybuffer-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS postMessaging resizable ArrayBuffer to OOPIF
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/cross-origin-transfer-resizable-arraybuffer.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/cross-origin-transfer-resizable-arraybuffer.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<title>postMessage transfer ArrayBuffer cross origin iframe</title>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+<script src='/common/get-host-info.sub.js'></script>
+
+<script>
+
+async_test(t => {
+  const oopif = document.createElement('iframe');
+
+  window.addEventListener('message', t.step_func((e) => {
+    if (e.data === 'started') {
+      const rab = new ArrayBuffer(32, { maxByteLength: 1024 });
+      oopif.contentWindow.postMessage(rab, '*', [rab]);
+    } else {
+      assert_equals(e.data, 'byteLength=32,maxByteLength=1024,resizable=true');
+      t.done();
+    }
+  }));
+
+  window.addEventListener('load', () => {
+    oopif.src = `${get_host_info().HTTP_REMOTE_ORIGIN}/html/infrastructure/safe-passing-of-structured-data/resources/iframe-resizable-arraybuffer-helper.html`;
+    document.body.appendChild(oopif);
+  });
+}, 'postMessaging resizable ArrayBuffer to OOPIF');
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any-expected.txt
@@ -132,7 +132,7 @@ PASS Serializing a non-serializable platform object fails
 PASS An object whose interface is deleted from the global must still deserialize
 PASS A subclass instance will deserialize as its closest serializable superclass
 PASS Resizable ArrayBuffer
-FAIL Growable SharedArrayBuffer promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: createBuffer"
+FAIL Growable SharedArrayBuffer assert_true: instanceof ArrayBuffer expected true got false
 PASS Length-tracking TypedArray
 PASS Length-tracking DataView
 PASS Serializing OOB TypedArray throws

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.js
@@ -1,4 +1,5 @@
 // META: global=window,worker
+// META: script=/common/sab.js
 // META: script=/html/webappapis/structured-clone/structured-clone-battery-of-tests.js
 // META: script=/html/webappapis/structured-clone/structured-clone-battery-of-tests-with-transferables.js
 // META: script=/html/webappapis/structured-clone/structured-clone-battery-of-tests-harness.js

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.serviceworker-expected.txt
@@ -117,7 +117,7 @@ PASS Serializing a non-serializable platform object fails
 PASS An object whose interface is deleted from the global must still deserialize
 PASS A subclass instance will deserialize as its closest serializable superclass
 PASS Resizable ArrayBuffer
-FAIL Growable SharedArrayBuffer promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: createBuffer"
+FAIL Growable SharedArrayBuffer assert_true: instanceof ArrayBuffer expected true got false
 PASS Length-tracking TypedArray
 PASS Length-tracking DataView
 PASS Serializing OOB TypedArray throws

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.sharedworker-expected.txt
@@ -117,7 +117,7 @@ PASS Serializing a non-serializable platform object fails
 PASS An object whose interface is deleted from the global must still deserialize
 PASS A subclass instance will deserialize as its closest serializable superclass
 PASS Resizable ArrayBuffer
-FAIL Growable SharedArrayBuffer promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: createBuffer"
+FAIL Growable SharedArrayBuffer assert_true: instanceof ArrayBuffer expected true got false
 PASS Length-tracking TypedArray
 PASS Length-tracking DataView
 PASS Serializing OOB TypedArray throws

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.worker-expected.txt
@@ -117,7 +117,7 @@ PASS Serializing a non-serializable platform object fails
 PASS An object whose interface is deleted from the global must still deserialize
 PASS A subclass instance will deserialize as its closest serializable superclass
 PASS Resizable ArrayBuffer
-FAIL Growable SharedArrayBuffer promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: createBuffer"
+FAIL Growable SharedArrayBuffer assert_true: instanceof ArrayBuffer expected true got false
 PASS Length-tracking TypedArray
 PASS Length-tracking DataView
 PASS Serializing OOB TypedArray throws

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/resources/iframe-resizable-arraybuffer-helper.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/resources/iframe-resizable-arraybuffer-helper.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<script>
+
+window.addEventListener('message', (e) => {
+  const buffer = e.data;
+  e.source.postMessage(`byteLength=${buffer.byteLength},maxByteLength=${buffer.maxByteLength},resizable=${buffer.resizable}`, '*');
+});
+
+window.parent.postMessage('started', '*');
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/resources/w3c-import.log
@@ -18,4 +18,5 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/resources/echo-iframe.html.headers
 /LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/resources/echo-worker.js
 /LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/resources/echo-worker.js.headers
+/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/resources/iframe-resizable-arraybuffer-helper.html
 /LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/resources/post-parent-type-error.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/WEB_FEATURES.yml
@@ -1,0 +1,17 @@
+features:
+- name: broadcast-channel
+  files:
+  - broadcastchannel-*
+- name: channel-messaging
+  files:
+  - window-messagechannel*
+  - window-*-messagechannel*
+- name: postmessage
+  files:
+  - blob-data.https.html
+  - identity-not-preserved.https.html
+  - no-coop-coep.https.any.js
+  - no-transferring.https.html
+  - window-serviceworker-failure.https.html
+  - window-sharedworker-failure.https.html
+  - window-simple-success.https.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/blob-data.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/blob-data.https-expected.txt
@@ -1,5 +1,4 @@
 
-
 Harness Error (TIMEOUT), message = null
 
 PASS blob frame: postMessaging to a dedicated HTTP sub-worker allows them to see each others' modifications
@@ -13,11 +12,11 @@ PASS data frame: self.crossOriginIsolated
 FAIL data frame: self.isSecureContext assert_true: expected true got false
 TIMEOUT data worker: postMessaging to a dedicated blob sub-worker allows them to see each others' modifications Test timed out
 PASS data worker: self.origin
-PASS blob worker: postMessaging to a dedicated HTTP sub-worker allows them to see each others' modifications
 FAIL data worker: self.crossOriginIsolated assert_equals: expected false but got true
+PASS data worker: self.isSecureContext
+PASS blob worker: postMessaging to a dedicated HTTP sub-worker allows them to see each others' modifications
 PASS blob worker: postMessaging to a dedicated blob sub-worker allows them to see each others' modifications
 PASS blob worker: self.origin
 PASS blob worker: self.crossOriginIsolated
-PASS data worker: self.isSecureContext
 PASS blob worker: self.isSecureContext
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/w3c-import.log
@@ -14,6 +14,7 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/blob-data.https.html
 /LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/blob-data.https.html.headers
 /LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/broadcastchannel-success-and-failure.https.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-simple-success.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-simple-success.https-expected.txt
@@ -9,6 +9,7 @@ PASS postMessaging to a dedicated worker allows them to see each others' modific
 PASS postMessaging to a dedicated worker allows them to see each others' modifications with Uint32Array
 PASS postMessaging to a dedicated worker allows them to see each others' modifications with BigInt64Array
 PASS postMessaging to a dedicated worker allows them to see each others' modifications with BigUint64Array
+PASS postMessaging to a dedicated worker allows them to see each others' modifications with Float16Array
 PASS postMessaging to a dedicated worker allows them to see each others' modifications with Float32Array
 PASS postMessaging to a dedicated worker allows them to see each others' modifications with Float64Array
 FAIL postMessaging to a same-origin iframe allows them to see each others' modifications assert_equals: The window must see changes made in the iframe expected 2 but got 1

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-simple-success.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-simple-success.https.html
@@ -23,6 +23,7 @@
   "Uint32Array",
   "BigInt64Array",
   "BigUint64Array",
+  "Float16Array",
   "Float32Array",
   "Float64Array"
 ].forEach(type => {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/structuredclone_0-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/structuredclone_0-expected.txt
@@ -40,4 +40,6 @@ PASS Error.message: getter is ignored when cloning
 PASS Error.message: undefined property is stringified
 PASS DOMException objects can be cloned
 PASS DOMException objects created by the UA can be cloned
+FAIL QuotaExceededError objects can be cloned Can't find variable: QuotaExceededError
+FAIL QuotaExceededError objects with empty quota/requested can be cloned Can't find variable: QuotaExceededError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/structuredclone_0.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/structuredclone_0.html
@@ -605,6 +605,42 @@
                     assert_unreached("Window must not be clonable");
                 });
             },
+            function() {
+                var t = async_test("QuotaExceededError objects can be cloned");
+                t.id = 41;
+                worker.onmessage = t.step_func_done(function(e) {
+                    assert_equals(Object.getPrototypeOf(e.data), QuotaExceededError.prototype, "Checking prototype");
+                    assert_equals(e.data.constructor, QuotaExceededError, "Checking constructor");
+                    assert_equals(e.data.name, "QuotaExceededError", "Checking name");
+                    assert_equals(e.data.message, "some message", "Checking message");
+                    assert_equals(e.data.code, DOMException.QUOTA_EXCEEDED_ERR, "Checking code");
+                    assert_equals(e.data.quota, 0.1, "Checking quota");
+                    assert_equals(e.data.requested, 1.0, "Checking requested");
+                    assert_equals(e.data.foo, undefined, "Checking custom property");
+                });
+                t.step(function() {
+                    const error = new QuotaExceededError(message = "some message", options = {quota: 0.1, requested: 1.0});
+                    worker.postMessage(error);
+                });
+            },
+            function() {
+                var t = async_test("QuotaExceededError objects with empty quota/requested can be cloned");
+                t.id = 42;
+                worker.onmessage = t.step_func_done(function(e) {
+                    assert_equals(Object.getPrototypeOf(e.data), QuotaExceededError.prototype, "Checking prototype");
+                    assert_equals(e.data.constructor, QuotaExceededError, "Checking constructor");
+                    assert_equals(e.data.name, "QuotaExceededError", "Checking name");
+                    assert_equals(e.data.message, "some message", "Checking message");
+                    assert_equals(e.data.code, DOMException.QUOTA_EXCEEDED_ERR, "Checking code");
+                    assert_equals(e.data.quota, null, "Checking quota");
+                    assert_equals(e.data.requested, null, "Checking requested");
+                    assert_equals(e.data.foo, undefined, "Checking custom property");
+                });
+                t.step(function() {
+                    const error = new QuotaExceededError(message = "some message");
+                    worker.postMessage(error);
+                });
+            },
         ];
     }, {explicit_done:true});
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/w3c-import.log
@@ -14,6 +14,8 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/WEB_FEATURES.yml
+/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/cross-origin-transfer-resizable-arraybuffer.html
 /LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.js
 /LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/structured-cloning-error-extra.html
 /LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/structured-cloning-error-stack-optional.sub.window.js

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/window-postmessage.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/window-postmessage.window-expected.txt
@@ -132,7 +132,7 @@ PASS Serializing a non-serializable platform object fails
 PASS An object whose interface is deleted from the global must still deserialize
 PASS A subclass instance will deserialize as its closest serializable superclass
 PASS Resizable ArrayBuffer
-FAIL Growable SharedArrayBuffer promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: createBuffer"
+FAIL Growable SharedArrayBuffer assert_true: instanceof ArrayBuffer expected true got false
 PASS Length-tracking TypedArray
 PASS Length-tracking DataView
 PASS Serializing OOB TypedArray throws

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/window-postmessage.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/window-postmessage.window.js
@@ -1,3 +1,4 @@
+// META: script=/common/sab.js
 // META: script=/html/webappapis/structured-clone/structured-clone-battery-of-tests.js
 // META: script=/html/webappapis/structured-clone/structured-clone-battery-of-tests-with-transferables.js
 // META: script=/html/webappapis/structured-clone/structured-clone-battery-of-tests-harness.js


### PR DESCRIPTION
#### e4e7f1a4ef414d57e2c31c941270ae80df8ba9c7
<pre>
Resync `html/infrastructure/safe-passing-of-structured-data` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=311160">https://bugs.webkit.org/show_bug.cgi?id=311160</a>
<a href="https://rdar.apple.com/173749854">rdar://173749854</a>

Reviewed by Vitor Roriz.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/77db2088f4d4d321751562bf2363bab1bbdbbc16">https://github.com/web-platform-tests/wpt/commit/77db2088f4d4d321751562bf2363bab1bbdbbc16</a>

* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/cross-origin-transfer-resizable-arraybuffer-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/cross-origin-transfer-resizable-arraybuffer.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.js:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/resources/iframe-resizable-arraybuffer-helper.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/resources/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/blob-data.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-simple-success.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-simple-success.https.html:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/structuredclone_0-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/structuredclone_0.html:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/window-postmessage.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/window-postmessage.window.js:

Canonical link: <a href="https://commits.webkit.org/310498@main">https://commits.webkit.org/310498@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1633c2461db1de3f8c5b58d1c7421b5f674d7b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153366 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26150 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19749 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162111 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106824 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26676 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26470 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118566 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83954 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156325 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20809 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137687 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99278 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19886 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17831 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9946 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129534 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15557 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164585 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17151 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126627 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25946 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/22484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126784 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34549 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25949 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137353 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82616 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21725 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14131 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25566 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25257 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25416 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25317 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->