### PR TITLE
[css-values-5 attr()] Substitute non-universal syntax as parsed values

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-length-specified-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-length-specified-expected.txt
@@ -1,5 +1,5 @@
 
 PASS type(<length>) lowercase
-FAIL type(<length>) uppercase assert_equals: expected "3em" but got "3EM"
+PASS type(<length>) uppercase
 PASS Unit (em) number
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-security-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-security-expected.txt
@@ -8,7 +8,7 @@ FAIL 'background-image: src("https://does-not-exist.test/404.png")' with data-fo
 PASS '--x: src(string("https://does-not-exist.test" attr(data-foo)))' with data-foo="/404.png"
 PASS 'background-image: src(string("https://does-not-exist.test" attr(data-foo)))' with data-foo="/404.png"
 FAIL 'background-image: src(string("https://does-not-exist.test/""404.png"))' with data-foo="/404.png" assert_equals: expected "src(url(\"https://does-not-exist.test/404.png\"))" but got "none"
-FAIL '--x: attr(data-foo type(<url>))' with data-foo="url(https://does-not-exist.test/404.png)" assert_equals: expected "url(\"https://does-not-exist.test/404.png\")" but got "url(https\\:\\/\\/does-not-exist\\.test\\/404\\.png)"
+PASS '--x: attr(data-foo type(<url>))' with data-foo="url(https://does-not-exist.test/404.png)"
 PASS 'background-image: attr(data-foo type(<url>))' with data-foo="url(https://does-not-exist.test/404.png)"
 PASS 'background-image: url("https://does-not-exist.test/404.png")' with data-foo="url(https://does-not-exist.test/404.png)"
 PASS '--x: image(attr(data-foo))' with data-foo="https://does-not-exist.test/404.png"

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -440,6 +440,26 @@ bool CSSPropertyParser::isValidCustomPropertyValueForSyntax(const CSSCustomPrope
     return !!consumeCustomPropertyValueWithSyntax(range, state, syntax).first;
 }
 
+// https://drafts.csswg.org/css-values-5/#parse-with-a-syntax
+RefPtr<CSSValue> CSSPropertyParser::parseWithSyntax(const CSSCustomPropertySyntax& syntax, CSSParserTokenRange range, const CSSParserContext& context)
+{
+    ASSERT(!syntax.isUniversal());
+
+    range.consumeWhitespace();
+
+    auto state = CSS::PropertyParserState {
+        .context = context,
+        .currentRule = StyleRuleType::Style,
+        .currentProperty = CSSPropertyCustom,
+        .important = IsImportant::No,
+    };
+
+    auto [value, syntaxType] = consumeCustomPropertyValueWithSyntax(range, state, syntax);
+    if (!value || !range.atEnd())
+        return { };
+    return value;
+}
+
 std::optional<CSSWideKeyword> CSSPropertyParser::parseCSSWideKeyword(CSSParserTokenRange range)
 {
     return consumeCSSWideKeyword(range);

--- a/Source/WebCore/css/parser/CSSPropertyParser.h
+++ b/Source/WebCore/css/parser/CSSPropertyParser.h
@@ -67,6 +67,7 @@ public:
 
     static ComputedStyleDependencies collectParsedCustomPropertyValueDependencies(const CSSCustomPropertySyntax&, CSSParserTokenRange, const CSSParserContext&);
     static bool isValidCustomPropertyValueForSyntax(const CSSCustomPropertySyntax&, CSSParserTokenRange, const CSSParserContext&);
+    static RefPtr<CSSValue> parseWithSyntax(const CSSCustomPropertySyntax&, CSSParserTokenRange, const CSSParserContext&);
 
     static std::optional<CSSWideKeyword> parseCSSWideKeyword(CSSParserTokenRange);
 };

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -34,6 +34,7 @@
 #include "CSSPropertyParserConsumer+Primitives.h"
 #include "CSSRegisteredCustomProperty.h"
 #include "CSSSelectorParser.h"
+#include "CSSSerializationContext.h"
 #include "CSSShorthandSubstitutionValue.h"
 #include "CSSSubstitutionValue.h"
 #include "CSSTokenizer.h"
@@ -414,13 +415,24 @@ bool SubstitutionResolver::substituteAttrFunction(CSSParserTokenRange argumentsR
         if (m_styleBuilder.state().m_inCycleAttrAttributes.contains(attributeName))
             return substituteFailure();
 
-        if (!parsedAttrType->syntax.isUniversal()) {
-            CSSParserTokenRange substitutedRange(*substitutedTokens);
-            if (!CSSPropertyParser::isValidCustomPropertyValueForSyntax(parsedAttrType->syntax, substitutedRange, context))
-                return substituteFailure();
+        if (parsedAttrType->syntax.isUniversal()) {
+            tokens.appendVector(*substitutedTokens);
+            return true;
         }
 
-        tokens.appendVector(*substitutedTokens);
+        // Parse against the syntax and re-tokenize from the normalized serialization.
+        CSSParserTokenRange substitutedRange(*substitutedTokens);
+        auto parsedValue = CSSPropertyParser::parseWithSyntax(parsedAttrType->syntax, substitutedRange, context);
+        if (!parsedValue)
+            return substituteFailure();
+
+        auto serialized = parsedValue->cssText(CSS::defaultSerializationContext());
+        CSSTokenizer resultTokenizer(serialized);
+        m_intermediateTokenStrings.appendVector(resultTokenizer.escapedStringsForAdoption());
+        m_intermediateTokenStrings.append(WTF::move(serialized));
+
+        tokens.append(resultTokenizer.tokenRange().span());
+
         return true;
     }
     }


### PR DESCRIPTION
#### 24e2aa92fec15b26702ba68860455edd325c111f
<pre>
[css-values-5 attr()] Substitute non-universal syntax as parsed values
<a href="https://bugs.webkit.org/show_bug.cgi?id=311259">https://bugs.webkit.org/show_bug.cgi?id=311259</a>
<a href="https://rdar.apple.com/173850959">rdar://173850959</a>

Reviewed by Alan Baradlay.

<a href="https://drafts.csswg.org/css-values-5/#attr-substitution">https://drafts.csswg.org/css-values-5/#attr-substitution</a>:

&quot;6. Substitute arbitrary substitution functions in attr value, ..., then &apos;parse with a &lt;syntax&gt;&apos; attr value&quot;

The &apos;parse with a &lt;syntax&gt;&apos; algorithm returns a CSS value so this means values with syntax need to be normalized.

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-length-specified-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-security-expected.txt:
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::parseWithSyntax):

Add a helper that returns a CSSValue.

* Source/WebCore/css/parser/CSSPropertyParser.h:
* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::SubstitutionResolver::substituteAttrFunction):

Serialize and re-tokenize the CSSValue.

Canonical link: <a href="https://commits.webkit.org/310372@main">https://commits.webkit.org/310372@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/605e546ee7eecb68d343490e1ffec1f456fa45b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153639 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26423 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20040 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162389 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107097 "An unexpected error occured. Recent messages:Printed configuration") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b9f09380-e59d-4c1c-8fe3-7cdd39a20a95) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155512 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26951 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26745 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118786 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/107097 "An unexpected error occured. Recent messages:Printed configuration") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3cd1cde4-d50d-4e60-b57c-180df6e55d52) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156598 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21040 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/137948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99497 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5dff4626-4703-4265-805f-fd45d0409dc2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20119 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18065 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10222 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129768 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15807 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164860 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7994 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17401 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126861 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26220 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22099 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127026 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34458 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26222 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137602 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82892 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21941 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14383 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25839 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90126 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25530 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25690 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25590 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->