### PR TITLE
Avoid heap allocation in CSSSelector::visitSimpleSelectors()

### DIFF
--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -34,8 +34,8 @@
 #include "MutableCSSSelector.h"
 #include "SelectorPseudoTypeMap.h"
 #include <memory>
-#include <queue>
 #include <wtf/Assertions.h>
+#include <wtf/Deque.h>
 #include <wtf/Hasher.h>
 #include <wtf/SmallMap.h>
 #include <wtf/StdLibExtras.h>
@@ -890,21 +890,19 @@ CSSSelector::CSSSelector(const CSSSelector& other, MutableSelectorCopyTag)
 
 bool CSSSelector::visitSimpleSelectors(VisitFunctor&& functor, VisitFunctionalPseudoClasses visitFunctionalPseudoClasses, VisitOnlySubject visitOnlySubject) const
 {
-    std::queue<const CSSSelector*> worklist;
-    worklist.push(this);
-    while (!worklist.empty()) {
-        auto current = worklist.front();
-        worklist.pop();
+    Deque<const CSSSelector*, 16> worklist;
+    worklist.append(this);
+    while (!worklist.isEmpty()) {
+        auto current = worklist.takeFirst();
 
-        // Effective C++ advices for this cast to deal with generic const/non-const member function.
-        if (functor(*const_cast<CSSSelector*>(current)))
+        if (functor(*current))
             return true;
 
         // Visit the selector list member (if any) recursively (such as: :has(<list>), :is(<list>),...)
         if (visitFunctionalPseudoClasses == VisitFunctionalPseudoClasses::Yes) {
             if (auto selectorList = current->selectorList()) {
                 for (auto& selector : *selectorList)
-                    worklist.push(&selector);
+                    worklist.append(&selector);
             }
         }
 
@@ -912,7 +910,7 @@ bool CSSSelector::visitSimpleSelectors(VisitFunctor&& functor, VisitFunctionalPs
         if (auto next = current->precedingInComplexSelector()) {
             // We stop visiting at the end of the compound selector (= when relation is anything else than subselector) if we are in subject only mode.
             if (current->relation() != Relation::Subselector || visitOnlySubject != VisitOnlySubject::Yes)
-                worklist.push(next);
+                worklist.append(next);
         }
     }
     return false;


### PR DESCRIPTION
#### 09f6a02b04a433e6006675390914d4876e27aef5
<pre>
Avoid heap allocation in CSSSelector::visitSimpleSelectors()
<a href="https://bugs.webkit.org/show_bug.cgi?id=311260">https://bugs.webkit.org/show_bug.cgi?id=311260</a>

Reviewed by Darin Adler and Sam Weinig.

Replace std::queue (backed by std::deque, which heap-allocates) with
a Deque&lt;..., 16&gt; with inline capacity of 16 to preserve BFS traversal
order while avoiding heap allocation for typical selector trees. I have
verified that this avoids heap allocation on Speedometer 3.

Also remove an unnecessary const_cast — the VisitFunctor already takes
`const CSSSelector&amp;`.

* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::visitSimpleSelectors const):

Canonical link: <a href="https://commits.webkit.org/310411@main">https://commits.webkit.org/310411@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56aaaa172e5eb48ef76eb617a5df891e4128d095

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153795 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26579 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20196 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162546 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/107256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/afaf20d2-478e-4a78-a960-08636c4d5991) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155668 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27108 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26901 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118902 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/107256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5cc13d0a-10de-4f8a-8922-5aca0fe38448) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156754 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21170 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138093 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99612 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/20250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/18208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/10378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/129898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/15952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165017 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/8150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17546 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126990 "Passed tests") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/26376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22239 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127157 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34485 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26378 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137747 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/83056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/22058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14530 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25995 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/90283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/25686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/25846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/25746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->