### PR TITLE
Remove OverlappingBackingStoreProvidersEnabled preference

### DIFF
--- a/LayoutTests/compositing/shared-backing/update-backing-sharing-on-size-change-expected.html
+++ b/LayoutTests/compositing/shared-backing/update-backing-sharing-on-size-change-expected.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ OverlappingBackingStoreProvidersEnabled=false ] -->
+<!DOCTYPE html>
 <style>
 * { position: absolute; box-shadow: 0px 1px 64px }
 </style>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -5986,20 +5986,6 @@ OriginAPIEnabled:
     WebCore:
       default: true
 
-OverlappingBackingStoreProvidersEnabled:
-  type: bool
-  status: stable
-  humanReadableName: "Overlapping backing stores"
-  humanReadableDescription: "Enable overlapping backing stores compositor optimization"
-  category: css
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
-
 OverlayRegionsEnabled:
   type: bool
   status: testable

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -316,9 +316,7 @@ struct RenderLayerCompositor::BackingSharingSnapshot {
 class RenderLayerCompositor::BackingSharingState {
     WTF_MAKE_NONCOPYABLE(BackingSharingState);
 public:
-    BackingSharingState(bool allowOverlappingProviders)
-        : m_allowOverlappingProviders(allowOverlappingProviders)
-    { }
+    BackingSharingState() = default;
 
     struct Provider {
         InlineWeakPtr<RenderLayer> providerLayer;
@@ -347,7 +345,7 @@ public:
     }
 
     void addBackingSharingCandidate(RenderLayer& candidateLayer, LayoutRect candidateAbsoluteBounds, RenderLayer& candidateStackingContext, const std::optional<BackingSharingSnapshot>&);
-    bool isAdditionalProviderCandidate(RenderLayer&, LayoutRect candidateAbsoluteBounds, RenderLayer* stackingContextAncestor) const;
+    bool isAdditionalProviderCandidate(RenderLayer* stackingContextAncestor) const;
     void startBackingSharingSequence(RenderLayer& candidateLayer, LayoutRect candidateAbsoluteBounds, RenderLayer& candidateStackingContext);
     void endBackingSharingSequence(RenderLayer&);
 
@@ -368,7 +366,6 @@ private:
     RenderLayer* m_backingSharingStackingContext { nullptr };
     BackingSharingSequenceIdentifier m_sequenceIdentifier { BackingSharingSequenceIdentifier::generate() };
     InlineWeakKeyHashSet<RenderLayer> m_layersPendingRepaint;
-    bool m_allowOverlappingProviders { false };
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, const RenderLayerCompositor::BackingSharingState::Provider&);
@@ -418,16 +415,6 @@ auto RenderLayerCompositor::BackingSharingState::backingProviderCandidateForLaye
 {
     if (layer.hasReflection())
         return nullptr;
-
-    if (!m_allowOverlappingProviders) {
-        for (auto& candidate : m_backingProviderCandidates) {
-            CheckedRef providerLayer = *candidate.providerLayer;
-            if (layer.ancestorLayerIsInContainingBlockChain(providerLayer))
-                return &candidate;
-        }
-
-        return nullptr;
-    }
 
     if (m_backingProviderCandidates.isEmpty())
         return nullptr;
@@ -520,24 +507,11 @@ auto RenderLayerCompositor::BackingSharingState::backingProviderForLayer(const R
     return nullptr;
 }
 
-bool RenderLayerCompositor::BackingSharingState::isAdditionalProviderCandidate(RenderLayer& candidateLayer, LayoutRect candidateAbsoluteBounds, RenderLayer* stackingContextAncestor) const
+bool RenderLayerCompositor::BackingSharingState::isAdditionalProviderCandidate(RenderLayer* stackingContextAncestor) const
 {
     ASSERT(!m_backingProviderCandidates.isEmpty());
     if (!stackingContextAncestor || stackingContextAncestor != m_backingSharingStackingContext)
         return false;
-
-    if (!m_allowOverlappingProviders) {
-        // Only allow multiple providers for overflow scroll, which we know clips its descendants.
-        if (!(m_backingProviderCandidates[0].providerLayer->canUseCompositedScrolling() && candidateLayer.canUseCompositedScrolling()))
-            return false;
-
-        // Disallow overlap between backing providers.
-        for (auto& candidate : m_backingProviderCandidates) {
-            if (candidateAbsoluteBounds.intersects(candidate.absoluteBounds))
-                return false;
-        }
-        return true;
-    }
 
     if (!m_backingProviderCandidates[0].providerLayer->canUseCompositedScrolling())
         return false;
@@ -1152,7 +1126,7 @@ bool RenderLayerCompositor::updateCompositingLayers(CompositingUpdateType update
     if (updateRoot->hasDescendantNeedingCompositingRequirementsTraversal() || updateRoot->needsCompositingRequirementsTraversal()) {
         CheckedRef rootLayer = rootRenderLayer();
         CompositingState compositingState(updateRoot);
-        BackingSharingState backingSharingState(m_renderView.settings().overlappingBackingStoreProvidersEnabled());
+        BackingSharingState backingSharingState;
         LayerOverlapMap overlapMap(rootLayer);
 
         computeCompositingRequirements(nullptr, rootLayer, overlapMap, compositingState, backingSharingState);
@@ -1895,8 +1869,9 @@ std::optional<RenderLayerCompositor::BackingSharingSnapshot> RenderLayerComposit
             return false;
 
         // If this layer is composited, we can only continue the sequence if it's a new provider candidate.
+        // FIXME: Can this computeExtent() call be removed?
         computeExtent(overlapMap, layer, layerExtent);
-        return !sharingState.isAdditionalProviderCandidate(layer, layerExtent.bounds, stackingContextAncestor);
+        return !sharingState.isAdditionalProviderCandidate(stackingContextAncestor);
     }();
 
     // A layer that composites resets backing-sharing, since subsequent layers need to composite to overlap it.
@@ -1948,7 +1923,7 @@ void RenderLayerCompositor::updateBackingSharingAfterDescendantTraversal(Backing
         }
 
         computeExtent(overlapMap, layer, layerExtent);
-        if (sharingState.isAdditionalProviderCandidate(layer, layerExtent.bounds, stackingContextAncestor)) {
+        if (sharingState.isAdditionalProviderCandidate(stackingContextAncestor)) {
             sharingState.addBackingSharingCandidate(layer, layerExtent.bounds, *stackingContextAncestor, backingSharingSnapshot);
             LOG_WITH_STREAM(Compositing, stream << TextStream::Repeat(depth * 2, ' ') << " - added additional provider candidate " << &layer);
             return;


### PR DESCRIPTION
#### bd2ad8109f59b389614f50540251267b4c2130f9
<pre>
Remove OverlappingBackingStoreProvidersEnabled preference
<a href="https://bugs.webkit.org/show_bug.cgi?id=311189">https://bugs.webkit.org/show_bug.cgi?id=311189</a>

Reviewed by Matt Woodrow.

It&apos;s been stable for close to two years.

Canonical link: <a href="https://commits.webkit.org/310457@main">https://commits.webkit.org/310457@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ca6e5eff50ed58496757ba662fe699ce85f912d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153891 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26675 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20292 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162642 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107356 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/319bbe9f-292a-4736-b6d7-d141b8c23bf8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155764 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27204 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26997 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118990 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84134 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3b175f20-a567-4a90-aa77-cb3953b177e9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156850 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21259 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138186 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99700 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2b818905-35c2-4606-9aaf-cf0f93b910cb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20348 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18310 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10474 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/145904 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130000 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16045 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165115 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/14715 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8246 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17639 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127079 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26472 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22329 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127246 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26474 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137840 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83173 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23512 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22146 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14624 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/185527 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26091 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90397 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47582 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25782 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25942 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25842 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->