### PR TITLE
[WebXR][SaferCPP] Do not hide smart pointers behind auto

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXRFrame.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRFrame.cpp
@@ -78,7 +78,7 @@ bool WebXRFrame::isOutsideNativeBoundsOfBoundedReferenceSpace(const WebXRSpace& 
 
 bool WebXRFrame::isLocalReferenceSpace(const WebXRSpace& space) const
 {
-    auto* referenceSpace = dynamicDowncast<WebXRReferenceSpace>(space);
+    RefPtr referenceSpace = dynamicDowncast<WebXRReferenceSpace>(space);
     if (!referenceSpace)
         return false;
 
@@ -208,7 +208,7 @@ ExceptionOr<RefPtr<WebXRViewerPose>> WebXRFrame::getViewerPose(const Document& d
         // 8.6. Let offset be an new XRRigidTransform object equal to the view offset of view in the relevant realm of session.
         // 8.7. Set xrview’s transform property to the result of multiplying the XRViewerPose's transform by the offset transform in the relevant realm of session
         auto offset = matrixFromPose(frameData.views[index].offset);
-        auto transform = WebXRRigidTransform::create(pose->transform().rawTransform() * offset);
+        Ref transform = WebXRRigidTransform::create(pose->transform().rawTransform() * offset);
 
         // Set projection matrix for each view
         std::array<float, 16> projection = WTF::switchOn(frameData.views[index].projection, [&](const PlatformXR::FrameData::Fov& fov) {
@@ -221,7 +221,7 @@ ExceptionOr<RefPtr<WebXRViewerPose>> WebXRFrame::getViewerPose(const Document& d
             // Use aspect projection for inline sessions
             double fov =  m_session->renderState().inlineVerticalFieldOfView().value_or(piOverTwoDouble);
             float aspect = 1;
-            auto layer = m_session->renderState().baseLayer();
+            RefPtr layer = m_session->renderState().baseLayer();
             if (layer)
                 aspect = static_cast<double>(layer->framebufferWidth()) / static_cast<double>(layer->framebufferHeight());
             double near = m_session->renderState().depthNear();
@@ -229,7 +229,7 @@ ExceptionOr<RefPtr<WebXRViewerPose>> WebXRFrame::getViewerPose(const Document& d
             return TransformationMatrix::fromProjection(fov, aspect, near, far).toColumnMajorFloatArray();
         });
 
-        auto xrView = WebXRView::create(Ref { *this }, view.eye, WTF::move(transform), Float32Array::create(projection.data(), projection.size()));
+        Ref xrView = WebXRView::create(Ref { *this }, view.eye, WTF::move(transform), Float32Array::create(projection.data(), projection.size()));
         xrView->setViewportModifiable(m_session->supportsViewportScaling());
 
         //  8.8. Append xrview to xrviews
@@ -294,7 +294,7 @@ ExceptionOr<bool> WebXRFrame::fillJointRadii(const Vector<Ref<WebXRJointSpace>>&
 
     // For each joint in the jointSpaces:
     // If joint’s session is different from session, throw an InvalidStateError and abort these steps.
-    for (const auto& jointSpace : jointSpaces) {
+    for (Ref jointSpace : jointSpaces) {
         if (jointSpace->session() != m_session.ptr())
             return Exception { ExceptionCode::InvalidStateError, "Joint space's session does not match frame's session"_s };
     }
@@ -334,7 +334,7 @@ ExceptionOr<bool> WebXRFrame::fillPoses(const Document& document, const Vector<R
 
     // For each space in the spaces sequence:
     // If space’s session is different from session, throw an InvalidStateError and abort these steps.
-    for (const auto& space : spaces) {
+    for (Ref space : spaces) {
         if (space->session() != m_session.ptr())
             return Exception { ExceptionCode::InvalidStateError, "Space's session does not match frame's session"_s };
     }

--- a/Source/WebCore/Modules/webxr/WebXRInputSourceArray.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRInputSourceArray.cpp
@@ -70,7 +70,7 @@ WebXRInputSource* WebXRInputSourceArray::item(unsigned index) const
 
 RefPtr<WebXRInputSource> WebXRInputSourceArray::itemByHandle(PlatformXR::InputSourceHandle handle) const
 {
-    for (auto& item : m_inputSources) {
+    for (Ref item : m_inputSources) {
         if (item->handle() == handle)
             return item.ptr();
     }
@@ -101,7 +101,7 @@ void WebXRInputSourceArray::update(double timestamp, const InputSourceList& inpu
             WTF::move(added),
             WTF::move(removed),
         };
-        auto event = XRInputSourcesChangeEvent::create(eventNames().inputsourceschangeEvent, WTF::move(init));
+        Ref event = XRInputSourcesChangeEvent::create(eventNames().inputsourceschangeEvent, WTF::move(init));
         ActiveDOMObject::queueTaskToDispatchEvent(m_session, TaskSource::WebXR, WTF::move(event));
     }
 
@@ -113,7 +113,7 @@ void WebXRInputSourceArray::update(double timestamp, const InputSourceList& inpu
         // 4. Dispatch event on frame’s session
         // 5. Set frame’s active boolean to false.
 
-        for (auto& event : inputEvents) {
+        for (Ref event : inputEvents) {
             ActiveDOMObject::queueTaskKeepingObjectAlive(m_session, TaskSource::WebXR, [session = Ref { m_session }, event = WTF::move(event)](auto&) {
                 event->setFrameActive(true);
                 session->dispatchEvent(event.copyRef());
@@ -132,7 +132,7 @@ void WebXRInputSourceArray::update(double timestamp, const InputSourceList& inpu
             { },
             WTF::move(removedWithInputEvents),
         };
-        auto event = XRInputSourcesChangeEvent::create(eventNames().inputsourceschangeEvent, WTF::move(init));
+        Ref event = XRInputSourcesChangeEvent::create(eventNames().inputsourceschangeEvent, WTF::move(init));
         ActiveDOMObject::queueTaskToDispatchEvent(m_session, TaskSource::WebXR, WTF::move(event));
     }
 }
@@ -179,7 +179,7 @@ void WebXRInputSourceArray::handleAddedOrUpdatedInputSources(double timestamp, c
             //   3.1 Let inputSource be a new XRInputSource in the relevant realm of this XRSession.
             //   3.2 Add inputSource to added.
 
-            auto input = WebXRInputSource::create(*document, m_session, timestamp, inputSource);
+            Ref input = WebXRInputSource::create(*document, m_session, timestamp, inputSource);
             added.append(input);
             input->pollEvents(inputEvents);
             m_inputSources.append(WTF::move(input));
@@ -208,7 +208,7 @@ void WebXRInputSourceArray::handleAddedOrUpdatedInputSources(double timestamp, c
             inputEvents.appendVector(sourceInputEvents);
             m_inputSources.removeAt(index);
 
-            auto newInputSource = WebXRInputSource::create(*document, m_session, timestamp, inputSource);
+            Ref newInputSource = WebXRInputSource::create(*document, m_session, timestamp, inputSource);
             added.append(newInputSource);
             newInputSource->pollEvents(inputEvents);
             m_inputSources.append(WTF::move(newInputSource));
@@ -222,4 +222,3 @@ void WebXRInputSourceArray::handleAddedOrUpdatedInputSources(double timestamp, c
 } // namespace WebCore
 
 #endif // ENABLE(WEBXR)
-

--- a/Source/WebCore/Modules/webxr/WebXRSession.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSession.cpp
@@ -63,7 +63,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WebXRSession);
 
 Ref<WebXRSession> WebXRSession::create(Document& document, XRSessionMode mode, PlatformXR::Device& device, FeatureList&& requestedFeatures)
 {
-    auto session = adoptRef(*new WebXRSession(document, mode, device, WTF::move(requestedFeatures)));
+    Ref session = adoptRef(*new WebXRSession(document, mode, device, WTF::move(requestedFeatures)));
     session->suspendIfNeeded();
     return session;
 }
@@ -99,7 +99,7 @@ WebXRSession::WebXRSession(Document& document, XRSessionMode mode, PlatformXR::D
 
 WebXRSession::~WebXRSession()
 {
-    auto device = m_device.get();
+    RefPtr device = m_device.get();
     if (!m_ended && device)
         device->shutDownTrackingAndRendering();
 }
@@ -197,7 +197,7 @@ ExceptionOr<void> WebXRSession::updateRenderState(const XRRenderStateInit& newSt
             m_pendingRenderState = m_activeRenderState->clone();
 
         for (size_t i = 0; i < newState.layers->size(); ++i) {
-            auto& layer = newState.layers->at(i);
+            const Ref layer = newState.layers->at(i);
 
             if (i != newState.layers->reverseFind(layer))
                 return Exception { ExceptionCode::TypeError, "Cannot set the same XRLayer instance multiple times in the layers array."_s };
@@ -232,7 +232,7 @@ bool WebXRSession::referenceSpaceIsSupported(XRReferenceSpaceType type) const
             return true;
 
         // 4. If type is local or local-floor, and the XR device supports reporting orientation data, return true.
-        auto device = m_device.get();
+        RefPtr device = m_device.get();
         if (device && device->supportsOrientationTracking())
             return true;
     }
@@ -276,7 +276,7 @@ void WebXRSession::requestReferenceSpace(XRReferenceSpaceType type, RequestRefer
             return;
         }
         // 2.2. Set up any platform resources required to track reference spaces of type type.
-        if (auto device = m_device.get())
+        if (RefPtr device = m_device.get())
             device->initializeReferenceSpace(type);
 
         // 2.3. Queue a task to run the following steps:
@@ -357,7 +357,7 @@ IntSize WebXRSession::nativeWebGLFramebufferResolution() const
 // https://immersive-web.github.io/webxr/#recommended-webgl-framebuffer-resolution
 IntSize WebXRSession::recommendedWebGLFramebufferResolution() const
 {
-    auto device = m_device.get();
+    RefPtr device = m_device.get();
     ASSERT(device);
     return device ? device->recommendedResolution(m_mode) : IntSize { };
 }
@@ -365,7 +365,7 @@ IntSize WebXRSession::recommendedWebGLFramebufferResolution() const
 // https://immersive-web.github.io/webxr/#view-viewport-modifiable
 bool WebXRSession::supportsViewportScaling() const
 {
-    auto device = m_device.get();
+    RefPtr device = m_device.get();
     ASSERT(device);
     // Only immersive sessions support viewport scaling.
     return isImmersive(m_mode) && device && device->supportsViewportScaling();
@@ -436,7 +436,7 @@ void WebXRSession::didCompleteShutdown()
     if (isImmersive(m_mode) && m_activeRenderState && m_activeRenderState->baseLayer())
         m_activeRenderState->baseLayer()->sessionEnded();
 
-    if (auto device = m_device.get())
+    if (RefPtr device = m_device.get())
         device->setTrackingAndRenderingClient(nullptr);
 
     // Resolve end promise from XRSession::end()
@@ -447,7 +447,7 @@ void WebXRSession::didCompleteShutdown()
 
     // From https://immersive-web.github.io/webxr/#shut-down-the-session
     // 7. Queue a task that fires an XRSessionEvent named end on session.
-    auto event = XRSessionEvent::create(eventNames().endEvent, { { false, false, false }, Ref { *this } });
+    Ref event = XRSessionEvent::create(eventNames().endEvent, { { false, false, false }, Ref { *this } });
     queueTaskToDispatchEvent(*this, TaskSource::WebXR, WTF::move(event));
 }
 
@@ -523,7 +523,7 @@ void WebXRSession::updateSessionVisibilityState(PlatformXR::VisibilityState visi
     // From https://immersive-web.github.io/webxr/#event-types
     // A user agent MUST dispatch a visibilitychange event on an XRSession each time the
     // visibility state of the XRSession has changed. The event MUST be of type XRSessionEvent.
-    auto event = XRSessionEvent::create(eventNames().visibilitychangeEvent, { { false, false, false }, Ref { *this } });
+    Ref event = XRSessionEvent::create(eventNames().visibilitychangeEvent, { { false, false, false }, Ref { *this } });
     queueTaskToDispatchEvent(*this, TaskSource::WebXR, WTF::move(event));
 }
 
@@ -533,7 +533,7 @@ void WebXRSession::applyPendingRenderState()
     // 1. Let activeState be session’s active render state.
     // 2. Let newState be session’s pending render state.
     // 3. Set session’s pending render state to null.
-    auto newState = WTF::move(m_pendingRenderState);
+    RefPtr newState = WTF::move(m_pendingRenderState);
     ASSERT(newState);
     ASSERT(!m_pendingRenderState);
 
@@ -564,7 +564,7 @@ void WebXRSession::applyPendingRenderState()
         m_activeRenderState->setDepthFar(m_maximumFarClipPlane);
 
     // 6.7 Let baseLayer be activeState’s baseLayer.
-    auto baseLayer = m_activeRenderState->baseLayer();
+    RefPtr baseLayer = m_activeRenderState->baseLayer();
 
     // 6.8 Set activeState’s composition enabled and output canvas as follows:
     if (m_mode == XRSessionMode::Inline && is<WebXRWebGLLayer>(baseLayer) && !baseLayer->isCompositionEnabled()) {
@@ -625,7 +625,7 @@ void WebXRSession::requestFrameIfNeeded()
     if (m_callbacks.isEmpty() || m_isDeviceFrameRequestPending)
         return;
 
-    auto device = m_device.get();
+    RefPtr device = m_device.get();
     if (!device)
         return;
     m_isDeviceFrameRequestPending = true;
@@ -709,7 +709,7 @@ void WebXRSession::onFrame(PlatformXR::FrameData&& frameData)
                     session.m_activeRenderState->baseLayer()->startFrame(session.m_frameData);
 #if ENABLE(WEBXR_LAYERS)
                 else if (session.m_activeRenderState->layers().size()) {
-                    for (auto& layer : session.m_activeRenderState->layers())
+                    for (Ref layer : session.m_activeRenderState->layers())
                         layer->startFrame(session.m_frameData);
                 }
 #endif
@@ -729,7 +729,7 @@ void WebXRSession::onFrame(PlatformXR::FrameData&& frameData)
             tracePoint(WebXRSessionFrameCallbacksStart);
             session.minimalUpdateRendering();
             // 6.5.For each entry in session’s list of currently running animation frame callbacks, in order:
-            for (auto& callback : callbacks) {
+            for (Ref callback : callbacks) {
                 //  6.6.If the entry’s cancelled boolean is true, continue to the next entry.
                 if (callback->isFiredOrCancelled())
                     continue;
@@ -759,12 +759,12 @@ void WebXRSession::onFrame(PlatformXR::FrameData&& frameData)
                 frameLayers.append(session.m_activeRenderState->baseLayer()->endFrame());
 #if ENABLE(WEBXR_LAYERS)
             else if (!session.m_activeRenderState->layers().isEmpty()) {
-                for (auto& layer : session.m_activeRenderState->layers())
+                for (Ref layer : session.m_activeRenderState->layers())
                     frameLayers.append(layer->endFrame());
             }
 #endif
 
-            if (auto device = session.m_device.get())
+            if (RefPtr device = session.m_device.get())
                 device->submitFrame(WTF::move(frameLayers));
         }
 
@@ -885,7 +885,7 @@ void WebXRSession::requestHitTestSourceForTransientInput(const XRTransientInputH
 
 ExceptionOr<void> WebXRSession::cancelHitTestSource(PlatformXR::HitTestSource source)
 {
-    auto device = this->device();
+    RefPtr device = this->device();
     if (device)
         device->deleteHitTestSource(source);
 
@@ -897,7 +897,7 @@ ExceptionOr<void> WebXRSession::cancelHitTestSource(PlatformXR::HitTestSource so
 
 ExceptionOr<void> WebXRSession::cancelTransientInputHitTestSource(PlatformXR::TransientInputHitTestSource source)
 {
-    auto device = this->device();
+    RefPtr device = this->device();
     if (device)
         device->deleteTransientInputHitTestSource(source);
 
@@ -912,7 +912,7 @@ ExceptionOr<void> WebXRSession::cancelTransientInputHitTestSource(PlatformXR::Tr
 void WebXRSession::initializeTrackingAndRendering(std::optional<XRCanvasConfiguration>&& init)
 {
     RefPtr document = downcast<Document>(scriptExecutionContext());
-    auto device = this->device();
+    RefPtr device = this->device();
     if (document && device)
         device->initializeTrackingAndRendering(document->securityOrigin().data(), m_mode, m_requestedFeatures, WTF::move(init));
 }

--- a/Source/WebCore/Modules/webxr/WebXRSystem.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSystem.cpp
@@ -63,7 +63,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WebXRSystem);
 
 Ref<WebXRSystem> WebXRSystem::create(Navigator& navigator)
 {
-    auto system = adoptRef(*new WebXRSystem(navigator));
+    Ref system = adoptRef(*new WebXRSystem(navigator));
     system->suspendIfNeeded();
     return system;
 }
@@ -98,7 +98,7 @@ void WebXRSystem::ensureImmersiveXRDeviceIsSelected(CompletionHandler<void()>&& 
     }
 
     // https://immersive-web.github.io/webxr/#enumerate-immersive-xr-devices
-    auto document = downcast<Document>(scriptExecutionContext());
+    RefPtr document = dynamicDowncast<Document>(scriptExecutionContext());
     if (!document || !document->page()) {
         callback();
         return;
@@ -113,7 +113,7 @@ void WebXRSystem::ensureImmersiveXRDeviceIsSelected(CompletionHandler<void()>&& 
         });
 
         // https://immersive-web.github.io/webxr/#select-an-immersive-xr-device
-        auto oldDevice = m_activeImmersiveDevice.get();
+        RefPtr oldDevice = m_activeImmersiveDevice.get();
         if (immersiveXRDevices.isEmpty()) {
             m_activeImmersiveDevice = nullptr;
             return;
@@ -169,7 +169,7 @@ void WebXRSystem::isSessionSupported(XRSessionMode mode, IsSessionSupportedPromi
 
     // 3. If the requesting document's origin is not allowed to use the "xr-spatial-tracking" feature policy,
     //    reject promise with a "SecurityError" DOMException and return it.
-    auto document = downcast<Document>(scriptExecutionContext());
+    RefPtr document = dynamicDowncast<Document>(scriptExecutionContext());
     if (!PermissionsPolicy::isFeatureEnabled(PermissionsPolicy::Feature::XRSpatialTracking, *document)) {
         promise.reject(Exception { ExceptionCode::SecurityError });
         return;
@@ -179,7 +179,7 @@ void WebXRSystem::isSessionSupported(XRSessionMode mode, IsSessionSupportedPromi
     // 4.1 Ensure an immersive XR device is selected.
     ensureImmersiveXRDeviceIsSelected([this, promise = WTF::move(promise), mode]() mutable {
         // 4.2 If the immersive XR device is null, resolve promise with false and abort these steps.
-        auto activeImmersiveDevice = m_activeImmersiveDevice.get();
+        RefPtr activeImmersiveDevice = m_activeImmersiveDevice.get();
         if (!activeImmersiveDevice) {
             promise.resolve(false);
             return;
@@ -306,7 +306,7 @@ bool WebXRSystem::isFeatureSupported(PlatformXR::SessionFeature feature, XRSessi
 
 #if ENABLE(WEBXR_HANDS)
     if (feature == PlatformXR::SessionFeature::HandTracking) {
-        auto scriptExecutionContext = this->scriptExecutionContext();
+        RefPtr scriptExecutionContext = this->scriptExecutionContext();
         if (!scriptExecutionContext || !scriptExecutionContext->settingsValues().webXRHandInputModuleEnabled)
             return false;
     }
@@ -317,7 +317,7 @@ bool WebXRSystem::isFeatureSupported(PlatformXR::SessionFeature feature, XRSessi
         if (!isImmersive(mode))
             return false;
 
-        auto scriptExecutionContext = this->scriptExecutionContext();
+        RefPtr scriptExecutionContext = this->scriptExecutionContext();
         // FIXME: remove the testing check once the feature is stable.
         if (!scriptExecutionContext || (!scriptExecutionContext->settingsValues().webXRLayersAPIEnabled && !m_testingDevices))
             return false;
@@ -474,7 +474,7 @@ void WebXRSystem::resolveFeaturePermissions(XRSessionMode mode, const XRSessionI
     //        of these prompts should be included when determining if there is a clear signal of user intent to enable feature.
     //  10.2. If a clear signal of user intent to enable feature has not been determined, continue to the next entry.
     //  10.3. If feature is not in granted, append feature to granted.
-    auto document = downcast<Document>(scriptExecutionContext());
+    RefPtr document = dynamicDowncast<Document>(scriptExecutionContext());
     if (!document || !document->page()) {
         completionHandler(std::nullopt);
         return;
@@ -554,7 +554,7 @@ void WebXRSystem::requestSession(Document& document, XRSessionMode mode, const X
         //  - Reject promise with a "NotSupportedError" DOMException.
         //  - If immersive is true, set pending immersive session to false.
         //  - Abort these steps.
-        auto device = weakDevice.get();
+        RefPtr device = weakDevice.get();
         if (!device || !device->supports(mode))
             return;
 
@@ -611,7 +611,7 @@ void WebXRSystem::stop()
 
 void WebXRSystem::registerSimulatedXRDeviceForTesting(PlatformXR::Device& device)
 {
-    auto scriptExecutionContext = this->scriptExecutionContext();
+    RefPtr scriptExecutionContext = this->scriptExecutionContext();
     if (!scriptExecutionContext || !scriptExecutionContext->settingsValues().webXREnabled)
         return;
 
@@ -626,7 +626,7 @@ void WebXRSystem::registerSimulatedXRDeviceForTesting(PlatformXR::Device& device
 
 void WebXRSystem::unregisterSimulatedXRDeviceForTesting(PlatformXR::Device& device)
 {
-    auto scriptExecutionContext = this->scriptExecutionContext();
+    RefPtr scriptExecutionContext = this->scriptExecutionContext();
     if (!scriptExecutionContext || !scriptExecutionContext->settingsValues().webXREnabled)
         return;
 
@@ -698,11 +698,11 @@ void WebXRSystem::DummyInlineDevice::requestFrame(std::optional<PlatformXR::Requ
     if (!scriptExecutionContext())
         return;
     // Inline XR sessions rely on document.requestAnimationFrame to perform the render loop.
-    auto document = downcast<Document>(scriptExecutionContext());
+    RefPtr document = dynamicDowncast<Document>(scriptExecutionContext());
     if (!document)
         return;
 
-    auto raf = InlineRequestAnimationFrameCallback::create(*scriptExecutionContext(), [callback = WTF::move(callback)]() mutable {
+    Ref raf = InlineRequestAnimationFrameCallback::create(*scriptExecutionContext(), [callback = WTF::move(callback)]() mutable {
         PlatformXR::FrameData data;
         data.isTrackingValid = true;
         data.isPositionValid = true;


### PR DESCRIPTION
#### 750203030daadc77f3bc45b1a106677758f0f50c
<pre>
[WebXR][SaferCPP] Do not hide smart pointers behind auto
<a href="https://bugs.webkit.org/show_bug.cgi?id=311267">https://bugs.webkit.org/show_bug.cgi?id=311267</a>

Reviewed by Mike Wyrzykowski and Dan Glastonbury.

As stated by the SaferCPP guidelines
<a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines#do-not-hide-smart-pointers-behind-auto">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines#do-not-hide-smart-pointers-behind-auto</a>
we should not hide smart pointers behind auto in order to make pointer
semantics and lifetime management immediately visible.

No new tests required as we&apos;re just replacing types.

* Source/WebCore/Modules/webxr/WebXRFrame.cpp:
(WebCore::WebXRFrame::isLocalReferenceSpace const):
(WebCore::WebXRFrame::getViewerPose):
(WebCore::WebXRFrame::fillJointRadii):
(WebCore::WebXRFrame::fillPoses):
* Source/WebCore/Modules/webxr/WebXRInputSourceArray.cpp:
(WebCore::WebXRInputSourceArray::itemByHandle const):
(WebCore::WebXRInputSourceArray::update):
(WebCore::WebXRInputSourceArray::handleAddedOrUpdatedInputSources):
* Source/WebCore/Modules/webxr/WebXRSession.cpp:
(WebCore::WebXRSession::create):
(WebCore::WebXRSession::~WebXRSession):
(WebCore::WebXRSession::updateRenderState):
(WebCore::WebXRSession::referenceSpaceIsSupported const):
(WebCore::WebXRSession::requestReferenceSpace):
(WebCore::WebXRSession::recommendedWebGLFramebufferResolution const):
(WebCore::WebXRSession::supportsViewportScaling const):
(WebCore::WebXRSession::didCompleteShutdown):
(WebCore::WebXRSession::updateSessionVisibilityState):
(WebCore::WebXRSession::applyPendingRenderState):
(WebCore::WebXRSession::requestFrameIfNeeded):
(WebCore::WebXRSession::onFrame):
(WebCore::WebXRSession::cancelHitTestSource):
(WebCore::WebXRSession::cancelTransientInputHitTestSource):
(WebCore::WebXRSession::initializeTrackingAndRendering):
* Source/WebCore/Modules/webxr/WebXRSystem.cpp:
(WebCore::WebXRSystem::create):
(WebCore::WebXRSystem::ensureImmersiveXRDeviceIsSelected):
(WebCore::WebXRSystem::isSessionSupported):
(WebCore::WebXRSystem::isFeatureSupported const):
(WebCore::WebXRSystem::resolveFeaturePermissions const):
(WebCore::WebXRSystem::requestSession):
(WebCore::WebXRSystem::registerSimulatedXRDeviceForTesting):
(WebCore::WebXRSystem::unregisterSimulatedXRDeviceForTesting):
(WebCore::WebXRSystem::DummyInlineDevice::requestFrame):

Canonical link: <a href="https://commits.webkit.org/310423@main">https://commits.webkit.org/310423@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47201307aa82544c9c00bad469e0cf10e7217871

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153659 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26443 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20060 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162409 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107117 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155532 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26971 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26765 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118801 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84040 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156618 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21056 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137970 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99512 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20135 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18085 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10242 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129784 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15829 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164880 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8014 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17423 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126877 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26240 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22117 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127043 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34494 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26242 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137624 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82919 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21955 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14406 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25859 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90147 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25550 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25710 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25610 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->