### PR TITLE
[GTK][WPE] Centralize Skia GPU texture/surface/image operations in SkiaUtilities

### DIFF
--- a/Source/WebCore/page/scrolling/coordinated/ScrollerCoordinated.cpp
+++ b/Source/WebCore/page/scrolling/coordinated/ScrollerCoordinated.cpp
@@ -32,19 +32,13 @@
 #include "BitmapTexturePool.h"
 #include "CoordinatedPlatformLayer.h"
 #include "CoordinatedPlatformLayerBufferRGB.h"
-#include "FontRenderOptions.h"
 #include "GLContext.h"
 #include "GLFence.h"
 #include "GraphicsContextSkia.h"
 #include "PlatformDisplay.h"
 #include "ScrollerImpAdwaita.h"
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
-#include <skia/core/SkColorSpace.h>
-#include <skia/core/SkImage.h>
-#include <skia/gpu/ganesh/GrBackendSurface.h>
-#include <skia/gpu/ganesh/SkSurfaceGanesh.h>
-#include <skia/gpu/ganesh/gl/GrGLBackendSurface.h>
-#include <skia/gpu/ganesh/gl/GrGLDirectContext.h>
+#include <skia/core/SkSurface.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #include <wtf/TZoneMallocInlines.h>
 
@@ -136,13 +130,7 @@ void ScrollerCoordinated::updateValues()
     Ref texture = BitmapTexturePool::singleton().acquireTexture(state.frameRect.size(), { BitmapTexture::Flags::SupportsAlpha });
 
     GLContext::ScopedGLContextCurrent scopedCurrent(*glContext);
-    GrGLTextureInfo externalTexture;
-    externalTexture.fTarget = GL_TEXTURE_2D;
-    externalTexture.fID = texture->id();
-    externalTexture.fFormat = GL_RGBA8;
-    auto backendTexture = GrBackendTextures::MakeGL(state.frameRect.size().width(), state.frameRect.size().height(), skgpu::Mipmapped::kNo, externalTexture);
-    SkSurfaceProps properties = FontRenderOptions::singleton().createSurfaceProps();
-    auto surface = SkSurfaces::WrapBackendTexture(grContext, backendTexture, kTopLeft_GrSurfaceOrigin, 0, kRGBA_8888_SkColorType, SkColorSpace::MakeSRGB(), &properties);
+    auto surface = texture->createSkiaSurface(grContext);
     if (!surface)
         return;
 

--- a/Source/WebCore/platform/Skia.cmake
+++ b/Source/WebCore/platform/Skia.cmake
@@ -25,6 +25,7 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/skia/SkiaSpanExtras.h
     platform/graphics/skia/SkiaSystemFallbackFontCache.h
     platform/graphics/skia/SkiaTextureAtlasPacker.h
+    platform/graphics/skia/SkiaUtilities.h
 )
 
 list(APPEND WebCore_LIBRARIES

--- a/Source/WebCore/platform/SourcesSkia.txt
+++ b/Source/WebCore/platform/SourcesSkia.txt
@@ -69,5 +69,6 @@ platform/graphics/skia/SkiaReplayAtlas.cpp
 platform/graphics/skia/SkiaReplayCanvas.cpp
 platform/graphics/skia/SkiaSystemFallbackFontCache.cpp
 platform/graphics/skia/SkiaTextureAtlasPacker.cpp
+platform/graphics/skia/SkiaUtilities.cpp
 
 platform/skia/SharedBufferSkia.cpp

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
@@ -43,6 +43,7 @@
 #include "SkiaImageAtlasLayoutBuilder.h"
 #include "SkiaPaintingEngine.h"
 #include "SkiaRecordingResult.h"
+#include "SkiaUtilities.h"
 #include <cmath>
 #include <ranges>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
@@ -58,8 +59,6 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkSurface.h>
 #include <skia/core/SkTileMode.h>
 #include <skia/effects/SkImageFilters.h>
-#include <skia/gpu/ganesh/GrBackendSurface.h>
-#include <skia/gpu/ganesh/SkImageGanesh.h>
 #include <skia/gpu/ganesh/SkSurfaceGanesh.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #include <wtf/MathExtras.h>
@@ -345,9 +344,7 @@ void GraphicsContextSkia::drawNativeImage(const NativeImage& nativeImage, const 
                 if (auto fence = createAcceleratedRenderingFence(nativeImage.platformImage(), nativeImage.grContext()))
                     fence->serverWait();
 
-                GrBackendTexture backendTexture;
-                if (SkImages::GetBackendTextureFromImage(image.get(), &backendTexture, false))
-                    imageInThisThread = SkImages::BorrowTextureFrom(grContext, backendTexture, kTopLeft_GrSurfaceOrigin, image->colorType(), image->alphaType(), image->refColorSpace());
+                imageInThisThread = SkiaUtilities::rewrapImageForContext(grContext, *image);
             }
         }
     }

--- a/Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.cpp
@@ -27,6 +27,7 @@
 #include "SkiaGPUAtlas.h"
 
 #if USE(SKIA)
+#include "BitmapTexture.h"
 #include "SkiaImageAtlasLayout.h"
 #if USE(GBM)
 #include "MemoryMappedGPUBuffer.h"
@@ -36,14 +37,7 @@
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkColorSpace.h>
 #include <skia/core/SkPixmap.h>
-#include <skia/gpu/ganesh/gl/GrGLBackendSurface.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
-
-#if USE(LIBEPOXY)
-#include <epoxy/gl.h>
-#else
-#include <GLES3/gl3.h>
-#endif
 
 namespace WebCore {
 
@@ -72,11 +66,7 @@ RefPtr<SkiaGPUAtlas> SkiaGPUAtlas::create(const SkiaImageAtlasLayout& layout, Re
 
     RELEASE_ASSERT(atlasSize == atlasTexture->size());
 
-    GrGLTextureInfo externalTexture;
-    externalTexture.fTarget = GL_TEXTURE_2D;
-    externalTexture.fID = atlasTexture->id();
-    externalTexture.fFormat = GL_RGBA8;
-    auto backendTexture = GrBackendTextures::MakeGL(atlasSize.width(), atlasSize.height(), skgpu::Mipmapped::kNo, externalTexture);
+    auto backendTexture = atlasTexture->createSkiaBackendTexture();
     if (!backendTexture.isValid())
         return nullptr;
 

--- a/Source/WebCore/platform/graphics/skia/SkiaReplayAtlas.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaReplayAtlas.cpp
@@ -30,12 +30,11 @@
 
 #include "PlatformDisplay.h"
 #include "SkiaGPUAtlas.h"
+#include "SkiaUtilities.h"
 #include <wtf/TZoneMallocInlines.h>
 
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
-#include <skia/core/SkColorSpace.h>
 #include <skia/gpu/ganesh/GrDirectContext.h>
-#include <skia/gpu/ganesh/SkImageGanesh.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 namespace WebCore {
@@ -62,7 +61,7 @@ std::unique_ptr<SkiaReplayAtlas> SkiaReplayAtlas::create(const SkiaGPUAtlas& gpu
     // The underlying GL texture was created on the main thread context but is
     // shareable via GL context sharing. However, the Skia SkImage wrapper is
     // context-specific and must be rewrapped for each worker's GrDirectContext.
-    auto rewrapped = SkImages::BorrowTextureFrom(grContext, gpuAtlas.backendTexture(), kTopLeft_GrSurfaceOrigin, kRGBA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
+    auto rewrapped = SkiaUtilities::borrowBackendTextureAsImage(grContext, gpuAtlas.backendTexture());
     if (!rewrapped)
         return nullptr;
 

--- a/Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.cpp
@@ -30,11 +30,7 @@
 #include "GLContext.h"
 #include "GLFence.h"
 #include "PlatformDisplay.h"
-
-WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
-#include <skia/gpu/ganesh/GrBackendSurface.h>
-#include <skia/gpu/ganesh/SkImageGanesh.h>
-WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+#include "SkiaUtilities.h"
 
 namespace WebCore {
 
@@ -84,12 +80,7 @@ sk_sp<SkImage> SkiaReplayCanvas::waitForRenderingCompletionAndRewrapImageIfNeede
     if (image->isValid(grContext->asRecorder()))
         return nullptr;
 
-    // FIXME: Add error reporting mechanism, a failure from GetBackendTextureFromImage() should be visible / reported.
-    GrBackendTexture backendTexture;
-    if (!SkImages::GetBackendTextureFromImage(image, &backendTexture, false))
-        return nullptr;
-
-    return SkImages::BorrowTextureFrom(grContext, backendTexture, kTopLeft_GrSurfaceOrigin, image->colorType(), image->alphaType(), image->refColorSpace());
+    return SkiaUtilities::rewrapImageForContext(grContext, *image);
 }
 
 void SkiaReplayCanvas::invokeDrawFunctionWithImage(const SkImage* image, Function<void(const SkImage*)>&& drawFunction)

--- a/Source/WebCore/platform/graphics/skia/SkiaUtilities.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaUtilities.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SkiaUtilities.h"
+
+#if USE(SKIA)
+
+#include "BitmapTexture.h"
+#include "ColorSpaceSkia.h"
+
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/gpu/ganesh/SkImageGanesh.h>
+#include <skia/gpu/ganesh/SkSurfaceGanesh.h>
+#include <skia/gpu/ganesh/gl/GrGLBackendSurface.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+
+#if USE(LIBEPOXY)
+#include <epoxy/gl.h>
+#else
+#include <GLES3/gl3.h>
+#endif
+
+namespace WebCore {
+namespace SkiaUtilities {
+
+GrBackendTexture createBackendTexture(const BitmapTexture& texture)
+{
+    RELEASE_ASSERT(texture.id());
+    RELEASE_ASSERT(!texture.size().isEmpty());
+
+    GrGLTextureInfo externalTexture;
+    externalTexture.fTarget = GL_TEXTURE_2D;
+    externalTexture.fID = texture.id();
+    externalTexture.fFormat = GL_RGBA8;
+    return GrBackendTextures::MakeGL(texture.size().width(), texture.size().height(), skgpu::Mipmapped::kNo, externalTexture);
+}
+
+sk_sp<SkSurface> createSurface(GrDirectContext* grContext, const BitmapTexture& texture, const SkSurfaceProps& properties, GrSurfaceOrigin origin, unsigned sampleCount)
+{
+    RELEASE_ASSERT(grContext);
+
+    auto backendTexture = createBackendTexture(texture);
+    return SkSurfaces::WrapBackendTexture(grContext, backendTexture, origin, sampleCount, kRGBA_8888_SkColorType, sRGBColorSpaceSingleton(), &properties);
+}
+
+sk_sp<SkImage> rewrapImageForContext(GrDirectContext* grContext, const SkImage& image)
+{
+    GrBackendTexture backendTexture;
+    if (!SkImages::GetBackendTextureFromImage(&image, &backendTexture, false))
+        return nullptr;
+    return SkImages::BorrowTextureFrom(grContext, backendTexture, kTopLeft_GrSurfaceOrigin, image.colorType(), image.alphaType(), image.refColorSpace());
+}
+
+sk_sp<SkImage> borrowBackendTextureAsImage(GrDirectContext* grContext, const GrBackendTexture& backendTexture)
+{
+    return SkImages::BorrowTextureFrom(grContext, backendTexture, kTopLeft_GrSurfaceOrigin, kRGBA_8888_SkColorType, kPremul_SkAlphaType, sRGBColorSpaceSingleton());
+}
+
+std::optional<unsigned> retrieveGLTextureID(const SkImage& image)
+{
+    GrBackendTexture backendTexture;
+    if (!SkImages::GetBackendTextureFromImage(&image, &backendTexture, false))
+        return std::nullopt;
+
+    GrGLTextureInfo textureInfo;
+    if (!GrBackendTextures::GetGLTextureInfo(backendTexture, &textureInfo))
+        return std::nullopt;
+
+    return textureInfo.fID;
+}
+
+} // namespace SkiaUtilities
+} // namespace WebCore
+
+#endif // USE(SKIA)

--- a/Source/WebCore/platform/graphics/skia/SkiaUtilities.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaUtilities.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(SKIA)
+
+#include <optional>
+
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkRefCnt.h>
+#include <skia/gpu/ganesh/GrBackendSurface.h>
+#include <skia/gpu/ganesh/GrDirectContext.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+
+class SkImage;
+class SkSurface;
+class SkSurfaceProps;
+enum GrSurfaceOrigin : int;
+
+namespace WebCore {
+
+class BitmapTexture;
+
+namespace SkiaUtilities {
+
+// Creates a GrBackendTexture from a BitmapTexture's GL texture.
+GrBackendTexture createBackendTexture(const BitmapTexture&);
+
+// Creates a Skia surface wrapping a BitmapTexture's GL texture.
+sk_sp<SkSurface> createSurface(GrDirectContext*, const BitmapTexture&, const SkSurfaceProps&, GrSurfaceOrigin = kTopLeft_GrSurfaceOrigin, unsigned sampleCount = 0);
+
+// Rewraps a GPU-backed SkImage for use in a different GrDirectContext.
+// Extracts the backend texture from the source image and creates a new
+// SkImage wrapper around it for the target context, preserving the
+// original image's color type, alpha type, and color space.
+sk_sp<SkImage> rewrapImageForContext(GrDirectContext*, const SkImage&);
+
+// Wraps a GrBackendTexture as a non-owning SkImage for the given context,
+// using RGBA8, premultiplied alpha, and sRGB color space.
+sk_sp<SkImage> borrowBackendTextureAsImage(GrDirectContext*, const GrBackendTexture&);
+
+// Extracts the GL texture ID from a GPU-backed SkImage, if available.
+std::optional<unsigned> retrieveGLTextureID(const SkImage&);
+
+} // namespace SkiaUtilities
+} // namespace WebCore
+
+#endif // USE(SKIA)

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
@@ -45,9 +45,12 @@
 #endif
 
 #if USE(SKIA)
+#include "FontRenderOptions.h"
+#include "SkiaUtilities.h"
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN // GLib/Win port
 #include <skia/core/SkImage.h>
 #include <skia/core/SkPixmap.h>
+#include <skia/core/SkSurface.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #endif
 
@@ -572,6 +575,19 @@ OptionSet<TextureMapperFlags> BitmapTexture::colorConvertFlags() const
     return TextureMapperFlags::ShouldConvertTextureARGBToRGBA;
 #endif
 }
+
+#if USE(SKIA)
+GrBackendTexture BitmapTexture::createSkiaBackendTexture() const
+{
+    return SkiaUtilities::createBackendTexture(*this);
+}
+
+sk_sp<SkSurface> BitmapTexture::createSkiaSurface(GrDirectContext* grContext, GrSurfaceOrigin origin, unsigned sampleCount) const
+{
+    auto properties = FontRenderOptions::singleton().createSurfaceProps();
+    return SkiaUtilities::createSurface(grContext, *this, properties, origin, sampleCount);
+}
+#endif
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.h
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.h
@@ -41,6 +41,16 @@
 #include "MemoryMappedGPUBuffer.h"
 #endif
 
+#if USE(SKIA)
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkRefCnt.h>
+#include <skia/gpu/ganesh/GrBackendSurface.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+class GrDirectContext;
+class SkSurface;
+enum GrSurfaceOrigin : int;
+#endif
+
 typedef void *EGLImage;
 
 namespace WebCore {
@@ -104,6 +114,11 @@ public:
     void copyFromExternalTexture(GLuint sourceTextureID, const IntRect& targetRect, const IntSize& sourceOffset);
 
     OptionSet<TextureMapperFlags> colorConvertFlags() const;
+
+#if USE(SKIA)
+    GrBackendTexture createSkiaBackendTexture() const;
+    sk_sp<SkSurface> createSkiaSurface(GrDirectContext*, GrSurfaceOrigin = kTopLeft_GrSurfaceOrigin, unsigned sampleCount = 0) const;
+#endif
 
 #if USE(GBM)
     MemoryMappedGPUBuffer* memoryMappedGPUBuffer() const LIFETIME_BOUND { return m_memoryMappedGPUBuffer.get(); }

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.cpp
@@ -40,10 +40,8 @@
 #if USE(SKIA)
 #include "GLContext.h"
 #include "PlatformDisplay.h"
+#include "SkiaUtilities.h"
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
-#include <skia/gpu/ganesh/GrBackendSurface.h>
-#include <skia/gpu/ganesh/SkImageGanesh.h>
-#include <skia/gpu/ganesh/gl/GrGLBackendSurface.h>
 #include <skia/core/SkPixmap.h> // NOLINT
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #endif
@@ -75,17 +73,11 @@ CoordinatedPlatformLayerBufferNativeImage::CoordinatedPlatformLayerBufferNativeI
     RELEASE_ASSERT(grContext);
     grContext->flushAndSubmit(GLFence::isSupported(display.glDisplay()) ? GrSyncCpu::kNo : GrSyncCpu::kYes);
 
-    unsigned textureID = 0;
-    GrBackendTexture backendTexture;
-    if (SkImages::GetBackendTextureFromImage(image, &backendTexture, false)) {
-        GrGLTextureInfo textureInfo;
-        if (GrBackendTextures::GetGLTextureInfo(backendTexture, &textureInfo))
-            textureID = textureInfo.fID;
-    }
+    auto textureID = SkiaUtilities::retrieveGLTextureID(*image);
     if (!textureID)
         return;
 
-    m_buffer = CoordinatedPlatformLayerBufferRGB::create(textureID, m_image->size(), m_flags, GLFence::create(display.glDisplay()));
+    m_buffer = CoordinatedPlatformLayerBufferRGB::create(*textureID, m_image->size(), m_flags, GLFence::create(display.glDisplay()));
 #endif
 }
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.cpp
@@ -42,9 +42,6 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkColorSpace.h>
 #include <skia/core/SkImage.h>
 #include <skia/core/SkStream.h>
-#include <skia/gpu/ganesh/GrBackendSurface.h>
-#include <skia/gpu/ganesh/SkSurfaceGanesh.h>
-#include <skia/gpu/ganesh/gl/GrGLBackendSurface.h>
 #include <skia/gpu/ganesh/gl/GrGLDirectContext.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #include <wtf/MainThread.h>
@@ -150,7 +147,7 @@ bool CoordinatedUnacceleratedTileBuffer::tryEnsureSurface()
 
     auto imageInfo = SkImageInfo::Make(m_size.width(), m_size.height(), kBGRA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
     // FIXME: ref buffer and unref on release proc?
-    SkSurfaceProps properties = FontRenderOptions::singleton().createSurfaceProps();
+    auto properties = FontRenderOptions::singleton().createSurfaceProps();
     m_surface = SkSurfaces::WrapPixels(imageInfo, data(), imageInfo.minRowBytes64(), &properties);
     return true;
 }
@@ -184,14 +181,6 @@ bool CoordinatedAcceleratedTileBuffer::tryEnsureSurface()
     if (!PlatformDisplay::sharedDisplay().skiaGLContext()->makeContextCurrent())
         return false;
 
-    GrGLTextureInfo externalTexture;
-    externalTexture.fTarget = GL_TEXTURE_2D;
-    externalTexture.fID = m_texture->id();
-    externalTexture.fFormat = GL_RGBA8;
-
-    const auto& size = m_texture->size();
-    auto backendTexture = GrBackendTextures::MakeGL(size.width(), size.height(), skgpu::Mipmapped::kNo, externalTexture);
-
 #if PLATFORM(GTK)
     // FIXME: there's a deadlock when two rendering threads try to create a texture with MSAA enabled. So, for now
     // we just disable MSAA for the GTK port to render tiles until we find a solution.
@@ -200,15 +189,7 @@ bool CoordinatedAcceleratedTileBuffer::tryEnsureSurface()
     unsigned msaaSampleCount = PlatformDisplay::sharedDisplay().msaaSampleCount();
 #endif
 
-    SkSurfaceProps properties = FontRenderOptions::singleton().createSurfaceProps();
-    m_surface = SkSurfaces::WrapBackendTexture(PlatformDisplay::sharedDisplay().skiaGrContext(),
-        backendTexture,
-        kTopLeft_GrSurfaceOrigin,
-        msaaSampleCount,
-        kRGBA_8888_SkColorType,
-        SkColorSpace::MakeSRGB(),
-        &properties);
-
+    m_surface = m_texture->createSkiaSurface(PlatformDisplay::sharedDisplay().skiaGrContext(), kTopLeft_GrSurfaceOrigin, msaaSampleCount);
     return true;
 }
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
@@ -30,7 +30,6 @@
 #include "WebPage.h"
 #include "WebProcess.h"
 #include <WebCore/BitmapTexture.h>
-#include <WebCore/FontRenderOptions.h>
 #include <WebCore/GLContext.h>
 #include <WebCore/GLFence.h>
 #include <WebCore/Page.h>
@@ -47,9 +46,6 @@
 
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkCanvas.h>
-#include <skia/gpu/ganesh/GrBackendSurface.h>
-#include <skia/gpu/ganesh/SkSurfaceGanesh.h>
-#include <skia/gpu/ganesh/gl/GrGLBackendSurface.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 #if PLATFORM(GTK) || ENABLE(WPE_PLATFORM)
@@ -158,16 +154,8 @@ void AcceleratedSurface::RenderTarget::createSkiaSurfaceForTexture(const BitmapT
 {
     auto& display = PlatformDisplay::sharedDisplay();
     GLContext::ScopedGLContextCurrent scopedCurrent(*display.skiaGLContext());
-    GrGLTextureInfo externalTexture;
-    externalTexture.fTarget = GL_TEXTURE_2D;
-    externalTexture.fID = texture.id();
-    externalTexture.fFormat = GL_RGBA8;
-
-    const auto& size = texture.size();
-    auto backendTexture = GrBackendTextures::MakeGL(size.width(), size.height(), skgpu::Mipmapped::kNo, externalTexture);
-    SkSurfaceProps properties = FontRenderOptions::singleton().createSurfaceProps();
     auto origin = m_surface->shouldPaintMirrored() ? kBottomLeft_GrSurfaceOrigin : kTopLeft_GrSurfaceOrigin;
-    m_skiaSurface = SkSurfaces::WrapBackendTexture(display.skiaGrContext(), backendTexture, origin, 0, kRGBA_8888_SkColorType, SkColorSpace::MakeSRGB(), &properties);
+    m_skiaSurface = texture.createSkiaSurface(display.skiaGrContext(), origin);
 }
 
 #if PLATFORM(GTK) || ENABLE(WPE_PLATFORM)


### PR DESCRIPTION
#### 7416051a013d214a0c2a5aa9da817ae6d912f7b8
<pre>
[GTK][WPE] Centralize Skia GPU texture/surface/image operations in SkiaUtilities
<a href="https://bugs.webkit.org/show_bug.cgi?id=311177">https://bugs.webkit.org/show_bug.cgi?id=311177</a>

Reviewed by Adrian Perez de Castro.

Consolidate repeated Skia GPU boilerplate (GrBackendTexture creation,
WrapBackendTexture, BorrowTextureFrom, GetBackendTextureFromImage) into
a new SkiaUtilities namespace and convenience methods on BitmapTexture.

- SkiaUtilities::createBackendTexture - creates GrBackendTexture from BitmapTexture
- SkiaUtilities::createSurface - wraps BitmapTexture as SkSurface
- SkiaUtilities::rewrapImageForContext - rewraps SkImage for cross-context use
- SkiaUtilities::borrowBackendTextureAsImage - borrows GrBackendTexture as SkImage
- SkiaUtilities::retrieveGLTextureID - extracts GL texture ID from SkImage
- BitmapTexture::createSkiaBackendTexture/createSkiaSurface - convenience wrappers

Covered by existing tests.

* Source/WebCore/page/scrolling/coordinated/ScrollerCoordinated.cpp:
(WebCore::ScrollerCoordinated::updateValues):
* Source/WebCore/platform/Skia.cmake:
* Source/WebCore/platform/SourcesSkia.txt:
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp:
(WebCore::GraphicsContextSkia::drawNativeImage):
* Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.cpp:
(WebCore::SkiaGPUAtlas::create):
* Source/WebCore/platform/graphics/skia/SkiaReplayAtlas.cpp:
(WebCore::SkiaReplayAtlas::create):
* Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.cpp:
(WebCore::SkiaReplayCanvas::waitForRenderingCompletionAndRewrapImageIfNeeded):
* Source/WebCore/platform/graphics/skia/SkiaUtilities.cpp: Added.
(WebCore::SkiaUtilities::createBackendTexture):
(WebCore::SkiaUtilities::createSurface):
(WebCore::SkiaUtilities::rewrapImageForContext):
(WebCore::SkiaUtilities::borrowBackendTextureAsImage):
(WebCore::SkiaUtilities::retrieveGLTextureID):
* Source/WebCore/platform/graphics/skia/SkiaUtilities.h: Added.
* Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp:
(WebCore::BitmapTexture::createSkiaBackendTexture const):
(WebCore::BitmapTexture::createSkiaSurface const):
* Source/WebCore/platform/graphics/texmap/BitmapTexture.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.cpp:
(WebCore::CoordinatedPlatformLayerBufferNativeImage::CoordinatedPlatformLayerBufferNativeImage):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.cpp:
(WebCore::CoordinatedUnacceleratedTileBuffer::tryEnsureSurface):
(WebCore::CoordinatedAcceleratedTileBuffer::tryEnsureSurface):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp:
(WebKit::AcceleratedSurface::RenderTarget::createSkiaSurfaceForTexture):

Canonical link: <a href="https://commits.webkit.org/310305@main">https://commits.webkit.org/310305@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2638304da778b8c96bf7f3cb426cb235135afab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153417 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26201 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19801 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162162 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155290 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26727 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26521 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118607 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156376 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20852 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137733 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99318 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19930 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17874 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9997 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/129577 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15603 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164636 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7772 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17197 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/126681 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25998 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/21908 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126846 "Found 1 new API test failure: WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34405 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26000 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137399 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82667 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21765 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14179 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25617 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89903 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25308 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25467 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25368 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->