### PR TITLE
[GTK][WPE] Handle common, non-error rtkit log messages on launch

### DIFF
--- a/Source/WTF/wtf/linux/RealTimeThreads.cpp
+++ b/Source/WTF/wtf/linux/RealTimeThreads.cpp
@@ -125,13 +125,15 @@ void RealTimeThreads::promoteThreadToRealTime(const Thread& thread)
     struct sched_param param;
     param.sched_priority = std::clamp(s_realTimeThreadPriority, sched_get_priority_min(SCHED_RR), sched_get_priority_max(SCHED_RR));
     auto error = sched_setscheduler(thread.id(), SCHED_RR | SCHED_RESET_ON_FORK, &param);
-    if (error) {
+    // Skip fallback for short-lived threads that no longer exist (ESRCH).
+    if (!error || errno == ESRCH)
+        return;
+
 #if USE(GLIB)
-        realTimeKitMakeThreadRealTime(getpid(), thread.id(), param.sched_priority);
+    realTimeKitMakeThreadRealTime(getpid(), thread.id(), param.sched_priority);
 #else
-        LOG_ERROR("Failed to set thread %d as real time: %s", thread.id(), safeStrerror(error).data());
+    LOG_ERROR("Failed to set thread %d as real time: %s", thread.id(), safeStrerror(error).data());
 #endif
-    }
 }
 
 void RealTimeThreads::demoteThreadFromRealTime(const Thread& thread)
@@ -221,7 +223,12 @@ void RealTimeThreads::realTimeKitMakeThreadRealTime(uint64_t processID, uint64_t
     GRefPtr<GVariant> result = adoptGRef(g_dbus_proxy_call_sync(m_realTimeKitProxy->get(), "MakeThreadRealtimeWithPID",
         g_variant_new("(ttu)", processID, threadID, priority), G_DBUS_CALL_FLAGS_NONE, s_dbusCallTimeout.millisecondsAs<int>(), nullptr, &error.outPtr()));
     if (!result) {
-        LOG_ERROR("Failed to make thread real time: %s", error->message);
+        // We use portal to promote sandboxed threads to real-time, as it takes care
+        // of mapping them. However, this fails under certain containers (e.g. webkit-container-sdk).
+        if (shouldUsePortal() && g_error_matches(error.get(), G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
+            LOG_ERROR("Portal was unable to make sandboxed process p%" PRId64 ", t%" PRId64 " real time", processID, threadID);
+        else
+            LOG_ERROR("Failed to make thread p%" PRId64 ", t%" PRId64 " real time: %s", processID, threadID, error->message);
         if (!g_error_matches(error.get(), G_DBUS_ERROR, G_DBUS_ERROR_UNKNOWN_INTERFACE))
             m_realTimeKitProxy = nullptr;
     }


### PR DESCRIPTION
#### 24184eef3b0cf58a131c2b575f61ec8d97b68e60
<pre>
[GTK][WPE] Handle common, non-error rtkit log messages on launch
<a href="https://bugs.webkit.org/show_bug.cgi?id=311258">https://bugs.webkit.org/show_bug.cgi?id=311258</a>

Reviewed by Adrian Perez de Castro and Michael Catanzaro.

When launching MiniBrowser, we attempt to promote a number of threads to
real-time. This has consistently been logging errors in two cases:

1. short-lived threads. These don&apos;t exist by the time we call
   sched_setscheduler, and will always log an error when we try to
   promote them with rtkit, because we ignored the errno set by
   sched_setscheduler.
2. threads in processes inside bwrap. sched_setscheduler fails to
   promote them, then xdg-desktop-portal tries but fails to map them.
   These threads still exist, but are out of reach. While portal should
   be able to map them, it seems to fail at least in certain containers.

This change checks errno as set by sched_setscheduler, avoiding the
extra rtkit attempt, and checks the G_IO_ERROR_NOT_FOUND error reported
by portal when mapping fails if we&apos;re running sandboxed.

* Source/WTF/wtf/linux/RealTimeThreads.cpp:
(WTF::RealTimeThreads::promoteThreadToRealTime):
(WTF::RealTimeThreads::realTimeKitMakeThreadRealTime):

Canonical link: <a href="https://commits.webkit.org/310444@main">https://commits.webkit.org/310444@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9db39a7586100a01eb7586ede853a00713e32e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153876 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26660 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20277 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162627 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107339 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27189 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26982 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118977 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84123 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156835 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21245 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138171 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99687 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20325 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/18287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10459 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/145889 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129973 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16030 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165100 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/14700 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8231 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17624 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127064 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26457 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22314 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127231 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34513 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26459 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137825 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83148 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22130 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14609 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/185512 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26076 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90364 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47578 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25767 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25927 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25827 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->