### PR TITLE
Web Inspector: Update COMPATIBILITY comments

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Controllers/AnimationManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/AnimationManager.js
@@ -126,7 +126,7 @@ WI.AnimationManager = class AnimationManager
         if (!animation)
             return;
 
-        // COMPATIBILITY (iOS 26.0, macOS 26.0): `Animation.effectChanged` removed the `effect` parameter in favor of `Animation.requestEffect`.
+        // COMPATIBILITY (macOS 15.4, iOS 18.4): `Animation.effectChanged` removed the `effect` parameter in favor of `Animation.requestEffect`.
         animation.effectChanged(effect);
     }
 

--- a/Source/WebInspectorUI/UserInterface/Controllers/CSSManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/CSSManager.js
@@ -646,7 +646,7 @@ WI.CSSManager = class CSSManager extends WI.Object
         this._styleSheetFrameURLMap.clear();
         this._modifiedStyles.clear();
 
-        // COMPATIBILITY (macOS 14.0, iOS 17.0): the `PrefersColorScheme` override used to be cleared on main frame navigation
+        // COMPATIBILITY (macOS 13.3, iOS 16.4): the `PrefersColorScheme` override used to be cleared on main frame navigation
         // Since support can't be tested directly, check for the `reason` parameter of `Console.messagesCleared` as that change shipped in the same release.
         // FIXME: Use explicit version checking once <https://webkit.org/b/148680> is fixed.
         if (!InspectorBackend.hasEvent("Console.messagesCleared", "reason")) {

--- a/Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js
@@ -226,8 +226,8 @@ WI.ConsoleManager = class ConsoleManager extends WI.Object
 
         switch (reason) {
         case WI.ConsoleManager.ClearReason.Frontend:
-            // COMPATIBILITY (iOS 18.0, macOS 15.0): `Console.ClearReason.Frontend` did not exist yet.
-            // COMPATIBILITY (iOS 18.0, macOS 15.0): `Console.setConsoleClearAPIEnabled` did not exist yet.
+            // COMPATIBILITY (macOS 14.4, iOS 17.4):: `Console.ClearReason.Frontend` did not exist yet.
+            // COMPATIBILITY (macOS 14.4, iOS 17.4):: `Console.setConsoleClearAPIEnabled` did not exist yet.
             console.assert(InspectorBackend.hasCommand("Console.setConsoleClearAPIEnabled"));
             this._clearMessages();
             return;
@@ -314,7 +314,7 @@ WI.ConsoleManager = class ConsoleManager extends WI.Object
 
     _setConsoleClearAPIEnabled(target)
     {
-        // COMPATIBILITY (iOS 18.0, macOS 15.0): `Console.setConsoleClearAPIEnabled` did not exist yet.
+        // COMPATIBILITY (macOS 14.4, iOS 17.4):: `Console.setConsoleClearAPIEnabled` did not exist yet.
         if (target.hasCommand("Console.setConsoleClearAPIEnabled"))
             target.ConsoleAgent.setConsoleClearAPIEnabled(WI.settings.consoleClearAPIEnabled.value);
     }

--- a/Source/WebInspectorUI/UserInterface/Controllers/TimelineManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/TimelineManager.js
@@ -84,7 +84,7 @@ WI.TimelineManager = class TimelineManager extends WI.Object
             return;
 
         // COMPATIBILITY (iOS 13): Timeline.enable did not exist yet.
-        // COMPATIBILITY (iOS 26.0, macOS 26.0): `Timeline.enable` did not exist yet for Worker targets.
+        // COMPATIBILITY (macOS 15.4, iOS 18.4): `Timeline.enable` did not exist yet for Worker targets.
         if (target.hasCommand("Timeline.enable"))
             target.TimelineAgent.enable();
 
@@ -269,7 +269,7 @@ WI.TimelineManager = class TimelineManager extends WI.Object
 
         for (let target of WI.targets) {
             // COMPATIBILITY (iOS 13): Timeline.disable did not exist yet.
-            // COMPATIBILITY (iOS 26.0, macOS 26.0): `Timeline.disable` did not exist yet for Worker targets.
+            // COMPATIBILITY (macOS 15.4, iOS 18.4): `Timeline.disable` did not exist yet for Worker targets.
             if (target.hasCommand("Timeline.disable"))
                 target.TimelineAgent.disable();
         }
@@ -1442,7 +1442,7 @@ WI.TimelineManager = class TimelineManager extends WI.Object
         let enabledTimelineTypes = this.enabledTimelineTypes;
 
         for (let target of targets) {
-            // COMPATIBILITY (iOS 26.0, macOS 26.0): `Timeline.setInstruments` did not exist yet for Worker targets.
+            // COMPATIBILITY (macOS 15.4, iOS 18.4): `Timeline.setInstruments` did not exist yet for Worker targets.
             if (!target.hasCommand("Timeline.setInstruments"))
                 continue;
 

--- a/Source/WebInspectorUI/UserInterface/Models/Animation.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Animation.js
@@ -62,7 +62,7 @@ WI.Animation = class Animation extends WI.Object
             stackTrace: WI.StackTrace.fromPayload(WI.assumingMainTarget(), payload.stackTrace),
         });
 
-        // COMPATIBILITY (iOS 26.0, macOS 26.0): `Animation` removed the `effect` property in favor of `Animation.requestEffect`.
+        // COMPATIBILITY (macOS 15.4, iOS 18.4): `Animation` removed the `effect` property in favor of `Animation.requestEffect`.
         if (payload.effect)
             animation.effectChanged(payload.effect);
 
@@ -284,7 +284,7 @@ WI.Animation = class Animation extends WI.Object
     {
         this._effect = null;
 
-        // COMPATIBILITY (iOS 26.0, macOS 26.0): `Animation.effectChanged` removed the `effect` parameter in favor of `Animation.requestEffect`.
+        // COMPATIBILITY (macOS 15.4, iOS 18.4): `Animation.effectChanged` removed the `effect` parameter in favor of `Animation.requestEffect`.
         if (!InspectorBackend.hasCommand("Animation.requestEffect"))
             this._updateEffect(effect);
 

--- a/Source/WebInspectorUI/UserInterface/Models/Canvas.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Canvas.js
@@ -58,7 +58,7 @@ WI.Canvas = class Canvas extends WI.Object
         this._recordingFrames = [];
         this._recordingBufferUsed = 0;
 
-        // COMPATIBILITY (macOS 14.2, iOS 17.2): `Canvas.canvasSizeChanged` did not exist yet.
+        // COMPATIBILITY (macOS 14.0, iOS 17.0): `Canvas.canvasSizeChanged` did not exist yet.
         if (!InspectorBackend.hasEvent("Canvas.canvasSizeChanged")) {
             console.assert(!size);
 
@@ -112,7 +112,7 @@ WI.Canvas = class Canvas extends WI.Object
             console.error("Invalid canvas context type", payload.contextType);
         }
 
-        // COMPATIBILITY (macOS 14.2, iOS 17.2): `width` and `height` did not exist yet.
+        // COMPATIBILITY (macOS 14.0, iOS 17.0): `width` and `height` did not exist yet.
         let size = ("width" in payload && "height" in payload) ? new WI.Size(payload.width, payload.height) : null;
 
         // COMPATIBILITY (macOS 13.0, iOS 16.0): `backtrace` was renamed to `stackTrace`.
@@ -384,7 +384,7 @@ WI.Canvas = class Canvas extends WI.Object
     {
         // Called from WI.CanvasManager.
 
-        // COMPATIBILITY (macOS 14.2, iOS 17.2): `width` and `height` did not exist yet.
+        // COMPATIBILITY (macOS 14.0, iOS 17.0): `width` and `height` did not exist yet.
         if (this._size?.equals(size))
             return;
 

--- a/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
+++ b/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
@@ -1345,7 +1345,7 @@ WI.DOMNode = class DOMNode extends WI.Object
             this.showLayoutOverlay();
     }
 
-    // COMPATIBILITY (iOS 18.0, macOS 15.0): `DOM.getMediaStats` did not exist yet.
+    // COMPATIBILITY (macOS 14.4, iOS 17.4): `DOM.getMediaStats` did not exist yet.
     async getMediaStats()
     {
         let target = WI.assumingMainTarget();

--- a/Source/WebInspectorUI/UserInterface/Models/Instrument.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Instrument.js
@@ -67,7 +67,7 @@ WI.Instrument = class Instrument
             return;
 
         for (let target of WI.targets) {
-            // COMPATIBILITY (iOS 26.0, macOS 26.0): `Timeline.start` did not exist yet for Worker targets.
+            // COMPATIBILITY (macOS 15.4, iOS 18.4): `Timeline.start` did not exist yet for Worker targets.
             if (target.hasDomain("Timeline"))
                 target.TimelineAgent.start();
         }
@@ -86,7 +86,7 @@ WI.Instrument = class Instrument
             return;
 
         for (let target of WI.targets) {
-            // COMPATIBILITY (iOS 26.0, macOS 26.0): `Timeline.stop` did not exist yet for Worker targets.
+            // COMPATIBILITY (macOS 15.4, iOS 18.4): `Timeline.stop` did not exist yet for Worker targets.
             if (target.hasDomain("Timeline"))
                 target.TimelineAgent.stop();
         }

--- a/Source/WebInspectorUI/UserInterface/Models/ScriptInstrument.js
+++ b/Source/WebInspectorUI/UserInterface/Models/ScriptInstrument.js
@@ -39,7 +39,7 @@ WI.ScriptInstrument = class ScriptInstrument extends WI.Instrument
 
         if (!initiatedByBackend) {
             for (let target of WI.targets) {
-                // COMPATIBILITY (iOS 26.0, macOS 26.0): `ScriptProfiler.startTracking` did not exist yet in Worker targets.
+                // COMPATIBILITY (macOS 15.4, iOS 18.4): `ScriptProfiler.startTracking` did not exist yet in Worker targets.
                 if (target.hasDomain("ScriptProfiler"))
                     target.ScriptProfilerAgent.startTracking(includeSamples);
             }
@@ -50,7 +50,7 @@ WI.ScriptInstrument = class ScriptInstrument extends WI.Instrument
     {
         if (!initiatedByBackend) {
             for (let target of WI.targets) {
-                // COMPATIBILITY (iOS 26.0, macOS 26.0): `ScriptProfiler.stopTracking` did not exist yet for Worker targets.
+                // COMPATIBILITY (macOS 15.4, iOS 18.4): `ScriptProfiler.stopTracking` did not exist yet for Worker targets.
                 if (target.hasDomain("ScriptProfiler"))
                     target.ScriptProfilerAgent.stopTracking();
             }

--- a/Source/WebInspectorUI/UserInterface/Protocol/AnimationObserver.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/AnimationObserver.js
@@ -39,7 +39,7 @@ WI.AnimationObserver = class AnimationObserver extends InspectorBackend.Dispatch
 
     effectChanged(animationId, effect)
     {
-        // COMPATIBILITY (iOS 26.0, macOS 26.0): `Animation.effectChanged` removed the `effect` parameter in favor of `Animation.requestEffect`.`
+        // COMPATIBILITY (macOS 15.4, iOS 18.4): `Animation.effectChanged` removed the `effect` parameter in favor of `Animation.requestEffect`.`
         WI.animationManager.effectChanged(animationId, effect);
     }
 

--- a/Source/WebInspectorUI/UserInterface/Views/CookieStorageContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/CookieStorageContentView.js
@@ -466,7 +466,7 @@ WI.CookieStorageContentView = class CookieStorageContentView extends WI.ContentV
         if (editingCookie)
             promises.push(target.PageAgent.deleteCookie(editingCookie.name, editingCookie.url));
 
-        // COMPATIBILITY (iOS 18.4, macOS 15.4): `Page.setCookie` did not have a `shouldPartition` parameter yet.
+        // COMPATIBILITY (macOS 15.2, iOS 18.2): `Page.setCookie` did not have a `shouldPartition` parameter yet.
         promises.push(target.PageAgent.setCookie.invoke({
             cookie: cookieProtocolPayload,
             shouldPartition: !cookieToSet.partitionKey && !!cookieToSet.partitioned,

--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.js
@@ -542,8 +542,8 @@ WI.DOMTreeContentView = class DOMTreeContentView extends WI.ContentView
             }, WI.settings.enabledDOMTreeBadgeTypes.value.includes(WI.DOMTreeElement.BadgeType.Scrollable));
         }
 
-        // COMPATIBILITY (iOS 26.0, macOS 26.0): `SlotAssigned` value for `CSS.LayoutFlag` did not exist yet.
-        // COMPATIBILITY (iOS 26.0, macOS 26.0): `SlotFilled` value for `CSS.LayoutFlag` did not exist yet.
+        // COMPATIBILITY (macOS 15.4, iOS 18.4): `SlotAssigned` value for `CSS.LayoutFlag` did not exist yet.
+        // COMPATIBILITY (macOS 15.4, iOS 18.4): `SlotFilled` value for `CSS.LayoutFlag` did not exist yet.
         if (InspectorBackend.Enum.CSS?.LayoutFlag?.SlotAssigned && InspectorBackend.Enum.CSS?.LayoutFlag?.SlotFilled) {
             let checked = WI.settings.enabledDOMTreeBadgeTypes.value.some((enabledDOMTreeBadgeType) => enabledDOMTreeBadgeType === WI.DOMTreeElement.BadgeType.SlotAssigned || enabledDOMTreeBadgeType === WI.DOMTreeElement.BadgeType.SlotFilled);
             contextMenu.appendCheckboxItem(WI.UIString("Slot", "Title for a badge applied to HTMLSlotElement that have assigned nodes or nodes that are assigned to HTMLSlotElement."), () => {

--- a/Source/WebInspectorUI/UserInterface/Views/ElementsTabContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ElementsTabContentView.js
@@ -40,7 +40,7 @@ WI.ElementsTabContentView = class ElementsTabContentView extends WI.ContentBrows
         if (InspectorBackend.hasCommand("CSS.getFontDataForNode"))
             detailsSidebarPanelConstructors.push(WI.FontDetailsSidebarPanel);
 
-        // COMPATIBILITY (iOS 18.0, macOS 15.0): `DOM.getMediaStats` did not exist yet.
+        // COMPATIBILITY (macOS 14.4, iOS 17.4):: `DOM.getMediaStats` did not exist yet.
         if (InspectorBackend.hasCommand("DOM.getMediaStats"))
             detailsSidebarPanelConstructors.push(WI.MediaDetailsSidebarPanel)
 

--- a/Source/WebInspectorUI/UserInterface/Views/LayoutDetailsSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/LayoutDetailsSidebarPanel.js
@@ -75,7 +75,7 @@ WI.LayoutDetailsSidebarPanel = class LayoutDetailsSidebarPanel extends WI.DOMDet
         gridSettingsGroup.addSetting(WI.settings.gridOverlayShowAreaNames, WI.UIString("Area Names", "Area names @ Layout Panel Overlay Options", "Label for option to toggle the area names setting for CSS grid overlays"));
         gridSettingsGroup.addSetting(WI.settings.gridOverlayShowExtendedGridLines, WI.UIString("Extended Grid Lines", "Show extended lines @ Layout Panel Overlay Options", "Label for option to toggle the extended lines setting for CSS grid overlays"));
 
-        // COMPATIBILITY (macOS X.Y, iOS X.Y): `DOM.GridOverlayConfig.showOrderNumbers` did not exist yet.
+        // COMPATIBILITY (macOS 26.2, iOS 26.2): `DOM.GridOverlayConfig.showOrderNumbers` did not exist yet.
         // Since support can't be tested directly, check for if the `Page.navigate` command has been removed.
         // FIXME: Use explicit version checking once https://webkit.org/b/148680 is fixed.
         if (!InspectorBackend.hasCommand("Page.navigate"))

--- a/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
@@ -363,7 +363,7 @@ WI.SettingsTabContentView = class SettingsTabContentView extends WI.TabContentVi
         consoleSettingsView.addSetting(WI.UIString("Traces:"), WI.settings.consoleAutoExpandTrace, WI.UIString("Auto-expand"));
         consoleSettingsView.addSetting(WI.UIString("Show:"), WI.settings.showConsoleMessageTimestamps, WI.UIString("Timestamps"));
 
-        // COMPATIBILITY (iOS 18.0, macOS 15.0): `Console.setConsoleClearAPIEnabled` did not exist yet.
+        // COMPATIBILITY (macOS 14.4, iOS 17.4):: `Console.setConsoleClearAPIEnabled` did not exist yet.
         if (InspectorBackend.hasCommand("Console.setConsoleClearAPIEnabled"))
             consoleSettingsView.addSetting(WI.UIString("Clear:"), WI.settings.consoleClearAPIEnabled, WI.UIString("Allow page to clear Console"));
 


### PR DESCRIPTION
#### 043d4b57d263e4299981014c9b932dfccdcabce7
<pre>
Web Inspector: Update COMPATIBILITY comments
<a href="https://bugs.webkit.org/show_bug.cgi?id=311104">https://bugs.webkit.org/show_bug.cgi?id=311104</a>
<a href="https://rdar.apple.com/173685740">rdar://173685740</a>

Reviewed by NOBODY (OOPS!).

Retroactively update compatibility comments for earlier shipped changes
to indicate the last version where they were *not* supported.

* Source/WebInspectorUI/UserInterface/Controllers/AnimationManager.js:
(WI.AnimationManager.prototype.effectChanged):
* Source/WebInspectorUI/UserInterface/Controllers/CSSManager.js:
(WI.CSSManager.prototype._mainResourceDidChange):
* Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js:
(WI.ConsoleManager.prototype.messagesCleared):
(WI.ConsoleManager.prototype._setConsoleClearAPIEnabled):
* Source/WebInspectorUI/UserInterface/Controllers/TimelineManager.js:
(WI.TimelineManager.prototype.initializeTarget):
(WI.TimelineManager.prototype.disable):
(WI.TimelineManager.prototype._updateAutoCaptureInstruments):
* Source/WebInspectorUI/UserInterface/Models/Animation.js:
(WI.Animation.fromPayload):
(WI.Animation.prototype.effectChanged):
* Source/WebInspectorUI/UserInterface/Models/Canvas.js:
(WI.Canvas.fromPayload):
(WI.Canvas.prototype.sizeChanged):
* Source/WebInspectorUI/UserInterface/Models/DOMNode.js:
(WI.DOMNode):
* Source/WebInspectorUI/UserInterface/Models/Instrument.js:
(WI.Instrument.startLegacyTimelineAgent):
(WI.Instrument.stopLegacyTimelineAgent):
* Source/WebInspectorUI/UserInterface/Models/ScriptInstrument.js:
(WI.ScriptInstrument.prototype.startInstrumentation):
(WI.ScriptInstrument.prototype.stopInstrumentation):
(WI.ScriptInstrument):
* Source/WebInspectorUI/UserInterface/Protocol/AnimationObserver.js:
(WI.AnimationObserver.prototype.effectChanged):
* Source/WebInspectorUI/UserInterface/Views/CookieStorageContentView.js:
(WI.CookieStorageContentView.prototype.async _willDismissCookiePopover):
* Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.js:
(WI.DOMTreeContentView.prototype._populateConfigureDOMTreeBadgesNavigationItemContextMenu):
* Source/WebInspectorUI/UserInterface/Views/ElementsTabContentView.js:
(WI.ElementsTabContentView):
* Source/WebInspectorUI/UserInterface/Views/LayoutDetailsSidebarPanel.js:
(WI.LayoutDetailsSidebarPanel.prototype.initialLayout):
* Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js:
(WI.SettingsTabContentView.prototype._createConsoleSettingsView):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/043d4b57d263e4299981014c9b932dfccdcabce7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153671 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/26455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20072 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/162421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/107129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26983 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/26777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/162421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/107129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156630 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/21068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/137973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/162421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/20147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/26777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/10254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/129796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/15832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/164892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/8026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/17426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/164892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/26252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/26777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/164892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/26254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/137627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/82932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/26254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/14409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/25871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/90159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/25562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/25722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/25622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->