### PR TITLE
Structured clone of SharedArrayBuffer should check cross-origin isolation

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any-expected.txt
@@ -2,8 +2,8 @@
 FAIL SharedArrayBuffer constructor does not exist without COOP+COEP assert_equals: expected (undefined) undefined but got (function) function "function SharedArrayBuffer() {
     [native code]
 }"
-FAIL SharedArrayBuffer over MessageChannel without COOP+COEP assert_throws_dom: function "() => channel.port1.postMessage(sab)" did not throw
-FAIL SharedArrayBuffer over BroadcastChannel without COOP+COEP assert_throws_dom: function "() => channel.postMessage(sab)" did not throw
+PASS SharedArrayBuffer over MessageChannel without COOP+COEP
+PASS SharedArrayBuffer over BroadcastChannel without COOP+COEP
 FAIL SharedArrayBuffer over postMessage() without COOP+COEP assert_throws_dom: function "() => self.postMessage(sab)" did not throw
 PASS Bonus: self.crossOriginIsolated
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.serviceworker-expected.txt
@@ -2,7 +2,7 @@
 FAIL SharedArrayBuffer constructor does not exist without COOP+COEP assert_equals: expected (undefined) undefined but got (function) function "function SharedArrayBuffer() {
     [native code]
 }"
-FAIL SharedArrayBuffer over MessageChannel without COOP+COEP assert_throws_dom: function "() => channel.port1.postMessage(sab)" did not throw
-FAIL SharedArrayBuffer over BroadcastChannel without COOP+COEP assert_throws_dom: function "() => channel.postMessage(sab)" did not throw
+PASS SharedArrayBuffer over MessageChannel without COOP+COEP
+PASS SharedArrayBuffer over BroadcastChannel without COOP+COEP
 PASS Bonus: self.crossOriginIsolated
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.sharedworker-expected.txt
@@ -2,7 +2,7 @@
 FAIL SharedArrayBuffer constructor does not exist without COOP+COEP assert_equals: expected (undefined) undefined but got (function) function "function SharedArrayBuffer() {
     [native code]
 }"
-FAIL SharedArrayBuffer over MessageChannel without COOP+COEP assert_throws_dom: function "() => channel.port1.postMessage(sab)" did not throw
-FAIL SharedArrayBuffer over BroadcastChannel without COOP+COEP assert_throws_dom: function "() => channel.postMessage(sab)" did not throw
+PASS SharedArrayBuffer over MessageChannel without COOP+COEP
+PASS SharedArrayBuffer over BroadcastChannel without COOP+COEP
 PASS Bonus: self.crossOriginIsolated
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.worker-expected.txt
@@ -2,7 +2,7 @@
 FAIL SharedArrayBuffer constructor does not exist without COOP+COEP assert_equals: expected (undefined) undefined but got (function) function "function SharedArrayBuffer() {
     [native code]
 }"
-FAIL SharedArrayBuffer over MessageChannel without COOP+COEP assert_throws_dom: function "() => channel.port1.postMessage(sab)" did not throw
-FAIL SharedArrayBuffer over BroadcastChannel without COOP+COEP assert_throws_dom: function "() => channel.postMessage(sab)" did not throw
+PASS SharedArrayBuffer over MessageChannel without COOP+COEP
+PASS SharedArrayBuffer over BroadcastChannel without COOP+COEP
 PASS Bonus: self.crossOriginIsolated
 

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/semantics/structured-clone/dedicated-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/semantics/structured-clone/dedicated-expected.txt
@@ -132,7 +132,7 @@ PASS Serializing a non-serializable platform object fails
 PASS An object whose interface is deleted from the global must still deserialize
 PASS A subclass instance will deserialize as its closest serializable superclass
 PASS Resizable ArrayBuffer
-FAIL Growable SharedArrayBuffer assert_true: instanceof ArrayBuffer expected true got false
+PASS Growable SharedArrayBuffer
 PASS Length-tracking TypedArray
 PASS Length-tracking DataView
 PASS Serializing OOB TypedArray throws

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/semantics/structured-clone/shared-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/semantics/structured-clone/shared-expected.txt
@@ -132,7 +132,7 @@ PASS Serializing a non-serializable platform object fails
 PASS An object whose interface is deleted from the global must still deserialize
 PASS A subclass instance will deserialize as its closest serializable superclass
 PASS Resizable ArrayBuffer
-FAIL Growable SharedArrayBuffer assert_true: instanceof ArrayBuffer expected true got false
+PASS Growable SharedArrayBuffer
 PASS Length-tracking TypedArray
 PASS Length-tracking DataView
 PASS Serializing OOB TypedArray throws

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2477,5 +2477,3 @@ webkit.org/b/308856 [ Debug ] http/tests/websocket/tests/hybi/handshake-ok-with-
 [ Tahoe ] accessibility/mac/intersection-with-selection-range.html [ Skip ]
 
 webkit.org/b/309850 [ Debug ] imported/w3c/web-platform-tests/uievents/mouse/mouse_boundary_events_after_removing_last_over_element.html [ Pass Failure ]
-
-webkit.org/b/311207 imported/w3c/web-platform-tests/workers/semantics/structured-clone/shared.html [ Pass Failure ]

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -29,6 +29,8 @@
 
 #include "BlobRegistry.h"
 #include "ByteArrayPixelBuffer.h"
+#include "CrossOriginMode.h"
+#include "CrossOriginOpenerPolicy.h"
 #include "CryptoKeyAES.h"
 #include "CryptoKeyEC.h"
 #include "CryptoKeyHMAC.h"
@@ -36,6 +38,7 @@
 #include "CryptoKeyRSA.h"
 #include "CryptoKeyRSAComponents.h"
 #include "CryptoKeyRaw.h"
+#include "Document.h"
 #include "IDBValue.h"
 #include "ImageBuffer.h"
 #include "JSAudioWorkletGlobalScope.h"
@@ -2169,6 +2172,25 @@ private:
                 if (arrayBuffer->isShared() && (m_context == SerializationContext::WorkerPostMessage || m_forStorage == SerializationForStorage::Yes)) {
                     // https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal
                     if (!JSC::Options::useSharedArrayBuffer() || m_forStorage == SerializationForStorage::Yes) {
+                        code = SerializationReturnCode::DataCloneError;
+                        return true;
+                    }
+                    // https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal (step 13)
+                    // Check the current settings object's cross-origin isolated capability.
+                    // The process-level crossOriginMode() global may not reflect per-document
+                    // COOP/COEP isolation (e.g. in the layout test runner which does not
+                    // perform COOP-based process swaps). Fall back to checking the context's
+                    // COOP (for documents) or COEP (for workers) directly.
+                    bool isCrossOriginIsolated = ScriptExecutionContext::crossOriginMode() == CrossOriginMode::Isolated;
+                    if (!isCrossOriginIsolated) {
+                        if (auto* context = m_lexicalGlobalObject ? executionContext(m_lexicalGlobalObject) : nullptr) {
+                            if (RefPtr document = dynamicDowncast<Document>(context))
+                                isCrossOriginIsolated = document->crossOriginOpenerPolicy().value == CrossOriginOpenerPolicyValue::SameOriginPlusCOEP;
+                            else
+                                isCrossOriginIsolated = context->crossOriginEmbedderPolicy().value == CrossOriginEmbedderPolicyValue::RequireCORP;
+                        }
+                    }
+                    if (!isCrossOriginIsolated) {
                         code = SerializationReturnCode::DataCloneError;
                         return true;
                     }


### PR DESCRIPTION
#### fb46262d8d2acbc97b1d3b4e7367f121581ce577
<pre>
Structured clone of SharedArrayBuffer should check cross-origin isolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=311214">https://bugs.webkit.org/show_bug.cgi?id=311214</a>
<a href="https://rdar.apple.com/173803010">rdar://173803010</a>

Reviewed by NOBODY (OOPS!).

Per the HTML spec StructuredSerializeInternal algorithm [1], step 13:
&quot;If value has an [[ArrayBufferData]] internal slot and
IsSharedArrayBuffer(value) is true, then [...] if the current settings
object&apos;s cross-origin isolated capability is not &quot;logical&quot;, then throw
a &quot;DataCloneError&quot; DOMException.&quot;

WebKit&apos;s SerializedScriptValue allowed SharedArrayBuffer serialization
in worker postMessage contexts without checking cross-origin isolation,
only gating on JSC::Options::useSharedArrayBuffer(). Other browsers
enforce the spec requirement, returning DataCloneError when not
cross-origin isolated.

The check uses the process-level crossOriginMode() as a fast path,
which is set correctly in production Safari via COOP-based process
swaps. As a fallback for environments where the process-level mode
may not reflect per-document isolation (e.g. the layout test runner),
it checks COOP directly on Document contexts
(SameOriginPlusCOEP implies both COOP and COEP are set) and COEP on
worker contexts (workers inherit isolation from their agent cluster
but don&apos;t carry COOP themselves).

[1] <a href="https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal">https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal</a>

* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any-expected.txt: Progression
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.serviceworker-expected.txt: Ditto
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.sharedworker-expected.txt: Ditto
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.worker-expected.txt: Ditto
* LayoutTests/imported/w3c/web-platform-tests/workers/semantics/structured-clone/dedicated-expected.txt: Ditto
* LayoutTests/imported/w3c/web-platform-tests/workers/semantics/structured-clone/shared-expected.txt: Ditto
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneSerializer::dumpIfTerminal):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb46262d8d2acbc97b1d3b4e7367f121581ce577

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153609 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26393 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20010 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162359 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107067 "An unexpected error occured. Recent messages:Printed configuration") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3d0c2105-0809-4287-9f51-5c5ee5279be7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155482 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26921 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26715 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118759 "Found 6 new test failures: js/structuredClone/structured-clone-of-ResizableSharedArrayBuffer.html workers/sab/growable-shared-array-buffer-serialization.html workers/sab/growable-shared-array-buffer-view-serialization-explicit-length.html workers/sab/growable-shared-array-buffer-view-serialization.html workers/worker-set-delete-terminate-crash.html workers/worker-terminate-crash.html (failure)") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/107067 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e4cc4c3c-260b-4461-8cf0-c57ef6798da6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156568 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21011 "Found 6 new test failures: js/structuredClone/structured-clone-of-ResizableSharedArrayBuffer.html workers/sab/growable-shared-array-buffer-serialization.html workers/sab/growable-shared-array-buffer-view-serialization-explicit-length.html workers/sab/growable-shared-array-buffer-view-serialization.html workers/worker-set-delete-terminate-crash.html workers/worker-terminate-crash.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137919 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99470 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20090 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18035 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10192 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129737 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15779 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164830 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7964 "Found 2 new failures in bindings/js/SerializedScriptValue.cpp") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17373 "Found 6 new test failures: js/structuredClone/structured-clone-of-ResizableSharedArrayBuffer.html workers/sab/growable-shared-array-buffer-serialization.html workers/sab/growable-shared-array-buffer-view-serialization-explicit-length.html workers/sab/growable-shared-array-buffer-view-serialization.html workers/worker-set-delete-terminate-crash.html workers/worker-terminate-crash.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126833 "Found 6 new test failures: js/structuredClone/structured-clone-of-ResizableSharedArrayBuffer.html workers/sab/growable-shared-array-buffer-serialization.html workers/sab/growable-shared-array-buffer-view-serialization-explicit-length.html workers/sab/growable-shared-array-buffer-view-serialization.html workers/worker-set-delete-terminate-crash.html workers/worker-terminate-crash.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26190 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22070 "Found 7 new test failures: imported/w3c/web-platform-tests/workers/semantics/structured-clone/shared.html js/structuredClone/structured-clone-of-ResizableSharedArrayBuffer.html workers/sab/growable-shared-array-buffer-serialization.html workers/sab/growable-shared-array-buffer-view-serialization-explicit-length.html workers/sab/growable-shared-array-buffer-view-serialization.html workers/worker-set-delete-terminate-crash.html workers/worker-terminate-crash.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126997 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26192 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137574 "") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82860 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21913 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14355 "Found 6 new test failures: js/structuredClone/structured-clone-of-ResizableSharedArrayBuffer.html workers/sab/growable-shared-array-buffer-serialization.html workers/sab/growable-shared-array-buffer-view-serialization-explicit-length.html workers/sab/growable-shared-array-buffer-view-serialization.html workers/worker-set-delete-terminate-crash.html workers/worker-terminate-crash.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25809 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90096 "Found 2 new failures in bindings/js/SerializedScriptValue.cpp") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25500 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25660 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25560 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->