### PR TITLE
REGRESSION(309194@main): broke Web Inspector custom <select> menus

### DIFF
--- a/LayoutTests/fast/forms/select/mac-wk2/select-synthetic-mousedown-opens-popup-expected.txt
+++ b/LayoutTests/fast/forms/select/mac-wk2/select-synthetic-mousedown-opens-popup-expected.txt
@@ -1,0 +1,5 @@
+Tests that a synthetic mousedown event opens an auto appearance select popup.
+
+
+PASS - popup opened via synthetic mousedown
+

--- a/LayoutTests/fast/forms/select/mac-wk2/select-synthetic-mousedown-opens-popup.html
+++ b/LayoutTests/fast/forms/select/mac-wk2/select-synthetic-mousedown-opens-popup.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<body>
+<p>Tests that a synthetic mousedown event opens an auto appearance select popup.</p>
+<select>
+  <option>one</option>
+  <option>two</option>
+</select>
+<pre id="result"></pre>
+<script>
+
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+const select = document.querySelector('select');
+
+function log(text) {
+    document.getElementById('result').textContent += text + '\n';
+}
+
+window.onload = () => {
+    if (!window.testRunner)
+        return;
+
+    select.dispatchEvent(new MouseEvent('mousedown', {button: 0}));
+    log(internals.isSelectPopupVisible(select) ? 'PASS - popup opened via synthetic mousedown' : 'FAIL - popup did not open');
+
+    testRunner.notifyDone();
+};
+
+</script>
+</body>

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -1551,12 +1551,15 @@ void HTMLSelectElement::menuListDefaultEventHandler(Event& event)
     ASSERT(renderer());
     ASSERT(usesMenuList());
 
-    if (!event.isTrusted())
-        return;
-
     auto& eventNames = WebCore::eventNames();
 
     bool isBaseSelectPicker = usesBaseAppearancePicker();
+
+    // FIXME: Eventually we should remove the isBaseSelectPicker conditional here, but that requires
+    // Web Inspector changes.
+    if (!event.isTrusted() && isBaseSelectPicker)
+        return;
+
     bool popoverOpen = isBaseSelectPicker && m_popover && m_popover->isPopoverShowing();
 
     if (event.type() == eventNames.keydownEvent) {


### PR DESCRIPTION
#### 9c992f69a6342d1e7281497757ef16f77ff3df8c
<pre>
REGRESSION(<a href="https://commits.webkit.org/309194@main">309194@main</a>): broke Web Inspector custom &lt;select&gt; menus
<a href="https://bugs.webkit.org/show_bug.cgi?id=311262">https://bugs.webkit.org/show_bug.cgi?id=311262</a>
<a href="https://rdar.apple.com/173851743">rdar://173851743</a>

Reviewed by NOBODY (OOPS!).

Web Inspector relies on a synthetic mousedown event opening &lt;select&gt;.
As working around this appears involved, we reduce the scope of
<a href="https://commits.webkit.org/309194@main">309194@main</a> to only target base-select &lt;select&gt; elements for now.

We add a novel test for this specific scenario as the tests converted
in <a href="https://commits.webkit.org/309194@main">309194@main</a> were actually testing something else entirely so keeping
them focused on those other aspects seems best.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c992f69a6342d1e7281497757ef16f77ff3df8c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153646 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26430 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20047 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162396 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107104 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155519 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26958 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26752 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118791 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84034 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e226d5ca-8370-4633-b122-bd5ade3543e5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156605 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21047 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137955 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99502 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3d5dd9ef-dad5-4cff-99b9-c01b8e763dab) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20126 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18072 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10229 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129775 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15814 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164867 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8001 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17408 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126866 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26227 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22105 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127032 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26229 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137609 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82899 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21946 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14391 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25846 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90133 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25537 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25697 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25597 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->