### PR TITLE
copyListenersNotCreatedFromMarkupToTarget() should preserve once and passive flags

### DIFF
--- a/LayoutTests/svg/custom/use-event-listener-once-option-preserved-expected.txt
+++ b/LayoutTests/svg/custom/use-event-listener-once-option-preserved-expected.txt
@@ -1,0 +1,10 @@
+Tests that the 'once' option on an event listener is preserved when copied to an SVG use shadow tree.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS count is 1
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/svg/custom/use-event-listener-once-option-preserved.html
+++ b/LayoutTests/svg/custom/use-event-listener-once-option-preserved.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<body>
+<svg id="svg" width="200" height="200">
+    <defs>
+        <rect id="target" width="200" height="200" fill="green"/>
+    </defs>
+</svg>
+<script src="../../resources/js-test.js"></script>
+<script>
+description("Tests that the 'once' option on an event listener is preserved when copied to an SVG use shadow tree.");
+
+var count = 0;
+
+// Add a { once: true } listener to the original element FIRST.
+var target = document.getElementById("target");
+target.addEventListener("test", function() { count++; }, { once: true });
+
+// Now dynamically create the <use> element so the shadow tree is built
+// AFTER the listener exists, ensuring transferEventListenersToShadowTree
+// copies it to the shadow clone.
+var svg = document.getElementById("svg");
+var use = document.createElementNS("http://www.w3.org/2000/svg", "use");
+use.setAttribute("href", "#target");
+svg.appendChild(use);
+
+// Force layout to build the shadow tree (which copies listeners).
+document.body.offsetHeight;
+
+// Access the shadow clone via internals and dispatch events to it.
+var shadowRoot = internals.shadowRoot(use);
+var shadowClone = shadowRoot.querySelector("rect");
+shadowClone.dispatchEvent(new Event("test"));
+shadowClone.dispatchEvent(new Event("test"));
+
+// With once properly preserved, the listener should fire only once.
+shouldBe("count", "1");
+</script>
+</body>
+</html>

--- a/LayoutTests/svg/custom/use-event-listener-passive-option-preserved-expected.txt
+++ b/LayoutTests/svg/custom/use-event-listener-passive-option-preserved-expected.txt
@@ -1,0 +1,10 @@
+Tests that the 'passive' option on an event listener is preserved when copied to an SVG use shadow tree.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS defaultPrevented is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/svg/custom/use-event-listener-passive-option-preserved.html
+++ b/LayoutTests/svg/custom/use-event-listener-passive-option-preserved.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<body>
+<svg id="svg" width="200" height="200">
+    <defs>
+        <rect id="target" width="200" height="200" fill="green"/>
+    </defs>
+</svg>
+<script src="../../resources/js-test.js"></script>
+<script>
+description("Tests that the 'passive' option on an event listener is preserved when copied to an SVG use shadow tree.");
+
+var defaultPrevented;
+
+// Add a { passive: true } listener to the original element FIRST.
+var target = document.getElementById("target");
+target.addEventListener("test", function(e) { e.preventDefault(); defaultPrevented = e.defaultPrevented; }, { passive: true });
+
+// Now dynamically create the <use> element so the shadow tree is built
+// AFTER the listener exists, ensuring transferEventListenersToShadowTree
+// copies it to the shadow clone.
+var svg = document.getElementById("svg");
+var use = document.createElementNS("http://www.w3.org/2000/svg", "use");
+use.setAttribute("href", "#target");
+svg.appendChild(use);
+
+// Force layout to build the shadow tree (which copies listeners).
+document.body.offsetHeight;
+
+// Access the shadow clone via internals and dispatch a cancelable event to it.
+var shadowRoot = internals.shadowRoot(use);
+var shadowClone = shadowRoot.querySelector("rect");
+shadowClone.dispatchEvent(new Event("test", { cancelable: true }));
+
+// With passive properly preserved, preventDefault() should be a no-op.
+shouldBeFalse("defaultPrevented");
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/EventListenerMap.cpp
+++ b/Source/WebCore/dom/EventListenerMap.cpp
@@ -203,7 +203,7 @@ static void copyListenersNotCreatedFromMarkupToTarget(const AtomString& eventTyp
         // Event listeners created from markup have already been transfered to the shadow tree during cloning.
         if (JSEventListener::wasCreatedFromMarkup(registeredListener->callback()))
             continue;
-        target->addEventListener(eventType, registeredListener->callback(), { { registeredListener->useCapture() }, std::nullopt, false, nullptr, false });
+        target->addEventListener(eventType, registeredListener->callback(), { { registeredListener->useCapture() }, registeredListener->isPassive(), registeredListener->isOnce(), nullptr, false });
     }
 }
 


### PR DESCRIPTION
#### 13d5a8ec67a43378fee57edd18c2b80b19dc8a56
<pre>
copyListenersNotCreatedFromMarkupToTarget() should preserve once and passive flags
<a href="https://bugs.webkit.org/show_bug.cgi?id=311174">https://bugs.webkit.org/show_bug.cgi?id=311174</a>

Reviewed by Ryosuke Niwa.

When copying JS-added event listeners to the SVG `&lt;use&gt;` shadow tree,
`copyListenersNotCreatedFromMarkupToTarget()` was hardcoding once to false
and passive to `std::nullopt` instead of preserving the original listener&apos;s
values. This meant a listener registered with `{ once: true }` would fire
repeatedly on the shadow clone.

Tests:
  svg/custom/use-event-listener-once-option-preserved.html
  svg/custom/use-event-listener-passive-option-preserved.html

* LayoutTests/svg/custom/use-event-listener-once-option-preserved-expected.txt: Added.
* LayoutTests/svg/custom/use-event-listener-once-option-preserved.html: Added.
* LayoutTests/svg/custom/use-event-listener-passive-option-preserved-expected.txt: Added.
* LayoutTests/svg/custom/use-event-listener-passive-option-preserved.html: Added.
* Source/WebCore/dom/EventListenerMap.cpp:
(WebCore::copyListenersNotCreatedFromMarkupToTarget):

Canonical link: <a href="https://commits.webkit.org/310355@main">https://commits.webkit.org/310355@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20fad372092a92d4f37a4eee9b3ce66a6e498d6c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153554 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26338 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19942 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162303 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/107012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1b8f1081-22c1-48f4-ae9f-53342ef093e0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155427 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26866 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26660 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118716 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/107012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/311e8d38-84a2-4848-9464-8c0e209d9f89) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156513 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20974 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137851 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99427 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/67786d89-3429-4272-8b00-b1654fdbdaf9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20053 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17989 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10137 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129700 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15721 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164775 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7909 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17315 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126786 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26135 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22025 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126951 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34438 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26137 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137517 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82805 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21876 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14297 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25754 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90041 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25445 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25605 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25505 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->