### PR TITLE
[css-values-5 attr()] Implement namespace parsing

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4450,9 +4450,7 @@ imported/w3c/web-platform-tests/css/css-values/calc-size/calc-size-flex-008.html
 imported/w3c/web-platform-tests/css/css-values/calc-size/calc-size-flex-009.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-values/viewport-units-scrollbars-dynamic-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-values/viewport-units-scrollbars-scroll-vw-002.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-values/attr-namespace-non-existing.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-values/attr-namespace-valid.xhtml [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-values/attr-namespace-wildcard.html [ ImageOnlyFailure ]
 
 # wpt css-sizing failures
 webkit.org/b/308648 imported/w3c/web-platform-tests/css/css-sizing/abspos-auto-sizing-fit-content-percentage-005.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-namespace-wildcard.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-namespace-wildcard.html
@@ -3,7 +3,7 @@
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="assert" content="Wildcard not supported in attr() function">
 <style>
-.a {
+.outer {
    background: green;
    height: 100px;
    width: 100px;
@@ -11,7 +11,9 @@
 
 .attr {
   background: attr(*|bar type(*));
+  height: 100%;
+  width: 100%;
 }
 </style>
 <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
-<div class="a attr" bar="red"></div>
+<div class="outer"><div class="attr" bar="red"></div></div>

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -606,10 +606,9 @@ std::unique_ptr<MutableCSSSelector> CSSSelectorParser::consumeCompoundSelector(C
 
     std::unique_ptr<MutableCSSSelector> compoundSelector;
 
-    AtomString namespacePrefix;
-    AtomString elementName;
-    const bool hasName = consumeName(range, elementName, namespacePrefix);
-    if (!hasName) {
+    auto parsedName = consumeQualifiedName(range);
+
+    if (!parsedName) {
         compoundSelector = consumeSimpleSelector(range);
         if (!compoundSelector)
             return nullptr;
@@ -636,8 +635,9 @@ std::unique_ptr<MutableCSSSelector> CSSSelectorParser::consumeCompoundSelector(C
     //
     // [1] https://drafts.csswg.org/selectors/#matches
     // [2] https://drafts.csswg.org/selectors/#selector-subject
-    SetForScope ignoreDefaultNamespace(m_ignoreDefaultNamespace, m_resistDefaultNamespace && !hasName && atEndIgnoringWhitespace(range));
+    SetForScope ignoreDefaultNamespace(m_ignoreDefaultNamespace, m_resistDefaultNamespace && !parsedName && atEndIgnoringWhitespace(range));
     if (!compoundSelector) {
+        auto namespacePrefix = parsedName->namespacePrefix;
         AtomString namespaceURI = determineNamespace(namespacePrefix);
         if (namespaceURI.isNull()) {
             m_failedParsing = true;
@@ -646,8 +646,10 @@ std::unique_ptr<MutableCSSSelector> CSSSelectorParser::consumeCompoundSelector(C
         if (namespaceURI == defaultNamespace())
             namespacePrefix = nullAtom();
         
-        return makeUnique<MutableCSSSelector>(QualifiedName(namespacePrefix, elementName, namespaceURI));
+        return makeUnique<MutableCSSSelector>(QualifiedName(namespacePrefix, parsedName->name, namespaceURI));
     }
+    auto namespacePrefix = parsedName ? parsedName->namespacePrefix : nullAtom();
+    auto elementName = parsedName ? parsedName->name : nullAtom();
     prependTypeSelectorIfNeeded(namespacePrefix, elementName, *compoundSelector);
     return splitCompoundAtImplicitShadowCrossingCombinator(WTF::move(compoundSelector), m_context);
 }
@@ -685,12 +687,12 @@ std::unique_ptr<MutableCSSSelector> CSSSelectorParser::consumeSimpleSelector(CSS
     return selector;
 }
 
-bool CSSSelectorParser::consumeName(CSSParserTokenRange& range, AtomString& name, AtomString& namespacePrefix)
+std::optional<ParsedQualifiedName> consumeQualifiedName(CSSParserTokenRange& range)
 {
-    name = nullAtom();
-    namespacePrefix = nullAtom();
+    AtomString name;
+    AtomString namespacePrefix;
 
-    const CSSParserToken& firstToken = range.peek();
+    auto& firstToken = range.peek();
     if (firstToken.type() == IdentToken) {
         name = firstToken.value().toAtomString();
         range.consume();
@@ -698,29 +700,29 @@ bool CSSSelectorParser::consumeName(CSSParserTokenRange& range, AtomString& name
         name = starAtom();
         range.consume();
     } else if (firstToken.type() == DelimiterToken && firstToken.delimiter() == '|') {
-        // This is an empty namespace, which'll get assigned this value below
+        // This is an empty namespace, which'll get assigned this value below.
         name = emptyAtom();
     } else
-        return false;
+        return { };
 
     if (range.peek().type() != DelimiterToken || range.peek().delimiter() != '|')
-        return true;
+        return ParsedQualifiedName { name, namespacePrefix };
 
     namespacePrefix = name;
+
     if (range.peek(1).type() == IdentToken) {
         range.consume();
         name = range.consume().value().toAtomString();
-    } else if (range.peek(1).type() == DelimiterToken && range.peek(1).delimiter() == '*') {
-        range.consume();
-        range.consume();
-        name = starAtom();
-    } else {
-        name = nullAtom();
-        namespacePrefix = nullAtom();
-        return false;
+        return ParsedQualifiedName { name, namespacePrefix };
     }
 
-    return true;
+    if (range.peek(1).type() == DelimiterToken && range.peek(1).delimiter() == '*') {
+        range.consume();
+        range.consume();
+        return ParsedQualifiedName { starAtom(), namespacePrefix };
+    }
+
+    return { };
 }
 
 std::unique_ptr<MutableCSSSelector> CSSSelectorParser::consumeId(CSSParserTokenRange& range)
@@ -772,19 +774,18 @@ std::unique_ptr<MutableCSSSelector> CSSSelectorParser::consumeAttribute(CSSParse
     CSSParserTokenRange block = range.consumeBlock();
     block.consumeWhitespace();
 
-    AtomString namespacePrefix;
-    AtomString attributeName;
-    if (!consumeName(block, attributeName, namespacePrefix))
+    auto parsedName = consumeQualifiedName(block);
+    if (!parsedName)
         return nullptr;
     block.consumeWhitespace();
 
-    AtomString namespaceURI = determineNamespace(namespacePrefix);
+    AtomString namespaceURI = determineNamespace(parsedName->namespacePrefix);
     if (namespaceURI.isNull())
         return nullptr;
 
-    QualifiedName qualifiedName = namespacePrefix.isNull()
-        ? QualifiedName(nullAtom(), attributeName, nullAtom())
-        : QualifiedName(namespacePrefix, attributeName, namespaceURI);
+    QualifiedName qualifiedName = parsedName->namespacePrefix.isNull()
+        ? QualifiedName(nullAtom(), parsedName->name, nullAtom())
+        : QualifiedName(parsedName->namespacePrefix, parsedName->name, namespaceURI);
 
     auto selector = makeUnique<MutableCSSSelector>();
 

--- a/Source/WebCore/css/parser/CSSSelectorParser.h
+++ b/Source/WebCore/css/parser/CSSSelectorParser.h
@@ -77,8 +77,6 @@ private:
     // This doesn't include element names, since they're handled specially.
     std::unique_ptr<MutableCSSSelector> consumeSimpleSelector(CSSParserTokenRange&);
 
-    bool consumeName(CSSParserTokenRange&, AtomString& name, AtomString& namespacePrefix);
-
     // These will return nullptr when the selector is invalid.
     std::unique_ptr<MutableCSSSelector> consumeId(CSSParserTokenRange&);
     std::unique_ptr<MutableCSSSelector> consumeClass(CSSParserTokenRange&);
@@ -112,6 +110,12 @@ private:
     bool m_disableForgivingParsing { false };
     const MutableCSSSelector* m_precedingPseudoElement { nullptr };
 };
+
+struct ParsedQualifiedName {
+    AtomString name;
+    AtomString namespacePrefix;
+};
+std::optional<ParsedQualifiedName> consumeQualifiedName(CSSParserTokenRange&);
 
 std::optional<CSSSelectorList> parseCSSSelectorList(CSSParserTokenRange, const CSSSelectorParserContext&, StyleSheetContents* = nullptr, CSSParserEnum::NestedContext = { });
 

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -33,6 +33,7 @@
 #include "CSSPropertyParser.h"
 #include "CSSPropertyParserConsumer+Primitives.h"
 #include "CSSRegisteredCustomProperty.h"
+#include "CSSSelectorParser.h"
 #include "CSSShorthandSubstitutionValue.h"
 #include "CSSSubstitutionValue.h"
 #include "CSSTokenizer.h"
@@ -231,11 +232,13 @@ bool SubstitutionResolver::substituteAttrFunction(CSSParserTokenRange argumentsR
     // attr() = attr( <attr-name> <attr-type>? , <declaration-value>?)
     auto range = CSSParserTokenRange { attrArgs->firstArg };
 
-    if (range.peek().type() != IdentToken)
+    // Consume <attr-name> = <wq-name> = [ <ident> | * ]? '|' <ident>  or  <ident>
+    auto parsedName = consumeQualifiedName(range);
+    if (!parsedName)
         return false;
+    range.consumeWhitespace();
 
-    // Consume <attr-name>
-    auto attributeName = range.consumeIncludingWhitespace().value().toAtomString();
+    auto attributeName = parsedName->name;
 
     // Consume optional <attr-type>.
     // https://drafts.csswg.org/css-values-5/#typedef-attr-type
@@ -337,6 +340,10 @@ bool SubstitutionResolver::substituteAttrFunction(CSSParserTokenRange argumentsR
             return false;
         return substituteFailure();
     }
+
+    // FIXME: Resolve namespace prefixes using the stylesheet's @namespace rules instead of always triggering fallback.
+    if (!parsedName->namespacePrefix.isNull())
+        return substituteFailure();
 
     if (attributeValue.isNull())
         return substituteFailure();


### PR DESCRIPTION
#### 5ddde6f1fc15364bce7d7df8d4b7dadb8636f14d
<pre>
[css-values-5 attr()] Implement namespace parsing
<a href="https://bugs.webkit.org/show_bug.cgi?id=311190">https://bugs.webkit.org/show_bug.cgi?id=311190</a>
<a href="https://rdar.apple.com/173781315">rdar://173781315</a>

Reviewed by Alan Baradlay.

Parse the attribute namespace prefix in attr(ns|foo).

<a href="https://drafts.csswg.org/css-values-5/#typedef-attr-name">https://drafts.csswg.org/css-values-5/#typedef-attr-name</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-namespace-wildcard.html:

The test expects *| to be rejected at validation time. With attribute grammar support this only happens
at computed value time. Update the test so the value becoming IACVT does not remove background-color completely.

* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::consumeCompoundSelector):
(WebCore::consumeQualifiedName):

Selector parsing already does namespace parsing for attributes.
Factor this into shareable function.

(WebCore::CSSSelectorParser::consumeAttribute):
(WebCore::CSSSelectorParser::consumeName): Deleted.
* Source/WebCore/css/parser/CSSSelectorParser.h:
* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::SubstitutionResolver::substituteAttrFunction):

Parse the namespace.
We don&apos;t yet resolve the namespace to an actual URL.

Canonical link: <a href="https://commits.webkit.org/310322@main">https://commits.webkit.org/310322@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99d1644aa35323013bd12850a771015fca214cc4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153468 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26252 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19852 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162217 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ac36021c-51ba-4189-a8c2-04143814550d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155341 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26778 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26572 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118650 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2eaa4e03-d178-487e-8127-0f13907f7a37) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156427 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20895 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137775 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99361 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/615f9ad0-98d5-4122-89a9-cdf32eea4992) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19973 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17917 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10051 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/129620 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15645 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164689 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/7823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17239 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126713 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26049 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/21952 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126878 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34413 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26051 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137441 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/82718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21807 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14221 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25668 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89954 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25359 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25518 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25419 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->