### PR TITLE
[css-values-5 attr()] Fix error handling in syntax parsing

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-all-types-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-all-types-expected.txt
@@ -59,7 +59,7 @@ PASS CSS Values and Units Test: attr 55
 PASS CSS Values and Units Test: attr 56
 PASS CSS Values and Units Test: attr 57
 PASS CSS Values and Units Test: attr 58
-FAIL CSS Values and Units Test: attr 59 assert_equals: Setting property 'width' to the value 'attr(data-foo type(invalid |), 10px)', where 'data-foo=0px' should not change it's value. expected "784px" but got "10px"
+PASS CSS Values and Units Test: attr 59
 PASS CSS Values and Units Test: attr 60
 PASS CSS Values and Units Test: attr 61
 PASS CSS Values and Units Test: attr 62

--- a/Source/WebCore/css/parser/CSSCustomPropertySyntax.cpp
+++ b/Source/WebCore/css/parser/CSSCustomPropertySyntax.cpp
@@ -126,8 +126,11 @@ std::optional<CSSCustomPropertySyntax> CSSCustomPropertySyntax::parse(StringView
 
             definition.append(*component);
 
-            skipExactly(buffer, '|');
-            skipWhile<isCSSSpace>(buffer);
+            if (skipExactly(buffer, '|')) {
+                skipWhile<isCSSSpace>(buffer);
+                if (!buffer.hasCharactersRemaining())
+                    return { };
+            }
         }
 
         if (definition.isEmpty())


### PR DESCRIPTION
#### 45bbe25bf07b1cd0ce1fb71686617bc8cca6f76e
<pre>
[css-values-5 attr()] Fix error handling in syntax parsing
<a href="https://bugs.webkit.org/show_bug.cgi?id=311255">https://bugs.webkit.org/show_bug.cgi?id=311255</a>
<a href="https://rdar.apple.com/173849148">rdar://173849148</a>

Reviewed by Alan Baradlay.

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-all-types-expected.txt:
* Source/WebCore/css/parser/CSSCustomPropertySyntax.cpp:
(WebCore::CSSCustomPropertySyntax::parse):

type(invalid |) should not parse.

Canonical link: <a href="https://commits.webkit.org/310373@main">https://commits.webkit.org/310373@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e48c99e0f38e193da5a0b7f7f48ed0f88146b3b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153635 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26419 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20036 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162385 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107093 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a8122d4d-72f4-4b55-8db1-51d1a1d0aba0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155508 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26947 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26741 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118782 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84027 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e370962b-3b45-4831-b769-22dbec5b7b8e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156594 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21034 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/137943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99493 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20113 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18061 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10218 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129761 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15802 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164856 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7990 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17396 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126857 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26216 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22095 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127022 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34455 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26218 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137597 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82886 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21939 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14378 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25835 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90122 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25526 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25686 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25586 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->