### PR TITLE
[Scroll anchoring] Add a heuristic that disables scroll anchoring for frequent adjustments

### DIFF
--- a/LayoutTests/fast/scrolling/scroll-anchoring/heuristic-disabled-above-threshold-expected.txt
+++ b/LayoutTests/fast/scrolling/scroll-anchoring/heuristic-disabled-above-threshold-expected.txt
@@ -1,0 +1,7 @@
+
+Testing anchoring with 10 of size 10 - expect anchoring false
+PASS anchoringActive is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/scroll-anchoring/heuristic-disabled-above-threshold-in-overflow-expected.txt
+++ b/LayoutTests/fast/scrolling/scroll-anchoring/heuristic-disabled-above-threshold-in-overflow-expected.txt
@@ -1,0 +1,7 @@
+
+Testing anchoring with 10 of size 10 - expect anchoring false
+PASS anchoringActive is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/scroll-anchoring/heuristic-disabled-above-threshold-in-overflow.html
+++ b/LayoutTests/fast/scrolling/scroll-anchoring/heuristic-disabled-above-threshold-in-overflow.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .scroller {
+            width: 400px;
+            height: 400px;
+            overflow-y: scroll;
+            border: 1px solid black;
+        }
+        
+        .changer {
+            background-color: cyan;
+            width: 200px;
+            height: 200px;
+        }
+
+        .anchor {
+            background-color: green;
+            width: 200px;
+            height: 200px;
+        }
+        
+        .spacer {
+            height: 2000px;
+        }
+    </style>
+    <script src="../../../resources/js-test.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script src="resources/scroll-anchoring-utils.js"></script>
+    <script>
+        jsTestIsAsync = true;
+        
+        async function doAdjustments(numAdjustments, amount, expectAnchoring)
+        {
+            const scroller = document.querySelector('.scroller');
+            const changer = document.querySelector('.changer');
+            
+            scroller.scrollTo(0, 250);
+            
+            for (let i = 0; i < numAdjustments - 1; ++i) {
+                toggleHeight(changer, amount);
+                await UIHelper.renderingUpdate();
+            }
+
+            // Test whether anchoring is active on the last one.
+            const currentScrollTop = scroller.scrollTop;
+            toggleHeight(changer, amount);
+            anchoringActive = scroller.scrollTop === (currentScrollTop + amount);
+
+            if (expectAnchoring)
+                shouldBeTrue('anchoringActive');
+            else
+                shouldBeFalse('anchoringActive');
+        }
+
+        window.addEventListener('load', async () => {
+            await UIHelper.delayFor(0);
+
+            let iterations = 10;
+            let amount = 10;
+            let expectAnchor = false;
+            debug(`\nTesting anchoring with ${iterations} of size ${amount} - expect anchoring ${expectAnchor}`);
+            await doAdjustments(iterations, amount, expectAnchor);
+
+            window.scrollTo(0, 0);
+            finishJSTest();
+            
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="scroller">
+        <div class="changer"></div>
+        <div class="anchor"></div>
+        <div class="spacer"></div>
+    </div>
+    <div id="console"></div>
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/scroll-anchoring/heuristic-disabled-above-threshold.html
+++ b/LayoutTests/fast/scrolling/scroll-anchoring/heuristic-disabled-above-threshold.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {
+            height: 5000px;
+        }
+        
+        .changer {
+            background-color: cyan;
+            width: 200px;
+            height: 200px;
+        }
+
+        .anchor {
+            background-color: green;
+            width: 200px;
+            height: 200px;
+        }
+    </style>
+    <script src="../../../resources/js-test.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script src="resources/scroll-anchoring-utils.js"></script>
+    <script>
+        jsTestIsAsync = true;
+        
+        async function doAdjustments(numAdjustments, amount, expectAnchoring)
+        {
+            const changer = document.querySelector('.changer');
+            
+            window.scrollTo(0, 250);
+
+            for (let i = 0; i < numAdjustments - 1; ++i) {
+                // Height toggles between two states.
+                toggleHeight(changer, amount);
+                changer.style.height = `${curHeight}px`;
+                await UIHelper.renderingUpdate();
+            }
+
+            // Test whether anchoring is active on the last one.
+            const currentScrollY = window.scrollY;
+            const adjustment = toggleHeight(changer, amount);
+            anchoringActive = window.scrollY === (currentScrollY + adjustment);
+
+            if (expectAnchoring)
+                shouldBeTrue('anchoringActive');
+            else
+                shouldBeFalse('anchoringActive');
+        }
+
+        window.addEventListener('load', async () => {
+            await UIHelper.delayFor(0);
+
+            let iterations = 10;
+            let amount = 10;
+            let expectAnchor = false;
+            debug(`\nTesting anchoring with ${iterations} of size ${amount} - expect anchoring ${expectAnchor}`);
+            await doAdjustments(iterations, amount, expectAnchor);
+
+            window.scrollTo(0, 0);
+            finishJSTest();
+            
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="changer"></div>
+    <div class="anchor"></div>
+    <div id="console"></div>
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/scroll-anchoring/heuristic-enabled-below-threshold-expected.txt
+++ b/LayoutTests/fast/scrolling/scroll-anchoring/heuristic-enabled-below-threshold-expected.txt
@@ -1,0 +1,7 @@
+
+Testing anchoring with 9 of size 10 - expect anchoring true
+PASS anchoringActive is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/scroll-anchoring/heuristic-enabled-below-threshold.html
+++ b/LayoutTests/fast/scrolling/scroll-anchoring/heuristic-enabled-below-threshold.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {
+            height: 5000px;
+        }
+        
+        .changer {
+            background-color: cyan;
+            width: 200px;
+            height: 200px;
+        }
+
+        .anchor {
+            background-color: green;
+            width: 200px;
+            height: 200px;
+        }
+            
+    </style>
+    <script src="../../../resources/js-test.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script src="resources/scroll-anchoring-utils.js"></script>
+    <script>
+        jsTestIsAsync = true;
+        
+        async function doAdjustments(numAdjustments, amount, expectAnchoring)
+        {
+            const changer = document.querySelector('.changer');
+
+            window.scrollTo(0, 250);
+
+            for (let i = 0; i < numAdjustments - 1; ++i) {
+                // Height toggles between two states.
+                toggleHeight(changer, amount);
+                await UIHelper.renderingUpdate();
+            }
+
+            // Test whether anchoring is active on the last one.
+            const currentScrollY = window.scrollY;
+            const adjustment = toggleHeight(changer, amount);
+            anchoringActive = window.scrollY === (currentScrollY + adjustment);
+
+            if (expectAnchoring)
+                shouldBeTrue('anchoringActive');
+            else
+                shouldBeFalse('anchoringActive');
+        }
+
+        window.addEventListener('load', async () => {
+            
+            await UIHelper.delayFor(0);
+
+            let iterations = 9;
+            let amount = 10;
+            let expectAnchor = true;
+            debug(`\nTesting anchoring with ${iterations} of size ${amount} - expect anchoring ${expectAnchor}`);
+            await doAdjustments(iterations, amount, expectAnchor);
+
+            window.scrollTo(0, 0);
+            finishJSTest();
+            
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="changer"></div>
+    <div class="anchor"></div>
+    <div id="console"></div>
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/scroll-anchoring/heuristic-enabled-large-cumulative-adjustment-expected.txt
+++ b/LayoutTests/fast/scrolling/scroll-anchoring/heuristic-enabled-large-cumulative-adjustment-expected.txt
@@ -1,0 +1,7 @@
+
+Testing anchoring with 10 of size 10 - expect anchoring true
+PASS anchoringActive is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/scroll-anchoring/heuristic-enabled-large-cumulative-adjustment.html
+++ b/LayoutTests/fast/scrolling/scroll-anchoring/heuristic-enabled-large-cumulative-adjustment.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {
+            height: 5000px;
+        }
+        
+        .changer {
+            background-color: cyan;
+            width: 200px;
+            height: 200px;
+        }
+
+        .anchor {
+            background-color: green;
+            width: 200px;
+            height: 200px;
+        }
+    </style>
+    <script src="../../../resources/js-test.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script src="resources/scroll-anchoring-utils.js"></script>
+    <script>
+        jsTestIsAsync = true;
+        
+        async function doAdjustments(numAdjustments, amount, expectAnchoring)
+        {
+            const changer = document.querySelector('.changer');
+            
+            let curHeight = baseHeight;
+            
+            window.scrollTo(0, 250);
+            
+            for (let i = 0; i < numAdjustments - 1; ++i) {
+                // Height keeps increasing.
+                curHeight += amount;
+                changer.style.height = `${curHeight}px`;
+                await UIHelper.renderingUpdate();
+            }
+            
+            // Test whether anchoring is active on the last one.
+            const currentScrollY = window.scrollY;
+            changer.style.height = `${curHeight + amount}px`;
+            anchoringActive = window.scrollY === (currentScrollY + amount);
+
+            if (expectAnchoring)
+                shouldBeTrue('anchoringActive');
+            else
+                shouldBeFalse('anchoringActive');
+        }
+
+        window.addEventListener('load', async () => {
+            await UIHelper.delayFor(0);
+
+            let iterations = 10;
+            let amount = 10;
+            let expectAnchor = true;
+            debug(`\nTesting anchoring with ${iterations} of size ${amount} - expect anchoring ${expectAnchor}`);
+            await doAdjustments(iterations, amount, expectAnchor);
+
+            window.scrollTo(0, 0);
+            finishJSTest();
+            
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="changer"></div>
+    <div class="anchor"></div>
+    <div id="console"></div>
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/scroll-anchoring/heuristic-renabled-after-delay-expected.txt
+++ b/LayoutTests/fast/scrolling/scroll-anchoring/heuristic-renabled-after-delay-expected.txt
@@ -1,0 +1,12 @@
+
+Testing anchoring with 11 of size 10 - expect anchoring false
+PASS anchoringActive is false
+
+Waiting for just over 3s
+
+Testing anchoring with 3 of size 10 - expect anchoring true
+PASS anchoringActive is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/scroll-anchoring/heuristic-renabled-after-delay.html
+++ b/LayoutTests/fast/scrolling/scroll-anchoring/heuristic-renabled-after-delay.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {
+            height: 5000px;
+        }
+        
+        .changer {
+            background-color: cyan;
+            width: 200px;
+            height: 200px;
+        }
+
+        .anchor {
+            background-color: green;
+            width: 200px;
+            height: 200px;
+        }
+            
+    </style>
+    <script src="../../../resources/js-test.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script src="resources/scroll-anchoring-utils.js"></script>
+    <script>
+        jsTestIsAsync = true;
+        
+        async function doAdjustments(numAdjustments, amount, expectAnchoring)
+        {
+            const changer = document.querySelector('.changer');
+            
+            window.scrollTo(0, 250);
+            
+            for (let i = 0; i < numAdjustments - 1; ++i) {
+                toggleHeight(changer, amount);
+                await UIHelper.renderingUpdate();
+            }
+
+            // Test whether anchoring is active on the last one.
+            const currentScrollY = window.scrollY;
+            const adjustment = toggleHeight(changer, amount);
+            anchoringActive = window.scrollY === (currentScrollY + adjustment);
+
+            if (expectAnchoring)
+                shouldBeTrue('anchoringActive');
+            else
+                shouldBeFalse('anchoringActive');
+        }
+
+        window.addEventListener('load', async () => {
+            await UIHelper.delayFor(0);
+
+            const amount = 10;
+            let iterations = 11;
+            let expectAnchor = false;
+            debug(`\nTesting anchoring with ${iterations} of size ${amount} - expect anchoring ${expectAnchor}`);
+            await doAdjustments(iterations, amount, expectAnchor);
+
+            window.scrollTo(0, 0);
+            
+            debug(`\nWaiting for just over 3s`);
+            await UIHelper.delayFor(3050);
+
+            iterations = 3;
+            expectAnchor = true;
+            debug(`\nTesting anchoring with ${iterations} of size ${amount} - expect anchoring ${expectAnchor}`);
+            await doAdjustments(iterations, amount, expectAnchor);
+
+            finishJSTest();
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="changer"></div>
+    <div class="anchor"></div>
+    <div id="console"></div>
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/scroll-anchoring/resources/scroll-anchoring-utils.js
+++ b/LayoutTests/fast/scrolling/scroll-anchoring/resources/scroll-anchoring-utils.js
@@ -1,0 +1,10 @@
+const baseHeight = 200;
+let curHeight = baseHeight;
+
+function toggleHeight(element, amount)
+{
+    const oldHeight = curHeight;
+    curHeight = (curHeight === baseHeight) ? curHeight + amount : baseHeight;
+    element.style.height = `${curHeight}px`;
+    return curHeight - oldHeight;
+}

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7644,6 +7644,9 @@ imported/w3c/web-platform-tests/css/css-scroll-anchoring/zero-scroll-offset-002.
 webkit.org/b/309421 imported/w3c/web-platform-tests/css/css-scroll-anchoring/vertical-rl-viewport-size-change-000.html [ ImageOnlyFailure ]
 webkit.org/b/309421 imported/w3c/web-platform-tests/css/css-scroll-anchoring/vertical-rl-viewport-size-change-001.html [ ImageOnlyFailure ]
 
+webkit.org/b/311235 fast/scrolling/scroll-anchoring/heuristic-disabled-above-threshold.html [ Pass Failure ]
+webkit.org/b/311235 fast/scrolling/scroll-anchoring/heuristic-renabled-after-delay.html [ Failure ]
+
 # Requires user interaction.
 imported/w3c/web-platform-tests/css/css-scroll-anchoring/fullscreen-crash.html [ Skip ]
 

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
@@ -119,6 +119,10 @@ void ScrollAnchoringController::scrollPositionDidChange()
         return;
 
     LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController::scrollPositionChanged() to " << m_owningScrollableArea->scrollPosition() << " - clearing scroll anchor");
+
+    if (m_owningScrollableArea->currentScrollType() == ScrollType::User)
+        m_disablementHeuristic.reset();
+
     clearAnchor();
     updateScrollableAreaRegistration();
 }
@@ -643,8 +647,16 @@ void ScrollAnchoringController::adjustScrollPositionForAnchoring()
     if (roundedAdjustment.isZero())
         return;
 
+    roundedAdjustment = constrainedToBlockDirection(roundedAdjustment, scrollerBox->writingMode());
+
+    if (m_disablementHeuristic.disabledByHeuristic(roundedAdjustment)) {
+        RELEASE_LOG(ScrollAnchoring, "ScrollAnchoringController::adjustScrollPositionForAnchoring() is main frame: %d, is main scroller: %d, adjustment (%.2f, %.2f) disabled by heuristic",  frameView().frame().isMainFrame(), !m_owningScrollableArea->isRenderLayer(), adjustment.width(), adjustment.height());
+        return;
+    }
+
     auto currentPosition = m_owningScrollableArea->scrollPosition();
-    auto newScrollPosition = currentPosition + constrainedToBlockDirection(roundedAdjustment, scrollerBox->writingMode());
+    auto newScrollPosition = currentPosition + roundedAdjustment;
+
     RELEASE_LOG(ScrollAnchoring, "ScrollAnchoringController::adjustScrollPositionForAnchoring() is main frame: %d, is main scroller: %d, adjusting from (%d, %d) to (%d, %d)",  frameView().frame().isMainFrame(), !m_owningScrollableArea->isRenderLayer(), currentPosition.x(), currentPosition.y(), newScrollPosition.x(), newScrollPosition.y());
     LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController " << this << " adjustScrollPositionForAnchoring() for scroller element: " << ValueOrNull(scrollableAreaBox()) << " anchor: " << *m_anchorObject << " adjusting from " << currentPosition << " to " << newScrollPosition);
 
@@ -680,6 +692,66 @@ void ScrollAnchoringController::stopSuppressingScrollAnchoring()
 {
     ASSERT(m_suppressionCount);
     --m_suppressionCount;
+}
+
+bool ScrollAnchoringController::DisablementHeuristic::disabledByHeuristic(IntSize adjustment)
+{
+    auto now = ApproximateTime::now();
+
+    if (m_nextEnablementTime && now < *m_nextEnablementTime) {
+        LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController::DisablementHeuristic - currently disabled");
+        return true;
+    }
+
+    auto nonZeroAxis = [](IntSize adjustment) {
+        if (adjustment.height())
+            return adjustment.height();
+        return adjustment.width();
+    };
+
+    if (!m_samplingStartTime) {
+        m_samplingStartTime = now;
+        m_accumulatedAdjustment = nonZeroAxis(adjustment);
+        m_samplingAdjustmentCount = 1;
+        return false;
+    }
+
+    ++m_samplingAdjustmentCount;
+    m_accumulatedAdjustment += nonZeroAxis(adjustment);
+
+    // This is designed to detect feedback between scroll anchoring and content changes that trigger scroll position oscillations,
+    // so look for adjustments that happen within a few frames that have cumulative small delta. Try to re-enable after 3s.
+    static constexpr unsigned maxAdjustments = 10;
+    static constexpr auto samplingDuration = 350_ms;
+    static constexpr auto reenablementDelay = 3_s;
+    static constexpr float meanAdjustmentMax = 2.0f;
+    auto timeSinceSamplingStart = now - *m_samplingStartTime;
+
+    if (timeSinceSamplingStart < samplingDuration) {
+        if (m_samplingAdjustmentCount < maxAdjustments)
+            return false;
+
+        auto meanAdjustment = std::abs(m_accumulatedAdjustment / m_samplingAdjustmentCount);
+        if (meanAdjustment > meanAdjustmentMax)
+            return false;
+
+        LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController::DisablementHeuristic - suppressing anchoring because " << m_samplingAdjustmentCount << " adjustments in the last " << timeSinceSamplingStart << " with mean adjustment " << meanAdjustment << ". Trying again in " << reenablementDelay);
+        reset();
+        m_nextEnablementTime = now + reenablementDelay;
+        return true;
+    }
+
+    reset();
+    return false;
+}
+
+void ScrollAnchoringController::DisablementHeuristic::reset()
+{
+    LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController::DisablementHeuristic - reset");
+    m_nextEnablementTime = { };
+    m_samplingStartTime = { };
+    m_accumulatedAdjustment = 0;
+    m_samplingAdjustmentCount = 0;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.h
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.h
@@ -27,7 +27,9 @@
 
 #include "FloatRect.h"
 #include "ScrollTypes.h"
+#include <wtf/ApproximateTime.h>
 #include <wtf/CheckedRef.h>
+#include <wtf/Markable.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
@@ -80,6 +82,20 @@ public:
     void NODELETE stopSuppressingScrollAnchoring();
 
 private:
+
+    class DisablementHeuristic {
+    public:
+        bool disabledByHeuristic(IntSize adjustment);
+        void reset();
+
+    private:
+        Markable<ApproximateTime> m_nextEnablementTime;
+
+        Markable<ApproximateTime> m_samplingStartTime;
+        float m_accumulatedAdjustment { 0 };
+        unsigned m_samplingAdjustmentCount { 0 };
+    };
+
     static bool isViableStatus(AnchorSearchStatus status)
     {
         return status == AnchorSearchStatus::Constrain || status == AnchorSearchStatus::Choose;
@@ -114,6 +130,8 @@ private:
     CheckedRef<ScrollableArea> m_owningScrollableArea;
     SingleThreadWeakPtr<RenderObject> m_anchorObject;
     FloatPoint m_lastAnchorOffset;
+
+    DisablementHeuristic m_disablementHeuristic;
 
     bool m_isUpdatingScrollPositionForAnchoring { false };
     bool m_isQueuedForScrollPositionUpdate { false };


### PR DESCRIPTION
#### e1f2eaabdb5cd246aee4a328b8a81cbbe0043662
<pre>
[Scroll anchoring] Add a heuristic that disables scroll anchoring for frequent adjustments
<a href="https://bugs.webkit.org/show_bug.cgi?id=311227">https://bugs.webkit.org/show_bug.cgi?id=311227</a>
<a href="https://rdar.apple.com/173680821">rdar://173680821</a>

Reviewed by Abrar Rahman Protyasha.

Some sites (e.g. depop.com, linkedin.com) suffer from scroll position oscillations triggered by scroll anchoring.
Such issues are easy to cause by accident by combining scroll position observation (e.g. via window.scrollY
or Intersection Observer) and content changes. Gecko has a heuristic to disable anchoring in cases like this,
so do something similar.

The goal here is to detect oscillations triggered by circular dependencies between anchoring scrolls
and content changes, which will generally show up with a single frame delay, but I allowed for about
two frames per update to account for slower web content, so I decided that 10 adjustments in 350ms
is the threshold above which anchoring will be temporarily disabled. It will re-enable after 3s.
A user scroll will also re-enable it. The heuristic also computes the sum of the cumulative adjustments,
looking for a small mean adjustment (since this indicates an oscillation between two states).

webkit.org/b/311235 needs to be fixed before all the tests pass on iOS.

Tests: fast/scrolling/scroll-anchoring/heuristic-disabled-above-threshold.html
       fast/scrolling/scroll-anchoring/heuristic-enabled-below-threshold.html
       fast/scrolling/scroll-anchoring/heuristic-renabled-after-delay.html

* LayoutTests/fast/scrolling/scroll-anchoring/heuristic-disabled-above-threshold-expected.txt: Added.
* LayoutTests/fast/scrolling/scroll-anchoring/heuristic-disabled-above-threshold-in-overflow-expected.txt: Added.
* LayoutTests/fast/scrolling/scroll-anchoring/heuristic-disabled-above-threshold-in-overflow.html: Added.
* LayoutTests/fast/scrolling/scroll-anchoring/heuristic-disabled-above-threshold.html: Added.
* LayoutTests/fast/scrolling/scroll-anchoring/heuristic-enabled-below-threshold-expected.txt: Added.
* LayoutTests/fast/scrolling/scroll-anchoring/heuristic-enabled-below-threshold.html: Added.
* LayoutTests/fast/scrolling/scroll-anchoring/heuristic-enabled-large-cumulative-adjustment-expected.txt: Added.
* LayoutTests/fast/scrolling/scroll-anchoring/heuristic-enabled-large-cumulative-adjustment.html: Added.
* LayoutTests/fast/scrolling/scroll-anchoring/heuristic-renabled-after-delay-expected.txt: Added.
* LayoutTests/fast/scrolling/scroll-anchoring/heuristic-renabled-after-delay.html: Added.
* LayoutTests/fast/scrolling/scroll-anchoring/resources/scroll-anchoring-utils.js: Added.
(toggleHeight):
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/page/scrolling/ScrollAnchoringController.cpp:
(WebCore::ScrollAnchoringController::scrollPositionDidChange):
(WebCore::ScrollAnchoringController::adjustScrollPositionForAnchoring):
(WebCore::ScrollAnchoringController::DisablementHeuristic::disabledByHeuristic):
(WebCore::ScrollAnchoringController::DisablementHeuristic::reset):
* Source/WebCore/page/scrolling/ScrollAnchoringController.h:

Canonical link: <a href="https://commits.webkit.org/310545@main">https://commits.webkit.org/310545@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97b52e4bafdddc1da45eff165af154ce894d9f07

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154144 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27401 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20562 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162898 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/107612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9e0acca5-6db3-4391-8279-273a01a9b81c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156017 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27534 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27252 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119218 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/107612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/319a1689-b271-49c7-abc0-c3d1354354b0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157103 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21466 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138427 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99914 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a1c21e6d-fa26-462b-8b47-189cdaa9f4c6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20554 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18552 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10730 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130216 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16272 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165370 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8579 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17880 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127311 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26948 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22594 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127457 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34582 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26872 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138065 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83465 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22335 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14857 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26562 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90664 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26143 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26374 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26215 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->