### PR TITLE
Refactor itemSkippingBackForwardItemsAddedByJSWithoutUserGesture in preparation for expanded usage

### DIFF
--- a/Source/WebKit/UIProcess/API/C/WKBackForwardListRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKBackForwardListRef.cpp
@@ -55,7 +55,7 @@ WKBackForwardListItemRef WKBackForwardListGetForwardItem(WKBackForwardListRef li
 
 WKBackForwardListItemRef WKBackForwardListGetItemAtIndex(WKBackForwardListRef listRef, int index)
 {
-    return toAPI(protect(toImpl(listRef)->itemAtIndex(index)).get());
+    return toAPI(protect(toImpl(listRef))->itemAtDeltaFromCurrentIndex(index).get());
 }
 
 void WKBackForwardListClear(WKBackForwardListRef listRef)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardList.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardList.mm
@@ -68,7 +68,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (WKBackForwardListItem *)itemAtIndex:(NSInteger)index
 {
-    return WebKit::wrapper(protect((*_list).itemAtIndex(index)).get());
+    return WebKit::wrapper(protect(*_list)->itemAtDeltaFromCurrentIndex(index).get());
 }
 
 - (NSArray *)backList

--- a/Source/WebKit/UIProcess/API/glib/WebKitBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitBackForwardList.cpp
@@ -212,7 +212,7 @@ WebKitBackForwardListItem* webkit_back_forward_list_get_nth_item(WebKitBackForwa
 {
     g_return_val_if_fail(WEBKIT_IS_BACK_FORWARD_LIST(backForwardList), 0);
 
-    return webkitBackForwardListGetOrCreateItem(backForwardList, backForwardList->priv->backForwardItems->itemAtIndex(index));
+    return webkitBackForwardListGetOrCreateItem(backForwardList, backForwardList->priv->backForwardItems->itemAtDeltaFromCurrentIndex(index).get());
 }
 
 /**

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -944,7 +944,7 @@ void WebAutomationSession::traverseHistoryInBrowsingContext(const Inspector::Pro
 #if ENABLE(BACK_FORWARD_LIST_SWIFT)
     RefPtr targetItem = backForwardList.itemAtIndex(targetIndex);
 #else
-    RefPtr targetItem = backForwardList->itemAtIndex(targetIndex);
+    RefPtr targetItem = backForwardList->itemAtDeltaFromCurrentIndex(targetIndex);
 #endif
     ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!targetItem, InternalError);
 

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -278,21 +278,23 @@ WebBackForwardListItem* WebBackForwardList::forwardItem() const
     return m_page && m_currentIndex && m_entries.size() && *m_currentIndex < m_entries.size() - 1 ? m_entries[*m_currentIndex + 1].ptr() : nullptr;
 }
 
-WebBackForwardListItem* WebBackForwardList::itemAtIndex(int index) const
+RefPtr<WebBackForwardListItem> WebBackForwardList::itemAtDeltaFromCurrentIndex(int delta) const
 {
-    ASSERT(!m_currentIndex || *m_currentIndex < m_entries.size());
-
-    if (!m_currentIndex || !m_page)
-        return nullptr;
-    
-    // Do range checks without doing math on index to avoid overflow.
-    if (index < 0 && static_cast<unsigned>(-index) > backListCount())
-        return nullptr;
-    
-    if (index > 0 && static_cast<unsigned>(index) > forwardListCount())
+    if (!m_currentIndex || (int)*m_currentIndex + delta < 0)
         return nullptr;
 
-    return m_entries[index + *m_currentIndex].ptr();
+    return itemAtIndexWithoutSkipping(*m_currentIndex + delta).first;
+}
+
+std::pair<RefPtr<WebBackForwardListItem>, size_t> WebBackForwardList::itemAtIndexWithoutSkipping(size_t index) const
+{
+    if (!m_page)
+        return { nullptr, index };
+
+    if (index >= m_entries.size())
+        return { nullptr, index };
+
+    return { { m_entries[index] }, index };
 }
 
 unsigned WebBackForwardList::backListCount() const
@@ -501,14 +503,19 @@ void WebBackForwardList::didRemoveItem(WebBackForwardListItem& backForwardListIt
 #endif
 }
 
-enum class NavigationDirection { Backward, Forward };
-static RefPtr<WebBackForwardListItem> itemSkippingBackForwardItemsAddedByJSWithoutUserGesture(const WebBackForwardList& backForwardList, NavigationDirection direction)
+std::pair<RefPtr<WebBackForwardListItem>, size_t> WebBackForwardList::itemStartingAtIndexSkippingItemsAddedByJSWithoutUserGesture(NavigationDirection direction, size_t startingIndex) const
 {
+    if (direction == NavigationDirection::Backward && !startingIndex)
+        return { nullptr, 0 };
+
     auto delta = direction == NavigationDirection::Backward ? -1 : 1;
-    int itemIndex = delta;
-    RefPtr item = backForwardList.itemAtIndex(itemIndex);
-    if (!item)
-        return nullptr;
+    size_t itemIndex = startingIndex + delta;
+
+    if (itemIndex >= m_entries.size())
+        return { nullptr, 0 };
+
+    auto item = itemAtIndexWithoutSkipping(itemIndex);
+    ASSERT(item.first);
 
 #if PLATFORM(COCOA)
     if (!linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::UIBackForwardSkipsHistoryItemsWithoutUserGesture))
@@ -519,7 +526,7 @@ static RefPtr<WebBackForwardListItem> itemSkippingBackForwardItemsAddedByJSWitho
     // Yahoo -> Yahoo#a (no userInteraction) -> Google -> Google#a (no user interaction) -> Google#b (no user interaction)
     // If we're on Google and navigate back, we don't want to skip anything and load Yahoo#a.
     // However, if we're on Yahoo and navigate forward, we do want to skip items and end up on Google#b.
-    if (direction == NavigationDirection::Backward && !protect(backForwardList.currentItem())->wasCreatedByJSWithoutUserInteraction())
+    if (direction == NavigationDirection::Backward && !protect(currentItem())->wasCreatedByJSWithoutUserInteraction())
         return item;
 
     // For example:
@@ -527,44 +534,48 @@ static RefPtr<WebBackForwardListItem> itemSkippingBackForwardItemsAddedByJSWitho
     // If we are on Google#b and navigate backwards, we want to skip over Google#a and Google, to end up on Yahoo#a.
     // If we are on Yahoo#a and navigate forwards, we want to skip over Google and Google#a, to end up on Google#b.
 
-    RefPtr originalItem = item;
-    while (item->wasCreatedByJSWithoutUserInteraction()) {
+    auto originalitem = item;
+    while (item.first->wasCreatedByJSWithoutUserInteraction()) {
         itemIndex += delta;
-        item = backForwardList.itemAtIndex(itemIndex);
-        if (!item)
-            return originalItem;
+        item = itemAtIndexWithoutSkipping(itemIndex);
+        if (!item.first)
+            return originalitem;
         RELEASE_LOG(Loading, "UI Navigation is skipping a WebBackForwardListItem because it was added by JavaScript without user interaction");
     }
 
     // We are now on the next item that has user interaction.
-    ASSERT(!item->wasCreatedByJSWithoutUserInteraction());
+    ASSERT(!item.first->wasCreatedByJSWithoutUserInteraction());
 
     if (direction == NavigationDirection::Backward) {
         // If going backwards, skip over next item with user iteraction since this is the one the user
         // thinks they're on.
         --itemIndex;
-        item = backForwardList.itemAtIndex(itemIndex);
-        if (!item)
-            return originalItem;
+        item = itemAtIndexWithoutSkipping(itemIndex);
+        if (!item.first)
+            return originalitem;
         RELEASE_LOG(Loading, "UI Navigation is skipping a WebBackForwardListItem that has user interaction because we started on an item that didn't have interaction");
     } else {
         // If going forward and there are items that we created by JS without user interaction, move forward to the last
         // one in the series.
-        RefPtr nextItem = backForwardList.itemAtIndex(itemIndex + 1);
-        while (nextItem && nextItem->wasCreatedByJSWithoutUserInteraction())
-            item = std::exchange(nextItem, backForwardList.itemAtIndex(++itemIndex));
+        auto nextItem = itemAtIndexWithoutSkipping(itemIndex + 1);
+        while (nextItem.first && nextItem.first->wasCreatedByJSWithoutUserInteraction())
+            item = std::exchange(nextItem, itemAtIndexWithoutSkipping(++itemIndex));
     }
     return item;
 }
 
 RefPtr<WebBackForwardListItem> WebBackForwardList::goBackItemSkippingItemsWithoutUserGesture() const
 {
-    return itemSkippingBackForwardItemsAddedByJSWithoutUserGesture(*this, NavigationDirection::Backward);
+    if (!m_currentIndex || !*m_currentIndex)
+        return nullptr;
+    return itemStartingAtIndexSkippingItemsAddedByJSWithoutUserGesture(NavigationDirection::Backward, *m_currentIndex).first;
 }
 
 RefPtr<WebBackForwardListItem> WebBackForwardList::goForwardItemSkippingItemsWithoutUserGesture() const
 {
-    return itemSkippingBackForwardItemsAddedByJSWithoutUserGesture(*this, NavigationDirection::Forward);
+    if (!m_currentIndex || *m_currentIndex >= m_entries.size())
+        return nullptr;
+    return itemStartingAtIndexSkippingItemsAddedByJSWithoutUserGesture(NavigationDirection::Forward, *m_currentIndex).first;
 }
 
 static inline void NODELETE setBackForwardItemIdentifier(FrameState& frameState, BackForwardItemIdentifier itemID)
@@ -741,10 +752,10 @@ void WebBackForwardList::backForwardAllItems(FrameIdentifier frameID, Completion
     }));
 }
 
-void WebBackForwardList::backForwardItemAtIndex(int32_t index, FrameIdentifier frameID, CompletionHandler<void(RefPtr<FrameState>&&)>&& completionHandler)
+void WebBackForwardList::backForwardItemAtIndex(int32_t delta, FrameIdentifier frameID, CompletionHandler<void(RefPtr<FrameState>&&)>&& completionHandler)
 {
     // FIXME: This should verify that the web process requesting the item hosts the specified frame.
-    if (RefPtr item = itemAtIndex(index)) {
+    if (RefPtr item = itemAtDeltaFromCurrentIndex(delta)) {
         if (RefPtr frameItem = item->mainFrameItem().childItemForFrameID(frameID))
             return completionHandler(frameItem->copyFrameStateWithChildren());
         completionHandler(item->copyMainFrameStateWithChildren());

--- a/Source/WebKit/UIProcess/WebBackForwardList.h
+++ b/Source/WebKit/UIProcess/WebBackForwardList.h
@@ -72,7 +72,7 @@ public:
     WebBackForwardListItem* NODELETE currentItem() const;
     WebBackForwardListItem* NODELETE backItem() const;
     WebBackForwardListItem* NODELETE forwardItem() const;
-    WebBackForwardListItem* NODELETE itemAtIndex(int) const;
+    RefPtr<WebBackForwardListItem> itemAtDeltaFromCurrentIndex(int) const;
 
     RefPtr<WebBackForwardListItem> goBackItemSkippingItemsWithoutUserGesture() const;
     RefPtr<WebBackForwardListItem> goForwardItemSkippingItemsWithoutUserGesture() const;
@@ -104,6 +104,10 @@ public:
 
 private:
     explicit WebBackForwardList(WebPageProxy&);
+
+    enum class NavigationDirection { Backward, Forward };
+    std::pair<RefPtr<WebBackForwardListItem>, size_t> itemStartingAtIndexSkippingItemsAddedByJSWithoutUserGesture(NavigationDirection, size_t startingIndex) const;
+    std::pair<RefPtr<WebBackForwardListItem>, size_t> itemAtIndexWithoutSkipping(size_t) const;
 
     void addItem(Ref<WebBackForwardListItem>&&);
     void addChildItem(WebCore::FrameIdentifier, Ref<FrameState>&&);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2825,7 +2825,7 @@ void WebPageProxy::goToBackForwardItemAtIndex(int32_t steps, FrameLoadType frame
 {
     WEBPAGEPROXY_RELEASE_LOG(Loading, "goToBackForwardItemAtIndex: steps=%d", steps);
 
-    RefPtr item = backForwardList().itemAtIndex(steps);
+    RefPtr item = backForwardList().itemAtDeltaFromCurrentIndex(steps);
     if (!item)
         return;
 


### PR DESCRIPTION
#### 22c089bb031b4aea71e20048edca2dcbc924c40b
<pre>
Refactor itemSkippingBackForwardItemsAddedByJSWithoutUserGesture in preparation for expanded usage
<a href="https://rdar.apple.com/173806479">rdar://173806479</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=311216">https://bugs.webkit.org/show_bug.cgi?id=311216</a>

Reviewed by Sihui Liu and Rupin Mittal.

Soon I&apos;ll be adding way more &quot;skip this back/forward item for the sake of the API&quot; logic.
As part of that change, we need to always know the real Vector index of an item we are
currently processing.

This change refactors itemSkippingBackForwardItemsAddedByJSWithoutUserGesture to:
1 - Make it a member of WebBackForwardList
2 - Take a starting index instead of assuming m_currentIndex
3 - Always return the index of the found item.

Should be a straight refactor with no behavior change.

* Source/WebKit/UIProcess/API/C/WKBackForwardListRef.cpp:
(WKBackForwardListGetItemAtIndex):
* Source/WebKit/UIProcess/API/Cocoa/WKBackForwardList.mm:
(-[WKBackForwardList itemAtIndex:]):
* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::traverseHistoryInBrowsingContext):
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::itemAtDeltaFromCurrentIndex const):
(WebKit::WebBackForwardList::itemAtIndexWithoutSkipping const):
(WebKit::WebBackForwardList::itemStartingAtIndexSkippingItemsAddedByJSWithoutUserGesture const):
(WebKit::WebBackForwardList::goBackItemSkippingItemsWithoutUserGesture const):
(WebKit::WebBackForwardList::goForwardItemSkippingItemsWithoutUserGesture const):
(WebKit::WebBackForwardList::backForwardItemAtIndex):
(WebKit::WebBackForwardList::itemAtIndex const): Deleted.
(WebKit::itemSkippingBackForwardItemsAddedByJSWithoutUserGesture): Deleted.
* Source/WebKit/UIProcess/WebBackForwardList.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::goToBackForwardItemAtIndex):

Canonical link: <a href="https://commits.webkit.org/310378@main">https://commits.webkit.org/310378@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ce8a3c9107fb59f4bddd46e8c761388ad70e99a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153673 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26457 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20074 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162423 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107131 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26985 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26779 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118816 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84045 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156632 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21069 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/137978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99527 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20148 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18097 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10256 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129797 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164894 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8028 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17431 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126889 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26254 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22129 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127055 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34462 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26256 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137632 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82934 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21967 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14414 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25873 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90161 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25564 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25724 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25624 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->