### PR TITLE
[Navigation API] Refactor NavigationAPIMethodTracker for better encapsulation

### DIFF
--- a/Source/WebCore/loader/HistoryController.h
+++ b/Source/WebCore/loader/HistoryController.h
@@ -43,7 +43,7 @@ class SerializedScriptValue;
 enum class ShouldGoToHistoryItem : uint8_t;
 enum class ShouldTreatAsContinuingLoad : uint8_t;
 
-struct NavigationAPIMethodTracker;
+class NavigationAPIMethodTracker;
 struct StringWithDirection;
 
 class HistoryController final : public CanMakeWeakPtr<HistoryController>  {

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -75,6 +75,7 @@
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(Navigation);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(NavigationAPIMethodTracker);
 
 Ref<NavigationAPIMethodTracker> NavigationAPIMethodTracker::create(JSC::JSGlobalObject& globalObject, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, JSC::JSValue&& info, RefPtr<SerializedScriptValue>&& serializedState)
 {
@@ -82,11 +83,11 @@ Ref<NavigationAPIMethodTracker> NavigationAPIMethodTracker::create(JSC::JSGlobal
 }
 
 NavigationAPIMethodTracker::NavigationAPIMethodTracker(JSC::JSGlobalObject& globalObject, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, JSC::JSValue&& infoValue, RefPtr<SerializedScriptValue>&& serializedStateValue)
-    : info(globalObject, infoValue)
-    , serializedState(serializedStateValue)
-    , committedPromise(WTF::move(committed))
-    , finishedPromise(WTF::move(finished))
-    , identifier(NavigationAPIMethodTrackerIdentifier::generate())
+    : m_info(globalObject, infoValue)
+    , m_serializedState(serializedStateValue)
+    , m_committedPromise(WTF::move(committed))
+    , m_finishedPromise(WTF::move(finished))
+    , m_identifier(Identifier::generate())
 {
 }
 
@@ -345,43 +346,43 @@ ExceptionOr<RefPtr<SerializedScriptValue>> Navigation::serializeState(JSC::JSVal
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#maybe-set-the-upcoming-non-traverse-api-method-tracker
-RefPtr<NavigationAPIMethodTracker> Navigation::maybeSetUpcomingNonTraversalTracker(JSC::JSGlobalObject& globalObject, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, JSC::JSValue info, RefPtr<SerializedScriptValue>&& serializedState)
+RefPtr<NavigationAPIMethodTracker> Navigation::TrackerManager::setUpcomingNonTraverse(JSC::JSGlobalObject& globalObject, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, JSC::JSValue info, RefPtr<SerializedScriptValue>&& serializedState, bool shouldStore)
 {
     RefPtr apiMethodTracker = NavigationAPIMethodTracker::create(globalObject, WTF::move(committed), WTF::move(finished), WTF::move(info), WTF::move(serializedState));
 
-    apiMethodTracker->finishedPromise->markAsHandled();
+    apiMethodTracker->finishedPromise().markAsHandled();
 
-    // FIXME: We should be able to assert m_upcomingNonTraverseMethodTracker is empty.
-    if (!hasEntriesAndEventsDisabled()) {
-        Locker locker { m_apiMethodTrackersLock };
-        m_upcomingNonTraverseMethodTracker = apiMethodTracker;
+    // FIXME: We should be able to assert m_upcomingNonTraverse is empty.
+    if (shouldStore) {
+        Locker locker { m_lock };
+        m_upcomingNonTraverse = apiMethodTracker;
     }
 
     return apiMethodTracker;
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#add-an-upcoming-traverse-api-method-tracker
-RefPtr<NavigationAPIMethodTracker> Navigation::addUpcomingTraverseAPIMethodTracker(JSC::JSGlobalObject& globalObject, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, const String& key, JSC::JSValue info)
+RefPtr<NavigationAPIMethodTracker> Navigation::TrackerManager::addUpcomingTraverse(JSC::JSGlobalObject& globalObject, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, const String& key, JSC::JSValue info)
 {
     RefPtr apiMethodTracker = NavigationAPIMethodTracker::create(globalObject, WTF::move(committed), WTF::move(finished), WTF::move(info), nullptr);
-    apiMethodTracker->key = key;
+    apiMethodTracker->setKey(key);
 
-    apiMethodTracker->finishedPromise->markAsHandled();
+    apiMethodTracker->finishedPromise().markAsHandled();
 
     {
-        Locker locker { m_apiMethodTrackersLock };
-        m_upcomingTraverseMethodTrackers.add(key, *apiMethodTracker);
+        Locker locker { m_lock };
+        m_upcomingTraverses.add(key, *apiMethodTracker);
     }
 
     return apiMethodTracker;
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigation-api-method-tracker-derived-result
-Navigation::Result Navigation::apiMethodTrackerDerivedResult(const NavigationAPIMethodTracker& apiMethodTracker)
+Navigation::Result Navigation::TrackerManager::derivedResult(const NavigationAPIMethodTracker& apiMethodTracker) const
 {
     return {
-        createDOMPromise(apiMethodTracker.committedPromise),
-        createDOMPromise(apiMethodTracker.finishedPromise),
+        createDOMPromise(protect(apiMethodTracker.committedPromise())),
+        createDOMPromise(protect(apiMethodTracker.finishedPromise())),
     };
 }
 
@@ -399,7 +400,7 @@ Navigation::Result Navigation::reload(JSC::JSGlobalObject& globalObject, ReloadO
     if (!protect(window->document())->isFullyActive() || window->document()->unloadCounter())
         return createErrorResult(WTF::move(committed), WTF::move(finished), ExceptionCode::InvalidStateError, "Invalid state"_s);
 
-    RefPtr apiMethodTracker = maybeSetUpcomingNonTraversalTracker(globalObject, WTF::move(committed), WTF::move(finished), WTF::move(options.info), WTF::move(state));
+    RefPtr apiMethodTracker = m_trackers.setUpcomingNonTraverse(globalObject, WTF::move(committed), WTF::move(finished), WTF::move(options.info), WTF::move(state), !hasEntriesAndEventsDisabled());
 
     RefPtr lexicalFrame = lexicalFrameFromCommonVM();
     auto initiatedByMainFrame = lexicalFrame && lexicalFrame->isMainFrame() ? InitiatedByMainFrame::Yes : InitiatedByMainFrame::Unknown;
@@ -413,7 +414,7 @@ Navigation::Result Navigation::reload(JSC::JSGlobalObject& globalObject, ReloadO
 
     frame->loader().changeLocation(WTF::move(frameLoadRequest));
 
-    return apiMethodTrackerDerivedResult(*apiMethodTracker);
+    return m_trackers.derivedResult(*apiMethodTracker);
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-navigate
@@ -440,23 +441,18 @@ Navigation::Result Navigation::navigate(JSC::JSGlobalObject& globalObject, const
     if (!protect(window->document())->isFullyActive() || window->document()->unloadCounter())
         return createErrorResult(WTF::move(committed), WTF::move(finished), ExceptionCode::InvalidStateError, "Invalid state"_s);
 
-    RefPtr apiMethodTracker = maybeSetUpcomingNonTraversalTracker(globalObject, WTF::move(committed), WTF::move(finished), WTF::move(options.info), serializedState.releaseReturnValue());
+    RefPtr apiMethodTracker = m_trackers.setUpcomingNonTraverse(globalObject, WTF::move(committed), WTF::move(finished), WTF::move(options.info), serializedState.releaseReturnValue(), !hasEntriesAndEventsDisabled());
 
     auto request = FrameLoadRequest(*frame(), WTF::move(newURL));
     request.setNavigationHistoryBehavior(options.history);
     request.setIsFromNavigationAPI(true);
     frame()->loader().loadFrameRequest(WTF::move(request), nullptr, { });
 
-    // If the load() call never made it to the point that NavigateEvent was emitted, thus promoteUpcomingAPIMethodTracker() called, this will be true.
-    {
-        Locker locker { m_apiMethodTrackersLock };
-        if (m_upcomingNonTraverseMethodTracker == apiMethodTracker) {
-            m_upcomingNonTraverseMethodTracker = nullptr;
-            return createErrorResult(WTF::move(apiMethodTracker->committedPromise), WTF::move(apiMethodTracker->finishedPromise), ExceptionCode::AbortError, "Navigation aborted"_s);
-        }
-    }
+    // If the load() call never made it to the point that NavigateEvent was emitted, thus promoteToOngoing() called, this will be true.
+    if (m_trackers.clearIfStillUpcomingNonTraverse(apiMethodTracker.get()))
+        return createErrorResult(Ref { apiMethodTracker->committedPromise() }, Ref { apiMethodTracker->finishedPromise() }, ExceptionCode::AbortError, "Navigation aborted"_s);
 
-    return apiMethodTrackerDerivedResult(*apiMethodTracker);
+    return m_trackers.derivedResult(*apiMethodTracker);
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#performing-a-navigation-api-traversal
@@ -480,21 +476,18 @@ Navigation::Result Navigation::performTraversal(JSC::JSGlobalObject& globalObjec
         return { createDOMPromise(committed), createDOMPromise(finished) };
     }
 
-    {
-        Locker locker { m_apiMethodTrackersLock };
-        if (auto existingMethodTracker = m_upcomingTraverseMethodTrackers.getOptional(key))
-            return apiMethodTrackerDerivedResult(*existingMethodTracker);
-    }
+    if (auto result = m_trackers.existingTraverseResult(key))
+        return *result;
 
-    RefPtr apiMethodTracker = addUpcomingTraverseAPIMethodTracker(globalObject, WTF::move(committed), WTF::move(finished), key, options.info);
+    RefPtr apiMethodTracker = m_trackers.addUpcomingTraverse(globalObject, WTF::move(committed), WTF::move(finished), key, options.info);
 
     // FIXME: 11. Let sourceSnapshotParams be the result of snapshotting source snapshot params given document.
     protect(frame->navigationScheduler())->scheduleHistoryNavigationByKey(key, [apiMethodTracker] (ScheduleHistoryNavigationResult result) {
         if (result == ScheduleHistoryNavigationResult::Aborted)
-            createErrorResult(WTF::move(apiMethodTracker->committedPromise), WTF::move(apiMethodTracker->finishedPromise), ExceptionCode::AbortError, "Navigation aborted"_s);
+            createErrorResult(Ref { apiMethodTracker->committedPromise() }, Ref { apiMethodTracker->finishedPromise() }, ExceptionCode::AbortError, "Navigation aborted"_s);
     });
 
-    return apiMethodTrackerDerivedResult(*apiMethodTracker);
+    return m_trackers.derivedResult(*apiMethodTracker);
 }
 
 size_t Navigation::entryIndexOfKey(const String& key) const
@@ -591,30 +584,30 @@ bool Navigation::hasEntriesAndEventsDisabled() const
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#resolve-the-finished-promise
-void Navigation::resolveFinishedPromise(NavigationAPIMethodTracker* apiMethodTracker)
+void Navigation::TrackerManager::resolveFinished(NavigationAPIMethodTracker* apiMethodTracker)
 {
-    RefPtr committedToEntry = apiMethodTracker->committedToEntry;
+    RefPtr committedToEntry = apiMethodTracker->committedToEntry();
     if (!committedToEntry) {
-        apiMethodTracker->finishedBeforeCommit = true;
+        apiMethodTracker->setFinishedBeforeCommit(true);
         return;
     }
 
-    Ref { apiMethodTracker->committedPromise }->resolve<IDLInterface<NavigationHistoryEntry>>(*committedToEntry);
-    Ref { apiMethodTracker->finishedPromise }->resolve<IDLInterface<NavigationHistoryEntry>>(*committedToEntry);
-    cleanupAPIMethodTracker(apiMethodTracker);
+    Ref { apiMethodTracker->committedPromise() }->resolve<IDLInterface<NavigationHistoryEntry>>(*committedToEntry);
+    Ref { apiMethodTracker->finishedPromise() }->resolve<IDLInterface<NavigationHistoryEntry>>(*committedToEntry);
+    cleanup(apiMethodTracker);
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#reject-the-finished-promise
-void Navigation::rejectFinishedPromise(NavigationAPIMethodTracker* apiMethodTracker, const Exception& exception, JSC::JSValue exceptionObject)
+void Navigation::TrackerManager::rejectFinished(NavigationAPIMethodTracker* apiMethodTracker, const Exception& exception, JSC::JSValue exceptionObject)
 {
-    RELEASE_LOG(Navigation, "rejectFinishedPromise: rejecting promises for tracker=%p with exception='%s'", apiMethodTracker, exception.message().utf8().data());
+    RELEASE_LOG(Navigation, "rejectFinished: rejecting promises for tracker=%p with exception='%s'", apiMethodTracker, exception.message().utf8().data());
 
     // Only reject committed promise if it hasn't been fulfilled yet (committedToEntry is null). If the navigation was "committed" (state updated)
     // before being aborted, the committed promise should remain fulfilled while only the finished promise gets rejected.
-    if (!apiMethodTracker->committedToEntry)
-        Ref { apiMethodTracker->committedPromise }->reject(exception, RejectAsHandled::No, exceptionObject);
-    Ref { apiMethodTracker->finishedPromise }->reject(exception, RejectAsHandled::Yes, exceptionObject);
-    cleanupAPIMethodTracker(apiMethodTracker);
+    if (!apiMethodTracker->committedToEntry())
+        Ref { apiMethodTracker->committedPromise() }->reject(exception, RejectAsHandled::No, exceptionObject);
+    Ref { apiMethodTracker->finishedPromise() }->reject(exception, RejectAsHandled::Yes, exceptionObject);
+    cleanup(apiMethodTracker);
 }
 
 void Navigation::rejectFinishedPromise(NavigationAPIMethodTracker* apiMethodTracker)
@@ -624,30 +617,30 @@ void Navigation::rejectFinishedPromise(NavigationAPIMethodTracker* apiMethodTrac
 
     auto* globalObject = protect(scriptExecutionContext())->globalObject();
     if (!globalObject && apiMethodTracker)
-        globalObject = apiMethodTracker->committedPromise->globalObject();
+        globalObject = apiMethodTracker->committedPromise().globalObject();
     if (!globalObject)
         return;
 
     JSC::JSLockHolder locker(globalObject->vm());
     auto exception = Exception(ExceptionCode::AbortError, "Navigation aborted"_s);
     auto domException = createDOMException(*globalObject, exception.isolatedCopy());
-    rejectFinishedPromise(apiMethodTracker, exception, domException);
+    m_trackers.rejectFinished(apiMethodTracker, exception, domException);
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#notify-about-the-committed-to-entry
-void Navigation::notifyCommittedToEntry(NavigationAPIMethodTracker* apiMethodTracker, NavigationHistoryEntry* entry, NavigationNavigationType navigationType)
+void Navigation::TrackerManager::notifyCommitted(NavigationAPIMethodTracker* apiMethodTracker, NavigationHistoryEntry* entry, NavigationNavigationType navigationType)
 {
     ASSERT(entry);
-    apiMethodTracker->committedToEntry = entry;
+    apiMethodTracker->setCommittedToEntry(entry);
     if (navigationType != NavigationNavigationType::Traverse) {
-        if (apiMethodTracker->serializedState)
-            RefPtr { apiMethodTracker->committedToEntry }->setState(WTF::move(apiMethodTracker->serializedState));
+        if (auto serializedState = apiMethodTracker->takeSerializedState())
+            protect(apiMethodTracker->committedToEntry())->setState(WTF::move(serializedState));
     }
 
-    if (apiMethodTracker->finishedBeforeCommit)
-        resolveFinishedPromise(apiMethodTracker);
+    if (apiMethodTracker->finishedBeforeCommit())
+        resolveFinished(apiMethodTracker);
     else
-        Ref { apiMethodTracker->committedPromise }->resolve<IDLInterface<NavigationHistoryEntry>>(*entry);
+        Ref { apiMethodTracker->committedPromise() }->resolve<IDLInterface<NavigationHistoryEntry>>(*entry);
 }
 
 void Navigation::updateNavigationEntry(Ref<HistoryItem>&& item, ShouldCopyStateObjectFromCurrentEntry shouldCopyStateObjectFromCurrentEntry)
@@ -761,13 +754,9 @@ void Navigation::updateForNavigation(Ref<HistoryItem>&& item, NavigationNavigati
             Ref { m_entries[*m_currentEntryIndex] }->setState(oldCurrentEntry->state());
     }
 
-    RefPtr<NavigationAPIMethodTracker> ongoingAPIMethodTracker;
-    {
-        Locker locker { m_apiMethodTrackersLock };
-        ongoingAPIMethodTracker = m_ongoingAPIMethodTracker;
-    }
+    RefPtr ongoingAPIMethodTracker = m_trackers.ongoing();
     if (ongoingAPIMethodTracker && shouldNotifyCommitted == ShouldNotifyCommitted::Yes)
-        notifyCommittedToEntry(ongoingAPIMethodTracker.get(), protect(currentEntry()).get(), navigationType);
+        m_trackers.notifyCommitted(ongoingAPIMethodTracker.get(), protect(currentEntry()).get(), navigationType);
 
     auto currentEntryChangeEvent = NavigationCurrentEntryChangeEvent::create(eventNames().currententrychangeEvent, {
         { false, false, false },
@@ -852,45 +841,85 @@ static bool documentCanHaveURLRewritten(const Document& document, const URL& tar
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#promote-an-upcoming-api-method-tracker-to-ongoing
-void Navigation::promoteUpcomingAPIMethodTracker(const String& destinationKey)
+void Navigation::TrackerManager::promoteToOngoing(TrackerPromotion promotion, const String& key)
 {
-    // FIXME: We should be able to assert m_ongoingAPIMethodTracker is unset.
+    // FIXME: We should be able to assert m_ongoing is unset.
 
-    Locker locker { m_apiMethodTrackersLock };
-    if (!destinationKey.isEmpty())
-        m_ongoingAPIMethodTracker = m_upcomingTraverseMethodTrackers.take(destinationKey);
-    else if (destinationKey.isNull()) {
-        m_ongoingAPIMethodTracker = WTF::move(m_upcomingNonTraverseMethodTracker);
-        m_upcomingNonTraverseMethodTracker = nullptr;
-    } else if (destinationKey.isEmpty() && !m_upcomingTraverseMethodTrackers.isEmpty()) {
-        // For traverse navigation where destination key is empty, try to use any available traverse method tracker.
-        // (e.g., cross-document navigation where NavigationHistoryEntry is not found).
-        auto firstTracker = m_upcomingTraverseMethodTrackers.begin();
-        if (firstTracker != m_upcomingTraverseMethodTrackers.end()) {
-            String trackerKey = firstTracker->key;
-            m_ongoingAPIMethodTracker = m_upcomingTraverseMethodTrackers.take(trackerKey);
+    Locker locker { m_lock };
+    switch (promotion) {
+    case TrackerPromotion::TraverseByKey:
+        m_ongoing = m_upcomingTraverses.take(key);
+        break;
+    case TrackerPromotion::NonTraverse:
+        m_ongoing = WTF::move(m_upcomingNonTraverse);
+        m_upcomingNonTraverse = nullptr;
+        break;
+    case TrackerPromotion::TraverseFallback:
+        if (!m_upcomingTraverses.isEmpty()) {
+            String trackerKey = m_upcomingTraverses.begin()->key;
+            m_ongoing = m_upcomingTraverses.take(trackerKey);
         }
+        break;
     }
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigation-api-method-tracker-clean-up
-void Navigation::cleanupAPIMethodTracker(NavigationAPIMethodTracker* apiMethodTracker)
+void Navigation::TrackerManager::cleanup(NavigationAPIMethodTracker* apiMethodTracker)
 {
-    Locker locker { m_apiMethodTrackersLock };
-    if (m_ongoingAPIMethodTracker == apiMethodTracker)
-        m_ongoingAPIMethodTracker = nullptr;
+    Locker locker { m_lock };
+    if (m_ongoing == apiMethodTracker)
+        m_ongoing = nullptr;
     else {
-        auto& key = apiMethodTracker->key;
-        // FIXME: We should be able to assert key isn't null and m_upcomingTraverseMethodTrackers contains it.
+        auto& key = apiMethodTracker->key();
+        // FIXME: We should be able to assert key isn't null and m_upcomingTraverses contains it.
         if (!key.isNull())
-            m_upcomingTraverseMethodTrackers.remove(key);
+            m_upcomingTraverses.remove(key);
     }
 }
 
+RefPtr<NavigationAPIMethodTracker> Navigation::TrackerManager::ongoing() const
+{
+    Locker locker { m_lock };
+    return m_ongoing;
+}
+
+NavigationAPIMethodTracker* Navigation::TrackerManager::upcomingTraverse(const String& key) const
+{
+    Locker locker { m_lock };
+    return m_upcomingTraverses.get(key);
+}
+
+std::optional<Navigation::Result> Navigation::TrackerManager::existingTraverseResult(const String& key) const
+{
+    Locker locker { m_lock };
+    if (auto existingMethodTracker = m_upcomingTraverses.getOptional(key))
+        return derivedResult(*existingMethodTracker);
+    return std::nullopt;
+}
+
+bool Navigation::TrackerManager::clearIfStillUpcomingNonTraverse(NavigationAPIMethodTracker* tracker)
+{
+    Locker locker { m_lock };
+    if (m_upcomingNonTraverse == tracker) {
+        m_upcomingNonTraverse = nullptr;
+        return true;
+    }
+    return false;
+}
+
+#if ASSERT_ENABLED
+void Navigation::TrackerManager::assertEmpty() const
+{
+    Locker locker { m_lock };
+    ASSERT(!m_ongoing);
+    ASSERT(!m_upcomingNonTraverse);
+    ASSERT(m_upcomingTraverses.isEmpty());
+}
+#endif
+
 NavigationAPIMethodTracker* Navigation::upcomingTraverseMethodTracker(const String& key) const
 {
-    Locker locker { m_apiMethodTrackersLock };
-    return m_upcomingTraverseMethodTrackers.get(key);
+    return m_trackers.upcomingTraverse(key);
 }
 
 auto Navigation::registerAbortHandler() -> Ref<AbortHandler>
@@ -910,13 +939,9 @@ void Navigation::abortOngoingNavigation(NavigateEvent& event)
     RefPtr scriptExecutionContext = this->scriptExecutionContext();
     auto* globalObject = scriptExecutionContext->globalObject();
     if (!globalObject) {
-        RefPtr<NavigationAPIMethodTracker> ongoingAPIMethodTracker;
-        {
-            Locker locker { m_apiMethodTrackersLock };
-            ongoingAPIMethodTracker = m_ongoingAPIMethodTracker;
-        }
+        RefPtr ongoingAPIMethodTracker = m_trackers.ongoing();
         if (ongoingAPIMethodTracker)
-            globalObject = ongoingAPIMethodTracker->committedPromise->globalObject();
+            globalObject = ongoingAPIMethodTracker->committedPromise().globalObject();
     }
     if (!globalObject)
         return;
@@ -949,13 +974,9 @@ void Navigation::abortOngoingNavigation(NavigateEvent& event)
 
     dispatchEvent(ErrorEvent::create(*globalObject, eventNames().navigateerrorEvent, exception.message(), errorInformation.sourceURL, errorInformation.line, errorInformation.column, { globalObject->vm(), domException }));
 
-    RefPtr<NavigationAPIMethodTracker> ongoingAPIMethodTracker;
-    {
-        Locker locker { m_apiMethodTrackersLock };
-        ongoingAPIMethodTracker = m_ongoingAPIMethodTracker;
-    }
+    RefPtr ongoingAPIMethodTracker = m_trackers.ongoing();
     if (ongoingAPIMethodTracker)
-        rejectFinishedPromise(ongoingAPIMethodTracker.get(), exception, domException);
+        m_trackers.rejectFinished(ongoingAPIMethodTracker.get(), exception, domException);
 
     if (RefPtr transition = m_transition) {
         transition->rejectPromise(exception, domException);
@@ -1117,8 +1138,8 @@ std::optional<Navigation::DispatchResult> Navigation::handleSameDocumentNavigati
 
     // For intercepted traverse navigations, notify committed after handlers have been invoked but before
     // they complete. This ensures the correct event ordering.
-    if (navigationType == NavigationNavigationType::Traverse && event.wasIntercepted() && apiMethodTracker && !apiMethodTracker->committedToEntry)
-        notifyCommittedToEntry(apiMethodTracker, protect(currentEntry()).get(), navigationType);
+    if (navigationType == NavigationNavigationType::Traverse && event.wasIntercepted() && apiMethodTracker && !apiMethodTracker->committedToEntry())
+        m_trackers.notifyCommitted(apiMethodTracker, protect(currentEntry()).get(), navigationType);
 
     if (!event.wasIntercepted() && !apiMethodTracker) {
         // For non-intercepted same-document navigations without a JS-initiated tracker
@@ -1154,7 +1175,7 @@ std::optional<Navigation::DispatchResult> Navigation::handleSameDocumentNavigati
                 protectedThis->dispatchEvent(Event::create(eventNames().navigatesuccessEvent, { }));
 
                 if (apiMethodTracker)
-                    protectedThis->resolveFinishedPromise(apiMethodTracker.get());
+                    protectedThis->m_trackers.resolveFinished(apiMethodTracker.get());
 
                 if (RefPtr transition = std::exchange(protectedThis->m_transition, nullptr))
                     transition->resolvePromise();
@@ -1179,7 +1200,7 @@ std::optional<Navigation::DispatchResult> Navigation::handleSameDocumentNavigati
                 protectedThis->dispatchEvent(ErrorEvent::create(*navGlobalObject, eventNames().navigateerrorEvent, errorMessage, errorInformation.sourceURL, errorInformation.line, errorInformation.column, { navGlobalObject->vm(), result }));
 
                 if (apiMethodTracker)
-                    Ref { apiMethodTracker->finishedPromise }->reject<IDLAny>(result, RejectAsHandled::Yes);
+                    Ref { apiMethodTracker->finishedPromise() }->reject<IDLAny>(result, RejectAsHandled::Yes);
 
                 if (RefPtr transition = std::exchange(protectedThis->m_transition, nullptr))
                     transition->rejectPromise(result);
@@ -1199,11 +1220,8 @@ Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavi
 {
     if (hasEntriesAndEventsDisabled()) {
 #if ASSERT_ENABLED
-        Locker locker { m_apiMethodTrackersLock };
+        m_trackers.assertEmpty();
 #endif
-        ASSERT(!m_ongoingAPIMethodTracker);
-        ASSERT(!m_upcomingNonTraverseMethodTracker);
-        ASSERT(m_upcomingTraverseMethodTrackers.isEmpty());
         return DispatchResult::Completed;
     }
 
@@ -1216,13 +1234,15 @@ Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavi
     if (wasBeingDispatched && classicHistoryAPIState)
         return DispatchResult::Completed;
 
-    promoteUpcomingAPIMethodTracker(destination->key());
+    const auto& destinationKey = destination->key();
+    if (destinationKey.isNull())
+        m_trackers.promoteToOngoing(TrackerPromotion::NonTraverse);
+    else if (!destinationKey.isEmpty())
+        m_trackers.promoteToOngoing(TrackerPromotion::TraverseByKey, destinationKey);
+    else
+        m_trackers.promoteToOngoing(TrackerPromotion::TraverseFallback);
 
-    RefPtr<NavigationAPIMethodTracker> ongoingAPIMethodTracker;
-    {
-        Locker locker { m_apiMethodTrackersLock };
-        ongoingAPIMethodTracker = m_ongoingAPIMethodTracker;
-    }
+    RefPtr ongoingAPIMethodTracker = m_trackers.ongoing();
 
     // Enforce rate limiting to prevent excessive navigation requests.
     // Only check for script-initiated navigations (those with an API method tracker).
@@ -1236,30 +1256,26 @@ Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavi
 
         // Reject the promises and clean up.
         auto exception = Exception { ExceptionCode::QuotaExceededError, "Navigation rate limit exceeded"_s };
-        Ref { ongoingAPIMethodTracker->committedPromise }->reject(exception);
-        Ref { ongoingAPIMethodTracker->finishedPromise }->reject(exception);
-        cleanupAPIMethodTracker(ongoingAPIMethodTracker.get());
+        Ref { ongoingAPIMethodTracker->committedPromise() }->reject(exception);
+        Ref { ongoingAPIMethodTracker->finishedPromise() }->reject(exception);
+        m_trackers.cleanup(ongoingAPIMethodTracker.get());
 
         return DispatchResult::Aborted;
     }
 
     RefPtr document = window()->document();
 
-    RefPtr<NavigationAPIMethodTracker> apiMethodTracker;
-    {
-        Locker locker { m_apiMethodTrackersLock };
-        apiMethodTracker = m_ongoingAPIMethodTracker;
-    }
+    RefPtr apiMethodTracker = m_trackers.ongoing();
     // FIXME: this should not be needed, we should pass it into FrameLoader.
-    if (apiMethodTracker && apiMethodTracker->serializedState)
-        destination->setStateObject(apiMethodTracker->serializedState.get());
+    if (apiMethodTracker && apiMethodTracker->serializedState())
+        destination->setStateObject(protect(apiMethodTracker->serializedState()));
     bool isSameDocument = destination->sameDocument();
     bool isTraversal = navigationType == NavigationNavigationType::Traverse;
     bool canIntercept = documentCanHaveURLRewritten(*document, destination->url()) && (!isTraversal || isSameDocument);
     bool canBeCanceled = !isTraversal || (document->isTopDocument() && isSameDocument); // FIXME: and user involvement is not browser-ui or navigation's relevant global object has transient activation.
     bool hashChange = !classicHistoryAPIState && equalIgnoringFragmentIdentifier(document->url(), destination->url()) && !equalRespectingNullity(document->url().fragmentIdentifier(),  destination->url().fragmentIdentifier());
-    auto info = apiMethodTracker ? apiMethodTracker->info.getValue() : JSC::jsUndefined();
-    auto world = apiMethodTracker ? apiMethodTracker->info.world() : nullptr;
+    auto info = apiMethodTracker ? apiMethodTracker->info().getValue() : JSC::jsUndefined();
+    auto world = apiMethodTracker ? apiMethodTracker->info().world() : nullptr;
 
     RefPtr scriptExecutionContext = this->scriptExecutionContext();
     RefPtr<DOMFormData> formData = nullptr;
@@ -1297,7 +1313,7 @@ Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavi
 
     // Free up no longer needed info.
     if (apiMethodTracker)
-        apiMethodTracker->info.clear();
+        apiMethodTracker->info().clear();
 
     Ref event = NavigateEvent::create(WTF::move(world), eventNames().navigateEvent, WTF::move(init), abortController.get());
     m_ongoingNavigateEvent = event.ptr();
@@ -1447,15 +1463,20 @@ bool Navigation::RateLimiter::navigationAllowed()
     return false;
 }
 
+void Navigation::TrackerManager::visitInGCThread(JSC::AbstractSlotVisitor& visitor)
+{
+    Locker locker { m_lock };
+    if (m_ongoing)
+        m_ongoing->info().visitInGCThread(visitor);
+    if (m_upcomingNonTraverse)
+        m_upcomingNonTraverse->info().visitInGCThread(visitor);
+    for (auto& tracker : m_upcomingTraverses.values())
+        tracker->info().visitInGCThread(visitor);
+}
+
 void Navigation::visitAdditionalChildrenInGCThread(JSC::AbstractSlotVisitor& visitor)
 {
-    Locker locker { m_apiMethodTrackersLock };
-    if (m_ongoingAPIMethodTracker)
-        m_ongoingAPIMethodTracker->info.visitInGCThread(visitor);
-    if (m_upcomingNonTraverseMethodTracker)
-        m_upcomingNonTraverseMethodTracker->info.visitInGCThread(visitor);
-    for (auto& tracker : m_upcomingTraverseMethodTrackers.values())
-        tracker->info.visitInGCThread(visitor);
+    m_trackers.visitInGCThread(visitor);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -51,34 +51,52 @@ class NavigationDestination;
 
 enum class FrameLoadType : uint8_t;
 
-enum class NavigationAPIMethodTrackerType { };
-using NavigationAPIMethodTrackerIdentifier = ObjectIdentifier<NavigationAPIMethodTrackerType>;
-
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigation-api-method-tracker
-struct NavigationAPIMethodTracker : public RefCounted<NavigationAPIMethodTracker> {
-    WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(NavigationAPIMethodTracker);
-
+class NavigationAPIMethodTracker : public RefCounted<NavigationAPIMethodTracker> {
+    WTF_MAKE_TZONE_ALLOCATED(NavigationAPIMethodTracker);
+public:
     static Ref<NavigationAPIMethodTracker> create(JSC::JSGlobalObject&, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, JSC::JSValue&& info, RefPtr<SerializedScriptValue>&& serializedState);
     ~NavigationAPIMethodTracker();
 
     bool operator==(const NavigationAPIMethodTracker& other) const
     {
-        // key is optional so we manually identify each tracker.
-        return identifier == other.identifier;
+        return m_identifier == other.m_identifier;
     }
 
-    bool finishedBeforeCommit { false };
-    String key;
-    JSValueInWrappedObject info;
-    RefPtr<SerializedScriptValue> serializedState;
-    RefPtr<NavigationHistoryEntry> committedToEntry;
-    Ref<DeferredPromise> committedPromise;
-    Ref<DeferredPromise> finishedPromise;
+    const String& key() const { return m_key; }
+    void setKey(const String& key) { m_key = key; }
+
+    JSValueInWrappedObject& info() { return m_info; }
+
+    SerializedScriptValue* serializedState() const { return m_serializedState.get(); }
+    void setSerializedState(RefPtr<SerializedScriptValue>&& state) { m_serializedState = WTF::move(state); }
+    RefPtr<SerializedScriptValue> takeSerializedState() { return WTF::move(m_serializedState); }
+
+    NavigationHistoryEntry* committedToEntry() const { return m_committedToEntry.get(); }
+    void setCommittedToEntry(NavigationHistoryEntry* entry) { m_committedToEntry = entry; }
+
+    DeferredPromise& committedPromise() { return m_committedPromise; }
+    const DeferredPromise& committedPromise() const { return m_committedPromise; }
+    DeferredPromise& finishedPromise() { return m_finishedPromise; }
+    const DeferredPromise& finishedPromise() const { return m_finishedPromise; }
+
+    bool finishedBeforeCommit() const { return m_finishedBeforeCommit; }
+    void setFinishedBeforeCommit(bool value) { m_finishedBeforeCommit = value; }
 
 private:
     NavigationAPIMethodTracker(JSC::JSGlobalObject&, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, JSC::JSValue&& info, RefPtr<SerializedScriptValue>&& serializedState);
 
-    NavigationAPIMethodTrackerIdentifier identifier;
+    enum class IdentifierType { };
+    using Identifier = ObjectIdentifier<IdentifierType>;
+
+    bool m_finishedBeforeCommit { false };
+    String m_key;
+    JSValueInWrappedObject m_info;
+    RefPtr<SerializedScriptValue> m_serializedState;
+    RefPtr<NavigationHistoryEntry> m_committedToEntry;
+    Ref<DeferredPromise> m_committedPromise;
+    Ref<DeferredPromise> m_finishedPromise;
+    Identifier m_identifier;
 };
 
 enum class ShouldCopyStateObjectFromCurrentEntry : bool { No, Yes };
@@ -167,6 +185,51 @@ public:
 
     void visitAdditionalChildrenInGCThread(JSC::AbstractSlotVisitor&);
 
+    // Controls how an upcoming tracker is promoted to the ongoing tracker.
+    enum class TrackerPromotion : uint8_t {
+        NonTraverse,
+        TraverseByKey,
+        TraverseFallback
+    };
+
+    // Manages NavigationAPIMethodTracker lifecycle: upcoming → ongoing → cleanup.
+    class TrackerManager {
+        WTF_MAKE_NONCOPYABLE(TrackerManager);
+    public:
+        TrackerManager() = default;
+
+        // Lifecycle: upcoming → ongoing → cleanup
+        RefPtr<NavigationAPIMethodTracker> setUpcomingNonTraverse(JSC::JSGlobalObject&, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, JSC::JSValue info, RefPtr<SerializedScriptValue>&&, bool shouldStore);
+        RefPtr<NavigationAPIMethodTracker> addUpcomingTraverse(JSC::JSGlobalObject&, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, const String& key, JSC::JSValue info);
+        void promoteToOngoing(TrackerPromotion, const String& key = { }) WTF_EXCLUDES_LOCK(m_lock);
+        void cleanup(NavigationAPIMethodTracker*) WTF_EXCLUDES_LOCK(m_lock);
+
+        // Promise resolution
+        void resolveFinished(NavigationAPIMethodTracker*);
+        void rejectFinished(NavigationAPIMethodTracker*, const Exception&, JSC::JSValue);
+        void notifyCommitted(NavigationAPIMethodTracker*, NavigationHistoryEntry*, NavigationNavigationType);
+
+        // Access
+        RefPtr<NavigationAPIMethodTracker> ongoing() const WTF_EXCLUDES_LOCK(m_lock);
+        NavigationAPIMethodTracker* upcomingTraverse(const String& key) const WTF_EXCLUDES_LOCK(m_lock);
+        std::optional<Result> existingTraverseResult(const String& key) const WTF_EXCLUDES_LOCK(m_lock);
+        bool clearIfStillUpcomingNonTraverse(NavigationAPIMethodTracker*) WTF_EXCLUDES_LOCK(m_lock);
+        Result derivedResult(const NavigationAPIMethodTracker&) const;
+
+#if ASSERT_ENABLED
+        void assertEmpty() const WTF_EXCLUDES_LOCK(m_lock);
+#endif
+
+        // GC support
+        void visitInGCThread(JSC::AbstractSlotVisitor&) WTF_EXCLUDES_LOCK(m_lock);
+
+    private:
+        mutable Lock m_lock;
+        RefPtr<NavigationAPIMethodTracker> m_ongoing WTF_GUARDED_BY_LOCK(m_lock);
+        RefPtr<NavigationAPIMethodTracker> m_upcomingNonTraverse WTF_GUARDED_BY_LOCK(m_lock);
+        HashMap<String, Ref<NavigationAPIMethodTracker>> m_upcomingTraverses WTF_GUARDED_BY_LOCK(m_lock);
+    };
+
     class AbortHandler : public RefCountedAndCanMakeWeakPtr<AbortHandler> {
     public:
         bool wasAborted() const { return m_wasAborted; }
@@ -183,7 +246,6 @@ public:
 
     // Rate limiter to prevent excessive navigation requests.
     class RateLimiter {
-        WTF_MAKE_TZONE_ALLOCATED(RateLimiter);
         WTF_MAKE_NONCOPYABLE(RateLimiter);
         WTF_MAKE_NONMOVABLE(RateLimiter);
     public:
@@ -250,15 +312,7 @@ private:
 
     void setActivation(HistoryItem* previousItem, std::optional<NavigationNavigationType>);
 
-    RefPtr<NavigationAPIMethodTracker> maybeSetUpcomingNonTraversalTracker(JSC::JSGlobalObject&, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, JSC::JSValue info, RefPtr<SerializedScriptValue>&&);
-    RefPtr<NavigationAPIMethodTracker> addUpcomingTraverseAPIMethodTracker(JSC::JSGlobalObject&, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, const String& key, JSC::JSValue info);
-    void cleanupAPIMethodTracker(NavigationAPIMethodTracker*) WTF_EXCLUDES_LOCK(m_apiMethodTrackersLock);
-    void resolveFinishedPromise(NavigationAPIMethodTracker*);
-    void rejectFinishedPromise(NavigationAPIMethodTracker*, const Exception&, JSC::JSValue exceptionObject);
     void abortOngoingNavigation(NavigateEvent&);
-    void promoteUpcomingAPIMethodTracker(const String& destinationKey) WTF_EXCLUDES_LOCK(m_apiMethodTrackersLock);
-    void notifyCommittedToEntry(NavigationAPIMethodTracker*, NavigationHistoryEntry*, NavigationNavigationType);
-    Result apiMethodTrackerDerivedResult(const NavigationAPIMethodTracker&);
 
     size_t entryIndexOfKey(const String&) const;
     bool hasEntryWithKey(const String&) const;
@@ -274,10 +328,7 @@ private:
     RefPtr<NavigateEvent> m_ongoingNavigateEvent;
     FocusDidChange m_focusChangedDuringOngoingNavigation { FocusDidChange::No };
     bool m_suppressNormalScrollRestorationDuringOngoingNavigation { false };
-    mutable Lock m_apiMethodTrackersLock;
-    RefPtr<NavigationAPIMethodTracker> m_ongoingAPIMethodTracker WTF_GUARDED_BY_LOCK(m_apiMethodTrackersLock);
-    RefPtr<NavigationAPIMethodTracker> m_upcomingNonTraverseMethodTracker WTF_GUARDED_BY_LOCK(m_apiMethodTrackersLock);
-    HashMap<String, Ref<NavigationAPIMethodTracker>> m_upcomingTraverseMethodTrackers WTF_GUARDED_BY_LOCK(m_apiMethodTrackersLock);
+    TrackerManager m_trackers;
     WeakHashSet<AbortHandler> m_abortHandlers;
     RateLimiter m_rateLimiter;
 };

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -237,7 +237,7 @@ struct CharacterRange;
 struct ClientOrigin;
 struct DocumentSyncSerializationData;
 struct FixedContainerEdges;
-struct NavigationAPIMethodTracker;
+class NavigationAPIMethodTracker;
 struct ResolvedCaptionDisplaySettingsOptions;
 struct SpatialBackdropSource;
 struct SystemPreviewInfo;


### PR DESCRIPTION
#### 2ac9156030ba42313663fa820806f6d1b64ceb66
<pre>
[Navigation API] Refactor NavigationAPIMethodTracker for better encapsulation
<a href="https://bugs.webkit.org/show_bug.cgi?id=311157">https://bugs.webkit.org/show_bug.cgi?id=311157</a>
<a href="https://rdar.apple.com/173746972">rdar://173746972</a>

Reviewed by NOBODY (OOPS!).

Refactor NavigationAPIMethodTracker and its management in Navigation
to improve encapsulation and clarity before implementing precommitHandler.

- Convert NavigationAPIMethodTracker from struct to class with private
  members and public accessors. Move IdentifierType and Identifier
  inside the class as private nested types.
- Replace the fragile isEmpty()/isNull() String dispatch in
  promoteUpcomingAPIMethodTracker() with an explicit TrackerPromotion
  enum (NonTraverse, TraverseByKey, TraverseFallback).
- Extract Navigation::TrackerManager inner class that owns the tracker
  lifecycle (upcoming → ongoing → cleanup), the Lock, and promise
  resolution/rejection methods. Navigation retains thin public
  delegates for rejectFinishedPromise() and upcomingTraverseMethodTracker().
- Remove unused WTF_MAKE_TZONE_ALLOCATED from RateLimiter (member-only,
  never heap-allocated).

No behavior change. All 417 Navigation API WPT tests pass.
- imported/w3c/web-platform-tests/navigation-api/
- http/tests/wpt/navigation-api/

* Source/WebCore/loader/HistoryController.h:
* Source/WebCore/page/Navigation.cpp:
(WebCore::NavigationAPIMethodTracker::NavigationAPIMethodTracker):
(WebCore::Navigation::TrackerManager::setUpcomingNonTraverse):
(WebCore::Navigation::TrackerManager::addUpcomingTraverse):
(WebCore::Navigation::TrackerManager::derivedResult const):
(WebCore::Navigation::reload):
(WebCore::Navigation::navigate):
(WebCore::Navigation::performTraversal):
(WebCore::Navigation::TrackerManager::resolveFinished):
(WebCore::Navigation::TrackerManager::rejectFinished):
(WebCore::Navigation::rejectFinishedPromise):
(WebCore::Navigation::TrackerManager::notifyCommitted):
(WebCore::Navigation::updateForNavigation):
(WebCore::Navigation::TrackerManager::promoteToOngoing):
(WebCore::Navigation::TrackerManager::cleanup):
(WebCore::Navigation::TrackerManager::ongoing const):
(WebCore::Navigation::TrackerManager::upcomingTraverse const):
(WebCore::Navigation::TrackerManager::existingTraverseResult const):
(WebCore::Navigation::TrackerManager::clearIfStillUpcomingNonTraverse):
(WebCore::Navigation::TrackerManager::assertEmpty const):
(WebCore::Navigation::upcomingTraverseMethodTracker const):
(WebCore::Navigation::abortOngoingNavigation):
(WebCore::Navigation::handleSameDocumentNavigation):
(WebCore::Navigation::innerDispatchNavigateEvent):
(WebCore::Navigation::TrackerManager::visitInGCThread):
(WebCore::Navigation::visitAdditionalChildrenInGCThread):
(WebCore::Navigation::maybeSetUpcomingNonTraversalTracker): Deleted.
(WebCore::Navigation::addUpcomingTraverseAPIMethodTracker): Deleted.
(WebCore::Navigation::apiMethodTrackerDerivedResult): Deleted.
(WebCore::Navigation::resolveFinishedPromise): Deleted.
(WebCore::Navigation::notifyCommittedToEntry): Deleted.
(WebCore::Navigation::promoteUpcomingAPIMethodTracker): Deleted.
(WebCore::Navigation::cleanupAPIMethodTracker): Deleted.
* Source/WebCore/page/Navigation.h:
(WebCore::NavigationAPIMethodTracker::operator== const):
(WebCore::NavigationAPIMethodTracker::key const):
(WebCore::NavigationAPIMethodTracker::setKey):
(WebCore::NavigationAPIMethodTracker::info):
(WebCore::NavigationAPIMethodTracker::serializedState const):
(WebCore::NavigationAPIMethodTracker::setSerializedState):
(WebCore::NavigationAPIMethodTracker::takeSerializedState):
(WebCore::NavigationAPIMethodTracker::committedToEntry const):
(WebCore::NavigationAPIMethodTracker::setCommittedToEntry):
(WebCore::NavigationAPIMethodTracker::committedPromise):
(WebCore::NavigationAPIMethodTracker::committedPromise const):
(WebCore::NavigationAPIMethodTracker::finishedPromise):
(WebCore::NavigationAPIMethodTracker::finishedPromise const):
(WebCore::NavigationAPIMethodTracker::finishedBeforeCommit const):
(WebCore::NavigationAPIMethodTracker::setFinishedBeforeCommit):
* Source/WebCore/page/Page.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/569e920404c8e3d8b394dd8a15094e3179e612a4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155638 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28896 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22055 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164399 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109433 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/795dc195-fcdf-416d-b682-83978d562b7c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157509 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/29043 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28746 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120455 "Failed to checkout and rebase branch from PR 62490") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109433 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/00aa7fff-5ef0-4c6e-ab61-642397bd3b50) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158595 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/29043 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/139755 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101144 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0f911e83-bb70-4f39-906b-fc63ee37971e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/29043 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19848 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12229 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/29043 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/17587 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166878 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/11054 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19198 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/128576 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/28440 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/23882 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128707 "Passed tests") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/28364 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139380 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/86193 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/23509 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/16177 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28058 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/92161 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/27635 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/27865 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27708 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->