### PR TITLE
[BFCache] Fix WebCore cacheability checks for RemoteFrame children

### DIFF
--- a/Source/WebCore/history/BackForwardCache.cpp
+++ b/Source/WebCore/history/BackForwardCache.cpp
@@ -49,6 +49,7 @@
 #include "LocalFrameView.h"
 #include "Logging.h"
 #include "Page.h"
+#include "RemoteFrame.h"
 #include "ScriptDisallowedScope.h"
 #include "SecurityOriginHash.h"
 #include "Settings.h"
@@ -57,6 +58,7 @@
 #include <pal/Logging.h>
 #include <wtf/MemoryPressureHandler.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/Scope.h>
 #include <wtf/SetForScope.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/CString.h>
@@ -81,8 +83,13 @@ static inline void logBackForwardCacheFailureDiagnosticMessage(Page* page, const
     logBackForwardCacheFailureDiagnosticMessage(protect(page->diagnosticLoggingClient()), reason);
 }
 
-static bool canCacheFrame(LocalFrame& frame, DiagnosticLoggingClient& diagnosticLoggingClient, unsigned indentLevel)
+static bool canCacheFrame(Frame&, DiagnosticLoggingClient&, unsigned indentLevel);
+static bool canCacheChildFrames(Frame&, DiagnosticLoggingClient&, unsigned indentLevel);
+
+static bool canCacheLocalFrame(LocalFrame& frame, DiagnosticLoggingClient& diagnosticLoggingClient, unsigned indentLevel)
 {
+    UNUSED_PARAM(indentLevel); // Used in PGLOG.
+
     PCLOG("+---"_s);
     Ref frameLoader = frame.loader();
 
@@ -181,14 +188,33 @@ static bool canCacheFrame(LocalFrame& frame, DiagnosticLoggingClient& diagnostic
         isCacheable = false;
     }
 
+    return isCacheable;
+}
+
+static bool canCacheChildFrames(Frame& frame, DiagnosticLoggingClient& diagnosticLoggingClient, unsigned indentLevel)
+{
+    bool isCacheable = true;
+    indentLevel++;
     for (RefPtr child = frame.tree().firstChild(); child; child = child->tree().nextSibling()) {
-        auto* localChild = dynamicDowncast<LocalFrame>(child.get());
-        if (!localChild)
-            continue;
-        if (!canCacheFrame(*localChild, diagnosticLoggingClient, indentLevel + 1))
+        if (!canCacheFrame(*child, diagnosticLoggingClient, indentLevel))
             isCacheable = false;
     }
-    
+    return isCacheable;
+}
+
+static bool canCacheFrame(Frame& frame, DiagnosticLoggingClient& diagnosticLoggingClient, unsigned indentLevel)
+{
+    PCLOG("+---"_s);
+    bool isCacheable = true;
+
+    if (RefPtr localFrame = dynamicDowncast<LocalFrame>(&frame)) {
+        if (!canCacheLocalFrame(*localFrame, diagnosticLoggingClient, indentLevel))
+            isCacheable = false;
+    }
+
+    if (!canCacheChildFrames(frame, diagnosticLoggingClient, indentLevel))
+        isCacheable = false;
+
     PCLOG(isCacheable ? " Frame CAN be cached"_s : " Frame CANNOT be cached"_s);
     PCLOG("+---"_s);
     
@@ -203,12 +229,22 @@ static bool canCachePage(Page& page)
     PCLOG("--------\n Determining if page can be cached:"_s);
 
     CheckedRef diagnosticLoggingClient = page.diagnosticLoggingClient();
-    RefPtr localMainFrame = page.localMainFrame();
-    if (!localMainFrame)
-        return false;
-    bool isCacheable = canCacheFrame(*localMainFrame, diagnosticLoggingClient, indentLevel + 1);
 
-    if (!page.settings().usesBackForwardCache() || page.isResourceCachingDisabledByWebInspector() || page.settings().siteIsolationEnabled()) {
+    RefPtr mainFrame = page.mainFrame();
+    if (!mainFrame)
+        return false;
+
+    bool isCacheable = true;
+
+    auto logResult = makeScopeExit([&] {
+        PCLOG(isCacheable ? " Page CAN be cached\n--------"_s : " Page CANNOT be cached\n--------"_s);
+        diagnosticLoggingClient->logDiagnosticMessageWithResult(DiagnosticLoggingKeys::backForwardCacheKey(), DiagnosticLoggingKeys::canCacheKey(), isCacheable ? DiagnosticLoggingResultPass : DiagnosticLoggingResultFail, ShouldSample::No);
+    });
+
+    if (!canCacheFrame(*mainFrame, diagnosticLoggingClient, indentLevel))
+        isCacheable = false;
+
+    if (!page.settings().usesBackForwardCache() || page.isResourceCachingDisabledByWebInspector()) {
         PCLOG("   -Page settings says b/f cache disabled"_s);
         logBackForwardCacheFailureDiagnosticMessage(diagnosticLoggingClient, DiagnosticLoggingKeys::isDisabledKey());
         isCacheable = false;
@@ -225,6 +261,13 @@ static bool canCachePage(Page& page)
         isCacheable = false;
     }
 #endif
+
+    // In iframe processes with Site Isolation, the main frame is a RemoteFrame.
+    // The checks below (loadType, Clear-Site-Data) are only meaningful for main
+    // frame navigations, not for iframe suspension driven by UIProcess IPC.
+    RefPtr localMainFrame = page.localMainFrame();
+    if (!localMainFrame)
+        return isCacheable;
 
     FrameLoadType loadType = localMainFrame->loader().loadType();
     switch (loadType) {
@@ -292,13 +335,7 @@ static bool canCachePage(Page& page)
             }
         }
     }
-    
-    if (isCacheable)
-        PCLOG(" Page CAN be cached\n--------"_s);
-    else
-        PCLOG(" Page CANNOT be cached\n--------"_s);
 
-    diagnosticLoggingClient->logDiagnosticMessageWithResult(DiagnosticLoggingKeys::backForwardCacheKey(), DiagnosticLoggingKeys::canCacheKey(), isCacheable ? DiagnosticLoggingResultPass : DiagnosticLoggingResultFail, ShouldSample::No);
     return isCacheable;
 }
 
@@ -498,6 +535,14 @@ bool BackForwardCache::addIfCacheable(HistoryItem& item, Page* page)
         return false;
 
     if (!page)
+        return false;
+
+    // FIXME (rdar://173799983): Remove this workaround once the UIProcess has a
+    // mechanism to detach RemotePageProxy objects from the BrowsingContextGroup
+    // during in-process (same-origin) navigations. Cross-process suspension
+    // (suspendPage with ForceSuspension::Yes) already handles this via
+    // BrowsingContextGroup exchange in suspendCurrentPageIfPossible.
+    if (page->settings().siteIsolationEnabled())
         return false;
 
     auto cachedPage = trySuspendPage(*page, ForceSuspension::No);


### PR DESCRIPTION
#### d1108a6fbaaba02b30e403d7c5425f961af59619
<pre>
[BFCache] Fix WebCore cacheability checks for RemoteFrame children
<a href="https://bugs.webkit.org/show_bug.cgi?id=311209">https://bugs.webkit.org/show_bug.cgi?id=311209</a>
<a href="https://rdar.apple.com/173799983">rdar://173799983</a>

Reviewed by Sihui Liu.

Fix BFCache cacheability checks for pages with RemoteFrame children
under Site Isolation:

- canCacheLocalFrame(): Extract LocalFrame-specific checks from the
  old canCacheFrame(LocalFrame&amp;).
- canCacheFrame(): New dispatcher that handles both LocalFrame and
  RemoteFrame, recursing through all children via canCacheChildFrames().
- canCachePage(): Use Page::mainFrame() instead of localMainFrame() to
  check all frames, remove siteIsolationEnabled() check from settings
  (now gated by shouldUseBackForwardCache), early return for iframe
  processes where loadType/Clear-Site-Data checks are N/A.
- addIfCacheable(): Skip in-process (same-origin) caching when Site
  Isolation is enabled. The UIProcess has no mechanism to detach
  RemotePageProxy objects from the BrowsingContextGroup during
  in-process navigations. Cross-process suspension already handles
  this via BrowsingContextGroup exchange in suspendCurrentPageIfPossible.

Covered by existing tests.

* Source/WebCore/history/BackForwardCache.cpp:
(WebCore::canCacheLocalFrame):
(WebCore::canCacheChildFrames):
(WebCore::canCacheFrame):
(WebCore::canCachePage):
(WebCore::BackForwardCache::addIfCacheable):

Canonical link: <a href="https://commits.webkit.org/310533@main">https://commits.webkit.org/310533@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/588638250e1d84e751ae341b0587623b04c3f05f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154129 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27386 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20547 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162882 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/107597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/37df9d4d-a7b6-4cc5-9543-7a49ae0246cb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156002 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27519 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27237 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119204 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/107597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157088 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/21459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138406 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99900 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/31b3c715-52e9-4e1d-8beb-c96f2dbd17db) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/20547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/18537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10715 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/130209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16251 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165355 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/8564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17858 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127298 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26933 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22579 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127444 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34574 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26857 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138044 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/83450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22315 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14836 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26547 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/90649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26128 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26359 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26200 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->