### PR TITLE
[IndexedDB API] Implement IDBIndex::getAllRecords()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllRecords.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllRecords.any-expected.txt
@@ -1,29 +1,27 @@
 
-FAIL Single item getAllRecords is not yet supported
-FAIL Empty index getAllRecords is not yet supported
-FAIL Get all records getAllRecords is not yet supported
-FAIL Get all records with empty options getAllRecords is not yet supported
-FAIL Get all records with large value getAllRecords is not yet supported
-FAIL Count getAllRecords is not yet supported
-FAIL Query with bound range getAllRecords is not yet supported
-FAIL Query with bound range and count getAllRecords is not yet supported
-FAIL Query with upper excluded bound range getAllRecords is not yet supported
-FAIL Query with lower excluded bound range getAllRecords is not yet supported
-FAIL Query with bound range and count for generated keys getAllRecords is not yet supported
-FAIL Query with Nonexistent key getAllRecords is not yet supported
-FAIL Zero count getAllRecords is not yet supported
-FAIL Max value count getAllRecords is not yet supported
-FAIL Query with empty range where first key < upperBound getAllRecords is not yet supported
-FAIL Query with empty range where lowerBound < last key getAllRecords is not yet supported
-FAIL Query index key that matches multiple records getAllRecords is not yet supported
-FAIL Query with multiEntry index getAllRecords is not yet supported
-FAIL Direction: next getAllRecords is not yet supported
-FAIL Direction: prev getAllRecords is not yet supported
-FAIL Direction: nextunique getAllRecords is not yet supported
-FAIL Direction: prevunique getAllRecords is not yet supported
-FAIL Direction and query getAllRecords is not yet supported
-FAIL Direction, query and count getAllRecords is not yet supported
-FAIL Get all records with invalid query keys assert_throws_dom: An invalid Date(NaN) key must throw an exception. function "() => {
-        queryTarget[getAllFunctionName](argument);
-      }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0
+PASS Single item
+PASS Empty index
+PASS Get all records
+PASS Get all records with empty options
+PASS Get all records with large value
+PASS Count
+PASS Query with bound range
+PASS Query with bound range and count
+PASS Query with upper excluded bound range
+PASS Query with lower excluded bound range
+PASS Query with bound range and count for generated keys
+PASS Query with Nonexistent key
+PASS Zero count
+PASS Max value count
+PASS Query with empty range where first key < upperBound
+PASS Query with empty range where lowerBound < last key
+PASS Query index key that matches multiple records
+PASS Query with multiEntry index
+PASS Direction: next
+PASS Direction: prev
+PASS Direction: nextunique
+PASS Direction: prevunique
+PASS Direction and query
+PASS Direction, query and count
+PASS Get all records with invalid query keys
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllRecords.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllRecords.any.serviceworker-expected.txt
@@ -1,29 +1,27 @@
 
-FAIL Single item getAllRecords is not yet supported
-FAIL Empty index getAllRecords is not yet supported
-FAIL Get all records getAllRecords is not yet supported
-FAIL Get all records with empty options getAllRecords is not yet supported
-FAIL Get all records with large value getAllRecords is not yet supported
-FAIL Count getAllRecords is not yet supported
-FAIL Query with bound range getAllRecords is not yet supported
-FAIL Query with bound range and count getAllRecords is not yet supported
-FAIL Query with upper excluded bound range getAllRecords is not yet supported
-FAIL Query with lower excluded bound range getAllRecords is not yet supported
-FAIL Query with bound range and count for generated keys getAllRecords is not yet supported
-FAIL Query with Nonexistent key getAllRecords is not yet supported
-FAIL Zero count getAllRecords is not yet supported
-FAIL Max value count getAllRecords is not yet supported
-FAIL Query with empty range where first key < upperBound getAllRecords is not yet supported
-FAIL Query with empty range where lowerBound < last key getAllRecords is not yet supported
-FAIL Query index key that matches multiple records getAllRecords is not yet supported
-FAIL Query with multiEntry index getAllRecords is not yet supported
-FAIL Direction: next getAllRecords is not yet supported
-FAIL Direction: prev getAllRecords is not yet supported
-FAIL Direction: nextunique getAllRecords is not yet supported
-FAIL Direction: prevunique getAllRecords is not yet supported
-FAIL Direction and query getAllRecords is not yet supported
-FAIL Direction, query and count getAllRecords is not yet supported
-FAIL Get all records with invalid query keys assert_throws_dom: An invalid Date(NaN) key must throw an exception. function "() => {
-        queryTarget[getAllFunctionName](argument);
-      }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0
+PASS Single item
+PASS Empty index
+PASS Get all records
+PASS Get all records with empty options
+PASS Get all records with large value
+PASS Count
+PASS Query with bound range
+PASS Query with bound range and count
+PASS Query with upper excluded bound range
+PASS Query with lower excluded bound range
+PASS Query with bound range and count for generated keys
+PASS Query with Nonexistent key
+PASS Zero count
+PASS Max value count
+PASS Query with empty range where first key < upperBound
+PASS Query with empty range where lowerBound < last key
+PASS Query index key that matches multiple records
+PASS Query with multiEntry index
+PASS Direction: next
+PASS Direction: prev
+PASS Direction: nextunique
+PASS Direction: prevunique
+PASS Direction and query
+PASS Direction, query and count
+PASS Get all records with invalid query keys
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllRecords.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllRecords.any.sharedworker-expected.txt
@@ -1,29 +1,27 @@
 
-FAIL Single item getAllRecords is not yet supported
-FAIL Empty index getAllRecords is not yet supported
-FAIL Get all records getAllRecords is not yet supported
-FAIL Get all records with empty options getAllRecords is not yet supported
-FAIL Get all records with large value getAllRecords is not yet supported
-FAIL Count getAllRecords is not yet supported
-FAIL Query with bound range getAllRecords is not yet supported
-FAIL Query with bound range and count getAllRecords is not yet supported
-FAIL Query with upper excluded bound range getAllRecords is not yet supported
-FAIL Query with lower excluded bound range getAllRecords is not yet supported
-FAIL Query with bound range and count for generated keys getAllRecords is not yet supported
-FAIL Query with Nonexistent key getAllRecords is not yet supported
-FAIL Zero count getAllRecords is not yet supported
-FAIL Max value count getAllRecords is not yet supported
-FAIL Query with empty range where first key < upperBound getAllRecords is not yet supported
-FAIL Query with empty range where lowerBound < last key getAllRecords is not yet supported
-FAIL Query index key that matches multiple records getAllRecords is not yet supported
-FAIL Query with multiEntry index getAllRecords is not yet supported
-FAIL Direction: next getAllRecords is not yet supported
-FAIL Direction: prev getAllRecords is not yet supported
-FAIL Direction: nextunique getAllRecords is not yet supported
-FAIL Direction: prevunique getAllRecords is not yet supported
-FAIL Direction and query getAllRecords is not yet supported
-FAIL Direction, query and count getAllRecords is not yet supported
-FAIL Get all records with invalid query keys assert_throws_dom: An invalid Date(NaN) key must throw an exception. function "() => {
-        queryTarget[getAllFunctionName](argument);
-      }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0
+PASS Single item
+PASS Empty index
+PASS Get all records
+PASS Get all records with empty options
+PASS Get all records with large value
+PASS Count
+PASS Query with bound range
+PASS Query with bound range and count
+PASS Query with upper excluded bound range
+PASS Query with lower excluded bound range
+PASS Query with bound range and count for generated keys
+PASS Query with Nonexistent key
+PASS Zero count
+PASS Max value count
+PASS Query with empty range where first key < upperBound
+PASS Query with empty range where lowerBound < last key
+PASS Query index key that matches multiple records
+PASS Query with multiEntry index
+PASS Direction: next
+PASS Direction: prev
+PASS Direction: nextunique
+PASS Direction: prevunique
+PASS Direction and query
+PASS Direction, query and count
+PASS Get all records with invalid query keys
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllRecords.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllRecords.any.worker-expected.txt
@@ -1,29 +1,27 @@
 
-FAIL Single item getAllRecords is not yet supported
-FAIL Empty index getAllRecords is not yet supported
-FAIL Get all records getAllRecords is not yet supported
-FAIL Get all records with empty options getAllRecords is not yet supported
-FAIL Get all records with large value getAllRecords is not yet supported
-FAIL Count getAllRecords is not yet supported
-FAIL Query with bound range getAllRecords is not yet supported
-FAIL Query with bound range and count getAllRecords is not yet supported
-FAIL Query with upper excluded bound range getAllRecords is not yet supported
-FAIL Query with lower excluded bound range getAllRecords is not yet supported
-FAIL Query with bound range and count for generated keys getAllRecords is not yet supported
-FAIL Query with Nonexistent key getAllRecords is not yet supported
-FAIL Zero count getAllRecords is not yet supported
-FAIL Max value count getAllRecords is not yet supported
-FAIL Query with empty range where first key < upperBound getAllRecords is not yet supported
-FAIL Query with empty range where lowerBound < last key getAllRecords is not yet supported
-FAIL Query index key that matches multiple records getAllRecords is not yet supported
-FAIL Query with multiEntry index getAllRecords is not yet supported
-FAIL Direction: next getAllRecords is not yet supported
-FAIL Direction: prev getAllRecords is not yet supported
-FAIL Direction: nextunique getAllRecords is not yet supported
-FAIL Direction: prevunique getAllRecords is not yet supported
-FAIL Direction and query getAllRecords is not yet supported
-FAIL Direction, query and count getAllRecords is not yet supported
-FAIL Get all records with invalid query keys assert_throws_dom: An invalid Date(NaN) key must throw an exception. function "() => {
-        queryTarget[getAllFunctionName](argument);
-      }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0
+PASS Single item
+PASS Empty index
+PASS Get all records
+PASS Get all records with empty options
+PASS Get all records with large value
+PASS Count
+PASS Query with bound range
+PASS Query with bound range and count
+PASS Query with upper excluded bound range
+PASS Query with lower excluded bound range
+PASS Query with bound range and count for generated keys
+PASS Query with Nonexistent key
+PASS Zero count
+PASS Max value count
+PASS Query with empty range where first key < upperBound
+PASS Query with empty range where lowerBound < last key
+PASS Query index key that matches multiple records
+PASS Query with multiEntry index
+PASS Direction: next
+PASS Direction: prev
+PASS Direction: nextunique
+PASS Direction: prevunique
+PASS Direction and query
+PASS Direction, query and count
+PASS Get all records with invalid query keys
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idlharness.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idlharness.any-expected.txt
@@ -156,15 +156,15 @@ PASS IDBKeyRange interface: [object IDBKeyRange] must inherit property "bound(an
 PASS IDBKeyRange interface: calling bound(any, any, optional boolean, optional boolean) on [object IDBKeyRange] with too few arguments must throw TypeError
 PASS IDBKeyRange interface: [object IDBKeyRange] must inherit property "includes(any)" with the proper type
 PASS IDBKeyRange interface: calling includes(any) on [object IDBKeyRange] with too few arguments must throw TypeError
-FAIL IDBRecord interface: existence and properties of interface object assert_own_property: self does not have own property "IDBRecord" expected property "IDBRecord" missing
-FAIL IDBRecord interface object length assert_own_property: self does not have own property "IDBRecord" expected property "IDBRecord" missing
-FAIL IDBRecord interface object name assert_own_property: self does not have own property "IDBRecord" expected property "IDBRecord" missing
-FAIL IDBRecord interface: existence and properties of interface prototype object assert_own_property: self does not have own property "IDBRecord" expected property "IDBRecord" missing
-FAIL IDBRecord interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "IDBRecord" expected property "IDBRecord" missing
-FAIL IDBRecord interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "IDBRecord" expected property "IDBRecord" missing
-FAIL IDBRecord interface: attribute key assert_own_property: self does not have own property "IDBRecord" expected property "IDBRecord" missing
-FAIL IDBRecord interface: attribute primaryKey assert_own_property: self does not have own property "IDBRecord" expected property "IDBRecord" missing
-FAIL IDBRecord interface: attribute value assert_own_property: self does not have own property "IDBRecord" expected property "IDBRecord" missing
+PASS IDBRecord interface: existence and properties of interface object
+PASS IDBRecord interface object length
+PASS IDBRecord interface object name
+PASS IDBRecord interface: existence and properties of interface prototype object
+PASS IDBRecord interface: existence and properties of interface prototype object's "constructor" property
+PASS IDBRecord interface: existence and properties of interface prototype object's @@unscopables property
+PASS IDBRecord interface: attribute key
+PASS IDBRecord interface: attribute primaryKey
+PASS IDBRecord interface: attribute value
 PASS IDBCursor interface: existence and properties of interface object
 PASS IDBCursor interface object length
 PASS IDBCursor interface object name

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idlharness.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idlharness.any.serviceworker-expected.txt
@@ -156,15 +156,15 @@ PASS IDBKeyRange interface: [object IDBKeyRange] must inherit property "bound(an
 PASS IDBKeyRange interface: calling bound(any, any, optional boolean, optional boolean) on [object IDBKeyRange] with too few arguments must throw TypeError
 PASS IDBKeyRange interface: [object IDBKeyRange] must inherit property "includes(any)" with the proper type
 PASS IDBKeyRange interface: calling includes(any) on [object IDBKeyRange] with too few arguments must throw TypeError
-FAIL IDBRecord interface: existence and properties of interface object assert_own_property: self does not have own property "IDBRecord" expected property "IDBRecord" missing
-FAIL IDBRecord interface object length assert_own_property: self does not have own property "IDBRecord" expected property "IDBRecord" missing
-FAIL IDBRecord interface object name assert_own_property: self does not have own property "IDBRecord" expected property "IDBRecord" missing
-FAIL IDBRecord interface: existence and properties of interface prototype object assert_own_property: self does not have own property "IDBRecord" expected property "IDBRecord" missing
-FAIL IDBRecord interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "IDBRecord" expected property "IDBRecord" missing
-FAIL IDBRecord interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "IDBRecord" expected property "IDBRecord" missing
-FAIL IDBRecord interface: attribute key assert_own_property: self does not have own property "IDBRecord" expected property "IDBRecord" missing
-FAIL IDBRecord interface: attribute primaryKey assert_own_property: self does not have own property "IDBRecord" expected property "IDBRecord" missing
-FAIL IDBRecord interface: attribute value assert_own_property: self does not have own property "IDBRecord" expected property "IDBRecord" missing
+PASS IDBRecord interface: existence and properties of interface object
+PASS IDBRecord interface object length
+PASS IDBRecord interface object name
+PASS IDBRecord interface: existence and properties of interface prototype object
+PASS IDBRecord interface: existence and properties of interface prototype object's "constructor" property
+PASS IDBRecord interface: existence and properties of interface prototype object's @@unscopables property
+PASS IDBRecord interface: attribute key
+PASS IDBRecord interface: attribute primaryKey
+PASS IDBRecord interface: attribute value
 PASS IDBCursor interface: existence and properties of interface object
 PASS IDBCursor interface object length
 PASS IDBCursor interface object name

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idlharness.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idlharness.any.sharedworker-expected.txt
@@ -156,15 +156,15 @@ PASS IDBKeyRange interface: [object IDBKeyRange] must inherit property "bound(an
 PASS IDBKeyRange interface: calling bound(any, any, optional boolean, optional boolean) on [object IDBKeyRange] with too few arguments must throw TypeError
 PASS IDBKeyRange interface: [object IDBKeyRange] must inherit property "includes(any)" with the proper type
 PASS IDBKeyRange interface: calling includes(any) on [object IDBKeyRange] with too few arguments must throw TypeError
-FAIL IDBRecord interface: existence and properties of interface object assert_own_property: self does not have own property "IDBRecord" expected property "IDBRecord" missing
-FAIL IDBRecord interface object length assert_own_property: self does not have own property "IDBRecord" expected property "IDBRecord" missing
-FAIL IDBRecord interface object name assert_own_property: self does not have own property "IDBRecord" expected property "IDBRecord" missing
-FAIL IDBRecord interface: existence and properties of interface prototype object assert_own_property: self does not have own property "IDBRecord" expected property "IDBRecord" missing
-FAIL IDBRecord interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "IDBRecord" expected property "IDBRecord" missing
-FAIL IDBRecord interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "IDBRecord" expected property "IDBRecord" missing
-FAIL IDBRecord interface: attribute key assert_own_property: self does not have own property "IDBRecord" expected property "IDBRecord" missing
-FAIL IDBRecord interface: attribute primaryKey assert_own_property: self does not have own property "IDBRecord" expected property "IDBRecord" missing
-FAIL IDBRecord interface: attribute value assert_own_property: self does not have own property "IDBRecord" expected property "IDBRecord" missing
+PASS IDBRecord interface: existence and properties of interface object
+PASS IDBRecord interface object length
+PASS IDBRecord interface object name
+PASS IDBRecord interface: existence and properties of interface prototype object
+PASS IDBRecord interface: existence and properties of interface prototype object's "constructor" property
+PASS IDBRecord interface: existence and properties of interface prototype object's @@unscopables property
+PASS IDBRecord interface: attribute key
+PASS IDBRecord interface: attribute primaryKey
+PASS IDBRecord interface: attribute value
 PASS IDBCursor interface: existence and properties of interface object
 PASS IDBCursor interface object length
 PASS IDBCursor interface object name

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idlharness.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idlharness.any.worker-expected.txt
@@ -156,15 +156,15 @@ PASS IDBKeyRange interface: [object IDBKeyRange] must inherit property "bound(an
 PASS IDBKeyRange interface: calling bound(any, any, optional boolean, optional boolean) on [object IDBKeyRange] with too few arguments must throw TypeError
 PASS IDBKeyRange interface: [object IDBKeyRange] must inherit property "includes(any)" with the proper type
 PASS IDBKeyRange interface: calling includes(any) on [object IDBKeyRange] with too few arguments must throw TypeError
-FAIL IDBRecord interface: existence and properties of interface object assert_own_property: self does not have own property "IDBRecord" expected property "IDBRecord" missing
-FAIL IDBRecord interface object length assert_own_property: self does not have own property "IDBRecord" expected property "IDBRecord" missing
-FAIL IDBRecord interface object name assert_own_property: self does not have own property "IDBRecord" expected property "IDBRecord" missing
-FAIL IDBRecord interface: existence and properties of interface prototype object assert_own_property: self does not have own property "IDBRecord" expected property "IDBRecord" missing
-FAIL IDBRecord interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "IDBRecord" expected property "IDBRecord" missing
-FAIL IDBRecord interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "IDBRecord" expected property "IDBRecord" missing
-FAIL IDBRecord interface: attribute key assert_own_property: self does not have own property "IDBRecord" expected property "IDBRecord" missing
-FAIL IDBRecord interface: attribute primaryKey assert_own_property: self does not have own property "IDBRecord" expected property "IDBRecord" missing
-FAIL IDBRecord interface: attribute value assert_own_property: self does not have own property "IDBRecord" expected property "IDBRecord" missing
+PASS IDBRecord interface: existence and properties of interface object
+PASS IDBRecord interface object length
+PASS IDBRecord interface object name
+PASS IDBRecord interface: existence and properties of interface prototype object
+PASS IDBRecord interface: existence and properties of interface prototype object's "constructor" property
+PASS IDBRecord interface: existence and properties of interface prototype object's @@unscopables property
+PASS IDBRecord interface: attribute key
+PASS IDBRecord interface: attribute primaryKey
+PASS IDBRecord interface: attribute value
 PASS IDBCursor interface: existence and properties of interface object
 PASS IDBCursor interface object length
 PASS IDBCursor interface object name

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any-expected.txt
@@ -27,7 +27,5 @@ FAIL IDBObjectStore getAllRecords() method with throwing/invalid keys assert_thr
   }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0
 PASS IDBIndex getAll() method with throwing/invalid keys
 PASS IDBIndex getAllKeys() method with throwing/invalid keys
-FAIL IDBIndex getAllRecords() method with throwing/invalid keys assert_throws_dom: options query key conversion with invalid key should throw DataError function "() => {
-    receiver[method]({query: invalid_key});
-  }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0
+PASS IDBIndex getAllRecords() method with throwing/invalid keys
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.serviceworker-expected.txt
@@ -27,7 +27,5 @@ FAIL IDBObjectStore getAllRecords() method with throwing/invalid keys assert_thr
   }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0
 PASS IDBIndex getAll() method with throwing/invalid keys
 PASS IDBIndex getAllKeys() method with throwing/invalid keys
-FAIL IDBIndex getAllRecords() method with throwing/invalid keys assert_throws_dom: options query key conversion with invalid key should throw DataError function "() => {
-    receiver[method]({query: invalid_key});
-  }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0
+PASS IDBIndex getAllRecords() method with throwing/invalid keys
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.sharedworker-expected.txt
@@ -27,7 +27,5 @@ FAIL IDBObjectStore getAllRecords() method with throwing/invalid keys assert_thr
   }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0
 PASS IDBIndex getAll() method with throwing/invalid keys
 PASS IDBIndex getAllKeys() method with throwing/invalid keys
-FAIL IDBIndex getAllRecords() method with throwing/invalid keys assert_throws_dom: options query key conversion with invalid key should throw DataError function "() => {
-    receiver[method]({query: invalid_key});
-  }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0
+PASS IDBIndex getAllRecords() method with throwing/invalid keys
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.worker-expected.txt
@@ -27,7 +27,5 @@ FAIL IDBObjectStore getAllRecords() method with throwing/invalid keys assert_thr
   }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0
 PASS IDBIndex getAll() method with throwing/invalid keys
 PASS IDBIndex getAllKeys() method with throwing/invalid keys
-FAIL IDBIndex getAllRecords() method with throwing/invalid keys assert_throws_dom: options query key conversion with invalid key should throw DataError function "() => {
-    receiver[method]({query: invalid_key});
-  }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0
+PASS IDBIndex getAllRecords() method with throwing/invalid keys
 

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -467,6 +467,7 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/indexeddb/IDBKeyRange.idl
     Modules/indexeddb/IDBObjectStore.idl
     Modules/indexeddb/IDBOpenDBRequest.idl
+    Modules/indexeddb/IDBRecord.idl
     Modules/indexeddb/IDBRequest.idl
     Modules/indexeddb/IDBTransaction.idl
     Modules/indexeddb/IDBTransactionDurability.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -527,6 +527,7 @@ $(PROJECT_DIR)/Modules/indexeddb/IDBIndex.idl
 $(PROJECT_DIR)/Modules/indexeddb/IDBKeyRange.idl
 $(PROJECT_DIR)/Modules/indexeddb/IDBObjectStore.idl
 $(PROJECT_DIR)/Modules/indexeddb/IDBOpenDBRequest.idl
+$(PROJECT_DIR)/Modules/indexeddb/IDBRecord.idl
 $(PROJECT_DIR)/Modules/indexeddb/IDBRequest.idl
 $(PROJECT_DIR)/Modules/indexeddb/IDBTransaction.idl
 $(PROJECT_DIR)/Modules/indexeddb/IDBTransactionDurability.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -1733,6 +1733,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIDBObjectStore.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIDBObjectStore.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIDBOpenDBRequest.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIDBOpenDBRequest.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIDBRecord.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIDBRecord.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIDBRequest.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIDBRequest.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIDBTransaction.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -389,6 +389,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/indexeddb/IDBKeyRange.idl \
     $(WebCore)/Modules/indexeddb/IDBObjectStore.idl \
     $(WebCore)/Modules/indexeddb/IDBOpenDBRequest.idl \
+    $(WebCore)/Modules/indexeddb/IDBRecord.idl \
     $(WebCore)/Modules/indexeddb/IDBRequest.idl \
     $(WebCore)/Modules/indexeddb/IDBTransaction.idl \
 	$(WebCore)/Modules/indexeddb/IDBTransactionDurability.idl \

--- a/Source/WebCore/Modules/indexeddb/IDBGetAllOptions.h
+++ b/Source/WebCore/Modules/indexeddb/IDBGetAllOptions.h
@@ -52,4 +52,4 @@ struct ParsedGetAllQueryOrOptions {
 
 ExceptionOr<ParsedGetAllQueryOrOptions> parseGetAllOptions(JSC::JSGlobalObject& execState, JSC::JSValue keyOrOptions);
 
-}
+} // namespace WebCore

--- a/Source/WebCore/Modules/indexeddb/IDBGetAllOptions.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBGetAllOptions.idl
@@ -23,6 +23,7 @@
 * THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+// https://w3c.github.io/IndexedDB/#dictdef-idbgetalloptions
 [
     EnabledBySetting=IndexedDBGetAllRecordsEnabled
 ] dictionary IDBGetAllOptions {

--- a/Source/WebCore/Modules/indexeddb/IDBGetAllResult.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBGetAllResult.cpp
@@ -48,6 +48,7 @@ void IDBGetAllResult::isolatedCopy(const IDBGetAllResult& source, IDBGetAllResul
 {
     destination.m_type = source.m_type;
     destination.m_keys = crossThreadCopy(source.m_keys);
+    destination.m_primaryKeys = crossThreadCopy(source.m_primaryKeys);
     destination.m_values = crossThreadCopy(source.m_values);
     destination.m_keyPath = crossThreadCopy(source.m_keyPath);
 }
@@ -55,6 +56,11 @@ void IDBGetAllResult::isolatedCopy(const IDBGetAllResult& source, IDBGetAllResul
 void IDBGetAllResult::addKey(IDBKeyData&& key)
 {
     m_keys.append(WTF::move(key));
+}
+
+void IDBGetAllResult::addPrimaryKey(IDBKeyData&& primaryKey)
+{
+    m_primaryKeys.append(WTF::move(primaryKey));
 }
 
 void IDBGetAllResult::addValue(IDBValue&& value)
@@ -65,6 +71,11 @@ void IDBGetAllResult::addValue(IDBValue&& value)
 const Vector<IDBKeyData>& IDBGetAllResult::keys() const
 {
     return m_keys;
+}
+
+const Vector<IDBKeyData>& IDBGetAllResult::primaryKeys() const
+{
+    return m_primaryKeys;
 }
 
 const Vector<IDBValue>& IDBGetAllResult::values() const

--- a/Source/WebCore/Modules/indexeddb/IDBGetAllResult.h
+++ b/Source/WebCore/Modules/indexeddb/IDBGetAllResult.h
@@ -52,16 +52,19 @@ public:
     IndexedDB::GetAllType type() const { return m_type; }
     const std::optional<IDBKeyPath>& keyPath() const LIFETIME_BOUND { return m_keyPath; }
     WEBCORE_EXPORT const Vector<IDBKeyData>& NODELETE keys() const;
+    WEBCORE_EXPORT const Vector<IDBKeyData>& NODELETE primaryKeys() const;
     WEBCORE_EXPORT const Vector<IDBValue>& NODELETE values() const;
 
     void addKey(IDBKeyData&&);
+    void addPrimaryKey(IDBKeyData&&);
     void addValue(IDBValue&&);
 
 private:
     friend struct IPC::ArgumentCoder<IDBGetAllResult>;
-    IDBGetAllResult(IndexedDB::GetAllType type, Vector<IDBKeyData>&& keys, Vector<IDBValue>&& values, std::optional<IDBKeyPath>&& keyPath)
+    IDBGetAllResult(IndexedDB::GetAllType type, Vector<IDBKeyData>&& keys, Vector<IDBKeyData>&& primaryKeys, Vector<IDBValue>&& values, std::optional<IDBKeyPath>&& keyPath)
         : m_type(type)
         , m_keys(WTF::move(keys))
+        , m_primaryKeys(WTF::move(primaryKeys))
         , m_values(WTF::move(values))
         , m_keyPath(WTF::move(keyPath))
     {
@@ -71,6 +74,7 @@ private:
 
     IndexedDB::GetAllType m_type { IndexedDB::GetAllType::Keys };
     Vector<IDBKeyData> m_keys;
+    Vector<IDBKeyData> m_primaryKeys;
     Vector<IDBValue> m_values;
     std::optional<IDBKeyPath> m_keyPath;
 };

--- a/Source/WebCore/Modules/indexeddb/IDBIndex.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBIndex.cpp
@@ -37,6 +37,7 @@
 #include "IDBObjectStore.h"
 #include "IDBRequest.h"
 #include "IDBTransaction.h"
+#include "JSIDBKeyRange.h"
 #include "Logging.h"
 #include "Settings.h"
 #include "WebCoreOpaqueRoot.h"
@@ -358,6 +359,9 @@ ExceptionOr<Ref<IDBRequest>> IDBIndex::doGetAllShared(IndexedDB::GetAllType getA
     case IndexedDB::GetAllType::Keys:
         callingFunctionExceptionMessagePrefix = "Failed to execute 'getAllKeys' on IDBIdex': "_s;
         break;
+    case IndexedDB::GetAllType::Records:
+        callingFunctionExceptionMessagePrefix = "Failed to execute 'getAllRecords' on IDBIdex': "_s;
+        break;
     }
 
     Ref transaction = m_objectStore->transaction();
@@ -440,9 +444,25 @@ ExceptionOr<Ref<IDBRequest>> IDBIndex::getAllKeys(JSGlobalObject& execState, JSV
     });
 }
 
-ExceptionOr<Ref<IDBRequest>> IDBIndex::getAllRecords(JSGlobalObject&, IDBGetAllOptions&&)
+ExceptionOr<Ref<IDBRequest>> IDBIndex::getAllRecords(JSGlobalObject& execState, IDBGetAllOptions&& options)
 {
-    return Exception { ExceptionCode::NotSupportedError, "getAllRecords is not yet supported"_s };
+    LOG(IndexedDB, "IDBIndex::getAllRecords");
+
+    return doGetAllShared(IndexedDB::GetAllType::Records, std::nullopt, [execState = &execState, options]() -> ExceptionOr<ParsedGetAllQueryOrOptions> {
+        auto query = options.query;
+
+        if (query.isUndefinedOrNull())
+            return ParsedGetAllQueryOrOptions { nullptr, options.count, options.direction };
+
+        if (RefPtr keyRange = JSIDBKeyRange::toWrapped(execState->vm(), query))
+            return ParsedGetAllQueryOrOptions { WTF::move(keyRange), options.count, options.direction };
+
+        auto onlyResultFromQuery = IDBKeyRange::only(*execState, query);
+        if (onlyResultFromQuery.hasException())
+            return Exception(ExceptionCode::DataError, "The query specified in options is not a valid key."_s);
+
+        return ParsedGetAllQueryOrOptions { onlyResultFromQuery.releaseReturnValue(), options.count, options.direction };
+    });
 }
 
 void IDBIndex::markAsDeleted()

--- a/Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp
@@ -617,6 +617,8 @@ ExceptionOr<Ref<IDBRequest>> IDBObjectStore::doGetAllShared(IndexedDB::GetAllTyp
     case IndexedDB::GetAllType::Keys:
         callingFunctionExceptionMessagePrefix = "Failed to execute 'getAllKeys' on IDBObjectStore': "_s;
         break;
+    case IndexedDB::GetAllType::Records:
+        return Exception { ExceptionCode::NotSupportedError, "getAllRecords is not yet supported"_s };
     }
 
     Ref transaction = m_transaction.get();

--- a/Source/WebCore/Modules/indexeddb/IDBRecord.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBRecord.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "IDBRecord.h"
+
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(IDBRecord);
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/indexeddb/IDBRecord.h
+++ b/Source/WebCore/Modules/indexeddb/IDBRecord.h
@@ -1,0 +1,66 @@
+/*
+* Copyright (C) 2026 Apple Inc. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+* THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+* PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+* BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+* THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#pragma once
+
+#include "IDBKeyData.h"
+#include "IDBKeyPath.h"
+#include "IDBValue.h"
+#include "ScriptWrappable.h"
+#include <optional>
+#include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
+
+namespace WebCore {
+
+class IDBRecord : public ScriptWrappable, public RefCounted<IDBRecord> {
+    WTF_MAKE_TZONE_ALLOCATED(IDBRecord);
+public:
+    static Ref<IDBRecord> create(IDBKeyData&& key, IDBKeyData&& primaryKey, IDBValue&& value, const std::optional<IDBKeyPath>& keyPath)
+    {
+        return adoptRef(*new IDBRecord(WTF::move(key), WTF::move(primaryKey), WTF::move(value), keyPath));
+    }
+
+    const IDBKeyData& key() const { return m_key; }
+    const IDBKeyData& primaryKey() const { return m_primaryKey; }
+    const IDBValue& value() const { return m_value; }
+    const std::optional<IDBKeyPath>& keyPath() const { return m_keyPath; }
+
+private:
+    IDBRecord(IDBKeyData&& key, IDBKeyData&& primaryKey, IDBValue&& value, const std::optional<IDBKeyPath>& keyPath)
+        : m_key(WTF::move(key))
+        , m_primaryKey(WTF::move(primaryKey))
+        , m_value(WTF::move(value))
+        , m_keyPath(keyPath)
+    {
+    }
+
+    IDBKeyData m_key;
+    IDBKeyData m_primaryKey;
+    IDBValue m_value;
+    std::optional<IDBKeyPath> m_keyPath;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/indexeddb/IDBRecord.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBRecord.idl
@@ -1,0 +1,34 @@
+/*
+* Copyright (C) 2026 Apple Inc. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+* THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+* PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+* BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+* THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+// https://w3c.github.io/IndexedDB/#idbrecord
+[
+    EnabledBySetting=IndexedDBGetAllRecordsEnabled,
+    Exposed=(Window,Worker)
+] interface IDBRecord {
+    [CustomGetter] readonly attribute any key;
+    [CustomGetter] readonly attribute any primaryKey;
+    [CustomGetter] readonly attribute any value;
+};

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
@@ -997,6 +997,9 @@ void IDBTransaction::didGetAllRecordsOnServer(IDBRequest& request, const IDBResu
     case IndexedDB::GetAllType::Values:
         request.setResult(getAllResult);
         break;
+    case IndexedDB::GetAllType::Records:
+        request.setResult(getAllResult);
+        break;
     }
 
     completeNoncursorRequest(request, resultData);

--- a/Source/WebCore/Modules/indexeddb/IndexedDB.h
+++ b/Source/WebCore/Modules/indexeddb/IndexedDB.h
@@ -96,9 +96,10 @@ enum class RequestType : uint8_t {
     Other,
 };
 
-enum class GetAllType : bool {
+enum class GetAllType : uint8_t {
     Keys,
     Values,
+    Records
 };
 
 enum class ConnectionClosedOnBehalfOfServer : bool { No, Yes };

--- a/Source/WebCore/Modules/indexeddb/server/MemoryIndex.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryIndex.h
@@ -46,7 +46,7 @@ class ThreadSafeDataBuffer;
 struct IDBKeyRangeData;
 
 namespace IndexedDB {
-enum class GetAllType : bool;
+enum class GetAllType : uint8_t;
 enum class IndexRecordType : bool;
 }
 

--- a/Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.h
@@ -46,7 +46,7 @@ class IDBValue;
 struct IDBKeyRangeData;
 
 namespace IndexedDB {
-enum class GetAllType : bool;
+enum class GetAllType : uint8_t;
 enum class IndexRecordType : bool;
 }
 

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
@@ -2329,10 +2329,20 @@ IDBError SQLiteIDBBackingStore::getAllIndexRecords(const IDBResourceIdentifier& 
     if (!targetCount)
         targetCount = std::numeric_limits<uint32_t>::max();
     while (!cursor->didComplete() && !cursor->didError() && currentCount < targetCount) {
-        IDBKeyData keyCopy = cursor->currentPrimaryKey();
-        result.addKey(WTF::move(keyCopy));
-        if (getAllRecordsData.getAllType == IndexedDB::GetAllType::Values)
+        switch (getAllRecordsData.getAllType) {
+        case IndexedDB::GetAllType::Keys:
+            result.addKey(IDBKeyData(cursor->currentPrimaryKey()));
+            break;
+        case IndexedDB::GetAllType::Values:
+            result.addKey(IDBKeyData(cursor->currentPrimaryKey()));
             result.addValue(IDBValue(cursor->currentValue()));
+            break;
+        case IndexedDB::GetAllType::Records:
+            result.addKey(IDBKeyData(cursor->currentKey()));
+            result.addPrimaryKey(IDBKeyData(cursor->currentPrimaryKey()));
+            result.addValue(IDBValue(cursor->currentValue()));
+            break;
+        };
 
         ++currentCount;
         cursor->advance(1);

--- a/Source/WebCore/Modules/indexeddb/shared/IDBGetAllRecordsData.cpp
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBGetAllRecordsData.cpp
@@ -54,9 +54,21 @@ String IDBGetAllRecordsData::loggingString() const
         RELEASE_ASSERT_NOT_REACHED();
     }();
 
+    auto getAllTypeString = [&] {
+        switch (getAllType) {
+        case IndexedDB::GetAllType::Keys:
+            return "Keys"_s;
+        case IndexedDB::GetAllType::Values:
+            return "Values"_s;
+        case IndexedDB::GetAllType::Records:
+            return "Records"_s;
+        }
+        RELEASE_ASSERT_NOT_REACHED();
+    }();
+
     if (indexIdentifier)
-        return makeString("<GetAllRecords: Idx "_s, *indexIdentifier, ", OS "_s, objectStoreIdentifier, ", "_s, getAllType == IndexedDB::GetAllType::Keys ? "Keys"_s : "Values"_s, ", cursorDirection "_s, directionString, ", range "_s, keyRangeData.loggingString(), '>');
-    return makeString("<GetAllRecords: OS "_s, objectStoreIdentifier, ", "_s, getAllType == IndexedDB::GetAllType::Keys ? "Keys"_s : "Values"_s, ", cursorDirection "_s, directionString, ", range "_s, keyRangeData.loggingString(), '>');
+        return makeString("<GetAllRecords: Idx "_s, *indexIdentifier, ", OS "_s, objectStoreIdentifier, ", "_s, "getAllType "_s, getAllTypeString, ", cursorDirection "_s, directionString, ", range "_s, keyRangeData.loggingString(), '>');
+    return makeString("<GetAllRecords: OS "_s, objectStoreIdentifier, ", "_s, "getAllType "_s, getAllTypeString, ", cursorDirection "_s, directionString, ", range "_s, keyRangeData.loggingString(), '>');
 }
 
 #endif

--- a/Source/WebCore/Modules/indexeddb/shared/IDBGetAllRecordsData.h
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBGetAllRecordsData.h
@@ -32,7 +32,7 @@
 namespace WebCore {
 
 namespace IndexedDB {
-enum class GetAllType : bool;
+enum class GetAllType : uint8_t;
 }
 
 struct IDBGetAllRecordsData {

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
@@ -35,6 +35,7 @@
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/WallTime.h>
 #include <wtf/WeakRandomNumber.h>
+#include <wtf/glib/GMallocString.h>
 #include <wtf/glib/GSpanExtras.h>
 #include <wtf/text/Base64.h>
 #include <wtf/text/StringToIntegerConversion.h>

--- a/Source/WebCore/Modules/streams/StreamTeeUtilities.cpp
+++ b/Source/WebCore/Modules/streams/StreamTeeUtilities.cpp
@@ -29,6 +29,7 @@
 
 #include "ContextDestructionObserverInlines.h"
 #include "EventLoop.h"
+#include "JSDOMConvertBufferSource.h"
 #include "JSDOMPromise.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSReadableStreamReadResult.h"

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -175,6 +175,7 @@ Modules/indexeddb/IDBKeyRange.cpp
 Modules/indexeddb/IDBKeyRangeData.cpp
 Modules/indexeddb/IDBObjectStore.cpp
 Modules/indexeddb/IDBOpenDBRequest.cpp
+Modules/indexeddb/IDBRecord.cpp
 Modules/indexeddb/IDBRequest.cpp
 Modules/indexeddb/IDBRequestCompletionEvent.cpp
 Modules/indexeddb/IDBTransaction.cpp
@@ -733,6 +734,7 @@ bindings/js/JSHistoryCustom.cpp
 bindings/js/JSIDBCursorCustom.cpp
 bindings/js/JSIDBCursorWithValueCustom.cpp
 bindings/js/JSIDBObjectStoreCustom.cpp
+bindings/js/JSIDBRecordCustom.cpp
 bindings/js/JSIDBRequestCustom.cpp
 bindings/js/JSIDBSerializationGlobalObject.cpp
 bindings/js/JSIDBTransactionCustom.cpp
@@ -4432,6 +4434,7 @@ JSIDBIndex.cpp
 JSIDBKeyRange.cpp
 JSIDBObjectStore.cpp
 JSIDBOpenDBRequest.cpp
+JSIDBRecord.cpp
 JSIDBRequest.cpp
 JSIDBTransaction.cpp
 JSIDBTransactionDurability.cpp

--- a/Source/WebCore/bindings/js/JSIDBRecordCustom.cpp
+++ b/Source/WebCore/bindings/js/JSIDBRecordCustom.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "JSIDBRecord.h"
+
+#include "IDBBindingUtilities.h"
+#include "JSDOMConvertIndexedDB.h"
+
+namespace WebCore {
+
+JSC::JSValue JSIDBRecord::key(JSC::JSGlobalObject& lexicalGlobalObject) const
+{
+    return toJS<IDLIDBKeyData>(lexicalGlobalObject, *jsCast<JSDOMGlobalObject*>(&lexicalGlobalObject), wrapped().key());
+}
+
+JSC::JSValue JSIDBRecord::primaryKey(JSC::JSGlobalObject& lexicalGlobalObject) const
+{
+    return toJS<IDLIDBKeyData>(lexicalGlobalObject, *jsCast<JSDOMGlobalObject*>(&lexicalGlobalObject), wrapped().primaryKey());
+}
+
+JSC::JSValue JSIDBRecord::value(JSC::JSGlobalObject& lexicalGlobalObject) const
+{
+    auto result = deserializeIDBValueWithKeyInjection(lexicalGlobalObject, wrapped().value(), wrapped().primaryKey(), wrapped().keyPath());
+    return result ? result.value() : jsNull();
+}
+
+} // namespace WebCore

--- a/Source/WebCore/bindings/js/JSIDBRequestCustom.cpp
+++ b/Source/WebCore/bindings/js/JSIDBRequestCustom.cpp
@@ -27,11 +27,14 @@
 #include "JSIDBRequest.h"
 
 #include "IDBBindingUtilities.h"
+#include "IDBRecord.h"
+#include "IndexedDB.h"
 #include "JSDOMConvertIndexedDB.h"
 #include "JSDOMConvertInterface.h"
 #include "JSDOMConvertSequences.h"
 #include "JSIDBCursor.h"
 #include "JSIDBDatabase.h"
+#include "JSIDBRecord.h"
 
 namespace WebCore {
 using namespace JSC;
@@ -85,20 +88,32 @@ JSC::JSValue JSIDBRequest::result(JSC::JSGlobalObject& lexicalGlobalObject) cons
         [&](const IDBGetAllResult& getAllResult) {
             return cachedPropertyValue(throwScope, lexicalGlobalObject, *this, resultWrapper, [&](JSC::ThrowScope& throwScope) {
                 auto& keys = getAllResult.keys();
+                auto& primaryKeys = getAllResult.primaryKeys();
                 auto& values = getAllResult.values();
                 auto& keyPath = getAllResult.keyPath();
+
+                auto* domGlobalObject = jsCast<JSDOMGlobalObject*>(&lexicalGlobalObject);
+
                 JSC::MarkedArgumentBuffer list;
-                list.ensureCapacity(values.size());
-                for (unsigned i = 0; i < values.size(); i ++) {
-                    auto result = deserializeIDBValueWithKeyInjection(lexicalGlobalObject, values[i], keys[i], keyPath);
-                    if (!result)
-                        return jsNull();
-                    list.append(result.value());
+                list.ensureCapacity(keys.size());
+
+                for (unsigned i = 0; i < keys.size(); i++) {
+                    if (getAllResult.type() == IndexedDB::GetAllType::Records) {
+                        Ref record = IDBRecord::create(IDBKeyData(keys[i]), IDBKeyData(primaryKeys[i]), IDBValue(values[i]), keyPath);
+                        list.append(toJS<IDLInterface<IDBRecord>>(lexicalGlobalObject, *domGlobalObject, throwScope, WTF::move(record)));
+                    } else {
+                        auto result = deserializeIDBValueWithKeyInjection(lexicalGlobalObject, values[i], keys[i], keyPath);
+                        if (!result)
+                            return jsNull();
+                        list.append(result.value());
+                    }
+
                     if (list.hasOverflowed()) [[unlikely]] {
                         propagateException(lexicalGlobalObject, throwScope, Exception(ExceptionCode::UnknownError));
                         return jsNull();
                     }
                 }
+
                 return JSValue(JSC::constructArray(&lexicalGlobalObject, static_cast<JSC::ArrayAllocationProfile*>(nullptr), list));
             });
         }

--- a/Source/WebCore/bindings/js/JSShadowRealmGlobalScopeBase.cpp
+++ b/Source/WebCore/bindings/js/JSShadowRealmGlobalScopeBase.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "JSShadowRealmGlobalScopeBase.h"
 
+#include "DOMWrapperWorld.h"
 #include "EventLoop.h"
 #include "JSShadowRealmGlobalScope.h"
 #include "ScriptModuleLoader.h"

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -285,6 +285,7 @@ namespace WebCore {
     macro(IDBKeyRange) \
     macro(IDBObjectStore) \
     macro(IDBOpenDBRequest) \
+    macro(IDBRecord) \
     macro(IDBRequest) \
     macro(IDBTransaction) \
     macro(IDBVersionChangeEvent) \

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -3,7 +3,7 @@
 # Copyright (C) 2006 Anders Carlsson <andersca@mac.com>
 # Copyright (C) 2006, 2007 Samuel Weinig <sam@webkit.org>
 # Copyright (C) 2006 Alexey Proskuryakov <ap@webkit.org>
-# Copyright (C) 2006-2025 Apple Inc. All rights reserved.
+# Copyright (C) 2006-2026 Apple Inc. All rights reserved.
 # Copyright (C) 2009 Cameron McCormack <cam@mcc.id.au>
 # Copyright (C) Research In Motion Limited 2010. All rights reserved.
 # Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -490,6 +490,7 @@ class WebCore::IDBGetResult {
 class WebCore::IDBGetAllResult {
     WebCore::IndexedDB::GetAllType type()
     Vector<WebCore::IDBKeyData> keys()
+    Vector<WebCore::IDBKeyData> primaryKeys()
     Vector<WebCore::IDBValue> values()
     std::optional<WebCore::IDBKeyPath> keyPath()
 }
@@ -1824,7 +1825,11 @@ enum class WebCore::InputMode : uint8_t {
     Search
 };
 
-enum class WebCore::IndexedDB::GetAllType : bool
+enum class WebCore::IndexedDB::GetAllType : uint8_t {
+    Keys,
+    Values,
+    Records
+};
 
 enum class WebCore::WorkerType : bool
 


### PR DESCRIPTION
#### fc3f6a39a4a1704c67a9d637463fdb3176bee8c0
<pre>
[IndexedDB API] Implement IDBIndex::getAllRecords()
<a href="https://bugs.webkit.org/show_bug.cgi?id=311172">https://bugs.webkit.org/show_bug.cgi?id=311172</a>
<a href="https://rdar.apple.com/173761551">rdar://173761551</a>

Reviewed by Brady Eidson.

The IndexedDB API (<a href="https://w3c.github.io/IndexedDB/#index-interface)">https://w3c.github.io/IndexedDB/#index-interface)</a> has specified
a new function getAllRecords() on IDBIndex. This takes in an IDBGetAllOptions and
returns an array of IDBRecords which contain the key, primaryKey, and value of the
record. The key is the index key, the primary key is the key of the associated
record in the object store.

This patch implements this.

The spec (<a href="https://w3c.github.io/IndexedDB/#dom-idbindex-getallrecords)">https://w3c.github.io/IndexedDB/#dom-idbindex-getallrecords)</a> says to run
these steps: <a href="https://w3c.github.io/IndexedDB/#create-a-request-to-retrieve-multiple-items">https://w3c.github.io/IndexedDB/#create-a-request-to-retrieve-multiple-items</a>

This follows the same steps as getAll() and getAllKeys(). So we reuse that code path
and add a new IndexedDB::GetAllType called Records.

We carry out steps 1-9 by calling doGetAllShared() with this new type. Since the input
passed in is already IDBGetAllOptions, we obtain the query, count, and direction
directly from it (step 9).

doGetAllShared() calls requestGetAllObjectStoreRecords which stores in the
IDBGetAllRecordsData object that our type is Records. This is already plumbed all
the way down to SQLiteIDBBackingStore::getAllIndexRecords().

The way getAll() and getAllKeys() work is that getAllIndexRecords() puts all of
the keys and values into a IDBGetAllResult. Later on, to put the needed data into
the result of the IDBRequest which will eventually be returned, we call
IDBTransaction::didGetAllRecordsOnServer(). Then upon the JS accessing the result,
JSIDBRequest::result() will convert the keys and values (which are stored as
IDBKeyData and IDBValue respectively) into JSValues and returns them in an array.

For getAllRecords(), the IDBRequest&apos;s result should be an array of IDBRecords,
which also contains primaryKeys. So we add a primaryKeys field to IDBGetAllResult.
Then, SQLiteIDBBackingStore::getAllIndexRecords() will put the primary keys into
the IDBGetAllResult.

Then, in the case of Records, IDBTransaction::didGetAllRecordsOnServer() will set
the IDBRequest result to the IDBGetAllResult.

When the IDBRequest result is accessed, it needs to return an array of IDBRecords.
So we first create the IDL and implementation of IDBRecord. It includes the keyPath
because in the case of in-line keys, we need the keyPath to reconstruct the value.
We add JSIDBRecordCustom.cpp with the custom getters for each field. We need this
since the IDL says the returned types are JSValues, but the IDBRecord class stores
IDBKeyRanges and IDBValues. The getter for value uses
deserializeIDBValueWithKeyInjection() to deal with the in-line keys case (the same
way JSIDBRequestCustom already does).

Next, we edit JSIDBRequestCustom.cpp to create the IDBRecord when the result field
is accessed. Just like in the Values case, the result is a IDBGetAllResult. We use
its keys, primaryKeys, and values to make the IDBRecord.

* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllRecords.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllRecords.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllRecords.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_getAllRecords.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idlharness.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idlharness.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idlharness.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idlharness.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.worker-expected.txt:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Modules/indexeddb/IDBGetAllOptions.h:
* Source/WebCore/Modules/indexeddb/IDBGetAllOptions.idl:
* Source/WebCore/Modules/indexeddb/IDBGetAllResult.cpp:
(WebCore::IDBGetAllResult::isolatedCopy):
(WebCore::IDBGetAllResult::addPrimaryKey):
(WebCore::IDBGetAllResult::primaryKeys const):
* Source/WebCore/Modules/indexeddb/IDBGetAllResult.h:
(WebCore::IDBGetAllResult::IDBGetAllResult):

Add m_primaryKeys which will be used for the primaryKey field of IDBRecord.

* Source/WebCore/Modules/indexeddb/IDBIndex.cpp:
(WebCore::IDBIndex::doGetAllShared):
(WebCore::IDBIndex::getAllRecords):
* Source/WebCore/Modules/indexeddb/IDBRecord.cpp:
* Source/WebCore/Modules/indexeddb/IDBRecord.h:
(WebCore::IDBRecord::create):
(WebCore::IDBRecord::key const):
(WebCore::IDBRecord::primaryKey const):
(WebCore::IDBRecord::value const):
(WebCore::IDBRecord::keyPath const):
(WebCore::IDBRecord::IDBRecord):
* Source/WebCore/Modules/indexeddb/IDBRecord.idl:

Add the IDBRecord IDL and implementation. We need to hold the keyPath as well
in case in-line keys are being used.

* Source/WebCore/Modules/indexeddb/IDBTransaction.cpp:
(WebCore::IDBTransaction::didGetAllRecordsOnServer):

For Records, set the result to the whole IDBGetAllResult since constructing
the IDBRecord will require the keys, primaryKeys, values, and keyPath.

* Source/WebCore/Modules/indexeddb/IndexedDB.h:
* Source/WebCore/Modules/indexeddb/server/MemoryIndex.h:
* Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.h:
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp:
(WebCore::IDBServer::SQLiteIDBBackingStore::getAllIndexRecords):

Store the primaryKeys in the IDBGetAllResult. For the Records case, the key is
the index key, and the primary key is the key of the associated record in the
object store. (Different from the Keys and Values cases where the key is the
index&apos;s record&apos;s value AKA the primary key of the associated record in the object
store).

* Source/WebCore/Modules/indexeddb/shared/IDBGetAllRecordsData.cpp:
(WebCore::IDBGetAllRecordsData::loggingString const):
* Source/WebCore/Modules/indexeddb/shared/IDBGetAllRecordsData.h:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSIDBRecordCustom.cpp:
(WebCore::JSIDBRecord::key const):
(WebCore::JSIDBRecord::primaryKey const):
(WebCore::JSIDBRecord::value const):

The getter for value uses deserializeIDBValueWithKeyInjection() to deal with the
in-line keys case (the same way JSIDBRequestCustom already does).

* Source/WebCore/bindings/js/JSIDBRequestCustom.cpp:
(WebCore::JSIDBRequest::result const):

Construct the array of IDBRecords that IDBRequest&apos;s result will hold.

* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/310374@main">https://commits.webkit.org/310374@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aeb0475f4e64526beb5dbad268e0c6c08b99e98b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153689 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26473 "Failed to checkout and rebase branch from PR 61751") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/20090 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/162439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/107147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155562 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27001 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26795 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/162439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/107147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156648 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/21087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/137995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/162439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/20166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/18115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/10272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/129815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/15854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/164910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/8044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/17448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/164910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/26270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/22147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/164910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/26272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/137649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/82950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23487 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/26272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/14431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/25889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/90177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/25580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/25740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/25640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->