### PR TITLE
[GTK][WPE] Centralize GLFence creation boilerplate in SkiaUtilities

### DIFF
--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
@@ -341,7 +341,7 @@ void GraphicsContextSkia::drawNativeImage(const NativeImage& nativeImage, const 
             if (!image->isValid(grContext->asRecorder())) {
                 // Ensure any pending GPU operations on the source image are complete before
                 // accessing its backend texture for rewrapping.
-                if (auto fence = createAcceleratedRenderingFence(nativeImage.platformImage(), nativeImage.grContext()))
+                if (auto fence = SkiaUtilities::flushAndSubmitImageWithFence(nativeImage.grContext(), nativeImage.platformImage()))
                     fence->serverWait();
 
                 imageInThisThread = SkiaUtilities::rewrapImageForContext(grContext, *image);
@@ -1292,48 +1292,6 @@ void GraphicsContextSkia::replayStateOnCanvas(SkCanvas& canvas) const
     canvas.setMatrix(m_canvas.getTotalMatrix());
 }
 
-static std::unique_ptr<GLFence> createFenceAfterFlush(GrDirectContext* grContext)
-{
-    auto& glDisplay = PlatformDisplay::sharedDisplay().glDisplay();
-    if (GLFence::isSupported(glDisplay)) {
-        grContext->submit(GrSyncCpu::kNo);
-
-        if (auto fence = GLFence::create(glDisplay))
-            return fence;
-    }
-
-    grContext->submit(GrSyncCpu::kYes);
-    return nullptr;
-}
-
-std::unique_ptr<GLFence> GraphicsContextSkia::createAcceleratedRenderingFence(SkSurface* surface)
-{
-    auto* glContext = PlatformDisplay::sharedDisplay().skiaGLContext();
-    if (!glContext || !glContext->makeContextCurrent())
-        return nullptr;
-
-    auto* recordingContext = surface->recordingContext();
-    auto* grContext = recordingContext ? recordingContext->asDirectContext() : nullptr;
-    if (!grContext)
-        return nullptr;
-
-    grContext->flush(surface);
-    return createFenceAfterFlush(grContext);
-}
-
-std::unique_ptr<GLFence> GraphicsContextSkia::createAcceleratedRenderingFence(const sk_sp<SkImage>& image, GrDirectContext* grContext)
-{
-    auto* glContext = PlatformDisplay::sharedDisplay().skiaGLContext();
-    if (!glContext || !glContext->makeContextCurrent())
-        return nullptr;
-
-    if (!grContext)
-        return nullptr;
-
-    grContext->flush(image);
-    return createFenceAfterFlush(grContext);
-}
-
 void GraphicsContextSkia::trackAcceleratedRenderingFenceIfNeeded(const sk_sp<SkImage>& image, GrDirectContext* grContext)
 {
     if (m_contextMode != ContextMode::RecordingMode)
@@ -1342,7 +1300,7 @@ void GraphicsContextSkia::trackAcceleratedRenderingFenceIfNeeded(const sk_sp<SkI
     if (!image || !image->isTextureBacked())
         return;
 
-    if (auto fence = createAcceleratedRenderingFence(image, grContext))
+    if (auto fence = SkiaUtilities::flushAndSubmitImageWithFence(grContext, image))
         m_imageToFenceMap.add(image.get(), WTF::move(fence));
 }
 

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
@@ -27,7 +27,6 @@
 
 #if USE(SKIA)
 
-#include "GLFence.h"
 #include "GraphicsContext.h"
 #include "SkiaRecordingResult.h"
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
@@ -123,9 +122,6 @@ public:
     SkPaint createStrokePaint() const;
 
     void drawSkiaText(const sk_sp<SkTextBlob>&, SkScalar, SkScalar, bool, bool);
-
-    static std::unique_ptr<GLFence> createAcceleratedRenderingFence(SkSurface*);
-    static std::unique_ptr<GLFence> createAcceleratedRenderingFence(const sk_sp<SkImage>&, GrDirectContext*);
 
 private:
     enum class ContextMode : bool {

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
@@ -39,6 +39,7 @@
 #include "ProcessCapabilities.h"
 #include "SkiaRecordingResult.h"
 #include "SkiaReplayCanvas.h"
+#include "SkiaUtilities.h"
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkPixmap.h>
 #include <skia/gpu/ganesh/GrBackendSurface.h>
@@ -223,18 +224,10 @@ std::unique_ptr<GLFence> ImageBufferSkiaAcceleratedBackend::flushCanvasRecording
 
     auto* recordingContext = m_surface->recordingContext();
     auto* grContext = recordingContext ? recordingContext->asDirectContext() : nullptr;
-
-    auto& glDisplay = PlatformDisplay::sharedDisplay().glDisplay();
-    if (GLFence::isSupported(glDisplay)) {
-        grContext->flushAndSubmit(m_surface.get(), GrSyncCpu::kNo);
-        if (auto fence = GLFence::create(glDisplay))
-            return fence;
-        grContext->submit(GrSyncCpu::kYes);
+    if (!grContext)
         return nullptr;
-    }
 
-    grContext->flushAndSubmit(m_surface.get(), GrSyncCpu::kYes);
-    return nullptr;
+    return SkiaUtilities::flushAndSubmitSurfaceWithFence(grContext, m_surface.get());
 }
 
 void ImageBufferSkiaAcceleratedBackend::flushContext()
@@ -246,10 +239,15 @@ void ImageBufferSkiaAcceleratedBackend::flushContext()
     }
 
     // Normal surface flush.
-    if (!m_surface)
+    if (!m_surface || !PlatformDisplay::sharedDisplay().skiaGLContext()->makeContextCurrent())
         return;
 
-    if (auto fence = GraphicsContextSkia::createAcceleratedRenderingFence(m_surface.get()))
+    auto* recordingContext = m_surface->recordingContext();
+    auto* grContext = recordingContext ? recordingContext->asDirectContext() : nullptr;
+    if (!grContext)
+        return;
+
+    if (auto fence = SkiaUtilities::flushAndSubmitSurfaceWithFence(grContext, m_surface.get()))
         fence->serverWait();
 }
 
@@ -358,14 +356,14 @@ static std::span<uint8_t> mutableSpan(SkData* data)
 
 void ImageBufferSkiaAcceleratedBackend::putPixelBuffer(const PixelBufferSourceView& pixelBuffer, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat)
 {
+    if (!PlatformDisplay::sharedDisplay().skiaGLContext()->makeContextCurrent())
+        return;
+
     // CPU needs to write pixels now, wait for GPU completion.
     if (auto fence = flushCanvasRecordingContextIfNeeded())
         fence->serverWait();
 
     UNUSED_PARAM(destFormat);
-
-    if (!PlatformDisplay::sharedDisplay().skiaGLContext()->makeContextCurrent())
-        return;
 
     ASSERT(IntRect({ 0, 0 }, pixelBuffer.size()).contains(srcRect));
     ASSERT(pixelBuffer.format().pixelFormat == PixelFormat::RGBA8 || pixelBuffer.format().pixelFormat == PixelFormat::BGRA8);

--- a/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp
@@ -41,6 +41,7 @@
 #include "SkiaImageAtlasLayout.h"
 #include "SkiaRecordingResult.h"
 #include "SkiaReplayCanvas.h"
+#include "SkiaUtilities.h"
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkColorSpace.h>
 #include <skia/core/SkPictureRecorder.h>
@@ -264,12 +265,7 @@ Ref<SkiaRecordingResult> SkiaPaintingEngine::record(const GraphicsLayerCoordinat
                 // BitmapTexture::updateContents() issues GL upload commands.
                 // On the DMA-buf path, uploading is CPU-side (memory-mapped),
                 // so this is a no-op flush but harmless.
-                auto& glDisplay = PlatformDisplay::sharedDisplay().glDisplay();
-                if (GLFence::isSupported(glDisplay)) {
-                    grContext->flushAndSubmit(GrSyncCpu::kNo);
-                    result->setUploadFence(GLFence::create(glDisplay));
-                } else
-                    grContext->flushAndSubmit(GrSyncCpu::kYes);
+                result->setUploadFence(SkiaUtilities::flushAndSubmitWithFence(grContext));
             }
         }
     } else {

--- a/Source/WebCore/platform/graphics/skia/SkiaUtilities.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaUtilities.cpp
@@ -30,6 +30,8 @@
 
 #include "BitmapTexture.h"
 #include "ColorSpaceSkia.h"
+#include "GLFence.h"
+#include "PlatformDisplay.h"
 
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/gpu/ganesh/SkImageGanesh.h>
@@ -90,6 +92,38 @@ std::optional<unsigned> retrieveGLTextureID(const SkImage& image)
         return std::nullopt;
 
     return textureInfo.fID;
+}
+
+static std::unique_ptr<GLFence> createFenceAfterFlush(GrDirectContext* grContext)
+{
+    auto& glDisplay = PlatformDisplay::sharedDisplay().glDisplay();
+    if (GLFence::isSupported(glDisplay)) {
+        grContext->submit(GrSyncCpu::kNo);
+
+        if (auto fence = GLFence::create(glDisplay))
+            return fence;
+    }
+
+    grContext->submit(GrSyncCpu::kYes);
+    return nullptr;
+}
+
+std::unique_ptr<GLFence> flushAndSubmitSurfaceWithFence(GrDirectContext* grContext, SkSurface* surface)
+{
+    grContext->flush(surface);
+    return createFenceAfterFlush(grContext);
+}
+
+std::unique_ptr<GLFence> flushAndSubmitImageWithFence(GrDirectContext* grContext, const sk_sp<SkImage>& image)
+{
+    grContext->flush(image);
+    return createFenceAfterFlush(grContext);
+}
+
+std::unique_ptr<GLFence> flushAndSubmitWithFence(GrDirectContext* grContext)
+{
+    grContext->flush();
+    return createFenceAfterFlush(grContext);
 }
 
 } // namespace SkiaUtilities

--- a/Source/WebCore/platform/graphics/skia/SkiaUtilities.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaUtilities.h
@@ -27,6 +27,7 @@
 
 #if USE(SKIA)
 
+#include <memory>
 #include <optional>
 
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
@@ -43,6 +44,7 @@ enum GrSurfaceOrigin : int;
 namespace WebCore {
 
 class BitmapTexture;
+class GLFence;
 
 namespace SkiaUtilities {
 
@@ -64,6 +66,21 @@ sk_sp<SkImage> borrowBackendTextureAsImage(GrDirectContext*, const GrBackendText
 
 // Extracts the GL texture ID from a GPU-backed SkImage, if available.
 std::optional<unsigned> retrieveGLTextureID(const SkImage&);
+
+// Flushes the surface, submits pending GPU commands, and creates a GLFence
+// for async synchronization. Falls back to synchronous submit if fences
+// are not supported or creation fails, and returns nullptr.
+std::unique_ptr<GLFence> flushAndSubmitSurfaceWithFence(GrDirectContext*, SkSurface*);
+
+// Flushes the image, submits pending GPU commands, and creates a GLFence
+// for async synchronization. Falls back to synchronous submit if fences
+// are not supported or creation fails, and returns nullptr.
+std::unique_ptr<GLFence> flushAndSubmitImageWithFence(GrDirectContext*, const sk_sp<SkImage>&);
+
+// Flushes and submits pending GPU commands and creates a GLFence for async
+// synchronization. Falls back to synchronous submit if fences are not
+// supported or creation fails, and returns nullptr.
+std::unique_ptr<GLFence> flushAndSubmitWithFence(GrDirectContext*);
 
 } // namespace SkiaUtilities
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.cpp
@@ -38,6 +38,7 @@
 #include "GLFence.h"
 #include "PlatformDisplay.h"
 #include "ProcessCapabilities.h"
+#include "SkiaUtilities.h"
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkColorSpace.h>
 #include <skia/core/SkImage.h>
@@ -202,14 +203,7 @@ void CoordinatedAcceleratedTileBuffer::completePainting()
         return;
     }
 
-    auto& glDisplay = PlatformDisplay::sharedDisplay().glDisplay();
-    if (GLFence::isSupported(glDisplay)) {
-        grContext->flushAndSubmit(m_surface.get(), GrSyncCpu::kNo);
-        m_fence = GLFence::create(glDisplay);
-        if (!m_fence)
-            grContext->submit(GrSyncCpu::kYes);
-    } else
-        grContext->flushAndSubmit(m_surface.get(), GrSyncCpu::kYes);
+    m_fence = SkiaUtilities::flushAndSubmitSurfaceWithFence(grContext, m_surface.get());
 
     CoordinatedTileBuffer::completePainting();
 }


### PR DESCRIPTION
#### 808bb0bb74f61e4c3e39f6059cf028d2dce407a9
<pre>
[GTK][WPE] Centralize GLFence creation boilerplate in SkiaUtilities
<a href="https://bugs.webkit.org/show_bug.cgi?id=311180">https://bugs.webkit.org/show_bug.cgi?id=311180</a>

Reviewed by Adrian Perez de Castro.

Move the duplicated &quot;flush + submit + create fence, fallback to sync submit&quot;
pattern into three new SkiaUtilities functions: flushAndSubmitSurfaceWithFence,
flushAndSubmitImageWithFence, and flushAndSubmitWithFence.

This eliminates repeated boilerplate across GraphicsContextSkia,
ImageBufferSkiaAcceleratedBackend, CoordinatedTileBuffer, and SkiaPaintingEngine.

Also removes GraphicsContextSkia::createAcceleratedRenderingFence since all
call sites already ensure the GL context is current -- simplifying the
desing.

Covered by existing tests.

Canonical link: <a href="https://commits.webkit.org/310333@main">https://commits.webkit.org/310333@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa768b22ceed5f839c5eede0ced3ec6db66c8f16

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153439 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26223 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19823 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162188 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106897 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155312 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26749 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26543 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118627 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83978 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156398 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20874 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137749 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99338 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19952 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17893 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10022 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129599 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15619 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164660 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7794 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17213 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126688 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26020 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21928 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126853 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26022 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137415 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82689 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23473 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21784 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14195 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25639 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89925 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25330 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25489 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25390 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->