### PR TITLE
[WPE] Favicon database support

### DIFF
--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -180,6 +180,7 @@ set(WPE_API_HEADER_TEMPLATES
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitEditingCommands.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitEditorState.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitError.h.in
+    ${WEBKIT_DIR}/UIProcess/API/glib/WebKitFaviconDatabase.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitFeature.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitFileChooserRequest.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitFindController.h.in

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -130,6 +130,7 @@ Shared/API/c/wpe/WKEventWPE.cpp
 Shared/Extensions/wpe/WebExtensionUtilitiesWPE.cpp
 
 UIProcess/API/glib/APIContentRuleListStoreGLib.cpp @no-unify
+UIProcess/API/glib/IconDatabase.cpp @no-unify
 UIProcess/API/glib/InputMethodFilter.cpp @no-unify
 UIProcess/API/glib/KeyAutoRepeatHandler.cpp @no-unify
 UIProcess/API/glib/WebKitApplicationInfo.cpp @no-unify
@@ -145,6 +146,7 @@ UIProcess/API/glib/WebKitDownload.cpp @no-unify
 UIProcess/API/glib/WebKitDownloadClient.cpp @no-unify
 UIProcess/API/glib/WebKitEditorState.cpp @no-unify
 UIProcess/API/glib/WebKitError.cpp @no-unify
+UIProcess/API/glib/WebKitFaviconDatabase.cpp @no-unify
 UIProcess/API/glib/WebKitFeature.cpp @no-unify
 UIProcess/API/glib/WebKitFileChooserRequest.cpp @no-unify
 UIProcess/API/glib/WebKitFindController.cpp @no-unify
@@ -152,6 +154,7 @@ UIProcess/API/glib/WebKitFormClient.cpp @no-unify
 UIProcess/API/glib/WebKitFormSubmissionRequest.cpp @no-unify
 UIProcess/API/glib/WebKitGeolocationManager.cpp @no-unify
 UIProcess/API/glib/WebKitGeolocationPermissionRequest.cpp @no-unify
+UIProcess/API/glib/WebKitIconLoadingClient.cpp @no-unify
 UIProcess/API/glib/WebKitImage.cpp @no-unify
 UIProcess/API/glib/WebKitInitialize.cpp @no-unify
 UIProcess/API/glib/WebKitInjectedBundleClient.cpp @no-unify

--- a/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp
@@ -66,6 +66,7 @@ using namespace WebCore;
  * the in-memory cache during the current execution.
  */
 
+#if PLATFORM(GTK)
 enum {
     FAVICON_CHANGED,
 
@@ -73,6 +74,7 @@ enum {
 };
 
 static std::array<unsigned, LAST_SIGNAL> signals;
+#endif // PLATFORM(GTK)
 
 struct _WebKitFaviconDatabasePrivate {
     RefPtr<IconDatabase> iconDatabase;
@@ -82,6 +84,7 @@ WEBKIT_DEFINE_FINAL_TYPE(WebKitFaviconDatabase, webkit_favicon_database, G_TYPE_
 
 static void webkit_favicon_database_class_init(WebKitFaviconDatabaseClass* faviconDatabaseClass)
 {
+#if PLATFORM(GTK)
     /**
      * WebKitFaviconDatabase::favicon-changed:
      * @database: the object on which the signal is emitted
@@ -104,6 +107,7 @@ static void webkit_favicon_database_class_init(WebKitFaviconDatabaseClass* favic
         G_TYPE_NONE, 2,
         G_TYPE_STRING,
         G_TYPE_STRING);
+#endif // PLATFORM(GTK)
 }
 
 WebKitFaviconDatabase* webkitFaviconDatabaseCreate()
@@ -129,7 +133,7 @@ void webkitFaviconDatabaseClose(WebKitFaviconDatabase* database)
     database->priv->iconDatabase = nullptr;
 }
 
-#if PLATFORM(GTK)
+#if PLATFORM(GTK) || ENABLE(2022_GLIB_API)
 void webkitFaviconDatabaseGetLoadDecisionForIcon(WebKitFaviconDatabase* database, const LinkIcon& icon, const String& pageURL, bool isEphemeral, Function<void(bool)>&& completionHandler)
 {
     if (!webkitFaviconDatabaseIsOpen(database)) {
@@ -145,8 +149,13 @@ void webkitFaviconDatabaseGetLoadDecisionForIcon(WebKitFaviconDatabase* database
                 return;
             }
 
+#if PLATFORM(GTK)
             if (found && changed)
                 g_signal_emit(database.get(), signals[FAVICON_CHANGED], 0, pageURL.utf8().data(), url.utf8().data());
+#else
+            UNUSED_PARAM(changed);
+#endif
+
             completionHandler(!found);
         });
 }
@@ -162,10 +171,12 @@ void webkitFaviconDatabaseSetIconForPageURL(WebKitFaviconDatabase* database, con
             if (!webkitFaviconDatabaseIsOpen(database.get()) || !success)
                 return;
 
+#if PLATFORM(GTK)
             g_signal_emit(database.get(), signals[FAVICON_CHANGED], 0, pageURL.utf8().data(), url.utf8().data());
+#endif
         });
 }
-#endif
+#endif // PLATFORM(GTK) || ENABLE(2022_GLIB_API)
 
 /**
  * webkit_favicon_database_error_quark:
@@ -272,6 +283,33 @@ cairo_surface_t* webkit_favicon_database_get_favicon_finish(WebKitFaviconDatabas
 #endif
 }
 
+/**
+ * webkit_favicon_database_get_favicon_uri:
+ * @database: a #WebKitFaviconDatabase
+ * @page_uri: URI of the page containing the icon
+ *
+ * Obtains the URI of the favicon for the given @page_uri.
+ *
+ * Returns: a newly allocated URI for the favicon, or %NULL if the
+ * database doesn't have a favicon for @page_uri.
+ */
+gchar* webkit_favicon_database_get_favicon_uri(WebKitFaviconDatabase* database, const gchar* pageURL)
+{
+    g_return_val_if_fail(WEBKIT_IS_FAVICON_DATABASE(database), nullptr);
+    g_return_val_if_fail(pageURL, nullptr);
+    ASSERT(RunLoop::isMain());
+
+    if (!webkitFaviconDatabaseIsOpen(database))
+        return nullptr;
+
+    const auto& iconURLsForPageURL = database->priv->iconDatabase->iconURLsForPageURL(String::fromUTF8(pageURL));
+    if (iconURLsForPageURL.isEmpty())
+        return nullptr;
+
+    return g_strdup(iconURLsForPageURL.last().utf8().data());
+}
+#endif // PLATFORM(GTK)
+
 #if ENABLE(2022_GLIB_API)
 /**
  * webkit_favicon_database_get_page_icons:
@@ -358,33 +396,6 @@ WebKitImageList* webkit_favicon_database_get_page_icons_finish(WebKitFaviconData
     return static_cast<WebKitImageList*>(g_task_propagate_pointer(G_TASK(result), error));
 }
 #endif // ENABLE(2022_GLIB_API)
-#endif // PLATFORM(GTK)
-
-/**
- * webkit_favicon_database_get_favicon_uri:
- * @database: a #WebKitFaviconDatabase
- * @page_uri: URI of the page containing the icon
- *
- * Obtains the URI of the favicon for the given @page_uri.
- *
- * Returns: a newly allocated URI for the favicon, or %NULL if the
- * database doesn't have a favicon for @page_uri.
- */
-gchar* webkit_favicon_database_get_favicon_uri(WebKitFaviconDatabase* database, const gchar* pageURL)
-{
-    g_return_val_if_fail(WEBKIT_IS_FAVICON_DATABASE(database), nullptr);
-    g_return_val_if_fail(pageURL, nullptr);
-    ASSERT(RunLoop::isMain());
-
-    if (!webkitFaviconDatabaseIsOpen(database))
-        return nullptr;
-
-    const auto& iconURLsForPageURL = database->priv->iconDatabase->iconURLsForPageURL(String::fromUTF8(pageURL));
-    if (iconURLsForPageURL.isEmpty())
-        return nullptr;
-
-    return g_strdup(iconURLsForPageURL.last().utf8().data());
-}
 
 /**
  * webkit_favicon_database_clear:

--- a/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.h.in
@@ -32,9 +32,10 @@
 #else
 #include <cairo.h>
 #endif
+#endif
+
 #if ENABLE(2022_GLIB_API)
 #include <@API_INCLUDE_PREFIX@/WebKitImage.h>
-#endif
 #endif
 
 G_BEGIN_DECLS
@@ -98,6 +99,11 @@ webkit_favicon_database_get_favicon_finish (WebKitFaviconDatabase *database,
                                             GError               **error);
 #endif
 
+WEBKIT_API gchar *
+webkit_favicon_database_get_favicon_uri    (WebKitFaviconDatabase *database,
+                                            const gchar           *page_uri);
+#endif // PLATFORM(GTK)
+
 #if ENABLE(2022_GLIB_API)
 WEBKIT_API void
 webkit_favicon_database_get_page_icons     (WebKitFaviconDatabase *database,
@@ -111,12 +117,8 @@ webkit_favicon_database_get_page_icons_finish
                                            (WebKitFaviconDatabase  *database,
                                             GAsyncResult           *result,
                                             GError                **error);
-#endif
-#endif
+#endif // ENABLE(2022_GLIB_API)
 
-WEBKIT_API gchar *
-webkit_favicon_database_get_favicon_uri    (WebKitFaviconDatabase *database,
-                                            const gchar           *page_uri);
 WEBKIT_API void
 webkit_favicon_database_clear              (WebKitFaviconDatabase *database);
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabasePrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabasePrivate.h
@@ -26,8 +26,10 @@
 WebKitFaviconDatabase* webkitFaviconDatabaseCreate();
 void webkitFaviconDatabaseOpen(WebKitFaviconDatabase*, const String& path, bool isEphemeral);
 void webkitFaviconDatabaseClose(WebKitFaviconDatabase*);
-#if PLATFORM(GTK)
+#if PLATFORM(GTK) || ENABLE(2022_GLIB_API)
 void webkitFaviconDatabaseGetLoadDecisionForIcon(WebKitFaviconDatabase*, const WebCore::LinkIcon&, const String&, bool isEphemeral, Function<void(bool)>&&);
 void webkitFaviconDatabaseSetIconForPageURL(WebKitFaviconDatabase*, const WebCore::LinkIcon&, API::Data&, const String&, bool isEphemeral);
+#endif
+#if PLATFORM(GTK)
 void webkitFaviconDatabaseGetFaviconInternal(WebKitFaviconDatabase*, const gchar* pageURI, bool isEphemeral, GCancellable*, GAsyncReadyCallback, gpointer);
 #endif

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -98,13 +98,16 @@
 #if PLATFORM(GTK)
 #include "GUniquePtrGtk.h"
 #include "GtkUtilities.h"
-#include "WebKitFaviconDatabasePrivate.h"
 #include "WebKitInputMethodContextImplGtk.h"
 #include "WebKitPointerLockPermissionRequest.h"
 #include "WebKitPrintOperationPrivate.h"
 #include "WebKitWebInspectorPrivate.h"
 #include "WebKitWebViewBasePrivate.h"
 #include <WebCore/RefPtrCairo.h>
+#endif
+
+#if PLATFORM(GTK) || ENABLE(2022_GLIB_API)
+#include "WebKitFaviconDatabasePrivate.h"
 #endif
 
 #if PLATFORM(WPE)
@@ -253,7 +256,7 @@ enum {
     PROP_THEME_COLOR,
     PROP_IS_IMMERSIVE_MODE_ENABLED,
 
-#if PLATFORM(GTK) && ENABLE(2022_GLIB_API)
+#if ENABLE(2022_GLIB_API)
     PROP_PAGE_ICONS,
 #endif
 
@@ -424,9 +427,10 @@ struct _WebKitWebViewPrivate {
 
     CString faviconURI;
     unsigned long faviconChangedHandlerID;
+#endif
+
 #if ENABLE(2022_GLIB_API)
     GRefPtr<WebKitImageList> pageIcons;
-#endif
 #endif
 
     GRefPtr<WebKitAuthenticationRequest> authenticationRequest;
@@ -688,6 +692,17 @@ static gboolean webkitWebViewIsEphemeral(WebKitWebView* webView)
 #endif
 }
 
+#if PLATFORM(GTK) || ENABLE(2022_GLIB_API)
+static WebKitFaviconDatabase* webkitWebViewGetFaviconDatabase(WebKitWebView* webView)
+{
+#if ENABLE(2022_GLIB_API)
+    return webkit_website_data_manager_get_favicon_database(webkitWebViewGetWebsiteDataManager(webView));
+#else
+    return webkit_web_context_get_favicon_database(webView->priv->context.get());
+#endif
+}
+#endif // PLATFORM(GTK) || ENABLE(2021_GLIB_API)
+
 #if PLATFORM(GTK)
 static void enableBackForwardNavigationGesturesChanged(WebKitSettings* settings, GParamSpec*, WebKitWebView* webView)
 {
@@ -734,15 +749,6 @@ static void gotFaviconCallback(GObject* object, GAsyncResult* result, gpointer u
     webView->priv->faviconCancellable = nullptr;
 }
 
-static WebKitFaviconDatabase* webkitWebViewGetFaviconDatabase(WebKitWebView* webView)
-{
-#if ENABLE(2022_GLIB_API)
-    return webkit_website_data_manager_get_favicon_database(webkitWebViewGetWebsiteDataManager(webView));
-#else
-    return webkit_web_context_get_favicon_database(webView->priv->context.get());
-#endif
-}
-
 static void webkitWebViewRequestFavicon(WebKitWebView* webView)
 {
     webkitWebViewCancelFaviconRequest(webView);
@@ -772,6 +778,7 @@ static void faviconChangedCallback(WebKitFaviconDatabase*, const char* pageURI, 
 
     webkitWebViewUpdateFaviconURI(webView, faviconURI);
 }
+#endif // PLATFORM(GTK)
 
 #if ENABLE(2022_GLIB_API)
 static void webkitWebViewUpdatePageIcons(WebKitWebView* webView, GRefPtr<WebKitImageList>&& pageIcons)
@@ -783,7 +790,6 @@ static void webkitWebViewUpdatePageIcons(WebKitWebView* webView, GRefPtr<WebKitI
     g_object_notify_by_pspec(G_OBJECT(webView), sObjProperties[PROP_PAGE_ICONS]);
 }
 #endif
-#endif // PLATFORM(GTK)
 
 static bool webkitWebViewIsConstructed(WebKitWebView* webView)
 {
@@ -1013,9 +1019,11 @@ static void webkitWebViewConstructed(GObject* object)
 #endif // ENABLE(CONTEXT_MENUS)
     attachFormClientToView(webView);
 
-#if PLATFORM(GTK)
+#if PLATFORM(GTK) || ENABLE(2022_GLIB_API)
     attachIconLoadingClientToView(webView);
+#endif
 
+#if PLATFORM(GTK)
     GRefPtr<WebKitInputMethodContext> imContext = adoptGRef(webkitInputMethodContextImplGtkNew());
     webkitInputMethodContextSetWebView(imContext.get(), webView);
     webkitWebViewBaseSetInputMethodContext(WEBKIT_WEB_VIEW_BASE(webView), imContext.get());
@@ -1245,7 +1253,7 @@ static void webkitWebViewGetProperty(GObject* object, guint propId, GValue* valu
     case PROP_IS_IMMERSIVE_MODE_ENABLED:
         g_value_set_boolean(value, webkit_web_view_is_immersive_mode_enabled(webView));
         break;
-#if PLATFORM(GTK) && ENABLE(2022_GLIB_API)
+#if ENABLE(2022_GLIB_API)
     case PROP_PAGE_ICONS:
         g_value_set_boxed(value, webkit_web_view_get_page_icons(webView));
         break;
@@ -1469,6 +1477,7 @@ static void webkit_web_view_class_init(WebKitWebViewClass* webViewClass)
             nullptr, nullptr,
             WEBKIT_PARAM_READABLE);
 #endif
+#endif // PLATFORM(GTK)
 
 #if ENABLE(2022_GLIB_API)
     /**
@@ -1484,7 +1493,6 @@ static void webkit_web_view_class_init(WebKitWebViewClass* webViewClass)
         WEBKIT_TYPE_IMAGE_LIST,
         WEBKIT_PARAM_READABLE);
 #endif
-#endif // PLATFORM(GTK)
 
     /**
      * WebKitWebView:uri:
@@ -2769,7 +2777,7 @@ void webkitWebViewLoadFailedWithTLSErrors(WebKitWebView* webView, const char* fa
     g_signal_emit(webView, signals[LOAD_CHANGED], 0, WEBKIT_LOAD_FINISHED);
 }
 
-#if PLATFORM(GTK)
+#if PLATFORM(GTK) || ENABLE(2022_GLIB_API)
 void webkitWebViewGetLoadDecisionForIcons(WebKitWebView* webView, const HashMap<CallbackID, WebCore::LinkIcon>& icons, CompletionHandler<void(HashSet<WebKit::CallbackID>&&)>&& completionHandler)
 {
     struct CallbackAggregator final : public ThreadSafeRefCounted<CallbackAggregator>  {
@@ -2839,7 +2847,7 @@ void webkitWebViewSetIcon(WebKitWebView* webView, const LinkIcon& icon, API::Dat
 
     webkitFaviconDatabaseSetIconForPageURL(database, icon, iconData, getPage(webView).pageLoadState().activeURL(), webkitWebViewIsEphemeral(webView));
 }
-#endif // PLATFORM(GTK)
+#endif // PLATFORM(GTK) || ENABLE(2022_GLIB_API)
 
 RefPtr<WebPageProxy> webkitWebViewCreateNewPage(WebKitWebView* webView, Ref<API::PageConfiguration>&& configuration, WebKitNavigationAction* navigationAction)
 {
@@ -6075,7 +6083,7 @@ void webkit_web_view_leave_immersive_mode(WebKitWebView* webView)
 #endif
 }
 
-#if PLATFORM(GTK) && ENABLE(2022_GLIB_API)
+#if ENABLE(2022_GLIB_API)
 /**
  * webkit_web_view_get_page_icons: (get-property page-icons):
  * @web_view: a #WebKitWebView

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
@@ -605,12 +605,11 @@ webkit_web_view_get_favicon                          (WebKitWebView             
 WEBKIT_API cairo_surface_t *
 webkit_web_view_get_favicon                          (WebKitWebView             *web_view);
 #endif
+#endif
 
 #if ENABLE(2022_GLIB_API)
 WEBKIT_API WebKitImageList *
 webkit_web_view_get_page_icons                       (WebKitWebView             *web_view);
-#endif
-
 #endif
 
 WEBKIT_API const gchar *

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h
@@ -54,7 +54,7 @@ void webkitWebViewWillStartLoad(WebKitWebView*);
 void webkitWebViewLoadChanged(WebKitWebView*, WebKitLoadEvent);
 void webkitWebViewLoadFailed(WebKitWebView*, WebKitLoadEvent, const char* failingURI, GError*);
 void webkitWebViewLoadFailedWithTLSErrors(WebKitWebView*, const char* failingURI, GError*, GTlsCertificateFlags, GTlsCertificate*);
-#if PLATFORM(GTK)
+#if PLATFORM(GTK) || ENABLE(2022_GLIB_API)
 void webkitWebViewGetLoadDecisionForIcons(WebKitWebView*, const HashMap<WebKit::CallbackID, WebCore::LinkIcon>&, CompletionHandler<void(HashSet<WebKit::CallbackID>&&)>&&);
 void webkitWebViewSetIcon(WebKitWebView*, const WebCore::LinkIcon&, API::Data&);
 void webkitWebViewUpdatePageIcons(WebKitWebView*);

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.cpp
@@ -39,7 +39,7 @@
 #include <wtf/glib/GUniquePtr.h>
 #include <wtf/glib/WTFGType.h>
 
-#if PLATFORM(GTK) && ENABLE(2022_GLIB_API)
+#if PLATFORM(GTK) || ENABLE(2022_GLIB_API)
 #include "WebKitFaviconDatabasePrivate.h"
 #endif
 
@@ -95,7 +95,7 @@ struct _WebKitWebsiteDataManagerPrivate {
     CString baseDataDirectory;
     CString baseCacheDirectory;
 
-#if PLATFORM(GTK) && ENABLE(2022_GLIB_API)
+#if PLATFORM(GTK) || ENABLE(2022_GLIB_API)
     GRefPtr<WebKitFaviconDatabase> faviconDatabase;
 #endif
 
@@ -1077,7 +1077,7 @@ void webkit_website_data_manager_set_network_proxy_settings(WebKitWebsiteDataMan
 }
 #endif
 
-#if PLATFORM(GTK) && ENABLE(2022_GLIB_API)
+#if PLATFORM(GTK) || ENABLE(2022_GLIB_API)
 static String webkitWebsiteDataManagerGetFaviconDatabasePath(WebKitWebsiteDataManager* manager)
 {
     if (webkit_website_data_manager_is_ephemeral(manager))

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.h.in
@@ -25,7 +25,7 @@
 #include <gio/gio.h>
 #include <@API_INCLUDE_PREFIX@/WebKitCookieManager.h>
 #include <@API_INCLUDE_PREFIX@/WebKitDefines.h>
-#if PLATFORM(GTK) && ENABLE(2022_GLIB_API)
+#if PLATFORM(GTK) || ENABLE(2022_GLIB_API)
 #include <@API_INCLUDE_PREFIX@/WebKitFaviconDatabase.h>
 #endif
 #include <@API_INCLUDE_PREFIX@/WebKitMemoryPressureSettings.h>
@@ -87,7 +87,7 @@ webkit_website_data_manager_get_base_data_directory                   (WebKitWeb
 WEBKIT_API const gchar *
 webkit_website_data_manager_get_base_cache_directory                  (WebKitWebsiteDataManager *manager);
 
-#if PLATFORM(GTK) && ENABLE(2022_GLIB_API)
+#if PLATFORM(GTK) || ENABLE(2022_GLIB_API)
 WEBKIT_API void
 webkit_website_data_manager_set_favicons_enabled                      (WebKitWebsiteDataManager *manager,
                                                                        gboolean                  enabled);

--- a/Source/WebKit/UIProcess/API/glib/webkit.h.in
+++ b/Source/WebKit/UIProcess/API/glib/webkit.h.in
@@ -61,7 +61,7 @@
 #include <@API_INCLUDE_PREFIX@/WebKitEditorState.h>
 #include <@API_INCLUDE_PREFIX@/WebKitEnumTypes.h>
 #include <@API_INCLUDE_PREFIX@/WebKitError.h>
-#if PLATFORM(GTK) || (PLATFORM(WPE) && !ENABLE(2022_GLIB_API))
+#if PLATFORM(GTK) || ENABLE(2022_GLIB_API)
 #include <@API_INCLUDE_PREFIX@/WebKitFaviconDatabase.h>
 #endif
 #include <@API_INCLUDE_PREFIX@/WebKitFeature.h>

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestWebKitFaviconDatabase.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestWebKitFaviconDatabase.cpp
@@ -19,7 +19,7 @@
 
 #include "config.h"
 
-#if PLATFORM(GTK)
+#if PLATFORM(GTK) || ENABLE(2022_GLIB_API)
 
 #include "WebKitTestServer.h"
 #include "WebViewTest.h"
@@ -52,7 +52,7 @@ public:
 
     ~FaviconDatabaseTest()
     {
-#if !USE(GTK4)
+#if PLATFORM(GTK) && !USE(GTK4)
         if (m_favicon)
             cairo_surface_destroy(m_favicon);
 #endif
@@ -87,7 +87,9 @@ public:
         m_database = webkit_website_data_manager_get_favicon_database(manager);
         g_assert_true(WEBKIT_IS_FAVICON_DATABASE(m_database.get()));
         assertObjectIsDeletedWhenTestFinishes(G_OBJECT(m_database.get()));
+#if PLATFORM(GTK)
         g_signal_connect(m_database.get(), "favicon-changed", G_CALLBACK(faviconChangedCallback), this);
+#endif
 #else
         GUniquePtr<char> databaseDirectory(g_build_filename(dataDirectory(), directory, nullptr));
         webkit_web_context_set_favicon_database_directory(m_webContext.get(), databaseDirectory.get());
@@ -104,6 +106,7 @@ public:
     }
 #endif
 
+#if PLATFORM(GTK)
     static void faviconChangedCallback(WebKitFaviconDatabase* database, const char* pageURI, const char* faviconURI, FaviconDatabaseTest* test)
     {
         if (!g_strcmp0(webkit_web_view_get_uri(test->webView()), pageURI)) {
@@ -127,6 +130,7 @@ public:
         if (test->m_loadFinished)
             test->quitMainLoop();
     }
+#endif // PLATFORM(GTK)
 
 #if ENABLE(2022_GLIB_API)
     static void viewPageIconsChangedCallback(WebKitWebView* webView, GParamSpec*, FaviconDatabaseTest* test)
@@ -147,10 +151,16 @@ public:
             return;
 
         test->m_loadFinished = true;
-        if (test->m_pageFaviconNotificationCount > 0)
+#if PLATFORM(GTK)
+        const bool shouldQuitMainLoop = test->m_pageFaviconNotificationCount > 0;
+#else
+        const bool shouldQuitMainLoop = test->m_pageIconsNoticationCount > 0;
+#endif
+        if (shouldQuitMainLoop)
             test->quitMainLoop();
     }
 
+#if PLATFORM(GTK)
     static void getFaviconCallback(GObject* sourceObject, GAsyncResult* result, void* data)
     {
         FaviconDatabaseTest* test = static_cast<FaviconDatabaseTest*>(data);
@@ -191,26 +201,34 @@ public:
         g_assert_true(test->webView() == webView);
         test->m_pageFaviconNotificationCount++;
     }
+#endif // PLATFORM(GTK)
 
 #if ENABLE(2022_GLIB_API)
     void waitUntilLoadFinishedAndPageIconsChanged()
     {
         g_clear_pointer(&m_pageIcons, webkit_image_list_unref);
-        m_pageFaviconNotificationCount = 0;
         m_pageIconsNoticationCount = 0;
         m_loadFinished = false;
 
+#if PLATFORM(GTK)
+        m_pageFaviconNotificationCount = 0;
         const auto faviconID = g_signal_connect(m_webView.get(), "notify::favicon", G_CALLBACK(faviconChangedCountCallback), this);
+#endif
+
         const auto pageIconsID = g_signal_connect(m_webView.get(), "notify::page-icons", G_CALLBACK(viewPageIconsChangedCallback), this);
         const auto loadChangedID = g_signal_connect(m_webView.get(), "load-changed", G_CALLBACK(viewLoadChangedCallback), this);
         g_main_loop_run(m_mainLoop);
 
+#if PLATFORM(GTK)
         g_signal_handler_disconnect(m_webView.get(), faviconID);
+#endif
+
         g_signal_handler_disconnect(m_webView.get(), pageIconsID);
         g_signal_handler_disconnect(m_webView.get(), loadChangedID);
     }
 #endif // ENABLE(2022_GLIB_API)
 
+#if PLATFORM(GTK)
     void getFaviconForPageURIAndWaitUntilReady(const char* pageURI)
     {
 #if !USE(GTK4)
@@ -271,26 +289,28 @@ public:
         g_signal_handler_disconnect(m_webView.get(), handlerID);
     }
 
-    GRefPtr<WebKitFaviconDatabase> m_database;
     unsigned m_faviconChangedID { 0 };
+    unsigned m_pageFaviconNotificationTimeoutID { 0 };
+    size_t m_pageFaviconNotificationCount { 0 };
+    std::optional<CString> m_faviconURI { std::nullopt };
+    GUniqueOutPtr<GError> m_error;
+    bool m_waitingForFaviconURI { false };
+    unsigned m_waitingForFaviconURITimeoutID { 0 };
+
 #if USE(GTK4)
     GRefPtr<GdkTexture> m_favicon;
 #else
     cairo_surface_t* m_favicon { nullptr };
 #endif
-    size_t m_pageFaviconNotificationCount { 0 };
-    unsigned m_pageFaviconNotificationTimeoutID { 0 };
-
-    std::optional<CString> m_faviconURI { std::nullopt };
-    GUniqueOutPtr<GError> m_error;
-    bool m_loadFinished { false };
-    bool m_waitingForFaviconURI { false };
-    unsigned m_waitingForFaviconURITimeoutID { 0 };
+#endif // PLATFORM(GTK)
 
 #if ENABLE(2022_GLIB_API)
     size_t m_pageIconsNoticationCount { 0 };
     WebKitImageList* m_pageIcons;
 #endif
+
+    GRefPtr<WebKitFaviconDatabase> m_database;
+    bool m_loadFinished { false };
 };
 
 static void serverCallback(SoupServer*, SoupServerMessage* message, const char* path, GHashTable* query, gpointer)
@@ -341,6 +361,7 @@ static void serverCallback(SoupServer*, SoupServerMessage* message, const char* 
     soup_message_body_complete(responseBody);
 }
 
+#if PLATFORM(GTK)
 static void testFaviconDatabaseInitialization(FaviconDatabaseTest* test, gconstpointer)
 {
     // In 2022 API favicon database is nullptr until favicons are enabled.
@@ -436,6 +457,7 @@ static void testFaviconDatabaseGetFavicon(FaviconDatabaseTest* test, gconstpoint
     g_assert_false(test->m_faviconURI.has_value());
     g_assert_nonnull(webkit_web_view_get_favicon(test->webView()));
 }
+#endif // PLATFORM(GTK)
 
 #if ENABLE(2022_GLIB_API)
 static void testFaviconDatabaseGetPageIcons(FaviconDatabaseTest *test, gconstpointer)
@@ -444,8 +466,11 @@ static void testFaviconDatabaseGetPageIcons(FaviconDatabaseTest *test, gconstpoi
 
     test->loadURI(kServer->getURIForPath("/multipleicons").data());
     test->waitUntilLoadFinishedAndPageIconsChanged();
+
+#if PLATFORM(GTK)
     test->waitUntilFaviconChangedTimes(3, 1500);
     g_assert_cmpint(test->m_pageFaviconNotificationCount, ==, 3);
+#endif
 
     g_assert_cmpint(test->m_pageIconsNoticationCount, ==, 1);
     g_assert_nonnull(test->m_pageIcons);
@@ -491,6 +516,7 @@ static void testFaviconDatabaseGetPageIcons(FaviconDatabaseTest *test, gconstpoi
 }
 #endif // ENABLE(2022_GLIB_API)
 
+#if PLATFORM(GTK)
 static void ephemeralViewFaviconChanged(WebKitWebView* webView, GParamSpec*, WebViewTest* test)
 {
     g_signal_handlers_disconnect_by_func(webView, reinterpret_cast<void*>(ephemeralViewFaviconChanged), test);
@@ -575,6 +601,8 @@ void testFaviconDatabaseClear(FaviconDatabaseTest* test, gconstpointer)
     g_assert_null(test->m_favicon);
     g_assert_null(webkit_favicon_database_get_favicon_uri(test->m_database.get(), kServer->getURIForPath("/foo").data()));
 }
+#endif // PLATFORM(GTK)
+
 
 void beforeAll()
 {
@@ -582,10 +610,13 @@ void beforeAll()
     kServer = new WebKitTestServer();
     kServer->run(serverCallback);
 
+#if PLATFORM(GTK)
+    // FIXME(311208): Enable these test cases for the WPE port.
     FaviconDatabaseTest::add("WebKitFaviconDatabase", "initialization", testFaviconDatabaseInitialization);
     FaviconDatabaseTest::add("WebKitFaviconDatabase", "get-favicon", testFaviconDatabaseGetFavicon);
     FaviconDatabaseTest::add("WebKitFaviconDatabase", "ephemeral", testFaviconDatabaseEphemeral);
     FaviconDatabaseTest::add("WebKitFaviconDatabase", "clear", testFaviconDatabaseClear);
+#endif
 #if ENABLE(2022_GLIB_API)
     FaviconDatabaseTest::add("WebKitFaviconDatabase", "get-page-icons", testFaviconDatabaseGetPageIcons);
 #endif

--- a/Tools/TestWebKitAPI/glib/PlatformWPE.cmake
+++ b/Tools/TestWebKitAPI/glib/PlatformWPE.cmake
@@ -26,3 +26,7 @@ endif ()
 if (ENABLE_WPE_PLATFORM)
     add_subdirectory(WPEPlatform)
 endif ()
+
+if (ENABLE_2022_GLIB_API)
+    ADD_WK2_TEST(TestWebKitFaviconDatabase ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestWebKitFaviconDatabase.cpp)
+endif ()


### PR DESCRIPTION
#### c7cf5a940290e1c6460cdfece64d72271b6656f2
<pre>
[WPE] Favicon database support
<a href="https://bugs.webkit.org/show_bug.cgi?id=296927">https://bugs.webkit.org/show_bug.cgi?id=296927</a>

Reviewed by Carlos Garcia Campos.

Adjust preprocessor guards to include only the parts that implement the
new &quot;page icons API&quot; when building the WPE port: the &quot;page-icons&quot; web
view property and getter, and the favicon database methods to obtain the
list of icons for a given URI.

The rest of code which implements the old &quot;favicons API&quot; is guarded to
be built only for the GTK port.

The TestWebKitFaviconDatabase test suite is rearranged to make the
&quot;get-page-icons&quot; test case build and run. The changes needed for this
already give a hint of how unwieldy it would have been to enable the
rest of the test cases, so that is left to be done later.

* Source/WebKit/PlatformWPE.cmake: Add needed files to the build.
* Source/WebKit/SourcesWPE.txt: Ditto.
* Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp:
(webkit_favicon_database_class_init):
(webkitFaviconDatabaseGetLoadDecisionForIcon):
(webkitFaviconDatabaseSetIconForPageURL):
(webkit_favicon_database_get_favicon_uri):
* Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabasePrivate.h:
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(webkitWebViewGetFaviconDatabase):
(webkitWebViewConstructed):
(webkitWebViewGetProperty):
(webkit_web_view_class_init):
* Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h:
* Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.h.in:
* Source/WebKit/UIProcess/API/glib/webkit.h.in:
* Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestWebKitFaviconDatabase.cpp:
(testFaviconDatabaseGetPageIcons):
(beforeAll):
* Tools/TestWebKitAPI/glib/PlatformWPE.cmake:

Canonical link: <a href="https://commits.webkit.org/310697@main">https://commits.webkit.org/310697@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/219eed998c1f58cbc47ba44b141c0713d7820aa1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154647 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27906 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21065 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163406 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/108116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156520 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28040 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27755 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119624 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/108116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157606 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21918 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138892 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100318 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/21003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11233 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130666 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16736 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165880 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9087 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18345 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127724 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27451 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23051 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127864 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34695 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27375 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138529 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84057 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22767 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15323 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27067 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91169 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26645 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26876 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26718 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->