### PR TITLE
Need a short description (OOPS!).

### DIFF
--- a/LayoutTests/compositing/webgl/background-subpixel-position-expected.html
+++ b/LayoutTests/compositing/webgl/background-subpixel-position-expected.html
@@ -1,0 +1,13 @@
+<style>
+div {
+    position: absolute;
+    top: 10.5px;
+    left: 10.5px;
+    width: 20px;
+    height: 20px;
+    background-color: rgba(0, 255, 0, 1);
+}
+</style>
+<body>
+<div></div>
+</body>

--- a/LayoutTests/compositing/webgl/background-subpixel-position.html
+++ b/LayoutTests/compositing/webgl/background-subpixel-position.html
@@ -1,0 +1,17 @@
+<style>
+canvas {
+    position: absolute;
+    top: 10.5px;
+    left: 10.5px;
+    background-color: red;
+}
+</style>
+<body>
+<canvas id="canvas" width="20" height="20"></canvas>
+<script>
+const canvas = document.getElementById("canvas");
+const gl = canvas.getContext("webgl");
+gl.clearColor(0, 1, 0, 1);
+gl.clear(gl.COLOR_BUFFER_BIT);
+</script>
+</body>

--- a/LayoutTests/compositing/webgl/hidpi-background-subpixel-position-expected.html
+++ b/LayoutTests/compositing/webgl/hidpi-background-subpixel-position-expected.html
@@ -1,0 +1,13 @@
+<style>
+div {
+    position: absolute;
+    top: 10.25px;
+    left: 10.25px;
+    width: 20px;
+    height: 20px;
+    background-color: rgba(0, 255, 0, 1);
+}
+</style>
+<body>
+<div></div>
+</body>

--- a/LayoutTests/compositing/webgl/hidpi-background-subpixel-position.html
+++ b/LayoutTests/compositing/webgl/hidpi-background-subpixel-position.html
@@ -1,0 +1,17 @@
+<style>
+canvas {
+    position: absolute;
+    top: 10.25px;
+    left: 10.25px;
+    background-color: red;
+}
+</style>
+<body>
+<canvas id="canvas" width="20" height="20"></canvas>
+<script>
+const canvas = document.getElementById("canvas");
+const gl = canvas.getContext("webgl");
+gl.clearColor(0, 1, 0, 1);
+gl.clear(gl.COLOR_BUFFER_BIT);
+</script>
+</body>

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -1468,7 +1468,7 @@ private:
 LayoutRect RenderLayerBacking::computePrimaryGraphicsLayerRect(const RenderLayer* compositedAncestor, const LayoutRect& parentGraphicsLayerRect) const
 {
     ComputedOffsets compositedBoundsOffset(m_owningLayer, compositedAncestor, compositedBounds(), parentGraphicsLayerRect, { });
-    return LayoutRect(encloseRectToDevicePixels(LayoutRect(toLayoutPoint(compositedBoundsOffset.fromParentGraphicsLayer()), compositedBounds().size()),
+    return LayoutRect(snapRectToDevicePixels(LayoutRect(toLayoutPoint(compositedBoundsOffset.fromParentGraphicsLayer()), compositedBounds().size()),
         deviceScaleFactor()));
 }
 


### PR DESCRIPTION
#### 668ffa34c39b374d2ef675a604f7ca8d6694d39a
<pre>
Need a short description (OOPS!).
Need the bug URL (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* LayoutTests/compositing/webgl/background-subpixel-position-expected.html: Added.
* LayoutTests/compositing/webgl/background-subpixel-position.html: Added.
* LayoutTests/compositing/webgl/hidpi-background-subpixel-position-expected.html: Added.
* LayoutTests/compositing/webgl/hidpi-background-subpixel-position.html: Added.
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::computePrimaryGraphicsLayerRect const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/668ffa34c39b374d2ef675a604f7ca8d6694d39a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153651 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26435 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20052 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162401 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107109 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155524 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26963 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26757 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118795 "Found 23 new test failures: compositing/ancestor-compositing-layer-is-on-subpixel-position.html compositing/backing/inline-block-no-backing.html compositing/backing/whitespace-nodes-no-backing.html compositing/canvas/accelerated-canvas-compositing-size-limit.html compositing/composited-parent-clipping-layer-on-subpixel-position.html compositing/hidpi-ancestor-subpixel-clipping.html compositing/hidpi-composited-container-and-graphics-layer-gap-changes.html compositing/hidpi-negative-composited-bounds-on-device-pixel.html compositing/hidpi-nested-compositing-layers-with-subpixel-accumulation.html compositing/hidpi-sibling-composited-content-offset.html ... (failure)") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/107109 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156610 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21055 "Found 15 new test failures: compositing/ancestor-compositing-layer-is-on-subpixel-position.html compositing/canvas/accelerated-canvas-compositing-size-limit.html compositing/composited-parent-clipping-layer-on-subpixel-position.html compositing/geometry/limit-layer-bounds-overflow-root.html compositing/hidpi-ancestor-subpixel-clipping.html compositing/hidpi-composited-container-and-graphics-layer-gap-changes.html compositing/hidpi-compositing-layer-with-tile-layers-on-subpixel-position.html compositing/hidpi-negative-composited-bounds-on-device-pixel.html compositing/hidpi-nested-compositing-layers-with-subpixel-accumulation.html compositing/hidpi-sibling-composited-content-offset.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137958 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99506 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20134 "Found 4 new test failures: imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/fixed-position-child-with-contain-ancestor.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/fixed-position-child-with-fo-ancestor.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/fixed-position-child-with-transformed-ancestor.tentative.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/fixed-position-child-with-will-change-ancestor.tentative.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18076 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10234 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129783 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15817 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164872 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8006 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17411 "Found 20 new test failures: compositing/ancestor-compositing-layer-is-on-subpixel-position.html compositing/canvas/accelerated-canvas-compositing-size-limit.html compositing/composited-parent-clipping-layer-on-subpixel-position.html compositing/fixed-positioned-pseudo-content-no-compositing.html compositing/hidpi-ancestor-subpixel-clipping.html compositing/hidpi-composited-container-and-graphics-layer-gap-changes.html compositing/hidpi-compositing-layer-with-tile-layers-on-subpixel-position.html compositing/hidpi-negative-composited-bounds-on-device-pixel.html compositing/hidpi-nested-compositing-layers-with-subpixel-accumulation.html compositing/hidpi-sibling-composited-content-offset.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126874 "Found 26 new test failures: compositing/ancestor-compositing-layer-is-on-subpixel-position.html compositing/backing/inline-block-no-backing.html compositing/backing/whitespace-nodes-no-backing.html compositing/canvas/accelerated-canvas-compositing-size-limit.html compositing/composited-parent-clipping-layer-on-subpixel-position.html compositing/geometry/composited-in-columns.html compositing/hidpi-ancestor-subpixel-clipping.html compositing/hidpi-composited-container-and-graphics-layer-gap-changes.html compositing/hidpi-negative-composited-bounds-on-device-pixel.html compositing/hidpi-nested-compositing-layers-with-subpixel-accumulation.html ... (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26232 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22109 "Found 20 new test failures: compositing/ancestor-compositing-layer-is-on-subpixel-position.html compositing/canvas/accelerated-canvas-compositing-size-limit.html compositing/composited-parent-clipping-layer-on-subpixel-position.html compositing/contents-opaque/control-layer.html compositing/fixed-positioned-pseudo-content-no-compositing.html compositing/hidpi-ancestor-subpixel-clipping.html compositing/hidpi-composited-container-and-graphics-layer-gap-changes.html compositing/hidpi-compositing-layer-with-tile-layers-on-subpixel-position.html compositing/hidpi-negative-composited-bounds-on-device-pixel.html compositing/hidpi-nested-compositing-layers-with-subpixel-accumulation.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127040 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26234 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137612 "Exiting early after 10 failures. 10 tests run. 2 failures") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82910 "Built successfully") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21947 "Found 4 new test failures: interaction-region/content-hint.html interaction-region/icon-masking.html interaction-region/nested-composited-text-painter.html interaction-region/position-only-update.html (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14394 "Found 20 new test failures: compositing/ancestor-compositing-layer-is-on-subpixel-position.html compositing/canvas/accelerated-canvas-compositing-size-limit.html compositing/composited-parent-clipping-layer-on-subpixel-position.html compositing/fixed-positioned-pseudo-content-no-compositing.html compositing/hidpi-ancestor-subpixel-clipping.html compositing/hidpi-composited-container-and-graphics-layer-gap-changes.html compositing/hidpi-compositing-layer-with-tile-layers-on-subpixel-position.html compositing/hidpi-negative-composited-bounds-on-device-pixel.html compositing/hidpi-nested-compositing-layers-with-subpixel-accumulation.html compositing/hidpi-sibling-composited-content-offset.html ... (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25851 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90139 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25542 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25702 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25602 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->