### PR TITLE
Avoid building inner text string just to compute its length in HTMLTextFormControlElement

### DIFF
--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -81,6 +81,50 @@ using namespace HTMLNames;
 
 static Position positionForIndex(TextControlInnerTextElement*, unsigned);
 
+static void stripTrailingNewline(StringBuilder& result)
+{
+    // Remove one trailing newline; there's always one that's collapsed out by rendering.
+    size_t size = result.length();
+    if (size && result[size - 1] == newlineCharacter)
+        result.shrink(size - 1);
+}
+
+// Should stay in sync with innerTextLengthFrom().
+static String innerTextValueFrom(TextControlInnerTextElement& innerText)
+{
+    StringBuilder result;
+    for (RefPtr<Node> node = innerText.firstChild(); node; node = NodeTraversal::next(*node, &innerText)) {
+        if (is<HTMLBRElement>(*node))
+            result.append(newlineCharacter);
+        else if (auto* textNode = dynamicDowncast<Text>(*node))
+            result.append(textNode->data());
+    }
+    stripTrailingNewline(result);
+    return result.toString();
+}
+
+// Should stay in sync with innerTextValueFrom().
+static unsigned innerTextLengthFrom(TextControlInnerTextElement& innerText)
+{
+    unsigned length = 0;
+    bool endsWithNewline = false;
+    for (RefPtr node = innerText.firstChild(); node; node = NodeTraversal::next(*node, &innerText)) {
+        if (is<HTMLBRElement>(*node)) {
+            ++length;
+            endsWithNewline = true;
+        } else if (auto* textNode = dynamicDowncast<Text>(*node)) {
+            if (unsigned nodeLength = textNode->length()) {
+                length += nodeLength;
+                endsWithNewline = textNode->data()[nodeLength - 1] == newlineCharacter;
+            }
+        }
+    }
+    // Remove one trailing newline; there's always one that's collapsed out by rendering.
+    if (endsWithNewline && length)
+        --length;
+    return length;
+}
+
 HTMLTextFormControlElement::HTMLTextFormControlElement(const QualifiedName& tagName, Document& document, HTMLFormElement* form)
     : HTMLFormControlElement(tagName, document, form)
     , m_cachedSelectionDirection(document.frame() && document.frame()->editor().behavior().shouldConsiderSelectionAsDirectional() ? SelectionHasForwardDirection : SelectionHasNoDirection)
@@ -329,7 +373,7 @@ bool HTMLTextFormControlElement::setSelectionRange(unsigned start, unsigned end,
     auto innerText = innerTextElementCreatingShadowSubtreeIfNeeded();
 
     // Clamps to the current value length.
-    unsigned innerTextValueLength = innerTextValue().length();
+    unsigned innerTextValueLength = innerText ? innerTextLengthFrom(*innerText) : 0;
     end = std::min(end, innerTextValueLength);
     start = std::min(start, end);
 
@@ -671,27 +715,6 @@ bool HTMLTextFormControlElement::wasEverChangedByUserEdit() const
     return m_wasEverChangedByUserEdit;
 }
 
-static void stripTrailingNewline(StringBuilder& result)
-{
-    // Remove one trailing newline; there's always one that's collapsed out by rendering.
-    size_t size = result.length();
-    if (size && result[size - 1] == newlineCharacter)
-        result.shrink(size - 1);
-}
-
-static String innerTextValueFrom(TextControlInnerTextElement& innerText)
-{
-    StringBuilder result;
-    for (RefPtr<Node> node = innerText.firstChild(); node; node = NodeTraversal::next(*node, &innerText)) {
-        if (is<HTMLBRElement>(*node))
-            result.append(newlineCharacter);
-        else if (auto* textNode = dynamicDowncast<Text>(*node))
-            result.append(textNode->data());
-    }
-    stripTrailingNewline(result);
-    return result.toString();
-}
-
 void HTMLTextFormControlElement::setInnerTextValue(String&& value)
 {
     LayoutDisallowedScope layoutDisallowedScope(LayoutDisallowedScope::Reason::PerformanceOptimization);
@@ -795,8 +818,8 @@ unsigned HTMLTextFormControlElement::indexForPosition(const Position& passedPosi
             ++index;
     }
 
-    unsigned length = innerTextValue().length();
-    index = std::min(index, length); // FIXME: We shouldn't have to call innerTextValue() just to ignore the last LF. See finishText.
+    unsigned length = innerTextLengthFrom(*innerText);
+    index = std::min(index, length);
 #if 0
     // FIXME: This assertion code was never built, has bit rotted, and needs to be fixed before it can be enabled:
     // https://bugs.webkit.org/show_bug.cgi?id=205706.


### PR DESCRIPTION
#### 788a900adfa5082fa1111af1db8cfedacd11a212
<pre>
Avoid building inner text string just to compute its length in HTMLTextFormControlElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=311250">https://bugs.webkit.org/show_bug.cgi?id=311250</a>

Reviewed by Anne van Kesteren.

innerTextValue() traverses the inner text element&apos;s DOM children and
builds a String via StringBuilder, which is wasteful when only the
length is needed. Add `innerTextLengthFrom()` that computes the length
by summing node lengths directly, and use it in `indexForPosition()`
and `setSelectionRange()`.

* Source/WebCore/html/HTMLTextFormControlElement.cpp:
(WebCore::stripTrailingNewline):
(WebCore::innerTextValueFrom):
(WebCore::innerTextLengthFrom):
(WebCore::HTMLTextFormControlElement::setSelectionRange):
(WebCore::HTMLTextFormControlElement::indexForPosition const):

Canonical link: <a href="https://commits.webkit.org/310396@main">https://commits.webkit.org/310396@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08ddc345aa7be133368d6a62adc6e99f8864f8e9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153645 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26429 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20046 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162395 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107103 "An unexpected error occured. Recent messages:Printed configuration") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c57d5b6a-910b-4e8b-a5a6-8aa37c78dd0d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155518 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26957 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26751 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118790 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/107103 "An unexpected error occured. Recent messages:Printed configuration") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c4652864-6b24-46cb-8a35-d3e2795bf9a4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156604 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21045 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137953 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99501 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b22a4a7f-be20-42fa-8635-893def7cff43) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20124 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18070 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10228 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129773 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15812 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164866 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8000 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17406 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126865 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26226 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22104 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127030 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34474 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26228 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137607 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82898 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21945 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14389 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25845 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90132 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25536 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25696 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25596 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->