### PR TITLE
[WGSL] webgpu:shader,validation,decl,var:* is failing

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/decl/var-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/decl/var-expected.txt
@@ -618,20 +618,7 @@ PASS :binding_collisions:a_group=1;b_group=1;a_binding=1;b_binding=0;b_use="diff
 PASS :binding_collisions:a_group=1;b_group=1;a_binding=1;b_binding=1;b_use="same"
 PASS :binding_collisions:a_group=1;b_group=1;a_binding=1;b_binding=1;b_use="different"
 PASS :binding_collision_unused_helper:
-FAIL :address_space_access_mode:address_space="private";access_mode="";trailing_comma=true assert_unreached:
-  - VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    1:4: error: only variables in the <storage> address space may specify an access mode
-
-    ---- shader ----
-    var<private,> x : u32;
-        fn foo() {
-
-        }
-      at (elided: below max severity)
-  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
-    1:3: only variables in the <storage> address space may specify an access mode
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
+PASS :address_space_access_mode:address_space="private";access_mode="";trailing_comma=true
 PASS :address_space_access_mode:address_space="private";access_mode="";trailing_comma=false
 PASS :address_space_access_mode:address_space="private";access_mode="read";trailing_comma=true
 PASS :address_space_access_mode:address_space="private";access_mode="read";trailing_comma=false
@@ -639,67 +626,15 @@ PASS :address_space_access_mode:address_space="private";access_mode="write";trai
 PASS :address_space_access_mode:address_space="private";access_mode="write";trailing_comma=false
 PASS :address_space_access_mode:address_space="private";access_mode="read_write";trailing_comma=true
 PASS :address_space_access_mode:address_space="private";access_mode="read_write";trailing_comma=false
-FAIL :address_space_access_mode:address_space="storage";access_mode="";trailing_comma=true assert_unreached:
-  - VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    1:35: error: Expected a Identifier, but got a >
-
-    ---- shader ----
-    @group(0) @binding(0) var<storage,> x : u32;
-        fn foo() {
-
-        }
-      at (elided: below max severity)
-  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
-    1:34: Expected a Identifier, but got a >
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
+PASS :address_space_access_mode:address_space="storage";access_mode="";trailing_comma=true
 PASS :address_space_access_mode:address_space="storage";access_mode="";trailing_comma=false
-FAIL :address_space_access_mode:address_space="storage";access_mode="read";trailing_comma=true assert_unreached:
-  - VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    1:26: error: Expected a >, but got a ,
-
-    ---- shader ----
-    @group(0) @binding(0) var<storage,read,> x : u32;
-        fn foo() {
-
-        }
-      at (elided: below max severity)
-  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
-    1:25: Expected a >, but got a ,
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
+PASS :address_space_access_mode:address_space="storage";access_mode="read";trailing_comma=true
 PASS :address_space_access_mode:address_space="storage";access_mode="read";trailing_comma=false
 PASS :address_space_access_mode:address_space="storage";access_mode="write";trailing_comma=true
 PASS :address_space_access_mode:address_space="storage";access_mode="write";trailing_comma=false
-FAIL :address_space_access_mode:address_space="storage";access_mode="read_write";trailing_comma=true assert_unreached:
-  - VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    1:26: error: Expected a >, but got a ,
-
-    ---- shader ----
-    @group(0) @binding(0) var<storage,read_write,> x : u32;
-        fn foo() {
-
-        }
-      at (elided: below max severity)
-  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
-    1:25: Expected a >, but got a ,
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
+PASS :address_space_access_mode:address_space="storage";access_mode="read_write";trailing_comma=true
 PASS :address_space_access_mode:address_space="storage";access_mode="read_write";trailing_comma=false
-FAIL :address_space_access_mode:address_space="uniform";access_mode="";trailing_comma=true assert_unreached:
-  - VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    1:26: error: only variables in the <storage> address space may specify an access mode
-
-    ---- shader ----
-    @group(0) @binding(0) var<uniform,> x : u32;
-        fn foo() {
-
-        }
-      at (elided: below max severity)
-  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
-    1:25: only variables in the <storage> address space may specify an access mode
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
+PASS :address_space_access_mode:address_space="uniform";access_mode="";trailing_comma=true
 PASS :address_space_access_mode:address_space="uniform";access_mode="";trailing_comma=false
 PASS :address_space_access_mode:address_space="uniform";access_mode="read";trailing_comma=true
 PASS :address_space_access_mode:address_space="uniform";access_mode="read";trailing_comma=false
@@ -707,20 +642,7 @@ PASS :address_space_access_mode:address_space="uniform";access_mode="write";trai
 PASS :address_space_access_mode:address_space="uniform";access_mode="write";trailing_comma=false
 PASS :address_space_access_mode:address_space="uniform";access_mode="read_write";trailing_comma=true
 PASS :address_space_access_mode:address_space="uniform";access_mode="read_write";trailing_comma=false
-FAIL :address_space_access_mode:address_space="function";access_mode="";trailing_comma=true assert_unreached:
-  - VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    3:10: error: only variables in the <storage> address space may specify an access mode
-
-    ---- shader ----
-
-        fn foo() {
-          var<function,> x : u32;
-        }
-      at (elided: below max severity)
-  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
-    3:9: only variables in the <storage> address space may specify an access mode
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
+PASS :address_space_access_mode:address_space="function";access_mode="";trailing_comma=true
 PASS :address_space_access_mode:address_space="function";access_mode="";trailing_comma=false
 PASS :address_space_access_mode:address_space="function";access_mode="read";trailing_comma=true
 PASS :address_space_access_mode:address_space="function";access_mode="read";trailing_comma=false
@@ -728,20 +650,7 @@ PASS :address_space_access_mode:address_space="function";access_mode="write";tra
 PASS :address_space_access_mode:address_space="function";access_mode="write";trailing_comma=false
 PASS :address_space_access_mode:address_space="function";access_mode="read_write";trailing_comma=true
 PASS :address_space_access_mode:address_space="function";access_mode="read_write";trailing_comma=false
-FAIL :address_space_access_mode:address_space="workgroup";access_mode="";trailing_comma=true assert_unreached:
-  - VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    1:4: error: only variables in the <storage> address space may specify an access mode
-
-    ---- shader ----
-    var<workgroup,> x : u32;
-        fn foo() {
-
-        }
-      at (elided: below max severity)
-  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
-    1:3: only variables in the <storage> address space may specify an access mode
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
+PASS :address_space_access_mode:address_space="workgroup";access_mode="";trailing_comma=true
 PASS :address_space_access_mode:address_space="workgroup";access_mode="";trailing_comma=false
 PASS :address_space_access_mode:address_space="workgroup";access_mode="read";trailing_comma=true
 PASS :address_space_access_mode:address_space="workgroup";access_mode="read";trailing_comma=false
@@ -802,18 +711,7 @@ PASS :write_access:addressSpace="function";explicitSpace=false;explicitAccess=tr
 PASS :initializer_type:
 PASS :var_access_mode_bad_other_template_contents:accessMode="read";prefix="storage,";suffix=",storage"
 PASS :var_access_mode_bad_other_template_contents:accessMode="read";prefix="storage,";suffix=",read"
-FAIL :var_access_mode_bad_other_template_contents:accessMode="read";prefix="storage,";suffix="," assert_unreached:
-  - VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    2:22: error: Expected a >, but got a ,
-
-    ---- shader ----
-    @group(0) @binding(0)
-                      var<storage,read,> x: i32;
-      at (elided: below max severity)
-  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
-    2:21: Expected a >, but got a ,
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
+PASS :var_access_mode_bad_other_template_contents:accessMode="read";prefix="storage,";suffix=","
 PASS :var_access_mode_bad_other_template_contents:accessMode="read";prefix="storage,";suffix=""
 PASS :var_access_mode_bad_other_template_contents:accessMode="read";prefix="";suffix=",storage"
 PASS :var_access_mode_bad_other_template_contents:accessMode="read";prefix="";suffix=",read"
@@ -825,18 +723,7 @@ PASS :var_access_mode_bad_other_template_contents:accessMode="read";prefix=",";s
 PASS :var_access_mode_bad_other_template_contents:accessMode="read";prefix=",";suffix=""
 PASS :var_access_mode_bad_other_template_contents:accessMode="read_write";prefix="storage,";suffix=",storage"
 PASS :var_access_mode_bad_other_template_contents:accessMode="read_write";prefix="storage,";suffix=",read"
-FAIL :var_access_mode_bad_other_template_contents:accessMode="read_write";prefix="storage,";suffix="," assert_unreached:
-  - VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    2:22: error: Expected a >, but got a ,
-
-    ---- shader ----
-    @group(0) @binding(0)
-                      var<storage,read_write,> x: i32;
-      at (elided: below max severity)
-  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
-    2:21: Expected a >, but got a ,
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
+PASS :var_access_mode_bad_other_template_contents:accessMode="read_write";prefix="storage,";suffix=","
 PASS :var_access_mode_bad_other_template_contents:accessMode="read_write";prefix="storage,";suffix=""
 PASS :var_access_mode_bad_other_template_contents:accessMode="read_write";prefix="";suffix=",storage"
 PASS :var_access_mode_bad_other_template_contents:accessMode="read_write";prefix="";suffix=",read"
@@ -888,94 +775,14 @@ PASS :shader_stage:stage="compute";kind="storage_rw"
 PASS :shader_stage:stage="compute";kind="uniform"
 PASS :shader_stage:stage="compute";kind="workgroup"
 PASS :shader_stage:stage="vertex";kind="handle_ro"
-FAIL :shader_stage:stage="vertex";kind="handle_wo" assert_unreached:
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-
-        @group(0) @binding(0) var v : texture_storage_2d<r32uint, write>;
-        @vertex
-            fn main() -> @builtin(position) vec4f {
-
-              _ = v;
-              return vec4f();
-            }
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
-    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
- Reached unreachable code
-FAIL :shader_stage:stage="vertex";kind="handle_rw" assert_unreached:
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-
-        @group(0) @binding(0) var v : texture_storage_2d<r32uint, read_write>;
-        @vertex
-            fn main() -> @builtin(position) vec4f {
-
-              _ = v;
-              return vec4f();
-            }
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
-    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
- Reached unreachable code
+PASS :shader_stage:stage="vertex";kind="handle_wo"
+PASS :shader_stage:stage="vertex";kind="handle_rw"
 PASS :shader_stage:stage="vertex";kind="function"
 PASS :shader_stage:stage="vertex";kind="private"
 PASS :shader_stage:stage="vertex";kind="storage_ro"
-FAIL :shader_stage:stage="vertex";kind="storage_rw" assert_unreached:
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-
-        @group(0) @binding(0) var<storage, read_write> v : u32;
-        @vertex
-            fn main() -> @builtin(position) vec4f {
-
-              _ = v;
-              return vec4f();
-            }
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
-    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
- Reached unreachable code
+PASS :shader_stage:stage="vertex";kind="storage_rw"
 PASS :shader_stage:stage="vertex";kind="uniform"
-FAIL :shader_stage:stage="vertex";kind="workgroup" assert_unreached:
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-
-        var<workgroup> v : u32;
-        @vertex
-            fn main() -> @builtin(position) vec4f {
-
-              _ = v;
-              return vec4f();
-            }
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
-    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
- Reached unreachable code
+PASS :shader_stage:stage="vertex";kind="workgroup"
 PASS :shader_stage:stage="fragment";kind="handle_ro"
 PASS :shader_stage:stage="fragment";kind="handle_wo"
 PASS :shader_stage:stage="fragment";kind="handle_rw"
@@ -984,24 +791,5 @@ PASS :shader_stage:stage="fragment";kind="private"
 PASS :shader_stage:stage="fragment";kind="storage_ro"
 PASS :shader_stage:stage="fragment";kind="storage_rw"
 PASS :shader_stage:stage="fragment";kind="uniform"
-FAIL :shader_stage:stage="fragment";kind="workgroup" assert_unreached:
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-
-        var<workgroup> v : u32;
-        @fragment
-            fn main() {
-
-              _ = v;
-            }
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
-    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
- Reached unreachable code
+PASS :shader_stage:stage="fragment";kind="workgroup"
 

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/atomics-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/atomics-expected.txt
@@ -20,26 +20,7 @@ PASS :stage:stage="vertex";atomicOp="xor"
 PASS :stage:stage="vertex";atomicOp="load"
 PASS :stage:stage="vertex";atomicOp="store"
 PASS :stage:stage="vertex";atomicOp="exchange"
-FAIL :stage:stage="vertex";atomicOp="compareexchangeweak" assert_unreached:
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-
-    @group(0) @binding(0) var<storage, read_write> a: atomic<i32>;
-
-    @vertex fn vmain() -> @builtin(position) vec4<f32> {
-      atomicCompareExchangeWeak(&a,1,1);
-      return vec4<f32>();
-    }
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
-    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
- Reached unreachable code
+PASS :stage:stage="vertex";atomicOp="compareexchangeweak"
 PASS :stage:stage="compute";atomicOp="add"
 PASS :stage:stage="compute";atomicOp="sub"
 PASS :stage:stage="compute";atomicOp="max"

--- a/Source/WebGPU/WGSL/IOValidator.cpp
+++ b/Source/WebGPU/WGSL/IOValidator.cpp
@@ -34,6 +34,12 @@
 #include <wtf/MathExtras.h>
 #include <wtf/text/MakeString.h>
 
+#define CHECK(__expression) { \
+    __expression; \
+    if (hasError()) [[unlikely]] \
+        return; \
+}
+
 namespace WGSL {
 
 enum class Direction : uint8_t {
@@ -47,8 +53,7 @@ public:
 
     IOValidator(ShaderModule&);
 
-    std::optional<FailedCheck> validate();
-    std::optional<FailedCheck> validateIO();
+    void validateIO();
 
     void visit(AST::Function&) override;
     void visit(AST::Parameter&) override;
@@ -60,8 +65,8 @@ private:
     using Locations = HashSet<uint64_t, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>>;
 
     void collectGlobals();
-    std::optional<FailedCheck> validateResources(const CallGraph::EntryPoint&);
-    std::optional<FailedCheck> validateEntryPointIO(const CallGraph::EntryPoint&);
+    void validateResources(const CallGraph::EntryPoint&);
+    void validateEntryPointIO(const CallGraph::EntryPoint&);
 
     void validateBuiltinIO(const SourceSpan&, const Type*, ShaderStage, Builtin, Direction, Builtins&);
     void validateLocationIO(const SourceSpan&, const Type*, ShaderStage, unsigned, Locations&);
@@ -71,10 +76,9 @@ private:
     template<typename... Arguments>
     void error(const SourceSpan&, Arguments&&...);
 
-    AST::Function* m_currentFunction { nullptr };
     ShaderModule& m_shaderModule;
     HashSet<const CallGraph::Global*> m_usedGlobals { };
-    bool m_hasSizeOrAlignmentAttributes { false };
+    ShaderStage m_stage { ShaderStage::Vertex };
 };
 
 IOValidator::IOValidator(ShaderModule& shaderModule)
@@ -82,25 +86,21 @@ IOValidator::IOValidator(ShaderModule& shaderModule)
 {
 }
 
-std::optional<FailedCheck> IOValidator::validateIO()
+void IOValidator::validateIO()
 {
     collectGlobals();
 
     for (auto& entryPoint : m_shaderModule.callGraph().entrypoints()) {
-        if (auto maybeError = validateEntryPointIO(entryPoint))
-            return *maybeError;
+        CHECK(validateEntryPointIO(entryPoint));
 
-        visit(entryPoint.function);
+        m_stage = entryPoint.stage;
+        CHECK(visit(entryPoint.function));
+
         const_cast<CallGraph::EntryPoint&>(entryPoint).usedGlobals.addAll(m_usedGlobals);
         m_usedGlobals.clear();
 
-        if (auto maybeError = validateResources(entryPoint))
-            return *maybeError;
+        CHECK(validateResources(entryPoint));
     }
-
-    if (!hasError()) [[likely]]
-        return std::nullopt;
-    return FailedCheck { Vector<Error> { result().error() }, { } };
 }
 
 void IOValidator::collectGlobals()
@@ -162,10 +162,30 @@ void IOValidator::visit(AST::IdentifierExpression& identifier)
     if (!variable || !*variable)
         return;
 
+    auto& var = *(*variable)->declaration;
+    if (auto addressSpace = var.addressSpace()) {
+        if (m_stage != ShaderStage::Compute && *addressSpace == AddressSpace::Workgroup) {
+            error(identifier.span(), "var with `workgroup` address space cannot be used by `"_s, toString(m_stage), "` pipeline stage"_s);
+            return;
+        }
+
+        if (m_stage == ShaderStage::Vertex) {
+            auto* textureStorage = std::get_if<Types::TextureStorage>(var.storeType());
+            if (textureStorage && std::to_underlying(textureStorage->access) & std::to_underlying(AccessMode::Write)) {
+                error(identifier.span(), "storage texture with `read_write` access mode cannot be used by `vertex` pipeline stage"_s);
+                return;
+            }
+
+            if (auto accessMode = var.accessMode(); *addressSpace == AddressSpace::Storage && accessMode.has_value() && std::to_underlying(*accessMode) & std::to_underlying(AccessMode::Write)) {
+                error(identifier.span(), "var with `storage` address space and `read_write` access mode cannot be used by `vertex` pipeline stage"_s);
+                return;
+            }
+        }
+    }
     m_usedGlobals.add(*variable);
 }
 
-std::optional<FailedCheck> IOValidator::validateResources(const CallGraph::EntryPoint& entryPoint)
+void IOValidator::validateResources(const CallGraph::EntryPoint& entryPoint)
 {
     HashMap<std::pair<unsigned, unsigned>, const CallGraph::Global*> usedGlobals;
     for (auto* global : entryPoint.usedGlobals) {
@@ -173,24 +193,19 @@ std::optional<FailedCheck> IOValidator::validateResources(const CallGraph::Entry
             continue;
 
         auto result = usedGlobals.add({ global->resource->group + 1, global->resource->binding + 1 }, global);
-        if (!result.isNewEntry)
-            return FailedCheck { Vector<Error> { Error(makeString("entry point '"_s, entryPoint.originalName, "' uses variables '"_s, result.iterator->value->declaration->originalName(), "' and '"_s, global->declaration->originalName(), "', both which use the same resource binding: @group("_s, global->resource->group, ") @binding("_s, global->resource->binding, ')'), global->declaration->span()) }, { } };
+        if (!result.isNewEntry) [[unlikely]] {
+            auto& var = *global->declaration;
+            auto& resource = *global->resource;
+            auto& entryPointName = entryPoint.originalName;
+            auto& originalDeclaration = result.iterator->value->declaration->originalName();
+            error(var.span(), "entry point '"_s, entryPointName, "' uses variables '"_s, originalDeclaration, "' and '"_s, var.originalName(), "', both which use the same resource binding: @group("_s, resource.group, ") @binding("_s, resource.binding, ')');
+            return;
+        }
     }
-    return std::nullopt;
 }
 
-std::optional<FailedCheck> IOValidator::validateEntryPointIO(const CallGraph::EntryPoint& entryPoint)
+void IOValidator::validateEntryPointIO(const CallGraph::EntryPoint& entryPoint)
 {
-#define CHECK(__expression) { \
-    __expression; \
-    if (hasError()) [[unlikely]] \
-        return failedCheck(); \
-}
-
-    const auto& failedCheck = [&] -> std::optional<FailedCheck> {
-        return { FailedCheck { Vector<Error> { result().error() }, { } } };
-    };
-
     auto& function = entryPoint.function;
     Builtins builtins;
     Locations locations;
@@ -215,15 +230,13 @@ std::optional<FailedCheck> IOValidator::validateEntryPointIO(const CallGraph::En
         }
 
         error(span, "missing entry point IO attribute on parameter"_s);
-        return failedCheck();
+        return;
     }
 
     if (!function.maybeReturnType()) {
-        if (entryPoint.stage == ShaderStage::Vertex) [[unlikely]] {
+        if (entryPoint.stage == ShaderStage::Vertex) [[unlikely]]
             error(function.span(), "a vertex shader must include the 'position' builtin in its return type"_s);
-            return failedCheck();
-        }
-        return std::nullopt;
+        return;
     }
 
     builtins.clear();
@@ -239,15 +252,11 @@ std::optional<FailedCheck> IOValidator::validateEntryPointIO(const CallGraph::En
         CHECK(validateStructIO(entryPoint.stage, *structType, Direction::Output, builtins, locations));
     } else [[unlikely]] {
         error(span, "missing entry point IO attribute on return type"_s);
-        return failedCheck();
+        return;
     }
 
-    if (entryPoint.stage == ShaderStage::Vertex && !builtins.contains(Builtin::Position)) [[unlikely]] {
+    if (entryPoint.stage == ShaderStage::Vertex && !builtins.contains(Builtin::Position)) [[unlikely]]
         error(span, "a vertex shader must include the 'position' builtin in its return type"_s);
-        return failedCheck();
-    }
-
-    return std::nullopt;
 }
 
 void IOValidator::validateBuiltinIO(const SourceSpan& span, const Type* type, ShaderStage stage, Builtin builtin, Direction direction, Builtins& builtins)
@@ -379,7 +388,13 @@ void IOValidator::error(const SourceSpan& span, Arguments&&... arguments)
 
 std::optional<FailedCheck> validateIO(ShaderModule& shaderModule)
 {
-    return IOValidator(shaderModule).validateIO();
+    IOValidator validator(shaderModule);
+    validator.validateIO();
+    if (validator.hasError()) [[unlikely]]
+        return FailedCheck { Vector<Error> { validator.result().error() }, { } };
+    return std::nullopt;
 }
 
 } // namespace WGSL
+
+#undef CHECK

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -1072,14 +1072,21 @@ Result<AST::VariableQualifier::Ref> Parser<Lexer>::parseVariableQualifier()
 
     AccessMode accessMode;
     if (current().type == TokenType::Comma) {
-        if (addressSpace != AddressSpace::Storage)
-            FAIL("only variables in the <storage> address space may specify an access mode"_s);
-
         consume();
-        PARSE(actualAccessMode, AccessMode);
-        accessMode = actualAccessMode;
+
+        if (current().type == TokenType::Identifier) {
+            if (addressSpace != AddressSpace::Storage)
+                FAIL("only variables in the <storage> address space may specify an access mode"_s);
+
+            PARSE(actualAccessMode, AccessMode);
+            accessMode = actualAccessMode;
+
+            if (current().type == TokenType::Comma)
+                consume();
+        }
     } else
         accessMode = defaultAccessModeForAddressSpace(addressSpace);
+
 
     CONSUME_TYPE(TemplateArgsRight);
     RETURN_ARENA_NODE(VariableQualifier, addressSpace, accessMode);

--- a/Source/WebGPU/WGSL/WGSLEnums.h
+++ b/Source/WebGPU/WGSL/WGSLEnums.h
@@ -42,9 +42,9 @@ namespace WGSL {
     value(Workgroup, workgroup) \
 
 #define ENUM_AccessMode(value) \
-    value(Read, read) \
-    value(ReadWrite, read_write) \
-    value(Write, write) \
+    value(Read, read, 1 << 0) \
+    value(ReadWrite, read_write, 1 << 1 | 1 << 0) \
+    value(Write, write, 1 << 1) \
 
 #define ENUM_TexelFormat(value) \
     value(BGRA8unorm, bgra8unorm) \

--- a/Tools/TestWebKitAPI/Tests/WGSL/shaders/array-vec3.wgsl
+++ b/Tools/TestWebKitAPI/Tests/WGSL/shaders/array-vec3.wgsl
@@ -1,7 +1,7 @@
 @group(0) @binding(0) var<storage, read_write> un: array<vec3f, 1>;
 
-@vertex
-fn main() -> @builtin(position) vec4f {
+@compute @workgroup_size(1)
+fn main() {
   {
     let x = un[0].x;
     let xy = un[0].xy;
@@ -27,5 +27,4 @@ fn main() -> @builtin(position) vec4f {
     v.x = x;
     v[1] = y;
   }
-  return vec4();
 }


### PR DESCRIPTION
#### f902b0ca6829f66aa5bace73f887f55b0714d50c
<pre>
[WGSL] webgpu:shader,validation,decl,var:* is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=311245">https://bugs.webkit.org/show_bug.cgi?id=311245</a>
<a href="https://rdar.apple.com/173838628">rdar://173838628</a>

Reviewed by Mike Wyrzykowski.

Correctly handle trailing commas in variable declarations and add missing checks
for which types of variables can accessed from a given pipeline stage.

* LayoutTests/http/tests/webgpu/webgpu/shader/validation/decl/var-expected.txt:
* Source/WebGPU/WGSL/IOValidator.cpp:
(WGSL::IOValidator::validateIO):
(WGSL::IOValidator::visit):
(WGSL::IOValidator::validateResources):
(WGSL::IOValidator::validateEntryPointIO):
(WGSL::validateIO):
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseVariableQualifier):
* Source/WebGPU/WGSL/WGSLEnums.h:

Canonical link: <a href="https://commits.webkit.org/310702@main">https://commits.webkit.org/310702@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3635461f1ec5fe48dc0762b72522c878c99fd3e4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154646 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27905 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21064 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163405 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108115 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156519 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28039 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27754 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119623 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/84592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157605 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21915 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138891 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100317 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21000 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19016 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11232 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130663 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16735 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165879 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9086 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18344 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127728 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27450 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23056 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127863 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34699 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27374 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138528 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84056 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22763 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15322 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27066 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91168 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26644 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26875 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26717 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->