### PR TITLE
[LBSE] Fix svg/text/text-paint-order-stroke-fill-gradient.svg

### DIFF
--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/TestExpectations
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/TestExpectations
@@ -182,7 +182,6 @@ svg/W3C-SVG-1.1/text-text-05-t.svg                 [ ImageOnlyFailure ]
 svg/hittest/text-multiple-dx-values.svg            [ ImageOnlyFailure ]
 svg/hittest/text-with-multiple-tspans.svg          [ ImageOnlyFailure ]
 svg/hittest/text-with-text-path.svg                [ ImageOnlyFailure ]
-svg/text/text-paint-order-stroke-fill-gradient.svg [ ImageOnlyFailure ]
 svg/text/text-text-05-t.svg                        [ ImageOnlyFailure ]
 
 # Text rendering has issues with CSS 'visibility'

--- a/LayoutTests/svg/compositing/transform-change-repainting-no-viewBox-repaintRects-expected.txt
+++ b/LayoutTests/svg/compositing/transform-change-repainting-no-viewBox-repaintRects-expected.txt
@@ -1,8 +1,8 @@
  (repaint rects
   (rect 19 19 180 180)
   (rect 19 19 180 180)
-  (rect 8 8 502 302)
   (rect 19 19 180 180)
+  (rect 8 8 502 302)
 )
 (GraphicsLayer
   (anchor 0.00 0.00)
@@ -23,11 +23,19 @@
               (bounds 500.00 300.00)
               (children 1
                 (GraphicsLayer
+                  (offsetFromRenderer width=10 height=10)
                   (position 10.00 10.00)
-                  (anchor 1.33 0.78)
+                  (anchor -0.06 -0.06)
                   (bounds 180.00 180.00)
-                  (drawsContent 1)
-                  (transform [0.71 0.71 0.00 0.00] [-0.71 0.71 0.00 0.00] [0.00 0.00 1.00 0.00] [0.00 0.00 0.00 1.00])
+                  (contentsVisible 0)
+                  (children 1
+                    (GraphicsLayer
+                      (anchor 1.33 0.78)
+                      (bounds 180.00 180.00)
+                      (drawsContent 1)
+                      (transform [0.71 0.71 0.00 0.00] [-0.71 0.71 0.00 0.00] [0.00 0.00 1.00 0.00] [0.00 0.00 0.00 1.00])
+                    )
+                  )
                 )
               )
             )

--- a/Source/WebCore/rendering/svg/RenderSVGViewportContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGViewportContainer.cpp
@@ -100,7 +100,15 @@ bool RenderSVGViewportContainer::needsHasSVGTransformFlags() const
     if (isOutermostSVGViewportContainer()) {
         if (useSVGSVGElement->useCurrentView())
             return true;
-        return !useSVGSVGElement->currentTranslateValue().isZero() || useSVGSVGElement->renderer()->style().usedZoom() != 1;
+        if (!useSVGSVGElement->currentTranslateValue().isZero() || useSVGSVGElement->renderer()->style().usedZoom() != 1)
+            return true;
+        // Need transform flags when the SVG root has a non-zero content box location
+        // (e.g., due to border or padding), so that the content box offset is propagated
+        // through the transform painting chain to transformed descendants.
+        // Use m_owningSVGRoot instead of parent() since this may be called during
+        // initializeStyle() before the renderer is attached to the tree.
+        if (m_owningSVGRoot)
+            return !m_owningSVGRoot->contentBoxLocation().isZero();
     }
 
     return false;


### PR DESCRIPTION
#### 84f00386e9f33eeb85396fea53324e84ef48536b
<pre>
[LBSE] Fix svg/text/text-paint-order-stroke-fill-gradient.svg
<a href="https://bugs.webkit.org/show_bug.cgi?id=311176">https://bugs.webkit.org/show_bug.cgi?id=311176</a>

Reviewed by Nikolas Zimmermann.

Make sure needsHasSVGTransformFlags returns true in case the root &lt;svg&gt;
has non zero content box origin, like what happens in text-paint-order-stroke-fill-gradient.svg
because of non-zero border width on the root &lt;svg&gt;.

* LayoutTests/platform/mac-tahoe-wk2-lbse-text/TestExpectations:
* LayoutTests/svg/compositing/transform-change-repainting-no-viewBox-repaintRects-expected.txt:
* Source/WebCore/rendering/svg/RenderSVGViewportContainer.cpp:
(WebCore::RenderSVGViewportContainer::needsHasSVGTransformFlags const):

Canonical link: <a href="https://commits.webkit.org/310319@main">https://commits.webkit.org/310319@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/761e5958fc3b59f24aab2af261c2d74b7f432e5d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153427 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26211 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19811 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162172 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155300 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26737 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26531 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118617 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156386 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20860 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137746 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99328 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19938 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17883 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10007 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129585 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15616 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164646 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7782 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17210 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126679 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26008 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21917 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/semantics/structured-clone/shared.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126843 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34411 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26010 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137412 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82677 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21771 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14192 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25627 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89913 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25318 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25477 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25378 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->