### PR TITLE
SVG tspan positioning bug with xml:space="preserve"

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/text/scripted/tspan-xml-space-preserve-position-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/text/scripted/tspan-xml-space-preserve-position-expected.txt
@@ -1,0 +1,7 @@
+A  BC  D
+
+PASS First tspan starts at its specified x/y
+PASS Second tspan starts at its specified x/y, not offset by inter-tspan whitespace
+PASS Second character of multi-char tspan follows naturally without position shift
+PASS Third tspan starts at its specified x/y
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/text/scripted/tspan-xml-space-preserve-position.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/text/scripted/tspan-xml-space-preserve-position.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<title>tspan positioning with xml:space="preserve" and whitespace between tspans</title>
+<link rel="help" href="https://svgwg.org/svg2-draft/text.html#WhiteSpace">
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=311185">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+text { font: 10px/1 Ahem; }
+</style>
+
+<svg width="200" height="200">
+  <text>
+    <tspan id="t1" x="10" y="20" xml:space="preserve">A</tspan>
+    <tspan id="t2" x="10" y="40" xml:space="preserve">BC</tspan>
+    <tspan id="t3" x="10" y="60" xml:space="preserve">D</tspan>
+  </text>
+</svg>
+
+<script>
+setup({ explicit_done: true });
+
+document.fonts.ready.then(() => {
+  test(() => {
+    const t1 = document.getElementById('t1');
+    assert_equals(t1.getStartPositionOfChar(0).x, 10, 'tspan 1 char 0 x');
+    assert_equals(t1.getStartPositionOfChar(0).y, 20, 'tspan 1 char 0 y');
+  }, 'First tspan starts at its specified x/y');
+
+  test(() => {
+    const t2 = document.getElementById('t2');
+    assert_equals(t2.getStartPositionOfChar(0).x, 10, 'tspan 2 char 0 x');
+    assert_equals(t2.getStartPositionOfChar(0).y, 40, 'tspan 2 char 0 y');
+  }, 'Second tspan starts at its specified x/y, not offset by inter-tspan whitespace');
+
+  test(() => {
+    const t2 = document.getElementById('t2');
+    const pos0 = t2.getStartPositionOfChar(0);
+    const pos1 = t2.getStartPositionOfChar(1);
+    assert_equals(pos1.x, pos0.x + 10, 'tspan 2 char 1 x');
+    assert_equals(pos1.y, 40, 'tspan 2 char 1 y');
+  }, 'Second character of multi-char tspan follows naturally without position shift');
+
+  test(() => {
+    const t3 = document.getElementById('t3');
+    assert_equals(t3.getStartPositionOfChar(0).x, 10, 'tspan 3 char 0 x');
+    assert_equals(t3.getStartPositionOfChar(0).y, 60, 'tspan 3 char 0 y');
+  }, 'Third tspan starts at its specified x/y');
+
+  done();
+});
+</script>

--- a/Source/WebCore/rendering/svg/SVGTextLayoutAttributesBuilder.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutAttributesBuilder.cpp
@@ -86,6 +86,8 @@ static inline void NODELETE processRenderSVGInlineText(const RenderSVGInlineText
     auto length = string.length();
     if (text.style().whiteSpaceCollapse() == WhiteSpaceCollapse::Preserve) {
         atCharacter += length;
+        if (length)
+            lastCharacterWasSpace = string[length - 1] == ' ';
         return;
     }
 


### PR DESCRIPTION
#### 279d4c423fd2228b9a4d3f72aa3b3c72b55320d7
<pre>
SVG tspan positioning bug with xml:space=&quot;preserve&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=311185">https://bugs.webkit.org/show_bug.cgi?id=311185</a>
<a href="https://rdar.apple.com/143722975">rdar://143722975</a>

Reviewed by Simon Fraser.

In processRenderSVGInlineText, the preserve fast path incremented the
character count but did not update lastCharacterWasSpace. This caused a
mismatch between SVGTextLayoutAttributesBuilder (position assignment) and
SVGTextMetricsBuilder (rendering metrics), so whitespace text nodes
between tspans consumed the x/y position data of the following tspan.

Test: imported/w3c/web-platform-tests/svg/text/scripted/tspan-xml-space-preserve-position.html

* LayoutTests/imported/w3c/web-platform-tests/svg/text/scripted/tspan-xml-space-preserve-position-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/text/scripted/tspan-xml-space-preserve-position.html: Added.
* Source/WebCore/rendering/svg/SVGTextLayoutAttributesBuilder.cpp:
(WebCore::processRenderSVGInlineText):

Canonical link: <a href="https://commits.webkit.org/310347@main">https://commits.webkit.org/310347@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0951b3657c5d461d11e15f12246507a00d8f2dcf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153516 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26300 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19901 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162265 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dc366b72-9e1f-4e52-8ad8-cd56ae09f940) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155389 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26827 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26621 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118694 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/08227c24-d694-47b3-900f-27af393dcb01) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156475 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20941 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137825 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99405 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20020 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17963 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10099 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/129666 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15695 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164737 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7871 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17289 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126758 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26097 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21999 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126923 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26099 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137491 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82766 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23478 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21850 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14271 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25716 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90003 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25407 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25567 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25467 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->