### PR TITLE
Use PseudoClassChangeInvalidation for :in-range/:out-of-range/:valid/:invalid when readonly changes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/input-in-range-in-has-with-readonly-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/input-in-range-in-has-with-readonly-expected.txt
@@ -1,0 +1,8 @@
+
+
+
+PASS :in-range in :has() invalidation when setting readonly
+PASS :in-range in :has() invalidation when removing readonly
+PASS :out-of-range in :has() invalidation when setting readonly
+PASS :out-of-range in :has() invalidation when removing readonly
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/input-in-range-in-has-with-readonly.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/input-in-range-in-has-with-readonly.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Selectors Invalidation: :in-range/:out-of-range in :has() when readonly changes</title>
+<link rel="help" href="https://drafts.csswg.org/selectors/#relational">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  #subject_inrange:has(#numberinput:in-range) { color: green }
+  #subject_outofrange:has(#numberinput2:out-of-range) { color: blue }
+</style>
+<div id="subject_inrange">
+  <input id="numberinput" type="number" min="1" max="10" value="5">
+</div>
+<div id="subject_outofrange">
+  <input id="numberinput2" type="number" min="1" max="10" value="12">
+</div>
+<script>
+  test(function() {
+    this.add_cleanup(() => { numberinput.readOnly = false; });
+
+    // value=5 is within [1,10], willValidate()=true, so :in-range matches.
+    assert_equals(getComputedStyle(subject_inrange).color, "rgb(0, 128, 0)",
+                  "ancestor should be green (input is in-range)");
+
+    // Setting readonly makes willValidate() return false, so :in-range no longer matches.
+    numberinput.readOnly = true;
+    assert_equals(getComputedStyle(subject_inrange).color, "rgb(0, 0, 0)",
+                  "ancestor should be black (readonly input is not in-range)");
+  }, ":in-range in :has() invalidation when setting readonly");
+
+  test(function() {
+    numberinput.readOnly = true;
+    this.add_cleanup(() => { numberinput.readOnly = false; });
+
+    // readonly, so :in-range does not match.
+    assert_equals(getComputedStyle(subject_inrange).color, "rgb(0, 0, 0)",
+                  "ancestor should be black (readonly input is not in-range)");
+
+    // Removing readonly makes willValidate() return true, so :in-range matches again.
+    numberinput.readOnly = false;
+    assert_equals(getComputedStyle(subject_inrange).color, "rgb(0, 128, 0)",
+                  "ancestor should be green (input is in-range again)");
+  }, ":in-range in :has() invalidation when removing readonly");
+
+  test(function() {
+    this.add_cleanup(() => { numberinput2.readOnly = false; });
+
+    // value=12 is outside [1,10], willValidate()=true, so :out-of-range matches.
+    assert_equals(getComputedStyle(subject_outofrange).color, "rgb(0, 0, 255)",
+                  "ancestor should be blue (input is out-of-range)");
+
+    // Setting readonly makes willValidate() return false, so :out-of-range no longer matches.
+    numberinput2.readOnly = true;
+    assert_equals(getComputedStyle(subject_outofrange).color, "rgb(0, 0, 0)",
+                  "ancestor should be black (readonly input is not out-of-range)");
+  }, ":out-of-range in :has() invalidation when setting readonly");
+
+  test(function() {
+    numberinput2.readOnly = true;
+    this.add_cleanup(() => { numberinput2.readOnly = false; });
+
+    // readonly, so :out-of-range does not match.
+    assert_equals(getComputedStyle(subject_outofrange).color, "rgb(0, 0, 0)",
+                  "ancestor should be black (readonly input is not out-of-range)");
+
+    // Removing readonly makes willValidate() return true, so :out-of-range matches again.
+    numberinput2.readOnly = false;
+    assert_equals(getComputedStyle(subject_outofrange).color, "rgb(0, 0, 255)",
+                  "ancestor should be blue (input is out-of-range again)");
+  }, ":out-of-range in :has() invalidation when removing readonly");
+</script>

--- a/Source/WebCore/html/HTMLFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLFormControlElement.cpp
@@ -162,15 +162,6 @@ void HTMLFormControlElement::disabledStateChanged()
         renderer->repaint();
 }
 
-void HTMLFormControlElement::readOnlyStateChanged()
-{
-    ValidatedFormListedElement::readOnlyStateChanged();
-
-    // Some input pseudo classes like :in-range/out-of-range change based on the readonly state.
-    // FIXME: Use PseudoClassChangeInvalidation instead for :has() support and more efficiency.
-    invalidateStyleForSubtree();
-}
-
 void HTMLFormControlElement::requiredStateChanged()
 {
     updateValidity();

--- a/Source/WebCore/html/HTMLFormControlElement.h
+++ b/Source/WebCore/html/HTMLFormControlElement.h
@@ -117,7 +117,6 @@ protected:
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
 
     void disabledStateChanged() override;
-    void readOnlyStateChanged() override;
     virtual void requiredStateChanged();
 
     bool isMouseFocusable() const override;

--- a/Source/WebCore/html/ValidatedFormListedElement.cpp
+++ b/Source/WebCore/html/ValidatedFormListedElement.cpp
@@ -320,7 +320,27 @@ void ValidatedFormListedElement::parseReadOnlyAttribute(const AtomString& value)
     bool newHasReadOnlyAttribute = !value.isNull();
     if (m_hasReadOnlyAttribute != newHasReadOnlyAttribute) {
         bool newMatchesReadWrite = supportsReadOnly() && !newHasReadOnlyAttribute;
-        Style::PseudoClassChangeInvalidation readWriteInvalidation(asHTMLElement(), { { CSSSelector::PseudoClass::ReadWrite, newMatchesReadWrite }, { CSSSelector::PseudoClass::ReadOnly, !newMatchesReadWrite } });
+        Ref element = asHTMLElement();
+
+        // :in-range/:out-of-range/:valid/:invalid depend on willValidate() which is affected by the readonly state.
+        // Temporarily apply the new readonly state to compute the new pseudo-class values.
+        m_hasReadOnlyAttribute = newHasReadOnlyAttribute;
+        m_willValidateInitialized = false;
+        bool newMatchesValid = matchesValidPseudoClass();
+        bool newMatchesInvalid = matchesInvalidPseudoClass();
+        bool newMatchesInRange = element->isInRange();
+        bool newMatchesOutOfRange = element->isOutOfRange();
+        // Restore old state so PseudoClassChangeInvalidation constructors capture the before-change state.
+        m_hasReadOnlyAttribute = !newHasReadOnlyAttribute;
+        m_willValidateInitialized = false;
+
+        Style::PseudoClassChangeInvalidation readWriteInvalidation(element, { { CSSSelector::PseudoClass::ReadWrite, newMatchesReadWrite }, { CSSSelector::PseudoClass::ReadOnly, !newMatchesReadWrite } });
+        Style::PseudoClassChangeInvalidation rangeAndValidityInvalidation(element, {
+            { CSSSelector::PseudoClass::InRange, newMatchesInRange },
+            { CSSSelector::PseudoClass::OutOfRange, newMatchesOutOfRange },
+            { CSSSelector::PseudoClass::Valid, newMatchesValid },
+            { CSSSelector::PseudoClass::Invalid, newMatchesInvalid },
+        });
         m_hasReadOnlyAttribute = newHasReadOnlyAttribute;
         readOnlyStateChanged();
     }


### PR DESCRIPTION
#### b9ea94f94e83317bc7a6a2e796e3216b3bb577c9
<pre>
Use PseudoClassChangeInvalidation for :in-range/:out-of-range/:valid/:invalid when readonly changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=311244">https://bugs.webkit.org/show_bug.cgi?id=311244</a>

Reviewed by Tim Nguyen and Anne van Kesteren.

HTMLFormControlElement::readOnlyStateChanged() was using invalidateStyleForSubtree()
to handle :in-range/:out-of-range pseudo-classes changing when the readonly attribute
is toggled. These pseudo-classes depend on willValidate(), which returns false for
readonly form controls.

invalidateStyleForSubtree() is both too broad (marks the entire subtree dirty) and
too narrow (doesn&apos;t invalidate ancestors). The latter means :has() selectors like
`form:has(input:in-range)` fail to update when a descendant&apos;s readonly state changes.

Fix this by adding PseudoClassChangeInvalidation for :in-range, :out-of-range,
:valid, and :invalid in ValidatedFormListedElement::parseReadOnlyAttribute(),
alongside the existing invalidation for :read-only/:read-write. To compute the exact
new pseudo-class values, we temporarily apply the new readonly state (updating
m_hasReadOnlyAttribute and clearing the willValidate cache), query the element&apos;s
pseudo-class matching methods (matchesValidPseudoClass, matchesInvalidPseudoClass,
isInRange, isOutOfRange), then restore the old state before constructing the RAII
invalidation objects so their constructors correctly capture the before-change state.

This also removes the now-unnecessary HTMLFormControlElement::readOnlyStateChanged()
override since it was only there for the invalidateStyleForSubtree() call.

Test: imported/w3c/web-platform-tests/css/selectors/invalidation/input-in-range-in-has-with-readonly.html

* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/input-in-range-in-has-with-readonly-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/input-in-range-in-has-with-readonly.html: Added.
* Source/WebCore/html/HTMLFormControlElement.cpp:
(WebCore::HTMLFormControlElement::readOnlyStateChanged): Deleted.
* Source/WebCore/html/HTMLFormControlElement.h:
* Source/WebCore/html/ValidatedFormListedElement.cpp:
(WebCore::ValidatedFormListedElement::parseReadOnlyAttribute):

Canonical link: <a href="https://commits.webkit.org/310484@main">https://commits.webkit.org/310484@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50a9f03f4921a65f7ed554d2dfde5cc664a0000f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153805 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26589 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20206 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162556 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107266 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d0fc3b63-49c1-4d6c-abe9-7f25cc76739b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155678 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27118 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26911 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118911 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84085 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bce6af4e-a54c-44cf-80ba-311b5077f8c7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156764 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21182 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138103 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99621 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/011dc8ef-ff15-4fd7-bf2f-c55ca2adf71f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20262 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18217 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10388 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129910 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15962 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165027 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8160 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17556 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/api/crashtests/huge-fetch.any.sharedworker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127000 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26386 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22247 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127167 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34533 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26388 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137757 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83066 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22067 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14541 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26005 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90293 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25696 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25856 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25756 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->