### PR TITLE
Workaround Swift iteration destructor issue

### DIFF
--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -54,6 +54,14 @@
 namespace WebKit {
 using namespace WebCore;
 
+static inline void setBackForwardItemIdentifiers(FrameState& frameState, BackForwardItemIdentifier itemID)
+{
+    frameState.itemID = itemID;
+    frameState.frameItemID = BackForwardFrameItemIdentifier::generate();
+    for (auto& child : frameState.children)
+        setBackForwardItemIdentifiers(child, itemID);
+}
+
 #if !ENABLE(BACK_FORWARD_LIST_SWIFT)
 
 static const unsigned DefaultCapacity = 100;
@@ -448,14 +456,6 @@ BackForwardListState WebBackForwardList::backForwardListState(WTF::Function<bool
         backForwardListState.currentIndex = backForwardListState.items.size() - 1;
 
     return backForwardListState;
-}
-
-static inline void setBackForwardItemIdentifiers(FrameState& frameState, BackForwardItemIdentifier itemID)
-{
-    frameState.itemID = itemID;
-    frameState.frameItemID = BackForwardFrameItemIdentifier::generate();
-    for (auto& child : frameState.children)
-        setBackForwardItemIdentifiers(child, itemID);
 }
 
 void WebBackForwardList::restoreFromState(BackForwardListState backForwardListState)
@@ -884,11 +884,6 @@ WebCore::BackForwardFrameItemIdentifier generateBackForwardFrameItemIdentifier()
     return WebCore::BackForwardFrameItemIdentifier::generate();
 }
 
-WebCore::BackForwardItemIdentifier generateBackForwardItemIdentifier()
-{
-    return WebCore::BackForwardItemIdentifier::generate();
-}
-
 // rdar://168139823 is the task of doing a productionized version of WebKit Swift logging
 void doLog(const WTF::String& msg)
 {
@@ -904,5 +899,19 @@ void messageCheckFailed(Ref<WebKit::WebProcessProxy> process)
 {
     MESSAGE_CHECK_BASE(false, process->connection());
 }
+
+// Workarounds for rdar://171011011
+void appendToBackForwardStateItems(Vector<WebKit::BackForwardListItemState>& items, const WebKit::WebBackForwardListItem& entry)
+{
+    items.append({ entry.copyMainFrameStateWithChildren(), entry.navigatedFrameID() });
+}
+
+Ref<WebKit::WebBackForwardListItem> createItemFromState(const WebKit::BackForwardListItemState& itemState, WebKit::WebPageProxyIdentifier pageIdentifier)
+{
+    Ref stateCopy = itemState.frameState->copy();
+    setBackForwardItemIdentifiers(stateCopy, WebCore::BackForwardItemIdentifier::generate());
+    return WebKit::WebBackForwardListItem::create(WTF::move(stateCopy), pageIdentifier, itemState.navigatedFrameID);
+}
+
 
 #endif // ENABLE(BACK_FORWARD_LIST_SWIFT)

--- a/Source/WebKit/UIProcess/WebBackForwardList.swift
+++ b/Source/WebKit/UIProcess/WebBackForwardList.swift
@@ -544,12 +544,7 @@ final class WebBackForwardList {
                 }
                 continue
             }
-            backForwardListState.items.append(
-                consuming: WebKit.BackForwardListItemState(
-                    frameState: entry.copyMainFrameStateWithChildren(),
-                    navigatedFrameID: entry.navigatedFrameID()
-                )
-            )
+            appendToBackForwardStateItems(&backForwardListState.items, entry)
         }
 
         if backForwardListState.items.isEmpty() {
@@ -562,14 +557,6 @@ final class WebBackForwardList {
         return backForwardListState
     }
 
-    private func setBackForwardItemIdentifiers(frameState: WebKit.FrameState, itemID: WebCore.BackForwardItemIdentifier) {
-        frameState.itemID = WebCore.MarkableBackForwardItemIdentifier(itemID)
-        frameState.frameItemID = WebCore.MarkableBackForwardFrameItemIdentifier(generateBackForwardFrameItemIdentifier())
-        for child in CxxVectorIterator(vec: frameState.children) {
-            setBackForwardItemIdentifiers(frameState: child.ptr(), itemID: itemID)
-        }
-    }
-
     func restoreFromState(backForwardListState: WebKit.BackForwardListState) {
         guard let page = page.get() else {
             return
@@ -579,10 +566,7 @@ final class WebBackForwardList {
         entries.removeAll()
         entries.reserveCapacity(backForwardListState.items.size())
         for itemState in CxxVectorIterator(vec: backForwardListState.items) {
-            let stateCopy = itemState.frameState.ptr().copy()
-            setBackForwardItemIdentifiers(frameState: stateCopy.ptr(), itemID: generateBackForwardItemIdentifier())
-            let item = WebKit.WebBackForwardListItem.create(consuming: stateCopy, page.identifier(), itemState.navigatedFrameID)
-            entries.append(item.ptr())
+            entries.append(createItemFromState(itemState, page.identifier()).ptr())
         }
 
         currentIndex = Optional(fromCxx: backForwardListState.currentIndex).map({ val in Int(val) })

--- a/Source/WebKit/UIProcess/WebBackForwardListSwiftUtilities.h
+++ b/Source/WebKit/UIProcess/WebBackForwardListSwiftUtilities.h
@@ -58,7 +58,6 @@ inline bool contentsMatch(const T& lhs, const T& rhs)
 
 // Workaround for rdar://162193891
 WebCore::BackForwardFrameItemIdentifier generateBackForwardFrameItemIdentifier();
-WebCore::BackForwardItemIdentifier generateBackForwardItemIdentifier();
 
 // Workaround for rdar://129159672
 inline void setOptionalUInt32Value(std::optional<uint32_t>& optional, uint32_t value)
@@ -94,5 +93,9 @@ inline bool filterSpecified(WebBackForwardListItemFilter& fn)
 {
     return bool(*fn);
 }
+
+// Workarounds for rdar://171011011
+void appendToBackForwardStateItems(Vector<WebKit::BackForwardListItemState>& items, const WebKit::WebBackForwardListItem& entry);
+Ref<WebKit::WebBackForwardListItem> createItemFromState(const WebKit::BackForwardListItemState&, WebKit::WebPageProxyIdentifier pageIdentifier);
 
 #endif // ENABLE(BACK_FORWARD_LIST_SWIFT)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm
@@ -361,6 +361,35 @@ TEST(WKBackForwardList, InteractionStateRestorationInvalid)
     EXPECT_STREQ([[list.currentItem URL] absoluteString].UTF8String, url3.absoluteString.UTF8String);
 }
 
+// Restoring state with multiple items causes the Swift restoreFromState loop to iterate more than
+// once, which can trigger an ASAN false positive if Swift reuses a stack slot that C++ poisoned
+// via leakRef in the previous iteration.
+TEST(WKBackForwardList, InteractionStateRestorationMultipleItems)
+{
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
+
+    RetainPtr url1 = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    RetainPtr url2 = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:url1]];
+    [webView _test_waitForDidFinishNavigation];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:url2]];
+    [webView _test_waitForDidFinishNavigation];
+
+    id interactionState = [webView interactionState];
+
+    webView = adoptNS([[WKWebView alloc] init]);
+    [webView setInteractionState:interactionState];
+    [webView _test_waitForDidFinishNavigation];
+
+    RetainPtr list = [webView backForwardList];
+    EXPECT_EQ((NSUInteger)1, list.get().backList.count);
+    EXPECT_EQ((NSUInteger)0, list.get().forwardList.count);
+    EXPECT_STREQ([[list.get().currentItem URL] absoluteString].UTF8String, url2.get().absoluteString.UTF8String);
+    EXPECT_STREQ([[list.get().backList.firstObject URL] absoluteString].UTF8String, url1.get().absoluteString.UTF8String);
+}
+
 @interface WKBackForwardNavigationDelegate : NSObject <WKNavigationDelegatePrivate>
 - (void)waitForDidFinishNavigationOrDidSameDocumentNavigation;
 @end


### PR DESCRIPTION
#### 87776cc7df8a259dd329a21e0242f9ed3451e842
<pre>
Workaround Swift iteration destructor issue
<a href="https://bugs.webkit.org/show_bug.cgi?id=311253">https://bugs.webkit.org/show_bug.cgi?id=311253</a>
<a href="https://rdar.apple.com/173815363">rdar://173815363</a>

Reviewed by Chris Dumez.

Swift does not always seem to call the Ref&lt;T&gt; destructor when it&apos;s in a loop;
this results in ASAN violations as memory is poisoned when the Swift
WebBackForwardList saves or restores state.

This change:
- adds a test for the restoration case, which was not previously hit in
  the test suite. (Without the rest of this PR, this test hits two
  ASAN violations - one in saving state and another in restoring).
- moves the relevant parts of session saving and restoration back to C++.
- moves setBackForwardItemIdentifiers outside of #ifdefs for Swift, since
  it&apos;s now used whether we&apos;re using C++ or Swift backForwardList
- removes generateBackForwardItemIdentifier, as it&apos;s no longer used from Swift

It&apos;s worth noting that the new C++ function &apos;createItemFromState&apos; in fact does
return a Ref&lt;T&gt;, which ends up in a stack slot in Swift. This could in
principle be subject to the same sort of bug we&apos;re trying to work around here;
in practice, though, it doesn&apos;t hit the ASAN problem, presumably because the
Ref is immediately converted to a Swift FRT and added to the vector.

Canonical link: <a href="https://commits.webkit.org/310371@main">https://commits.webkit.org/310371@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7f2c3e84c6552dcba3a0d55561896881fb4041f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153634 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26418 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20035 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162384 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107092 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/558337c4-4319-4a80-b685-32b8cc152b27) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155507 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26946 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26740 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118781 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84026 "7 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0824ed71-d320-46a7-b85e-eb2872624ff2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156593 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21036 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/137946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99492 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20115 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18060 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10217 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129763 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15805 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164855 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7989 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17399 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126856 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26215 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22094 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127021 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34451 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26217 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137600 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82885 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21934 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14381 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25834 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90121 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25525 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25685 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25585 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->