### PR TITLE
Better align the reported entityTransform / camera settings between ModelPlayers

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/Model/MeshImpl.cpp
+++ b/Source/WebKit/GPUProcess/graphics/Model/MeshImpl.cpp
@@ -83,9 +83,9 @@ std::optional<WebModel::Float4x4> MeshImpl::entityTransform() const
 }
 #endif
 
-void MeshImpl::setCameraDistance(float distance)
+void MeshImpl::setFOV(float fovY)
 {
-    m_backing->setCameraDistance(distance);
+    m_backing->setFOV(fovY);
 }
 
 void MeshImpl::setBackgroundColor(const WebModel::Float3& color)

--- a/Source/WebKit/GPUProcess/graphics/Model/MeshImpl.h
+++ b/Source/WebKit/GPUProcess/graphics/Model/MeshImpl.h
@@ -74,7 +74,7 @@ private:
 #if PLATFORM(COCOA)
     std::optional<WebModel::Float4x4> entityTransform() const final;
 #endif
-    void setCameraDistance(float) final;
+    void setFOV(float) final;
     void setBackgroundColor(const WebModel::Float3&) final;
     void play(bool) final;
     void setEnvironmentMap(const WebModel::ImageAsset&) final;

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift
@@ -45,8 +45,10 @@ class Renderer {
         // swift-format-ignore: NeverForceUnwrap
         renderer!.renderTargetDescriptor
     }
+
     var pose: _Proto_Pose_v1
-    var modelDistance: Float = 1.0
+    private static let cameraDistance: Float = 0.5
+    var fovY: Float = 60 * .pi / 180
     var clearColor: MTLClearColor = .init(red: 1, green: 1, blue: 1, alpha: 1)
     let memoryOwner: task_id_token_t
 
@@ -58,7 +60,10 @@ class Renderer {
 
         self.device = device
         self.commandQueue = commandQueue
-        self.pose = .init(translation: [0, 0, 1], rotation: .init(ix: 0, iy: 0, iz: 0, r: 1))
+        self.pose = .init(
+            translation: [0, 0, Self.cameraDistance],
+            rotation: .init(ix: 0, iy: 0, iz: 0, r: 1)
+        )
         self.memoryOwner = memoryOwner
     }
 
@@ -98,10 +103,10 @@ class Renderer {
 
         let aspect = Float(texture.width) / Float(texture.height)
         let projection = _Proto_LowLevelRenderer_v1.Camera.Projection.perspective(
-            fovYRadians: 60 * .pi / 180,
+            fovYRadians: fovY,
             aspectRatio: aspect,
-            nearZ: modelDistance * 0.01,
-            farZ: modelDistance * 100,
+            nearZ: Self.cameraDistance * 0.01,
+            farZ: Self.cameraDistance * 100,
             reverseZ: true
         )
 
@@ -119,12 +124,8 @@ class Renderer {
         renderCommandBuffer.commit()
     }
 
-    internal func setCameraDistance(_ distance: Float) {
-        modelDistance = distance
-        pose = .init(
-            translation: [0, 0, distance],
-            rotation: simd_quatf(angle: 0, axis: [0, 0, 1]),
-        )
+    internal func setFOV(_ fovYRadians: Float) {
+        fovY = fovYRadians
     }
 
     internal func setBackgroundColor(_ color: simd_float3) {

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h
@@ -442,7 +442,7 @@ NS_SWIFT_SENDABLE
 - (void)updateTexture:(WKBridgeUpdateTexture *)descriptor;
 - (void)updateMaterial:(WKBridgeUpdateMaterial *)descriptor completionHandler:(void (^)(void))completionHandler;
 - (void)setTransform:(simd_float4x4)transform;
-- (void)setCameraDistance:(float)distance;
+- (void)setFOV:(float)fovY;
 - (void)setBackgroundColor:(simd_float3)color;
 - (void)setPlaying:(BOOL)play;
 - (void)setEnvironmentMap:(WKBridgeImageAsset *)imageAsset;

--- a/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.cpp
+++ b/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.cpp
@@ -107,9 +107,9 @@ void RemoteMesh::updateTransform(const WebModel::Float4x4& transform)
     m_backing->setEntityTransform(transform);
 }
 
-void RemoteMesh::setCameraDistance(float distance)
+void RemoteMesh::setFOV(float fovY)
 {
-    m_backing->setCameraDistance(distance);
+    m_backing->setFOV(fovY);
 }
 
 void RemoteMesh::setBackgroundColor(const WebModel::Float3& color)

--- a/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.h
+++ b/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.h
@@ -95,7 +95,7 @@ private:
     void updateTexture(const WebModel::UpdateTextureDescriptor&, CompletionHandler<void(bool)>&&);
     void updateMaterial(const WebModel::UpdateMaterialDescriptor&, CompletionHandler<void(bool)>&&);
     void updateTransform(const WebModel::Float4x4& transform);
-    void setCameraDistance(float);
+    void setFOV(float fovY);
     void setBackgroundColor(const WebModel::Float3&);
     void play(bool);
     void setEnvironmentMap(const WebModel::ImageAsset&);

--- a/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.messages.in
@@ -36,7 +36,7 @@ messages -> RemoteMesh Stream {
     void UpdateTexture(struct WebModel::UpdateTextureDescriptor descriptor) -> (bool success)
     void UpdateMaterial(struct WebModel::UpdateMaterialDescriptor descriptor) -> (bool success)
     void UpdateTransform(struct WebModel::Float4x4 transform)
-    void SetCameraDistance(float distance)
+    void SetFOV(float fovY)
     void SetBackgroundColor(struct WebModel::Float3 color)
     void Play(bool playing)
     void SetEnvironmentMap(struct WebModel::ImageAsset imageAsset)

--- a/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
@@ -382,8 +382,6 @@ extension WKBridgeReceiver {
 
     @nonobjc
     fileprivate var modelTransform: simd_float4x4
-    @nonobjc
-    fileprivate var modelDistance: Float
 
     @nonobjc
     fileprivate var dontCaptureAgain: Bool = false
@@ -409,7 +407,6 @@ extension WKBridgeReceiver {
         self.commandQueue = configuration.commandQueue
         self.deformationSystem = try _Proto_LowLevelDeformationSystem_v1.make(configuration.device, configuration.commandQueue).get()
         modelTransform = matrix_identity_float4x4
-        modelDistance = 1.0
         self.meshInstancePlainArray = []
         let meshInstances = try configuration.renderContext.makeMeshInstanceArray(renderTargets: [configuration.renderTarget], count: 16)
         let lightingFunction = configuration.renderContext.makePhysicallyBasedLightingFunction()
@@ -761,9 +758,8 @@ extension WKBridgeReceiver {
     }
 
     @objc
-    func setCameraDistance(_ distance: Float) {
-        modelDistance = distance
-        appRenderer.setCameraDistance(modelDistance)
+    func setFOV(_ fovY: Float) {
+        appRenderer.setFOV(fovY)
     }
 
     @objc
@@ -2364,7 +2360,7 @@ extension WKBridgeReceiver {
     }
 
     @objc
-    func setCameraDistance(_ distance: Float) {
+    func setFOV(_ fovY: Float) {
     }
 
     @objc

--- a/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.h
+++ b/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.h
@@ -68,7 +68,7 @@ public:
     void NODELETE updateTexture(const WebModel::UpdateTextureDescriptor&);
     void NODELETE updateMaterial(const WebModel::UpdateMaterialDescriptor&);
     void NODELETE setTransform(const simd_float4x4&);
-    void NODELETE setCameraDistance(float);
+    void NODELETE setFOV(float);
     void NODELETE setBackgroundColor(const simd_float3&);
     void NODELETE setEnvironmentMap(const WebModel::ImageAsset&);
     void NODELETE play(bool);

--- a/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm
+++ b/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm
@@ -1101,13 +1101,12 @@ void WebMesh::setTransform(const simd_float4x4& transform)
 #endif
 }
 
-void WebMesh::setCameraDistance(float distance)
+void WebMesh::setFOV(float fovY)
 {
 #if ENABLE(GPU_PROCESS_MODEL)
-    [m_receiver setCameraDistance:distance];
-    render();
+    [m_receiver setFOV:fovY];
 #else
-    UNUSED_PARAM(distance);
+    UNUSED_PARAM(fovY);
 #endif
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.cpp
@@ -247,17 +247,17 @@ std::optional<WebModel::Float4x4> RemoteMeshProxy::entityTransform() const
 }
 #endif
 
-void RemoteMeshProxy::setCameraDistance(float distance)
+static constexpr float kCSSPixelsPerMeter = 96 / 2.54 * 100;
+// Fixed camera distance matching the ModelRenderer
+static constexpr float kCameraDistance = 0.5;
+
+void RemoteMeshProxy::setFOV(float fovY)
 {
 #if ENABLE(GPU_PROCESS_MODEL)
-    if (areSameSignAndAlmostEqual(distance, m_cameraDistance))
-        return;
-
-    auto sendResult = send(Messages::RemoteMesh::SetCameraDistance(distance));
+    auto sendResult = send(Messages::RemoteMesh::SetFOV(fovY));
     UNUSED_PARAM(sendResult);
-    m_cameraDistance = distance;
 #else
-    UNUSED_PARAM(distance);
+    UNUSED_PARAM(fovY);
 #endif
 }
 
@@ -339,10 +339,6 @@ void RemoteMeshProxy::setStageMode(WebCore::StageModeOperation stageMode)
 }
 
 
-static constexpr float kCSSPixelsPerMeter = 96 / 2.54 * 100;
-// Based on the 60° fovYRadians in ModelRenderer.swift
-static constexpr float kVerticalFOVScale = 1.1547;
-
 #if ENABLE(GPU_PROCESS_MODEL)
 void RemoteMeshProxy::computeTransform()
 {
@@ -359,11 +355,7 @@ void RemoteMeshProxy::computeTransform()
             scale = std::fmin(viewportWidth / extents.x, viewportHeight / extents.y);
         depth = extents.z;
     } else {
-        float boundingDiameter = std::max(
-            { simd_length(simd_make_float2(extents.x, extents.y))
-            , simd_length(simd_make_float2(extents.x, extents.z))
-            , simd_length(simd_make_float2(extents.y, extents.z)) }
-        );
+        float boundingDiameter = simd_length(simd_make_float3(extents.x, extents.y, extents.z));
         if (boundingDiameter > FLT_EPSILON)
             scale = std::fmin(viewportWidth, viewportHeight) / boundingDiameter;
         depth = boundingDiameter;
@@ -382,7 +374,8 @@ void RemoteMeshProxy::computeTransform()
         -simd_dot(center.xyz, simd_make_float3(result.column0.z, result.column1.z, result.column2.z)) - scale * depth / 2,
         1.f);
 
-    setCameraDistance(viewportHeight / kVerticalFOVScale);
+    setFOV(2 * std::atan(viewportHeight / (2 * kCameraDistance)));
+
     setEntityTransformInternal(result);
     m_computedTransform = result;
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.h
@@ -106,7 +106,7 @@ private:
 #endif
     bool supportsTransform(const WebCore::TransformationMatrix&) const final;
     void setScale(float) final;
-    void setCameraDistance(float) final;
+    void setFOV(float);
     void setBackgroundColor(const WebModel::Float3&) final;
     void setViewportSize(float, float) final;
     void setStageMode(WebCore::StageModeOperation) final;
@@ -126,7 +126,6 @@ private:
     std::optional<WebModel::Float4x4> m_computedTransform;
 #endif
 #if ENABLE(GPU_PROCESS_MODEL)
-    float m_cameraDistance { 1.f };
     float m_viewportWidth { 0.f };
     float m_viewportHeight { 0.f };
     WebCore::StageModeOperation m_stageMode;

--- a/Source/WebKit/WebProcess/Model/Mesh.h
+++ b/Source/WebKit/WebProcess/Model/Mesh.h
@@ -79,7 +79,7 @@ public:
     virtual void setEntityTransform(const WebModel::Float4x4&) = 0;
     virtual bool supportsTransform(const WebCore::TransformationMatrix&) const { return false; }
     virtual void setScale(float) { }
-    virtual void setCameraDistance(float) = 0;
+    virtual void setFOV(float) { }
     virtual void setBackgroundColor(const WebModel::Float3&) { }
     virtual void setViewportSize(float, float) { }
     virtual void setStageMode(WebCore::StageModeOperation) { }

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
@@ -262,6 +262,7 @@ void WebModelPlayer::load(WebCore::Model& modelSource, WebCore::LayoutSize size)
     if (!gpu)
         return;
 
+    auto cssSize = size;
     size.scale(document->deviceScaleFactor());
     m_currentPixelSize = WebCore::IntSize(size.width().toUnsigned(), size.height().toUnsigned());
 
@@ -296,7 +297,7 @@ void WebModelPlayer::load(WebCore::Model& modelSource, WebCore::LayoutSize size)
         if (surfaceHandles.size())
             protectedThis->m_displayBuffers = WTF::move(surfaceHandles);
     });
-    m_currentModel->setViewportSize(size.width().toFloat(), size.height().toFloat());
+    m_currentModel->setViewportSize(cssSize.width().toFloat(), cssSize.height().toFloat());
 
     m_modelLoader = adoptNS([allocWKBridgeModelLoaderInstance() init]);
     Ref protectedThis = Ref { *this };
@@ -371,6 +372,7 @@ void WebModelPlayer::sizeDidChange(WebCore::LayoutSize size)
     if (!document)
         return;
 
+    auto cssSize = size;
     size.scale(document->deviceScaleFactor());
     auto newPixelSize = WebCore::IntSize(size.width().toUnsigned(), size.height().toUnsigned());
     if (newPixelSize == m_currentPixelSize)
@@ -389,7 +391,7 @@ void WebModelPlayer::sizeDidChange(WebCore::LayoutSize size)
     });
 
     if (RefPtr model = m_currentModel)
-        model->setViewportSize(size.width().toFloat(), size.height().toFloat());
+        model->setViewportSize(cssSize.width().toFloat(), cssSize.height().toFloat());
     notifyEntityTransformUpdated();
 }
 


### PR DESCRIPTION
#### 852b51e65951cc0732da7190f1ff8f78461c0b59
<pre>
Better align the reported entityTransform / camera settings between ModelPlayers
<a href="https://bugs.webkit.org/show_bug.cgi?id=311204">https://bugs.webkit.org/show_bug.cgi?id=311204</a>
&lt;<a href="https://rdar.apple.com/173785037">rdar://173785037</a>&gt;

Reviewed by Mike Wyrzykowski.

Switch to a fixed camera distance and a dynamic FOV.
Use a simpler bounding sphere computation matching the RealityKit one.
Use the LayoutSize when setting the viewport size on the Mesh.

These changes taken together better align both the `entityTransform`
reported back to the page and the visual presentation of the model.

* Source/WebKit/GPUProcess/graphics/Model/MeshImpl.cpp:
(WebKit::MeshImpl::setFOV):
(WebKit::MeshImpl::setCameraDistance): Deleted.
* Source/WebKit/GPUProcess/graphics/Model/MeshImpl.h:
* Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift:
(Renderer.fovY):
(Renderer.setFOV(_:)):
(Renderer.modelDistance): Deleted.
(Renderer.setCameraDistance(_:)): Deleted.
* Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h:
* Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.cpp:
(WebKit::RemoteMesh::setFOV):
(WebKit::RemoteMesh::setCameraDistance): Deleted.
* Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.h:
* Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.messages.in:
* Source/WebKit/GPUProcess/graphics/Model/USDModel.swift:
(Material.modelTransform):
(Material.setFOV(_:)):
(WKBridgeReceiver.setFOV(_:)):
(Material.modelDistance): Deleted.
(Material.setCameraDistance(_:)): Deleted.
(WKBridgeReceiver.setCameraDistance(_:)): Deleted.
* Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.h:
* Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm:
(WebKit::WebMesh::setFOV):
(WebKit::WebMesh::setCameraDistance): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.cpp:
(WebKit::RemoteMeshProxy::setFOV):
(WebKit::RemoteMeshProxy::setCameraDistance): Deleted.
setCameraDistance -&gt; setFOV

(WebKit::RemoteMeshProxy::computeTransform):
Update the bounding sphere computation.

* Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.h:
* Source/WebKit/WebProcess/Model/Mesh.h:
(WebKit::Mesh::setFOV):
* Source/WebKit/WebProcess/Model/WebModelPlayer.mm:
(WebKit::WebModelPlayer::load):
(WebKit::WebModelPlayer::sizeDidChange):
Use the LayoutSize for the viewport.

Canonical link: <a href="https://commits.webkit.org/310332@main">https://commits.webkit.org/310332@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be4f549086403b87a70c28b0f4c74ffd3240a8b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153479 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26263 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19863 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162228 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/54784f61-c028-438e-adb5-178dad53ddc9) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26789 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26583 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118660 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ab644e7d-12db-41a4-9400-903f54fe786e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156438 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20910 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137788 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99371 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8934a56a-9d47-48f3-a72b-320474360113) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19988 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17925 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10062 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/129635 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164700 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7834 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17252 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126723 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26060 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21961 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/semantics/structured-clone/shared.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126888 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34419 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26062 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137454 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82729 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21819 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14234 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25679 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89965 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25370 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25529 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25430 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->