### PR TITLE
[YARR] Fixed-count mixed-width character class should restore index on backtrack

### DIFF
--- a/JSTests/stress/regexp-unicode-mixed-width-charclass-fixed-count-backtrack.js
+++ b/JSTests/stress/regexp-unicode-mixed-width-charclass-fixed-count-backtrack.js
@@ -1,0 +1,61 @@
+function shouldBeArray(actual, expected, msg) {
+    if (actual === null || expected === null) {
+        if (actual !== expected)
+            throw new Error(`FAIL: ${msg}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+        return;
+    }
+    if (actual.length !== expected.length)
+        throw new Error(`FAIL: ${msg}: length mismatch: expected ${expected.length}, got ${actual.length}`);
+    for (let i = 0; i < expected.length; i++) {
+        if (actual[i] !== expected[i])
+            throw new Error(`FAIL: ${msg}: index ${i}: expected ${JSON.stringify(expected[i])}, got ${JSON.stringify(actual[i])}`);
+    }
+}
+
+let np = "\u{10000}"; // U+10000 (non-BMP, 2 code units)
+let emoji = "\u{1F600}";
+
+for (let i = 0; i < testLoopCount; i++) {
+    // Backtrack from in-loop failure: index advanced for surrogates, then class fails
+    shouldBeArray(/[a\u{10000}]{2}Z|./u.exec(np + np + "X"), [np], "{2} 2x non-BMP, fail at Z, alt2 dot");
+    shouldBeArray(/[a\u{10000}]{3}Z|b/u.exec("a" + np + "Xb"), ["b"], "{3} BMP+non-BMP, fail in loop, alt2 char");
+    shouldBeArray(/[a\u{10000}]{2}Z|\u{10000}a/u.exec(np + "aXY"), [np + "a"], "{2} non-BMP+BMP, fail at Z, alt2 seq");
+    shouldBeArray(/[a\u{10000}]{3}|./u.exec(np + "aXY"), [np], "{3} non-BMP+BMP, fail in loop (count 2/3), alt2 dot");
+    shouldBeArray(/[a\u{10000}]{2}Z|X/u.exec("aaX"), ["X"], "{2} all-BMP, fail at Z, alt2 (sanity: index unchanged)");
+    shouldBeArray(/[a\u{10000}]{2}Z|\u{10000}\u{10000}/u.exec(np + np + "X"), [np + np], "{2} 2x non-BMP, fail at Z, alt2 same");
+
+    // Backtrack from following-term failure: full {n} matched, index advanced, then trailing fails
+    shouldBeArray(/[a\u{10000}]{2}Z|a\u{10000}/u.exec("a" + np + "X"), ["a" + np], "{2} matched, Z fails, alt2 prefix");
+    shouldBeArray(/[a\u{10000}]{3}Q|\u{10000}{2}/u.exec(np + np + np + "X"), [np + np], "{3} 3x non-BMP matched, Q fails, alt2");
+
+    // Inverted class (also takes mixed-width else branch)
+    shouldBeArray(/[^b]{2}Z|./u.exec(np + np + "X"), [np], "{2} inverted 2x non-BMP, fail at Z, alt2 dot");
+    shouldBeArray(/[^b]{2}Z|\u{10000}a/u.exec(np + "aX"), [np + "a"], "{2} inverted non-BMP+BMP, fail at Z, alt2");
+
+    // /v flag
+    shouldBeArray(/[a\u{10000}]{2}Z|./v.exec(np + np + "X"), [np], "{2} 2x non-BMP /v, fail at Z, alt2 dot");
+
+    // Multiple surrogates in {n} (cumulative index drift)
+    shouldBeArray(/[a\u{10000}]{4}Z|./u.exec(np + np + np + np + "X"), [np], "{4} 4x non-BMP (drift+4), fail at Z, alt2 dot");
+    shouldBeArray(/[a\u{10000}]{4}Z|\u{10000}{4}/u.exec(np + np + np + np + "X"), [np + np + np + np], "{4} 4x non-BMP, fail, alt2 4x");
+
+    // Mixed BMP and non-BMP in same {n} (partial drift)
+    shouldBeArray(/[a\u{10000}]{4}Z|./u.exec("a" + np + "a" + np + "X"), ["a"], "{4} BMP-nonBMP-BMP-nonBMP (drift+2), fail, alt2 dot");
+
+    // Short input: jumpIfNoAvailableInput fires before loop (storeToFrame must precede jump)
+    shouldBeArray(/[a\u{10000}]{2}Z|x/u.exec(""), null, "{2} empty input (jump fires before loop)");
+    shouldBeArray(/[a\u{10000}]{2}Z|x/u.exec("x"), ["x"], "{2} 1-unit input (jump fires before loop)");
+
+    // Capture group around the term
+    shouldBeArray(/([a\u{10000}]{2})Z|(.)/u.exec(np + np + "X"), [np, undefined, np], "{2} capture, fail at Z, alt2 dot");
+
+    // Positive cases: should still match
+    shouldBeArray(/[a\u{10000}]{2}Z/u.exec(np + np + "Z"), [np + np + "Z"], "{2} 2x non-BMP + Z (positive)");
+    shouldBeArray(/[a\u{10000}]{3}/u.exec("a" + np + "a"), ["a" + np + "a"], "{3} mixed (positive)");
+    shouldBeArray(/[a\u{10000}]{2}/u.exec(np + "a"), [np + "a"], "{2} non-BMP+BMP (positive)");
+    shouldBeArray(/[^b]{3}Z/u.exec(np + np + np + "Z"), [np + np + np + "Z"], "{3} inverted 3x non-BMP + Z (positive)");
+
+    // Fixed-width class control: hasOnlyNonBMP, no index drift, should still work
+    shouldBeArray(/[\u{1F600}-\u{1F64F}]{2}Z|./u.exec(emoji + emoji + "X"), [emoji], "{2} fixed-width non-BMP-only, fail at Z, alt2 (control)");
+    shouldBeArray(/[\u{1F600}-\u{1F64F}]{2}Z/u.exec(emoji + emoji + "Z"), [emoji + emoji + "Z"], "{2} fixed-width non-BMP-only + Z (positive control)");
+}

--- a/Source/JavaScriptCore/yarr/Yarr.h
+++ b/Source/JavaScriptCore/yarr/Yarr.h
@@ -34,7 +34,7 @@
 namespace JSC { namespace Yarr {
 
 #define YarrStackSpaceForBackTrackInfoPatternCharacter 2 // Only for !fixed quantifiers.
-#define YarrStackSpaceForBackTrackInfoCharacterClass 2 // Only for !fixed quantifiers.
+#define YarrStackSpaceForBackTrackInfoCharacterClass 2 // Greedy/NonGreedy, or FixedCount with unicode/unicodeSets flag.
 #define YarrStackSpaceForBackTrackInfoBackReference 3
 #define YarrStackSpaceForBackTrackInfoAlternative 1 // One per alternative.
 #define YarrStackSpaceForBackTrackInfoParentheticalAssertion 1

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -2970,8 +2970,11 @@ class YarrGenerator final : public YarrJITInfo {
 
         MacroAssembler::JumpList done;
 
-        if (m_decodeSurrogatePairs)
+        if (m_decodeSurrogatePairs) {
+            if (!term->isFixedWidthCharacterClass())
+                storeToFrame(m_regs.index, term->frameLocation + BackTrackInfoCharacterClass::beginIndex());
             op.m_jumps.append(jumpIfNoAvailableInput());
+        }
 
         Checked<unsigned> scaledMaxCount = term->quantityMaxCount;
 #if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
@@ -3020,6 +3023,19 @@ class YarrGenerator final : public YarrJITInfo {
 
     void backtrackCharacterClassFixed(size_t opIndex)
     {
+#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
+        if (m_decodeSurrogatePairs) {
+            YarrOp& op = m_ops[opIndex];
+            PatternTerm* term = op.m_term;
+            if (!term->isFixedWidthCharacterClass()) {
+                m_backtrackingState.link(*this, op);
+                op.m_jumps.link(&m_jit);
+                loadFromFrame(term->frameLocation + BackTrackInfoCharacterClass::beginIndex(), m_regs.index);
+                m_backtrackingState.fallthrough();
+                return;
+            }
+        }
+#endif
         backtrackTermDefault(opIndex);
     }
 


### PR DESCRIPTION
#### c4f242d634ec1e5d689a7a459eae2d0690ee7295
<pre>
[YARR] Fixed-count mixed-width character class should restore index on backtrack
<a href="https://bugs.webkit.org/show_bug.cgi?id=311241">https://bugs.webkit.org/show_bug.cgi?id=311241</a>

Reviewed by Yusuke Suzuki.

generateCharacterClassFixed&apos;s mixed-width path increments the index
register for each surrogate pair matched in the loop, but
backtrackCharacterClassFixed never restores it. The Once, Greedy, and
NonGreedy variants all save the index to the frame&apos;s beginIndex slot
and reload it on backtrack; do the same for Fixed.

Unlike Once, Fixed can fail mid-loop with the index already advanced,
so op.m_jumps must also be linked before the load (not just the
backtracking state). The store is placed before jumpIfNoAvailableInput
so all backtrack entry paths read a valid frame value, and we return
early since op.m_jumps is consumed (JumpList::link does not clear).

The frame slot was already reserved for FixedCount under eitherUnicode
in setupDisjunctionOffsets; the JIT just never used it.

Follows up on 309968@main, which fixed the surrogate-advancement issue
for Greedy/NonGreedy via advanceIndexAfterCharacterClassTermMatch.
Fixed has its own inlined advancement and was missed.

Test: JSTests/stress/regexp-unicode-mixed-width-charclass-fixed-count-backtrack.js

* JSTests/stress/regexp-unicode-mixed-width-charclass-fixed-count-backtrack.js: Added.
(shouldBeArray):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:

Canonical link: <a href="https://commits.webkit.org/310477@main">https://commits.webkit.org/310477@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92d17f26a5918a56376598c31626e3444a4c6ba5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153599 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26383 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20000 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162349 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107057 "An unexpected error occured. Recent messages:Printed configuration") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26911 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26705 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118750 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/107057 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156558 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21004 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137908 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99461 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20083 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18024 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10182 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/145612 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129730 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15768 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164820 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/14423 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7954 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17362 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126825 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26180 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22060 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126989 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34530 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26182 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137563 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82850 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21904 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14344 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/185235 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25799 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90086 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47509 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25490 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25650 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25550 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->