### PR TITLE
[WebXR] Add missing serialization type definitions

### DIFF
--- a/Source/WebKit/Shared/XR/PlatformXR.serialization.in
+++ b/Source/WebKit/Shared/XR/PlatformXR.serialization.in
@@ -48,6 +48,8 @@ enum class PlatformXR::SessionFeature : uint8_t {
 #endif
 };
 
+using PlatformXR::Device::FeatureList = Vector<PlatformXR::SessionFeature>;
+
 enum class PlatformXR::SessionMode : uint8_t {
     Inline,
     ImmersiveVr,
@@ -108,6 +110,8 @@ header: <WebCore/PlatformXR.h>
     float left;
     float right;
 };
+
+using PlatformXR::FrameData::Projection = PlatformXR::FrameData::Projection;
 
 [Nested] struct PlatformXR::FrameData::View {
     PlatformXR::FrameData::Pose offset;
@@ -188,6 +192,8 @@ header: <WebCore/PlatformXR.h>
     float radius;
 };
 
+using PlatformXR::FrameData::HandJointsVector = Vector<std::optional<PlatformXR::FrameData::InputSourceHandJoint>>;
+
 #endif
 
 #if ENABLE(WEBXR)
@@ -224,6 +230,8 @@ enum class PlatformXR::InputSourceSpaceType : uint8_t {
     Grip,
 };
 
+using PlatformXR::InputSourceHandle = int;
+
 [CustomHeader] struct PlatformXR::InputSourceSpaceInfo {
     PlatformXR::InputSourceHandle handle;
     PlatformXR::InputSourceSpaceType type;
@@ -251,7 +259,12 @@ using PlatformXR::NativeOriginInformation = Variant<PlatformXR::ReferenceSpaceTy
     PlatformXR::InputSourceHandle inputSource;
     Vector<PlatformXR::FrameData::HitTestResult> results;
 };
+
+using PlatformXR::HitTestSource = WebCore::XRHitTestSourceIdentifier;
+using PlatformXR::TransientInputHitTestSource = WebCore::XRHitTestSourceIdentifier;
 #endif
+
+using PlatformXR::LayerHandle = int;
 
 header: <WebCore/PlatformXR.h>
 [CustomHeader, RValue] struct PlatformXR::FrameData {


### PR DESCRIPTION
#### bcd7278414c494b3a6e9de2ccf9381dd78610c54
<pre>
[WebXR] Add missing serialization type definitions
<a href="https://bugs.webkit.org/show_bug.cgi?id=311197">https://bugs.webkit.org/show_bug.cgi?id=311197</a>

Reviewed by Dan Glastonbury.

These types are missing their definition from the corresponding
serialization.in file, as detected by IPC testing.

* Source/WebKit/Shared/XR/PlatformXR.serialization.in:

Canonical link: <a href="https://commits.webkit.org/310353@main">https://commits.webkit.org/310353@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e86461cd7f9e249b0246b2fc2c5dfff09c332fed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153461 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26245 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19845 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162210 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106919 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26771 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26565 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118642 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83988 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156420 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20889 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137778 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99353 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19967 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17908 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10044 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/145474 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129614 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164682 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7816 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17242 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126704 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26042 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21943 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126869 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34436 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26044 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137444 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82711 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21799 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14224 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25661 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89947 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25352 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25511 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25412 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->