### PR TITLE
[AutoFill Debugging] Make text extraction more streamlined (list items and shortened URLs)

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt
@@ -3,10 +3,8 @@ root
         aria-label='Main Page Title','Welcome to Test Page',[…]
     navigation,role='navigation',aria-label='Main navigation'
         list
-            list-item
-                link,uid=…,events=click,url='mailto:wenson_hsieh@apple.com','Section 1',[…]
-            list-item
-                link,uid=…,events=click,url='https://example.com/','Section 2',[…]
+            link,uid=…,events=click,url='mailto:wenson_hsieh@apple.com','Section 1',[…]
+            link,uid=…,events=click,url='https://example.com/','Section 2',[…]
     role='main'
         section,aria-label='Interactive Elements'
             button,uid=…,events=click,aria-describedby='This button does nothing',aria-label='Test button','Click Me',[…]
@@ -31,10 +29,8 @@ root
             role='complementary',aria-label='Related information'
                 'Related Links',[…]
                 list
-                    list-item
-                        link,uid=…,url='https://webkit.org/','Example Link',[…]
-                    list-item
-                        link,uid=…,url='https://apple.com/','Test Link',[…]
+                    link,uid=…,url='https://webkit.org/','Example Link',[…]
+                    link,uid=…,url='https://apple.com/','Test Link',[…]
             role='region'
                 role='status','Ready',[…]
                 button,uid=…,events=click,'Update Status',[…]

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-expected.txt
@@ -5,10 +5,8 @@ root
         aria-label='Main Page Title','Welcome to Test Page'
     navigation,role='navigation',aria-label='Main navigation'
         list
-            list-item
-                link,'Section 1'
-            list-item
-                link,'Section 2'
+            link,'Section 1'
+            link,'Section 2'
     role='main'
         section,aria-label='Interactive Elements'
             button,aria-describedby='This button does nothing',aria-label='Test button','Click Me'
@@ -23,10 +21,8 @@ root
             role='complementary',aria-label='Related information'
                 'Related Links'
                 list
-                    list-item
-                        link,'Example Link'
-                    list-item
-                        link,'Test Link'
+                    link,'Example Link'
+                    link,'Test Link'
             role='region'
                 role='status','Ready'
                 button,'Update Status'

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-discretionary-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-discretionary-expected.txt
@@ -2,10 +2,8 @@ root
     'Welcome to Test Page'
     navigation
         list
-            list-item
-                link,'Section 1'
-            list-item
-                link,'Section 2'
+            link,'Section 1'
+            link,'Section 2'
     'Here’s to the crazy ones. The misfits. The rebels. The troublemakers. The round pegs in the square holes. The ones who see things differently. They’re not fond of rules. And they have no respect for the status quo.'
     section
         button,'Click Me'
@@ -19,10 +17,8 @@ root
             'This is some article content with highlighted text.'
         'Related Links'
         list
-            list-item
-                link,'Example Link'
-            list-item
-                link,'Test Link'
+            link,'Example Link'
+            link,'Test Link'
         'Ready'
         button,'Update Status'
     'The quick brown fox jumped over the lazy dog.'

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-expected.txt
@@ -2,10 +2,8 @@ root
     'Welcome to Test Page'
     navigation
         list
-            list-item
-                link,'Section 1'
-            list-item
-                link,'Section 2'
+            link,'Section 1'
+            link,'Section 2'
     'Here’s to the crazy ones…'
     section
         button,'Click Me'
@@ -19,10 +17,8 @@ root
             'This is some article content…'
         'Related Links'
         list
-            list-item
-                link,'Example Link'
-            list-item
-                link,'Test Link'
+            link,'Example Link'
+            link,'Test Link'
         'Ready'
         button,'Update Status'
     'The quick brown fox jumped…'

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-sanitization-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-sanitization-expected.txt
@@ -20,9 +20,9 @@ root
 	'WordJoinerTest'
 	'BOMTest'
 	list
-		list-item,'First item'
-		list-item,'Second item'
-		list-item,'Third item'
+		'First item'
+		'Second item'
+		'Third item'
 	'Repeated text'
 	'Different text'
 

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
@@ -744,11 +744,17 @@ private:
             if (!shortenURLs())
                 return url.string();
 
+            auto stringToShorten = shortenedString;
+            if (!m_options.topHostName.isEmpty() && stringToShorten.startsWithIgnoringASCIICase(m_options.topHostName)) {
+                auto rest = stringToShorten.substring(m_options.topHostName.length());
+                stringToShorten = rest.isEmpty() ? "/"_s : rest;
+            }
+
             RefPtr cache = m_options.urlCache;
             if (!cache)
-                return shortenedString;
+                return stringToShorten;
 
-            auto result = cache->add(shortenedString, url, type);
+            auto result = cache->add(stringToShorten, url, type);
             if (!result.isEmpty())
                 m_shortenedURLStrings.append(result);
 
@@ -1642,6 +1648,11 @@ static void addTextRepresentationRecursive(const TextExtraction::Item& item, std
         if (isStrikethrough)
             aggregator.popStrikethrough();
     });
+
+    if (aggregator.useTextTreeOutput() && containerType == TextExtraction::ContainerType::ListItem && item.children.size() == 1 && !item.nodeIdentifier) {
+        addTextRepresentationRecursive(item.children[0], std::optional { identifier }, depth, aggregator, hasAdjacentLinkAfter);
+        return;
+    }
 
     bool omitChildTextNode = [&] {
         if (aggregator.useMarkdownOutput())

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.h
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.h
@@ -80,10 +80,11 @@ struct TextExtractionOptions {
         , flags(other.flags)
         , outputFormat(other.outputFormat)
         , urlCache(WTF::move(other.urlCache))
+        , topHostName(WTF::move(other.topHostName))
     {
     }
 
-    TextExtractionOptions(WebCore::FrameIdentifier&& mainFrameIdentifier, Vector<TextExtractionFilterCallback>&& filters, Vector<String>&& items, HashMap<String, String>&& replacementStrings, std::optional<TextExtractionVersion> version, TextExtractionOptionFlags flags, TextExtractionOutputFormat outputFormat, TextExtractionURLCache* urlCache = nullptr, std::optional<uint64_t> maxWordsPerParagraph = std::nullopt)
+    TextExtractionOptions(WebCore::FrameIdentifier&& mainFrameIdentifier, Vector<TextExtractionFilterCallback>&& filters, Vector<String>&& items, HashMap<String, String>&& replacementStrings, std::optional<TextExtractionVersion> version, TextExtractionOptionFlags flags, TextExtractionOutputFormat outputFormat, TextExtractionURLCache* urlCache = nullptr, std::optional<uint64_t> maxWordsPerParagraph = std::nullopt, String&& topHostName = { })
         : mainFrameIdentifier(WTF::move(mainFrameIdentifier))
         , filterCallbacks(WTF::move(filters))
         , nativeMenuItems(WTF::move(items))
@@ -93,6 +94,7 @@ struct TextExtractionOptions {
         , flags(flags)
         , outputFormat(outputFormat)
         , urlCache(urlCache)
+        , topHostName(WTF::move(topHostName))
     {
     }
 
@@ -105,6 +107,7 @@ struct TextExtractionOptions {
     TextExtractionOptionFlags flags;
     TextExtractionOutputFormat outputFormat { TextExtractionOutputFormat::TextTree };
     RefPtr<TextExtractionURLCache> urlCache;
+    String topHostName;
 };
 
 struct TextExtractionResult {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -7017,7 +7017,8 @@ static RetainPtr<_WKTextExtractionResult> createEmptyTextExtractionResult()
         version,
         replacementStrings = extractReplacementStrings(configuration),
         outputFormat = textExtractionOutputFormat(configuration),
-        endTextExtractionScope = WTF::move(endTextExtractionScope)
+        endTextExtractionScope = WTF::move(endTextExtractionScope),
+        topHostName = URL { _page->pageLoadState().activeURL() }.host().toString()
     ](auto&& result) mutable {
         RetainPtr strongSelf = weakSelf.get();
         if (!strongSelf)
@@ -7118,6 +7119,7 @@ static RetainPtr<_WKTextExtractionResult> createEmptyTextExtractionResult()
             outputFormat,
             urlCache.get(),
             WTF::move(maxWordsPerParagraph),
+            WTF::move(topHostName),
         };
         WebKit::convertToText(WTF::move(result->rootItem), WTF::move(options), [weakSelf, startTime, urlCache, completionHandler = WTF::move(completionHandler), endTextExtractionScope = WTF::move(endTextExtractionScope)](auto&& result) {
             RetainPtr strongSelf = weakSelf.get();

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm
@@ -1334,4 +1334,32 @@ TEST(TextExtractionTests, ClickInteractionWithExtractionContext)
     EXPECT_WK_STREQ("original", [webView stringByEvaluatingJavaScript:@"document.getElementById('result').textContent"]);
 }
 
+TEST(TextExtractionTests, ShortenURLsWithTopHostName)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:^{
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        [[configuration preferences] _setTextExtractionEnabled:YES];
+        return configuration.autorelease();
+    }()]);
+
+    RetainPtr markup = @"<!DOCTYPE html>"
+        "<html><body>"
+        "    <a href=\"https://webkit.org/blog/post\">Same-host link</a>"
+        "    <a href=\"https://webkit.org\">Root link</a>"
+        "    <a href=\"https://example.com/other\">Cross-host link</a>"
+        "</body></html>";
+    [webView synchronouslyLoadHTMLString:markup.get() baseURL:[NSURL URLWithString:@"http://webkit.org"]];
+
+    RetainPtr debugText = [webView synchronouslyGetDebugText:^{
+        RetainPtr configuration = adoptNS([_WKTextExtractionConfiguration new]);
+        [configuration setIncludeURLs:YES];
+        [configuration setShortenURLs:YES];
+        return configuration.autorelease();
+    }()];
+
+    EXPECT_TRUE([debugText containsString:@"url='/blog/post'"]);
+    EXPECT_TRUE([debugText containsString:@"url='/'"]);
+    EXPECT_TRUE([debugText containsString:@"example.com/other"]);
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 51ba057f023184ecc1938997575852b558269544
<pre>
[AutoFill Debugging] Make text extraction more streamlined (list items and shortened URLs)
<a href="https://bugs.webkit.org/show_bug.cgi?id=311240">https://bugs.webkit.org/show_bug.cgi?id=311240</a>
<a href="https://rdar.apple.com/problem/173832204">rdar://problem/173832204</a>

Reviewed by Abrar Rahman Protyasha.

Make two small tweaks to further streamline text extraction output:

1.  When URL shortening is enabled, if the shortened URL host matches the current top URL host, omit
    that part from the extraction results.

2.  Skip list items that only contain a single child element.

Test: TextExtractionTests.ShortenURLsWithTopHostName

* LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-discretionary-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-sanitization-expected.txt:

Rebaseline various layout tests.

* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::TextExtractionAggregator::stringForURL):
(WebKit::addTextRepresentationRecursive):
* Source/WebKit/Shared/TextExtractionToStringConversion.h:
(WebKit::TextExtractionOptions::TextExtractionOptions):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _extractDebugTextWithConfigurationWithoutUpdatingFilterRules:assertionScope:completionHandler:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm:
(TestWebKitAPI::(TextExtractionTests, ShortenURLsWithTopHostName)):

Canonical link: <a href="https://commits.webkit.org/310368@main">https://commits.webkit.org/310368@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf2215edd6bf2aca19d1a7cfa1182ea88e88e1f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153597 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26381 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19998 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162347 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107055 "An unexpected error occured. Recent messages:Printed configuration") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155470 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26909 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26703 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118748 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/107055 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a1f9c1c5-e96f-4e9e-9baf-ae44d433a240) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156556 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21005 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/137905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99459 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/05c23a8f-65d8-4214-9949-22e33f857892) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20084 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18023 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10180 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129731 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15765 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164818 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7952 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17359 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126823 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26178 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22059 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126987 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34448 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26180 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137560 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82848 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21902 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14341 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25797 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90084 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25488 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25648 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25548 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->