### PR TITLE
Avoid unnecessary style invalidation in ValidatedFormListedElement::updateValidity()

### DIFF
--- a/Source/WebCore/html/ValidatedFormListedElement.cpp
+++ b/Source/WebCore/html/ValidatedFormListedElement.cpp
@@ -260,10 +260,10 @@ void ValidatedFormListedElement::updateValidity()
     if (newIsValid != m_isValid) {
         SUPPRESS_UNCOUNTED_LOCAL auto& element = asHTMLElement();
         Style::PseudoClassChangeInvalidation styleInvalidation(element, {
-            { CSSSelector::PseudoClass::Valid, newIsValid },
-            { CSSSelector::PseudoClass::Invalid, !newIsValid },
-            { CSSSelector::PseudoClass::UserValid, m_wasInteractedWithSinceLastFormSubmitEvent && newIsValid },
-            { CSSSelector::PseudoClass::UserInvalid, m_wasInteractedWithSinceLastFormSubmitEvent && !newIsValid },
+            { CSSSelector::PseudoClass::Valid, willValidate && newIsValid },
+            { CSSSelector::PseudoClass::Invalid, willValidate && !newIsValid },
+            { CSSSelector::PseudoClass::UserValid, willValidate && m_wasInteractedWithSinceLastFormSubmitEvent && newIsValid },
+            { CSSSelector::PseudoClass::UserInvalid, willValidate && m_wasInteractedWithSinceLastFormSubmitEvent && !newIsValid },
         });
 
         m_isValid = newIsValid;


### PR DESCRIPTION
#### 7805da4a934aee2ba0b2cc14004a18c03cf042a9
<pre>
Avoid unnecessary style invalidation in ValidatedFormListedElement::updateValidity()
<a href="https://bugs.webkit.org/show_bug.cgi?id=311257">https://bugs.webkit.org/show_bug.cgi?id=311257</a>

Reviewed by Anne van Kesteren.

PseudoClassChangeInvalidation requires the caller to pass the correct
new matching state for each pseudo-class. The :valid, :invalid,
:user-valid, and :user-invalid pseudo-classes only match when the
element is a candidate for constraint validation (willValidate() returns
true). For example, matchesValidPseudoClass() returns
willValidate() &amp;&amp; isValidFormControlElement(), not just
isValidFormControlElement().

Previously, updateValidity() passed newIsValid / !newIsValid directly
as the new state, without accounting for willValidate. When an element
is not a validation candidate (e.g. it is disabled), this told the
invalidation system that the element was entering or leaving the :valid
/ :invalid states, when in reality neither pseudo-class applies. This
caused the style system to unnecessarily collect and process rule sets
for selectors it didn&apos;t need to re-evaluate.

Gate each parameter on willValidate so the invalidation system receives
the actual new matching state. When willValidate is false, all four
parameters are now false, and the invalidation system correctly
recognizes that no :valid/:invalid/:user-valid/:user-invalid selector
matching has changed, skipping the unnecessary work.

This is safe because:
- When willValidate is true, the behavior is identical to before.
- When willValidate is false, the element never matches any of these
  four pseudo-classes (both before and after the m_isValid change), so
  no rule invalidation is needed, and passing false is the correct
  new state for all four.
- The m_isValid member is still updated unconditionally, so if
  willValidate later becomes true, the cached validity is correct.

No new tests, this only caused extra invalidation work so it is not
web-observable.

* Source/WebCore/html/ValidatedFormListedElement.cpp:
(WebCore::ValidatedFormListedElement::updateValidity):

Canonical link: <a href="https://commits.webkit.org/310397@main">https://commits.webkit.org/310397@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d9c3f60ddede8046fc8bd6fedf3542fecc9fa31

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153637 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26421 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20038 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162387 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107095 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8f86bed3-aecc-45af-a90f-f4f3dea70ec9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155510 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26949 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26743 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118783 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84029 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7fdf17eb-6330-49b7-b701-9d5e1d888bfe) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156596 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21037 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137944 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99494 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f2121da4-a22a-4c03-9b9a-874ea5d95ebf) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20116 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18063 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10220 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129765 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15803 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164858 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7992 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17397 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126858 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26218 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22097 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127023 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34475 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26220 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137598 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82888 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21936 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14379 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25837 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90124 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25528 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25688 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25588 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->