### PR TITLE
Web Inspector: REGRESSION(309194@main) Popups for WI.MultipleScopeBarItem don't show up anymore

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/MultipleScopeBarItem.js
+++ b/Source/WebInspectorUI/UserInterface/Views/MultipleScopeBarItem.js
@@ -182,23 +182,6 @@ WI.MultipleScopeBarItem = class MultipleScopeBarItem extends WI.Object
         // Only handle left mouse clicks.
         if (event.button !== 0)
             return;
-
-        if (event.__original)
-            return;
-
-        // Only support click to select when the item is not selected yet.
-        // Clicking when selected will cause the menu to appear instead.
-        if (this._element.classList.contains("selected")) {
-            let newEvent = new event.constructor(event.type, event);
-            newEvent.__original = event;
-
-            event.stop();
-
-            this._selectElement.dispatchEvent(newEvent);
-            return;
-        }
-
-        this.selected = true;
     }
 
     _selectElementSelectionChanged(event)

--- a/Source/WebInspectorUI/UserInterface/Views/ScopeBar.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ScopeBar.css
@@ -91,13 +91,11 @@
 
 .scope-bar > li.multiple > select {
     position: absolute;
-    top: -1px;
+    top: -3px;
     inset-inline-start: calc(var(--scope-bar-padding) - var(--scope-bar-padding-default) - 2px);
-    width: 0;
-    height: 0;
+    width: 100%;
     margin: 0;
     opacity: 0;
-    pointer-events: none;
 }
 
 .scope-bar > li:focus::after,


### PR DESCRIPTION
#### 45bac2bccd719354f1ea4ca12f030850b961b9b6
<pre>
Web Inspector: REGRESSION(309194@main) Popups for WI.MultipleScopeBarItem don&apos;t show up anymore
<a href="https://bugs.webkit.org/show_bug.cgi?id=311266">https://bugs.webkit.org/show_bug.cgi?id=311266</a>
<a href="https://rdar.apple.com/173857179">rdar://173857179</a>

Reviewed by Devin Rousso.

Web Inspector relies on non-standard behavior to trigger a &lt;select&gt; element
by means of a synthetic click event. The change in <a href="https://commits.webkit.org/309194@main">https://commits.webkit.org/309194@main</a>
aligns WebKit behavior to other browser engines to prevent this behavior.

In absence of `HTMLSelectElement.showPicker()`, which is not yet enabled in Web Inspector,
we can work around the change by making the `&lt;select&gt;` element cover the hit area,
obscure it visually, and allow original clicks on it.

This is a common cross-browser technique to implement the selected state of
a custom `&lt;select&gt;` element while preserving the ergonomics of the options list
provided by the user agent.

When custom elements are enabled in WebKit, Web Inspector can adopt them and drop this workaround.

* Source/WebInspectorUI/UserInterface/Views/MultipleScopeBarItem.js:
(WI.MultipleScopeBarItem.prototype._handleMouseDown):
(WI.MultipleScopeBarItem._selectElementSelectionChanged): Deleted.
* Source/WebInspectorUI/UserInterface/Views/ScopeBar.css:
(.scope-bar &gt; li.multiple &gt; select):

Canonical link: <a href="https://commits.webkit.org/310437@main">https://commits.webkit.org/310437@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e188d280429c11752627772a36a31b5e79d66bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153654 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26438 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20055 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162404 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107112 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9f11f99c-5fc5-4fb3-baf0-dac2bc8270ce) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26966 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26760 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118797 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/107112 "An unexpected error occured. Recent messages:Printed configuration") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e9df3c0e-f77a-448a-8d76-1e16938ed596) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156613 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21049 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137964 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99508 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/377c3064-a757-4b10-89ea-97fdacc89450) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20128 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18079 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10237 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129777 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15823 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164875 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8009 "Failed to build and analyze WebKit") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17417 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126873 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26235 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22111 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127039 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34506 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26237 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137618 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82914 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21950 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14400 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25854 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90142 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25545 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25705 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25605 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->