### PR TITLE
AX: Update FrameGeometry when the frame rect moves

### DIFF
--- a/LayoutTests/accessibility/mac/iframe-position-after-div-move-expected.txt
+++ b/LayoutTests/accessibility/mac/iframe-position-after-div-move-expected.txt
@@ -1,0 +1,8 @@
+This test verifies that moving a div containing an iframe updates the screen position of elements inside that iframe.
+
+PASS: delta was equal or approximately equal to 200.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/iframe-position-after-div-move.html
+++ b/LayoutTests/accessibility/mac/iframe-position-after-div-move.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<style>
+body { margin: 0; }
+#container {
+    position: absolute;
+    top: 100px;
+    left: 10px;
+}
+iframe {
+    width: 200px;
+    height: 100px;
+    border: none;
+}
+</style>
+</head>
+<body>
+
+<div id="container">
+    <iframe id="iframe" onload="runTest()" src="data:text/html,<body style='margin:0'><button id='target' style='width:80px;height:30px'>Click me</button></body>"></iframe>
+</div>
+
+<script>
+window.jsTestIsAsync = true;
+
+var output = "This test verifies that moving a div containing an iframe updates the screen position of elements inside that iframe.\n\n";
+
+var target, initialY, movedY, delta;
+function runTest() {
+    if (!window.accessibilityController)
+        return;
+
+    setTimeout(async function() {
+        // Wait for the iframe's frame geometry to be initialized and the
+        // target element inside the iframe to be accessible.
+        await waitFor(() => {
+            var iframeContainer = accessibilityController.accessibleElementById("container");
+            if (!iframeContainer)
+                return false;
+            var iframeScrollView = iframeContainer.childAtIndex(0);
+            if (!iframeScrollView || !iframeScrollView.isFrameGeometryInitialized)
+                return false;
+            target = accessibilityController.accessibleElementById("target");
+            return target;
+        });
+
+        initialY = target.y;
+
+        // Move the container div down by 200px.
+        document.getElementById("container").style.top = "300px";
+        // Wait for the element's absolute screen y to change after the move.
+        await waitFor(() => {
+            target = accessibilityController.accessibleElementById("target");
+            return target && target.y !== initialY;
+        });
+
+        movedY = target.y;
+        delta = Math.abs(movedY - initialY);
+        output += expectNumber("delta", 200, 5);
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -295,6 +295,7 @@ public:
     virtual IntRect rootViewToAccessibilityScreen(const IntRect&) const = 0;
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     virtual void requestFrameScreenPosition(FrameIdentifier) const { }
+    virtual void scheduleAccessibilityFrameGeometryUpdate() const { }
 #endif
 #if PLATFORM(IOS_FAMILY)
     virtual void relayAccessibilityNotification(String&&, RetainPtr<NSData>&&) const = 0;

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -463,6 +463,16 @@ void LocalFrameView::setFrameRect(const IntRect& newRect)
     if (RefPtr document = m_frame->document())
         document->didChangeViewSize();
 
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    // When an iframe's position changes in its parent (e.g. containing div moved),
+    // schedule a debounced update of all frame geometries so accessibility screen
+    // coordinates stay current for the moved frame and any descendants.
+    if (!m_frame->isMainFrame() && AXObjectCache::accessibilityEnabled()) {
+        if (RefPtr page = m_frame->page())
+            page->chrome().client().scheduleAccessibilityFrameGeometryUpdate();
+    }
+#endif
+
     viewportContentsChanged();
 }
 

--- a/Source/WebCore/page/RemoteFrameView.cpp
+++ b/Source/WebCore/page/RemoteFrameView.cpp
@@ -26,7 +26,12 @@
 #include "config.h"
 #include "RemoteFrameView.h"
 
+#include "AXObjectCache.h"
+#include "Chrome.h"
+#include "ChromeClient.h"
+#include "DocumentPage.h"
 #include "GraphicsContext.h"
+#include "Page.h"
 #include "RemoteFrame.h"
 #include "RemoteFrameClient.h"
 #include <wtf/TZoneMallocInlines.h>
@@ -49,8 +54,16 @@ void RemoteFrameView::setFrameRect(const IntRect& newRect)
 {
     IntRect oldRect = frameRect();
     setFrameRectWithoutSync(newRect);
-    if (newRect != oldRect)
+    if (newRect != oldRect) {
         m_frame->client().frameRectDidChange(newRect);
+
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+        if (AXObjectCache::accessibilityEnabled()) {
+            if (RefPtr page = m_frame->page())
+                page->chrome().client().scheduleAccessibilityFrameGeometryUpdate();
+        }
+#endif
+    }
 }
 
 LayoutRect RemoteFrameView::layoutViewportRect() const

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -468,10 +468,6 @@ struct PerWebProcessState {
 
 #if PLATFORM(IOS_FAMILY)
     RefPtr<RunLoop::DispatchTimer> _pendingInteractiveObscuredInsetsChangeTimer;
-#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
-    RefPtr<RunLoop::DispatchTimer> _pendingAccessibilityFrameGeometryUpdateTimer;
-    MonotonicTime _lastAccessibilityFrameGeometryUpdate;
-#endif
 #endif
 
     // This value tracks the current adjustment added to the bottom inset due to the keyboard sliding out from the bottom

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -140,9 +140,6 @@
 static const Seconds delayBeforeNoVisibleContentsRectsLogging = 1_s;
 static const Seconds delayBeforeNoCommitsLogging = 5_s;
 static constexpr Seconds delayBeforeUpdatingVisibleContentRectsWhenChangingObscuredInsetsInteractively = 100_ms;
-#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
-static constexpr Seconds accessibilityFrameGeometryUpdateDelay = 100_ms;
-#endif
 static const unsigned highlightMargin = 5;
 
 static WebCore::IntDegrees deviceOrientationForUIInterfaceOrientation(UIInterfaceOrientation orientation)
@@ -1296,20 +1293,7 @@ static void changeContentOffsetBoundedInValidRange(UIScrollView *scrollView, Web
 {
     _perProcessState.commitDidRestoreScrollPosition = NO;
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
-    // Update accessibility frame geometry after layer tree commits. Fire immediately
-    // on the first call (or if enough time has elapsed), but throttle rapid successive
-    // commits to avoid excessive updating.
-    auto timeSinceLastUpdate = MonotonicTime::now() - _lastAccessibilityFrameGeometryUpdate;
-    if (timeSinceLastUpdate >= accessibilityFrameGeometryUpdateDelay) {
-        _lastAccessibilityFrameGeometryUpdate = MonotonicTime::now();
-        _page->updateAccessibilityFrameGeometry();
-    } else if (!_pendingAccessibilityFrameGeometryUpdateTimer || !_pendingAccessibilityFrameGeometryUpdateTimer->isActive()) {
-        _pendingAccessibilityFrameGeometryUpdateTimer = RunLoop::mainSingleton().dispatchAfter(accessibilityFrameGeometryUpdateDelay, [retainedSelf = retainPtr(self)] {
-            retainedSelf->_pendingAccessibilityFrameGeometryUpdateTimer = nullptr;
-            retainedSelf->_lastAccessibilityFrameGeometryUpdate = MonotonicTime::now();
-            retainedSelf->_page->updateAccessibilityFrameGeometry();
-        });
-    }
+    _page->scheduleAccessibilityFrameGeometryUpdate();
 #endif
 }
 
@@ -2077,7 +2061,7 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     // After scrolling completes, recompute the screen position for each frame
     // so accessibility clients get up-to-date screen coordinates.
-    _page->updateAccessibilityFrameGeometry();
+    _page->scheduleAccessibilityFrameGeometryUpdate();
 #endif
 
     if (CheckedPtr coordinator = _page->scrollingCoordinatorProxy())

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -10073,6 +10073,30 @@ void WebPageProxy::updateAccessibilityFrameGeometry()
     for (RefPtr frame = m_mainFrame; frame; frame = frame->traverseNext().frame)
         requestFrameScreenPosition(frame->frameID());
 }
+
+void WebPageProxy::scheduleAccessibilityFrameGeometryUpdate()
+{
+    if (WebCore::isAccessibilityModeOff(m_accessibilityMode))
+        return;
+
+    // Fire immediately on the first call (or if enough time has elapsed), but
+    // throttle rapid successive calls to avoid excessive updating.
+    static constexpr Seconds updateDelay = 100_ms;
+    auto timeSinceLastUpdate = MonotonicTime::now() - m_lastAccessibilityFrameGeometryUpdate;
+    if (timeSinceLastUpdate >= updateDelay) {
+        m_lastAccessibilityFrameGeometryUpdate = MonotonicTime::now();
+        updateAccessibilityFrameGeometry();
+    } else if (!m_pendingAccessibilityFrameGeometryUpdateTimer || !m_pendingAccessibilityFrameGeometryUpdateTimer->isActive()) {
+        m_pendingAccessibilityFrameGeometryUpdateTimer = RunLoop::mainSingleton().dispatchAfter(updateDelay, [weakThis = WeakPtr { *this }] {
+            RefPtr protectedThis = weakThis.get();
+            if (!protectedThis)
+                return;
+            protectedThis->m_pendingAccessibilityFrameGeometryUpdateTimer = nullptr;
+            protectedThis->m_lastAccessibilityFrameGeometryUpdate = MonotonicTime::now();
+            protectedThis->updateAccessibilityFrameGeometry();
+        });
+    }
+}
 #endif // ENABLE(ACCESSIBILITY_LOCAL_FRAME)
 
 void WebPageProxy::runBeforeUnloadConfirmPanel(IPC::Connection& connection, FrameIdentifier frameID, FrameInfoData&& frameInfo, String&& message, CompletionHandler<void(bool)>&& reply)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1578,6 +1578,7 @@ public:
     void accessibilitySettingsDidChange();
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     void updateAccessibilityFrameGeometry();
+    void scheduleAccessibilityFrameGeometryUpdate();
 #endif
     void setAccessibilityMode(WebCore::AccessibilityMode);
 
@@ -3883,6 +3884,10 @@ private:
     bool m_isEditable { false };
 
     WebCore::AccessibilityMode m_accessibilityMode { };
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    MonotonicTime m_lastAccessibilityFrameGeometryUpdate;
+    RefPtr<RunLoop::DispatchTimer> m_pendingAccessibilityFrameGeometryUpdateTimer;
+#endif
 
     double m_textZoomFactor { 1 };
     double m_pageZoomFactor { 1 };

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -55,6 +55,7 @@ messages -> WebPageProxy {
     RootViewToAccessibilityScreen(WebCore::IntRect rect) -> (WebCore::IntRect screenFrame) Synchronous
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     RequestFrameScreenPosition(WebCore::FrameIdentifier frameID)
+    ScheduleAccessibilityFrameGeometryUpdate()
 #endif
 #if PLATFORM(IOS_FAMILY)
     RelayAccessibilityNotification(String notificationName, std::span<const uint8_t> notificationData)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -836,6 +836,12 @@ void WebChromeClient::requestFrameScreenPosition(FrameIdentifier frameID) const
     if (RefPtr page = m_page.get())
         page->requestFrameScreenPosition(frameID);
 }
+
+void WebChromeClient::scheduleAccessibilityFrameGeometryUpdate() const
+{
+    if (RefPtr page = m_page.get())
+        page->scheduleAccessibilityFrameGeometryUpdate();
+}
 #endif
 
 void WebChromeClient::mainFrameDidChange()

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -140,6 +140,7 @@ private:
     WebCore::IntRect rootViewToAccessibilityScreen(const WebCore::IntRect&) const final;
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     void requestFrameScreenPosition(WebCore::FrameIdentifier) const final;
+    void scheduleAccessibilityFrameGeometryUpdate() const final;
 #endif
 
     void mainFrameDidChange() final;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4605,6 +4605,11 @@ void WebPage::requestFrameScreenPosition(FrameIdentifier frameID)
 {
     send(Messages::WebPageProxy::RequestFrameScreenPosition(frameID));
 }
+
+void WebPage::scheduleAccessibilityFrameGeometryUpdate()
+{
+    send(Messages::WebPageProxy::ScheduleAccessibilityFrameGeometryUpdate());
+}
 #endif
 
 KeyboardUIMode WebPage::keyboardUIMode()

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1030,6 +1030,7 @@ public:
     // Allows remote web processes to request an asynchronous update to their screen position, computed in the UI process.
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     void requestFrameScreenPosition(WebCore::FrameIdentifier);
+    void scheduleAccessibilityFrameGeometryUpdate();
 #endif
 #if PLATFORM(IOS_FAMILY)
     void relayAccessibilityNotification(String&&, RetainPtr<NSData>&&);


### PR DESCRIPTION
#### fca3595ecd25c612b8610cc1014a4a5c50d80def
<pre>
AX: Update FrameGeometry when the frame rect moves
<a href="https://bugs.webkit.org/show_bug.cgi?id=311220">https://bugs.webkit.org/show_bug.cgi?id=311220</a>
<a href="https://rdar.apple.com/173810609">rdar://173810609</a>

Reviewed by Tyler Wilcock.

When an iframe moves due to styling or layout, the UIProcess will be informed via
[Local/Remote]FrameView::setFrameRect. We need to update FrameGeometry when that
happens, so this patch adds in a hook to those methods.

This patch also centralizes the coalescing of frame calls to the UI process, so that
only one place has to manage the frequency of FrameGeometry updates:
scheduleAccessibilityFrameGeometryUpdate. This allows us to remove the iOS-specific
debouncing added earlier for UI-process scroll.

Test: accessibility/mac/iframe-position-after-div-move.html

* LayoutTests/accessibility/mac/iframe-position-after-div-move-expected.txt: Added.
* LayoutTests/accessibility/mac/iframe-position-after-div-move.html: Added.
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::scheduleAccessibilityFrameGeometryUpdate const):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::setFrameRect):
* Source/WebCore/page/RemoteFrameView.cpp:
(WebCore::RemoteFrameView::setFrameRect):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _layerTreeCommitComplete]):
(-[WKWebView _didFinishScrolling:]):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::scheduleAccessibilityFrameGeometryUpdate):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::scheduleAccessibilityFrameGeometryUpdate const):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::scheduleAccessibilityFrameGeometryUpdate):
* Source/WebKit/WebProcess/WebPage/WebPage.h:

Canonical link: <a href="https://commits.webkit.org/310385@main">https://commits.webkit.org/310385@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0e0a5cfe59cbb6c0da22007705e960d728b76a8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153676 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26460 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20077 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162426 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107134 "An unexpected error occured. Recent messages:Printed configuration") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155549 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26988 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26782 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118829 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/107134 "An unexpected error occured. Recent messages:Printed configuration") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156635 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21078 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137985 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99531 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20157 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18104 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10259 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129806 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15844 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164897 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8031 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17438 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126892 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26257 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22136 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127058 "Found 2 new API test failures: TestWebKit:WebKit.AboutBlankLoad, TestWebKit:WebKit.EvaluateEmptyJavaScript (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34464 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26259 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137639 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82937 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21974 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14421 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25876 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90164 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25567 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25727 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25627 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->