### PR TITLE
REGRESSION(309729@main): TestWebKitAPI.ObscuredContentInsets.TopOverhangColorExtensionLayer* is flakily failing

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ObscuredContentInsets.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ObscuredContentInsets.mm
@@ -41,9 +41,43 @@
 #import <WebKit/WKWebViewConfigurationPrivate.h>
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/WKWebViewPrivateForTesting.h>
+#import <wtf/Function.h>
 #import <wtf/RetainPtr.h>
 
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+
+@interface FixedContentColorObserver : NSObject
+- (instancetype)initWithWebView:(WKWebView *)webView callback:(Function<void()>&&)callback;
+@end
+
+@implementation FixedContentColorObserver {
+    RetainPtr<NSObject> _observable;
+    Function<void()> _callback;
+}
+
+- (instancetype)initWithWebView:(WKWebView *)webView callback:(Function<void()>&&)callback
+{
+    if (!(self = [super init]))
+        return nil;
+
+    _observable = webView;
+    _callback = WTF::move(callback);
+    [_observable addObserver:self forKeyPath:@"_sampledTopFixedPositionContentColor" options:0 context:nil];
+    return self;
+}
+
+- (void)dealloc
+{
+    [_observable removeObserver:self forKeyPath:@"_sampledTopFixedPositionContentColor" context:nullptr];
+    [super dealloc];
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
+{
+    _callback();
+}
+
+@end
 
 @interface TopScrollPocketObserver : NSObject
 @property (nonatomic, readonly) NSUInteger changeCount;
@@ -444,7 +478,16 @@ TEST(ObscuredContentInsets, TopOverhangColorExtensionLayerAppearsImmediatelyAfte
     [webView setObscuredContentInsets:NSEdgeInsetsMake(100, 0, 0, 0)];
     [webView waitForNextPresentationUpdate];
 
-    [webView synchronouslyLoadTestPageNamed:@"top-fixed-element"];
+    {
+        bool colorArrived = false;
+        RetainPtr observer = adoptNS([[FixedContentColorObserver alloc] initWithWebView:webView.get() callback:[&] {
+            colorArrived = true;
+        }]);
+
+        [webView synchronouslyLoadTestPageNamed:@"top-fixed-element"];
+        Util::run(&colorArrived);
+    }
+
     [webView waitForNextPresentationUpdate];
 
     RetainPtr layerBeforeReload = [webView firstLayerWithNameContaining:@"top overhang"];
@@ -456,17 +499,21 @@ TEST(ObscuredContentInsets, TopOverhangColorExtensionLayerAppearsImmediatelyAfte
     RetainPtr actualColorBeforeReload = [NSColor colorWithCGColor:[layerBeforeReload backgroundColor]];
     EXPECT_TRUE(Util::compareColors(actualColorBeforeReload, expectedColor.get()));
 
-    __block bool layerChecked = false;
-    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
-    [navigationDelegate setDidCommitNavigation:^(WKWebView *view, WKNavigation *) {
-        [view _doAfterNextPresentationUpdate:^{
-            layerChecked = true;
+    {
+        __block bool navigationCommitted = false;
+        RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+        [navigationDelegate setDidCommitNavigation:^(WKWebView *view, WKNavigation *) {
+            [view _doAfterNextPresentationUpdate:^{
+                navigationCommitted = true;
+            }];
         }];
-    }];
-    [webView setNavigationDelegate:navigationDelegate.get()];
+        [webView setNavigationDelegate:navigationDelegate.get()];
 
-    [webView reload];
-    Util::run(&layerChecked);
+        [webView reload];
+        Util::run(&navigationCommitted);
+    }
+
+    [webView waitForNextPresentationUpdate];
 
     RetainPtr layerAfterReload = [webView firstLayerWithNameContaining:@"top overhang"];
     EXPECT_NOT_NULL(layerAfterReload.get());
@@ -484,7 +531,16 @@ TEST(ObscuredContentInsets, TopOverhangColorExtensionLayerRemovedQuicklyAfterNav
     [webView setObscuredContentInsets:NSEdgeInsetsMake(100, 0, 0, 0)];
     [webView waitForNextPresentationUpdate];
 
-    [webView synchronouslyLoadTestPageNamed:@"top-fixed-element"];
+    {
+        bool colorArrived = false;
+        RetainPtr observer = adoptNS([[FixedContentColorObserver alloc] initWithWebView:webView.get() callback:[&] {
+            colorArrived = true;
+        }]);
+
+        [webView synchronouslyLoadTestPageNamed:@"top-fixed-element"];
+        Util::run(&colorArrived);
+    }
+
     [webView waitForNextPresentationUpdate];
 
     EXPECT_NOT_NULL([webView firstLayerWithNameContaining:@"top overhang"]);


### PR DESCRIPTION
#### 87e07b5f024a4aceac3975792d3c6b5a5d4e1944
<pre>
REGRESSION(<a href="https://commits.webkit.org/309729@main">309729@main</a>): TestWebKitAPI.ObscuredContentInsets.TopOverhangColorExtensionLayer* is flakily failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=311145">https://bugs.webkit.org/show_bug.cgi?id=311145</a>
<a href="https://rdar.apple.com/173732239">rdar://173732239</a>

Reviewed by NOBODY (OOPS!).

Handle race condition between the dispatch and processing of an IPC message.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/ObscuredContentInsets.mm:
(-[FixedContentColorObserver initWithWebView:callback:]):
(-[FixedContentColorObserver dealloc]):
(-[FixedContentColorObserver observeValueForKeyPath:ofObject:change:context:]):
(TestWebKitAPI::TEST(ObscuredContentInsets, TopOverhangColorExtensionLayerAppearsImmediatelyAfterReload)):
(TestWebKitAPI::TEST(ObscuredContentInsets, TopOverhangColorExtensionLayerRemovedQuicklyAfterNavigatingToPageWithoutFixedHeader)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87e07b5f024a4aceac3975792d3c6b5a5d4e1944

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153661 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26445 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20062 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162411 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107119 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b0f83e54-30a2-49f9-9190-8473e7e8f43e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155534 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26973 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26767 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118802 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84041 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5d9cb92b-c409-49a7-8d15-d41fb92fb5c1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156620 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21065 "Found 1 new test failure: accessibility/opacity-0-bounding-box.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137962 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99513 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b09f808a-2359-4f4f-9075-8d680b3ebb11) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20144 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18087 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10244 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129793 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15821 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164882 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17415 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126879 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26242 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22119 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127045 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26244 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137616 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82921 "Built successfully") | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23665 "") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21959 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14398 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25861 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25552 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25712 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25612 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->