### PR TITLE
SQLiteStatement::columnName() should not implicitly call step()

### DIFF
--- a/Source/WebCore/platform/sql/SQLiteStatement.cpp
+++ b/Source/WebCore/platform/sql/SQLiteStatement.cpp
@@ -193,10 +193,6 @@ bool SQLiteStatement::isColumnDeclaredAsBlob(int col)
 String SQLiteStatement::columnName(int col)
 {
     ASSERT(col >= 0);
-    if (!hasStartedStepping() && step() != SQLITE_ROW)
-        return String();
-    if (columnCount() <= col)
-        return String();
     return sqliteColumnName(m_statement, col);
 }
 

--- a/Source/WebCore/platform/sql/SQLiteStatement.h
+++ b/Source/WebCore/platform/sql/SQLiteStatement.h
@@ -60,13 +60,11 @@ public:
     WEBCORE_EXPORT int step();
     WEBCORE_EXPORT int reset();
     
-    // steps and finalizes the query.
-    // returns true if all 3 steps succeed with step() returning SQLITE_DONE
-    // returns false otherwise  
+    // Returns true if step() returns SQLITE_DONE, false otherwise.
     WEBCORE_EXPORT bool executeCommand();
 
-    // Returns -1 on last-step failing.  Otherwise, returns number of rows
-    // returned in the last step()
+    // Returns the number of columns in the current result row, or 0 if
+    // step() has not been called or did not return SQLITE_ROW.
     int columnCount();
 
     bool isReadOnly();


### PR DESCRIPTION
#### 276b2796c0f4380bb49bb45630e27431c6e5f1e9
<pre>
SQLiteStatement::columnName() should not implicitly call step()
<a href="https://bugs.webkit.org/show_bug.cgi?id=311165">https://bugs.webkit.org/show_bug.cgi?id=311165</a>

Reviewed by Sihui Liu.

columnName() was calling step() to get the first result row before
returning column metadata. This is unnecessary because
sqlite3_column_name() works on the prepared statement directly and
does not require step() to have been called. It also returns NULL
for out-of-range column indices [1], so the explicit bounds check is
not needed either.

Also fix stale comments on executeCommand() and columnCount().

[1] <a href="https://sqlite.org/forum/info/51f8700e486f2686#">https://sqlite.org/forum/info/51f8700e486f2686#</a>:~:text=(1)%20By%20Erlend%20E.,SQLite%20always%20makes%20up%20one.

* Source/WebCore/platform/sql/SQLiteStatement.cpp:
(WebCore::SQLiteStatement::columnName):
* Source/WebCore/platform/sql/SQLiteStatement.h:

Canonical link: <a href="https://commits.webkit.org/310342@main">https://commits.webkit.org/310342@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e92240b77da7534768d7498dee776c7cf2c4ee05

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153414 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26198 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19798 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162159 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106872 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c911a3aa-8237-453e-9d65-44cf1c6bfd23) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155287 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26724 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26518 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118605 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83972 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1442bcf0-3bcb-4ca5-83a5-86857b44ca53) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156373 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20849 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137729 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99316 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3ca0a825-777d-4d73-ac7f-0a0e3dbf0fbc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19927 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17871 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9994 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129574 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15599 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164633 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7769 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17193 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126666 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25995 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21905 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/semantics/structured-clone/shared.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126830 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34430 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25997 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137395 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82664 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21761 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14175 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25614 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89900 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25305 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25464 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25365 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->