### PR TITLE
Add tests for 310112@main.

### DIFF
--- a/LayoutTests/http/tests/scroll-to-text-fragment/generation-long-selection-uses-start-and-end-expected.txt
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/generation-long-selection-uses-start-and-end-expected.txt
@@ -1,0 +1,1 @@
+:~:text=This%20is%20a,the%20entire%20selection.

--- a/LayoutTests/http/tests/scroll-to-text-fragment/generation-long-selection-uses-start-and-end.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/generation-long-selection-uses-start-and-end.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<head>
+<meta charset="utf-8" />
+<title>Scroll to text fragment generation - a long selection uses start and end text instead of inlining</title>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.addEventListener('load', () => {
+    const range = document.createRange();
+    range.selectNodeContents(document.getElementById("test"));
+    document.body.innerText = internals.textFragmentDirectiveForRange(range).split('#')[1];
+});
+</script>
+</head>
+<body>Prefix words here. <span id="test">This is a long sentence that is being used to test that when a selection exceeds the maximum inline string length the fragment directive generator will use start and end text instead of inlining the entire selection.</span> And suffix words here.</body>
+</html>

--- a/LayoutTests/http/tests/scroll-to-text-fragment/generation-short-selection-is-inlined-expected.txt
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/generation-short-selection-is-inlined-expected.txt
@@ -1,0 +1,1 @@
+:~:text=The%20quick%20brown%20fox%20jumped%20over%20the%20lazy%20sleeping%20dog%20near%20the%20river.

--- a/LayoutTests/http/tests/scroll-to-text-fragment/generation-short-selection-is-inlined.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/generation-short-selection-is-inlined.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<head>
+<meta charset="utf-8" />
+<title>Scroll to text fragment generation - a short selection is inlined in the fragment directive</title>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.addEventListener('load', () => {
+    const range = document.createRange();
+    range.selectNodeContents(document.getElementById("test"));
+    document.body.innerText = internals.textFragmentDirectiveForRange(range).split('#')[1];
+});
+</script>
+</head>
+<body>Prefix words here. <span id="test">The quick brown fox jumped over the lazy sleeping dog near the river.</span> And suffix words here.</body>
+</html>


### PR DESCRIPTION
#### a8643c9755b0a89bab5f6439517dbb13c963c34b
<pre>
Add tests for 310112@main.
<a href="https://bugs.webkit.org/show_bug.cgi?id=311217">https://bugs.webkit.org/show_bug.cgi?id=311217</a>
<a href="https://rdar.apple.com/173808616">rdar://173808616</a>

Reviewed by Tim Horton.

* LayoutTests/http/tests/scroll-to-text-fragment/generation-long-selection-uses-start-and-end-expected.txt: Added.
* LayoutTests/http/tests/scroll-to-text-fragment/generation-long-selection-uses-start-and-end.html: Added.
* LayoutTests/http/tests/scroll-to-text-fragment/generation-short-selection-is-inlined-expected.txt: Added.
* LayoutTests/http/tests/scroll-to-text-fragment/generation-short-selection-is-inlined.html: Added.

Canonical link: <a href="https://commits.webkit.org/310352@main">https://commits.webkit.org/310352@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0adf678c37421604f1419a6d13c47836592cc49

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153514 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26298 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19899 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162263 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26825 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26619 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118692 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4767662d-6faf-4fb4-a2ac-c9b37952bf23) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156473 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20939 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137823 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99403 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b011b9c4-5eb6-47cf-bb92-f9f6c37bae74) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20018 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17961 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10097 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129664 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15693 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164735 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17287 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126756 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26095 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21997 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126921 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34435 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26097 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137489 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82764 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21847 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14269 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25714 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25405 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25564 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25465 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->