### PR TITLE
[GTK][WPE] Consolidate dma-buf / EGL image creation code into DMABufBuffer methods

### DIFF
--- a/Source/WTF/wtf/unix/UnixFileDescriptor.h
+++ b/Source/WTF/wtf/unix/UnixFileDescriptor.h
@@ -46,6 +46,12 @@ public:
         : m_value(fd)
     { }
 
+    enum BorrowTag { Borrow };
+    UnixFileDescriptor(int fd, BorrowTag)
+        : m_value(fd)
+        , m_shouldClose(false)
+    { }
+
     enum DuplicationTag { Duplicate };
     UnixFileDescriptor(int fd, DuplicationTag)
     {
@@ -70,7 +76,7 @@ public:
 
     ~UnixFileDescriptor()
     {
-        if (m_value >= 0)
+        if (m_value >= 0 && m_shouldClose)
             closeWithRetry(std::exchange(m_value, -1));
     }
 
@@ -87,6 +93,7 @@ public:
 
 private:
     int m_value { -1 };
+    bool m_shouldClose : 1 { true };
 };
 
 } // namespace WTF

--- a/Source/WebCore/platform/TextureMapper.cmake
+++ b/Source/WebCore/platform/TextureMapper.cmake
@@ -88,6 +88,7 @@ if (USE_COORDINATED_GRAPHICS)
     list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
         page/scrolling/coordinated/ScrollingTreeCoordinated.h
 
+        platform/graphics/gbm/DMABufBufferAttributes.h
         platform/graphics/texmap/coordinated/CoordinatedAnimatedBackingStoreClient.h
         platform/graphics/texmap/coordinated/CoordinatedBackingStore.h
         platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h

--- a/Source/WebCore/platform/graphics/gbm/DMABufBuffer.cpp
+++ b/Source/WebCore/platform/graphics/gbm/DMABufBuffer.cpp
@@ -28,7 +28,17 @@
 
 #if USE(GBM)
 #include "CoordinatedPlatformLayerBuffer.h"
+#include "GBMVersioning.h"
+#include "GLDisplay.h"
 #include <atomic>
+#include <drm_fourcc.h>
+
+#if USE(LIBEPOXY)
+#include <epoxy/egl.h>
+#else
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
+#endif
 
 namespace WebCore {
 
@@ -38,9 +48,9 @@ static uint64_t generateID()
     return ++id;
 }
 
-DMABufBuffer::DMABufBuffer(const IntSize& size, uint32_t fourcc, Vector<WTF::UnixFileDescriptor>&& fds, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier)
+DMABufBuffer::DMABufBuffer(Attributes&& attributes)
     : m_id(generateID())
-    , m_attributes({ size, fourcc, WTF::move(fds), WTF::move(offsets), WTF::move(strides), modifier })
+    , m_attributes(WTF::move(attributes))
 {
 }
 
@@ -63,6 +73,119 @@ std::optional<DMABufBuffer::Attributes> DMABufBuffer::takeAttributes()
         return std::nullopt;
 
     return DMABufBuffer::Attributes { WTF::move(m_attributes.size), std::exchange(m_attributes.fourcc, 0), WTF::move(m_attributes.fds), WTF::move(m_attributes.offsets), WTF::move(m_attributes.strides), std::exchange(m_attributes.modifier, 0) };
+}
+
+std::optional<DMABufBufferAttributes> DMABufBufferAttributes::fromGBMBufferObject(struct gbm_bo* bo, EnableModifiers enableModifiers)
+{
+    if (!bo)
+        return std::nullopt;
+
+    int planeCount = gbm_bo_get_plane_count(bo);
+    if (planeCount <= 0)
+        return std::nullopt;
+
+    DMABufBufferAttributes attributes;
+    attributes.size = { static_cast<int>(gbm_bo_get_width(bo)), static_cast<int>(gbm_bo_get_height(bo)) };
+    attributes.fourcc = gbm_bo_get_format(bo);
+    attributes.modifier = enableModifiers == EnableModifiers::Yes ? gbm_bo_get_modifier(bo) : DRM_FORMAT_MOD_INVALID;
+
+    for (int i = 0; i < planeCount; ++i) {
+        int fd = gbm_bo_get_fd_for_plane(bo, i);
+        if (fd < 0) {
+            LOG_ERROR("DMABufBufferAttributes::fromGBMBufferObject(), failed to export dma-buf for plane %d", i);
+            return std::nullopt;
+        }
+        attributes.fds.append(UnixFileDescriptor { fd, UnixFileDescriptor::Adopt });
+        attributes.offsets.append(gbm_bo_get_offset(bo, i));
+        attributes.strides.append(gbm_bo_get_stride_for_plane(bo, i));
+    }
+
+    return attributes;
+}
+
+EGLImage DMABufBuffer::createEGLImage(GLDisplay& display) const
+{
+    return createEGLImage(display, m_attributes);
+}
+
+static std::optional<Vector<EGLAttrib>> buildEGLAttributesForDMABuf(const DMABufBuffer::Attributes& dmaBufAttributes, DMABufBuffer::Attributes::EnableModifiers enableModifiers)
+{
+    auto planeCount = dmaBufAttributes.fds.size();
+    if (!planeCount || planeCount > DMABufBuffer::Attributes::maxPlaneCountForEGLImage)
+        return std::nullopt;
+
+    bool hasModifiers = dmaBufAttributes.modifier != DRM_FORMAT_MOD_INVALID && enableModifiers == DMABufBuffer::Attributes::EnableModifiers::Yes;
+
+    // 6 base attributes + per-plane (6 + optional 4 modifier) + EGL_NONE terminator.
+    static constexpr unsigned baseAttributeCount = 6;
+    static constexpr unsigned planeAttributeCount = 6;
+    static constexpr unsigned modifierAttributeCount = 4;
+
+    Vector<EGLAttrib> eglAttributes;
+    eglAttributes.reserveInitialCapacity(baseAttributeCount + planeCount * (planeAttributeCount + (hasModifiers ? modifierAttributeCount : 0)) + 1);
+
+    eglAttributes.appendList<EGLAttrib>({
+        EGL_WIDTH, static_cast<EGLAttrib>(dmaBufAttributes.size.width()),
+        EGL_HEIGHT, static_cast<EGLAttrib>(dmaBufAttributes.size.height()),
+        EGL_LINUX_DRM_FOURCC_EXT, static_cast<EGLAttrib>(dmaBufAttributes.fourcc.value)
+    });
+
+    static constexpr std::array planeAttributeNames = {
+        std::array { EGL_DMA_BUF_PLANE0_FD_EXT, EGL_DMA_BUF_PLANE0_OFFSET_EXT, EGL_DMA_BUF_PLANE0_PITCH_EXT, EGL_DMA_BUF_PLANE0_MODIFIER_HI_EXT, EGL_DMA_BUF_PLANE0_MODIFIER_LO_EXT },
+        std::array { EGL_DMA_BUF_PLANE1_FD_EXT, EGL_DMA_BUF_PLANE1_OFFSET_EXT, EGL_DMA_BUF_PLANE1_PITCH_EXT, EGL_DMA_BUF_PLANE1_MODIFIER_HI_EXT, EGL_DMA_BUF_PLANE1_MODIFIER_LO_EXT },
+        std::array { EGL_DMA_BUF_PLANE2_FD_EXT, EGL_DMA_BUF_PLANE2_OFFSET_EXT, EGL_DMA_BUF_PLANE2_PITCH_EXT, EGL_DMA_BUF_PLANE2_MODIFIER_HI_EXT, EGL_DMA_BUF_PLANE2_MODIFIER_LO_EXT },
+        std::array { EGL_DMA_BUF_PLANE3_FD_EXT, EGL_DMA_BUF_PLANE3_OFFSET_EXT, EGL_DMA_BUF_PLANE3_PITCH_EXT, EGL_DMA_BUF_PLANE3_MODIFIER_HI_EXT, EGL_DMA_BUF_PLANE3_MODIFIER_LO_EXT },
+    };
+
+    for (size_t i = 0; i < planeCount; ++i) {
+        const auto& names = planeAttributeNames[i];
+        eglAttributes.appendList<EGLAttrib>({
+            names[0], static_cast<EGLAttrib>(dmaBufAttributes.fds[i].value()),
+            names[1], static_cast<EGLAttrib>(dmaBufAttributes.offsets[i]),
+            names[2], static_cast<EGLAttrib>(dmaBufAttributes.strides[i])
+        });
+
+        if (hasModifiers) {
+            eglAttributes.appendList<EGLAttrib>({
+                names[3], static_cast<EGLAttrib>(dmaBufAttributes.modifier >> 32),
+                names[4], static_cast<EGLAttrib>(dmaBufAttributes.modifier & 0xffffffff)
+            });
+        }
+    }
+
+    eglAttributes.append(EGL_NONE);
+    return eglAttributes;
+}
+
+EGLImage DMABufBuffer::createEGLImage(EGLDisplay eglDisplay) const
+{
+    return createEGLImage(eglDisplay, m_attributes);
+}
+
+EGLImage DMABufBuffer::createEGLImage(GLDisplay& display, const Attributes& dmaBufAttributes)
+{
+    auto enableModifiers = display.extensions().EXT_image_dma_buf_import_modifiers
+        ? DMABufBuffer::Attributes::EnableModifiers::Yes : DMABufBuffer::Attributes::EnableModifiers::No;
+    auto eglAttributes = buildEGLAttributesForDMABuf(dmaBufAttributes, enableModifiers);
+    if (!eglAttributes)
+        return EGL_NO_IMAGE;
+    return display.createImage(EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr, *eglAttributes);
+}
+
+EGLImage DMABufBuffer::createEGLImage(EGLDisplay eglDisplay, const Attributes& dmaBufAttributes)
+{
+    auto eglAttributes = buildEGLAttributesForDMABuf(dmaBufAttributes, DMABufBuffer::Attributes::EnableModifiers::Yes);
+    if (!eglAttributes || eglDisplay == EGL_NO_DISPLAY)
+        return EGL_NO_IMAGE;
+
+    static PFNEGLCREATEIMAGEKHRPROC s_eglCreateImageKHR = reinterpret_cast<PFNEGLCREATEIMAGEKHRPROC>(eglGetProcAddress("eglCreateImageKHR"));
+    if (!s_eglCreateImageKHR)
+        return EGL_NO_IMAGE;
+
+    auto intAttributes = eglAttributes->map<Vector<EGLint>>([](EGLAttrib value) {
+        return static_cast<EGLint>(value);
+    });
+    return s_eglCreateImageKHR(eglDisplay, EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr, intAttributes.span().data());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/gbm/DMABufBuffer.h
+++ b/Source/WebCore/platform/graphics/gbm/DMABufBuffer.h
@@ -26,32 +26,24 @@
 #pragma once
 
 #if USE(COORDINATED_GRAPHICS) && USE(GBM)
-#include "IntSize.h"
-#include <optional>
+#include "DMABufBufferAttributes.h"
 #include <wtf/ThreadSafeRefCounted.h>
-#include <wtf/Vector.h>
-#include <wtf/unix/UnixFileDescriptor.h>
+
+typedef void* EGLDisplay;
+typedef void* EGLImage;
 
 namespace WebCore {
 
 class CoordinatedPlatformLayerBuffer;
-
-struct DMABufBufferAttributes {
-    IntSize size;
-    uint32_t fourcc { 0 };
-    Vector<WTF::UnixFileDescriptor> fds;
-    Vector<uint32_t> offsets;
-    Vector<uint32_t> strides;
-    uint64_t modifier { 0 };
-};
+class GLDisplay;
 
 class DMABufBuffer final : public ThreadSafeRefCounted<DMABufBuffer> {
 public:
     using Attributes = DMABufBufferAttributes;
 
-    static Ref<DMABufBuffer> create(const IntSize& size, uint32_t fourcc, Vector<WTF::UnixFileDescriptor>&& fds, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier)
+    static Ref<DMABufBuffer> create(Attributes&& attributes)
     {
-        return adoptRef(*new DMABufBuffer(size, fourcc, WTF::move(fds), WTF::move(offsets), WTF::move(strides), modifier));
+        return adoptRef(*new DMABufBuffer(WTF::move(attributes)));
     }
     static Ref<DMABufBuffer> create(uint64_t id, Attributes&& attributes)
     {
@@ -71,11 +63,16 @@ public:
     std::optional<TransferFunction> transferFunction() const { return m_transferFunction; }
     void setTransferFunction(TransferFunction transferFunction) { m_transferFunction = transferFunction; }
 
+    EGLImage createEGLImage(GLDisplay&) const;
+    EGLImage createEGLImage(EGLDisplay) const;
+    static EGLImage createEGLImage(GLDisplay&, const Attributes&);
+    static EGLImage createEGLImage(EGLDisplay, const Attributes&);
+
     CoordinatedPlatformLayerBuffer* buffer() const LIFETIME_BOUND { return m_buffer.get(); }
     void setBuffer(std::unique_ptr<CoordinatedPlatformLayerBuffer>&&);
 
 private:
-    DMABufBuffer(const IntSize&, uint32_t fourcc, Vector<WTF::UnixFileDescriptor>&&, Vector<uint32_t>&&, Vector<uint32_t>&&, uint64_t modifier);
+    explicit DMABufBuffer(Attributes&&);
     DMABufBuffer(uint64_t id, Attributes&&);
 
     uint64_t m_id { 0 };

--- a/Source/WebCore/platform/graphics/gbm/DMABufBufferAttributes.h
+++ b/Source/WebCore/platform/graphics/gbm/DMABufBufferAttributes.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2024, 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE COMPUTER, INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE COMPUTER, INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(COORDINATED_GRAPHICS)
+#include "FourCC.h"
+#include "IntSize.h"
+#include <optional>
+#include <wtf/Vector.h>
+#include <wtf/unix/UnixFileDescriptor.h>
+
+#if USE(GBM)
+struct gbm_bo;
+#endif
+
+namespace WebCore {
+
+class DMABufBufferAttributes {
+public:
+    // EGL_EXT_image_dma_buf_import supports up to 4 planes (PLANE0..PLANE3).
+    static constexpr unsigned maxPlaneCountForEGLImage = 4;
+
+    IntSize size;
+    FourCC fourcc;
+    Vector<WTF::UnixFileDescriptor> fds;
+    Vector<uint32_t> offsets;
+    Vector<uint32_t> strides;
+    uint64_t modifier { 0 };
+
+#if USE(GBM)
+    enum class EnableModifiers : bool { No, Yes };
+    static std::optional<DMABufBufferAttributes> fromGBMBufferObject(struct gbm_bo*, EnableModifiers = EnableModifiers::Yes);
+#endif
+};
+
+} // namespace WebCore
+
+#endif // USE(COORDINATED_GRAPHICS)

--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.cpp
@@ -124,65 +124,29 @@ GraphicsContextGLTextureMapperGBM::DrawingBuffer GraphicsContextGLTextureMapperG
 
     const auto size = getInternalFramebufferSize();
     struct gbm_bo* bo = nullptr;
-    bool disableModifiers = m_drawingBufferFormat.modifiers.size() == 1 && m_drawingBufferFormat.modifiers[0] == DRM_FORMAT_MOD_INVALID;
-    if (!disableModifiers && !m_drawingBufferFormat.modifiers.isEmpty())
+    auto enableModifiers = m_drawingBufferFormat.modifiers.size() == 1 && m_drawingBufferFormat.modifiers[0] == DRM_FORMAT_MOD_INVALID
+        ? DMABufBufferAttributes::EnableModifiers::No : DMABufBufferAttributes::EnableModifiers::Yes;
+    if (enableModifiers == DMABufBufferAttributes::EnableModifiers::Yes && !m_drawingBufferFormat.modifiers.isEmpty())
         bo = gbm_bo_create_with_modifiers2(gbmDevice->device(), size.width(), size.height(), m_drawingBufferFormat.fourcc, m_drawingBufferFormat.modifiers.span().data(), m_drawingBufferFormat.modifiers.size(), GBM_BO_USE_RENDERING);
     if (!bo)
         bo = gbm_bo_create(gbmDevice->device(), size.width(), size.height(), m_drawingBufferFormat.fourcc, GBM_BO_USE_RENDERING);
     if (!bo)
         return { };
 
-    Vector<UnixFileDescriptor> fds;
-    Vector<uint32_t> offsets;
-    Vector<uint32_t> strides;
-    uint32_t format = gbm_bo_get_format(bo);
-    int planeCount = gbm_bo_get_plane_count(bo);
-    uint64_t modifier = disableModifiers ? DRM_FORMAT_MOD_INVALID : gbm_bo_get_modifier(bo);
-
-    Vector<EGLint> attributes = {
-        EGL_WIDTH, size.width(),
-        EGL_HEIGHT, size.height(),
-        EGL_LINUX_DRM_FOURCC_EXT, static_cast<EGLint>(format),
-    };
-
-#define ADD_PLANE_ATTRIBUTES(planeIndex) { \
-    fds.append(UnixFileDescriptor { gbm_bo_get_fd_for_plane(bo, planeIndex), UnixFileDescriptor::Adopt }); \
-    offsets.append(gbm_bo_get_offset(bo, planeIndex)); \
-    strides.append(gbm_bo_get_stride_for_plane(bo, planeIndex)); \
-    std::array<EGLint, 6> planeAttributes { \
-        EGL_DMA_BUF_PLANE##planeIndex##_FD_EXT, fds.last().value(), \
-        EGL_DMA_BUF_PLANE##planeIndex##_OFFSET_EXT, static_cast<EGLint>(offsets.last()), \
-        EGL_DMA_BUF_PLANE##planeIndex##_PITCH_EXT, static_cast<EGLint>(strides.last()) \
-    }; \
-    attributes.append(std::span<const EGLint> { planeAttributes }); \
-    if (modifier != DRM_FORMAT_MOD_INVALID) { \
-        std::array<EGLint, 4> modifierAttributes { \
-            EGL_DMA_BUF_PLANE##planeIndex##_MODIFIER_HI_EXT, static_cast<EGLint>(modifier >> 32), \
-            EGL_DMA_BUF_PLANE##planeIndex##_MODIFIER_LO_EXT, static_cast<EGLint>(modifier & 0xffffffff) \
-        }; \
-        attributes.append(std::span<const EGLint> { modifierAttributes }); \
-    } \
+    auto dmaBufAttributes = DMABufBufferAttributes::fromGBMBufferObject(bo, enableModifiers);
+    if (!dmaBufAttributes) {
+        gbm_bo_destroy(bo);
+        return { };
     }
 
-    if (planeCount > 0)
-        ADD_PLANE_ATTRIBUTES(0);
-    if (planeCount > 1)
-        ADD_PLANE_ATTRIBUTES(1);
-    if (planeCount > 2)
-        ADD_PLANE_ATTRIBUTES(2);
-    if (planeCount > 3)
-        ADD_PLANE_ATTRIBUTES(3);
-
-#undef ADD_PLANE_ATTRIBUTES
-
-    attributes.append(EGL_NONE);
-
-    auto* image = EGL_CreateImageKHR(m_displayObj, EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr, attributes.span().data());
+    Ref dmaBuf = DMABufBuffer::create(WTF::move(*dmaBufAttributes));
+    auto image = dmaBuf->createEGLImage(m_displayObj);
     gbm_bo_destroy(bo);
+
     if (!image)
         return { };
 
-    return { DMABufBuffer::create(size, format, WTF::move(fds), WTF::move(offsets), WTF::move(strides), modifier), image };
+    return { WTF::move(dmaBuf), image };
 }
 
 void GraphicsContextGLTextureMapperGBM::freeDrawingBuffers()
@@ -288,40 +252,6 @@ void GraphicsContextGLTextureMapperGBM::prepareForDisplayWithFinishedSignal(Func
 GCGLExternalImage GraphicsContextGLTextureMapperGBM::createExternalImage(ExternalImageSource&& source, GCGLenum, GCGLint)
 {
     GraphicsContextGLExternalImageSource imageSource = WTF::move(source);
-    Vector<EGLint> attributes = {
-        EGL_WIDTH, imageSource.size.width(),
-        EGL_HEIGHT, imageSource.size.height(),
-        EGL_LINUX_DRM_FOURCC_EXT, static_cast<EGLint>(imageSource.fourcc)
-    };
-
-#define ADD_PLANE_ATTRIBUTES(planeIndex) { \
-    std::array<EGLAttrib, 6> planeAttributes { \
-        EGL_DMA_BUF_PLANE##planeIndex##_FD_EXT, imageSource.fds[planeIndex].value(), \
-        EGL_DMA_BUF_PLANE##planeIndex##_OFFSET_EXT, static_cast<EGLint>(imageSource.offsets[planeIndex]), \
-        EGL_DMA_BUF_PLANE##planeIndex##_PITCH_EXT, static_cast<EGLint>(imageSource.strides[planeIndex]) \
-    }; \
-    attributes.append(std::span<const EGLAttrib> { planeAttributes }); \
-    if (imageSource.modifier != DRM_FORMAT_MOD_INVALID && PlatformDisplay::sharedDisplay().eglExtensions().EXT_image_dma_buf_import_modifiers) { \
-        std::array<EGLint, 4> modifierAttributes { \
-            EGL_DMA_BUF_PLANE##planeIndex##_MODIFIER_HI_EXT, static_cast<EGLint>(imageSource.modifier >> 32), \
-            EGL_DMA_BUF_PLANE##planeIndex##_MODIFIER_LO_EXT, static_cast<EGLint>(imageSource.modifier & 0xffffffff) \
-        }; \
-        attributes.append(std::span<const EGLint> { modifierAttributes }); \
-    } \
-    };
-    auto planeCount = imageSource.fds.size();
-    if (planeCount > 0)
-        ADD_PLANE_ATTRIBUTES(0);
-    if (planeCount > 1)
-        ADD_PLANE_ATTRIBUTES(1);
-    if (planeCount > 2)
-        ADD_PLANE_ATTRIBUTES(2);
-    if (planeCount > 3)
-        ADD_PLANE_ATTRIBUTES(3);
-
-#undef ADD_PLANE_ATTRIBUTES
-
-    attributes.append(EGL_NONE);
 
     if (m_displayObj == EGL_NO_DISPLAY) {
         addError(GCGLErrorCode::InvalidOperation);
@@ -329,7 +259,8 @@ GCGLExternalImage GraphicsContextGLTextureMapperGBM::createExternalImage(Externa
         return { };
     }
 
-    auto eglImage = EGL_CreateImageKHR(m_displayObj, EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr, attributes.span().data());
+    DMABufBufferAttributes dmaBufAttributes { imageSource.size, imageSource.fourcc, WTF::move(imageSource.fds), WTF::move(imageSource.offsets), WTF::move(imageSource.strides), imageSource.modifier };
+    auto eglImage = DMABufBuffer::createEGLImage(m_displayObj, dmaBufAttributes);
     if (!eglImage) {
         LOG(XR, "invalid operation importing the image %d", EGL_GetError());
         addError(GCGLErrorCode::InvalidOperation);

--- a/Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.cpp
+++ b/Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.cpp
@@ -179,24 +179,14 @@ bool MemoryMappedGPUBuffer::isVivanteSuperTiled() const
 
 bool MemoryMappedGPUBuffer::createDMABufFromGBMBufferObject(struct gbm_bo* bo)
 {
-    Vector<UnixFileDescriptor> fds;
-    Vector<uint32_t> offsets;
-    Vector<uint32_t> strides;
+    auto attributes = DMABufBufferAttributes::fromGBMBufferObject(bo);
+    if (!attributes)
+        return false;
 
-    auto format = gbm_bo_get_format(bo);
-    auto planeCount = gbm_bo_get_plane_count(bo);
-
-    for (int i = 0; i < planeCount; ++i) {
-        if (auto fd = exportGBMBufferObjectAsDMABuf(bo, i))
-            fds.append(WTF::move(fd));
-        else
-            return false;
-        offsets.append(gbm_bo_get_offset(bo, i));
-        strides.append(gbm_bo_get_stride_for_plane(bo, i));
-    }
+    attributes->modifier = m_modifier;
 
     ASSERT(!m_dmaBuf);
-    m_dmaBuf = DMABufBuffer::create(m_size, format, WTF::move(fds), WTF::move(offsets), WTF::move(strides), m_modifier);
+    m_dmaBuf = DMABufBuffer::create(WTF::move(*attributes));
     return true;
 }
 
@@ -256,66 +246,12 @@ EGLImage MemoryMappedGPUBuffer::createEGLImageFromDMABuf()
 {
     ASSERT(m_dmaBuf);
 
-    const auto& attributes = m_dmaBuf->attributes();
-    auto planeCount = attributes.fds.size();
-
-    Vector<EGLAttrib> eglAttributes {
-        EGL_WIDTH, static_cast<EGLAttrib>(m_allocatedSize.width()),
-        EGL_HEIGHT, static_cast<EGLAttrib>(m_allocatedSize.height()),
-        EGL_LINUX_DRM_FOURCC_EXT, static_cast<EGLAttrib>(attributes.fourcc)
-    };
-
-    static constexpr std::array planeAttributeNames = {
-        std::array { EGL_DMA_BUF_PLANE0_FD_EXT, EGL_DMA_BUF_PLANE0_OFFSET_EXT, EGL_DMA_BUF_PLANE0_PITCH_EXT, EGL_DMA_BUF_PLANE0_MODIFIER_HI_EXT, EGL_DMA_BUF_PLANE0_MODIFIER_LO_EXT },
-        std::array { EGL_DMA_BUF_PLANE1_FD_EXT, EGL_DMA_BUF_PLANE1_OFFSET_EXT, EGL_DMA_BUF_PLANE1_PITCH_EXT, EGL_DMA_BUF_PLANE1_MODIFIER_HI_EXT, EGL_DMA_BUF_PLANE1_MODIFIER_LO_EXT },
-        std::array { EGL_DMA_BUF_PLANE2_FD_EXT, EGL_DMA_BUF_PLANE2_OFFSET_EXT, EGL_DMA_BUF_PLANE2_PITCH_EXT, EGL_DMA_BUF_PLANE2_MODIFIER_HI_EXT, EGL_DMA_BUF_PLANE2_MODIFIER_LO_EXT },
-        std::array { EGL_DMA_BUF_PLANE3_FD_EXT, EGL_DMA_BUF_PLANE3_OFFSET_EXT, EGL_DMA_BUF_PLANE3_PITCH_EXT, EGL_DMA_BUF_PLANE3_MODIFIER_HI_EXT, EGL_DMA_BUF_PLANE3_MODIFIER_LO_EXT },
-    };
-
-    for (size_t i = 0; i < planeCount; ++i) {
-        const auto& names = planeAttributeNames[i];
-        std::array<EGLAttrib, 6> planeAttrs {
-            names[0], static_cast<EGLAttrib>(attributes.fds[i].value()),
-            names[1], static_cast<EGLAttrib>(attributes.offsets[i]),
-            names[2], static_cast<EGLAttrib>(attributes.strides[i])
-        };
-        eglAttributes.append(std::span<const EGLAttrib> { planeAttrs });
-
-        if (m_modifier != DRM_FORMAT_MOD_INVALID) {
-            std::array<EGLAttrib, 4> modifierAttrs {
-                names[3], static_cast<EGLAttrib>(m_modifier >> 32),
-                names[4], static_cast<EGLAttrib>(m_modifier & 0xffffffff)
-            };
-            eglAttributes.append(std::span<const EGLAttrib> { modifierAttrs });
-        }
-    }
-
-    eglAttributes.append(EGL_NONE);
-
     auto& display = WebCore::PlatformDisplay::sharedDisplay();
-    auto eglImage = display.createEGLImage(EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr, eglAttributes);
+    auto eglImage = m_dmaBuf->createEGLImage(display.glDisplay());
     if (!eglImage)
         LOG_ERROR("MemoryMappedGPUBuffer::createEGLImageFromDMABuf(), failed to export GBM buffer as EGLImage");
 
     return eglImage;
-}
-
-UnixFileDescriptor MemoryMappedGPUBuffer::exportGBMBufferObjectAsDMABuf(struct gbm_bo* bo, unsigned planeIndex)
-{
-    auto handle = gbm_bo_get_handle_for_plane(bo, planeIndex);
-    if (handle.s32 == -1) {
-        LOG_ERROR("MemoryMappedGPUBuffer::exportGBMBufferObjectAsDMABuf(), failed to obtain gbm handle for plane %u", planeIndex);
-        return { };
-    }
-
-    int fd = 0;
-    int ret = drmPrimeHandleToFD(gbm_device_get_fd(gbm_bo_get_device(bo)), handle.u32, DRM_CLOEXEC | DRM_RDWR, &fd);
-    if (ret < 0) {
-        LOG_ERROR("MemoryMappedGPUBuffer::exportGBMBufferObjectAsDMABuf(), failed to export dma-buf for plane %u", planeIndex);
-        return { };
-    }
-
-    return UnixFileDescriptor { fd, UnixFileDescriptor::Adopt };
 }
 
 void MemoryMappedGPUBuffer::updateContents(AccessScope& scope, const void* srcData, const IntRect& targetRect, unsigned bytesPerLine)

--- a/Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.h
+++ b/Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.h
@@ -119,7 +119,6 @@ private:
 
     struct gbm_bo* allocate(struct gbm_device*, const GLDisplay::BufferFormat&);
     bool createDMABufFromGBMBufferObject(struct gbm_bo*);
-    UnixFileDescriptor exportGBMBufferObjectAsDMABuf(struct gbm_bo*, unsigned planeIndex);
 
     void updateContentsInLinearFormat(const void* srcData, const IntRect& targetRect, unsigned bytesPerLine);
     void updateContentsInVivanteSuperTiledFormat(const void* srcData, const IntRect& targetRect, unsigned bytesPerLine);

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
@@ -833,7 +833,7 @@ RefPtr<DMABufBuffer> VideoFrameGStreamer::getDMABuf()
         fourcc = *fourccFromFormat;
     ASSERT(fourcc);
 
-    RefPtr dmabuf = DMABufBuffer::create(size, fourcc, WTF::move(fds), WTF::move(offsets), WTF::move(strides), modifier);
+    Ref dmabuf = DMABufBuffer::create({ size, fourcc, WTF::move(fds), WTF::move(offsets), WTF::move(strides), modifier });
 
     DMABufBuffer::ColorSpace colorSpace = DMABufBuffer::ColorSpace::Bt601;
     DMABufBuffer::TransferFunction transferFunction = DMABufBuffer::TransferFunction::Bt709;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.cpp
@@ -66,50 +66,14 @@ CoordinatedPlatformLayerBufferDMABuf::CoordinatedPlatformLayerBufferDMABuf(Ref<D
 
 CoordinatedPlatformLayerBufferDMABuf::~CoordinatedPlatformLayerBufferDMABuf() = default;
 
-static RefPtr<BitmapTexture> importToTexture(const IntSize& size, const IntSize& subsampling, uint32_t fourcc, const Vector<int>& fds, const Vector<uint32_t>& offsets, const Vector<uint32_t>& strides, uint64_t modifier, OptionSet<BitmapTexture::Flags> textureFlags)
+static RefPtr<BitmapTexture> importToTexture(const IntSize& textureSize, const DMABufBuffer::Attributes& dmaBufAttributes, OptionSet<BitmapTexture::Flags> textureFlags)
 {
     auto& display = PlatformDisplay::sharedDisplay();
-    Vector<EGLAttrib> attributes = {
-        EGL_WIDTH, size.width() / subsampling.width(),
-        EGL_HEIGHT, size.height() / subsampling.height(),
-        EGL_LINUX_DRM_FOURCC_EXT, static_cast<EGLAttrib>(fourcc)
-    };
-
-#define ADD_PLANE_ATTRIBUTES(planeIndex) { \
-    std::array<EGLAttrib, 6> planeAttributes { \
-        EGL_DMA_BUF_PLANE##planeIndex##_FD_EXT, fds[planeIndex], \
-        EGL_DMA_BUF_PLANE##planeIndex##_OFFSET_EXT, static_cast<EGLAttrib>(offsets[planeIndex]), \
-        EGL_DMA_BUF_PLANE##planeIndex##_PITCH_EXT, static_cast<EGLAttrib>(strides[planeIndex]) \
-    }; \
-    attributes.append(std::span<const EGLAttrib> { planeAttributes }); \
-    if (modifier != DRM_FORMAT_MOD_INVALID && display.eglExtensions().EXT_image_dma_buf_import_modifiers) { \
-        std::array<EGLAttrib, 4> modifierAttributes { \
-            EGL_DMA_BUF_PLANE##planeIndex##_MODIFIER_HI_EXT, static_cast<EGLAttrib>(modifier >> 32), \
-            EGL_DMA_BUF_PLANE##planeIndex##_MODIFIER_LO_EXT, static_cast<EGLAttrib>(modifier & 0xffffffff) \
-        }; \
-        attributes.append(std::span<const EGLAttrib> { modifierAttributes }); \
-    } \
-    }
-
-    auto planeCount = fds.size();
-    if (planeCount > 0)
-        ADD_PLANE_ATTRIBUTES(0);
-    if (planeCount > 1)
-        ADD_PLANE_ATTRIBUTES(1);
-    if (planeCount > 2)
-        ADD_PLANE_ATTRIBUTES(2);
-    if (planeCount > 3)
-        ADD_PLANE_ATTRIBUTES(3);
-
-#undef ADD_PLANE_ATTRIBUTES
-
-    attributes.append(EGL_NONE);
-
-    auto image = display.createEGLImage(EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr, attributes);
+    auto image = DMABufBuffer::createEGLImage(display.glDisplay(), dmaBufAttributes);
     if (!image)
         return nullptr;
 
-    auto texture = BitmapTexturePool::singleton().createTextureForImage(image, size, textureFlags);
+    auto texture = BitmapTexturePool::singleton().createTextureForImage(image, textureSize, textureFlags);
     display.destroyEGLImage(image);
     return texture;
 }
@@ -204,14 +168,17 @@ std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferDM
     std::array<unsigned, 4> yuvPlaneOffset;
 
     const auto& attributes = m_dmabuf->attributes();
-    const auto& iter = yuvFormatPlaneInfo().find(attributes.fourcc);
+    const auto& iter = yuvFormatPlaneInfo().find(attributes.fourcc.value);
     if (iter == yuvFormatPlaneInfo().end())
         return nullptr;
 
     const auto& planeInfo = iter->value;
     for (unsigned i = 0; i < planeInfo.size(); ++i) {
         const auto& plane = planeInfo[i];
-        auto texture = importToTexture(attributes.size, plane.subsampling, plane.fourcc, { attributes.fds[i].value() }, { attributes.offsets[i] }, { attributes.strides[i] }, attributes.modifier, textureFlags);
+        IntSize adjustedSize { attributes.size.width() / plane.subsampling.width(), attributes.size.height() / plane.subsampling.height() };
+        auto planeFds = Vector<UnixFileDescriptor>::from(UnixFileDescriptor { attributes.fds[i].value(), UnixFileDescriptor::Borrow });
+        DMABufBuffer::Attributes planeAttributes { adjustedSize, plane.fourcc, WTF::move(planeFds), { attributes.offsets[i] }, { attributes.strides[i] }, attributes.modifier };
+        auto texture = importToTexture(attributes.size, planeAttributes, textureFlags);
         if (!texture)
             return nullptr;
         textures.append(WTF::move(texture));
@@ -255,16 +222,13 @@ std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferDM
 std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferDMABuf::importDMABuf() const
 {
     const auto& attributes = m_dmabuf->attributes();
-    if (formatIsYUV(attributes.fourcc))
+    if (formatIsYUV(attributes.fourcc.value))
         return importYUV();
 
     OptionSet<BitmapTexture::Flags> textureFlags;
     if (m_flags.contains(TextureMapperFlags::ShouldBlend))
         textureFlags.add(BitmapTexture::Flags::SupportsAlpha);
-    Vector<int> fds = attributes.fds.map<Vector<int>>([] (const UnixFileDescriptor& fd) {
-        return fd.value();
-    });
-    auto texture = importToTexture(attributes.size, { 1, 1 }, attributes.fourcc, fds, attributes.offsets, attributes.strides, attributes.modifier, textureFlags);
+    auto texture = importToTexture(attributes.size, attributes, textureFlags);
     return texture ? CoordinatedPlatformLayerBufferRGB::create(texture.releaseNonNull(), m_flags, nullptr) : nullptr;
 }
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.h
@@ -32,7 +32,7 @@
 namespace WebCore {
 
 class DMABufBuffer;
-struct DMABufBufferAttributes;
+class DMABufBufferAttributes;
 
 class CoordinatedPlatformLayerBufferDMABuf final : public CoordinatedPlatformLayerBuffer {
 public:

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
@@ -38,7 +38,7 @@ messages -> RemoteGraphicsContextGL Stream {
     void PrepareForDisplay() -> (std::optional<WebKit::WCContentBufferIdentifier> contentBuffer) Synchronous
 #endif
 #if USE(GBM)
-    void PrepareForDisplay() -> (uint64_t bufferID, struct std::optional<WebCore::DMABufBufferAttributes> dmabufAttributes, UnixFileDescriptor fenceFD) Synchronous NotStreamEncodableReply
+    void PrepareForDisplay() -> (uint64_t bufferID, std::optional<WebCore::DMABufBufferAttributes> dmabufAttributes, UnixFileDescriptor fenceFD) Synchronous NotStreamEncodableReply
 #endif
 #if !PLATFORM(COCOA) && !USE(GRAPHICS_LAYER_WC) && !USE(GBM)
     void PrepareForDisplay() -> () Synchronous

--- a/Source/WebKit/Shared/gbm/DMABufBuffer.serialization.in
+++ b/Source/WebKit/Shared/gbm/DMABufBuffer.serialization.in
@@ -21,10 +21,10 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #if USE(GBM)
-header: <WebCore/DMABufBuffer.h>
-[RValue, CustomHeader] struct WebCore::DMABufBufferAttributes {
+header: <WebCore/DMABufBufferAttributes.h>
+[CustomHeader] class WebCore::DMABufBufferAttributes {
     WebCore::IntSize size;
-    uint32_t fourcc;
+    WebCore::FourCC fourcc;
     Vector<WTF::UnixFileDescriptor> fds;
     Vector<uint32_t> offsets;
     Vector<uint32_t> strides;

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.cpp
@@ -39,6 +39,7 @@
 #endif
 
 #if USE(GBM)
+#include <WebCore/DMABufBuffer.h>
 #include <WebCore/GBMDevice.h>
 #include <WebCore/GBMVersioning.h>
 #include <drm_fourcc.h>
@@ -249,54 +250,15 @@ std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRLayer::exportOpenXRT
         return std::nullopt;
     }
 
-    Vector<UnixFileDescriptor> fds;
-    Vector<uint32_t> offsets;
-    Vector<uint32_t> strides;
-    uint32_t fourcc = gbm_bo_get_format(buffer);
-    uint64_t modifier = gbm_bo_get_modifier(buffer);
-    int planeCount = gbm_bo_get_plane_count(buffer);
-
-    Vector<EGLAttrib> attributes = {
-        EGL_WIDTH, static_cast<EGLAttrib>(gbm_bo_get_width(buffer)),
-        EGL_HEIGHT, static_cast<EGLAttrib>(gbm_bo_get_height(buffer)),
-        EGL_LINUX_DRM_FOURCC_EXT, static_cast<EGLAttrib>(fourcc),
-    };
-
-#define ADD_PLANE_ATTRIBUTES(planeIndex) { \
-    fds.append(UnixFileDescriptor { gbm_bo_get_fd_for_plane(buffer, planeIndex), UnixFileDescriptor::Adopt }); \
-    offsets.append(gbm_bo_get_offset(buffer, planeIndex)); \
-    strides.append(gbm_bo_get_stride_for_plane(buffer, planeIndex)); \
-    std::array<EGLAttrib, 6> planeAttributes { \
-        EGL_DMA_BUF_PLANE##planeIndex##_FD_EXT, fds.last().value(), \
-        EGL_DMA_BUF_PLANE##planeIndex##_OFFSET_EXT, static_cast<EGLAttrib>(offsets.last()), \
-        EGL_DMA_BUF_PLANE##planeIndex##_PITCH_EXT, static_cast<EGLAttrib>(strides.last()) \
-    }; \
-    attributes.append(std::span<const EGLAttrib> { planeAttributes }); \
-    if (modifier != DRM_FORMAT_MOD_INVALID) { \
-        std::array<EGLAttrib, 4> modifierAttributes { \
-            EGL_DMA_BUF_PLANE##planeIndex##_MODIFIER_HI_EXT, static_cast<EGLAttrib>(modifier >> 32), \
-            EGL_DMA_BUF_PLANE##planeIndex##_MODIFIER_LO_EXT, static_cast<EGLAttrib>(modifier & 0xffffffff) \
-        }; \
-        attributes.append(std::span<const EGLAttrib> { modifierAttributes }); \
-    } \
+    auto dmaBufAttributes = WebCore::DMABufBufferAttributes::fromGBMBufferObject(buffer);
+    if (!dmaBufAttributes) {
+        gbm_bo_destroy(buffer);
+        RELEASE_LOG(XR, "Failed to extract DMA-buf attributes from GBM buffer for OpenXR texture");
+        return std::nullopt;
     }
 
-    if (planeCount > 0)
-        ADD_PLANE_ATTRIBUTES(0);
-    if (planeCount > 1)
-        ADD_PLANE_ATTRIBUTES(1);
-    if (planeCount > 2)
-        ADD_PLANE_ATTRIBUTES(2);
-    if (planeCount > 3)
-        ADD_PLANE_ATTRIBUTES(3);
-
-#undef ADD_PLANE_ATTRIBS
-
-    attributes.append(EGL_NONE);
-
-    auto image = display.createImage(EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr, attributes);
+    auto image = WebCore::DMABufBuffer::createEGLImage(display, *dmaBufAttributes);
     gbm_bo_destroy(buffer);
-
     if (!image) {
         RELEASE_LOG(XR, "Failed to create EGL image from OpenXR texture");
         return std::nullopt;
@@ -319,11 +281,11 @@ std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRLayer::exportOpenXRT
     m_exportedTexturesMap.add(openxrTexture, exportedTexture);
 
     return PlatformXR::FrameData::ExternalTexture {
-        .fds = WTF::move(fds),
-        .strides = WTF::move(strides),
-        .offsets = WTF::move(offsets),
-        .fourcc = fourcc,
-        .modifier = modifier
+        .fds = WTF::move(dmaBufAttributes->fds),
+        .strides = WTF::move(dmaBufAttributes->strides),
+        .offsets = WTF::move(dmaBufAttributes->offsets),
+        .fourcc = dmaBufAttributes->fourcc.value,
+        .modifier = dmaBufAttributes->modifier
     };
 }
 #endif // USE(GBM)

--- a/Source/WebKit/UIProcess/glib/AcceleratedBackingStore.messages.in
+++ b/Source/WebKit/UIProcess/glib/AcceleratedBackingStore.messages.in
@@ -26,7 +26,7 @@
     ExceptionForEnabledBy
 ]
 messages -> AcceleratedBackingStore {
-    DidCreateDMABufBuffer(uint64_t id, WebCore::IntSize size, uint32_t format, Vector<UnixFileDescriptor> fds, Vector<uint32_t> offsets, Vector<uint32_t> strides, uint64_t modifier, WebKit::RendererBufferFormat::Usage usage)
+    DidCreateDMABufBuffer(uint64_t id, WebCore::DMABufBufferAttributes dmaBufAttributes, WebKit::RendererBufferFormat::Usage usage)
     DidCreateSHMBuffer(uint64_t id, WebCore::ShareableBitmapHandle handle)
 
 #if OS(ANDROID)

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.cpp
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.cpp
@@ -52,13 +52,10 @@
 #endif
 
 #if USE(GBM)
+#include <WebCore/DMABufBuffer.h>
 #include <WebCore/DRMDeviceManager.h>
 #include <WebCore/GBMDevice.h>
 #include <gbm.h>
-
-static constexpr uint64_t s_dmabufInvalidModifier = DRM_FORMAT_MOD_INVALID;
-#else
-static constexpr uint64_t s_dmabufInvalidModifier = ((1ULL << 56) - 1);
 #endif
 
 #if PLATFORM(X11) && USE(GTK4)
@@ -305,23 +302,23 @@ static RefPtr<NativeImage> nativeImageFromGdkTexture(GdkTexture* texture)
 #endif
 
 #if GTK_CHECK_VERSION(4, 13, 4)
-RefPtr<AcceleratedBackingStore::Buffer> AcceleratedBackingStore::BufferDMABuf::create(WebPageProxy& webPage, uint64_t id, uint64_t surfaceID, const IntSize& size, RendererBufferFormat::Usage usage, uint32_t format, Vector<UnixFileDescriptor>&& fds, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier)
+RefPtr<AcceleratedBackingStore::Buffer> AcceleratedBackingStore::BufferDMABuf::create(WebPageProxy& webPage, uint64_t id, uint64_t surfaceID, RendererBufferFormat::Usage usage, DMABufBufferAttributes&& dmaBufAttributes)
 {
     GRefPtr<GdkDmabufTextureBuilder> builder = adoptGRef(gdk_dmabuf_texture_builder_new());
     gdk_dmabuf_texture_builder_set_display(builder.get(), gtk_widget_get_display(webPage.viewWidget()));
-    gdk_dmabuf_texture_builder_set_width(builder.get(), size.width());
-    gdk_dmabuf_texture_builder_set_height(builder.get(), size.height());
-    gdk_dmabuf_texture_builder_set_fourcc(builder.get(), format);
-    gdk_dmabuf_texture_builder_set_modifier(builder.get(), modifier);
-    auto planeCount = fds.size();
+    gdk_dmabuf_texture_builder_set_width(builder.get(), dmaBufAttributes.size.width());
+    gdk_dmabuf_texture_builder_set_height(builder.get(), dmaBufAttributes.size.height());
+    gdk_dmabuf_texture_builder_set_fourcc(builder.get(), dmaBufAttributes.fourcc.value);
+    gdk_dmabuf_texture_builder_set_modifier(builder.get(), dmaBufAttributes.modifier);
+    auto planeCount = dmaBufAttributes.fds.size();
     gdk_dmabuf_texture_builder_set_n_planes(builder.get(), planeCount);
     for (unsigned i = 0; i < planeCount; ++i) {
-        gdk_dmabuf_texture_builder_set_fd(builder.get(), i, fds[i].value());
-        gdk_dmabuf_texture_builder_set_stride(builder.get(), i, strides[i]);
-        gdk_dmabuf_texture_builder_set_offset(builder.get(), i, offsets[i]);
+        gdk_dmabuf_texture_builder_set_fd(builder.get(), i, dmaBufAttributes.fds[i].value());
+        gdk_dmabuf_texture_builder_set_stride(builder.get(), i, dmaBufAttributes.strides[i]);
+        gdk_dmabuf_texture_builder_set_offset(builder.get(), i, dmaBufAttributes.offsets[i]);
     }
 
-    return adoptRef(*new BufferDMABuf(webPage, id, surfaceID, size, usage, WTF::move(fds), WTF::move(builder)));
+    return adoptRef(*new BufferDMABuf(webPage, id, surfaceID, dmaBufAttributes.size, usage, WTF::move(dmaBufAttributes.fds), WTF::move(builder)));
 }
 
 AcceleratedBackingStore::BufferDMABuf::BufferDMABuf(WebPageProxy& webPage, uint64_t id, uint64_t surfaceID, const IntSize& size, RendererBufferFormat::Usage usage, Vector<UnixFileDescriptor>&& fds, GRefPtr<GdkDmabufTextureBuilder>&& builder)
@@ -369,63 +366,25 @@ void AcceleratedBackingStore::BufferDMABuf::release()
 }
 #endif
 
-RefPtr<AcceleratedBackingStore::Buffer> AcceleratedBackingStore::BufferEGLImage::create(WebPageProxy& webPage, uint64_t id, uint64_t surfaceID, const IntSize& size, RendererBufferFormat::Usage usage, uint32_t format, Vector<UnixFileDescriptor>&& fds, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier)
+RefPtr<AcceleratedBackingStore::Buffer> AcceleratedBackingStore::BufferEGLImage::create(WebPageProxy& webPage, uint64_t id, uint64_t surfaceID, const IntSize& size, RendererBufferFormat::Usage usage, DMABufBufferAttributes&& dmaBufAttributes)
 {
     auto* glDisplay = Display::singleton().glDisplay();
     if (!glDisplay)
         return nullptr;
 
-    Vector<EGLAttrib> attributes = {
-        EGL_WIDTH, size.width(),
-        EGL_HEIGHT, size.height(),
-        EGL_LINUX_DRM_FOURCC_EXT, static_cast<EGLAttrib>(format)
-    };
-
-#define ADD_PLANE_ATTRIBUTES(planeIndex) { \
-    std::array<EGLAttrib, 6> planeAttributes { \
-        EGL_DMA_BUF_PLANE##planeIndex##_FD_EXT, fds[planeIndex].value(), \
-        EGL_DMA_BUF_PLANE##planeIndex##_OFFSET_EXT, static_cast<EGLAttrib>(offsets[planeIndex]), \
-        EGL_DMA_BUF_PLANE##planeIndex##_PITCH_EXT, static_cast<EGLAttrib>(strides[planeIndex]) \
-    }; \
-    attributes.append(std::span<const EGLAttrib> { planeAttributes }); \
-    if (modifier != s_dmabufInvalidModifier && glDisplay->extensions().EXT_image_dma_buf_import_modifiers) { \
-        std::array<EGLAttrib, 4> modifierAttributes { \
-            EGL_DMA_BUF_PLANE##planeIndex##_MODIFIER_HI_EXT, static_cast<EGLAttrib>(modifier >> 32), \
-            EGL_DMA_BUF_PLANE##planeIndex##_MODIFIER_LO_EXT, static_cast<EGLAttrib>(modifier & 0xffffffff) \
-        }; \
-        attributes.append(std::span<const EGLAttrib> { modifierAttributes }); \
-    } \
-    }
-
-    auto planeCount = fds.size();
-    if (planeCount > 0)
-        ADD_PLANE_ATTRIBUTES(0);
-    if (planeCount > 1)
-        ADD_PLANE_ATTRIBUTES(1);
-    if (planeCount > 2)
-        ADD_PLANE_ATTRIBUTES(2);
-    if (planeCount > 3)
-        ADD_PLANE_ATTRIBUTES(3);
-
-#undef ADD_PLANE_ATTRIBUTES
-
-    attributes.append(EGL_NONE);
-
-    auto* image = glDisplay->createImage(EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr, attributes);
+    auto* image = DMABufBuffer::createEGLImage(*glDisplay, dmaBufAttributes);
     if (!image) {
         WTFLogAlways("Failed to create EGL image from DMABuf of size %dx%d", size.width(), size.height());
         return nullptr;
     }
 
-    return adoptRef(*new BufferEGLImage(webPage, id, surfaceID, size, usage, format, WTF::move(fds), modifier, image));
+    return adoptRef(*new BufferEGLImage(webPage, id, surfaceID, size, usage, WTF::move(dmaBufAttributes), image));
 }
 
-AcceleratedBackingStore::BufferEGLImage::BufferEGLImage(WebPageProxy& webPage, uint64_t id, uint64_t surfaceID, const IntSize& size, RendererBufferFormat::Usage usage, uint32_t format, Vector<UnixFileDescriptor>&& fds, uint64_t modifier, EGLImage image)
+AcceleratedBackingStore::BufferEGLImage::BufferEGLImage(WebPageProxy& webPage, uint64_t id, uint64_t surfaceID, const IntSize& size, RendererBufferFormat::Usage usage, DMABufBufferAttributes&& dmaBufAttributes, EGLImage image)
     : Buffer(webPage, id, surfaceID, size, usage)
-    , m_fds(WTF::move(fds))
+    , m_dmaBufAttributes(WTF::move(dmaBufAttributes))
     , m_image(image)
-    , m_fourcc(format)
-    , m_modifier(modifier)
 {
 }
 
@@ -494,7 +453,7 @@ void AcceleratedBackingStore::BufferEGLImage::didUpdateContents(Buffer*, const R
 
 RendererBufferDescription AcceleratedBackingStore::BufferEGLImage::description() const
 {
-    return { RendererBufferDescription::Type::DMABuf, m_usage, m_fourcc, m_modifier };
+    return { RendererBufferDescription::Type::DMABuf, m_usage, m_dmaBufAttributes.fourcc.value, m_dmaBufAttributes.modifier };
 }
 
 RefPtr<NativeImage> AcceleratedBackingStore::BufferEGLImage::asNativeImageForTesting() const
@@ -719,29 +678,31 @@ void AcceleratedBackingStore::BufferSHM::release()
     didRelease();
 }
 
-void AcceleratedBackingStore::didCreateDMABufBuffer(uint64_t id, const IntSize& size, uint32_t format, Vector<WTF::UnixFileDescriptor>&& fds, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier, RendererBufferFormat::Usage usage)
+void AcceleratedBackingStore::didCreateDMABufBuffer(uint64_t id, DMABufBufferAttributes&& dmaBufAttributes, RendererBufferFormat::Usage usage)
 {
     RefPtr webPage = m_webPage.get();
     if (!webPage)
         return;
 
+    auto size = dmaBufAttributes.size;
+
 #if USE(GBM)
     if (!Display::singleton().glDisplayIsSharedWithGtk()) {
-        ASSERT(fds.size() == 1 && strides.size() == 1);
-        if (auto buffer = BufferGBM::create(*webPage, id, m_surfaceID, size, usage, format, WTF::move(fds[0]), strides[0]))
+        ASSERT(dmaBufAttributes.fds.size() == 1 && dmaBufAttributes.strides.size() == 1);
+        if (RefPtr buffer = BufferGBM::create(*webPage, id, m_surfaceID, size, usage, dmaBufAttributes.fourcc.value, WTF::move(dmaBufAttributes.fds[0]), dmaBufAttributes.strides[0]))
             m_buffers.add(id, WTF::move(buffer));
         return;
     }
 #endif
 
 #if GTK_CHECK_VERSION(4, 13, 4)
-    if (auto buffer = BufferDMABuf::create(*webPage, id, m_surfaceID, size, usage, format, WTF::move(fds), WTF::move(offsets), WTF::move(strides), modifier)) {
+    if (RefPtr buffer = BufferDMABuf::create(*webPage, id, m_surfaceID, usage, WTF::move(dmaBufAttributes))) {
         m_buffers.add(id, WTF::move(buffer));
         return;
     }
 #endif
 
-    if (auto buffer = BufferEGLImage::create(*webPage, id, m_surfaceID, size, usage, format, WTF::move(fds), WTF::move(offsets), WTF::move(strides), modifier))
+    if (RefPtr buffer = BufferEGLImage::create(*webPage, id, m_surfaceID, size, usage, WTF::move(dmaBufAttributes)))
         m_buffers.add(id, WTF::move(buffer));
 }
 

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.h
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.h
@@ -28,6 +28,7 @@
 #include "FenceMonitor.h"
 #include "MessageReceiver.h"
 #include "RendererBufferDescription.h"
+#include <WebCore/DMABufBufferAttributes.h>
 #include <WebCore/IntRect.h>
 #include <WebCore/IntSize.h>
 #include <WebCore/RefPtrCairo.h>
@@ -43,6 +44,7 @@
 typedef void *EGLImage;
 
 #if USE(GBM)
+#include <WebCore/DMABufBuffer.h>
 struct gbm_bo;
 #endif
 
@@ -91,7 +93,7 @@ private:
     // IPC::MessageReceiver.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 
-    void didCreateDMABufBuffer(uint64_t id, const WebCore::IntSize&, uint32_t format, Vector<WTF::UnixFileDescriptor>&&, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier, RendererBufferFormat::Usage);
+    void didCreateDMABufBuffer(uint64_t id, WebCore::DMABufBufferAttributes&&, RendererBufferFormat::Usage);
     void didCreateSHMBuffer(uint64_t id, WebCore::ShareableBitmapHandle&&);
     void didDestroyBuffer(uint64_t id);
     void frame(uint64_t id, Rects&&, WTF::UnixFileDescriptor&&);
@@ -151,7 +153,7 @@ private:
 #if GTK_CHECK_VERSION(4, 13, 4)
     class BufferDMABuf final : public Buffer {
     public:
-        static RefPtr<Buffer> create(WebPageProxy&, uint64_t id, uint64_t surfaceID, const WebCore::IntSize&, RendererBufferFormat::Usage, uint32_t format, Vector<WTF::UnixFileDescriptor>&&, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier);
+        static RefPtr<Buffer> create(WebPageProxy&, uint64_t id, uint64_t surfaceID, RendererBufferFormat::Usage, WebCore::DMABufBufferAttributes&&);
 
     private:
         BufferDMABuf(WebPageProxy&, uint64_t id, uint64_t surfaceID, const WebCore::IntSize&, RendererBufferFormat::Usage, Vector<WTF::UnixFileDescriptor>&&, GRefPtr<GdkDmabufTextureBuilder>&&);
@@ -171,11 +173,11 @@ private:
 
     class BufferEGLImage final : public Buffer {
     public:
-        static RefPtr<Buffer> create(WebPageProxy&, uint64_t id, uint64_t surfaceID, const WebCore::IntSize&, RendererBufferFormat::Usage, uint32_t format, Vector<WTF::UnixFileDescriptor>&&, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier);
+        static RefPtr<Buffer> create(WebPageProxy&, uint64_t id, uint64_t surfaceID, const WebCore::IntSize&, RendererBufferFormat::Usage, WebCore::DMABufBufferAttributes&&);
         ~BufferEGLImage();
 
     private:
-        BufferEGLImage(WebPageProxy&, uint64_t id, uint64_t surfaceID, const WebCore::IntSize&, RendererBufferFormat::Usage, uint32_t format, Vector<WTF::UnixFileDescriptor>&&, uint64_t modifier, EGLImage);
+        BufferEGLImage(WebPageProxy&, uint64_t id, uint64_t surfaceID, const WebCore::IntSize&, RendererBufferFormat::Usage, WebCore::DMABufBufferAttributes&&, EGLImage);
 
         Buffer::Type type() const override { return Buffer::Type::EglImage; }
         void didUpdateContents(Buffer*, const Rects&) override;
@@ -188,7 +190,7 @@ private:
         RefPtr<WebCore::NativeImage> asNativeImageForTesting() const override;
         void release() override;
 
-        Vector<WTF::UnixFileDescriptor> m_fds;
+        WebCore::DMABufBufferAttributes m_dmaBufAttributes;
         EGLImage m_image { nullptr };
 #if USE(GTK4)
         GRefPtr<GdkTexture> m_texture;
@@ -196,8 +198,6 @@ private:
         GRefPtr<GdkGLContext> m_gdkGLContext;
         unsigned m_textureID { 0 };
 #endif
-        uint32_t m_fourcc { 0 };
-        uint64_t m_modifier { 0 };
     };
 
 #if USE(GBM)

--- a/Source/WebKit/UIProcess/wpe/AcceleratedBackingStore.cpp
+++ b/Source/WebKit/UIProcess/wpe/AcceleratedBackingStore.cpp
@@ -138,13 +138,13 @@ void AcceleratedBackingStore::notifyBufferConfigurationIfNeeded()
     wpe_view_buffers_changed(m_wpeView.get(), buffersSpan.data(), buffersSpan.size());
 }
 
-void AcceleratedBackingStore::didCreateDMABufBuffer(uint64_t id, const WebCore::IntSize& size, uint32_t format, Vector<WTF::UnixFileDescriptor>&& fds, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier, RendererBufferFormat::Usage usage)
+void AcceleratedBackingStore::didCreateDMABufBuffer(uint64_t id, WebCore::DMABufBufferAttributes&& dmaBufAttributes, RendererBufferFormat::Usage usage)
 {
     Vector<int> fileDescriptors;
-    fileDescriptors.reserveInitialCapacity(fds.size());
-    for (auto& fd : fds)
+    fileDescriptors.reserveInitialCapacity(dmaBufAttributes.fds.size());
+    for (auto& fd : dmaBufAttributes.fds)
         fileDescriptors.append(fd.release());
-    GRefPtr<WPEBuffer> buffer = adoptGRef(WPE_BUFFER(wpe_buffer_dma_buf_new(wpe_view_get_display(m_wpeView.get()), size.width(), size.height(), format, fds.size(), fileDescriptors.mutableSpan().data(), offsets.mutableSpan().data(), strides.mutableSpan().data(), modifier)));
+    GRefPtr<WPEBuffer> buffer = adoptGRef(WPE_BUFFER(wpe_buffer_dma_buf_new(wpe_view_get_display(m_wpeView.get()), dmaBufAttributes.size.width(), dmaBufAttributes.size.height(), dmaBufAttributes.fourcc.value, dmaBufAttributes.fds.size(), fileDescriptors.mutableSpan().data(), dmaBufAttributes.offsets.mutableSpan().data(), dmaBufAttributes.strides.mutableSpan().data(), dmaBufAttributes.modifier)));
     g_object_set_data(G_OBJECT(buffer.get()), "wk-buffer-format-usage", GUINT_TO_POINTER(usage));
     m_bufferIDs.add(buffer.get(), id);
     m_buffers.add(id, WTF::move(buffer));

--- a/Source/WebKit/UIProcess/wpe/AcceleratedBackingStore.h
+++ b/Source/WebKit/UIProcess/wpe/AcceleratedBackingStore.h
@@ -29,6 +29,7 @@
 #include "FenceMonitor.h"
 #include "MessageReceiver.h"
 #include "RendererBufferDescription.h"
+#include <WebCore/DMABufBufferAttributes.h>
 #include <WebCore/IntRect.h>
 #include <WebCore/IntSize.h>
 #include <wtf/HashMap.h>
@@ -82,7 +83,7 @@ private:
     // IPC::MessageReceiver.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 
-    void didCreateDMABufBuffer(uint64_t id, const WebCore::IntSize&, uint32_t format, Vector<WTF::UnixFileDescriptor>&&, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier, RendererBufferFormat::Usage);
+    void didCreateDMABufBuffer(uint64_t id, WebCore::DMABufBufferAttributes&&, RendererBufferFormat::Usage);
     void didCreateSHMBuffer(uint64_t id, WebCore::ShareableBitmapHandle&&);
 #if OS(ANDROID)
     void didCreateAndroidBuffer(uint64_t id, RefPtr<AHardwareBuffer>&&);

--- a/Source/WebKit/WPEPlatform/wpe/WPEBufferDMABuf.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEBufferDMABuf.cpp
@@ -137,34 +137,32 @@ static gpointer wpeBufferDMABufImportToEGLImage(WPEBuffer* buffer, GError** erro
         EGL_LINUX_DRM_FOURCC_EXT, static_cast<EGLint>(priv->format)
     };
 
-    static const uint64_t invalidModifier = ((1ULL << 56) - 1);
-#define ADD_PLANE_ATTRIBUTES(planeIndex) { \
-    std::array<EGLAttrib, 6> planeAttributes { \
-        EGL_DMA_BUF_PLANE##planeIndex##_FD_EXT, priv->fds[planeIndex].value(), \
-        EGL_DMA_BUF_PLANE##planeIndex##_OFFSET_EXT, static_cast<EGLint>(priv->offsets[planeIndex]), \
-        EGL_DMA_BUF_PLANE##planeIndex##_PITCH_EXT, static_cast<EGLint>(priv->strides[planeIndex]) \
-    }; \
-    attributes.append(std::span<const EGLAttrib> { planeAttributes }); \
-    if (priv->modifier != invalidModifier && wpeDisplayCheckEGLExtension(display, "EXT_image_dma_buf_import_modifiers")) { \
-        std::array<EGLint, 4> modifierAttributes { \
-            EGL_DMA_BUF_PLANE##planeIndex##_MODIFIER_HI_EXT, static_cast<EGLint>(priv->modifier >> 32), \
-            EGL_DMA_BUF_PLANE##planeIndex##_MODIFIER_LO_EXT, static_cast<EGLint>(priv->modifier & 0xffffffff) \
-        }; \
-        attributes.append(std::span<const EGLint> { modifierAttributes }); \
-    } \
-    }
+    static constexpr uint64_t invalidModifier = ((1ULL << 56) - 1);
+    static constexpr std::array planeAttributeNames = {
+        std::array { EGL_DMA_BUF_PLANE0_FD_EXT, EGL_DMA_BUF_PLANE0_OFFSET_EXT, EGL_DMA_BUF_PLANE0_PITCH_EXT, EGL_DMA_BUF_PLANE0_MODIFIER_HI_EXT, EGL_DMA_BUF_PLANE0_MODIFIER_LO_EXT },
+        std::array { EGL_DMA_BUF_PLANE1_FD_EXT, EGL_DMA_BUF_PLANE1_OFFSET_EXT, EGL_DMA_BUF_PLANE1_PITCH_EXT, EGL_DMA_BUF_PLANE1_MODIFIER_HI_EXT, EGL_DMA_BUF_PLANE1_MODIFIER_LO_EXT },
+        std::array { EGL_DMA_BUF_PLANE2_FD_EXT, EGL_DMA_BUF_PLANE2_OFFSET_EXT, EGL_DMA_BUF_PLANE2_PITCH_EXT, EGL_DMA_BUF_PLANE2_MODIFIER_HI_EXT, EGL_DMA_BUF_PLANE2_MODIFIER_LO_EXT },
+        std::array { EGL_DMA_BUF_PLANE3_FD_EXT, EGL_DMA_BUF_PLANE3_OFFSET_EXT, EGL_DMA_BUF_PLANE3_PITCH_EXT, EGL_DMA_BUF_PLANE3_MODIFIER_HI_EXT, EGL_DMA_BUF_PLANE3_MODIFIER_LO_EXT },
+    };
 
     auto planeCount = priv->fds.size();
-    if (planeCount > 0)
-        ADD_PLANE_ATTRIBUTES(0);
-    if (planeCount > 1)
-        ADD_PLANE_ATTRIBUTES(1);
-    if (planeCount > 2)
-        ADD_PLANE_ATTRIBUTES(2);
-    if (planeCount > 3)
-        ADD_PLANE_ATTRIBUTES(3);
+    bool hasModifiers = priv->modifier != invalidModifier && wpeDisplayCheckEGLExtension(display, "EXT_image_dma_buf_import_modifiers");
 
-#undef ADD_PLANE_ATTRIBUTES
+    for (size_t i = 0; i < planeCount; ++i) {
+        const auto& names = planeAttributeNames[i];
+        attributes.appendList<EGLint>({
+            names[0], priv->fds[i].value(),
+            names[1], static_cast<EGLint>(priv->offsets[i]),
+            names[2], static_cast<EGLint>(priv->strides[i])
+        });
+
+        if (hasModifiers) {
+            attributes.appendList<EGLint>({
+                names[3], static_cast<EGLint>(priv->modifier >> 32),
+                names[4], static_cast<EGLint>(priv->modifier & 0xffffffff)
+            });
+        }
+    }
 
     attributes.append(EGL_NONE);
     priv->eglImage = s_eglCreateImageKHR(eglDisplay, EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr, attributes.span().data());

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
@@ -61,6 +61,7 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #endif
 
 #if USE(GBM)
+#include <WebCore/DMABufBuffer.h>
 #include <WebCore/DRMDeviceManager.h>
 #include <WebCore/GBMVersioning.h>
 #include <drm_fourcc.h>
@@ -254,8 +255,9 @@ std::unique_ptr<AcceleratedSurface::RenderTarget> AcceleratedSurface::RenderTarg
 
     struct gbm_bo* bo = nullptr;
     uint32_t flags = bufferFormat.usage == RendererBufferFormat::Usage::Scanout ? GBM_BO_USE_SCANOUT : GBM_BO_USE_RENDERING;
-    bool disableModifiers = bufferFormat.modifiers.size() == 1 && bufferFormat.modifiers[0] == DRM_FORMAT_MOD_INVALID;
-    if (!disableModifiers && !bufferFormat.modifiers.isEmpty())
+    auto enableModifiers = bufferFormat.modifiers.size() == 1 && bufferFormat.modifiers[0] == DRM_FORMAT_MOD_INVALID
+        ? DMABufBufferAttributes::EnableModifiers::No : DMABufBufferAttributes::EnableModifiers::Yes;
+    if (enableModifiers == DMABufBufferAttributes::EnableModifiers::Yes && !bufferFormat.modifiers.isEmpty())
         bo = gbm_bo_create_with_modifiers2(gbmDevice->device(), size.width(), size.height(), bufferFormat.fourcc, bufferFormat.modifiers.span().data(), bufferFormat.modifiers.size(), flags);
 
     if (!bo) {
@@ -269,64 +271,25 @@ std::unique_ptr<AcceleratedSurface::RenderTarget> AcceleratedSurface::RenderTarg
         return nullptr;
     }
 
-    Vector<UnixFileDescriptor> fds;
-    Vector<uint32_t> offsets;
-    Vector<uint32_t> strides;
-    uint32_t format = gbm_bo_get_format(bo);
-    int planeCount = gbm_bo_get_plane_count(bo);
-    uint64_t modifier = disableModifiers ? DRM_FORMAT_MOD_INVALID : gbm_bo_get_modifier(bo);
-
-    Vector<EGLAttrib> attributes = {
-        EGL_WIDTH, static_cast<EGLAttrib>(gbm_bo_get_width(bo)),
-        EGL_HEIGHT, static_cast<EGLAttrib>(gbm_bo_get_height(bo)),
-        EGL_LINUX_DRM_FOURCC_EXT, static_cast<EGLAttrib>(format),
-    };
-
-#define ADD_PLANE_ATTRIBUTES(planeIndex) { \
-    fds.append(UnixFileDescriptor { gbm_bo_get_fd_for_plane(bo, planeIndex), UnixFileDescriptor::Adopt }); \
-    offsets.append(gbm_bo_get_offset(bo, planeIndex)); \
-    strides.append(gbm_bo_get_stride_for_plane(bo, planeIndex)); \
-    std::array<EGLAttrib, 6> planeAttributes { \
-        EGL_DMA_BUF_PLANE##planeIndex##_FD_EXT, fds.last().value(), \
-        EGL_DMA_BUF_PLANE##planeIndex##_OFFSET_EXT, static_cast<EGLAttrib>(offsets.last()), \
-        EGL_DMA_BUF_PLANE##planeIndex##_PITCH_EXT, static_cast<EGLAttrib>(strides.last()) \
-    }; \
-    attributes.append(std::span<const EGLAttrib> { planeAttributes }); \
-    if (modifier != DRM_FORMAT_MOD_INVALID) { \
-        std::array<EGLAttrib, 4> modifierAttributes { \
-            EGL_DMA_BUF_PLANE##planeIndex##_MODIFIER_HI_EXT, static_cast<EGLAttrib>(modifier >> 32), \
-            EGL_DMA_BUF_PLANE##planeIndex##_MODIFIER_LO_EXT, static_cast<EGLAttrib>(modifier & 0xffffffff) \
-        }; \
-        attributes.append(std::span<const EGLAttrib> { modifierAttributes }); \
-    } \
+    auto dmaBufAttributes = DMABufBufferAttributes::fromGBMBufferObject(bo, enableModifiers);
+    if (!dmaBufAttributes) {
+        gbm_bo_destroy(bo);
+        WTFLogAlways("Failed to extract DMA-buf attributes from GBM buffer of size %dx%d", size.width(), size.height()); // NOLINT
+        return nullptr;
     }
 
-    if (planeCount > 0)
-        ADD_PLANE_ATTRIBUTES(0);
-    if (planeCount > 1)
-        ADD_PLANE_ATTRIBUTES(1);
-    if (planeCount > 2)
-        ADD_PLANE_ATTRIBUTES(2);
-    if (planeCount > 3)
-        ADD_PLANE_ATTRIBUTES(3);
-
-#undef ADD_PLANE_ATTRIBS
-
-    attributes.append(EGL_NONE);
-
     auto& display = PlatformDisplay::sharedDisplay();
-    auto image = display.createEGLImage(EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr, attributes);
+    auto image = DMABufBuffer::createEGLImage(display.glDisplay(), *dmaBufAttributes);
     gbm_bo_destroy(bo);
-
     if (!image) {
         WTFLogAlways("Failed to create EGL image for DMABufs with size %dx%d", size.width(), size.height());
         return nullptr;
     }
 
-    return makeUnique<RenderTargetEGLImage>(surface, size, image, format, WTF::move(fds), WTF::move(offsets), WTF::move(strides), modifier, bufferFormat.usage);
+    return makeUnique<RenderTargetEGLImage>(surface, size, image, WTF::move(*dmaBufAttributes), bufferFormat.usage);
 }
 
-AcceleratedSurface::RenderTargetEGLImage::RenderTargetEGLImage(AcceleratedSurface& surface, const IntSize& size, EGLImage image, uint32_t format, Vector<UnixFileDescriptor>&& fds, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier, RendererBufferFormat::Usage usage)
+AcceleratedSurface::RenderTargetEGLImage::RenderTargetEGLImage(AcceleratedSurface& surface, const IntSize& size, EGLImage image, DMABufBufferAttributes&& dmaBufAttributes, RendererBufferFormat::Usage usage)
     : RenderTargetShareableBuffer(surface, size)
     , m_image(image)
 {
@@ -335,7 +298,7 @@ AcceleratedSurface::RenderTargetEGLImage::RenderTargetEGLImage(AcceleratedSurfac
         createSkiaSurfaceForTexture(*m_texture);
     } else
         initializeColorBuffer();
-    WebProcess::singleton().parentProcessConnection()->send(Messages::AcceleratedBackingStore::DidCreateDMABufBuffer(m_id, size, format, WTF::move(fds), WTF::move(offsets), WTF::move(strides), modifier, usage), m_surface->surfaceID());
+    WebProcess::singleton().parentProcessConnection()->send(Messages::AcceleratedBackingStore::DidCreateDMABufBuffer(m_id, WTF::move(dmaBufAttributes), usage), m_surface->surfaceID());
 }
 #endif // USE(GBM)
 
@@ -529,7 +492,7 @@ AcceleratedSurface::RenderTargetTexture::RenderTargetTexture(AcceleratedSurface&
     else
         glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_texture->id(), 0);
 
-    WebProcess::singleton().parentProcessConnection()->send(Messages::AcceleratedBackingStore::DidCreateDMABufBuffer(m_id, size, format, WTF::move(fds), WTF::move(offsets), WTF::move(strides), modifier, RendererBufferFormat::Usage::Rendering), m_surface->surfaceID());
+    WebProcess::singleton().parentProcessConnection()->send(Messages::AcceleratedBackingStore::DidCreateDMABufBuffer(m_id, { size, format, WTF::move(fds), WTF::move(offsets), WTF::move(strides), modifier }, RendererBufferFormat::Usage::Rendering), m_surface->surfaceID());
 }
 
 AcceleratedSurface::RenderTargetTexture::~RenderTargetTexture() = default;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
@@ -49,6 +49,7 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #endif
 
 #if USE(GBM)
+#include <WebCore/DMABufBuffer.h>
 #include <WebCore/DRMDevice.h>
 #include <WebCore/GBMDevice.h>
 struct gbm_bo;
@@ -267,7 +268,7 @@ private:
     class RenderTargetEGLImage final : public RenderTargetShareableBuffer {
     public:
         static std::unique_ptr<RenderTarget> create(AcceleratedSurface&, const WebCore::IntSize&, const BufferFormat&);
-        RenderTargetEGLImage(AcceleratedSurface&, const WebCore::IntSize&, EGLImage, uint32_t format, Vector<WTF::UnixFileDescriptor>&&, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier, RendererBufferFormat::Usage);
+        RenderTargetEGLImage(AcceleratedSurface&, const WebCore::IntSize&, EGLImage, WebCore::DMABufBufferAttributes&&, RendererBufferFormat::Usage);
 #if OS(ANDROID)
         RenderTargetEGLImage(AcceleratedSurface&, const WebCore::IntSize&, EGLImage, RefPtr<AHardwareBuffer>&&);
 #endif


### PR DESCRIPTION
#### 4ca156ae3080e424f8c1c7237b43d39235dbfdf5
<pre>
[GTK][WPE] Consolidate dma-buf / EGL image creation code into DMABufBuffer methods
<a href="https://bugs.webkit.org/show_bug.cgi?id=311251">https://bugs.webkit.org/show_bug.cgi?id=311251</a>

Reviewed by Adrian Perez de Castro.

Eliminate duplicated ADD_PLANE_ATTRIBUTES macros across many call sites by
introducing shared helpers: DMABufBufferAttributes::constructFromGBMBufferObject
for GBM buffer attribute extraction, and DMABufBuffer::createEGLImage overloads
for both GLDisplay and raw EGLDisplay (ANGLE) contexts.

Extract DMABufBufferAttributes into its own header without USE(GBM) guard
so non-GBM builds can use the struct as well.

Also modernize WPEBufferDMABuf.cpp to use the same std::array + loop
pattern. As a WPEPlatform class it cannot use the WebCore functionality
but it should still use the same approach as implemented in
DMABufBufferAttributes.

Covered by existing tests.

* Source/WTF/wtf/unix/UnixFileDescriptor.h:
(WTF::UnixFileDescriptor::UnixFileDescriptor):
(WTF::UnixFileDescriptor::~UnixFileDescriptor):
* Source/WebCore/platform/TextureMapper.cmake:
* Source/WebCore/platform/graphics/gbm/DMABufBuffer.cpp:
(WebCore::DMABufBuffer::DMABufBuffer):
(WebCore::DMABufBufferAttributes::fromGBMBufferObject):
(WebCore::DMABufBuffer::createEGLImage const):
(WebCore::buildEGLAttributesForDMABuf):
(WebCore::DMABufBuffer::createEGLImage):
* Source/WebCore/platform/graphics/gbm/DMABufBuffer.h:
* Source/WebCore/platform/graphics/gbm/DMABufBufferAttributes.h: Copied from Source/WebCore/platform/graphics/gbm/DMABufBuffer.cpp.
* Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.cpp:
(WebCore::GraphicsContextGLTextureMapperGBM::createDrawingBuffer const):
(WebCore::GraphicsContextGLTextureMapperGBM::createExternalImage):
* Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.cpp:
(WebCore::MemoryMappedGPUBuffer::createDMABufFromGBMBufferObject):
(WebCore::MemoryMappedGPUBuffer::createEGLImageFromDMABuf):
(WebCore::MemoryMappedGPUBuffer::exportGBMBufferObjectAsDMABuf): Deleted.
* Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.h:
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp:
(WebCore::VideoFrameGStreamer::getDMABuf):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.cpp:
(WebCore::importToTexture):
(WebCore::CoordinatedPlatformLayerBufferDMABuf::importYUV const):
(WebCore::CoordinatedPlatformLayerBufferDMABuf::importDMABuf const):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in:
* Source/WebKit/Shared/gbm/DMABufBuffer.serialization.in:
* Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.cpp:
(WebKit::OpenXRLayer::exportOpenXRTextureGBM):
* Source/WebKit/UIProcess/glib/AcceleratedBackingStore.messages.in:
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.cpp:
(WebKit::AcceleratedBackingStore::BufferDMABuf::create):
(WebKit::AcceleratedBackingStore::BufferEGLImage::create):
(WebKit::AcceleratedBackingStore::BufferEGLImage::BufferEGLImage):
(WebKit::AcceleratedBackingStore::BufferEGLImage::description const):
(WebKit::AcceleratedBackingStore::didCreateDMABufBuffer):
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.h:
* Source/WebKit/UIProcess/wpe/AcceleratedBackingStore.cpp:
(WebKit::AcceleratedBackingStore::didCreateDMABufBuffer):
* Source/WebKit/UIProcess/wpe/AcceleratedBackingStore.h:
* Source/WebKit/WPEPlatform/wpe/WPEBufferDMABuf.cpp:
(wpeBufferDMABufImportToEGLImage):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp:
(WebKit::AcceleratedSurface::RenderTargetEGLImage::create):
(WebKit::AcceleratedSurface::RenderTargetEGLImage::RenderTargetEGLImage):
(WebKit::AcceleratedSurface::RenderTargetTexture::RenderTargetTexture):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h:

Canonical link: <a href="https://commits.webkit.org/310393@main">https://commits.webkit.org/310393@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7513f8ee1f2a79ef12dd30264e73e5675677d912

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153726 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26510 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20127 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162476 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107184 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155599 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27038 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26832 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118864 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/107184 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156685 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21119 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/138036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99574 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/20198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/18152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10309 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/145739 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129847 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15895 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164947 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/14550 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/8081 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17489 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126938 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26307 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/22183 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127105 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34471 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26309 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137690 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82987 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22010 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/14472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/185362 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25926 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90214 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47544 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25617 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25777 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25677 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->