### PR TITLE
Ligatures cause non-zero layout width for text with font-size: 0

### DIFF
--- a/LayoutTests/fast/text/font-size-zero-ligatures-expected.txt
+++ b/LayoutTests/fast/text/font-size-zero-ligatures-expected.txt
@@ -1,0 +1,11 @@
+Tests that text with font-size:0 has zero width even when the font has ligatures. Ligature substitution via CTFontShapeGlyphs in the simple text path should not produce non-zero advances when the font size is zero.
+
+PASS testWidth('fi', 'Hoefler Text') is 0
+PASS testWidth('fl', 'Hoefler Text') is 0
+PASS testWidth('ffi', 'Hoefler Text') is 0
+PASS testWidth('abc', 'Helvetica') is 0
+PASS sanity.getBoundingClientRect().width > 0 is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/text/font-size-zero-ligatures.html
+++ b/LayoutTests/fast/text/font-size-zero-ligatures.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<p id="description">Tests that text with font-size:0 has zero width even when the font has ligatures.
+Ligature substitution via CTFontShapeGlyphs in the simple text path should not produce
+non-zero advances when the font size is zero.</p>
+<div id="console"></div>
+<script>
+function testWidth(text, fontFamily) {
+    var s = document.createElement('span');
+    s.style.fontSize = "0px";
+    s.style.fontFamily = fontFamily;
+    s.textContent = text;
+    document.body.appendChild(s);
+    var width = s.getBoundingClientRect().width;
+    document.body.removeChild(s);
+    return width;
+}
+
+// Hoefler Text has common ligatures for "fi", "fl", "ffi". It is system font.
+// These exercise the simple text path where Font::applyTransforms() calls
+// CTFontShapeGlyphs which performs ligature substitution.
+shouldBe("testWidth('fi', 'Hoefler Text')", "0");
+shouldBe("testWidth('fl', 'Hoefler Text')", "0");
+shouldBe("testWidth('ffi', 'Hoefler Text')", "0");
+
+// Control: text without ligatures should also be zero.
+shouldBe("testWidth('abc', 'Helvetica')", "0");
+
+// Sanity check: non-zero font-size still produces non-zero width.
+var sanity = document.createElement('span');
+sanity.style.fontSize = "16px";
+sanity.style.fontFamily = "Hoefler Text";
+sanity.textContent = "fi";
+document.body.appendChild(sanity);
+shouldBeTrue("sanity.getBoundingClientRect().width > 0");
+document.body.removeChild(sanity);
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-size-zero-ligatures-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-size-zero-ligatures-expected.txt
@@ -1,0 +1,6 @@
+
+PASS font-size: 0 without ligature produces zero width
+PASS font-size: 0 with fi ligature produces zero width
+PASS font-size: 0 with multiple ligatures produces zero width
+PASS Ligature text and non-ligature text at font-size: 0 produce identical container width
+ ab fi ffi ffl

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-size-zero-ligatures.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-size-zero-ligatures.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>font-size: 0 with ligatures should not affect layout</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts-4/#font-size-prop">
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=311246">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+@font-face {
+  font-family: "LatoLiga";
+  src: url(/fonts/Lato-Medium-Liga.ttf);
+}
+
+.container {
+  display: inline-block;
+  font-family: "LatoLiga", serif;
+}
+
+.zero {
+  font-size: 0;
+}
+</style>
+<body>
+<div id="log"></div>
+
+<!-- Reference: empty container -->
+<div class="container" id="empty"></div>
+
+<!-- Text without ligature, font-size: 0 -->
+<div class="container"><span class="zero" id="no-liga">ab</span></div>
+
+<!-- Text with fi ligature, font-size: 0 -->
+<div class="container"><span class="zero" id="with-liga">fi</span></div>
+
+<!-- Text with multiple ligature pairs, font-size: 0 -->
+<div class="container"><span class="zero" id="multi-liga">ffi ffl</span></div>
+
+<script>
+setup({ explicit_done: true });
+
+document.fonts.ready.then(() => {
+  const noLiga = document.getElementById("no-liga");
+  const withLiga = document.getElementById("with-liga");
+  const multiLiga = document.getElementById("multi-liga");
+
+  test(() => {
+    assert_equals(noLiga.offsetWidth, 0,
+      "Text without ligature at font-size: 0 should have zero width");
+  }, "font-size: 0 without ligature produces zero width");
+
+  test(() => {
+    assert_equals(withLiga.offsetWidth, 0,
+      "Text with fi ligature at font-size: 0 should have zero width");
+  }, "font-size: 0 with fi ligature produces zero width");
+
+  test(() => {
+    assert_equals(multiLiga.offsetWidth, 0,
+      "Text with multiple ligatures at font-size: 0 should have zero width");
+  }, "font-size: 0 with multiple ligatures produces zero width");
+
+  test(() => {
+    const noLigaParentWidth = noLiga.closest(".container").offsetWidth;
+    const withLigaParentWidth = withLiga.closest(".container").offsetWidth;
+    assert_equals(noLigaParentWidth, withLigaParentWidth,
+      "Containers with font-size: 0 text should be the same width regardless of ligatures");
+  }, "Ligature text and non-ligature text at font-size: 0 produce identical container width");
+
+  done();
+});
+</script>
+</body>

--- a/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
@@ -619,6 +619,9 @@ GlyphBufferAdvance Font::applyTransforms(GlyphBuffer& glyphBuffer, unsigned begi
 {
     UNUSED_PARAM(requiresShaping);
 
+    if (!platformData().size())
+        return makeGlyphBufferAdvance();
+
     auto handler = ^(CFRange range, CGGlyph** newGlyphsPointer, CGSize** newAdvancesPointer, CGPoint** newOffsetsPointer, CFIndex** newIndicesPointer)
     {
         range.location = std::min(std::max(range.location, static_cast<CFIndex>(0)), static_cast<CFIndex>(glyphBuffer.size()));


### PR DESCRIPTION
#### 36d29c6355ca11bc06ed5ec58e18517ba67f6918
<pre>
Ligatures cause non-zero layout width for text with font-size: 0
<a href="https://bugs.webkit.org/show_bug.cgi?id=311246">https://bugs.webkit.org/show_bug.cgi?id=311246</a>
<a href="https://rdar.apple.com/173840866">rdar://173840866</a>

Reviewed by Vitor Roriz.

This patch aligns WebKit with Gekco / Firefox and Blink / Chromium.

CTFontShapeGlyphs in the simple text path can produce non-zero glyph
advances when performing ligature substitution on a zero-sized CTFont,
because CoreText treats size 0 as &quot;use default size&quot;. This causes text
with ligatures (e.g. &quot;fi&quot; in Hoefler Text, &quot;tt&quot; in Manrope) to affect
layout even when font-size is 0, shifting surrounding content.

The complex text path already guards against this in
ComplexTextController::collectComplexTextRuns(), and
platformWidthForGlyph() also skips CTFontGetAdvancesForGlyphs at
size 0. Add the same guard to Font::applyTransforms() so
CTFontShapeGlyphs is not called for zero-sized fonts.

Credits to Karl Dubost for writing Web Platform Test for this.

Tests: fast/text/font-size-zero-ligatures.html: Uses system font (macOS only)
       imported/w3c/web-platform-tests/css/css-fonts/font-size-zero-ligatures.html: Uses web font

* LayoutTests/fast/text/font-size-zero-ligatures-expected.txt: Added.
* LayoutTests/fast/text/font-size-zero-ligatures.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-size-zero-ligatures-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-size-zero-ligatures.html: Added.
* Source/WebCore/platform/graphics/coretext/FontCoreText.cpp:
(WebCore::Font::applyTransforms const):

Canonical link: <a href="https://commits.webkit.org/310394@main">https://commits.webkit.org/310394@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8106cd0440574d77628621ea230ca54f9351fed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153622 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26406 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20023 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162372 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107080 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b6459b27-acfa-46ea-aef5-54e32a1111d3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155495 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26934 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26728 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118772 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84021 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/453720be-d321-4cfc-9b27-3c16916ea6c8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156581 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21025 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137933 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99483 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0f297324-3fbc-4ebb-89f7-4c0e3a545669) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20104 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18050 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10205 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129751 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15792 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164843 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7977 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17386 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126846 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26203 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22084 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127010 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34470 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26205 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137587 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82873 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21926 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14368 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25822 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90109 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25513 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25673 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25573 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->