### PR TITLE
Adopt ReflectSetter for HTMLScriptElement::async

### DIFF
--- a/Source/WebCore/html/HTMLScriptElement.cpp
+++ b/Source/WebCore/html/HTMLScriptElement.cpp
@@ -186,12 +186,6 @@ ExceptionOr<void> HTMLScriptElement::setInnerText(Variant<Ref<TrustedScript>, St
     return { };
 }
 
-void HTMLScriptElement::setAsync(bool async)
-{
-    setBooleanAttribute(asyncAttr, async);
-    handleAsyncAttribute();
-}
-
 bool HTMLScriptElement::async() const
 {
     return hasAttributeWithoutSynchronization(asyncAttr) || forceAsync();

--- a/Source/WebCore/html/HTMLScriptElement.h
+++ b/Source/WebCore/html/HTMLScriptElement.h
@@ -53,7 +53,6 @@ public:
     String src() const;
     ExceptionOr<void> setSrc(Variant<Ref<TrustedScriptURL>, String>&&);
 
-    WEBCORE_EXPORT void setAsync(bool);
     WEBCORE_EXPORT bool NODELETE async() const;
 
     WEBCORE_EXPORT String crossOrigin() const;

--- a/Source/WebCore/html/HTMLScriptElement.idl
+++ b/Source/WebCore/html/HTMLScriptElement.idl
@@ -28,7 +28,7 @@
     [CEReactions=NotNeeded, Reflect="for"] attribute DOMString htmlFor;
     [CEReactions=NotNeeded, Reflect] attribute DOMString event;
     [CEReactions=NotNeeded, Reflect] attribute DOMString charset;
-    [CEReactions=NotNeeded] attribute boolean async;
+    [CEReactions=NotNeeded, ReflectSetter] attribute boolean async;
     [CEReactions=NotNeeded, Reflect] attribute boolean defer;
     [CEReactions=NotNeeded] attribute (TrustedScriptURL or USVString) src;
     [CEReactions=NotNeeded, Reflect] attribute DOMString type;

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLScriptElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLScriptElement.mm
@@ -97,7 +97,7 @@
 - (void)setAsync:(BOOL)newAsync
 {
     WebCore::JSMainThreadNullState state;
-    IMPL->setAsync(newAsync);
+    IMPL->setBooleanAttribute(WebCore::HTMLNames::asyncAttr, newAsync);
 }
 
 - (BOOL)defer


### PR DESCRIPTION
#### 2f5c1086facd2fc04dbfb33af1d473365aa45509
<pre>
Adopt ReflectSetter for HTMLScriptElement::async
<a href="https://bugs.webkit.org/show_bug.cgi?id=311179">https://bugs.webkit.org/show_bug.cgi?id=311179</a>

Reviewed by NOBODY (OOPS!).

Use [ReflectSetter] in the IDL to auto-generate the setter for the async
attribute, instead of having a manual setAsync() that just calls
setBooleanAttribute(). This matches the pattern already used by
SVGScriptElement and other attributes on HTMLScriptElement.

The previous manual setAsync() also had a redundant handleAsyncAttribute()
call after setBooleanAttribute(), since setBooleanAttribute() already
triggers attributeChanged(), which calls handleAsyncAttribute() for the
async attribute.

* Source/WebCore/html/HTMLScriptElement.cpp:
(WebCore::HTMLScriptElement::setAsync): Deleted.
* Source/WebCore/html/HTMLScriptElement.h:
* Source/WebCore/html/HTMLScriptElement.idl:
* Source/WebKitLegacy/mac/DOM/DOMHTMLScriptElement.mm:
(-[DOMHTMLScriptElement setAsync:]):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f5c1086facd2fc04dbfb33af1d473365aa45509

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153420 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26204 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19804 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162165 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106878 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a60cdce8-19f7-433d-a5b8-710988ab3c44) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155293 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26730 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26524 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118610 "Found 9 new test failures: fast/dom/Document/document-current-script.html fast/dom/HTMLScriptElement/script-async-attr.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/async_007.htm imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/async_010.htm imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/091.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/105.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/123.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/126.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/ordering/in-order.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83979 "5 flakes 8 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ad1f791c-7752-48bf-bd64-de1fd75f2456) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156379 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20854 "Found 4 new test failures: fast/dom/Document/document-current-script.html fast/dom/HTMLScriptElement/script-async-attr.html http/tests/misc/async-script-removed.html http/tests/misc/script-async-load-execute-in-order.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137737 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99321 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/07bf73a7-3e4e-4e39-8932-f7b639745a2f) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19932 "Found 8 new test failures: imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/async_007.htm imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/async_010.htm imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/091.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/105.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/123.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/126.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/execorder.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/ordering/in-order.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17877 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10000 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129579 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15607 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164639 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7775 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17201 "Found 11 new test failures: fast/dom/Document/document-current-script.html fast/dom/HTMLScriptElement/script-async-attr.html http/tests/misc/async-script-removed.html http/tests/misc/script-async-load-execute-in-order.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/async_007.htm imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/async_010.htm imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/091.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/105.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/123.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/126.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126671 "Found 10 new test failures: fast/dom/Document/document-current-script.html fast/dom/HTMLScriptElement/script-async-attr.html http/tests/misc/async-script-removed.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/async_007.htm imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/async_010.htm imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/091.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/105.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/123.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/126.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/ordering/in-order.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26001 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21911 "Found 11 new test failures: fast/dom/Document/document-current-script.html fast/dom/HTMLScriptElement/script-async-attr.html http/tests/misc/async-script-removed.html http/tests/misc/script-async-load-execute-in-order.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/async_007.htm imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/async_010.htm imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/091.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/105.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/123.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/126.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126835 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26003 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137403 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82670 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21773 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14183 "Found 11 new test failures: fast/dom/Document/document-current-script.html fast/dom/HTMLScriptElement/script-async-attr.html http/tests/misc/async-script-removed.html http/tests/misc/script-async-load-execute-in-order.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/async_007.htm imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/async_010.htm imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/091.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/105.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/123.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/126.html ... (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25620 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89906 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25311 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25470 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25371 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->