### PR TITLE
Reset doesGC expectation upon VM termination to avoid stale assertion

### DIFF
--- a/JSTests/stress/validate-does-gc-heap-bigint-compare-watchdog.js
+++ b/JSTests/stress/validate-does-gc-heap-bigint-compare-watchdog.js
@@ -1,0 +1,11 @@
+//@ skip if not $jitTests
+//@ runDefault("--jitPolicyScale=0.1", "--watchdog-exception-ok", "--watchdog=1000", "--useConcurrentGC=0", "--useLLInt=0", "--validateExceptionChecks=1", "--alwaysUseShadowChicken=1", "--useConcurrentJIT=0", "--useOSREntryToFTL=0", "--maximumInliningRecursion=1", "--thresholdForOptimizeAfterLongWarmUp=2690", "--forceGCSlowPaths=1", "--useZombieMode=1", "--useArityFixupInlining=0", "--useLoopUnrolling=0", "--useB3TailDup=0", "--airRandomizeRegs=1", "--useOMGInlining=0")
+
+// 32 bit ARM turns off JIT by default, causing an error because useLLInt and useJIT can't both be false
+
+if ($vm.useJIT()) {
+    for (let i = 0; i - 4194304; i++) {
+        for (let j = 0n; j < 2n ** 31n;)
+            break;
+    }
+}

--- a/Source/JavaScriptCore/dfg/DFGDoesGCCheck.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGCCheck.cpp
@@ -61,6 +61,9 @@ void DoesGCCheck::verifyCanGC(VM& vm)
             case Special::FTLOSRExit:
                 dataLog(" @ FTL osr exit");
                 break;
+            case Special::Termination:
+                dataLog(" @ termination");
+                break;
             case Special::NumberOfSpecials:
                 RELEASE_ASSERT_NOT_REACHED();
             }

--- a/Source/JavaScriptCore/dfg/DFGDoesGCCheck.h
+++ b/Source/JavaScriptCore/dfg/DFGDoesGCCheck.h
@@ -40,6 +40,7 @@ struct DoesGCCheck {
         Uninitialized,
         DFGOSRExit,
         FTLOSRExit,
+        Termination,
         NumberOfSpecials
     };
 

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -1020,6 +1020,11 @@ void VM::throwTerminationException()
 {
     ASSERT(hasTerminationRequest());
     ASSERT(!traps().isDeferringTermination());
+    // Termination can occur while executing DFG/FTL code that has set
+    // doesGC expectations. Reset the expectation so that subsequent
+    // heap access (e.g. JSLock re-acquisition) doesn't hit a stale
+    // doesGC assertion.
+    setDoesGCExpectation(true, DoesGCCheck::Special::Termination);
     setException(terminationException());
     if (m_executionForbiddenOnTermination)
         setExecutionForbidden();


### PR DESCRIPTION
#### f5b52841f6b58d89da360e1b98b50190d6ae0bcb
<pre>
Reset doesGC expectation upon VM termination to avoid stale assertion
<a href="https://bugs.webkit.org/show_bug.cgi?id=311229">https://bugs.webkit.org/show_bug.cgi?id=311229</a>
<a href="https://rdar.apple.com/172191300">rdar://172191300</a>

Reviewed by Yusuke Suzuki.

If the VM terminates in the middle of DFG/FTL JIT code, right now
m_doesGC contains the value corresponding to the last node executed. If
this happens, the next time a thread tries to acquire a JSLock it will
read the stale value in m_doesGC and potentially crash. OSR exits from
JIT code already reset the value to true, so throwTerminationException
should do the same thing.

Test: JSTests/stress/validate-does-gc-heap-bigint-compare-watchdog.js

* JSTests/stress/validate-does-gc-heap-bigint-compare-watchdog.js: Added.
(vm.useJIT):
* Source/JavaScriptCore/dfg/DFGDoesGCCheck.cpp:
(JSC::DFG::DoesGCCheck::verifyCanGC):
* Source/JavaScriptCore/dfg/DFGDoesGCCheck.h:
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::throwTerminationException):

Canonical link: <a href="https://commits.webkit.org/310722@main">https://commits.webkit.org/310722@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3341d7b7e3243f2dc2960b0423f003bba30c36a9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153797 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26581 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20198 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162548 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107258 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27110 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26903 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118904 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84078 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2ff1e801-7e65-4a70-8e5a-17600c9a6520) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156756 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21174 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138097 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99614 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c7a92a58-e633-43a9-971f-a7b2c1c6cd86) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20254 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18210 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10380 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/145810 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129902 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15956 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165019 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/14621 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8152 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17550 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126992 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26378 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22241 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127159 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34710 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26380 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137751 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/83058 "The change is no longer eligible for processing.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22059 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14534 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/185433 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25997 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90285 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47564 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25688 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25848 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25748 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->