### PR TITLE
[JSC] Use `tryFindOneChar` for dynamic one-char search string in DFG/FTL `String#indexOf` call

### DIFF
--- a/JSTests/microbenchmarks/string-indexof-flat-dynamic-onechar.js
+++ b/JSTests/microbenchmarks/string-indexof-flat-dynamic-onechar.js
@@ -1,0 +1,18 @@
+// Control group: flat base, non-constant 1-char needle.
+// This exercises the same operationStringIndexOf but base->isRope() is false,
+// so the new branch is a single not-taken check. Should show no regression.
+
+let flat = "a".repeat(150000);
+let needles = ["x", "y"];
+let sum = 0;
+
+function test(s, n) {
+    return s.indexOf(n);
+}
+noInline(test);
+
+for (let i = 0; i < 2e4; i++)
+    sum += test(flat, needles[i & 1]);
+
+if (sum !== -2e4)
+    throw new Error("bad: " + sum);

--- a/JSTests/microbenchmarks/string-indexof-rope-dynamic-onechar-hit.js
+++ b/JSTests/microbenchmarks/string-indexof-rope-dynamic-onechar-hit.js
@@ -1,0 +1,27 @@
+// Same shape as string-indexof-rope-dynamic-onechar.js but needle HITS early.
+// Baseline: flatten 150KB then find at index ~100.
+// Patched: scan ~100 bytes in fiber[0], return — no flatten.
+//
+// left/right must themselves be resolved so the top-level rope's fibers are
+// plain strings (tryFindOneChar bails on nested rope fibers). "a".repeat(n)
+// returns a flat string; "x"+flat makes a rope, so we resolve it once up front.
+
+let left  = "x" + "a".repeat(74999);
+left.indexOf("never-matches"); // multi-char search → view() → resolves left in place
+let right = "b".repeat(75000);
+
+let needles = ["x", "x"];
+let sum = 0;
+
+function test(s, n) {
+    return s.indexOf(n);
+}
+noInline(test);
+
+for (let i = 0; i < 2e4; i++) {
+    let r = left + right;
+    sum += test(r, needles[i & 1]);
+}
+
+if (sum !== 0)
+    throw new Error("bad: " + sum);

--- a/JSTests/microbenchmarks/string-indexof-rope-dynamic-onechar.js
+++ b/JSTests/microbenchmarks/string-indexof-rope-dynamic-onechar.js
@@ -1,0 +1,26 @@
+// needle is a non-constant 1-char string → DFG/FTL calls operationStringIndexOf,
+// not the WithOneChar variant. Before the patch this unconditionally resolved the rope.
+//
+// The rope must be a single-level rope with resolved fibers so that tryFindOneChar
+// can walk it without bailing out. `a + b + c` produces MakeRope(MakeRope(a,b),c)
+// whose first fiber is itself a rope → immediate bailout. Use two resolved fibers.
+
+let left  = "a".repeat(75000);
+let right = "b".repeat(75000);
+
+let needles = ["x", "y"];
+let sum = 0;
+
+function test(s, n) {
+    return s.indexOf(n);
+}
+noInline(test);
+
+for (let i = 0; i < 2e4; i++) {
+    // Fresh 2-fiber rope each iteration. MakeRope is not LICM'd (ExitsForExceptions).
+    let r = left + right;
+    sum += test(r, needles[i & 1]);
+}
+
+if (sum !== -2e4)
+    throw new Error("bad: " + sum);

--- a/JSTests/stress/string-indexof-rope-walk-dynamic-onechar.js
+++ b/JSTests/stress/string-indexof-rope-walk-dynamic-onechar.js
@@ -1,0 +1,100 @@
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error((msg ? msg + ": " : "") + "got " + actual + ", expected " + expected);
+}
+
+function makeRope(unit, depth) {
+    // depth-level balanced ternary rope, each fiber is `unit`
+    let s = unit;
+    for (let i = 0; i < depth; i++)
+        s = s + s + s;
+    return s;
+}
+
+function flatten(s) { s.charCodeAt(0); return s; }
+
+// Shallow 2-fiber rope with resolved fibers: tryFindOneChar walks without bailout.
+// Length = 1500 + 1500 = 3000 >= minLengthForRopeWalk (0x128 = 296)
+let shallowLeft = flatten("a".repeat(500) + "b" + "a".repeat(499) + "c" + "a".repeat(499));
+let shallowRight = flatten("a".repeat(499) + "d" + "a".repeat(500) + "e" + "a".repeat(499));
+function mkShallowRope() { return shallowLeft + shallowRight; }
+let shallowRope = mkShallowRope();
+let shallowFlat = ("" + shallowRope).slice(0); // force resolve
+
+// Deep rope: nested rope fibers → tryFindOneChar bails out (nullopt), falls through to view()
+let deepRope = makeRope("a".repeat(100) + "X" + "a".repeat(99), 4); // depth 4, len = 200 * 81 = 16200
+let deepFlat = ("" + deepRope).slice(0);
+
+// 16-bit 2-fiber rope with resolved fibers
+let wideLeft = flatten("あ".repeat(500) + "漢" + "あ".repeat(499));
+let wideRight = flatten("あ".repeat(500) + "字" + "あ".repeat(499));
+function mkWideRope() { return wideLeft + wideRight; }
+let wideRope = mkWideRope();
+let wideFlat = ("" + wideRope).slice(0);
+
+// needle must be a variable so DFG/FTL can't fold to WithOneChar at compile time.
+// Also pass through a function parameter to defeat tryGetString.
+function indexOf2(s, needle) { return s.indexOf(needle); }
+function indexOf3(s, needle, start) { return s.indexOf(needle, start); }
+noInline(indexOf2);
+noInline(indexOf3);
+
+let needles1 = ["a", "b", "c", "d", "e", "X", "z", ""];
+let needles2 = ["ab", "ba", "aa"];
+let needlesW = ["あ", "漢", "字"];
+
+for (let i = 0; i < testLoopCount; i++) {
+    // shallow rope, 1-char needle: hit/miss
+    for (let n of needles1) {
+        shouldBe(indexOf2(shallowRope, n), shallowFlat.indexOf(n), "shallow/" + n);
+        shouldBe(indexOf2(shallowRope, n), indexOf2(shallowFlat, n), "shallow-cross/" + n);
+    }
+    // shallow rope, 1-char needle with start index: before/at/after first occurrence, fiber boundary, past end
+    for (let start of [0, 499, 500, 501, 1000, 1001, 1499, 1500, 1501, 1999, 2000, 2999, 3000, 9999, -5]) {
+        for (let n of ["b", "c", "d", "e", "z"]) {
+            shouldBe(indexOf3(shallowRope, n, start), shallowFlat.indexOf(n, start), "shallow-idx/" + n + "/" + start);
+        }
+    }
+    // 0-char / 2-char needle: fall-through path, must still be correct
+    for (let n of needles2) {
+        shouldBe(indexOf2(shallowRope, n), shallowFlat.indexOf(n), "shallow-multi/" + n);
+        shouldBe(indexOf3(shallowRope, n, 100), shallowFlat.indexOf(n, 100), "shallow-multi-idx/" + n);
+    }
+    // deep rope: bail-out path, pos advanced then fall-through
+    for (let n of ["X", "a", "z"]) {
+        shouldBe(indexOf2(deepRope, n), deepFlat.indexOf(n), "deep/" + n);
+        shouldBe(indexOf3(deepRope, n, 5000), deepFlat.indexOf(n, 5000), "deep-idx/" + n);
+    }
+    // 16-bit
+    for (let n of needlesW) {
+        shouldBe(indexOf2(wideRope, n), wideFlat.indexOf(n), "wide/" + n);
+        shouldBe(indexOf3(wideRope, n, 600), wideFlat.indexOf(n, 600), "wide-idx/" + n);
+    }
+    // flat base: result unchanged
+    shouldBe(indexOf2(shallowFlat, "b"), 500, "flat-b");
+    shouldBe(indexOf3(shallowFlat, "c", 600), 1000, "flat-c-idx");
+}
+
+// Fiber-boundary characters: last/first char of each resolved fiber.
+let boundLeft = flatten("a".repeat(1499) + "P");
+let boundRight = flatten("Q" + "a".repeat(1499));
+function mkBoundRope() { return boundLeft + boundRight; }
+let boundFlat = flatten(mkBoundRope());
+for (let i = 0; i < testLoopCount; i++) {
+    let boundRope = mkBoundRope();
+    shouldBe(indexOf2(boundRope, "P"), 1499, "bound-P");
+    shouldBe(indexOf2(boundRope, "Q"), 1500, "bound-Q");
+    shouldBe(indexOf3(boundRope, "P", 1499), 1499, "bound-P-at");
+    shouldBe(indexOf3(boundRope, "P", 1500), -1, "bound-P-past");
+    shouldBe(indexOf3(boundRope, "Q", 1500), 1500, "bound-Q-at");
+    shouldBe(indexOf2(boundRope, "P"), boundFlat.indexOf("P"), "bound-cross-P");
+    shouldBe(indexOf2(boundRope, "Q"), boundFlat.indexOf("Q"), "bound-cross-Q");
+}
+
+// Below minLengthForRopeWalk: short rope skips the optimization, falls through
+let shortRope = ("a".repeat(50) + "M") + ("a".repeat(50)) + ("a".repeat(50));
+let shortFlat = ("" + shortRope).slice(0);
+for (let i = 0; i < testLoopCount; i++) {
+    shouldBe(indexOf2(shortRope, "M"), shortFlat.indexOf("M"), "short-M");
+    shouldBe(indexOf3(shortRope, "M", 40), shortFlat.indexOf("M", 40), "short-M-idx");
+}

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -3353,13 +3353,25 @@ JSC_DEFINE_JIT_OPERATION(operationStringIndexOf, UCPUStrictInt32, (JSGlobalObjec
 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    unsigned pos = 0;
+    if (argument->length() == 1 && base->isRope() && base->length() >= JSString::minLengthForRopeWalk) {
+        auto otherView = argument->view(globalObject);
+        OPERATION_RETURN_IF_EXCEPTION(scope, 0);
+        if (auto result = base->tryFindOneChar(globalObject, otherView[0], pos)) {
+            if (*result != notFound)
+                OPERATION_RETURN(scope, toUCPUStrictInt32(static_cast<int32_t>(*result)));
+            OPERATION_RETURN(scope, toUCPUStrictInt32(-1));
+        }
+        // nullopt: bail out, fall through to resolve. pos is advanced past the searched range.
+    }
+
     auto thisView = base->view(globalObject);
     OPERATION_RETURN_IF_EXCEPTION(scope, 0);
 
     auto otherView = argument->view(globalObject);
     OPERATION_RETURN_IF_EXCEPTION(scope, 0);
 
-    size_t result = thisView->find(vm.adaptiveStringSearcherTables(), otherView);
+    size_t result = thisView->find(vm.adaptiveStringSearcherTables(), otherView, pos);
     if (result == notFound)
         OPERATION_RETURN(scope, toUCPUStrictInt32(-1));
     OPERATION_RETURN(scope, toUCPUStrictInt32(result));
@@ -3400,19 +3412,30 @@ JSC_DEFINE_JIT_OPERATION(operationStringIndexOfWithIndex, UCPUStrictInt32, (JSGl
 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    int32_t length = base->length();
+    unsigned pos = 0;
+    if (position >= 0)
+        pos = std::min<uint32_t>(position, length);
+
+    if (static_cast<unsigned>(length) < argument->length() + pos)
+        OPERATION_RETURN(scope, toUCPUStrictInt32(-1));
+
+    if (argument->length() == 1 && base->isRope() && base->length() >= JSString::minLengthForRopeWalk) {
+        auto otherView = argument->view(globalObject);
+        OPERATION_RETURN_IF_EXCEPTION(scope, 0);
+        if (auto result = base->tryFindOneChar(globalObject, otherView[0], pos)) {
+            if (*result != notFound)
+                OPERATION_RETURN(scope, toUCPUStrictInt32(static_cast<int32_t>(*result)));
+            OPERATION_RETURN(scope, toUCPUStrictInt32(-1));
+        }
+        // nullopt: bail out, fall through to resolve. pos is advanced past the searched range.
+    }
+
     auto thisView = base->view(globalObject);
     OPERATION_RETURN_IF_EXCEPTION(scope, 0);
 
     auto otherView = argument->view(globalObject);
     OPERATION_RETURN_IF_EXCEPTION(scope, 0);
-
-    int32_t length = thisView->length();
-    unsigned pos = 0;
-    if (position >= 0)
-        pos = std::min<uint32_t>(position, length);
-
-    if (static_cast<unsigned>(length) < otherView->length() + pos)
-        OPERATION_RETURN(scope, toUCPUStrictInt32(-1));
 
     size_t result = thisView->find(vm.adaptiveStringSearcherTables(), otherView, pos);
     if (result == notFound)


### PR DESCRIPTION
#### 3a21b755052629c9adea4138b7dceddba7dc686b
<pre>
[JSC] Use `tryFindOneChar` for dynamic one-char search string in DFG/FTL `String#indexOf` call
<a href="https://bugs.webkit.org/show_bug.cgi?id=311168">https://bugs.webkit.org/show_bug.cgi?id=311168</a>

Reviewed by Yusuke Suzuki.

DFG/FTL pick operationStringIndexOfWithOneChar only when the search
string is a compile-time constant. A variable search string that is one
character at runtime falls into operationStringIndexOf and
operationStringIndexOfWithIndex, which resolve the rope base
unconditionally via view().

Check argument-&gt;length() == 1 at runtime and call tryFindOneChar,
matching what stringIndexOfImpl already does in the C++ slow path. The
WithIndex variant hoists length/pos computation above view() so the
early-out and rope-walk guard run before resolving the base; a side
effect is that indexOf(ch, str.length) on a rope now returns -1 without
flattening.

                                                 TipOfTree                  Patched

string-indexof-rope-dynamic-onechar-hit       85.9583+-26.4181    ^      1.9109+-2.1950        ^ definitely 44.9820x faster
string-indexof-rope-dynamic-onechar          170.7843+-66.1731    ^     68.8757+-17.0792       ^ definitely 2.4796x faster

Tests: JSTests/microbenchmarks/string-indexof-flat-dynamic-onechar.js
       JSTests/microbenchmarks/string-indexof-rope-dynamic-onechar-hit.js
       JSTests/microbenchmarks/string-indexof-rope-dynamic-onechar.js
       JSTests/stress/string-indexof-rope-walk-dynamic-onechar.js

* JSTests/microbenchmarks/string-indexof-flat-dynamic-onechar.js: Added.
(test):
* JSTests/microbenchmarks/string-indexof-rope-dynamic-onechar-hit.js: Added.
(test):
* JSTests/microbenchmarks/string-indexof-rope-dynamic-onechar.js: Added.
(test):
* JSTests/stress/string-indexof-rope-walk-dynamic-onechar.js: Added.
(shouldBe):
(flatten):
(mkShallowRope):
(mkWideRope):
(indexOf2):
(indexOf3):
(mkBoundRope):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):

Canonical link: <a href="https://commits.webkit.org/310511@main">https://commits.webkit.org/310511@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea61577840a2c3b96c981eb25388c100613b2ffa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153384 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26168 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19767 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162129 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106842 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26694 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26488 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118580 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83962 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156343 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20826 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137701 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99292 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19903 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17847 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9964 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/145397 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129551 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15571 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164603 "Built successfully") | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/14205 "Found unexpected failure with change (failure)") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7739 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17165 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126642 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25965 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21880 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126799 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34559 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25967 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137367 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82634 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21739 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14147 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/185019 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25584 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89870 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47456 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25275 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25434 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25335 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->