### PR TITLE
[libpas] pas_report_crash_extract_pgm_failure should use the supplied task id when invoking the reader callback

### DIFF
--- a/Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj
@@ -563,7 +563,7 @@
 		2B2E2FD22949A41100F85C38 /* pas_malloc_stack_logging.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B2E2FD02949A41100F85C38 /* pas_malloc_stack_logging.h */; };
 		2B6055E42805368B00C8BDAC /* BmallocTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B6055E32805368B00C8BDAC /* BmallocTests.cpp */; };
 		2BDF4F4529E8B36F0056BF50 /* pas_report_crash.h in Headers */ = {isa = PBXBuildFile; fileRef = 2BDF4F4429E8B36F0056BF50 /* pas_report_crash.h */; };
-		2BDF4F4729E8B3AD0056BF50 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		2BDF4F4729E8B3AD0056BF50 /* pas_report_crash.c in Sources */ = {isa = PBXBuildFile; fileRef = 2BDF4F4829E8B5510056BF50 /* pas_report_crash.c */; };
 		2BE4B7CB2D2D845E0099B3C5 /* pas_small_medium_bootstrap_free_heap.h in Headers */ = {isa = PBXBuildFile; fileRef = 2BE4B7C72D2D845E0099B3C5 /* pas_small_medium_bootstrap_free_heap.h */; };
 		2BE4B7CC2D2D845E0099B3C5 /* pas_small_medium_bootstrap_heap_page_provider.h in Headers */ = {isa = PBXBuildFile; fileRef = 2BE4B7C92D2D845E0099B3C5 /* pas_small_medium_bootstrap_heap_page_provider.h */; };
 		2BE4B7CD2D2D845E0099B3C5 /* pas_small_medium_bootstrap_heap_page_provider.c in Sources */ = {isa = PBXBuildFile; fileRef = 2BE4B7CA2D2D845E0099B3C5 /* pas_small_medium_bootstrap_heap_page_provider.c */; };
@@ -2782,7 +2782,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2BDF4F4729E8B3AD0056BF50 /* (null) in Sources */,
 				0F8A806625EECC1D00790B4A /* bmalloc_heap.c in Sources */,
 				0F8A806825EECC1D00790B4A /* bmalloc_heap_config.c in Sources */,
 				2C11E8912728A893002162D0 /* bmalloc_type.c in Sources */,
@@ -2899,6 +2898,7 @@
 				0FD48B3023A9ABB30026C46D /* pas_random.c in Sources */,
 				0FF08F3422A58F1200386575 /* pas_red_black_tree.c in Sources */,
 				0FA5E4592492D5BA00CE962A /* pas_redundant_local_allocator_node.c in Sources */,
+				2BDF4F4729E8B3AD0056BF50 /* pas_report_crash.c in Sources */,
 				0F5B6091235E88EF00CAE629 /* pas_reserved_memory_provider.c in Sources */,
 				0F4F60FA25979BC8008B4A82 /* pas_root.c in Sources */,
 				0F99999C36AAAA0000213121 /* pas_runtime_config.c in Sources */,

--- a/Source/bmalloc/libpas/src/libpas/pas_report_crash.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_report_crash.c
@@ -35,25 +35,18 @@
 #include "pas_probabilistic_guard_malloc_allocator.h"
 
 #ifdef __APPLE__
+
+typedef struct {
+    crash_reporter_memory_reader_t crm_reader;
+    task_t task;
+} crash_reporter_reader_data;
+
 static void* pas_enumerator_reader_adapter(pas_enumerator* enumerator,
                                            void* remote_address, size_t size, void* arg)
 {
     PAS_UNUSED_PARAM(enumerator);
-    crash_reporter_memory_reader_t crm_reader = (crash_reporter_memory_reader_t)arg;
-    return crm_reader(0, (vm_address_t)remote_address, size);
-}
-
-static pas_enumerator* setup_enumerator_for_crash_reporting(mach_vm_address_t pas_dead_root,
-                                                           crash_reporter_memory_reader_t crm_reader)
-{
-    return pas_enumerator_create((pas_root*)pas_dead_root,
-                                pas_enumerator_reader_adapter,
-                                (void*)crm_reader,
-                                NULL, /* recorder */
-                                NULL, /* recorder_arg */
-                                pas_enumerator_do_not_record_meta_records,
-                                pas_enumerator_do_not_record_payload_records,
-                                pas_enumerator_do_not_record_object_records);
+    crash_reporter_reader_data* data = (crash_reporter_reader_data*)arg;
+    return data->crm_reader(data->task, (vm_address_t)remote_address, size);
 }
 
 static PAS_ALWAYS_INLINE bool PAS_WARN_UNUSED_RETURN pas_fault_address_is_in_bounds(addr64_t fault_address, addr64_t bottom, addr64_t top)
@@ -93,14 +86,26 @@ static PAS_ALWAYS_INLINE kern_return_t PAS_WARN_UNUSED_RETURN pas_update_report_
  */
 kern_return_t pas_report_crash_extract_pgm_failure(vm_address_t fault_address, mach_vm_address_t pas_dead_root, unsigned version, task_t task, pas_report_crash_pgm_report* report, crash_reporter_memory_reader_t crm_reader)
 {
-    PAS_UNUSED_PARAM(task);
+
+    crash_reporter_reader_data reader_data;
 
     if (!report)
         return KERN_INVALID_ARGUMENT;
     if (!crm_reader)
         return KERN_INVALID_ARGUMENT;
 
-    pas_enumerator* enumerator = setup_enumerator_for_crash_reporting(pas_dead_root, crm_reader);
+    reader_data.crm_reader = crm_reader;
+    reader_data.task = task;
+
+    pas_enumerator* enumerator = pas_enumerator_create(
+        (pas_root*)pas_dead_root,
+        pas_enumerator_reader_adapter,
+        (void*)&reader_data,
+        NULL, /* recorder */
+        NULL, /* recorder_arg */
+        pas_enumerator_do_not_record_meta_records,
+        pas_enumerator_do_not_record_payload_records,
+        pas_enumerator_do_not_record_object_records);
     if (!enumerator)
         return KERN_FAILURE;
 

--- a/Source/bmalloc/libpas/src/test/PGMTests.cpp
+++ b/Source/bmalloc/libpas/src/test/PGMTests.cpp
@@ -589,6 +589,50 @@ void testPGMAllocMetadataOnly()
 }
 #endif
 
+#ifdef __APPLE__
+static task_t received_task;
+
+static void* mockCrashReporterReader(task_t task, vm_address_t address, size_t size)
+{
+    (void)size;
+    received_task = task;
+    return (void*)address;
+}
+
+void testPGMCrashReportTaskPassthrough()
+{
+    pas_probabilistic_guard_malloc_initialize_pgm_as_enabled(1);
+
+    pas_heap_lock_lock();
+    pas_root* root = pas_root_create();
+    pas_heap_lock_unlock();
+
+    // Allocate and free to populate PGM hash map with a freed entry.
+    int* arr = static_cast<int*>(bmalloc_allocate(1000 * sizeof(int), pas_non_compact_allocation_mode));
+    CHECK(arr);
+    bmalloc_deallocate(arr);
+
+    // Use the allocation address as fault address so it matches a UAF entry.
+    vm_address_t fault_address = (vm_address_t)arr;
+    task_t sentinel_task = (task_t)0xDEAD;
+    received_task = 0;
+
+    pas_report_crash_pgm_report report = { };
+    kern_return_t result = pas_report_crash_extract_pgm_failure(
+        fault_address,
+        (mach_vm_address_t)root,
+        pas_crash_report_version,
+        sentinel_task,
+        &report,
+        mockCrashReporterReader);
+
+    // Verify the task was passed through to the mock reader.
+    CHECK_EQUAL(received_task, sentinel_task);
+    CHECK_EQUAL(result, KERN_SUCCESS);
+    CHECK(report.error_type);
+}
+#endif
+
 } // anonymous namespace
 
 void addPGMTests()
@@ -606,5 +650,8 @@ void addPGMTests()
     ADD_TEST(testPGMMetadataDoubleFreeBehavior());
     ADD_TEST(testPGMBmallocAllocationBacktrace());
     ADD_TEST(testPGMAllocMetadataOnly());
+#endif
+#ifdef __APPLE__
+    ADD_TEST(testPGMCrashReportTaskPassthrough());
 #endif
 }


### PR DESCRIPTION
#### f7b2175c9c2330e1917d2e5b3cfb917d256b9617
<pre>
[libpas] pas_report_crash_extract_pgm_failure should use the supplied task id when invoking the reader callback
<a href="https://bugs.webkit.org/show_bug.cgi?id=311270">https://bugs.webkit.org/show_bug.cgi?id=311270</a>
<a href="https://rdar.apple.com/173765415">rdar://173765415</a>

Reviewed by Marcus Plutowski.

ReportCrash supplies a task id to use when calling back. The libpas
code should use that when invoking the callbacks.

Added test to PGMTests.cpp to verify the supplied task is used.

* Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj:
* Source/bmalloc/libpas/src/libpas/pas_report_crash.c:
(pas_enumerator_reader_adapter):
(pas_report_crash_extract_pgm_failure):
(setup_enumerator_for_crash_reporting): Deleted.
* Source/bmalloc/libpas/src/test/PGMTests.cpp:
(std::mockCrashReporterReader):
(std::testPGMCrashReportTaskPassthrough):
(addPGMTests):

Canonical link: <a href="https://commits.webkit.org/310473@main">https://commits.webkit.org/310473@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8166c5c206e5980f78bda92a4fdecc7fef2a6fd3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153679 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26463 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20080 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162429 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107137 "An unexpected error occured. Recent messages:Printed configuration") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26991 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26785 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118821 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/107137 "An unexpected error occured. Recent messages:Printed configuration") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156638 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21074 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137983 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99532 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20153 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18103 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10262 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/145692 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129802 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15842 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164900 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/14503 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17436 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126894 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26260 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22135 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127060 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26262 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137637 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82940 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23521 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21970 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14419 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/185315 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25879 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47531 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25570 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25730 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25630 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->