### PR TITLE
[Site Isolation] window.frameElement cross-origin access does not log "Blocked a frame" console error

### DIFF
--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -261,7 +261,6 @@ http/tests/security/contentSecurityPolicy/iframe-redirect-allowed-by-frame-src2.
 http/tests/security/contentSecurityPolicy/object-redirect-allowed.html [ Failure ]
 http/tests/security/contentSecurityPolicy/object-redirect-allowed2.html [ Failure ]
 http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/proper-nested-upgrades.html [ Failure ]
-http/tests/security/cross-frame-access-put.html [ Failure ]
 http/tests/security/cross-origin-blob-transfer.html [ Failure ]
 http/tests/security/cross-origin-local-storage.html [ Failure ]
 http/tests/security/file-system-access-via-dataTransfer.html [ Failure ]

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -44,7 +44,6 @@ bindings/js/DOMPromiseProxy.h
 bindings/js/JSCanvasRenderingContext2DCustom.cpp
 bindings/js/JSCustomElementInterface.cpp
 bindings/js/JSDOMBindingSecurity.cpp
-bindings/js/JSDOMBindingSecurity.h
 bindings/js/JSDOMConvertBase.h
 bindings/js/JSDOMConvertNullable.h
 bindings/js/JSDOMGlobalObject.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -87,7 +87,6 @@ bindings/js/JSCSSRuleCustom.h
 bindings/js/JSCanvasRenderingContext2DCustom.cpp
 bindings/js/JSCustomElementInterface.cpp
 bindings/js/JSDOMBindingSecurity.cpp
-bindings/js/JSDOMBindingSecurity.h
 bindings/js/JSDOMBindingSecurityInlines.h
 bindings/js/JSDOMConvertBase.h
 bindings/js/JSDOMConvertCallbacks.h

--- a/Source/WebCore/bindings/js/JSDOMBindingSecurity.h
+++ b/Source/WebCore/bindings/js/JSDOMBindingSecurity.h
@@ -25,6 +25,7 @@
 
 #include <WebCore/ExceptionOr.h>
 #include <WebCore/HTMLFrameOwnerElement.h>
+#include <WebCore/LocalDOMWindow.h>
 #include <WebCore/RemoteFrame.h>
 #include <wtf/Forward.h>
 
@@ -37,7 +38,6 @@ namespace WebCore {
 
 class DOMWindow;
 class Frame;
-class LocalDOMWindow;
 class LocalFrame;
 class Node;
 
@@ -52,6 +52,7 @@ template<typename T> T* checkSecurityForNode(JSC::JSGlobalObject&, T*);
 template<typename T> T* checkSecurityForNodeWithFrameOwner(JSC::JSGlobalObject&, T*, const HTMLFrameOwnerElement&);
 template<typename T> ExceptionOr<T*> checkSecurityForNode(JSC::JSGlobalObject&, ExceptionOr<T*>&&);
 template<typename T> ExceptionOr<T*> checkSecurityForNode(JSC::JSGlobalObject&, ExceptionOr<T&>&&);
+template<typename T> ExceptionOr<T*> checkSecurityForNodeWithDOMWindow(JSC::JSGlobalObject&, ExceptionOr<T*>&&, const DOMWindow&);
 
 bool shouldAllowAccessToDOMWindow(JSC::JSGlobalObject*, LocalDOMWindow&, SecurityReportingOption = LogSecurityError);
 bool shouldAllowAccessToDOMWindow(JSC::JSGlobalObject&, LocalDOMWindow&, String& message);
@@ -101,6 +102,26 @@ template<typename T> inline ExceptionOr<T*> BindingSecurity::checkSecurityForNod
     if (value.hasException())
         return value.releaseException();
     return checkSecurityForNode(lexicalGlobalObject, value.releaseReturnValue());
+}
+
+template<typename T> inline ExceptionOr<T*> BindingSecurity::checkSecurityForNodeWithDOMWindow(JSC::JSGlobalObject& lexicalGlobalObject, ExceptionOr<T*>&& value, const DOMWindow& window)
+{
+    if (value.hasException())
+        return value.releaseException();
+
+    RefPtr node = value.releaseReturnValue();
+    if (node)
+        return shouldAllowAccessToNode(lexicalGlobalObject, node.get()) ? node.get() : nullptr;
+
+    // With site isolation, the owner element is in the parent's process. Explicitly
+    // check the remote parent frame to log the cross-origin error.
+    if (RefPtr localWindow = dynamicDowncast<LocalDOMWindow>(window)) {
+        if (RefPtr frame = localWindow->frame()) {
+            if (RefPtr parentFrame = dynamicDowncast<RemoteFrame>(frame->tree().parent()))
+                shouldAllowAccessToFrame(&lexicalGlobalObject, parentFrame.get());
+        }
+    }
+    return nullptr;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -8385,6 +8385,10 @@ sub NativeToJSValue
         AddToImplIncludes("JSDOMBindingSecurity.h", $conditional);
         $value = "BindingSecurity::checkSecurityForNodeWithFrameOwner($lexicalGlobalObjectReference, $value, impl)";
     }
+    if ($context->extendedAttributes->{CheckSecurityForNodeWithDOMWindow}) {
+        AddToImplIncludes("JSDOMBindingSecurity.h", $conditional);
+        $value = "BindingSecurity::checkSecurityForNodeWithDOMWindow($lexicalGlobalObjectReference, $value, impl)";
+    }
 
     my $IDLType = GetIDLType($interface, $type);
 

--- a/Source/WebCore/bindings/scripts/IDLAttributes.json
+++ b/Source/WebCore/bindings/scripts/IDLAttributes.json
@@ -70,6 +70,9 @@
         "CheckSecurityForNodeWithFrameOwner": {
             "contextsAllowed": ["attribute", "operation"]
         },
+        "CheckSecurityForNodeWithDOMWindow": {
+            "contextsAllowed": ["attribute", "operation"]
+        },
         "Clamp": {
             "contextsAllowed": ["type"],
             "standard": {

--- a/Source/WebCore/page/DOMWindow.idl
+++ b/Source/WebCore/page/DOMWindow.idl
@@ -80,7 +80,7 @@
     undefined stop();
 
     // other browsing contexts
-    [CheckSecurityForNode] readonly attribute Element? frameElement;
+    [CheckSecurityForNodeWithDOMWindow] readonly attribute Element? frameElement;
     [CallWith=ActiveWindow&FirstWindow] WindowProxy? open(optional USVString url = "", optional [AtomString] DOMString target = "_blank", optional [LegacyNullToEmptyString] DOMString features = "");
 
     // the user agent


### PR DESCRIPTION
#### b2630b88dc2420b31df955babfd65fdfe9745683
<pre>
[Site Isolation] window.frameElement cross-origin access does not log &quot;Blocked a frame&quot; console error
<a href="https://bugs.webkit.org/show_bug.cgi?id=311215">https://bugs.webkit.org/show_bug.cgi?id=311215</a>
<a href="https://rdar.apple.com/173803357">rdar://173803357</a>

Reviewed by Sihui Liu.

With site isolation and a cross-origin parent frame, LocalDOMWindow::frameElement() returns
null because Frame::ownerElement() is in the parent&apos;s process. BindingSecurity::shouldAllowAccessToNode()
short-circuits on the null target parameter so canAccessTargetOrigin() is never called and the
cross-origin console error is never logged.

Add [CheckSecurityForNodeWithDOMWindow] IDL attribute and BindingSecurity::checkSecurityForNodeWithDOMWindow(),
following the pattern of [CheckSecurityForNodeWithFrameOwner]. When the node is null and the DOMWindow&apos;s
parent frame is a RemoteFrame, explicitly call BindingSecurity::shouldAllowAccessToFrame()
to produce the console error.

* LayoutTests/platform/mac-site-isolation/TestExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/bindings/js/JSDOMBindingSecurity.h:
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(NativeToJSValue):
* Source/WebCore/bindings/scripts/IDLAttributes.json:
* Source/WebCore/page/DOMWindow.idl:

Canonical link: <a href="https://commits.webkit.org/310476@main">https://commits.webkit.org/310476@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ed90aaef716d5bf1e1aa139d60374ccfe055535

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153929 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26713 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20334 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162679 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107395 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4a13a632-60a3-4c93-aa3f-8aedcbc37cb2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155802 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27244 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27035 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119037 "Found 1 new test failure: storage/indexeddb/keypath-fetch-key-private.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84166 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156888 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21295 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138224 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99733 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20388 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18352 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10511 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130046 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16078 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165152 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8293 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17677 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127127 "Found 2 new test failures: inspector/canvas/create-context-2d.html inspector/dom-debugger/dom-breakpoint-node-removed-ancestor.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26512 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22375 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127279 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34529 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26516 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137872 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83226 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22178 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14658 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26129 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90445 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25820 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25984 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25880 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->