### PR TITLE
REGRESSION(309388@main): Crash in core DOM code due to malformed DOM tree

### DIFF
--- a/LayoutTests/fast/animation/request-animation-frame-during-dom-mutation-expected.txt
+++ b/LayoutTests/fast/animation/request-animation-frame-during-dom-mutation-expected.txt
@@ -1,0 +1,4 @@
+This tests scheduling requestAnimationFrame right before removing an iframe, which synchronously trigger the update rendering steps.
+WebKit should not hit any debug assertions or crash.
+
+

--- a/LayoutTests/fast/animation/request-animation-frame-during-dom-mutation.html
+++ b/LayoutTests/fast/animation/request-animation-frame-during-dom-mutation.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+function runTest() {
+    const videoContainer = document.getElementById('videoContainer');
+    iframeContainer.appendChild(iframe);
+    setTimeout(() => {
+        // Removing iframe here triggers WebKitTestRunner/DumpRenderTree to update rendering synchronously.
+        try {
+            document.body.insertBefore(iframe, videoContainer);
+        } catch (error) { }
+    }, 0);
+    requestAnimationFrame(() => {
+        videoContainer.remove();
+    });
+}
+</script>
+<body onload="runTest()">
+<p>This tests scheduling requestAnimationFrame right before removing an iframe, which synchronously trigger the update rendering steps.<br>
+WebKit should not hit any debug assertions or crash.</p>
+<iframe id="iframe" srcdoc="abc"></iframe>
+<span id="videoContainer"></span>
+<span id="iframeContainer"></span>
+<video id="video" controls></video>

--- a/Source/WebCore/dom/ScriptedAnimationController.cpp
+++ b/Source/WebCore/dom/ScriptedAnimationController.cpp
@@ -161,6 +161,14 @@ void ScriptedAnimationController::serviceRequestAnimationFrameCallbacks(ReducedR
     Ref protectedThis { *this };
     Ref document = *m_document;
 
+    RefPtr frame = document->frame();
+    if (!frame)
+        return;
+
+    CheckedRef script = frame->script();
+    if (!script->canExecuteScripts(ReasonForCallingCanExecuteScripts::AboutToExecuteScript) || script->isPaused())
+        return;
+
     for (auto& [callback, userGestureTokenToForward, scheduledWorkScope] : callbackDataList) {
         if (callback->m_firedOrCancelled)
             continue;

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -803,6 +803,14 @@ void HTMLVideoElement::serviceRequestVideoFrameCallbacks(ReducedResolutionSecond
     if (!videoFrameMetadata || !document().window())
         return;
 
+    RefPtr frame = document().frame();
+    if (!frame)
+        return;
+
+    CheckedRef script = frame->script();
+    if (!script->canExecuteScripts(ReasonForCallingCanExecuteScripts::AboutToExecuteScript) || script->isPaused())
+        return;
+
     processVideoFrameMetadataTimestamps(*videoFrameMetadata, protect(document().window()->performance()));
 
     Ref protectedThis { *this };


### PR DESCRIPTION
#### 18f7c49e6bdbdfa98ef3a3122e9e96fa0f01aa07
<pre>
REGRESSION(309388@main): Crash in core DOM code due to malformed DOM tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=311243">https://bugs.webkit.org/show_bug.cgi?id=311243</a>
<a href="https://rdar.apple.com/173397633">rdar://173397633</a>

Reviewed by Chris Dumez.

The crash was caused by a malformed DOM tree. This happens because removing an iframe can trigger
in WebKitTestRunner / DumpRenderTree to update the rendering synchronously during a node removal.

This in turn could run arbitrary scripts via requestAnimationFrame. But because it don&apos;t call
ScriptController::canExecuteScripts, it does not increment s_scriptExecutionCount. As a result,
the secondary check for when scripts mutated DOM in ContainerNode::insertBefore does not get
triggered and results in a malformed DOM.

Fixed the bug by calling canExecuteScripts in serviceRequestAnimationFrameCallbacks to update
s_scriptExecutionCount so that the secondary pre-insertion check gets triggered. Due to the way
run-webkit-tests interacts with WebKitTestRunner, run-webkit-tests does not hit this crash while
manually calling WebKitTestRunner via run-test-runner will hit it. The attached test case does
reproduce the crash in DumpRenderTree.

This PR also fixes serviceRequestVideoFrameCallbacks but unfortunately without a test case.

Test: fast/animation/request-animation-frame-during-dom-mutation.html

* LayoutTests/fast/animation/request-animation-frame-during-dom-mutation-expected.txt: Added.
* LayoutTests/fast/animation/request-animation-frame-during-dom-mutation.html: Added.
* Source/WebCore/dom/ScriptedAnimationController.cpp:
(WebCore::ScriptedAnimationController::serviceRequestAnimationFrameCallbacks):
* Source/WebCore/html/HTMLVideoElement.cpp:
(WebCore::HTMLVideoElement::serviceRequestVideoFrameCallbacks):

Canonical link: <a href="https://commits.webkit.org/310666@main">https://commits.webkit.org/310666@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec9e58ca706e487d45dff7111e6a1659e4504d88

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154016 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27271 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20431 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162768 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107482 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155889 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27404 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27124 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119107 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84201 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156975 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21358 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138303 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99807 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20447 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18430 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10601 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130104 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16155 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165241 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8441 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17756 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127198 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26818 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22516 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127351 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26742 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137949 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83321 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23587 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22230 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14737 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26433 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90525 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26014 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26244 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26086 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->