### PR TITLE
EventListenerMap::replace() should preserve existing listener options

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/event-handler-attribute-replace-preserves-passive-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/event-handler-attribute-replace-preserves-passive-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Replacing a wheel event handler attribute on body via setAttribute preserves its passive flag
+PASS Replacing a wheel event handler attribute on document element via setAttribute preserves its passive flag
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/event-handler-attribute-replace-preserves-passive.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/event-handler-attribute-replace-preserves-passive.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<title>Event handler attribute replacement via setAttribute preserves passive flag</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-content-attributes">
+<link rel="help" href="https://dom.spec.whatwg.org/#dom-eventtarget-addeventlistener">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+// Wheel event listeners on document/body are made passive by default by user
+// agents. When such a listener is replaced via setAttribute (e.g. setting the
+// onwheel attribute again), the passive flag should be preserved from the
+// existing listener rather than being reset to defaults.
+
+test(function() {
+    // Set onwheel on body via setAttribute for the first time.
+    // The UA may make this passive since wheel listeners on body are passive
+    // by default per spec recommendation.
+    document.body.setAttribute("onwheel",
+        "event.preventDefault(); window._defaultPrevented1 = event.defaultPrevented;");
+
+    var event1 = new Event("wheel", { cancelable: true });
+    document.body.dispatchEvent(event1);
+
+    var initialPassive = !window._defaultPrevented1;
+
+    // Now replace the onwheel handler via setAttribute again.
+    document.body.setAttribute("onwheel",
+        "event.preventDefault(); window._defaultPrevented2 = event.defaultPrevented;");
+
+    var event2 = new Event("wheel", { cancelable: true });
+    document.body.dispatchEvent(event2);
+
+    // The passive flag from the initial listener should be preserved after
+    // replacement via setAttribute.
+    assert_equals(window._defaultPrevented2, window._defaultPrevented1,
+        "preventDefault behavior should be the same before and after setAttribute replacement");
+
+    // Clean up.
+    document.body.removeAttribute("onwheel");
+    delete window._defaultPrevented1;
+    delete window._defaultPrevented2;
+}, "Replacing a wheel event handler attribute on body via setAttribute preserves its passive flag");
+
+test(function() {
+    document.documentElement.setAttribute("onwheel",
+        "event.preventDefault(); window._defaultPrevented3 = event.defaultPrevented;");
+
+    var event1 = new Event("wheel", { cancelable: true });
+    document.documentElement.dispatchEvent(event1);
+
+    document.documentElement.setAttribute("onwheel",
+        "event.preventDefault(); window._defaultPrevented4 = event.defaultPrevented;");
+
+    var event2 = new Event("wheel", { cancelable: true });
+    document.documentElement.dispatchEvent(event2);
+
+    assert_equals(window._defaultPrevented4, window._defaultPrevented3,
+        "preventDefault behavior should be the same before and after setAttribute replacement");
+
+    document.documentElement.removeAttribute("onwheel");
+    delete window._defaultPrevented3;
+    delete window._defaultPrevented4;
+}, "Replacing a wheel event handler attribute on document element via setAttribute preserves its passive flag");
+</script>
+</body>

--- a/Source/WebCore/dom/EventListenerMap.cpp
+++ b/Source/WebCore/dom/EventListenerMap.cpp
@@ -102,18 +102,19 @@ static inline size_t findListener(const EventListenerVector& listeners, EventLis
     return notFound;
 }
 
-void EventListenerMap::replace(const AtomString& eventType, EventListener& oldListener, Ref<EventListener>&& newListener, const RegisteredEventListener::Options& options)
+void EventListenerMap::replacePreservingOptions(const AtomString& eventType, EventListener& oldListener, Ref<EventListener>&& newListener, bool useCapture)
 {
     releaseAssertOrSetThreadUID();
     Locker locker { m_lock };
 
     auto* listeners = find(eventType);
     ASSERT(listeners);
-    size_t index = findListener(*listeners, oldListener, options.capture);
+    size_t index = findListener(*listeners, oldListener, useCapture);
     ASSERT(index != notFound);
     auto& registeredListener = listeners->at(index);
+    auto existingOptions = registeredListener->options();
     registeredListener->markAsRemoved();
-    registeredListener = RegisteredEventListener::create(WTF::move(newListener), options);
+    registeredListener = RegisteredEventListener::create(WTF::move(newListener), existingOptions);
 }
 
 bool EventListenerMap::add(const AtomString& eventType, Ref<EventListener>&& listener, const RegisteredEventListener::Options& options)

--- a/Source/WebCore/dom/EventListenerMap.h
+++ b/Source/WebCore/dom/EventListenerMap.h
@@ -74,7 +74,7 @@ public:
         m_entries.clear();
     }
 
-    void replace(const AtomString& eventType, EventListener& oldListener, Ref<EventListener>&& newListener, const RegisteredEventListener::Options&);
+    void replacePreservingOptions(const AtomString& eventType, EventListener& oldListener, Ref<EventListener>&& newListener, bool useCapture = false);
     bool add(const AtomString& eventType, Ref<EventListener>&&, const RegisteredEventListener::Options&);
     bool remove(const AtomString& eventType, EventListener&, bool useCapture);
     WEBCORE_EXPORT EventListenerVector* NODELETE find(const AtomString& eventType);

--- a/Source/WebCore/dom/EventTarget.cpp
+++ b/Source/WebCore/dom/EventTarget.cpp
@@ -215,7 +215,7 @@ bool EventTarget::setAttributeEventListener(const AtomString& eventType, RefPtr<
         listener->checkValidityForEventTarget(*this);
 #endif
 
-        eventTargetData()->eventListenerMap.replace(eventType, *existingListener, *listener, { });
+        eventTargetData()->eventListenerMap.replacePreservingOptions(eventType, *existingListener, *listener);
 
         InspectorInstrumentation::didAddEventListener(*this, eventType, *listener, false);
 

--- a/Source/WebCore/dom/RegisteredEventListener.h
+++ b/Source/WebCore/dom/RegisteredEventListener.h
@@ -61,6 +61,8 @@ public:
     bool wasRemoved() const { return m_wasRemoved; }
     bool trustedOnly() const { return m_trustedOnly; }
 
+    Options options() const { return { m_useCapture, m_isPassive, m_isOnce, m_trustedOnly }; }
+
     void markAsRemoved() { m_wasRemoved = true; }
 
 private:


### PR DESCRIPTION
#### 65aa62f3712ac09a9c0cb35813f67da2ff2e6218
<pre>
EventListenerMap::replace() should preserve existing listener options
<a href="https://bugs.webkit.org/show_bug.cgi?id=311170">https://bugs.webkit.org/show_bug.cgi?id=311170</a>

Reviewed by Anne van Kesteren and Ryosuke Niwa.

EventListenerMap::replace(), used when replacing attribute event listeners
via setAttribute(), was resetting the RegisteredEventListener options
(passive, once, capture, trustedOnly) to defaults instead of preserving
them from the existing listener. This caused wheel/touch attribute event
listeners on document/body to lose their passive flag when the attribute
was reassigned, since the passive flag is set by
Quirks::shouldMakeEventListenerPassive() only during addEventListener().

Added RegisteredEventListener::options() getter and used it in replace()
to preserve existing options.

Test: imported/w3c/web-platform-tests/dom/events/event-handler-attribute-replace-preserves-passive.html

* LayoutTests/imported/w3c/web-platform-tests/dom/events/event-handler-attribute-replace-preserves-passive-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/events/event-handler-attribute-replace-preserves-passive.html: Added.
* Source/WebCore/dom/EventListenerMap.cpp:
(WebCore::EventListenerMap::replacePreservingOptions):
(WebCore::EventListenerMap::replace):
* Source/WebCore/dom/EventListenerMap.h:
* Source/WebCore/dom/EventTarget.cpp:
(WebCore::EventTarget::setAttributeEventListener):
* Source/WebCore/dom/RegisteredEventListener.h:
(WebCore::RegisteredEventListener::options const):

Canonical link: <a href="https://commits.webkit.org/310362@main">https://commits.webkit.org/310362@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42308f87c92271ae9e7af81bac481c8e657caa5b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153601 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26385 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20002 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162351 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/107059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b62e5e54-c68e-43f3-91b3-ccafc0003fe4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155474 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26913 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26707 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118752 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/107059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/495b896d-6045-4593-a009-b2cdb48a20b7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156560 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21006 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/137911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99463 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/20085 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18026 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10184 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129732 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15771 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164822 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7956 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17365 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126827 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26182 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22062 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126991 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34444 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26184 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137566 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82852 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21906 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14347 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25801 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90088 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25492 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25652 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25552 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->