### PR TITLE
[GLIB] Prefer Vector::appendList() to ::appendVector() when using an initializer list

### DIFF
--- a/Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp
+++ b/Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp
@@ -197,8 +197,8 @@ static void bindSymlinksRealPath(Vector<CString>& args, const String& path, cons
 {
     auto realPath = FileSystem::realPath(path);
     if (path != realPath) {
-        CString rpath = realPath.utf8();
-        args.appendVector(Vector<CString>({ bindOption, rpath.data(), rpath.data() }));
+        auto rpath = realPath.utf8();
+        args.appendList<CString>({ bindOption, rpath, rpath });
     }
 }
 
@@ -224,7 +224,7 @@ static void bindIfExists(Vector<CString>& args, const CStringView& path, BindFla
     // links.
     if (!startsWith(path.span(), "/etc/"_s)) {
         auto pathString = CString(path.span());
-        args.appendVector(Vector<CString>({ bindType, pathString, pathString }));
+        args.appendList<CString>({ bindType, pathString, pathString });
     }
 }
 
@@ -244,7 +244,7 @@ static void bindDBusSession(Vector<CString>& args, XDGDBusProxy& dbusProxy, bool
 
     GUniquePtr<char> sandboxedSessionBusPath(g_build_filename(sandboxedUserRuntimeDirectory().data(), "bus", nullptr));
     GUniquePtr<char> proxyAddress(g_strdup_printf("unix:path=%s", sandboxedSessionBusPath.get()));
-    args.appendVector(Vector<CString> {
+    args.appendList<CString>({
         "--ro-bind", *dbusSessionProxyPath, sandboxedSessionBusPath.get(),
         "--setenv", "DBUS_SESSION_BUS_ADDRESS", proxyAddress.get()
     });
@@ -391,9 +391,9 @@ static void bindA11y(Vector<CString>& args, XDGDBusProxy& dbusProxy, const Strin
         return;
 
     ASSERT(sandboxedAccessibilityBusAddress.startsWith("unix:path="_s));
-    auto sandboxedAccessibilityBusPath = sandboxedAccessibilityBusAddress.substring(strlen("unix:path="));
-    args.appendVector(Vector<CString> {
-        "--ro-bind", *accessibilityProxyPath, sandboxedAccessibilityBusPath.utf8(),
+    auto sandboxedAccessibilityBusPath = sandboxedAccessibilityBusAddress.substring(strlen("unix:path=")).utf8();
+    args.appendList<CString>({
+        "--ro-bind", *accessibilityProxyPath, sandboxedAccessibilityBusPath,
         "--setenv", "AT_SPI_BUS_ADDRESS", sandboxedAccessibilityBusAddress.utf8(),
     });
 }
@@ -465,7 +465,7 @@ static void bindGStreamerData(Vector<CString>& args)
 
 static void bindOpenGL(Vector<CString>& args)
 {
-    args.appendVector(Vector<CString>({
+    args.appendList({
         "--dev-bind-try", "/dev/dri", "/dev/dri",
         // Mali
         "--dev-bind-try", "/dev/mali", "/dev/mali",
@@ -482,14 +482,14 @@ static void bindOpenGL(Vector<CString>& args)
         "--dev-bind-try", "/dev/fb0", "/dev/fb0",
         "--dev-bind-try", "/dev/fb1", "/dev/fb1",
 #endif
-    }));
+    });
 }
 
 static void bindV4l(Vector<CString>& args)
 {
-    args.appendVector(Vector<CString>({
+    args.appendList({
         "--dev-bind-try", "/dev/v4l", "/dev/v4l",
-    }));
+    });
 
     for (StringView fileName : FileSystem::listDirectory("/dev"_s)) {
         bool isV4LNode = [&] () {
@@ -505,9 +505,9 @@ static void bindV4l(Vector<CString>& args)
             continue;
 
         CString path = FileSystem::pathByAppendingComponent("/dev"_s, fileName).utf8();
-        args.appendVector(Vector<CString>({
+        args.appendList<CString>({
             "--dev-bind-try", path, path,
-        }));
+        });
     }
 }
 
@@ -774,10 +774,10 @@ static std::optional<CString> directoryContainingDBusSocket(const char* dbusAddr
 static void addExtraPaths(const HashMap<CString, SandboxPermission>& paths, Vector<CString>& args)
 {
     for (const auto& pathAndPermission : paths) {
-        args.appendVector(Vector<CString>({
+        args.appendList<CString>({
             pathAndPermission.value == SandboxPermission::ReadOnly ? "--ro-bind-try": "--bind-try",
             pathAndPermission.key, pathAndPermission.key
-        }));
+        });
     }
 }
 
@@ -839,13 +839,13 @@ GRefPtr<GSubprocess> bubblewrapSpawn(GSubprocessLauncher* launcher, const Proces
         const char* dataDir = g_get_user_data_dir();
         GUniquePtr<char> rrOutputDir(g_build_filename(dataDir, "rr", nullptr));
 
-        sandboxArgs.appendVector(Vector<CString>({
+        sandboxArgs.appendList<CString>({
             // Other binaries are helpful for debugging such as gdbserver.
             "--ro-bind-try", "/bin", "/bin",
             "--ro-bind-try", "/usr/bin", "/usr/bin",
             // rr writes to this directory.
             "--bind-try", rrOutputDir.get(), rrOutputDir.get(),
-        }));
+        });
     } else {
         // In some configurations cross pid namespace debugging has issues.
         sandboxArgs.append("--unshare-pid");
@@ -854,26 +854,26 @@ GRefPtr<GSubprocess> bubblewrapSpawn(GSubprocessLauncher* launcher, const Proces
     addExtraPaths(launchOptions.extraSandboxPaths, sandboxArgs);
 
     if (launchOptions.processType == ProcessLauncher::ProcessType::DBusProxy) {
-        sandboxArgs.appendVector(Vector<CString>({
+        sandboxArgs.appendList<CString>({
             "--ro-bind", DBUS_PROXY_EXECUTABLE, DBUS_PROXY_EXECUTABLE,
-            "--bind", sandboxedUserRuntimeDirectory().data(), sandboxedUserRuntimeDirectory().data(),
-        }));
+            "--bind", sandboxedUserRuntimeDirectory(), sandboxedUserRuntimeDirectory(),
+        });
 
         // xdg-dbus-proxy is trusted, so it's OK to mount the directories that contain the session
         // bus and a11y bus sockets wherever they may be. xdg-dbus-proxy is sandboxed only because
         // we have to mount .flatpak-info in its mount namespace so that portals may use it as a
         // trusted way to get the app ID of the process that is using it.
         if (auto sessionBusDirectory = directoryContainingDBusSocket(g_getenv("DBUS_SESSION_BUS_ADDRESS"))) {
-            sandboxArgs.appendVector(Vector<CString>({
+            sandboxArgs.appendList<CString>({
                 "--bind", *sessionBusDirectory, *sessionBusDirectory,
-            }));
+            });
         }
 
 #if USE(ATSPI)
         if (auto a11yBusDirectory = directoryContainingDBusSocket(launchOptions.extraInitializationData.get("accessibilityBusAddress"_s).utf8().data())) {
-            sandboxArgs.appendVector(Vector<CString>({
+            sandboxArgs.appendList<CString>({
                 "--bind", *a11yBusDirectory, *a11yBusDirectory,
-            }));
+            });
         }
 #endif
     }
@@ -888,9 +888,9 @@ GRefPtr<GSubprocess> bubblewrapSpawn(GSubprocessLauncher* launcher, const Proces
     if (libraryPath && libraryPath[0]) {
         // On distros using a suid bwrap it drops this env var
         // so we have to pass it through to the children.
-        sandboxArgs.appendVector(Vector<CString>({
+        sandboxArgs.appendList<CString>({
             "--setenv", "LD_LIBRARY_PATH", libraryPath,
-        }));
+        });
     }
 
     bindSymlinksRealPath(sandboxArgs, "/etc/resolv.conf"_s);
@@ -906,9 +906,9 @@ GRefPtr<GSubprocess> bubblewrapSpawn(GSubprocessLauncher* launcher, const Proces
         g_subprocess_launcher_take_fd(launcher, flatpakInfoFd, flatpakInfoFd);
         GUniquePtr<char> flatpakInfoFdStr(g_strdup_printf("%d", flatpakInfoFd));
 
-        sandboxArgs.appendVector(Vector<CString>({
+        sandboxArgs.appendList<CString>({
             "--ro-bind-data", flatpakInfoFdStr.get(), "/.flatpak-info"
-        }));
+        });
     }
 
     bindIfExists(sandboxArgs, "/run/systemd/journal/socket");
@@ -932,9 +932,9 @@ GRefPtr<GSubprocess> bubblewrapSpawn(GSubprocessLauncher* launcher, const Proces
 
         Vector<String> extraPaths = { "mediaKeysDirectory"_s, "waylandSocket"_s };
         for (const auto& path : extraPaths) {
-            String extraPath = launchOptions.extraInitializationData.get(path);
+            auto extraPath = launchOptions.extraInitializationData.get(path).utf8();
             if (!extraPath.isEmpty())
-                sandboxArgs.appendVector(Vector<CString>({ "--bind-try", extraPath.utf8(), extraPath.utf8() }));
+                sandboxArgs.appendList<CString>({ "--bind-try", extraPath, extraPath });
         }
 
         bindDBusSession(sandboxArgs, dbusProxy, flatpakInfoFd != -1);
@@ -983,7 +983,7 @@ GRefPtr<GSubprocess> bubblewrapSpawn(GSubprocessLauncher* launcher, const Proces
     int seccompFd = setupSeccomp();
     GUniquePtr<char> fdStr(g_strdup_printf("%d", seccompFd));
     g_subprocess_launcher_take_fd(launcher, seccompFd, seccompFd);
-    sandboxArgs.appendVector(Vector<CString>({ "--seccomp", fdStr.get() }));
+    sandboxArgs.appendList<CString>({ "--seccomp", fdStr.get() });
 
     int bwrapFd = argumentsToFileDescriptor(sandboxArgs, "bwrap");
     GUniquePtr<char> bwrapFdStr(g_strdup_printf("%d", bwrapFd));

--- a/Source/WebKit/UIProcess/Launcher/glib/FlatpakLauncher.cpp
+++ b/Source/WebKit/UIProcess/Launcher/glib/FlatpakLauncher.cpp
@@ -53,7 +53,7 @@ GRefPtr<GSubprocess> flatpakSpawn(GSubprocessLauncher* launcher, const WebKit::P
     };
 
     if (launchOptions.processType == ProcessLauncher::ProcessType::Web) {
-        flatpakArgs.appendVector(Vector<CString>({
+        flatpakArgs.appendList({
             "--sandbox",
             "--no-network",
             "--sandbox-flag=share-gpu",
@@ -61,7 +61,7 @@ GRefPtr<GSubprocess> flatpakSpawn(GSubprocessLauncher* launcher, const WebKit::P
             "--sandbox-flag=share-sound",
             "--sandbox-flag=allow-a11y",
             "--sandbox-flag=allow-dbus", // Note that this only allows portals and $appid.Sandbox.* access
-        }));
+        });
 
         // GST_DEBUG_FILE points to an absolute file path, so we need write permissions for its parent directory.
         if (const char* debugFilePath = g_getenv("GST_DEBUG_FILE")) {

--- a/Source/WebKit/UIProcess/Launcher/glib/XDGDBusProxy.cpp
+++ b/Source/WebKit/UIProcess/Launcher/glib/XDGDBusProxy.cpp
@@ -72,8 +72,8 @@ std::optional<CString> XDGDBusProxy::dbusSessionProxy(const char* baseDirectory,
     if (m_dbusSessionProxyPath.isNull())
         return std::nullopt;
 
-    m_args.appendVector(Vector<CString> {
-        CString(dbusAddress), m_dbusSessionProxyPath,
+    m_args.appendList<CString>({
+        dbusAddress, m_dbusSessionProxyPath,
         "--filter"
     });
 
@@ -103,7 +103,7 @@ std::optional<CString> XDGDBusProxy::accessibilityProxy(const char* baseDirector
 
     auto webProcessA11yOwnArg = makeString("--own="_s, accessibilityBusName);
 
-    m_args.appendVector(Vector<CString> {
+    m_args.appendList<CString>({
         accessibilityBusAddress.utf8(), m_accessibilityProxyPath,
         "--filter",
         "--sloppy-names",


### PR DESCRIPTION
#### dd04266bff24bc7ea506e946d64a14c75089b9f9
<pre>
[GLIB] Prefer Vector::appendList() to ::appendVector() when using an initializer list
<a href="https://bugs.webkit.org/show_bug.cgi?id=311181">https://bugs.webkit.org/show_bug.cgi?id=311181</a>

Reviewed by Adrian Perez de Castro and Philippe Normand.

Using ::appendVector() in these cases is wrong because a temporary
vector is created just for the call. Calling appendList() directly
instead avoids the intermediate vector creation.

Also fix some unnecessary string conversions in the process.

* Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp:
(WebKit::bindSymlinksRealPath):
(WebKit::bindIfExists):
(WebKit::bindDBusSession):
(WebKit::bindA11y):
(WebKit::bindOpenGL):
(WebKit::bindV4l):
(WebKit::addExtraPaths):
(WebKit::bubblewrapSpawn):
* Source/WebKit/UIProcess/Launcher/glib/FlatpakLauncher.cpp:
(WebKit::flatpakSpawn):
* Source/WebKit/UIProcess/Launcher/glib/XDGDBusProxy.cpp:
(WebKit::XDGDBusProxy::dbusSessionProxy):
(WebKit::XDGDBusProxy::accessibilityProxy):

Canonical link: <a href="https://commits.webkit.org/310304@main">https://commits.webkit.org/310304@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c62e2edfb8775277c3d982d4b18b69ea693072e2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153425 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26209 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19809 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162170 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26735 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26529 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118616 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156384 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20859 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137741 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99327 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/19937 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17882 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10005 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/129584 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164644 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/7780 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17205 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126677 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26006 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/21916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126841 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26008 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137407 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/82675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23461 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21768 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14187 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25625 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89911 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25316 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25475 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25376 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->