### PR TITLE
Split WebCore::CustomIdentifier into separate CSS::CustomIdent/Style::CustomIdent types

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -107,6 +107,7 @@ set(WebCore_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBCORE_DIR}/css/values/borders"
     "${WEBCORE_DIR}/css/values/color"
     "${WEBCORE_DIR}/css/values/color-adjust"
+    "${WEBCORE_DIR}/css/values/counter-styles"
     "${WEBCORE_DIR}/css/values/easing"
     "${WEBCORE_DIR}/css/values/filter-effects"
     "${WEBCORE_DIR}/css/values/grid"

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1064,7 +1064,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     css/CSSColorValue.h
     css/CSSComputedStyleDeclaration.h
     css/CSSConditionRule.h
-    css/CSSCounterStyle.h
     css/CSSCounterStyleDescriptors.h
     css/CSSCounterValue.h
     css/CSSCustomPropertyValue.h
@@ -1188,6 +1187,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     css/values/motion/CSSRayFunction.h
 
+    css/values/primitives/CSSCustomIdent.h
     css/values/primitives/CSSPosition.h
     css/values/primitives/CSSPrimitiveData.h
     css/values/primitives/CSSPrimitiveKeywordList.h
@@ -3346,6 +3346,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     style/values/position/StyleInset.h
 
+    style/values/primitives/StyleCustomIdent.h
     style/values/primitives/StyleCoordinatedValueList.h
     style/values/primitives/StyleCoordinatedValueListValue.h
     style/values/primitives/StyleLengthWrapper.h

--- a/Source/WebCore/SaferCPPExpectations/NoDeleteCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoDeleteCheckerExpectations
@@ -8,6 +8,7 @@ Modules/webtransport/WebTransportDatagramsWritable.cpp
 css/CSSComputedStyleDeclaration.cpp
 css/PropertySetCSSDescriptors.cpp
 css/StyleSheetList.cpp
+css/parser/CSSParserTokenRange.cpp
 dom/ChildNodeList.cpp
 dom/Document.cpp
 dom/Node.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -50,6 +50,7 @@ bindings/js/StructuredClone.cpp
 css/CSSStyleSheet.cpp
 css/SelectorChecker.cpp
 css/ShorthandSerializer.cpp
+css/values/CSSValueAggregates.h
 dom/Position.cpp
 dom/Range.cpp
 dom/SpaceSplitString.cpp

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -894,13 +894,13 @@ css/CSSColorValue.cpp
 css/CSSComputedStyleDeclaration.cpp
 css/CSSConditionRule.cpp
 css/CSSContainerRule.cpp
-css/CSSCounterStyle.cpp
 css/CSSCounterStyleDescriptors.cpp
 css/CSSCounterStyleRegistry.cpp
 css/CSSCounterStyleRule.cpp
 css/CSSCounterValue.cpp
 css/CSSCrossfadeValue.cpp
 css/CSSCursorImageValue.cpp
+css/CSSCustomIdentValue.cpp
 css/CSSCustomPropertyValue.cpp
 css/CSSDynamicRangeLimitValue.cpp
 css/CSSEasingFunctionValue.cpp
@@ -963,6 +963,7 @@ css/CSSRatioValue.cpp
 css/CSSRayValue.cpp
 css/CSSRectValue.cpp
 css/CSSReflectValue.cpp
+css/CSSRegisteredCounterStyle.cpp
 css/CSSRegisteredCustomProperty.cpp
 css/CSSRule.cpp
 css/CSSRuleList.cpp
@@ -1178,6 +1179,7 @@ css/values/color/CSSResolvedColor.cpp
 css/values/grid/CSSGridNamedAreaMap.cpp
 css/values/images/CSSGradient.cpp
 css/values/motion/CSSRayFunction.cpp
+css/values/primitives/CSSCustomIdent.cpp
 css/values/primitives/CSSPosition.cpp
 css/values/primitives/CSSPrimitiveNumericCategory.cpp
 css/values/primitives/CSSPrimitiveNumericTypes+Canonicalization.cpp
@@ -3373,6 +3375,7 @@ style/values/overflow/StyleScrollbarGutter.cpp
 style/values/overflow/StyleOverflowClipMargin.cpp
 style/values/page/StylePageSize.cpp
 style/values/pointerevents/StyleTouchAction.cpp
+style/values/primitives/StyleCustomIdent.cpp
 style/values/primitives/StyleLengthResolution.cpp
 style/values/primitives/StyleLengthWrapper+DeprecatedCSSValueConversion.cpp
 style/values/primitives/StyleLengthWrapperData.cpp

--- a/Source/WebCore/animation/CSSAnimation.cpp
+++ b/Source/WebCore/animation/CSSAnimation.cpp
@@ -215,7 +215,7 @@ void CSSAnimation::syncStyleOriginatedTimeline()
         [&](const CSS::Keyword::None&) {
             setTimeline(nullptr);
         },
-        [&](const CustomIdentifier&) {
+        [&](const Style::CustomIdent&) {
             CheckedRef styleOriginatedTimelinesController = document->ensureStyleOriginatedTimelinesController();
             styleOriginatedTimelinesController->attachAnimation(*this);
         },
@@ -241,7 +241,7 @@ void CSSAnimation::syncStyleOriginatedTimeline()
 
     // If we're not dealing with a named timeline, we should make sure we have no
     // pending attachment operation for this timeline name.
-    if (!m_backingStyleAnimation.timeline().isCustomIdentifier()) {
+    if (!m_backingStyleAnimation.timeline().isCustomIdent()) {
         CheckedRef styleOriginatedTimelinesController = document->ensureStyleOriginatedTimelinesController();
         styleOriginatedTimelinesController->removePendingOperationsForCSSAnimation(*this);
     }

--- a/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
+++ b/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
@@ -73,7 +73,7 @@ static const WeakStyleable originatingElementExcludingTimelineScope(const Ref<Sc
     return timeline->timelineScopeDeclaredElement() ? WeakStyleable() : originatingElement(timeline);
 }
 
-Vector<WeakStyleable> StyleOriginatedTimelinesController::relatedTimelineScopeElements(const CustomIdentifier& name)
+Vector<WeakStyleable> StyleOriginatedTimelinesController::relatedTimelineScopeElements(const Style::CustomIdent& name)
 {
     Vector<WeakStyleable> timelineScopeElements;
     for (auto& scope : m_timelineScopeEntries) {
@@ -174,7 +174,7 @@ void StyleOriginatedTimelinesController::updateTimelineForTimelineScope(const Re
     for (auto& entry : m_timelineScopeEntries) {
         if (auto entryElement = entry.second.styleable()) {
             Ref protectedEntryElement { entryElement->element };
-            if (Ref { timelineElement->element }->isComposedTreeDescendantOf(protectedEntryElement.get()) && (entry.first.type == Style::NameScope::Type::All || entry.first.names.contains(CustomIdentifier { name })))
+            if (Ref { timelineElement->element }->isComposedTreeDescendantOf(protectedEntryElement.get()) && (entry.first.type == Style::NameScope::Type::All || entry.first.names.contains(Style::CustomIdent { name })))
                 matchedTimelineScopeElements.appendIfNotContains(*entryElement);
         }
     }
@@ -225,7 +225,7 @@ void StyleOriginatedTimelinesController::updateCSSAnimationsAssociatedWithNamedT
             if (RefPtr cssAnimation = dynamicDowncast<CSSAnimation>(animation.get())) {
                 if (!cssAnimation->owningElement())
                     continue;
-                if (auto timelineName = cssAnimation->backingStyleAnimation().timeline().tryCustomIdentifier()) {
+                if (auto timelineName = cssAnimation->backingStyleAnimation().timeline().tryCustomIdent()) {
                     if (timelineName->value == name)
                         cssAnimationsWithMatchingTimelineName.add(*cssAnimation);
                 }
@@ -345,7 +345,7 @@ void StyleOriginatedTimelinesController::attachAnimation(CSSAnimation& animation
     if (!target)
         return;
 
-    auto timelineName = protectedAnimation->backingStyleAnimation().timeline().tryCustomIdentifier();
+    auto timelineName = protectedAnimation->backingStyleAnimation().timeline().tryCustomIdent();
     if (!timelineName)
         return;
 

--- a/Source/WebCore/animation/StyleOriginatedTimelinesController.h
+++ b/Source/WebCore/animation/StyleOriginatedTimelinesController.h
@@ -78,7 +78,7 @@ public:
 
 private:
     Vector<Ref<ScrollTimeline>>& timelinesForName(const AtomString&) LIFETIME_BOUND;
-    Vector<WeakStyleable> relatedTimelineScopeElements(const CustomIdentifier&);
+    Vector<WeakStyleable> relatedTimelineScopeElements(const Style::CustomIdent&);
     void updateCSSAnimationsAssociatedWithNamedTimeline(const AtomString&);
 
     enum class AllowsDeferral : bool { No, Yes };

--- a/Source/WebCore/css/CSSCounterStyleDescriptors.cpp
+++ b/Source/WebCore/css/CSSCounterStyleDescriptors.cpp
@@ -27,6 +27,7 @@
 #include "CSSCounterStyleDescriptors.h"
 
 #include "CSSCounterStyleRule.h"
+#include "CSSCustomIdentValue.h"
 #include "CSSMarkup.h"
 #include "CSSPrimitiveValue.h"
 #include "CSSValueList.h"
@@ -70,11 +71,13 @@ CSSCounterStyleDescriptors::Ranges rangeFromCSSValue(const CSSValue& value)
 
 CSSCounterStyleDescriptors::Symbol symbolFromCSSValue(const CSSValue* value)
 {
-    auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value);
-    if (!primitiveValue)
-        return { };
+    if (RefPtr customIdentValue = dynamicDowncast<CSSCustomIdentValue>(value))
+        return { .isCustomIdent = true, .text = customIdentValue->customIdent().value };
 
-    return { primitiveValue->isCustomIdent(), primitiveValue->stringValue() };
+    if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value))
+        return { .isCustomIdent = false, .text = primitiveValue->stringValue() };
+
+    return { };
 }
 
 static CSSCounterStyleDescriptors::AdditiveSymbols additiveSymbolsFromStyleProperties(const StyleProperties& properties)
@@ -163,11 +166,11 @@ static CSSCounterStyleDescriptors::Name fallbackNameFromStyleProperties(const St
 
 CSSCounterStyleDescriptors::Name fallbackNameFromCSSValue(const CSSValue& value)
 {
-    auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value);
-    if (!primitiveValue)
-        return { };
-
-    return makeAtomString(primitiveValue->stringValue());
+    if (RefPtr customIdentValue = dynamicDowncast<CSSCustomIdentValue>(value))
+        return customIdentValue->customIdent().value;
+    if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value); primitiveValue && primitiveValue->isValueID())
+        return nameStringForSerialization(primitiveValue->valueID());
+    return { };
 }
 
 static CSSCounterStyleDescriptors::Symbol prefixFromStyleProperties(const StyleProperties& properties)
@@ -208,8 +211,11 @@ CSSCounterStyleDescriptors::SystemData extractSystemDataFromCSSValue(const CSSVa
         // This value must be `fixed` or `extends`, both of which can or must have an additional component.
         Ref secondValue = systemValue->second();
         if (system == CSSCounterStyleDescriptors::System::Extends) {
-            ASSERT(secondValue->isCustomIdent());
-            result.first = AtomString { secondValue->isCustomIdent() ? secondValue->customIdent() : "decimal"_s };
+            ASSERT(secondValue->isValueID() || secondValue->isCustomIdentValue());
+            if (secondValue->isValueID())
+                result.first = nameStringForSerialization(secondValue->valueID());
+            else
+                result.first = downcast<CSSCustomIdentValue>(secondValue)->customIdent().value;
         } else if (system == CSSCounterStyleDescriptors::System::Fixed) {
             ASSERT(secondValue->isInteger());
             result.second = secondValue->isInteger() ? secondValue->integerDeprecated() : 1;

--- a/Source/WebCore/css/CSSCounterStyleRegistry.cpp
+++ b/Source/WebCore/css/CSSCounterStyleRegistry.cpp
@@ -26,7 +26,6 @@
 #include "config.h"
 #include "CSSCounterStyleRegistry.h"
 
-#include "CSSCounterStyle.h"
 #include "CSSPrimitiveValue.h"
 #include "CSSValuePair.h"
 #include "StyleListStyleType.h"
@@ -62,13 +61,13 @@ void CSSCounterStyleRegistry::resolveReferencesIfNeeded()
     m_hasUnresolvedReferences = false;
 }
 
-void CSSCounterStyleRegistry::resolveExtendsReference(CSSCounterStyle& counterStyle, CounterStyleMap* map)
+void CSSCounterStyleRegistry::resolveExtendsReference(CSSRegisteredCounterStyle& counterStyle, CounterStyleMap* map)
 {
-    HashSet<CSSCounterStyle*> countersInChain;
+    HashSet<CSSRegisteredCounterStyle*> countersInChain;
     resolveExtendsReference(counterStyle, countersInChain, map);
 }
 
-void CSSCounterStyleRegistry::resolveExtendsReference(CSSCounterStyle& counter, HashSet<CSSCounterStyle*>& countersInChain, CounterStyleMap* map)
+void CSSCounterStyleRegistry::resolveExtendsReference(CSSRegisteredCounterStyle& counter, HashSet<CSSRegisteredCounterStyle*>& countersInChain, CounterStyleMap* map)
 {
     ASSERT(counter.isExtendsSystem() && counter.isExtendsUnresolved());
     if (!(counter.isExtendsSystem() && counter.isExtendsUnresolved()))
@@ -97,7 +96,7 @@ void CSSCounterStyleRegistry::resolveExtendsReference(CSSCounterStyle& counter, 
         counter.extendAndResolve(extendedCounter);
 }
 
-void CSSCounterStyleRegistry::resolveFallbackReference(CSSCounterStyle& counter, CounterStyleMap* map)
+void CSSCounterStyleRegistry::resolveFallbackReference(CSSRegisteredCounterStyle& counter, CounterStyleMap* map)
 {
     counter.setFallbackReference(counterStyle(counter.fallbackName(), map));
 }
@@ -105,15 +104,15 @@ void CSSCounterStyleRegistry::resolveFallbackReference(CSSCounterStyle& counter,
 void CSSCounterStyleRegistry::addCounterStyle(const CSSCounterStyleDescriptors& descriptors)
 {
     m_hasUnresolvedReferences = true;
-    m_authorCounterStyles.set(descriptors.m_name, CSSCounterStyle::create(descriptors, false));
+    m_authorCounterStyles.set(descriptors.m_name, CSSRegisteredCounterStyle::create(descriptors, false));
 }
 
 void CSSCounterStyleRegistry::addUserAgentCounterStyle(const CSSCounterStyleDescriptors& descriptors)
 {
-    userAgentCounterStyles().set(descriptors.m_name, CSSCounterStyle::create(descriptors, true));
+    userAgentCounterStyles().set(descriptors.m_name, CSSRegisteredCounterStyle::create(descriptors, true));
 }
 
-Ref<CSSCounterStyle> CSSCounterStyleRegistry::decimalCounter()
+Ref<CSSRegisteredCounterStyle> CSSCounterStyleRegistry::decimalCounter()
 {
     auto& userAgentCounters = userAgentCounterStyles();
     auto iterator = userAgentCounters.find("decimal"_s);
@@ -124,7 +123,7 @@ Ref<CSSCounterStyle> CSSCounterStyleRegistry::decimalCounter()
 }
 
 // A valid map means that the search begins at the author counter style map, otherwise we skip the search to the UA counter styles.
-Ref<CSSCounterStyle> CSSCounterStyleRegistry::counterStyle(const AtomString& name, CounterStyleMap* map)
+Ref<CSSRegisteredCounterStyle> CSSCounterStyleRegistry::counterStyle(const AtomString& name, CounterStyleMap* map)
 {
     if (name.isEmpty())
         return decimalCounter();
@@ -142,7 +141,7 @@ Ref<CSSCounterStyle> CSSCounterStyleRegistry::counterStyle(const AtomString& nam
     return decimalCounter();
 }
 
-Ref<CSSCounterStyle> CSSCounterStyleRegistry::resolvedCounterStyle(const Style::CounterStyle& style)
+Ref<CSSRegisteredCounterStyle> CSSCounterStyleRegistry::resolvedCounterStyle(const Style::CounterStyle& style)
 {
     resolveReferencesIfNeeded();
     return counterStyle(style.identifier.value, &m_authorCounterStyles);

--- a/Source/WebCore/css/CSSCounterStyleRegistry.h
+++ b/Source/WebCore/css/CSSCounterStyleRegistry.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "CSSCounterStyle.h"
+#include "CSSRegisteredCounterStyle.h"
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
 #include <wtf/text/AtomStringHash.h>
@@ -39,7 +39,7 @@ struct CounterStyle;
 class StyleRuleCounterStyle;
 enum CSSValueID : uint16_t;
 
-using CounterStyleMap = HashMap<AtomString, Ref<CSSCounterStyle>>;
+using CounterStyleMap = HashMap<AtomString, Ref<CSSRegisteredCounterStyle>>;
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSCounterStyleRegistry);
 class CSSCounterStyleRegistry {
@@ -47,9 +47,9 @@ class CSSCounterStyleRegistry {
 public:
     CSSCounterStyleRegistry() = default;
 
-    static Ref<CSSCounterStyle> decimalCounter();
+    static Ref<CSSRegisteredCounterStyle> decimalCounter();
 
-    Ref<CSSCounterStyle> resolvedCounterStyle(const Style::CounterStyle&);
+    Ref<CSSRegisteredCounterStyle> resolvedCounterStyle(const Style::CounterStyle&);
     void resolveReferencesIfNeeded();
 
     void addCounterStyle(const CSSCounterStyleDescriptors&);
@@ -66,11 +66,11 @@ private:
     static CounterStyleMap& NODELETE userAgentCounterStyles();
 
     // If no map is passed on, user-agent counter styles map will be used
-    static void resolveFallbackReference(CSSCounterStyle&, CounterStyleMap* = nullptr);
-    static void resolveExtendsReference(CSSCounterStyle&, CounterStyleMap* = nullptr);
-    static void resolveExtendsReference(CSSCounterStyle&, HashSet<CSSCounterStyle*>&, CounterStyleMap* = nullptr);
+    static void resolveFallbackReference(CSSRegisteredCounterStyle&, CounterStyleMap* = nullptr);
+    static void resolveExtendsReference(CSSRegisteredCounterStyle&, CounterStyleMap* = nullptr);
+    static void resolveExtendsReference(CSSRegisteredCounterStyle&, HashSet<CSSRegisteredCounterStyle*>&, CounterStyleMap* = nullptr);
 
-    static Ref<CSSCounterStyle> counterStyle(const AtomString&, CounterStyleMap* = nullptr);
+    static Ref<CSSRegisteredCounterStyle> counterStyle(const AtomString&, CounterStyleMap* = nullptr);
 
     void NODELETE invalidate();
 

--- a/Source/WebCore/css/CSSCounterStyleRule.h
+++ b/Source/WebCore/css/CSSCounterStyleRule.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "CSSCounterStyle.h"
+#include "CSSCounterStyleDescriptors.h"
 #include "CSSRule.h"
 #include "StyleProperties.h"
 #include "StyleRule.h"

--- a/Source/WebCore/css/CSSCounterValue.cpp
+++ b/Source/WebCore/css/CSSCounterValue.cpp
@@ -26,15 +26,11 @@
 #include "config.h"
 #include "CSSCounterValue.h"
 
-#include "CSSMarkup.h"
-#include "CSSPrimitiveValue.h"
-#include <wtf/PointerComparison.h> 
-#include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
 
-CSSCounterValue::CSSCounterValue(AtomString&& identifier, AtomString&& separator, Ref<CSSValue>&& counterStyle)
+CSSCounterValue::CSSCounterValue(CSS::CustomIdent&& identifier, AtomString&& separator, CSS::CounterStyle&& counterStyle)
     : CSSValue(ClassType::Counter)
     , m_identifier(WTF::move(identifier))
     , m_separator(WTF::move(separator))
@@ -42,38 +38,66 @@ CSSCounterValue::CSSCounterValue(AtomString&& identifier, AtomString&& separator
 {
 }
 
-Ref<CSSCounterValue> CSSCounterValue::create(AtomString&& identifier, AtomString&& separator, Ref<CSSValue>&& counterStyle)
+Ref<CSSCounterValue> CSSCounterValue::create(CSS::CustomIdent&& identifier, AtomString&& separator, CSS::CounterStyle&& counterStyle)
 {
     return adoptRef(*new CSSCounterValue(WTF::move(identifier), WTF::move(separator), WTF::move(counterStyle)));
 }
 
 bool CSSCounterValue::equals(const CSSCounterValue& other) const
 {
-    return m_identifier == other.m_identifier && m_separator == other.m_separator && arePointingToEqualData(m_counterStyle, other.m_counterStyle);
+    return m_identifier == other.m_identifier
+        && m_separator == other.m_separator
+        && m_counterStyle == other.m_counterStyle;
 }
 
-String CSSCounterValue::customCSSText(const CSS::SerializationContext&) const
+String CSSCounterValue::customCSSText(const CSS::SerializationContext& context) const
 {
-    bool isDecimal = m_counterStyle->valueID() == CSSValueDecimal || (m_counterStyle->isCustomIdent() && m_counterStyle->customIdent() == "decimal"_s);
-    auto styleSeparator = isDecimal ? ""_s : ", "_s;
-    auto styleLiteral = isDecimal ? ""_s : counterStyleCSSText();
-    if (m_separator.isEmpty())
-        return makeString("counter("_s, m_identifier, styleSeparator, styleLiteral, ')');
-    StringBuilder result;
-    result.append("counters("_s, m_identifier, ", "_s);
-    serializeString(result, m_separator);
-    result.append(styleSeparator, styleLiteral, ')');
-    return result.toString();
+    bool hasDefaultCounterStyle = WTF::switchOn(m_counterStyle.identifier,
+        [](CSSValueID predefinedKeyword) {
+            return predefinedKeyword == CSSValueDecimal;
+        },
+        [](const CSS::CustomIdent& ident) {
+            return ident.value == nameStringForSerialization(CSSValueDecimal);
+        }
+    );
+
+    if (m_separator.isEmpty()) {
+        StringBuilder builder;
+        builder.append("counter("_s);
+        CSS::serializationForCSS(builder, context, m_identifier);
+        if (!hasDefaultCounterStyle) {
+            builder.append(", "_s);
+            WTF::switchOn(m_counterStyle.identifier,
+                [&](CSSValueID predefinedKeyword) {
+                    builder.append(nameLiteralForSerialization(predefinedKeyword));
+                },
+                [&](const CSS::CustomIdent& customIdent) {
+                    CSS::serializationForCSS(builder, context, customIdent);
+                 }
+            );
+        }
+        builder.append(')');
+        return builder.toString();
+    }
+
+    StringBuilder builder;
+    builder.append("counters("_s);
+    CSS::serializationForCSS(builder, context, m_identifier);
+    builder.append(", "_s);
+    CSS::serializationForCSS(builder, context, m_separator);
+    if (!hasDefaultCounterStyle) {
+        builder.append(", "_s);
+        WTF::switchOn(m_counterStyle.identifier,
+            [&](CSSValueID predefinedKeyword) {
+                builder.append(nameLiteralForSerialization(predefinedKeyword));
+            },
+            [&](const CSS::CustomIdent& customIdent) {
+                CSS::serializationForCSS(builder, context, customIdent);
+             }
+        );
+    }
+    builder.append(')');
+    return builder.toString();
 }
 
-String CSSCounterValue::counterStyleCSSText() const
-{
-    if (m_counterStyle->isValueID())
-        return nameString(m_counterStyle->valueID()).string();
-    if (m_counterStyle->isCustomIdent())
-        return m_counterStyle->customIdent();
-
-    ASSERT_NOT_REACHED();
-    return emptyString();
-}
 } // namespace WebCore

--- a/Source/WebCore/css/CSSCounterValue.h
+++ b/Source/WebCore/css/CSSCounterValue.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include "CSSCounterStyle.h"
+#include "CSSCustomIdent.h"
 #include "CSSValue.h"
 #include <wtf/Function.h>
 #include <wtf/text/AtomString.h>
@@ -33,29 +35,26 @@ namespace WebCore {
 
 class CSSCounterValue final : public CSSValue {
 public:
-    static Ref<CSSCounterValue> NODELETE create(AtomString&& identifier, AtomString&& separator, Ref<CSSValue>&& counterStyle);
+    static Ref<CSSCounterValue> create(CSS::CustomIdent&&, AtomString&& separator, CSS::CounterStyle&&);
 
-    const AtomString& identifier() const LIFETIME_BOUND { return m_identifier; }
+    const CSS::CustomIdent& identifier() const LIFETIME_BOUND { return m_identifier; }
     const AtomString& separator() const LIFETIME_BOUND { return m_separator; }
-    CSSValue& counterStyle() const { return m_counterStyle; }
-    String counterStyleCSSText() const;
+    const CSS::CounterStyle& counterStyle() const { return m_counterStyle; }
 
     String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSCounterValue&) const;
 
-    IterationStatus customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>& func) const
+    IterationStatus customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>&) const
     {
-        if (func(m_counterStyle) == IterationStatus::Done)
-            return IterationStatus::Done;
         return IterationStatus::Continue;
     }
 
 private:
-    CSSCounterValue(AtomString&& identifier, AtomString&& separator, Ref<CSSValue>&& counterStyle);
+    CSSCounterValue(CSS::CustomIdent&& identifier, AtomString&& separator, CSS::CounterStyle&&);
 
-    AtomString m_identifier;
+    CSS::CustomIdent m_identifier;
     AtomString m_separator;
-    const Ref<CSSValue> m_counterStyle;
+    CSS::CounterStyle m_counterStyle;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSCustomIdentValue.cpp
+++ b/Source/WebCore/css/CSSCustomIdentValue.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSCustomIdentValue.h"
+
+#include "CSSPrimitiveNumericTypes+CSSValueVisitation.h"
+#include "CSSPrimitiveNumericTypes+ComputedStyleDependencies.h"
+#include "CSSPrimitiveNumericTypes+Serialization.h"
+
+namespace WebCore {
+
+Ref<CSSCustomIdentValue> CSSCustomIdentValue::create(CSS::CustomIdent customIdent)
+{
+    return adoptRef(*new CSSCustomIdentValue(WTF::move(customIdent)));
+}
+
+CSSCustomIdentValue::CSSCustomIdentValue(CSS::CustomIdent&& customIdent)
+    : CSSValue(ClassType::CustomIdent)
+    , m_customIdent(WTF::move(customIdent))
+{
+}
+
+String CSSCustomIdentValue::customCSSText(const CSS::SerializationContext& context) const
+{
+    return CSS::serializationForCSS(context, m_customIdent);
+}
+
+bool CSSCustomIdentValue::equals(const CSSCustomIdentValue& other) const
+{
+    return m_customIdent == other.m_customIdent;
+}
+
+IterationStatus CSSCustomIdentValue::customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
+{
+    return CSS::visitCSSValueChildren(func, m_customIdent);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/css/CSSCustomIdentValue.h
+++ b/Source/WebCore/css/CSSCustomIdentValue.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSCustomIdent.h"
+#include "CSSValue.h"
+
+namespace WebCore {
+
+class CSSCustomIdentValue final : public CSSValue {
+public:
+    static Ref<CSSCustomIdentValue> create(CSS::CustomIdent);
+
+    const CSS::CustomIdent& customIdent() const LIFETIME_BOUND { return m_customIdent; }
+
+    String customCSSText(const CSS::SerializationContext&) const;
+    bool equals(const CSSCustomIdentValue&) const;
+
+    IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>&) const;
+
+private:
+    CSSCustomIdentValue(CSS::CustomIdent&&);
+
+    CSS::CustomIdent m_customIdent;
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_CSS_VALUE(CSSCustomIdentValue, isCustomIdentValue())

--- a/Source/WebCore/css/CSSGridLineNamesValue.cpp
+++ b/Source/WebCore/css/CSSGridLineNamesValue.cpp
@@ -31,34 +31,28 @@
 #include "config.h"
 #include "CSSGridLineNamesValue.h"
 
-#include "CSSMarkup.h"
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
 
-String CSSGridLineNamesValue::customCSSText(const CSS::SerializationContext&) const
-{
-    StringBuilder result;
-    result.append('[');
-    bool first = true;
-    for (auto& name : m_names) {
-        if (!std::exchange(first, false))
-            result.append(' ');
-        serializeIdentifier(result, name);
-    }
-    result.append(']');
-    return result.toString();
-}
-
-CSSGridLineNamesValue::CSSGridLineNamesValue(std::span<const String> names)
+CSSGridLineNamesValue::CSSGridLineNamesValue(SpaceSeparatedVector<CSS::CustomIdent>&& names)
     : CSSValue(ClassType::GridLineNames)
-    , m_names(names.begin(), names.end())
+    , m_names(WTF::move(names))
 {
 }
 
-Ref<CSSGridLineNamesValue> CSSGridLineNamesValue::create(std::span<const String> names)
+Ref<CSSGridLineNamesValue> CSSGridLineNamesValue::create(SpaceSeparatedVector<CSS::CustomIdent>&& names)
 {
-    return adoptRef(*new CSSGridLineNamesValue(names));
+    return adoptRef(*new CSSGridLineNamesValue(WTF::move(names)));
+}
+
+String CSSGridLineNamesValue::customCSSText(const CSS::SerializationContext& context) const
+{
+    StringBuilder builder;
+    builder.append('[');
+    CSS::serializationForCSS(builder, context, m_names);
+    builder.append(']');
+    return builder.toString();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSGridLineNamesValue.h
+++ b/Source/WebCore/css/CSSGridLineNamesValue.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "CSSCustomIdent.h"
 #include "CSSValue.h"
 #include <wtf/FixedVector.h>
 #include <wtf/text/WTFString.h>
@@ -38,17 +39,17 @@ namespace WebCore {
 
 class CSSGridLineNamesValue final : public CSSValue {
 public:
-    static Ref<CSSGridLineNamesValue> create(std::span<const String>);
+    static Ref<CSSGridLineNamesValue> create(SpaceSeparatedVector<CSS::CustomIdent>&&);
 
-    std::span<const String> names() const { return m_names; }
+    const SpaceSeparatedVector<CSS::CustomIdent>& names() const { return m_names; }
 
     String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSGridLineNamesValue& other) const { return m_names == other.m_names; }
 
 private:
-    explicit CSSGridLineNamesValue(std::span<const String>);
+    explicit CSSGridLineNamesValue(SpaceSeparatedVector<CSS::CustomIdent>&&);
 
-    FixedVector<String> m_names;
+    SpaceSeparatedVector<CSS::CustomIdent> m_names;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSGridLineValue.cpp
+++ b/Source/WebCore/css/CSSGridLineValue.cpp
@@ -26,57 +26,48 @@
 #include "config.h"
 #include "CSSGridLineValue.h"
 
-#include <wtf/Vector.h>
+#include "CSSPrimitiveNumericTypes+Serialization.h"
 #include <wtf/text/StringBuilder.h>
-#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
-String CSSGridLineValue::customCSSText(const CSS::SerializationContext& context) const
-{
-    Vector<String> parts;
-    if (m_spanValue)
-        parts.append(m_spanValue->cssText(context));
-    // Only return the numeric value if not 1, or if it provided without a span value.
-    // https://drafts.csswg.org/css-grid-2/#grid-placement-span-int
-    if (m_numericValue) {
-        if (m_numericValue->isOne() != true || !m_spanValue || !m_gridLineName)
-            parts.append(m_numericValue->cssText(context));
-    }
-    if (m_gridLineName)
-        parts.append(m_gridLineName->cssText(context));
-    return makeStringByJoining(parts, " "_s);
-}
-
-CSSGridLineValue::CSSGridLineValue(RefPtr<CSSPrimitiveValue>&& spanValue, RefPtr<CSSPrimitiveValue>&& numericValue, RefPtr<CSSPrimitiveValue>&& gridLineName)
+CSSGridLineValue::CSSGridLineValue(std::optional<CSS::Keyword::Span> span, std::optional<CSS::Integer<>>&& numeric, std::optional<CSS::CustomIdent>&& gridLineName)
     : CSSValue(ClassType::GridLineValue)
-    , m_spanValue(WTF::move(spanValue))
-    , m_numericValue(WTF::move(numericValue))
+    , m_span(span)
+    , m_numeric(WTF::move(numeric))
     , m_gridLineName(WTF::move(gridLineName))
 {
 }
 
-Ref<CSSGridLineValue> CSSGridLineValue::create(RefPtr<CSSPrimitiveValue>&& spanValue, RefPtr<CSSPrimitiveValue>&& numericValue, RefPtr<CSSPrimitiveValue>&& gridLineName)
+Ref<CSSGridLineValue> CSSGridLineValue::create(std::optional<CSS::Keyword::Span> span, std::optional<CSS::Integer<>>&& numeric, std::optional<CSS::CustomIdent>&& gridLineName)
 {
-    return adoptRef(*new CSSGridLineValue(WTF::move(spanValue), WTF::move(numericValue), WTF::move(gridLineName)));
+    return adoptRef(*new CSSGridLineValue(span, WTF::move(numeric), WTF::move(gridLineName)));
 }
 
 bool CSSGridLineValue::equals(const CSSGridLineValue& other) const
 {
-    auto equals = [](CSSPrimitiveValue* value, CSSPrimitiveValue* otherValue) {
-        if ((!value && otherValue) || (value && !otherValue))
-            return false;
-        return (!value && !otherValue) || value->equals(*otherValue);
-    };
-
-    if (!equals(protect(spanValue()).get(), protect(other.spanValue()).get()))
+    if (m_span != other.m_span)
         return false;
-    if (!equals(protect(numericValue()).get(), protect(other.numericValue()).get()))
+    if (m_numeric != other.m_numeric)
         return false;
-    if (!equals(protect(gridLineName()).get(), protect(other.gridLineName()).get()))
+    if (m_gridLineName != other.m_gridLineName)
         return false;
-
     return true;
+}
+
+String CSSGridLineValue::customCSSText(const CSS::SerializationContext& context) const
+{
+    using SerializationType = SpaceSeparatedTuple<
+        std::optional<CSS::Keyword::Span>,
+        std::optional<CSS::Integer<>>,
+        std::optional<CSS::CustomIdent>
+    >;
+
+    return CSS::serializationForCSS(context, SerializationType {
+        m_span,
+        m_numeric && (m_numeric->raw() != 1 || !m_span || !m_gridLineName) ? m_numeric : std::nullopt,
+        m_gridLineName
+    });
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSGridLineValue.h
+++ b/Source/WebCore/css/CSSGridLineValue.h
@@ -25,27 +25,29 @@
 
 #pragma once
 
-#include "CSSPrimitiveValue.h"
+#include "CSSCustomIdent.h"
+#include "CSSPrimitiveNumericTypes.h"
 #include "CSSValue.h"
 
 namespace WebCore {
 
 class CSSGridLineValue final : public CSSValue {
 public:
-    static Ref<CSSGridLineValue> NODELETE create(RefPtr<CSSPrimitiveValue>&&, RefPtr<CSSPrimitiveValue>&&, RefPtr<CSSPrimitiveValue>&&);
+    static Ref<CSSGridLineValue> NODELETE create(std::optional<CSS::Keyword::Span>, std::optional<CSS::Integer<>>&&, std::optional<CSS::CustomIdent>&&);
 
     String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSGridLineValue& other) const;
 
-    CSSPrimitiveValue* spanValue() const { return m_spanValue.get(); }
-    CSSPrimitiveValue* numericValue() const { return m_numericValue.get(); }
-    CSSPrimitiveValue* gridLineName() const { return m_gridLineName.get(); }
+    std::optional<CSS::Keyword::Span> span() const { return m_span; }
+    const std::optional<CSS::Integer<>>& numeric() const { return m_numeric; }
+    const std::optional<CSS::CustomIdent>& gridLineName() const { return m_gridLineName; }
 
 private:
-    explicit CSSGridLineValue(RefPtr<CSSPrimitiveValue>&&, RefPtr<CSSPrimitiveValue>&&, RefPtr<CSSPrimitiveValue>&&);
-    const RefPtr<CSSPrimitiveValue> m_spanValue;
-    const RefPtr<CSSPrimitiveValue> m_numericValue;
-    const RefPtr<CSSPrimitiveValue> m_gridLineName;
+    explicit CSSGridLineValue(std::optional<CSS::Keyword::Span>, std::optional<CSS::Integer<>>&&, std::optional<CSS::CustomIdent>&&);
+
+    const std::optional<CSS::Keyword::Span> m_span;
+    const std::optional<CSS::Integer<>> m_numeric;
+    const std::optional<CSS::CustomIdent> m_gridLineName;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -128,7 +128,6 @@ static inline bool NODELETE isValidCSSUnitTypeForDoubleConversion(CSSUnitType un
         return true;
     case CSSUnitType::CSS_ATTR:
     case CSSUnitType::CSS_FONT_FAMILY:
-    case CSSUnitType::CustomIdent:
     case CSSUnitType::CSS_PROPERTY_ID:
     case CSSUnitType::CSS_STRING:
     case CSSUnitType::CSS_UNKNOWN:
@@ -148,7 +147,6 @@ static inline bool isStringType(CSSUnitType type)
 {
     switch (type) {
     case CSSUnitType::CSS_STRING:
-    case CSSUnitType::CustomIdent:
     case CSSUnitType::CSS_ATTR:
     case CSSUnitType::CSS_FONT_FAMILY:
         return true;
@@ -247,7 +245,6 @@ CSSUnitType CSSPrimitiveValue::primitiveType() const
     switch (type) {
     case CSSUnitType::CSS_PROPERTY_ID:
     case CSSUnitType::CSS_VALUE_ID:
-    case CSSUnitType::CustomIdent:
         return CSSUnitType::CSS_IDENT;
     case CSSUnitType::CSS_FONT_FAMILY:
         // Web-exposed content expects font family values to have CSSUnitType::CSS_STRING primitive type
@@ -323,7 +320,6 @@ CSSPrimitiveValue::~CSSPrimitiveValue()
     auto type = primitiveUnitType();
     switch (type) {
     case CSSUnitType::CSS_STRING:
-    case CSSUnitType::CustomIdent:
     case CSSUnitType::CSS_FONT_FAMILY:
         if (m_value.string)
             m_value.string->deref();
@@ -475,11 +471,6 @@ Ref<CSSPrimitiveValue> CSSPrimitiveValue::create(Ref<CSSCalc::Value> value)
 Ref<CSSPrimitiveValue> CSSPrimitiveValue::create(Ref<CSSAttrValue> value)
 {
     return adoptRef(*new CSSPrimitiveValue(WTF::move(value)));
-}
-
-Ref<CSSPrimitiveValue> CSSPrimitiveValue::createCustomIdent(String value)
-{
-    return adoptRef(*new CSSPrimitiveValue(WTF::move(value), CSSUnitType::CustomIdent));
 }
 
 Ref<CSSPrimitiveValue> CSSPrimitiveValue::createFontFamily(String value)
@@ -825,7 +816,6 @@ String CSSPrimitiveValue::stringValue() const
 {
     switch (primitiveUnitType()) {
     case CSSUnitType::CSS_STRING:
-    case CSSUnitType::CustomIdent:
     case CSSUnitType::CSS_FONT_FAMILY:
         return m_value.string;
     case CSSUnitType::CSS_VALUE_ID:
@@ -932,7 +922,6 @@ ASCIILiteral CSSPrimitiveValue::unitTypeString(CSSUnitType unitType)
     case CSSUnitType::CSS_STRING:
     case CSSUnitType::CSS_UNKNOWN:
     case CSSUnitType::CSS_VALUE_ID:
-    case CSSUnitType::CustomIdent:
         return ""_s;
     }
     ASSERT_NOT_REACHED();
@@ -1023,12 +1012,6 @@ ALWAYS_INLINE String CSSPrimitiveValue::serializeInternal(const CSS::Serializati
         return formatNumberValue("em"_s);
     case CSSUnitType::CSS_STRING:
         return serializeString(m_value.string);
-    case CSSUnitType::CustomIdent: {
-        StringBuilder builder;
-        serializeIdentifier(builder, m_value.string);
-        return builder.toString();
-    }
-
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_ANGLE:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_LENGTH:
     case CSSUnitType::CSS_IDENT:
@@ -1143,7 +1126,6 @@ bool CSSPrimitiveValue::equals(const CSSPrimitiveValue& other) const
     case CSSUnitType::CSS_VALUE_ID:
         return m_value.valueID == other.m_value.valueID;
     case CSSUnitType::CSS_STRING:
-    case CSSUnitType::CustomIdent:
     case CSSUnitType::CSS_FONT_FAMILY:
         return equal(m_value.string, other.m_value.string);
     case CSSUnitType::CSS_ATTR:
@@ -1243,7 +1225,6 @@ bool CSSPrimitiveValue::addDerivedHash(Hasher& hasher) const
         add(hasher, m_value.valueID);
         break;
     case CSSUnitType::CSS_STRING:
-    case CSSUnitType::CustomIdent:
     case CSSUnitType::CSS_FONT_FAMILY:
         add(hasher, String { m_value.string });
         break;
@@ -1252,7 +1233,6 @@ bool CSSPrimitiveValue::addDerivedHash(Hasher& hasher) const
         break;
     case CSSUnitType::CSS_CALC:
         add(hasher, m_value.calc);
-        break;
         break;
     case CSSUnitType::CSS_IDENT:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_ANGLE:

--- a/Source/WebCore/css/CSSPrimitiveValue.h
+++ b/Source/WebCore/css/CSSPrimitiveValue.h
@@ -101,10 +101,6 @@ public:
     bool isString() const { return primitiveUnitType() == CSSUnitType::CSS_STRING; }
     static Ref<CSSPrimitiveValue> create(String);
 
-    static Ref<CSSPrimitiveValue> createCustomIdent(String);
-    bool isCustomIdent() const { return primitiveUnitType() == CSSUnitType::CustomIdent; }
-    String customIdent() const { ASSERT(isCustomIdent()); return stringValue(); }
-
     static Ref<CSSPrimitiveValue> createFontFamily(String);
     bool isFontFamily() const { return primitiveUnitType() == CSSUnitType::CSS_FONT_FAMILY; }
 
@@ -220,7 +216,11 @@ private:
 
     // MARK: Non-converting
     double doubleValue(const CSSToLengthConversionData&) const;
-    double doubleValueNoConversionDataRequired() const { ASSERT(!isCalculated()); return m_value.number; }
+    double doubleValueNoConversionDataRequired() const
+    {
+        ASSERT(!isCalculated());
+        return m_value.number;
+    }
     double doubleValueDeprecated() const;
     double doubleValueDividingBy100IfPercentage(const CSSToLengthConversionData&) const;
     double NODELETE doubleValueDividingBy100IfPercentageNoConversionDataRequired() const;
@@ -723,12 +723,6 @@ inline bool isValueID(const Ref<CSSValue>& value, CSSValueID id)
     return isValueID(value.get(), id);
 }
 
-inline bool isCustomIdentValue(const CSSValue& value)
-{
-    auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value);
-    return primitiveValue && primitiveValue->isCustomIdent();
-}
-
 inline bool CSSValue::isValueID() const
 {
     auto* value = dynamicDowncast<CSSPrimitiveValue>(*this);
@@ -739,18 +733,6 @@ inline CSSValueID CSSValue::valueID() const
 {
     auto* value = dynamicDowncast<CSSPrimitiveValue>(*this);
     return value ? value->valueID() : CSSValueInvalid;
-}
-
-inline bool CSSValue::isCustomIdent() const
-{
-    auto* value = dynamicDowncast<CSSPrimitiveValue>(*this);
-    return value && value->isCustomIdent();
-}
-
-inline String CSSValue::customIdent() const
-{
-    ASSERT(isCustomIdent());
-    return downcast<CSSPrimitiveValue>(*this).stringValue();
 }
 
 inline bool CSSValue::isString() const

--- a/Source/WebCore/css/CSSRegisteredCounterStyle.cpp
+++ b/Source/WebCore/css/CSSRegisteredCounterStyle.cpp
@@ -24,7 +24,7 @@
  */
 
 #include "config.h"
-#include "CSSCounterStyle.h"
+#include "CSSRegisteredCounterStyle.h"
 
 #include "CSSCounterStyleDescriptors.h"
 #include "CSSCounterStyleRegistry.h"
@@ -39,7 +39,7 @@
 namespace WebCore {
 
 // https://www.w3.org/TR/css-counter-styles-3/#cyclic-system
-String CSSCounterStyle::counterForSystemCyclic(int value) const
+String CSSRegisteredCounterStyle::counterForSystemCyclic(int value) const
 {
     auto amountOfSymbols = symbols().size();
     ASSERT(amountOfSymbols > 0);
@@ -54,7 +54,7 @@ String CSSCounterStyle::counterForSystemCyclic(int value) const
 }
 
 // https://www.w3.org/TR/css-counter-styles-3/#fixed-system
-String CSSCounterStyle::counterForSystemFixed(int value) const
+String CSSRegisteredCounterStyle::counterForSystemFixed(int value) const
 {
     if (value < firstSymbolValueForFixedSystem())
         return { };
@@ -65,7 +65,7 @@ String CSSCounterStyle::counterForSystemFixed(int value) const
 }
 
 // https://www.w3.org/TR/css-counter-styles-3/#symbolic-system
-String CSSCounterStyle::counterForSystemSymbolic(unsigned value) const
+String CSSRegisteredCounterStyle::counterForSystemSymbolic(unsigned value) const
 {
     auto amountOfSymbols = symbols().size();
     ASSERT(amountOfSymbols > 0);
@@ -83,7 +83,7 @@ String CSSCounterStyle::counterForSystemSymbolic(unsigned value) const
 }
 
 // https://www.w3.org/TR/css-counter-styles-3/#alphabetic-system
-String CSSCounterStyle::counterForSystemAlphabetic(unsigned value) const
+String CSSRegisteredCounterStyle::counterForSystemAlphabetic(unsigned value) const
 {
     auto amountOfSymbols = symbols().size();
     ASSERT(amountOfSymbols >= 2);
@@ -104,7 +104,7 @@ String CSSCounterStyle::counterForSystemAlphabetic(unsigned value) const
 }
 
 // https://www.w3.org/TR/css-counter-styles-3/#numeric-system
-String CSSCounterStyle::counterForSystemNumeric(unsigned value) const
+String CSSRegisteredCounterStyle::counterForSystemNumeric(unsigned value) const
 {
     auto amountOfSymbols = symbols().size();
     ASSERT(amountOfSymbols >= 2);
@@ -124,7 +124,7 @@ String CSSCounterStyle::counterForSystemNumeric(unsigned value) const
 }
 
 // https://www.w3.org/TR/css-counter-styles-3/#additive-system
-String CSSCounterStyle::counterForSystemAdditive(unsigned value) const
+String CSSRegisteredCounterStyle::counterForSystemAdditive(unsigned value) const
 {
     auto& additiveSymbols = this->additiveSymbols();
     if (!value) {
@@ -241,14 +241,14 @@ static String counterForSystemCJK(int number, const std::array<char16_t, 17>& ta
     return std::span<const char16_t> { characters }.first(length);
 }
 
-String CSSCounterStyle::counterForSystemDisclosureClosed(WritingMode writingMode)
+String CSSRegisteredCounterStyle::counterForSystemDisclosureClosed(WritingMode writingMode)
 {
     if (writingMode.isVerticalTypographic())
         return span(writingMode.isInlineTopToBottom() ? blackDownPointingTriangle : blackUpPointingTriangle);
     return span(writingMode.isBidiLTR() ? blackRightPointingTriangle : blackLeftPointingTriangle);
 }
 
-String CSSCounterStyle::counterForSystemDisclosureOpen(WritingMode writingMode)
+String CSSRegisteredCounterStyle::counterForSystemDisclosureOpen(WritingMode writingMode)
 {
     switch (writingMode.blockDirection()) {
     case FlowDirection::TopToBottom:
@@ -264,7 +264,7 @@ String CSSCounterStyle::counterForSystemDisclosureOpen(WritingMode writingMode)
     return { };
 }
 
-String CSSCounterStyle::counterForSystemSimplifiedChineseInformal(int value)
+String CSSRegisteredCounterStyle::counterForSystemSimplifiedChineseInformal(int value)
 {
     static constexpr std::array<char16_t, 17> simplifiedChineseInformalTable {
         0x842C, 0x5104, 0x5146, // These three group markers are probably wrong; OK because we don't use this on big enough numbers.
@@ -276,7 +276,7 @@ String CSSCounterStyle::counterForSystemSimplifiedChineseInformal(int value)
     return counterForSystemCJK(value, simplifiedChineseInformalTable, Formality::Informal);
 }
 
-String CSSCounterStyle::counterForSystemSimplifiedChineseFormal(int value)
+String CSSRegisteredCounterStyle::counterForSystemSimplifiedChineseFormal(int value)
 {
     static constexpr std::array<char16_t, 17> simplifiedChineseFormalTable {
         0x842C, 0x5104, 0x5146, // These three group markers are probably wrong; OK because we don't use this on big enough numbers.
@@ -288,7 +288,7 @@ String CSSCounterStyle::counterForSystemSimplifiedChineseFormal(int value)
     return counterForSystemCJK(value, simplifiedChineseFormalTable, Formality::Formal);
 }
 
-String CSSCounterStyle::counterForSystemTraditionalChineseInformal(int value)
+String CSSRegisteredCounterStyle::counterForSystemTraditionalChineseInformal(int value)
 {
     static constexpr std::array<char16_t, 17> traditionalChineseInformalTable {
         0x842C, 0x5104, 0x5146,
@@ -300,7 +300,7 @@ String CSSCounterStyle::counterForSystemTraditionalChineseInformal(int value)
     return counterForSystemCJK(value, traditionalChineseInformalTable, Formality::Informal);
 }
 
-String CSSCounterStyle::counterForSystemTraditionalChineseFormal(int value)
+String CSSRegisteredCounterStyle::counterForSystemTraditionalChineseFormal(int value)
 {
     static constexpr std::array<char16_t, 17> traditionalChineseFormalTable {
         0x842C, 0x5104, 0x5146, // These three group markers are probably wrong; OK because we don't use this on big enough numbers.
@@ -312,7 +312,7 @@ String CSSCounterStyle::counterForSystemTraditionalChineseFormal(int value)
     return counterForSystemCJK(value, traditionalChineseFormalTable, Formality::Formal);
 }
 
-String CSSCounterStyle::counterForSystemEthiopicNumeric(unsigned value)
+String CSSRegisteredCounterStyle::counterForSystemEthiopicNumeric(unsigned value)
 {
     ASSERT(value >= 1);
 
@@ -354,7 +354,7 @@ String CSSCounterStyle::counterForSystemEthiopicNumeric(unsigned value)
     return std::span<const char16_t> { buffer }.first(length);
 }
 
-String CSSCounterStyle::initialRepresentation(int value, WritingMode writingMode) const
+String CSSRegisteredCounterStyle::initialRepresentation(int value, WritingMode writingMode) const
 {
     unsigned absoluteValue = std::abs(value);
     switch (system()) {
@@ -392,7 +392,7 @@ String CSSCounterStyle::initialRepresentation(int value, WritingMode writingMode
     return { };
 }
 
-String CSSCounterStyle::fallbackText(int value, WritingMode writingMode)
+String CSSRegisteredCounterStyle::fallbackText(int value, WritingMode writingMode)
 {
     if (m_isFallingBack || !fallback().get()) {
         m_isFallingBack = false;
@@ -404,7 +404,7 @@ String CSSCounterStyle::fallbackText(int value, WritingMode writingMode)
     return fallbackText;
 }
 
-String CSSCounterStyle::text(int value, WritingMode writingMode)
+String CSSRegisteredCounterStyle::text(int value, WritingMode writingMode)
 {
     if (!isInRange(value))
         return fallbackText(value, writingMode);
@@ -420,18 +420,18 @@ String CSSCounterStyle::text(int value, WritingMode writingMode)
     return result;
 }
 
-bool CSSCounterStyle::shouldApplyNegativeSymbols(int value) const
+bool CSSRegisteredCounterStyle::shouldApplyNegativeSymbols(int value) const
 {
     auto system = this->system();
     return value < 0 && (system == CSSCounterStyleDescriptors::System::Symbolic || system == CSSCounterStyleDescriptors::System::Numeric || system == CSSCounterStyleDescriptors::System::Alphabetic || system == CSSCounterStyleDescriptors::System::Additive);
 }
 
-void CSSCounterStyle::applyNegativeSymbols(String& text) const
+void CSSRegisteredCounterStyle::applyNegativeSymbols(String& text) const
 {
     text = negative().m_suffix.text.isEmpty() ? makeString(negative().m_prefix.text, text) : makeString(negative().m_prefix.text, text, negative().m_suffix.text);
 }
 
-bool CSSCounterStyle::applyPadSymbols(String& text, int value) const
+bool CSSRegisteredCounterStyle::applyPadSymbols(String& text, int value) const
 {
     // We limit the max UTF-16 padding length to 150 to match Firefox. This complies with CSS
     // Counter Styles Level 3, which requires us to support counter representations of at least 60
@@ -461,7 +461,7 @@ bool CSSCounterStyle::applyPadSymbols(String& text, int value) const
     return true;
 }
 
-bool CSSCounterStyle::isInRange(int value) const
+bool CSSRegisteredCounterStyle::isInRange(int value) const
 {
     if (isAutoRange()) {
         switch (system()) {
@@ -495,24 +495,24 @@ bool CSSCounterStyle::isInRange(int value) const
     return false;
 }
 
-CSSCounterStyle::CSSCounterStyle(const CSSCounterStyleDescriptors& descriptors, bool isPredefinedCounterStyle)
+CSSRegisteredCounterStyle::CSSRegisteredCounterStyle(const CSSCounterStyleDescriptors& descriptors, bool isPredefinedCounterStyle)
     : m_descriptors { descriptors }
     , m_predefinedCounterStyle { isPredefinedCounterStyle }
 {
 }
 
-Ref<CSSCounterStyle> CSSCounterStyle::create(const CSSCounterStyleDescriptors& descriptors, bool isPredefinedCounterStyle)
+Ref<CSSRegisteredCounterStyle> CSSRegisteredCounterStyle::create(const CSSCounterStyleDescriptors& descriptors, bool isPredefinedCounterStyle)
 {
-    return adoptRef(*new CSSCounterStyle(descriptors, isPredefinedCounterStyle));
+    return adoptRef(*new CSSRegisteredCounterStyle(descriptors, isPredefinedCounterStyle));
 }
 
-void CSSCounterStyle::setFallbackReference(Ref<CSSCounterStyle>&& fallback)
+void CSSRegisteredCounterStyle::setFallbackReference(Ref<CSSRegisteredCounterStyle>&& fallback)
 {
     m_fallbackReference = WeakPtr { fallback };
 }
 
 // The counter's system value is promoted to the value of the counter we are extending.
-void CSSCounterStyle::extendAndResolve(const CSSCounterStyle& extendedCounterStyle)
+void CSSRegisteredCounterStyle::extendAndResolve(const CSSRegisteredCounterStyle& extendedCounterStyle)
 {
     m_descriptors.m_isExtendedResolved = true;
 

--- a/Source/WebCore/css/CSSRegisteredCounterStyle.h
+++ b/Source/WebCore/css/CSSRegisteredCounterStyle.h
@@ -36,11 +36,11 @@ namespace WebCore {
 
 class StyleRuleCounterStyle;
 
-class CSSCounterStyle : public RefCountedAndCanMakeWeakPtr<CSSCounterStyle> {
+class CSSRegisteredCounterStyle : public RefCountedAndCanMakeWeakPtr<CSSRegisteredCounterStyle> {
 public:
-    static Ref<CSSCounterStyle> create(const CSSCounterStyleDescriptors&, bool isPredefinedCounterStyle);
+    static Ref<CSSRegisteredCounterStyle> create(const CSSCounterStyleDescriptors&, bool isPredefinedCounterStyle);
 
-    bool operator==(const CSSCounterStyle& other) const
+    bool operator==(const CSSRegisteredCounterStyle& other) const
     {
         return m_descriptors == other.m_descriptors
             && m_predefinedCounterStyle == other.m_predefinedCounterStyle;
@@ -74,11 +74,11 @@ public:
     void setSpeakAs(CSSCounterStyleDescriptors::SpeakAs speakAs) { m_descriptors.m_speakAs = speakAs; }
     void setFirstSymbolValueForFixedSystem(int firstSymbolValue) { m_descriptors.m_fixedSystemFirstSymbolValue = firstSymbolValue; }
 
-    void NODELETE setFallbackReference(Ref<CSSCounterStyle>&&);
+    void NODELETE setFallbackReference(Ref<CSSRegisteredCounterStyle>&&);
     bool isFallbackUnresolved() { return !m_fallbackReference; }
     bool isExtendsUnresolved() { return !m_descriptors.m_isExtendedResolved; };
     bool isExtendsSystem() const { return system() == CSSCounterStyleDescriptors::System::Extends; }
-    void extendAndResolve(const CSSCounterStyle&);
+    void extendAndResolve(const CSSRegisteredCounterStyle&);
 
     static String counterForSystemSimplifiedChineseInformal(int);
     static String counterForSystemSimplifiedChineseFormal(int);
@@ -89,7 +89,7 @@ public:
     static String counterForSystemDisclosureOpen(WritingMode);
 
 private:
-    CSSCounterStyle(const CSSCounterStyleDescriptors&, bool isPredefinedCounterStyle);
+    CSSRegisteredCounterStyle(const CSSCounterStyleDescriptors&, bool isPredefinedCounterStyle);
 
     // https://www.w3.org/TR/css-counter-styles-3/#counter-style-range
     bool NODELETE isInRange(int) const;
@@ -97,9 +97,9 @@ private:
     bool usesNegativeSign();
     bool NODELETE shouldApplyNegativeSymbols(int) const;
     // https://www.w3.org/TR/css-counter-styles-3/#counter-style-fallback
-    WeakPtr<CSSCounterStyle> fallback() const { return m_fallbackReference; };
+    WeakPtr<CSSRegisteredCounterStyle> fallback() const { return m_fallbackReference; };
     String fallbackText(int, WritingMode);
-    // Generates a CSSCounterStyle object as it was defined by a 'decimal' descriptor. It is used as a last-resource in case we can't resolve fallback references.
+    // Generates a CSSRegisteredCounterStyle object as it was defined by a 'decimal' descriptor. It is used as a last-resource in case we can't resolve fallback references.
     bool applyPadSymbols(String&, int) const;
     void applyNegativeSymbols(String&) const;
     // Initial text representation for the counter, before applying pad and/or negative symbols. Suffix and Prefix are also not considered as described by https://www.w3.org/TR/css-counter-styles-3/#counter-styles.
@@ -121,8 +121,8 @@ private:
     CSSCounterStyleDescriptors m_descriptors;
     bool m_predefinedCounterStyle { false };
     CSSCounterStyleDescriptors::Name m_fallbackName;
-    WeakPtr<const CSSCounterStyle> m_fallbackReference { nullptr };
-    WeakPtr<const CSSCounterStyle> m_extendsReference { nullptr };
+    WeakPtr<const CSSRegisteredCounterStyle> m_fallbackReference { nullptr };
+    WeakPtr<const CSSRegisteredCounterStyle> m_extendsReference { nullptr };
     bool m_isFallingBack { false };
     bool m_isExtendedUnresolved { true };
 };

--- a/Source/WebCore/css/CSSUnits.cpp
+++ b/Source/WebCore/css/CSSUnits.cpp
@@ -122,7 +122,6 @@ CSSUnitCategory unitCategory(CSSUnitType type)
     case CSSUnitType::CSS_STRING:
     case CSSUnitType::CSS_UNKNOWN:
     case CSSUnitType::CSS_VALUE_ID:
-    case CSSUnitType::CustomIdent:
         return CSSUnitCategory::Other;
     }
     ASSERT_NOT_REACHED();
@@ -205,7 +204,6 @@ TextStream& operator<<(TextStream& ts, CSSUnitType unitType)
     case CSSUnitType::CSS_DIMENSION: ts << "dimension"_s; break;
     case CSSUnitType::CSS_STRING: ts << "string"_s; break;
     case CSSUnitType::CSS_IDENT: ts << "ident"_s; break;
-    case CSSUnitType::CustomIdent: ts << "custom-ident"_s; break;
     case CSSUnitType::CSS_ATTR: ts << "attr"_s; break;
     case CSSUnitType::CSS_VW: ts << "vw"_s; break;
     case CSSUnitType::CSS_VH: ts << "vh"_s; break;
@@ -381,7 +379,6 @@ bool conversionToCanonicalUnitRequiresConversionData(CSSUnitType unit)
     case CSSUnitType::CSS_STRING:
     case CSSUnitType::CSS_UNKNOWN:
     case CSSUnitType::CSS_VALUE_ID:
-    case CSSUnitType::CustomIdent:
         break;
     }
 

--- a/Source/WebCore/css/CSSUnits.h
+++ b/Source/WebCore/css/CSSUnits.h
@@ -122,8 +122,6 @@ enum class CSSUnitType : uint8_t {
     CSS_LH,
     CSS_RLH,
 
-    CustomIdent,
-
     CSS_TURN,
     CSS_REM,
     CSS_REX,

--- a/Source/WebCore/css/CSSValue.cpp
+++ b/Source/WebCore/css/CSSValue.cpp
@@ -42,6 +42,7 @@
 #include "CSSCounterValue.h"
 #include "CSSCrossfadeValue.h"
 #include "CSSCursorImageValue.h"
+#include "CSSCustomIdentValue.h"
 #include "CSSCustomPropertyValue.h"
 #include "CSSDynamicRangeLimitValue.h"
 #include "CSSEasingFunctionValue.h"
@@ -137,6 +138,8 @@ template<typename Visitor> constexpr decltype(auto) CSSValue::visitDerived(Visit
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSCrossfadeValue>(*this));
     case CursorImage:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSCursorImageValue>(*this));
+    case CustomIdent:
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSCustomIdentValue>(*this));
     case CustomProperty:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSCustomPropertyValue>(*this));
     case DynamicRangeLimit:
@@ -370,6 +373,7 @@ Ref<DeprecatedCSSOMValue> CSSValue::createDeprecatedCSSOMWrapper(CSSStyleDeclara
     case Primitive:
     case Color:
     case Counter:
+    case CustomIdent:
     case Quad:
     case Rect:
     case URL:

--- a/Source/WebCore/css/CSSValue.h
+++ b/Source/WebCore/css/CSSValue.h
@@ -84,6 +84,7 @@ public:
     bool isCounter() const { return m_classType == ClassType::Counter; }
     bool isCrossfadeValue() const { return m_classType == ClassType::Crossfade; }
     bool isCursorImageValue() const { return m_classType == ClassType::CursorImage; }
+    bool isCustomIdentValue() const { return m_classType == ClassType::CustomIdent; }
     bool isCustomPropertyValue() const { return m_classType == ClassType::CustomProperty; }
     bool isDynamicRangeLimitValue() const { return m_classType == ClassType::DynamicRangeLimit; }
     bool isEasingFunctionValue() const { return m_classType == ClassType::EasingFunction; }
@@ -171,9 +172,6 @@ public:
     static constexpr size_t ValueSeparatorBits = 2;
     enum ValueSeparator : uint8_t { SpaceSeparator, CommaSeparator, SlashSeparator };
 
-    inline bool isCustomIdent() const;
-    inline String customIdent() const;
-
     inline bool isString() const;
     inline String string() const;
 
@@ -226,6 +224,7 @@ protected:
         ColorScheme,
 #endif
         Counter,
+        CustomIdent,
         CustomProperty,
         DynamicRangeLimit,
         EasingFunction,

--- a/Source/WebCore/css/CSSViewTransitionRule.cpp
+++ b/Source/WebCore/css/CSSViewTransitionRule.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "CSSViewTransitionRule.h"
 
+#include "CSSCustomIdentValue.h"
 #include "CSSPropertyParser.h"
 #include "CSSStyleSheet.h"
 #include "CSSTokenizer.h"
@@ -58,8 +59,8 @@ StyleRuleViewTransition::StyleRuleViewTransition(Ref<StyleProperties>&& properti
 
     if (auto value = properties->getPropertyCSSValue(CSSPropertyTypes)) {
         auto processSingleValue = [&](const CSSValue& currentValue) {
-            if (currentValue.isCustomIdent())
-                m_types.append(currentValue.customIdent());
+            if (RefPtr customIdentValue = dynamicDowncast<CSSCustomIdentValue>(currentValue))
+                m_types.append(customIdentValue->customIdent().value);
         };
         if (auto* list = dynamicDowncast<CSSValueList>(*value)) {
             for (Ref currentValue : *list)

--- a/Source/WebCore/css/DeprecatedCSSOMPrimitiveValue.cpp
+++ b/Source/WebCore/css/DeprecatedCSSOMPrimitiveValue.cpp
@@ -28,6 +28,7 @@
 
 #include "CSSColorValue.h"
 #include "CSSCounterValue.h"
+#include "CSSCustomIdentValue.h"
 #include "CSSRectValue.h"
 #include "CSSSerializationContext.h"
 #include "CSSURLValue.h"
@@ -52,6 +53,8 @@ unsigned short DeprecatedCSSOMPrimitiveValue::primitiveType() const
         return CSS_RGBCOLOR;
     if (m_value->isURL())
         return CSS_URI;
+    if (m_value->isCustomIdentValue())
+        return CSS_IDENT;
 
     RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(m_value.get());
     if (!primitiveValue)
@@ -69,7 +72,6 @@ unsigned short DeprecatedCSSOMPrimitiveValue::primitiveType() const
     case CSSUnitType::CSS_HZ:                           return CSS_HZ;
     case CSSUnitType::CSS_IDENT:                        return CSS_IDENT;
     case CSSUnitType::CSS_INTEGER:                      return CSS_NUMBER;
-    case CSSUnitType::CustomIdent:                      return CSS_IDENT;
     case CSSUnitType::CSS_IN:                           return CSS_IN;
     case CSSUnitType::CSS_KHZ:                          return CSS_KHZ;
     case CSSUnitType::CSS_MM:                           return CSS_MM;
@@ -125,20 +127,36 @@ ExceptionOr<float> DeprecatedCSSOMPrimitiveValue::getFloatValue(unsigned short u
 ExceptionOr<String> DeprecatedCSSOMPrimitiveValue::getStringValue() const
 {
     switch (primitiveType()) {
-    case CSS_ATTR:      return downcast<CSSPrimitiveValue>(m_value.get()).stringValue();
-    case CSS_IDENT:     return downcast<CSSPrimitiveValue>(m_value.get()).stringValue();
-    case CSS_STRING:    return downcast<CSSPrimitiveValue>(m_value.get()).stringValue();
-    case CSS_URI:       return downcast<CSSURLValue>(m_value.get()).stringValue();
+    case CSS_ATTR:
+        return downcast<CSSPrimitiveValue>(m_value.get()).stringValue();
+    case CSS_IDENT:
+        if (RefPtr customIdentValue = dynamicDowncast<CSSCustomIdentValue>(m_value))
+            return String { customIdentValue->customIdent().value.string() };
+        return downcast<CSSPrimitiveValue>(m_value.get()).stringValue();
+    case CSS_STRING:
+        return downcast<CSSPrimitiveValue>(m_value.get()).stringValue();
+    case CSS_URI:
+        return downcast<CSSURLValue>(m_value.get()).stringValue();
 
     // All other, including newer types, should raise an exception.
-    default:            return Exception { ExceptionCode::InvalidAccessError };
+    default:
+        return Exception { ExceptionCode::InvalidAccessError };
     }
 }
 
 ExceptionOr<Ref<DeprecatedCSSOMCounter>> DeprecatedCSSOMPrimitiveValue::getCounterValue() const
 {
-    if (RefPtr value = dynamicDowncast<CSSCounterValue>(m_value.get()))
-        return DeprecatedCSSOMCounter::create(value->identifier(), value->separator(), value->counterStyleCSSText());
+    if (RefPtr value = dynamicDowncast<CSSCounterValue>(m_value.get())) {
+        auto counterStyle = WTF::switchOn(value->counterStyle().identifier,
+            [](CSSValueID predefinedKeyword) -> String {
+                return nameLiteralForSerialization(predefinedKeyword);
+            },
+            [](const CSS::CustomIdent& customIdent) -> String {
+                return customIdent.value.string();
+            }
+        );
+        return DeprecatedCSSOMCounter::create(value->identifier().value, value->separator(), WTF::move(counterStyle));
+    }
     return Exception { ExceptionCode::InvalidAccessError };
 }
     

--- a/Source/WebCore/css/ShorthandSerializer.cpp
+++ b/Source/WebCore/css/ShorthandSerializer.cpp
@@ -26,6 +26,7 @@
 #include "ShorthandSerializer.h"
 
 #include "CSSBorderImageWidthValue.h"
+#include "CSSCustomIdentValue.h"
 #include "CSSGridLineNamesValue.h"
 #include "CSSGridTemplateAreasValue.h"
 #include "CSSParserIdioms.h"
@@ -546,9 +547,8 @@ public:
 
     CSSValueID valueIDIncludingCustomIdent(unsigned index) const
     {
-        RefPtr value = dynamicDowncast<CSSPrimitiveValue>(m_values[index].get());
-        if (value && value->isCustomIdent())
-            return cssValueKeywordID(value->stringValue());
+        if (RefPtr customIdentValue = dynamicDowncast<CSSCustomIdentValue>(m_values[index].get()))
+            return cssValueKeywordID(customIdentValue->customIdent().value);
         return valueID(index).value_or(CSSValueInvalid);
     }
 
@@ -1141,10 +1141,13 @@ String ShorthandSerializer::serializeGrid() const
     return makeString("auto-flow"_s, dense, ' ', serializeLonghandValue(autoRowsIndex), " / "_s, serializeLonghandValue(columnsIndex));
 }
 
-static bool canOmitTrailingGridAreaValue(CSSValue& value, CSSValue& trailing, const CSS::SerializationContext& context)
+static bool canOmitTrailingGridAreaValue(CSSValue& value, CSSValue& trailing)
 {
-    if (isCustomIdentValue(value))
-        return isCustomIdentValue(trailing) && value.cssText(context) == trailing.cssText(context);
+    if (RefPtr customIdentValue = dynamicDowncast<CSSCustomIdentValue>(value)) {
+        if (RefPtr customIdentTrailing = dynamicDowncast<CSSCustomIdentValue>(trailing))
+            return customIdentValue->customIdent() == customIdentTrailing->customIdent();
+        return false;
+    }
     return isValueID(trailing, CSSValueAuto);
 }
 
@@ -1152,11 +1155,11 @@ String ShorthandSerializer::serializeGridArea() const
 {
     ASSERT(length() == 4);
     unsigned longhandsToSerialize = 4;
-    if (canOmitTrailingGridAreaValue(longhandValue(1), longhandValue(3), m_serializationContext)) {
+    if (canOmitTrailingGridAreaValue(longhandValue(1), longhandValue(3))) {
         --longhandsToSerialize;
-        if (canOmitTrailingGridAreaValue(longhandValue(0), longhandValue(2), m_serializationContext)) {
+        if (canOmitTrailingGridAreaValue(longhandValue(0), longhandValue(2))) {
             --longhandsToSerialize;
-            if (canOmitTrailingGridAreaValue(longhandValue(0), longhandValue(1), m_serializationContext))
+            if (canOmitTrailingGridAreaValue(longhandValue(0), longhandValue(1)))
                 --longhandsToSerialize;
         }
     }
@@ -1166,7 +1169,7 @@ String ShorthandSerializer::serializeGridArea() const
 String ShorthandSerializer::serializeGridRowColumn() const
 {
     ASSERT(length() == 2);
-    return serializeLonghands(canOmitTrailingGridAreaValue(longhandValue(0), longhandValue(1), m_serializationContext) ? 1 : 2, " / "_s);
+    return serializeLonghands(canOmitTrailingGridAreaValue(longhandValue(0), longhandValue(1)) ? 1 : 2, " / "_s);
 }
 
 String ShorthandSerializer::serializeGridTemplate() const

--- a/Source/WebCore/css/calc/CSSCalcRandomCachingKey.h
+++ b/Source/WebCore/css/calc/CSSCalcRandomCachingKey.h
@@ -25,11 +25,11 @@
 #pragma once
 
 #include <WebCore/CSSCalcTree.h>
+#include <WebCore/StyleCustomIdent.h>
 #include <optional>
 #include <wtf/HashFunctions.h>
 #include <wtf/HashTraits.h>
 #include <wtf/Hasher.h>
-#include <wtf/text/AtomString.h>
 
 namespace WebCore {
 namespace CSSCalc {
@@ -37,19 +37,39 @@ namespace CSSCalc {
 struct RandomCachingKey {
     using Identifier = Variant<
         Random::SharingOptions::Auto,
-        AtomString,
+        Style::CustomIdent,
         WTF::HashTableDeletedValueType,
         WTF::HashTableEmptyValueType
     >;
     Identifier identifier;
 
-    RandomCachingKey(Variant<Random::SharingOptions::Auto, AtomString>&& identifier)
-        : identifier { WTF::switchOn(WTF::move(identifier), [](auto&& alternative) { return Identifier { WTF::move(alternative) }; }) }
+    RandomCachingKey(const Random::SharingOptions::Auto& identifier)
+        : identifier { identifier }
     {
     }
 
-    RandomCachingKey(const Variant<Random::SharingOptions::Auto, AtomString>& identifier)
-        : identifier { WTF::switchOn(identifier, [](const auto& alternative) { return Identifier { alternative }; }) }
+    RandomCachingKey(Random::SharingOptions::Auto&& identifier)
+        : identifier { WTF::move(identifier) }
+    {
+    }
+
+    RandomCachingKey(const Style::CustomIdent& identifier)
+        : identifier { identifier }
+    {
+    }
+
+    RandomCachingKey(Style::CustomIdent&& identifier)
+        : identifier { WTF::move(identifier) }
+    {
+    }
+
+    RandomCachingKey(Variant<Random::SharingOptions::Auto, Style::CustomIdent>&& identifier)
+        : identifier { convertToIdentifier(WTF::move(identifier)) }
+    {
+    }
+
+    RandomCachingKey(const Variant<Random::SharingOptions::Auto, Style::CustomIdent>& identifier)
+        : identifier { convertToIdentifier(identifier) }
     {
     }
 
@@ -67,6 +87,17 @@ struct RandomCachingKey {
     bool isHashTableEmptyValue() const { return std::holds_alternative<WTF::HashTableEmptyValueType>(identifier); }
 
     bool operator==(const RandomCachingKey&) const = default;
+
+private:
+    static Identifier convertToIdentifier(Variant<Random::SharingOptions::Auto, Style::CustomIdent>&& identifier)
+    {
+        return WTF::switchOn(WTF::move(identifier), [](auto&& alternative) { return Identifier { WTF::move(alternative) }; });
+    }
+
+    static Identifier convertToIdentifier(const Variant<Random::SharingOptions::Auto, Style::CustomIdent>& identifier)
+    {
+        return WTF::switchOn(identifier, [](const auto& alternative) { return Identifier { alternative }; });
+    }
 };
 
 } // namespace CSSCalc
@@ -84,8 +115,8 @@ struct CSSCalcRandomCachingKeyHash {
                 add(hasher, autoValue.property);
                 add(hasher, autoValue.index);
             },
-            [&](const AtomString& string) {
-                add(hasher, string);
+            [&](const WebCore::Style::CustomIdent& customIdent) {
+                add(hasher, customIdent);
             },
             [](const WTF::HashTableDeletedValueType&) {
                 RELEASE_ASSERT_NOT_REACHED();

--- a/Source/WebCore/css/calc/CSSCalcTree+Evaluation.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Evaluation.cpp
@@ -35,6 +35,7 @@
 #include "CSSUnevaluatedCalc.h"
 #include "RenderStyle.h"
 #include "StyleBuilderState.h"
+#include "StyleCustomIdent.h"
 
 namespace WebCore {
 namespace CSSCalc {
@@ -211,13 +212,26 @@ std::optional<double> evaluate(const IndirectNode<Random>& root, const Evaluatio
 
     auto randomBaseValue = WTF::switchOn(root->sharing,
         [&](const Random::SharingOptions& sharingOptions) -> std::optional<double> {
-            if (!sharingOptions.elementScoped.has_value() && !options.conversionData->styleBuilderState()->element())
+            CheckedPtr builderState = options.conversionData->styleBuilderState();
+
+            if (sharingOptions.elementScoped.has_value() && !builderState->element())
                 return { };
 
-            return protect(options.conversionData->styleBuilderState())->lookupCSSRandomBaseValue(
-                sharingOptions.identifier,
-                sharingOptions.elementScoped
+            return WTF::switchOn(sharingOptions.identifier,
+                [&](const Random::SharingOptions::Auto& autoValue) {
+                    return builderState->lookupCSSRandomBaseValue(
+                        autoValue,
+                        sharingOptions.elementScoped
+                    );
+                },
+                [&](const CSS::CustomIdent& customIdent) {
+                    return builderState->lookupCSSRandomBaseValue(
+                        Style::toStyle(customIdent, *builderState),
+                        sharingOptions.elementScoped
+                    );
+                }
             );
+
         },
         [&](const Random::SharingFixed& sharingFixed) -> std::optional<double> {
             return WTF::switchOn(sharingFixed.value,
@@ -263,9 +277,9 @@ std::optional<double> evaluate(const IndirectNode<AnchorSize>& anchorSize, const
     CheckedPtr builderState = options.conversionData->styleBuilderState();
 
     std::optional<Style::ScopedName> anchorSizeScopedName;
-    if (!anchorSize->elementName.isNull()) {
+    if (anchorSize->elementName) {
         anchorSizeScopedName = Style::ScopedName {
-            .name = anchorSize->elementName,
+            .name = Style::toStyle(*anchorSize->elementName, *builderState).value,
             .scopeOrdinal = builderState->styleScopeOrdinal()
         };
     }
@@ -305,9 +319,9 @@ std::optional<double> evaluateWithoutFallback(const Anchor& anchor, const Evalua
     );
 
     std::optional<Style::ScopedName> anchorScopedName;
-    if (!anchor.elementName.isNull()) {
+    if (anchor.elementName) {
         anchorScopedName = Style::ScopedName {
-            .name = anchor.elementName,
+            .name = Style::toStyle(*anchor.elementName, *builderState).value,
             .scopeOrdinal = builderState->styleScopeOrdinal()
         };
     }

--- a/Source/WebCore/css/calc/CSSCalcTree+NumericIdentity.h
+++ b/Source/WebCore/css/calc/CSSCalcTree+NumericIdentity.h
@@ -212,7 +212,6 @@ constexpr NumericIdentity toNumericIdentity(const NonCanonicalDimension& dimensi
     case CSSUnitType::CSS_STRING:
     case CSSUnitType::CSS_UNKNOWN:
     case CSSUnitType::CSS_VALUE_ID:
-    case CSSUnitType::CustomIdent:
         break;
     }
 

--- a/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
@@ -671,7 +671,7 @@ static std::optional<Random::SharingOptions> consumeOptionalRandomSharingOptions
 {
     // <random-value-sharing> = [ auto | <dashed-ident> ] || element-scoped | fixed <number [0,1]>
 
-    std::optional<Variant<Random::SharingOptions::Auto, AtomString>> identifier;
+    std::optional<Variant<Random::SharingOptions::Auto, CSS::CustomIdent>> identifier;
     std::optional<CSS::Keyword::ElementScoped> elementScoped;
 
     CSSParserTokenRangeGuard guard { tokens };
@@ -684,8 +684,8 @@ static std::optional<Random::SharingOptions> consumeOptionalRandomSharingOptions
             identifier = makeRandomSharingAuto(state);
             return true;
         }
-        if (tokens.peek().type() == IdentToken && isValidCustomIdentifier(tokens.peek().id()) && tokens.peek().value().startsWith("--"_s)) {
-            identifier = tokens.consumeIncludingWhitespace().value().toAtomString();
+        if (auto dashedIdent = CSSPropertyParserHelpers::consumeUnresolvedDashedIdent(tokens, state.propertyParserState)) {
+            identifier = WTF::move(*dashedIdent);
             return true;
         }
         return false;
@@ -713,7 +713,7 @@ static std::optional<Random::SharingOptions> consumeOptionalRandomSharingOptions
     guard.commit();
 
     return Random::SharingOptions {
-        .identifier = identifier.value_or(AtomString { }),
+        .identifier = identifier.value_or(CSS::CustomIdent { nullAtom() }),
         .elementScoped = elementScoped
     };
 }
@@ -1037,7 +1037,7 @@ static std::optional<TypedChild> consumeAnchor(CSSParserTokenRange& tokens, int 
     if (!state.propertyParserState.context.propertySettings.cssAnchorPositioningEnabled)
         return { };
 
-    auto anchorElement = CSSPropertyParserHelpers::consumeDashedIdentRaw(tokens);
+    auto anchorElement = CSSPropertyParserHelpers::consumeUnresolvedDashedIdent(tokens, state.propertyParserState);
 
     // <anchor-side> = inside | outside | top | left | right | bottom | start | end | self-start | self-end | <percentage> | center
     auto anchorSide = [&]() -> std::optional<AnchorSide> {
@@ -1071,8 +1071,8 @@ static std::optional<TypedChild> consumeAnchor(CSSParserTokenRange& tokens, int 
     if (!anchorSide)
         return { };
 
-    if (anchorElement.isNull())
-        anchorElement = CSSPropertyParserHelpers::consumeDashedIdentRaw(tokens);
+    if (!anchorElement)
+        anchorElement = CSSPropertyParserHelpers::consumeUnresolvedDashedIdent(tokens, state.propertyParserState);
 
     auto type = Type::makeLength();
     std::optional<Child> fallback;
@@ -1093,7 +1093,7 @@ static std::optional<TypedChild> consumeAnchor(CSSParserTokenRange& tokens, int 
     state.requiresConversionData = true;
 
     auto anchor = Anchor {
-        .elementName = AtomString { WTF::move(anchorElement) },
+        .elementName = WTF::move(anchorElement),
         .side = WTF::move(*anchorSide),
         .fallback = WTF::move(fallback)
     };
@@ -1134,20 +1134,20 @@ static std::optional<TypedChild> consumeAnchorSize(CSSParserTokenRange& tokens, 
         return { };
 
     // parse <anchor-element>
-    auto maybeAnchorElement = CSSPropertyParserHelpers::consumeDashedIdentRaw(tokens);
+    auto maybeAnchorElement = CSSPropertyParserHelpers::consumeUnresolvedDashedIdent(tokens, state.propertyParserState);
 
     // then parse <anchor-size>
     auto maybeAnchorSize = CSSPropertyParserHelpers::consumeIdentRaw<CSSValueWidth, CSSValueHeight, CSSValueBlock, CSSValueInline, CSSValueSelfBlock, CSSValueSelfInline>(tokens);
 
     // if we could parse <anchor-size> but not <anchor-element>, it's possible <anchor-element> is specified
     // after <anchor-size>, so re-parse <anchor-element>
-    if (maybeAnchorSize && maybeAnchorElement.isNull())
-        maybeAnchorElement = CSSPropertyParserHelpers::consumeDashedIdentRaw(tokens);
+    if (maybeAnchorSize && !maybeAnchorElement)
+        maybeAnchorElement = CSSPropertyParserHelpers::consumeUnresolvedDashedIdent(tokens, state.propertyParserState);
 
     std::optional<TypedChild> fallback;
 
     // if either <anchor-element> or <anchor-size> is present
-    if (maybeAnchorSize || !maybeAnchorElement.isNull()) {
+    if (maybeAnchorSize || maybeAnchorElement) {
         // if a comma follows...
         if (CSSPropertyParserHelpers::consumeCommaIncludingWhitespace(tokens)) {
             // it must be followed by the fallback value.
@@ -1175,7 +1175,7 @@ static std::optional<TypedChild> consumeAnchorSize(CSSParserTokenRange& tokens, 
     state.requiresConversionData = true;
 
     auto anchorSize = AnchorSize {
-        .elementName = AtomString { WTF::move(maybeAnchorElement) },
+        .elementName = WTF::move(maybeAnchorElement),
         .dimension = maybeAnchorSize ? cssValueIDToAnchorSizeDimension(*maybeAnchorSize) : std::nullopt,
         .fallback = fallback ? std::make_optional(WTF::move(fallback->child)) : std::nullopt
     };

--- a/Source/WebCore/css/calc/CSSCalcTree+Serialization.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Serialization.cpp
@@ -201,7 +201,6 @@ static unsigned NODELETE sortPriority(CSSUnitType unit)
     case CSSUnitType::CSS_STRING:
     case CSSUnitType::CSS_UNKNOWN:
     case CSSUnitType::CSS_VALUE_ID:
-    case CSSUnitType::CustomIdent:
         break;
     }
 
@@ -385,15 +384,21 @@ void serializeMathFunctionArguments(StringBuilder& builder, const IndirectNode<R
 {
     WTF::switchOn(fn->sharing,
         [&](const Random::SharingOptions& options) {
-            if (!std::holds_alternative<AtomString>(options.identifier) && options.elementScoped)
-                return;
-            if (std::holds_alternative<AtomString>(options.identifier) && !std::get<AtomString>(options.identifier).isNull()) {
-                if (options.elementScoped)
-                    builder.append(std::get<AtomString>(options.identifier), ' ', nameLiteralForSerialization(CSSValueElementScoped), ", "_s);
-                else if (std::holds_alternative<AtomString>(options.identifier))
-                    builder.append(std::get<AtomString>(options.identifier), ", "_s);
-            } else if (options.elementScoped)
-                builder.append(nameLiteralForSerialization(CSSValueElementScoped), ", "_s);
+            WTF::switchOn(options.identifier,
+                [&](const Random::SharingOptions::Auto&) {
+                    // Noting to do.
+                },
+                [&](const CSS::CustomIdent& customIdent) {
+                    if (!customIdent.value.isNull()) {
+                        CSS::serializationForCSS(builder, state.serializationContext, customIdent);
+                        if (options.elementScoped)
+                            builder.append(' ', nameLiteralForSerialization(CSSValueElementScoped), ", "_s);
+                        else
+                            builder.append(", "_s);
+                    } else if (options.elementScoped)
+                        builder.append(' ', nameLiteralForSerialization(CSSValueElementScoped), ", "_s);
+                }
+            );
         },
         [&](const Random::SharingFixed& fixed) {
             builder.append(nameLiteralForSerialization(CSSValueFixed), ' ');
@@ -414,8 +419,8 @@ void serializeMathFunctionArguments(StringBuilder& builder, const IndirectNode<R
 
 void serializeMathFunctionArguments(StringBuilder& builder, const IndirectNode<Anchor>& anchor, SerializationState& state)
 {
-    if (!anchor->elementName.isNull()) {
-        serializeIdentifier(builder, anchor->elementName);
+    if (anchor->elementName) {
+        CSS::serializationForCSS(builder, state.serializationContext, *anchor->elementName);
         builder.append(' ');
     }
 
@@ -461,20 +466,17 @@ static void serializeAnchorSizeDimension(StringBuilder& builder, Style::AnchorSi
 
 void serializeMathFunctionArguments(StringBuilder& builder, const IndirectNode<AnchorSize>& anchorSize, SerializationState& state)
 {
-    bool hasElementName = !anchorSize->elementName.isNull();
-
-    if (hasElementName)
-        serializeIdentifier(builder, anchorSize->elementName);
+    if (anchorSize->elementName)
+        CSS::serializationForCSS(builder, state.serializationContext, *anchorSize->elementName);
 
     if (anchorSize->dimension) {
-        if (hasElementName)
+        if (anchorSize->elementName)
             builder.append(' ');
-
         serializeAnchorSizeDimension(builder, *anchorSize->dimension);
     }
 
     if (anchorSize->fallback) {
-        if (hasElementName || anchorSize->dimension)
+        if (anchorSize->elementName || anchorSize->dimension)
             builder.append(", "_s);
 
         serializeWithoutOmittingPrefix(builder, *anchorSize->fallback, state);
@@ -491,10 +493,10 @@ template<typename Op> void serializeMathFunctionArguments(StringBuilder& builder
                 serializeCalculationTree(builder, *root, state);
             }
         },
-        [&](const AtomString& root) {
-            if (!root.isNull()) {
+        [&](const CSS::CustomIdent& root) {
+            if (!root.value.isNull()) {
                 builder.append(std::exchange(separator, ", "_s));
-                serializeIdentifier(builder, root);
+                CSS::serializationForCSS(builder, state.serializationContext, root);
             }
         },
         [&](const auto& root) {
@@ -509,7 +511,8 @@ void serializeWithoutOmittingPrefix(StringBuilder& builder, const Child& child, 
     WTF::switchOn(child,
         [&](Leaf auto& op) {
             serializeCalculationTree(builder, op, state);
-        }, [&](auto& op) {
+        },
+        [&](auto& op) {
             serializeMathFunction(builder, op, state);
         }
     );

--- a/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
@@ -285,7 +285,6 @@ std::optional<CanonicalDimension> canonicalize(NonCanonicalDimension root, const
     case CSSUnitType::CSS_STRING:
     case CSSUnitType::CSS_UNKNOWN:
     case CSSUnitType::CSS_VALUE_ID:
-    case CSSUnitType::CustomIdent:
         break;
     }
 
@@ -1333,11 +1332,23 @@ std::optional<Child> simplify(Random& root, const SimplificationOptions& options
 
             auto randomBaseValue = WTF::switchOn(root.sharing,
                 [&](const Random::SharingOptions& sharingOptions) -> std::optional<double> {
-                    if (sharingOptions.elementScoped.has_value() && !options.conversionData->styleBuilderState()->element())
+                    CheckedPtr builderState = options.conversionData->styleBuilderState();
+                    if (sharingOptions.elementScoped.has_value() && !builderState->element())
                         return { };
-                    return protect(options.conversionData->styleBuilderState())->lookupCSSRandomBaseValue(
-                        sharingOptions.identifier,
-                        sharingOptions.elementScoped
+
+                    return WTF::switchOn(sharingOptions.identifier,
+                        [&](const Random::SharingOptions::Auto& autoValue) {
+                            return builderState->lookupCSSRandomBaseValue(
+                                autoValue,
+                                sharingOptions.elementScoped
+                            );
+                        },
+                        [&](const CSS::CustomIdent& customIdent) {
+                            return builderState->lookupCSSRandomBaseValue(
+                                Style::toStyle(customIdent, *builderState),
+                                sharingOptions.elementScoped
+                            );
+                        }
                     );
                 },
                 [&](const Random::SharingFixed& sharingFixed) -> std::optional<double> {
@@ -1420,9 +1431,9 @@ std::optional<Child> simplify(AnchorSize& anchorSize, const SimplificationOption
     CheckedPtr builderState = options.conversionData->styleBuilderState();
 
     std::optional<Style::ScopedName> anchorSizeScopedName;
-    if (!anchorSize.elementName.isNull()) {
+    if (anchorSize.elementName) {
         anchorSizeScopedName = Style::ScopedName {
-            .name = anchorSize.elementName,
+            .name = Style::toStyle(*anchorSize.elementName, *builderState).value,
             .scopeOrdinal = builderState->styleScopeOrdinal()
         };
     }

--- a/Source/WebCore/css/calc/CSSCalcTree+Traversal.h
+++ b/Source/WebCore/css/calc/CSSCalcTree+Traversal.h
@@ -63,7 +63,7 @@ template<typename F, typename Op> void forAllChildren(const Op& root, const F& f
         {
             functor(root);
         }
-        void operator()(const AtomString& root)
+        void operator()(const CSS::CustomIdent& root)
         {
             functor(root);
         }
@@ -112,7 +112,7 @@ template<typename F, typename Op> void forAllChildNodes(const Op& root, const F&
         {
             functor(root);
         }
-        void operator()(const AtomString&)
+        void operator()(const CSS::CustomIdent&)
         {
         }
         void operator()(const Random::Sharing&)

--- a/Source/WebCore/css/calc/CSSCalcTree.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree.cpp
@@ -177,7 +177,6 @@ Child makeNumeric(double value, CSSUnitType unit)
     case CSSUnitType::CSS_STRING:
     case CSSUnitType::CSS_UNKNOWN:
     case CSSUnitType::CSS_VALUE_ID:
-    case CSSUnitType::CustomIdent:
         break;
     }
 

--- a/Source/WebCore/css/calc/CSSCalcTree.h
+++ b/Source/WebCore/css/calc/CSSCalcTree.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/CSSCalcType.h>
+#include <WebCore/CSSCustomIdent.h>
 #include <WebCore/CSSPrimitiveNumeric.h>
 #include <WebCore/CSSPrimitiveNumericRange.h>
 #include <WebCore/CSSUnits.h>
@@ -33,7 +34,6 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
-#include <wtf/text/AtomString.h>
 
 namespace WebCore {
 
@@ -753,7 +753,7 @@ struct Random {
 
             bool operator==(const Auto&) const = default;
         };
-        Variant<Auto, AtomString> identifier;
+        Variant<Auto, CSS::CustomIdent> identifier;
         std::optional<CSS::Keyword::ElementScoped> elementScoped;
 
         bool operator==(const SharingOptions&) const = default;
@@ -821,7 +821,7 @@ struct Anchor {
 
     // Can't use Style::ScopedName here, since the scope ordinal is not available at
     // parsing time.
-    AtomString elementName;
+    std::optional<CSS::CustomIdent> elementName;
     AnchorSide side;
     std::optional<Child> fallback;
 
@@ -836,9 +836,7 @@ struct AnchorSize {
     // <anchor-element> = <dashed-ident>
     // <anchor-size> = width | height | block | inline | self-block | self-inline
 
-    // Can't use Style::ScopedName here, since the scope ordinal is not available at
-    // parsing time.
-    AtomString elementName; // <anchor-element>
+    std::optional<CSS::CustomIdent> elementName; // <anchor-element>
     std::optional<Style::AnchorSizeDimension> dimension; // <anchor-size>
     std::optional<Child> fallback;
 

--- a/Source/WebCore/css/calc/CSSCalcType.cpp
+++ b/Source/WebCore/css/calc/CSSCalcType.cpp
@@ -305,7 +305,6 @@ Type Type::determineType(CSSUnitType unitType)
     case CSSUnitType::CSS_STRING:
     case CSSUnitType::CSS_UNKNOWN:
     case CSSUnitType::CSS_VALUE_ID:
-    case CSSUnitType::CustomIdent:
         break;
     }
 

--- a/Source/WebCore/css/parser/CSSCustomPropertySyntax.cpp
+++ b/Source/WebCore/css/parser/CSSCustomPropertySyntax.cpp
@@ -96,7 +96,7 @@ auto CSSCustomPropertySyntax::parseComponent(std::span<const CharacterType> span
 
     auto multiplier = consumeMultiplier();
 
-    return Component { Type::CustomIdent, multiplier, ident };
+    return Component { Type::Ident, multiplier, ident };
 }
 
 std::optional<CSSCustomPropertySyntax> CSSCustomPropertySyntax::parse(StringView syntax)

--- a/Source/WebCore/css/parser/CSSCustomPropertySyntax.h
+++ b/Source/WebCore/css/parser/CSSCustomPropertySyntax.h
@@ -44,6 +44,7 @@ struct CSSCustomPropertySyntax {
         Color,
         Image,
         URL,
+        Ident,
         CustomIdent,
         String,
         TransformFunction,

--- a/Source/WebCore/css/parser/CSSParser.cpp
+++ b/Source/WebCore/css/parser/CSSParser.cpp
@@ -528,20 +528,22 @@ RefPtr<StyleRuleBase> CSSParser::consumeQualifiedRule(CSSParserTokenRange& range
     // https://github.com/w3c/csswg-drafts/issues/9336#issuecomment-1719806755
     if (range.peek().type() == LeftBraceToken) {
         auto rangeCopyForDashedIdent = initialRange;
-        auto customProperty = CSSPropertyParserHelpers::consumeDashedIdent(rangeCopyForDashedIdent);
-        // This rule is ambigous with a custom property because it looks like "--ident: ...."
-        if (customProperty && rangeCopyForDashedIdent.peek().type() == ColonToken) {
-            if (isStyleNestedContext()) {
-                // Error, consume until semicolon or end of block.
-                while (!range.atEnd() && range.peek().type() != SemicolonToken)
-                    range.consumeComponentValue();
-                if (range.peek().type() == SemicolonToken)
-                    range.consume();
+        // This rule is ambiguous with a custom property because it looks like "--ident: ...."
+        if (rangeCopyForDashedIdent.peek().type() == IdentToken && rangeCopyForDashedIdent.peek().value().startsWith("--"_s)) {
+            rangeCopyForDashedIdent.consumeIncludingWhitespace();
+            if (rangeCopyForDashedIdent.peek().type() == ColonToken) {
+                if (isStyleNestedContext()) {
+                    // Error, consume until semicolon or end of block.
+                    while (!range.atEnd() && range.peek().type() != SemicolonToken)
+                        range.consumeComponentValue();
+                    if (range.peek().type() == SemicolonToken)
+                        range.consume();
+                    return { };
+                }
+                // Error, consume until end of block.
+                range.consumeBlock();
                 return { };
             }
-            // Error, consume until end of block.
-            range.consumeBlock();
-            return { };
         }
     }
 
@@ -917,7 +919,7 @@ RefPtr<StyleRuleFontFeatureValues> CSSParser::consumeFontFeatureValuesRule(CSSPa
 
 RefPtr<StyleRuleFontPaletteValues> CSSParser::consumeFontPaletteValuesRule(CSSParserTokenRange prelude, CSSParserTokenRange block)
 {
-    RefPtr name = CSSPropertyParserHelpers::consumeDashedIdent(prelude);
+    auto name = CSSPropertyParserHelpers::consumeEagerlyResolvableDashedIdentRaw(prelude);
     if (!name || !prelude.atEnd())
         return nullptr; // Parse error; expected custom ident in @font-palette-values header
 
@@ -978,7 +980,7 @@ RefPtr<StyleRuleFontPaletteValues> CSSParser::consumeFontPaletteValuesRule(CSSPa
         });
     }
 
-    return StyleRuleFontPaletteValues::create(AtomString { name->stringValue() }, WTF::move(fontFamilies), WTF::move(basePalette), WTF::move(overrideColors));
+    return StyleRuleFontPaletteValues::create(name.toAtomString(), WTF::move(fontFamilies), WTF::move(basePalette), WTF::move(overrideColors));
 }
 
 RefPtr<StyleRuleKeyframes> CSSParser::consumeKeyframesRule(CSSParserTokenRange prelude, CSSParserTokenRange block)
@@ -1079,7 +1081,7 @@ RefPtr<StyleRulePositionTry> CSSParser::consumePositionTryRule(CSSParserTokenRan
         return nullptr;
 
     // Prelude should ONLY be a <dashed-ident>.
-    AtomString ruleName { CSSPropertyParserHelpers::consumeDashedIdentRaw(prelude) };
+    auto ruleName = CSSPropertyParserHelpers::consumeEagerlyResolvableDashedIdentRaw(prelude);
     if (!ruleName)
         return nullptr;
     if (!prelude.atEnd())
@@ -1094,7 +1096,7 @@ RefPtr<StyleRulePositionTry> CSSParser::consumePositionTryRule(CSSParserTokenRan
     }
 
     auto declarations = consumeDeclarationListInNewNestingContext(block, StyleRuleType::PositionTry);
-    return StyleRulePositionTry::create(WTF::move(ruleName), createStyleProperties(declarations, m_context.mode));
+    return StyleRulePositionTry::create(ruleName.toAtomString(), createStyleProperties(declarations, m_context.mode));
 }
 
 RefPtr<StyleRuleFunction> CSSParser::consumeFunctionRule(CSSParserTokenRange prelude, CSSParserTokenRange block)

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -31,6 +31,7 @@
 #include "config.h"
 #include "CSSPropertyParser.h"
 
+#include "CSSCustomIdentValue.h"
 #include "CSSCustomPropertySyntax.h"
 #include "CSSCustomPropertyValue.h"
 #include "CSSMarkup.h"
@@ -67,11 +68,13 @@
 #include "CSSWideKeyword.h"
 #include "ComputedStyleDependencies.h"
 #include "StyleBuilder.h"
+#include "StyleCustomIdent.h"
 #include "StyleCustomProperty.h"
 #include "StylePrimitiveNumericTypes+CSSValueConversion.h"
 #include "StylePropertyShorthand.h"
 #include "StylePropertyShorthandFunctions.h"
 #include "StyleRuleType.h"
+#include "StyleURL.h"
 #include <memory>
 #include <wtf/StdLibExtras.h>
 #include <wtf/text/ParsingUtilities.h>
@@ -473,16 +476,16 @@ std::pair<RefPtr<CSSValue>, CSSCustomPropertySyntax::Type> consumeCustomProperty
 
     auto consumeSingleValue = [&](auto& range, auto& component) -> RefPtr<CSSValue> {
         switch (component.type) {
+        case CSSCustomPropertySyntax::Type::Ident:
+            if (range.peek().type() != IdentToken || range.peek().value() != component.ident)
+                return nullptr;
+            return CSSCustomIdentValue::create(CSS::CustomIdent { range.consumeIncludingWhitespace().value().toAtomString() });
+        case CSSCustomPropertySyntax::Type::CustomIdent:
+            return consumeCustomIdent(range, state);
         case CSSCustomPropertySyntax::Type::Length:
             return CSSPrimitiveValueResolver<CSS::Length<>>::consumeAndResolve(range, state);
         case CSSCustomPropertySyntax::Type::LengthPercentage:
             return CSSPrimitiveValueResolver<CSS::LengthPercentage<>>::consumeAndResolve(range, state);
-        case CSSCustomPropertySyntax::Type::CustomIdent:
-            if (RefPtr value = consumeCustomIdent(range)) {
-                if (component.ident.isNull() || value->stringValue() == component.ident)
-                    return value;
-            }
-            return nullptr;
         case CSSCustomPropertySyntax::Type::Percentage:
             return CSSPrimitiveValueResolver<CSS::Percentage<>>::consumeAndResolve(range, state);
         case CSSCustomPropertySyntax::Type::Integer:
@@ -584,8 +587,9 @@ std::optional<Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>> consume
         }
         case CSSCustomPropertySyntax::Type::URL:
             return Style::toStyle(downcast<CSSURLValue>(value).url(), builderState);
+        case CSSCustomPropertySyntax::Type::Ident:
         case CSSCustomPropertySyntax::Type::CustomIdent:
-            return CustomIdentifier { AtomString { downcast<CSSPrimitiveValue>(value).stringValue() } };
+            return Style::toStyleFromCSSValue<Style::CustomIdent>(builderState, value);
         case CSSCustomPropertySyntax::Type::String:
             return downcast<CSSPrimitiveValue>(value).stringValue();
         case CSSCustomPropertySyntax::Type::TransformFunction:

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Animations.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Animations.cpp
@@ -27,6 +27,7 @@
 #include "CSSPropertyParserConsumer+Animations.h"
 
 #include "CSSCalcSymbolTable.h"
+#include "CSSCustomIdentValue.h"
 #include "CSSParserContext.h"
 #include "CSSParserIdioms.h"
 #include "CSSParserTokenRange.h"
@@ -122,7 +123,7 @@ Vector<std::pair<CSSValueID, double>> parseKeyframeKeyList(const String& string,
     return result;
 }
 
-RefPtr<CSSValue> consumeKeyframesName(CSSParserTokenRange& range, CSS::PropertyParserState&)
+RefPtr<CSSValue> consumeKeyframesName(CSSParserTokenRange& range, CSS::PropertyParserState& state)
 {
     // <keyframes-name> = <custom-ident> | <string>
     // https://drafts.csswg.org/css-animations/#typedef-keyframes-name
@@ -135,11 +136,11 @@ RefPtr<CSSValue> consumeKeyframesName(CSSParserTokenRange& range, CSS::PropertyP
 
         auto valueId = cssValueKeywordID(token.value());
         if (isValidCustomIdentifier(valueId) && valueId != CSSValueNone)
-            return CSSPrimitiveValue::createCustomIdent(token.value().toString());
+            return CSSCustomIdentValue::create(CSS::CustomIdent { token.value().toAtomString() });
         return CSSPrimitiveValue::create(token.value().toString());
     }
 
-    return consumeCustomIdent(range);
+    return consumeCustomIdent(range, state);
 }
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+ColorAdjust.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+ColorAdjust.cpp
@@ -31,6 +31,7 @@
 #include "CSSParserContext.h"
 #include "CSSParserIdioms.h"
 #include "CSSParserTokenRange.h"
+#include "CSSPropertyParserConsumer+Ident.h"
 #include "CSSPropertyParserState.h"
 #include "CSSValueKeywords.h"
 
@@ -39,7 +40,7 @@ namespace CSSPropertyParserHelpers {
 
 #if ENABLE(DARK_MODE_CSS)
 
-std::optional<CSS::ColorScheme> consumeUnresolvedColorScheme(CSSParserTokenRange& range, CSS::PropertyParserState&)
+std::optional<CSS::ColorScheme> consumeUnresolvedColorScheme(CSSParserTokenRange& range, CSS::PropertyParserState& state)
 {
     // <'color-scheme'> = normal | [ light | dark | <custom-ident> ]+ && only?
     // https://drafts.csswg.org/css-color-adjust/#propdef-color-scheme
@@ -66,37 +67,40 @@ std::optional<CSS::ColorScheme> consumeUnresolvedColorScheme(CSSParserTokenRange
     }
 
     while (!range.atEnd()) {
-        if (range.peek().type() != IdentToken)
-            return { };
-
-        CSSValueID id = range.peek().id();
-
-        switch (id) {
-        case CSSValueNormal:
-            // `normal` is only allowed as a single value, and was handled earlier.
-            // Don't allow it in the list.
-            return { };
-
-        case CSSValueOnly:
-            // `only` can either appear first, handled before the loop, or last,
-            // handled here.
-
-            if (result->only)
-                return { };
-            range.consumeIncludingWhitespace();
-            result->only = CSS::Keyword::Only { };
-
-            if (!range.atEnd())
+        if (range.peek().type() == IdentToken) {
+            switch (CSSValueID id = range.peek().id()) {
+            case CSSValueNormal:
+                // `normal` is only allowed as a single value, and was handled earlier.
+                // Don't allow it in the list.
                 return { };
 
-            break;
+            case CSSValueOnly:
+                // `only` can either appear first, handled before the loop, or last,
+                // handled here.
 
-        default:
-            if (!isValidCustomIdentifier(id))
+                if (result->only)
+                    return { };
+                range.consumeIncludingWhitespace();
+                result->only = CSS::Keyword::Only { };
+
+                if (!range.atEnd())
+                    return { };
+
+                break;
+
+            default:
+                if (!isValidCustomIdentifier(id))
+                    return { };
+
+                result->schemes.value.append(CSS::CustomIdent { range.consumeIncludingWhitespace().value().toAtomString() });
+                break;
+            }
+        } else {
+            auto customIdent = consumeUnresolvedCustomIdentExcluding(range, state, { CSSValueNormal, CSSValueOnly });
+            if (!customIdent)
                 return { };
 
-            result->schemes.value.append(CustomIdentifier { range.consumeIncludingWhitespace().value().toAtomString() });
-            break;
+            result->schemes.value.append(WTF::move(*customIdent));
         }
     }
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Content.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Content.cpp
@@ -27,7 +27,6 @@
 #include "CSSPropertyParserConsumer+Content.h"
 
 #include "CSSCounterValue.h"
-#include "CSSParserContext.h"
 #include "CSSParserTokenRange.h"
 #include "CSSPrimitiveValue.h"
 #include "CSSPropertyParserConsumer+Attr.h"
@@ -74,23 +73,22 @@ static RefPtr<CSSValue> consumeCounterContent(CSSParserTokenRange args, CSS::Pro
     // counter()  =  counter( <counter-name>, <counter-style>? )
     // https://www.w3.org/TR/css-lists-3/#funcdef-counter
 
-    AtomString identifier { consumeCustomIdentRaw(args) };
-    if (identifier.isNull())
+    auto customIdent = consumeUnresolvedCustomIdent(args, state);
+    if (!customIdent)
         return nullptr;
 
-    RefPtr<CSSValue> counterStyle;
+    std::optional<CSS::CounterStyle> counterStyle;
     if (consumeCommaIncludingWhitespace(args)) {
-        counterStyle = consumeCounterStyle(args, state);
+        counterStyle = consumeUnresolvedCounterStyle(args, state);
         if (!counterStyle)
             return nullptr;
-    }
-    if (!counterStyle)
-        counterStyle = CSSPrimitiveValue::create(CSSValueDecimal);
+    } else
+        counterStyle = CSS::CounterStyle { CSS::CustomIdent { nameLiteral(CSSValueDecimal) } };
 
     if (!args.atEnd())
         return nullptr;
 
-    return CSSCounterValue::create(WTF::move(identifier), AtomString { nullAtom() }, counterStyle.releaseNonNull());
+    return CSSCounterValue::create(WTF::move(*customIdent), AtomString { nullAtom() }, WTF::move(*counterStyle));
 }
 
 static RefPtr<CSSValue> consumeCountersContent(CSSParserTokenRange args, CSS::PropertyParserState& state)
@@ -98,27 +96,26 @@ static RefPtr<CSSValue> consumeCountersContent(CSSParserTokenRange args, CSS::Pr
     // counters() = counters( <counter-name>, <string>, <counter-style>? )
     // https://www.w3.org/TR/css-lists-3/#funcdef-counters
 
-    AtomString identifier { consumeCustomIdentRaw(args) };
-    if (identifier.isNull())
+    auto customIdent = consumeUnresolvedCustomIdent(args, state);
+    if (!customIdent)
         return nullptr;
 
     if (!consumeCommaIncludingWhitespace(args) || args.peek().type() != StringToken)
         return nullptr;
     auto separator = args.consumeIncludingWhitespace().value().toAtomString();
 
-    RefPtr<CSSValue> counterStyle;
+    std::optional<CSS::CounterStyle> counterStyle;
     if (consumeCommaIncludingWhitespace(args)) {
-        counterStyle = consumeCounterStyle(args, state);
+        counterStyle = consumeUnresolvedCounterStyle(args, state);
         if (!counterStyle)
             return nullptr;
-    }
-    if (!counterStyle)
-        counterStyle = CSSPrimitiveValue::create(CSSValueDecimal);
+    } else
+        counterStyle = CSS::CounterStyle { CSS::CustomIdent { AtomString { nameLiteral(CSSValueDecimal) } } };
 
     if (!args.atEnd())
         return nullptr;
 
-    return CSSCounterValue::create(WTF::move(identifier), WTF::move(separator), counterStyle.releaseNonNull());
+    return CSSCounterValue::create(WTF::move(*customIdent), WTF::move(separator), WTF::move(*counterStyle));
 }
 
 RefPtr<CSSValue> consumeContent(CSSParserTokenRange& range, CSS::PropertyParserState& state)

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+CounterStyles.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+CounterStyles.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "CSSPropertyParserConsumer+CounterStyles.h"
 
+#include "CSSCustomIdentValue.h"
 #include "CSSParserContext.h"
 #include "CSSParserIdioms.h"
 #include "CSSParserTokenRange.h"
@@ -46,25 +47,40 @@
 namespace WebCore {
 namespace CSSPropertyParserHelpers {
 
-static bool NODELETE isPredefinedCounterStyle(CSSValueID valueID)
+bool isPredefinedCounterStyle(CSSValueID valueID)
 {
     // https://drafts.csswg.org/css-counter-styles-3/#predefined-counters
 
     return valueID >= CSSValueDisc && valueID <= CSSValueEthiopicNumeric;
 }
 
-RefPtr<CSSValue> consumeCounterStyle(CSSParserTokenRange& range, CSS::PropertyParserState&)
+std::optional<CSS::CounterStyle> consumeUnresolvedCounterStyle(CSSParserTokenRange& range, CSS::PropertyParserState& state)
 {
     // <counter-style> = <counter-style-name excluding=none> | <symbols()>
     // https://drafts.csswg.org/css-counter-styles-3/#typedef-counter-style
 
     // FIXME: Implement support for `symbols()`.
 
-    if (range.peek().id() == CSSValueNone)
-        return nullptr;
-    if (auto predefinedValues = consumeIdent(range, isPredefinedCounterStyle))
-        return predefinedValues;
-    return consumeCustomIdent(range);
+    if (isPredefinedCounterStyle(range.peek().id()))
+        return CSS::CounterStyle { range.consumeIncludingWhitespace().id() };
+
+    auto customIdent = consumeUnresolvedCustomIdentExcluding(range, state, { CSSValueNone });
+    if (!customIdent)
+        return { };
+
+    return CSS::CounterStyle { WTF::move(*customIdent) };
+}
+
+RefPtr<CSSValue> consumeCounterStyle(CSSParserTokenRange& range, CSS::PropertyParserState& state)
+{
+    // <counter-style> = <counter-style-name excluding=none> | <symbols()>
+    // https://drafts.csswg.org/css-counter-styles-3/#typedef-counter-style
+
+    // FIXME: Implement support for `symbols()`.
+    if (isPredefinedCounterStyle(range.peek().id()))
+        return CSSPrimitiveValue::create(range.consumeIncludingWhitespace().id());
+
+    return consumeCustomIdentExcluding(range, state, { CSSValueNone });
 }
 
 AtomString consumeCounterStyleNameInPrelude(CSSParserTokenRange& prelude, CSSParserMode mode)
@@ -88,7 +104,7 @@ AtomString consumeCounterStyleNameInPrelude(CSSParserTokenRange& prelude, CSSPar
     return isPredefinedCounterStyle(nameToken.id()) ? name.convertToASCIILowercaseAtom() : name.toAtomString();
 }
 
-RefPtr<CSSValue> consumeCounterStyleName(CSSParserTokenRange& range, CSS::PropertyParserState&)
+RefPtr<CSSValue> consumeCounterStyleName(CSSParserTokenRange& range, CSS::PropertyParserState& state)
 {
     // <counter-style-name> is a <custom-ident> that is not an ASCII case-insensitive match for "none".
     // https://drafts.csswg.org/css-counter-styles-3/#typedef-counter-style-name
@@ -96,10 +112,12 @@ RefPtr<CSSValue> consumeCounterStyleName(CSSParserTokenRange& range, CSS::Proper
     auto valueID = range.peek().id();
     if (valueID == CSSValueNone)
         return nullptr;
+
     // If the value is an ASCII case-insensitive match for any of the predefined counter styles, lowercase it.
-    if (auto name = consumeCustomIdent(range, isPredefinedCounterStyle(valueID)))
-        return name;
-    return nullptr;
+    if (isPredefinedCounterStyle(valueID))
+        return CSSPrimitiveValue::create(range.consumeIncludingWhitespace().id());
+
+    return consumeCustomIdentExcluding(range, state, { CSSValueNone });
 }
 
 RefPtr<CSSValue> consumeCounterStyleSystem(CSSParserTokenRange& range, CSS::PropertyParserState& state)

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+CounterStyles.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+CounterStyles.h
@@ -35,6 +35,7 @@ class CSSValue;
 enum CSSValueID : uint16_t;
 
 namespace CSS {
+struct CounterStyle;
 struct PropertyParserState;
 }
 
@@ -42,7 +43,10 @@ namespace CSSPropertyParserHelpers {
 
 // https://drafts.csswg.org/css-counter-styles-3/
 
+bool NODELETE isPredefinedCounterStyle(CSSValueID);
+
 // MARK: <counter-style> consumer
+std::optional<CSS::CounterStyle> consumeUnresolvedCounterStyle(CSSParserTokenRange&, CSS::PropertyParserState&);
 RefPtr<CSSValue> consumeCounterStyle(CSSParserTokenRange&, CSS::PropertyParserState&);
 
 // MARK: @counter-style consumer

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "CSSPropertyParserConsumer+Grid.h"
 
+#include "CSSCustomIdentValue.h"
 #include "CSSFunctionValue.h"
 #include "CSSGridAutoRepeatValue.h"
 #include "CSSGridIntegerRepeatValue.h"
@@ -38,13 +39,12 @@
 #include "CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h"
 #include "CSSPropertyParserConsumer+Ident.h"
 #include "CSSPropertyParserConsumer+IntegerDefinitions.h"
-#include "CSSPropertyParserConsumer+LengthPercentageDefinitions.h"
+#include "CSSPropertyParserConsumer+MetaConsumer.h"
 #include "CSSPropertyParserConsumer+Primitives.h"
 #include "CSSPropertyParserState.h"
 #include "CSSSubgridValue.h"
 #include "CSSValueList.h"
 #include "CSSValuePool.h"
-#include "GridArea.h"
 #include "StyleGridPosition.h"
 #include <wtf/Vector.h>
 #include <wtf/text/StringView.h>
@@ -57,11 +57,9 @@ bool isGridBreadthIdent(CSSValueID id)
     return identMatches<CSSValueMinContent, CSSValueWebkitMinContent, CSSValueMaxContent, CSSValueWebkitMaxContent, CSSValueAuto>(id);
 }
 
-static RefPtr<CSSPrimitiveValue> consumeCustomIdentForGridLine(CSSParserTokenRange& range)
+static std::optional<CSS::CustomIdent> consumeCustomIdentForGridLine(CSSParserTokenRange& range, CSS::PropertyParserState& state)
 {
-    if (range.peek().id() == CSSValueAuto || range.peek().id() == CSSValueSpan)
-        return nullptr;
-    return consumeCustomIdent(range);
+    return consumeUnresolvedCustomIdentExcluding(range, state, { CSSValueAuto, CSSValueSpan });
 }
 
 std::optional<CSS::GridNamedAreaMapRow> consumeUnresolvedGridTemplateAreasRow(CSSParserTokenRange& range, CSS::PropertyParserState&)
@@ -109,7 +107,7 @@ std::optional<CSS::GridNamedAreaMapRow> consumeUnresolvedGridTemplateAreasRow(CS
         areaName.append(character);
     }
     if (!areaName.isEmpty())
-        row->append(areaName.toString());
+        row->append(areaName.toAtomString());
 
     return row;
 }
@@ -126,39 +124,45 @@ RefPtr<CSSValue> consumeGridLine(CSSParserTokenRange& range, CSS::PropertyParser
     if (range.peek().id() == CSSValueAuto)
         return consumeIdent(range);
 
-    RefPtr<CSSPrimitiveValue> spanValue;
-    RefPtr<CSSPrimitiveValue> gridLineName;
-    RefPtr<CSSPrimitiveValue> numericValue = CSSPrimitiveValueResolver<CSS::Integer<>>::consumeAndResolve(range, state);
+    auto consumeSpanKeyword = [](auto& range) -> std::optional<CSS::Keyword::Span> {
+        if (consumeIdentRaw<CSSValueSpan>(range))
+            return CSS::Keyword::Span { };
+        return std::nullopt;
+    };
+
+    std::optional<CSS::Keyword::Span> spanKeyword;
+    std::optional<CSS::CustomIdent> gridLineName;
+    std::optional<CSS::Integer<>> numericValue = MetaConsumer<CSS::Integer<>>::consume(range, state);
     if (numericValue) {
-        gridLineName = consumeCustomIdentForGridLine(range);
-        spanValue = consumeIdent<CSSValueSpan>(range);
+        gridLineName = consumeCustomIdentForGridLine(range, state);
+        spanKeyword = consumeSpanKeyword(range);
     } else {
-        spanValue = consumeIdent<CSSValueSpan>(range);
-        if (spanValue) {
-            numericValue = CSSPrimitiveValueResolver<CSS::Integer<>>::consumeAndResolve(range, state);
-            gridLineName = consumeCustomIdentForGridLine(range);
+        spanKeyword = consumeSpanKeyword(range);
+        if (spanKeyword) {
+            numericValue = MetaConsumer<CSS::Integer<>>::consume(range, state);
+            gridLineName = consumeCustomIdentForGridLine(range, state);
             if (!numericValue)
-                numericValue = CSSPrimitiveValueResolver<CSS::Integer<>>::consumeAndResolve(range, state);
+                numericValue = MetaConsumer<CSS::Integer<>>::consume(range, state);
         } else {
-            gridLineName = consumeCustomIdentForGridLine(range);
+            gridLineName = consumeCustomIdentForGridLine(range, state);
             if (gridLineName) {
-                numericValue = CSSPrimitiveValueResolver<CSS::Integer<>>::consumeAndResolve(range, state);
-                spanValue = consumeIdent<CSSValueSpan>(range);
-                if (!spanValue && !numericValue)
-                    return gridLineName;
+                numericValue = MetaConsumer<CSS::Integer<>>::consume(range, state);
+                spanKeyword = consumeSpanKeyword(range);
+                if (!spanKeyword && !numericValue)
+                    return CSSCustomIdentValue::create(WTF::move(*gridLineName));
             } else
                 return nullptr;
         }
     }
 
-    if (spanValue && !numericValue && !gridLineName)
+    if (spanKeyword && !numericValue && !gridLineName)
         return nullptr; // "span" keyword alone is invalid.
-    if (spanValue && numericValue && numericValue->isNegative().value_or(false))
-        return nullptr; // Negative numbers are not allowed for span.
-    if (numericValue && numericValue->isZero().value_or(false))
+    if (spanKeyword && numericValue && numericValue->isKnownNegative())
+        return nullptr; // Negative numbers are not allowed when the "span" keyword is specified.
+    if (numericValue && numericValue->isKnownZero())
         return nullptr; // An <integer> value of zero makes the declaration invalid.
 
-    return CSSGridLineValue::create(WTF::move(spanValue), WTF::move(numericValue), WTF::move(gridLineName));
+    return CSSGridLineValue::create(spanKeyword, WTF::move(numericValue), WTF::move(gridLineName));
 }
 
 static bool isGridTrackFixedSized(const CSSPrimitiveValue& primitiveValue)
@@ -245,21 +249,21 @@ RefPtr<CSSValue> consumeGridTrackSize(CSSParserTokenRange& range, CSS::PropertyP
     return consumeGridBreadth(range, state);
 }
 
-RefPtr<CSSGridLineNamesValue> consumeGridLineNames(CSSParserTokenRange& range, CSS::PropertyParserState&, AllowEmpty allowEmpty)
+RefPtr<CSSGridLineNamesValue> consumeGridLineNames(CSSParserTokenRange& range, CSS::PropertyParserState& state, AllowEmpty allowEmpty)
 {
     CSSParserTokenRange rangeCopy = range;
     if (rangeCopy.consumeIncludingWhitespace().type() != LeftBracketToken)
         return nullptr;
 
-    Vector<String, 4> lineNames;
-    while (auto lineName = consumeCustomIdentForGridLine(rangeCopy))
-        lineNames.append(lineName->customIdent());
+    SpaceSeparatedVector<CSS::CustomIdent> lineNames;
+    while (auto lineName = consumeCustomIdentForGridLine(rangeCopy, state))
+        lineNames.value.append(WTF::move(*lineName));
     if (rangeCopy.consumeIncludingWhitespace().type() != RightBracketToken)
         return nullptr;
     range = rangeCopy;
     if (allowEmpty == AllowEmpty::No && lineNames.isEmpty())
         return nullptr;
-    return CSSGridLineNamesValue::create(lineNames);
+    return CSSGridLineNamesValue::create(WTF::move(lineNames));
 }
 
 static bool consumeGridTrackRepeatFunction(CSSParserTokenRange& range, CSS::PropertyParserState& state, CSSValueListBuilder& list, bool& isAutoRepeat, bool& allTracksAreFixedSized)

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.h
@@ -36,8 +36,9 @@ class CSSValue;
 enum CSSValueID : uint16_t;
 
 namespace CSS {
+struct CustomIdent;
 struct PropertyParserState;
-using GridNamedAreaMapRow = Vector<String, 8>;
+using GridNamedAreaMapRow = Vector<AtomString, 8>;
 }
 
 namespace CSSPropertyParserHelpers {

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Ident.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Ident.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "CSSPropertyParserConsumer+Ident.h"
 
+#include "CSSCustomIdentValue.h"
 #include "CSSParserIdioms.h"
 #include "CSSValuePool.h"
 
@@ -64,42 +65,76 @@ RefPtr<CSSPrimitiveValue> consumeIdentRange(CSSParserTokenRange& range, CSSValue
 // MARK: <custom-ident>
 // https://drafts.csswg.org/css-values/#custom-idents
 
-String consumeCustomIdentRaw(CSSParserTokenRange& range, bool shouldLowercase)
+StringView consumeEagerlyResolvableCustomIdentRaw(CSSParserTokenRange& range)
 {
+    // FIXME: When support for the ident() function is added, this will only succeed if the ident() function can be eagerly resolved without additional context.
+
     if (range.peek().type() != IdentToken || !isValidCustomIdentifier(range.peek().id()))
-        return String();
-    auto identifier = range.consumeIncludingWhitespace().value();
-    return shouldLowercase ? identifier.convertToASCIILowercase() : identifier.toString();
+        return { };
+    return range.consumeIncludingWhitespace().value();
 }
 
-RefPtr<CSSPrimitiveValue> consumeCustomIdent(CSSParserTokenRange& range, bool shouldLowercase)
+StringView consumeEagerlyResolvableCustomIdentRawExcluding(CSSParserTokenRange& range, std::initializer_list<CSSValueID> excluding)
 {
-    auto identifier = consumeCustomIdentRaw(range, shouldLowercase);
-    if (identifier.isNull())
-        return nullptr;
-    return CSSPrimitiveValue::createCustomIdent(WTF::move(identifier));
+    // FIXME: When support for the ident() function is added, this will only succeed if the ident() function can be eagerly resolved without additional context.
+
+    if (range.peek().type() != IdentToken || !isValidCustomIdentifier(range.peek().id()) || std::ranges::find(excluding, range.peek().id()) != excluding.end())
+        return { };
+    return range.consumeIncludingWhitespace().value();
+}
+
+std::optional<CSS::CustomIdent> consumeUnresolvedCustomIdent(CSSParserTokenRange& range, CSS::PropertyParserState&)
+{
+    if (range.peek().type() != IdentToken || !isValidCustomIdentifier(range.peek().id()))
+        return { };
+    return CSS::CustomIdent { range.consumeIncludingWhitespace().value().toAtomString() };
+}
+
+std::optional<CSS::CustomIdent> consumeUnresolvedCustomIdentExcluding(CSSParserTokenRange& range, CSS::PropertyParserState&, std::initializer_list<CSSValueID> excluding)
+{
+    if (range.peek().type() != IdentToken || !isValidCustomIdentifier(range.peek().id()) || std::ranges::find(excluding, range.peek().id()) != excluding.end())
+        return { };
+    return CSS::CustomIdent { range.consumeIncludingWhitespace().value().toAtomString() };
+}
+
+RefPtr<CSSValue> consumeCustomIdent(CSSParserTokenRange& range, CSS::PropertyParserState& state)
+{
+    if (auto unresolved = consumeUnresolvedCustomIdent(range, state))
+        return CSSCustomIdentValue::create(WTF::move(*unresolved));
+    return nullptr;
+}
+
+RefPtr<CSSValue> consumeCustomIdentExcluding(CSSParserTokenRange& range, CSS::PropertyParserState& state, std::initializer_list<CSSValueID> excluding)
+{
+    if (auto unresolved = consumeUnresolvedCustomIdentExcluding(range, state, excluding))
+        return CSSCustomIdentValue::create(WTF::move(*unresolved));
+    return nullptr;
 }
 
 // MARK: <dashed-ident>
 // https://drafts.csswg.org/css-values/#dashed-idents
 
-String consumeDashedIdentRaw(CSSParserTokenRange& range, bool shouldLowercase)
+StringView consumeEagerlyResolvableDashedIdentRaw(CSSParserTokenRange& range)
 {
-    auto rangeCopy = range;
-    auto identifier = consumeCustomIdentRaw(range, shouldLowercase);
-    if (!identifier.startsWith("--"_s)) {
-        range = rangeCopy;
+    // FIXME: When support for the ident() function is added, this will only succeed if the ident() function can be eagerly resolved without additional context.
+
+    if (range.peek().type() != IdentToken || !range.peek().value().startsWith("--"_s))
         return { };
-    }
-    return identifier;
+    return range.consumeIncludingWhitespace().value();
 }
 
-RefPtr<CSSPrimitiveValue> consumeDashedIdent(CSSParserTokenRange& range, bool shouldLowercase)
+std::optional<CSS::CustomIdent> consumeUnresolvedDashedIdent(CSSParserTokenRange& range, CSS::PropertyParserState&)
 {
-    auto identifier = consumeDashedIdentRaw(range, shouldLowercase);
-    if (identifier.isNull())
-        return nullptr;
-    return CSSPrimitiveValue::createCustomIdent(WTF::move(identifier));
+    if (range.peek().type() != IdentToken || !range.peek().value().startsWith("--"_s))
+        return { };
+    return CSS::CustomIdent { range.consumeIncludingWhitespace().value().toAtomString() };
+}
+
+RefPtr<CSSValue> consumeDashedIdent(CSSParserTokenRange& range, CSS::PropertyParserState& state)
+{
+    if (auto unresolved = consumeUnresolvedDashedIdent(range, state))
+        return CSSCustomIdentValue::create(WTF::move(*unresolved));
+    return nullptr;
 }
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Ident.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Ident.h
@@ -33,6 +33,12 @@
 #include <wtf/RefPtr.h>
 
 namespace WebCore {
+
+namespace CSS {
+struct CustomIdent;
+struct PropertyParserState;
+}
+
 namespace CSSPropertyParserHelpers {
 
 // MARK: - Ident
@@ -57,15 +63,23 @@ template<typename Map> std::optional<typename Map::ValueType> peekIdentUsingMapp
 // MARK: <custom-ident>
 // https://drafts.csswg.org/css-values/#custom-idents
 
-String consumeCustomIdentRaw(CSSParserTokenRange&, bool shouldLowercase = false);
-RefPtr<CSSPrimitiveValue> consumeCustomIdent(CSSParserTokenRange&, bool shouldLowercase = false);
-RefPtr<CSSPrimitiveValue> consumeCustomIdentExcluding(CSSParserTokenRange&, std::initializer_list<CSSValueID> excluding, bool shouldLowercase = false);
+StringView consumeEagerlyResolvableCustomIdentRaw(CSSParserTokenRange&);
+StringView consumeEagerlyResolvableCustomIdentRawExcluding(CSSParserTokenRange&, std::initializer_list<CSSValueID>);
+
+std::optional<CSS::CustomIdent> consumeUnresolvedCustomIdent(CSSParserTokenRange&, CSS::PropertyParserState&);
+std::optional<CSS::CustomIdent> consumeUnresolvedCustomIdentExcluding(CSSParserTokenRange&, CSS::PropertyParserState&, std::initializer_list<CSSValueID>);
+
+RefPtr<CSSValue> consumeCustomIdent(CSSParserTokenRange&, CSS::PropertyParserState&);
+RefPtr<CSSValue> consumeCustomIdentExcluding(CSSParserTokenRange&, CSS::PropertyParserState&, std::initializer_list<CSSValueID>);
 
 // MARK: <dashed-ident>
 // https://drafts.csswg.org/css-values/#dashed-idents
 
-String consumeDashedIdentRaw(CSSParserTokenRange&, bool shouldLowercase = false);
-RefPtr<CSSPrimitiveValue> consumeDashedIdent(CSSParserTokenRange&, bool shouldLowercase = false);
+StringView consumeEagerlyResolvableDashedIdentRaw(CSSParserTokenRange&);
+
+std::optional<CSS::CustomIdent> consumeUnresolvedDashedIdent(CSSParserTokenRange&, CSS::PropertyParserState&);
+
+RefPtr<CSSValue> consumeDashedIdent(CSSParserTokenRange&, CSS::PropertyParserState&);
 
 // MARK: -
 
@@ -126,13 +140,6 @@ template<typename Map> std::optional<typename Map::ValueType> peekIdentUsingMapp
     if (auto value = map.tryGet(range.peek().id()))
         return std::make_optional(*value);
     return std::nullopt;
-}
-
-inline RefPtr<CSSPrimitiveValue> consumeCustomIdentExcluding(CSSParserTokenRange& range, std::initializer_list<CSSValueID> excluding, bool shouldLowercase)
-{
-    if (std::ranges::find(excluding, range.peek().id()) != excluding.end())
-        return nullptr;
-    return consumeCustomIdent(range, shouldLowercase);
 }
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Lists.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Lists.cpp
@@ -49,7 +49,7 @@ static RefPtr<CSSValue> consumeCounter(CSSParserTokenRange& range, CSS::Property
 
     CSSValueListBuilder list;
     do {
-        auto counterName = consumeCustomIdent(range);
+        auto counterName = consumeCustomIdent(range, state);
         if (!counterName)
             return nullptr;
         if (auto counterValue = CSSPrimitiveValueResolver<CSS::Integer<>>::consumeAndResolve(range, state))

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+PositionTry.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+PositionTry.cpp
@@ -25,6 +25,7 @@
 #include "config.h"
 #include "CSSPropertyParserConsumer+PositionTry.h"
 
+#include "CSSCustomIdentValue.h"
 #include "CSSParserContext.h"
 #include "CSSParserTokenRange.h"
 #include "CSSPropertyParserConsumer+Anchor.h"
@@ -56,7 +57,7 @@ RefPtr<CSSValue> consumePositionTryFallbacks(CSSParserTokenRange& range, CSS::Pr
 
         // Try to parse [<dashed-ident> || <try-tactic>]
         // <try-tactic> = flip-block || flip-inline || flip-start || flip-x || flip-y
-        auto tryRuleIdent = consumeDashedIdentRaw(range);
+        auto tryRuleIdent = consumeUnresolvedDashedIdent(range, state);
 
         Vector<CSSValueID, 5> tryTactics;
         while (auto tactic = consumeIdentRaw<CSSValueFlipBlock, CSSValueFlipInline, CSSValueFlipStart, CSSValueFlipX, CSSValueFlipY>(range)) {
@@ -65,12 +66,12 @@ RefPtr<CSSValue> consumePositionTryFallbacks(CSSParserTokenRange& range, CSS::Pr
             tryTactics.append(*tactic);
         }
 
-        if (tryRuleIdent.isNull())
-            tryRuleIdent = consumeDashedIdentRaw(range);
+        if (!tryRuleIdent)
+            tryRuleIdent = consumeUnresolvedDashedIdent(range, state);
 
         CSSValueListBuilder list;
-        if (!tryRuleIdent.isNull())
-            list.append(CSSPrimitiveValue::createCustomIdent(tryRuleIdent));
+        if (tryRuleIdent)
+            list.append(CSSCustomIdentValue::create(WTF::move(*tryRuleIdent)));
         for (auto tactic : tryTactics)
             list.append(CSSPrimitiveValue::create(tactic));
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Transitions.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Transitions.cpp
@@ -36,18 +36,22 @@
 namespace WebCore {
 namespace CSSPropertyParserHelpers {
 
-static RefPtr<CSSValue> consumeSingleTransitionPropertyIdent(CSSParserTokenRange& range, const CSSParserToken& token)
+static RefPtr<CSSValue> consumeSingleTransitionPropertyIdent(CSSParserTokenRange& range, CSS::PropertyParserState& state, const CSSParserToken& token)
 {
-    if (token.id() == CSSValueAll)
-        return consumeIdent(range);
-    if (auto property = token.parseAsCSSPropertyID()) {
-        range.consumeIncludingWhitespace();
-        return CSSPrimitiveValue::create(property);
+    // <single-transition-property> = all | <custom-ident>
+
+    if (token.type() == IdentToken) {
+        if (token.id() == CSSValueAll)
+            return consumeIdent(range);
+        if (auto property = token.parseAsCSSPropertyID()) {
+            range.consumeIncludingWhitespace();
+            return CSSPrimitiveValue::create(property);
+        }
     }
-    return consumeCustomIdent(range);
+    return consumeCustomIdent(range, state);
 }
 
-RefPtr<CSSValue> consumeSingleTransitionPropertyOrNone(CSSParserTokenRange& range, CSS::PropertyParserState&)
+RefPtr<CSSValue> consumeSingleTransitionPropertyOrNone(CSSParserTokenRange& range, CSS::PropertyParserState& state)
 {
     // This variant of consumeSingleTransitionProperty is used for the slightly different
     // parse rules used for the 'transition' shorthand which allows 'none':
@@ -56,15 +60,12 @@ RefPtr<CSSValue> consumeSingleTransitionPropertyOrNone(CSSParserTokenRange& rang
     // https://drafts.csswg.org/css-transitions/#single-transition-property
 
     auto& token = range.peek();
-    if (token.type() != IdentToken)
-        return nullptr;
     if (token.id() == CSSValueNone)
         return consumeIdent(range);
-
-    return consumeSingleTransitionPropertyIdent(range, token);
+    return consumeSingleTransitionPropertyIdent(range, state, token);
 }
 
-RefPtr<CSSValue> consumeSingleTransitionProperty(CSSParserTokenRange& range, CSS::PropertyParserState&)
+RefPtr<CSSValue> consumeSingleTransitionProperty(CSSParserTokenRange& range, CSS::PropertyParserState& state)
 {
     // "The <custom-ident> production in <single-transition-property> also excludes the keyword
     //  none, in addition to the keywords always excluded from <custom-ident>."
@@ -73,12 +74,9 @@ RefPtr<CSSValue> consumeSingleTransitionProperty(CSSParserTokenRange& range, CSS
     // https://drafts.csswg.org/css-transitions/#single-transition-property
 
     auto& token = range.peek();
-    if (token.type() != IdentToken)
-        return nullptr;
     if (token.id() == CSSValueNone)
         return nullptr;
-
-    return consumeSingleTransitionPropertyIdent(range, token);
+    return consumeSingleTransitionPropertyIdent(range, state, token);
 }
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+ViewTransition.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+ViewTransition.cpp
@@ -26,17 +26,16 @@
 #include "config.h"
 #include "CSSPropertyParserConsumer+ViewTransition.h"
 
+#include "CSSCustomIdentValue.h"
 #include "CSSParserTokenRange.h"
-#include "CSSPrimitiveValue.h"
 #include "CSSPropertyParserConsumer+Ident.h"
 #include "CSSValueKeywords.h"
 #include "CSSValueList.h"
-#include "CSSValuePool.h"
 
 namespace WebCore {
 namespace CSSPropertyParserHelpers {
 
-RefPtr<CSSValue> consumeViewTransitionTypes(CSSParserTokenRange& range, CSS::PropertyParserState&)
+RefPtr<CSSValue> consumeViewTransitionTypes(CSSParserTokenRange& range, CSS::PropertyParserState& state)
 {
     // <'types'> = none | <custom-ident>+
     // https://www.w3.org/TR/css-view-transitions-2/#descdef-view-transition-types
@@ -46,14 +45,12 @@ RefPtr<CSSValue> consumeViewTransitionTypes(CSSParserTokenRange& range, CSS::Pro
 
     CSSValueListBuilder list;
     do {
-        if (range.peek().id() == CSSValueNone)
-            return nullptr;
-        auto type = consumeCustomIdent(range);
+        auto type = consumeUnresolvedCustomIdentExcluding(range, state, { CSSValueNone });
         if (!type)
+             return nullptr;
+        if (type->value.startsWith("-ua-"_s))
             return nullptr;
-        if (type->customIdent().startsWith("-ua-"_s))
-            return nullptr;
-        list.append(type.releaseNonNull());
+        list.append(CSSCustomIdentValue::create(WTF::move(*type)));
     } while (!range.atEnd());
     return CSSValueList::createSpaceSeparated(WTF::move(list));
 }

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+WillChange.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+WillChange.cpp
@@ -74,7 +74,7 @@ RefPtr<CSSValue> consumeWillChange(CSSParserTokenRange& range, CSS::PropertyPars
                 range.consumeIncludingWhitespace();
                 break;
             }
-            if (auto customIdent = consumeCustomIdent(range)) {
+            if (auto customIdent = consumeCustomIdent(range, state)) {
                 // Append properties we don't recognize, but that are legal.
                 values.append(customIdent.releaseNonNull());
                 break;

--- a/Source/WebCore/css/parser/CSSPropertyParserCustom.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserCustom.h
@@ -34,6 +34,7 @@
 #include "CSSBorderImageSliceValue.h"
 #include "CSSBorderImageWidthValue.h"
 #include "CSSBorderRadius.h"
+#include "CSSCustomIdentValue.h"
 #include "CSSFontStyleRangeValue.h"
 #include "CSSFontVariantLigaturesParser.h"
 #include "CSSFontVariantNumericParser.h"
@@ -1376,7 +1377,7 @@ inline bool PropertyParserCustom::consumeGridItemPositionShorthand(CSSParserToke
         if (!endValue)
             return false;
     } else {
-        endValue = isCustomIdentValue(*startValue) ? startValue : CSSPrimitiveValue::create(CSSValueAuto);
+        endValue = is<CSSCustomIdentValue>(*startValue) ? startValue : CSSPrimitiveValue::create(CSSValueAuto);
     }
     if (!range.atEnd())
         return false;
@@ -1413,11 +1414,11 @@ inline bool PropertyParserCustom::consumeGridAreaShorthand(CSSParserTokenRange& 
     if (!range.atEnd())
         return false;
     if (!columnStartValue)
-        columnStartValue = isCustomIdentValue(*rowStartValue) ? rowStartValue : CSSPrimitiveValue::create(CSSValueAuto);
+        columnStartValue = is<CSSCustomIdentValue>(*rowStartValue) ? rowStartValue : CSSPrimitiveValue::create(CSSValueAuto);
     if (!rowEndValue)
-        rowEndValue = isCustomIdentValue(*rowStartValue) ? rowStartValue : CSSPrimitiveValue::create(CSSValueAuto);
+        rowEndValue = is<CSSCustomIdentValue>(*rowStartValue) ? rowStartValue : CSSPrimitiveValue::create(CSSValueAuto);
     if (!columnEndValue)
-        columnEndValue = isCustomIdentValue(*columnStartValue) ? columnStartValue : CSSPrimitiveValue::create(CSSValueAuto);
+        columnEndValue = is<CSSCustomIdentValue>(*columnStartValue) ? columnStartValue : CSSPrimitiveValue::create(CSSValueAuto);
 
     result.addPropertyForCurrentShorthand(state, CSSPropertyGridRowStart, rowStartValue.releaseNonNull());
     result.addPropertyForCurrentShorthand(state, CSSPropertyGridColumnStart, columnStartValue.releaseNonNull());
@@ -1474,10 +1475,11 @@ inline bool PropertyParserCustom::consumeGridTemplateShorthand(CSSParserTokenRan
             if (!previousLineNames)
                 templateRows.append(lineNames.releaseNonNull());
             else {
-                Vector<String> combinedLineNames;
-                combinedLineNames.append(previousLineNames->names());
-                combinedLineNames.append(lineNames->names());
-                templateRows.last() = CSSGridLineNamesValue::create(combinedLineNames);
+                SpaceSeparatedVector<CSS::CustomIdent> combinedLineNames;
+                combinedLineNames.value.reserveInitialCapacity(previousLineNames->names().size() + lineNames->names().size());
+                combinedLineNames.value.appendVector(previousLineNames->names().value);
+                combinedLineNames.value.appendVector(lineNames->names().value);
+                templateRows.last() = CSSGridLineNamesValue::create(WTF::move(combinedLineNames));
             }
         }
 
@@ -2126,7 +2128,7 @@ inline bool PropertyParserCustom::consumeScrollTimelineShorthand(CSSParserTokenR
 
     do {
         // A valid scroll-timeline-name is required.
-        if (RefPtr name = CSSPropertyParsing::consumeSingleScrollTimelineName(range))
+        if (RefPtr name = CSSPropertyParsing::consumeSingleScrollTimelineName(range, state))
             namesList.append(name.releaseNonNull());
         else
             return false;
@@ -2160,7 +2162,7 @@ inline bool PropertyParserCustom::consumeViewTimelineShorthand(CSSParserTokenRan
 
     do {
         // A valid view-timeline-name is required.
-        if (RefPtr name = CSSPropertyParsing::consumeSingleScrollTimelineName(range))
+        if (RefPtr name = CSSPropertyParsing::consumeSingleScrollTimelineName(range, state))
             namesList.append(name.releaseNonNull());
         else
             return false;

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -323,11 +323,11 @@ static std::optional<FixedVector<AtomString>> consumeCommaSeparatedCustomIdentLi
     Vector<AtomString> customIdents { };
 
     do {
-        auto ident = CSSPropertyParserHelpers::consumeCustomIdentRaw(range);
-        if (ident.isEmpty())
+        auto ident = CSSPropertyParserHelpers::consumeEagerlyResolvableCustomIdentRaw(range);
+        if (!ident)
             return std::nullopt;
 
-        customIdents.append(WTF::move(ident));
+        customIdents.append(ident.toAtomString());
     } while (CSSPropertyParserHelpers::consumeCommaIncludingWhitespace(range));
 
     if (!range.atEnd())

--- a/Source/WebCore/css/query/ContainerQueryParser.cpp
+++ b/Source/WebCore/css/query/ContainerQueryParser.cpp
@@ -25,8 +25,7 @@
 #include "config.h"
 #include "ContainerQueryParser.h"
 
-#include "CSSPrimitiveValue.h"
-#include "CSSPropertyParsing.h"
+#include "CSSPropertyParserConsumer+Ident.h"
 #include "ContainerQueryFeatures.h"
 #include "MediaQueryParserContext.h"
 
@@ -43,10 +42,8 @@ std::optional<ContainerQuery> ContainerQueryParser::consumeContainerQuery(CSSPar
     auto consumeName = [&] {
         if (range.peek().type() == LeftParenthesisToken || range.peek().type() == FunctionToken)
             return nullAtom();
-        RefPtr nameValue = CSSPropertyParsing::consumeSingleContainerName(range);
-        if (RefPtr namePrimitive = dynamicDowncast<CSSPrimitiveValue>(nameValue))
-            return AtomString { namePrimitive->stringValue() };
-        return nullAtom();
+
+        return CSSPropertyParserHelpers::consumeEagerlyResolvableCustomIdentRawExcluding(range, { CSSValueNone, CSSValueAnd, CSSValueOr, CSSValueNot }).toAtomString();
     };
 
     auto name = consumeName();

--- a/Source/WebCore/css/scripts/process-css-properties.py
+++ b/Source/WebCore/css/scripts/process-css-properties.py
@@ -9419,8 +9419,8 @@ class TermGeneratorReferenceTerm(TermGenerator):
                 return f"consumeImage({range_string}, {state_string}, {{ }})"
             elif isinstance(builtin, BuiltinCustomIdentConsumer):
                 if builtin.excluding:
-                    return f"consumeCustomIdentExcluding({range_string}, {{ { ', '.join(ValueKeywordName(id).id for id in builtin.excluding)} }})"
-                return f"consumeCustomIdent({range_string})"
+                    return f"consumeCustomIdentExcluding({range_string}, {state_string}, {{ { ', '.join(ValueKeywordName(id).id for id in builtin.excluding)} }})"
+                return f"consumeCustomIdent({range_string}, {state_string})"
             elif isinstance(builtin, BuiltinURLConsumer):
                 if builtin.allowed_modifiers:
                     return f"consumeURL({range_string}, {state_string}, {{ {builtin.allowed_modifiers} }})"
@@ -9477,9 +9477,9 @@ class TermGeneratorReferenceTerm(TermGenerator):
             elif isinstance(builtin, BuiltinStringConsumer):
                 return False
             elif isinstance(builtin, BuiltinCustomIdentConsumer):
-                return False
+                return True
             elif isinstance(builtin, BuiltinDashedIdentConsumer):
-                return False
+                return True
             elif isinstance(builtin, BuiltinURLConsumer):
                 return True
             elif isinstance(builtin, BuiltinFeatureTagValueConsumer):

--- a/Source/WebCore/css/typedom/CSSKeywordValue.cpp
+++ b/Source/WebCore/css/typedom/CSSKeywordValue.cpp
@@ -30,6 +30,7 @@
 #include "config.h"
 #include "CSSKeywordValue.h"
 
+#include "CSSCustomIdentValue.h"
 #include "CSSMarkup.h"
 #include "CSSPrimitiveValue.h"
 #include "CSSPropertyParser.h"
@@ -81,7 +82,7 @@ RefPtr<CSSValue> CSSKeywordValue::toCSSValue() const
 {
     auto keyword = cssValueKeywordID(m_value);
     if (keyword == CSSValueInvalid)
-        return CSSPrimitiveValue::createCustomIdent(m_value);
+        return CSSCustomIdentValue::create(CSS::CustomIdent { AtomString { m_value } });
     return CSSPrimitiveValue::create(keyword);
 }
 

--- a/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
+++ b/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
@@ -289,6 +289,8 @@ ExceptionOr<Ref<CSSStyleValue>> CSSStyleValueFactory::reifyValue(Document& docum
         default:
             break;
         }
+    } else if (auto* customIdentValue = dynamicDowncast<CSSCustomIdentValue>(cssValue)) {
+        return upcast<CSSStyleValue>(CSSKeywordValue::rectifyKeywordish(customIdentValue->cssText(CSS::defaultSerializationContext())));
     } else if (auto* imageValue = dynamicDowncast<CSSImageValue>(cssValue))
         return Ref<CSSStyleValue> { CSSStyleImageValue::create(const_cast<CSSImageValue&>(*imageValue), document) };
     else if (auto* referenceValue = dynamicDowncast<CSSSubstitutionValue>(cssValue)) {

--- a/Source/WebCore/css/values/CSSValueAggregates.cpp
+++ b/Source/WebCore/css/values/CSSValueAggregates.cpp
@@ -29,18 +29,6 @@
 
 namespace WebCore {
 
-// MARK: - CustomIdentifier
-
-WTF::TextStream& operator<<(WTF::TextStream& ts, const CustomIdentifier& value)
-{
-    return ts << value.value;
-}
-
-void add(Hasher& hasher, const CustomIdentifier& value)
-{
-    add(hasher, value.value);
-}
-
 // MARK: - PropertyIdentifier
 
 WTF::TextStream& operator<<(WTF::TextStream& ts, const PropertyIdentifier& value)

--- a/Source/WebCore/css/values/CSSValueAggregates.h
+++ b/Source/WebCore/css/values/CSSValueAggregates.h
@@ -195,17 +195,6 @@ template<typename... Ts> inline constexpr auto TreatAsVariantLike<Variant<Ts...>
 
 // MARK: - Standard Leaf Types
 
-// Helper type used to represent an arbitrary constant identifier.
-struct CustomIdentifier {
-    AtomString value;
-
-    bool operator==(const CustomIdentifier&) const = default;
-    bool operator==(const AtomString& other) const { return value == other; }
-};
-TextStream& operator<<(TextStream&, const CustomIdentifier&);
-
-void NODELETE add(Hasher&, const CustomIdentifier&);
-
 // Helper type used to represent an arbitrary property identifier.
 struct PropertyIdentifier {
     CSSPropertyID value;
@@ -2098,11 +2087,5 @@ struct supports_text_stream_insertion<WebCore::MinimallySerializingSpaceSeparate
 
 template<typename T>
 struct supports_text_stream_insertion<WebCore::MinimallySerializingSpaceSeparatedRectCorners<T>> : supports_text_stream_insertion<T> { };
-
-template<>
-struct MarkableTraits<WebCore::CustomIdentifier> {
-    static bool isEmptyValue(const WebCore::CustomIdentifier& value) { return value.value.isNull(); }
-    static WebCore::CustomIdentifier emptyValue() { return WebCore::CustomIdentifier { nullAtom() }; }
-};
 
 } // namespace WTF

--- a/Source/WebCore/css/values/CSSValueTypes.cpp
+++ b/Source/WebCore/css/values/CSSValueTypes.cpp
@@ -36,11 +36,6 @@
 namespace WebCore {
 namespace CSS {
 
-void serializationForCSSCustomIdentifier(StringBuilder& builder, const SerializationContext&, const CustomIdentifier& value)
-{
-    WebCore::serializeIdentifier(builder, value.value);
-}
-
 void serializationForCSSPropertyIdentifier(StringBuilder& builder, const SerializationContext&, const PropertyIdentifier& value)
 {
     builder.append(nameLiteral(value.value));
@@ -59,11 +54,6 @@ void serializationForCSSString(StringBuilder& builder, const SerializationContex
 Ref<CSSValue> makePrimitiveCSSValue(CSSValueID value)
 {
     return CSSPrimitiveValue::create(value);
-}
-
-Ref<CSSValue> makePrimitiveCSSValue(const CustomIdentifier& value)
-{
-    return CSSPrimitiveValue::createCustomIdent(value.value);
 }
 
 Ref<CSSValue> makePrimitiveCSSValue(const PropertyIdentifier& value)

--- a/Source/WebCore/css/values/CSSValueTypes.h
+++ b/Source/WebCore/css/values/CSSValueTypes.h
@@ -63,7 +63,6 @@ struct SerializeInvoker {
 };
 inline constexpr SerializeInvoker serializationForCSS{};
 
-void serializationForCSSCustomIdentifier(StringBuilder&, const SerializationContext&, const CustomIdentifier&);
 void serializationForCSSPropertyIdentifier(StringBuilder&, const SerializationContext&, const PropertyIdentifier&);
 void serializationForCSSString(StringBuilder&, const SerializationContext&, const WTF::AtomString&);
 void serializationForCSSString(StringBuilder&, const SerializationContext&, const WTF::String&);
@@ -180,14 +179,6 @@ template<CSSValueID C> struct Serialize<Constant<C>> {
     template<typename... Rest> void operator()(StringBuilder& builder, const SerializationContext&, const Constant<C>& value, Rest&&...)
     {
         builder.append(nameLiteralForSerialization(value.value));
-    }
-};
-
-// Specialization for `CustomIdentifier`.
-template<> struct Serialize<CustomIdentifier> {
-    template<typename... Rest> void operator()(StringBuilder& builder, const SerializationContext& context, const CustomIdentifier& value, Rest&&...)
-    {
-        serializationForCSSCustomIdentifier(builder, context, value);
     }
 };
 
@@ -318,14 +309,6 @@ template<VariantLike CSSType> struct ComputedStyleDependenciesCollector<CSSType>
 // Specialization for `Constant`.
 template<CSSValueID C> struct ComputedStyleDependenciesCollector<Constant<C>> {
     constexpr void operator()(ComputedStyleDependencies&, const Constant<C>&)
-    {
-        // Nothing to do.
-    }
-};
-
-// Specialization for `CustomIdentifier`.
-template<> struct ComputedStyleDependenciesCollector<CustomIdentifier> {
-    constexpr void operator()(ComputedStyleDependencies&, const CustomIdentifier&)
     {
         // Nothing to do.
     }
@@ -464,14 +447,6 @@ template<CSSValueID C> struct CSSValueChildrenVisitor<Constant<C>> {
     }
 };
 
-// Specialization for `CustomIdentifier`.
-template<> struct CSSValueChildrenVisitor<CustomIdentifier> {
-    constexpr IterationStatus operator()(NOESCAPE const Function<IterationStatus(CSSValue&)>&, const CustomIdentifier&)
-    {
-        return IterationStatus::Continue;
-    }
-};
-
 // Specialization for `PropertyIdentifier`.
 template<> struct CSSValueChildrenVisitor<PropertyIdentifier> {
     constexpr IterationStatus operator()(NOESCAPE const Function<IterationStatus(CSSValue&)>&, const PropertyIdentifier&)
@@ -517,7 +492,6 @@ struct CSSValueCreationInvoker {
 inline constexpr CSSValueCreationInvoker createCSSValue{};
 
 Ref<CSSValue> NODELETE makePrimitiveCSSValue(CSSValueID);
-Ref<CSSValue> makePrimitiveCSSValue(const CustomIdentifier&);
 Ref<CSSValue> makePrimitiveCSSValue(const PropertyIdentifier&);
 Ref<CSSValue> makePrimitiveCSSValue(const WTF::AtomString&);
 Ref<CSSValue> makePrimitiveCSSValue(const WTF::String&);
@@ -589,14 +563,6 @@ template<CSSValueID Id> struct CSSValueCreation<Constant<Id>> {
     template<typename... Rest> Ref<CSSValue> operator()(CSSValuePool&, const Constant<Id>&, Rest&&...)
     {
         return makePrimitiveCSSValue(Id);
-    }
-};
-
-// Specialization for `CustomIdentifier`.
-template<> struct CSSValueCreation<CustomIdentifier> {
-    template<typename... Rest> Ref<CSSValue> operator()(CSSValuePool&, const CustomIdentifier& customIdentifier, Rest&&...)
-    {
-        return makePrimitiveCSSValue(customIdentifier);
     }
 };
 

--- a/Source/WebCore/css/values/color-adjust/CSSColorScheme.h
+++ b/Source/WebCore/css/values/color-adjust/CSSColorScheme.h
@@ -26,9 +26,9 @@
 
 #pragma once
 
+#include <WebCore/CSSCustomIdent.h>
 #include <WebCore/CSSValueTypes.h>
 #include <wtf/Vector.h>
-#include <wtf/text/AtomString.h>
 
 #if ENABLE(DARK_MODE_CSS)
 
@@ -38,7 +38,7 @@ namespace CSS {
 // <'color-scheme'> = normal | [ light | dark | <custom-ident> ]+ && only?
 // https://drafts.csswg.org/css-color-adjust/#propdef-color-scheme
 struct ColorScheme {
-    SpaceSeparatedVector<CustomIdentifier> schemes;
+    SpaceSeparatedVector<CustomIdent> schemes;
     std::optional<Keyword::Only> only;
 
     // As an optimization, if `schemes` is empty, that indicates the

--- a/Source/WebCore/css/values/counter-styles/CSSCounterStyle.h
+++ b/Source/WebCore/css/values/counter-styles/CSSCounterStyle.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/CSSCustomIdent.h>
+#include <WebCore/CSSValueTypes.h>
+
+namespace WebCore {
+namespace CSS {
+
+// <counter-style> = <custom-ident excluding=none>
+// https://drafts.csswg.org/css-counter-styles-3/#typedef-counter-style
+struct CounterStyle {
+    // Stores predefined style types using their CSSValueID representation.
+    Variant<CSSValueID, CustomIdent> identifier;
+
+    bool operator==(const CounterStyle&) const = default;
+};
+DEFINE_TYPE_WRAPPER_GET(CounterStyle, identifier);
+
+} // namespace CSS
+} // namespace WebCore
+
+DEFINE_TUPLE_LIKE_CONFORMANCE_FOR_TYPE_WRAPPER(WebCore::CSS::CounterStyle)

--- a/Source/WebCore/css/values/grid/CSSGridNamedAreaMap.h
+++ b/Source/WebCore/css/values/grid/CSSGridNamedAreaMap.h
@@ -27,14 +27,16 @@
 #include <WebCore/CSSValueTypes.h>
 #include <WebCore/GridArea.h>
 #include <wtf/HashMap.h>
-#include <wtf/text/WTFString.h>
+#include <wtf/text/AtomStringHash.h>
 
 namespace WebCore {
 namespace CSS {
 
+struct CustomIdent;
+
 // Parsed representation of the `<string>+` of <'grid-template-areas'>.
 struct GridNamedAreaMap {
-    using Map = HashMap<String, GridArea>;
+    using Map = HashMap<AtomString, GridArea>;
 
     Map map;
     size_t rowCount { 0 };
@@ -44,7 +46,7 @@ struct GridNamedAreaMap {
 };
 
 // A single `<string>` of <'grid-template-areas'>.
-using GridNamedAreaMapRow = Vector<String, 8>;
+using GridNamedAreaMapRow = Vector<AtomString, 8>;
 
 // Adds a row to a `GridNamedAreaMap`. Returns `true` on success, `false` on failure.
 bool addRow(GridNamedAreaMap&, const GridNamedAreaMapRow&);

--- a/Source/WebCore/css/values/primitives/CSSCustomIdent.cpp
+++ b/Source/WebCore/css/values/primitives/CSSCustomIdent.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2026 saku
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSCustomIdent.h"
+
+#include "CSSCustomIdentValue.h"
+#include "CSSMarkup.h"
+#include <wtf/Hasher.h>
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+namespace CSS {
+
+void Serialize<CustomIdent>::operator()(StringBuilder& builder, const SerializationContext&, const CustomIdent& value)
+{
+    WebCore::serializeIdentifier(builder, value.value);
+}
+
+Ref<CSSValue> CSSValueCreation<CustomIdent>::operator()(CSSValuePool&, const CustomIdent& value)
+{
+    return CSSCustomIdentValue::create(value);
+}
+
+// MARK: - Logging
+
+WTF::TextStream& operator<<(WTF::TextStream& ts, const CustomIdent& value)
+{
+    return ts << value.value;
+}
+
+// MARK: - Hashing
+
+void add(Hasher& hasher, const CustomIdent& value)
+{
+    add(hasher, value.value);
+}
+
+} // namespace CSS
+} // namespace WebCore

--- a/Source/WebCore/css/values/primitives/CSSCustomIdent.h
+++ b/Source/WebCore/css/values/primitives/CSSCustomIdent.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2026 saku
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/CSSValueTypes.h>
+#include <wtf/text/AtomString.h>
+
+namespace WebCore {
+namespace CSS {
+
+// https://drafts.csswg.org/css-values-4/#identifier-value
+struct CustomIdent {
+    AtomString value;
+
+    std::optional<AtomString> tryResolved() const
+    {
+        // FIXME: When ident() function is added, only successfully resolve when there are no <integer> components.
+        return value;
+    }
+
+    bool operator==(const CustomIdent&) const = default;
+};
+
+template<> struct Serialize<CustomIdent> { void operator()(StringBuilder&, const SerializationContext&, const CustomIdent&); };
+template<> struct ComputedStyleDependenciesCollector<CustomIdent> { constexpr void operator()(ComputedStyleDependencies&, const CustomIdent&) { } };
+template<> struct CSSValueChildrenVisitor<CustomIdent> { constexpr IterationStatus operator()(NOESCAPE const Function<IterationStatus(CSSValue&)>&, const CustomIdent&) { return IterationStatus::Continue; } };
+template<> struct CSSValueCreation<CustomIdent> { Ref<CSSValue> operator()(CSSValuePool&, const CustomIdent&); };
+
+// MARK: - Logging
+
+WTF::TextStream& operator<<(WTF::TextStream&, const CustomIdent&);
+
+// MARK: - Hashing
+
+void NODELETE add(Hasher&, const CustomIdent&);
+
+} // namespace CSS
+} // namespace WebCore

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumeric.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumeric.h
@@ -143,8 +143,12 @@ template<NumericRaw RawType> struct PrimitiveNumeric {
         return visitor(asRaw());
     }
 
-    bool isKnownZero() const { return isRaw() && m_data.payload.number == 0; }
-    bool isKnownNotZero() const { return isRaw() && m_data.payload.number != 0; }
+    bool isKnownZero() const requires (range.min <= 0 && range.max >= 0) { return isRaw() && m_data.payload.number == 0; }
+    bool isKnownNotZero() const requires (range.min <= 0 && range.max >= 0) { return isRaw() && m_data.payload.number != 0; }
+    bool isKnownPositive() const requires (range.max > 0) { return isRaw() && m_data.payload.number > 0; }
+    bool isKnownPositiveOrZero() const requires (range.max >= 0) { return isRaw() && m_data.payload.number >= 0; }
+    bool isKnownNegative() const requires (range.min < 0) { return isRaw() && m_data.payload.number < 0; }
+    bool isKnownNegativeOrZero() const requires (range.min <= 0) { return isRaw() && m_data.payload.number <= 0; }
 
     bool isRaw() const { return m_data.isRaw(); }
     bool isCalc() const { return m_data.isCalc(); }

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h
@@ -188,6 +188,12 @@ template<Range range, std::signed_integral T, typename U> constexpr T clampToRan
     }
 }
 
+// Clamps a value to within `range` of the specified numeric type.
+template<typename Numeric, Range range = Numeric::range, typename T = typename Numeric::ResolvedValueType, typename U> constexpr T clampToRangeOf(U value)
+{
+    return clampToRange<range, T, U>(value);
+}
+
 // Checks if a floating point value is within `range`.
 template<Range range, std::floating_point T> constexpr bool isWithinRange(T value)
 {

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "ViewTransition.h"
 
+#include "CSSCustomIdentValue.h"
 #include "CSSFunctionValue.h"
 #include "CSSKeyframeRule.h"
 #include "CSSKeyframesRule.h"
@@ -383,12 +384,12 @@ static AtomString effectiveViewTransitionName(RenderLayerModelObject& renderer, 
             Ref element = *renderer.element();
             return makeAtomString("-ua-auto-"_s, String::number(element->nodeIdentifier().toRawValue()));
         },
-        [&](const CustomIdentifier& customIdentifier) {
+        [&](const Style::CustomIdent& customIdent) {
             SUPPRESS_UNCHECKED_LOCAL auto scope = computeScope();
             if (!scope)
                 return nullAtom();
 
-            return customIdentifier.value;
+            return customIdent.value;
         }
     );
 }
@@ -669,9 +670,9 @@ void ViewTransition::setupDynamicStyleSheet(const AtomString& name, const Captur
     // image animation name rule
     if (capturedElement.oldImage) {
         CSSValueListBuilder list;
-        list.append(CSSPrimitiveValue::createCustomIdent("-ua-view-transition-fade-out"_s));
+        list.append(CSSCustomIdentValue::create(CSS::CustomIdent { "-ua-view-transition-fade-out"_s }));
         if (capturedElement.newElement)
-            list.append(CSSPrimitiveValue::createCustomIdent("-ua-mix-blend-mode-plus-lighter"_s));
+            list.append(CSSCustomIdentValue::create(CSS::CustomIdent { "-ua-mix-blend-mode-plus-lighter"_s }));
         Ref valueList = CSSValueList::createCommaSeparated(WTF::move(list));
         Ref props = MutableStyleProperties::create();
         props->setProperty(CSSPropertyAnimationName, WTF::move(valueList));
@@ -681,9 +682,9 @@ void ViewTransition::setupDynamicStyleSheet(const AtomString& name, const Captur
 
     if (capturedElement.newElement) {
         CSSValueListBuilder list;
-        list.append(CSSPrimitiveValue::createCustomIdent("-ua-view-transition-fade-in"_s));
+        list.append(CSSCustomIdentValue::create(CSS::CustomIdent { "-ua-view-transition-fade-in"_s }));
         if (capturedElement.oldImage)
-            list.append(CSSPrimitiveValue::createCustomIdent("-ua-mix-blend-mode-plus-lighter"_s));
+            list.append(CSSCustomIdentValue::create(CSS::CustomIdent { "-ua-mix-blend-mode-plus-lighter"_s }));
         Ref valueList = CSSValueList::createCommaSeparated(WTF::move(list));
         Ref props = MutableStyleProperties::create();
         props->setProperty(CSSPropertyAnimationName, WTF::move(valueList));
@@ -696,7 +697,7 @@ void ViewTransition::setupDynamicStyleSheet(const AtomString& name, const Captur
 
     // group animation name rule
     {
-        Ref list = CSSValueList::createCommaSeparated(CSSPrimitiveValue::createCustomIdent(makeString("-ua-view-transition-group-anim-"_s, name)));
+        Ref list = CSSValueList::createCommaSeparated(CSSCustomIdentValue::create(CSS::CustomIdent { makeAtomString("-ua-view-transition-group-anim-"_s, name) }));
         Ref props = MutableStyleProperties::create();
         props->setProperty(CSSPropertyAnimationName, WTF::move(list));
 

--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -1485,7 +1485,7 @@ static Style::GridOrderedNamedLinesMap gridLineNames(const RenderStyle* renderSt
         return { };
     
     Style::GridOrderedNamedLinesMap combinedGridLineNames;
-    auto appendLineNames = [&](unsigned index, const Vector<String>& newNames) {
+    auto appendLineNames = [&](unsigned index, const Vector<Style::CustomIdent>& newNames) {
         if (auto result = combinedGridLineNames.map.add(index, newNames); !result.isNewEntry)
             result.iterator->value.appendVector(newNames);
     };
@@ -1728,7 +1728,7 @@ std::optional<InspectorOverlay::Highlight::GridHighlightOverlay> InspectorOverla
             for (auto lineName : columnLineNames.map.get(i)) {
                 if (!lineLabel.isEmpty())
                     lineLabel.append(thinSpace, bullet, thinSpace);
-                lineLabel.append(lineName);
+                lineLabel.append(lineName.value);
             }
         }
 
@@ -1816,7 +1816,7 @@ std::optional<InspectorOverlay::Highlight::GridHighlightOverlay> InspectorOverla
             for (auto lineName : rowLineNames.map.get(i)) {
                 if (!lineLabel.isEmpty())
                     lineLabel.append(thinSpace, bullet, thinSpace);
-                lineLabel.append(lineName);
+                lineLabel.append(lineName.value);
             }
         }
 

--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
@@ -137,7 +137,7 @@ static Style::RepeatTrackList repeatTrackListWithPercentagesConvertedToAuto(cons
             [](const Style::GridTrackSize& trackSize) -> Style::RepeatEntry {
                 return trackSizeWithPercentagesConvertedToAuto(trackSize);
             },
-            [](const Vector<String>& lineNames) -> Style::RepeatEntry {
+            [](const Vector<Style::CustomIdent>& lineNames) -> Style::RepeatEntry {
                 return lineNames;
             });
     });
@@ -150,7 +150,7 @@ static Style::GridTemplateList gridTemplateListWithPercentagesConvertedToAuto(co
             [](const Style::GridTrackSize& trackSize) -> Style::GridTrackEntry {
                 return trackSizeWithPercentagesConvertedToAuto(trackSize);
             },
-            [](const Vector<String>& lineNames) -> Style::GridTrackEntry {
+            [](const Vector<Style::CustomIdent>& lineNames) -> Style::GridTrackEntry {
                 return lineNames;
             },
             [](const Style::GridTrackEntryRepeat& repeat) -> Style::GridTrackEntry {

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
@@ -122,7 +122,7 @@ static bool hasValidColumnEnd(const Style::GridPositionExplicit& explicitColumnS
         [&](const Style::GridPositionSpan&) {
             return false;
         },
-        [&](const CustomIdentifier&) {
+        [&](const Style::CustomIdent&) {
             return false;
         }
     );
@@ -142,7 +142,7 @@ static bool hasValidColumnEnd(const CSS::Keyword::Auto& autoColumnStart, const S
         [](const Style::GridPositionSpan&) {
             return false;
         },
-        [](const CustomIdentifier&) {
+        [](const Style::CustomIdent&) {
             return false;
         }
     );
@@ -172,7 +172,7 @@ static bool hasValidRowEnd(const Style::GridPositionExplicit& explicitRowStart, 
         [&](const Style::GridPositionSpan&) {
             return false;
         },
-        [&](const CustomIdentifier&) {
+        [&](const Style::CustomIdent&) {
             return false;
         }
     );
@@ -286,7 +286,7 @@ static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& 
                     return GridAvoidanceReason::GridHasUnsupportedGridTemplateColumns;
                 return { };
             },
-            [&](const Vector<String>& names) -> std::optional<GridAvoidanceReason> {
+            [&](const Vector<Style::CustomIdent>& names) -> std::optional<GridAvoidanceReason> {
                 if (!names.isEmpty())
                     return GridAvoidanceReason::GridHasUnsupportedGridTemplateColumns;
                 return std::nullopt;
@@ -321,7 +321,7 @@ static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& 
                     return GridAvoidanceReason::GridHasUnsupportedGridTemplateRows;
                 return { };
             },
-            [&](const Vector<String>& names) -> std::optional<GridAvoidanceReason> {
+            [&](const Vector<Style::CustomIdent>& names) -> std::optional<GridAvoidanceReason> {
                 if (!names.isEmpty())
                     return GridAvoidanceReason::GridHasUnsupportedGridTemplateRows;
                 return std::nullopt;
@@ -442,7 +442,7 @@ static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& 
             [&](const Style::GridPositionSpan&) -> std::optional<GridAvoidanceReason> {
                 return GridAvoidanceReason::GridItemHasUnsupportedColumnPlacement;
             },
-            [&](const CustomIdentifier&) -> std::optional<GridAvoidanceReason> {
+            [&](const Style::CustomIdent&) -> std::optional<GridAvoidanceReason> {
                 return GridAvoidanceReason::GridItemHasUnsupportedColumnPlacement;
             }
         );
@@ -477,7 +477,7 @@ static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& 
             [&](const Style::GridPositionSpan&) -> std::optional<GridAvoidanceReason> {
                 return GridAvoidanceReason::GridItemHasUnsupportedRowPlacement;
             },
-            [&](const CustomIdentifier&) -> std::optional<GridAvoidanceReason> {
+            [&](const Style::CustomIdent&) -> std::optional<GridAvoidanceReason> {
                 return GridAvoidanceReason::GridItemHasUnsupportedRowPlacement;
             }
         );

--- a/Source/WebCore/rendering/RenderCounter.cpp
+++ b/Source/WebCore/rendering/RenderCounter.cpp
@@ -473,7 +473,7 @@ void RenderCounter::updateCounter()
                 break;
             container = container->parent();
         }
-        makeCounterNode(*container, m_counter.identifier, true)->addRenderer(const_cast<RenderCounter&>(*this));
+        makeCounterNode(*container, m_counter.identifier.value, true)->addRenderer(const_cast<RenderCounter&>(*this));
     }
 
     setText(originalText(), true);
@@ -563,7 +563,7 @@ void RenderCounter::rendererStyleChangedSlowCase(RenderElement& renderer, const 
     }
 }
 
-Ref<CSSCounterStyle> RenderCounter::counterStyle() const
+Ref<CSSRegisteredCounterStyle> RenderCounter::counterStyle() const
 {
     return document().counterStyleRegistry().resolvedCounterStyle(m_counter.style);
 }

--- a/Source/WebCore/rendering/RenderCounter.h
+++ b/Source/WebCore/rendering/RenderCounter.h
@@ -27,7 +27,7 @@
 
 namespace WebCore {
 
-class CSSCounterStyle;
+class CSSRegisteredCounterStyle;
 class CounterNode;
 
 class RenderCounter final : public RenderText {
@@ -51,7 +51,7 @@ private:
     ASCIILiteral renderName() const override;
     String originalText() const override;
 
-    Ref<CSSCounterStyle> counterStyle() const;
+    Ref<CSSRegisteredCounterStyle> counterStyle() const;
 
     Style::Content::Counter m_counter;
     SingleThreadWeakPtr<CounterNode> m_counterNode;

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -579,7 +579,7 @@ LayoutRect RenderListMarker::selectionRectForRepaint(const RenderLayerModelObjec
     return { };
 }
 
-RefPtr<CSSCounterStyle> RenderListMarker::counterStyle() const
+RefPtr<CSSRegisteredCounterStyle> RenderListMarker::counterStyle() const
 {
     auto counterStyle = style().listStyleType().tryCounterStyle();
     if (!counterStyle)

--- a/Source/WebCore/rendering/RenderListMarker.h
+++ b/Source/WebCore/rendering/RenderListMarker.h
@@ -26,7 +26,7 @@
 
 namespace WebCore {
 
-class CSSCounterStyle;
+class CSSRegisteredCounterStyle;
 class RenderListItem;
 class StyleRuleCounterStyle;
 
@@ -101,7 +101,7 @@ private:
     LayoutRect NODELETE localSelectionRect();
     void paintDisclosureMarker(GraphicsContext&, const FloatRect& markerRect);
 
-    RefPtr<CSSCounterStyle> counterStyle() const;
+    RefPtr<CSSRegisteredCounterStyle> counterStyle() const;
     bool widthUsesMetricsOfPrimaryFont() const;
 
 private:

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -1104,7 +1104,7 @@ static CheckedPtr<const Element> anchorScopeForAnchorName(const RenderBoxModelOb
             continue;
 
         if (Style::NameScope::Type::All == currentAncestorAnchorScope.type
-            || currentAncestorAnchorScope.names.contains(CustomIdentifier { anchorName.name() }))
+            || currentAncestorAnchorScope.names.contains(CustomIdent { anchorName.name() }))
             return currentAncestor;
     }
 

--- a/Source/WebCore/style/ScopedName.cpp
+++ b/Source/WebCore/style/ScopedName.cpp
@@ -26,7 +26,6 @@
 #include "config.h"
 #include "ScopedName.h"
 
-#include "CSSPrimitiveValue.h"
 #include "StyleBuilderChecking.h"
 #include <wtf/text/TextStream.h>
 
@@ -35,33 +34,25 @@ namespace Style {
 
 // MARK: - Conversion
 
-auto CSSValueConversion<ScopedName>::operator()(BuilderState& state, const CSSPrimitiveValue& primitiveValue) -> ScopedName
-{
-    if (!primitiveValue.isCustomIdent()) {
-        state.setCurrentPropertyInvalidAtComputedValueTime();
-        return { };
-    }
-
-    return {
-        .name = AtomString { primitiveValue.customIdent() },
-        .scopeOrdinal = state.styleScopeOrdinal()
-    };
-}
-
 auto CSSValueConversion<ScopedName>::operator()(BuilderState& state, const CSSValue& value) -> ScopedName
 {
-    RefPtr primitiveValue = requiredDowncast<CSSPrimitiveValue>(state, value);
-    if (!primitiveValue)
-        return { };
+    if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
+        if (primitiveValue->isString()) {
+            return ScopedName {
+                .name = AtomString { primitiveValue->string() },
+                .scopeOrdinal = state.styleScopeOrdinal(),
+                .isIdentifier = false,
+            };
+        }
 
-    if (!primitiveValue->isCustomIdent()) {
         state.setCurrentPropertyInvalidAtComputedValueTime();
-        return { };
+        return ScopedName { nullAtom() };
     }
 
     return ScopedName {
-        .name = AtomString { primitiveValue->customIdent() },
-        .scopeOrdinal = state.styleScopeOrdinal()
+        .name = toStyleFromCSSValue<CustomIdent>(state, value).value,
+        .scopeOrdinal = state.styleScopeOrdinal(),
+        .isIdentifier = true,
     };
 }
 

--- a/Source/WebCore/style/ScopedName.h
+++ b/Source/WebCore/style/ScopedName.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <WebCore/StyleCustomIdent.h>
 #include <WebCore/StyleScopeOrdinal.h>
 #include <WebCore/StyleValueTypes.h>
 #include <wtf/text/AtomString.h>
@@ -40,7 +41,7 @@ struct ScopedName {
     {
         auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
         if (isIdentifier)
-            return visitor(CustomIdentifier { name });
+            return visitor(CustomIdent { name });
         return visitor(name);
     }
 
@@ -50,7 +51,6 @@ struct ScopedName {
 // MARK: - Conversion
 
 template<> struct CSSValueConversion<ScopedName> {
-    ScopedName operator()(BuilderState&, const CSSPrimitiveValue&);
     ScopedName operator()(BuilderState&, const CSSValue&);
 };
 

--- a/Source/WebCore/style/StyleBuilderChecking.h
+++ b/Source/WebCore/style/StyleBuilderChecking.h
@@ -37,8 +37,8 @@ namespace Style {
 template<typename ValueType>
 const ValueType* requiredDowncast(BuilderState&, const CSSValue&);
 
-template<typename ValueType>
-std::optional<std::pair<Ref<const ValueType>, Ref<const ValueType>>> requiredPairDowncast(BuilderState&, const CSSValue&);
+template<typename ValueType1, typename ValueType2 = ValueType1>
+std::optional<std::pair<Ref<const ValueType1>, Ref<const ValueType2>>> requiredPairDowncast(BuilderState&, const CSSValue&);
 
 template<typename ValueType> struct TypedRequiredListIterator {
     using iterator_category = std::forward_iterator_tag;
@@ -90,16 +90,16 @@ inline const ValueType* requiredDowncast(BuilderState& builderState, const CSSVa
     return typedValue;
 }
 
-template<typename ValueType>
-inline std::optional<std::pair<Ref<const ValueType>, Ref<const ValueType>>> requiredPairDowncast(BuilderState& builderState, const CSSValue& value)
+template<typename ValueType1, typename ValueType2>
+inline std::optional<std::pair<Ref<const ValueType1>, Ref<const ValueType2>>> requiredPairDowncast(BuilderState& builderState, const CSSValue& value)
 {
     RefPtr pairValue = requiredDowncast<CSSValuePair>(builderState, value);
     if (!pairValue) [[unlikely]]
         return { };
-    RefPtr firstValue = requiredDowncast<ValueType>(builderState, pairValue->first());
+    RefPtr firstValue = requiredDowncast<ValueType1>(builderState, pairValue->first());
     if (!firstValue) [[unlikely]]
         return { };
-    RefPtr secondValue = requiredDowncast<ValueType>(builderState, pairValue->second());
+    RefPtr secondValue = requiredDowncast<ValueType2>(builderState, pairValue->second());
     if (!secondValue) [[unlikely]]
         return { };
     return { { firstValue.releaseNonNull(), secondValue.releaseNonNull() } };

--- a/Source/WebCore/style/StyleCustomProperty.h
+++ b/Source/WebCore/style/StyleCustomProperty.h
@@ -28,6 +28,7 @@
 #include <WebCore/CSSValueAggregates.h>
 #include <WebCore/CSSVariableData.h>
 #include <WebCore/StyleColor.h>
+#include <WebCore/StyleCustomIdent.h>
 #include <WebCore/StyleImageWrapper.h>
 #include <WebCore/StylePrimitiveNumeric.h>
 #include <WebCore/StyleTransformFunction.h>
@@ -63,7 +64,7 @@ public:
         ImageWrapper,
         Color,
         URL,
-        CustomIdentifier,
+        CustomIdent,
         String,
         TransformFunction
     >;

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -1370,14 +1370,14 @@ template<CSSPropertyID propertyID, typename List, typename Mapper> void extractC
 
 template<GridTrackSizingDirection direction> Ref<CSSValue> extractGridTemplateValue(ExtractorState& state)
 {
-    auto addValuesForNamedGridLinesAtIndex = [](auto& list, auto& collector, auto i, auto renderEmpty) {
+    auto addValuesForNamedGridLinesAtIndex = [&](auto& list, auto& collector, auto i, auto renderEmpty) {
         if (collector.isEmpty() && !renderEmpty)
             return;
 
-        Vector<String> lineNames;
-        collector.collectLineNamesForIndex(lineNames, i);
+        SpaceSeparatedVector<Style::CustomIdent> lineNames;
+        collector.collectLineNamesForIndex(lineNames.value, i);
         if (!lineNames.isEmpty() || renderEmpty)
-            list.append(CSSGridLineNamesValue::create(lineNames));
+            list.append(CSSGridLineNamesValue::create(toCSS(lineNames, state.style)));
     };
 
     auto& tracks = state.style.gridTemplateList(direction);
@@ -1441,11 +1441,13 @@ template<GridTrackSizingDirection direction> Ref<CSSValue> extractGridTemplateVa
     auto& computedTracks = tracks.list;
 
     auto repeatVisitor = [&](CSSValueListBuilder& list, const RepeatEntry& entry) {
-        if (std::holds_alternative<Vector<String>>(entry)) {
-            const auto& names = std::get<Vector<String>>(entry);
+        if (std::holds_alternative<Vector<Style::CustomIdent>>(entry)) {
+            const auto& names = std::get<Vector<Style::CustomIdent>>(entry);
             if (names.isEmpty() && !isSubgrid)
                 return;
-            list.append(CSSGridLineNamesValue::create(names));
+            list.append(CSSGridLineNamesValue::create(SpaceSeparatedVector<CSS::CustomIdent>::map(names, [&](auto& name) {
+                return toCSS(name, state.style);
+            })));
         } else
             list.append(createCSSValue(state.pool, state.style, std::get<GridTrackSize>(entry)));
     };
@@ -1455,12 +1457,14 @@ template<GridTrackSizingDirection direction> Ref<CSSValue> extractGridTemplateVa
             [&](const GridTrackSize& size) {
                 list.append(createCSSValue(state.pool, state.style, size));
             },
-            [&](const Vector<String>& names) {
+            [&](const Vector<CustomIdent>& names) {
                 // Subgrids don't have track sizes specified, so empty line names sets
                 // need to be serialized, as they are meaningful placeholders.
                 if (names.isEmpty() && !isSubgrid)
                     return;
-                list.append(CSSGridLineNamesValue::create(names));
+                list.append(CSSGridLineNamesValue::create(SpaceSeparatedVector<CSS::CustomIdent>::map(names, [&](auto& name) {
+                    return toCSS(name, state.style);
+                })));
             },
             [&](const GridTrackEntryRepeat& repeat) {
                 CSSValueListBuilder repeatedValues;

--- a/Source/WebCore/style/StyleInterpolation.cpp
+++ b/Source/WebCore/style/StyleInterpolation.cpp
@@ -227,7 +227,7 @@ static bool typeOfSyntaxValueCanBeInterpolated(const CustomProperty::Value& synt
         [](const URL&) {
             return false;
         },
-        [](const CustomIdentifier&) {
+        [](const CustomIdent&) {
             return false;
         },
         [](const String&) {

--- a/Source/WebCore/style/StyleNameScope.cpp
+++ b/Source/WebCore/style/StyleNameScope.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "StyleNameScope.h"
 
+#include "CSSCustomIdentValue.h"
 #include "StyleBuilderChecking.h"
 #include <wtf/text/TextStream.h>
 
@@ -40,23 +41,25 @@ auto CSSValueConversion<NameScope>::operator()(BuilderState& state, const CSSVal
             return CSS::Keyword::None { };
         case CSSValueAll:
             return { CSS::Keyword::All { }, state.styleScopeOrdinal() };
-        case CSSValueInvalid:
-            return { CommaSeparatedListHashSet<CustomIdentifier> { { AtomString { primitiveValue->stringValue() } } }, state.styleScopeOrdinal() };
         default:
             state.setCurrentPropertyInvalidAtComputedValueTime();
             return CSS::Keyword::None { };
         }
     }
 
-    auto list = requiredListDowncast<CSSValueList, CSSPrimitiveValue>(state, value);
+    if (RefPtr customIdentValue = dynamicDowncast<CSSCustomIdentValue>(value))
+        return { CommaSeparatedListHashSet<CustomIdent> { toStyleFromCSSValue<CustomIdent>(state, *customIdentValue) }, state.styleScopeOrdinal() };
+
+    auto list = requiredListDowncast<CSSValueList, CSSCustomIdentValue>(state, value);
     if (!list)
         return CSS::Keyword::None { };
 
-    CommaSeparatedListHashSet<CustomIdentifier> names;
-    for (Ref item : *list)
-        names.value.add({ AtomString { item->stringValue() } });
-
-    return { WTF::move(names), state.styleScopeOrdinal() };
+    return {
+        CommaSeparatedListHashSet<CustomIdent>::map(*list, [&](auto& item) {
+            return toStyleFromCSSValue<CustomIdent>(state, item);
+        }),
+        state.styleScopeOrdinal()
+    };
 }
 
 } // namespace Style

--- a/Source/WebCore/style/StyleNameScope.h
+++ b/Source/WebCore/style/StyleNameScope.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/StyleCustomIdent.h>
 #include <WebCore/StyleScopeOrdinal.h>
 #include <WebCore/StyleValueTypes.h>
 
@@ -51,7 +52,7 @@ struct NameScope {
     {
     }
 
-    NameScope(CommaSeparatedListHashSet<CustomIdentifier>&& names, ScopeOrdinal scopeOrdinal)
+    NameScope(CommaSeparatedListHashSet<CustomIdent>&& names, ScopeOrdinal scopeOrdinal)
         : type { Type::Ident }
         , names { WTF::move(names) }
         , scopeOrdinal { scopeOrdinal }
@@ -59,7 +60,7 @@ struct NameScope {
     }
 
     Type type { Type::None };
-    CommaSeparatedListHashSet<CustomIdentifier> names;
+    CommaSeparatedListHashSet<CustomIdent> names;
     ScopeOrdinal scopeOrdinal { ScopeOrdinal::Element };
 
     template<typename... F> constexpr decltype(auto) switchOn(F&&...) const;

--- a/Source/WebCore/style/StyleOrderedNamedLinesCollector.h
+++ b/Source/WebCore/style/StyleOrderedNamedLinesCollector.h
@@ -52,12 +52,12 @@ public:
 
     bool isEmpty() const { return m_orderedNamedGridLines.map.isEmpty() && m_orderedNamedAutoRepeatGridLines.map.isEmpty(); }
 
-    virtual void collectLineNamesForIndex(Vector<String>&, unsigned index) const = 0;
+    virtual void collectLineNamesForIndex(Vector<Style::CustomIdent>&, unsigned index) const = 0;
     virtual int namedGridLineCount() const { return m_orderedNamedGridLines.map.size(); }
 
 protected:
     enum class NamedLinesType : bool { NamedLines, AutoRepeatNamedLines };
-    void appendLines(Vector<String>&, unsigned index, NamedLinesType) const;
+    void appendLines(Vector<Style::CustomIdent>&, unsigned index, NamedLinesType) const;
 
     const GridOrderedNamedLinesMap& m_orderedNamedGridLines;
     const GridOrderedNamedLinesMap& m_orderedNamedAutoRepeatGridLines;
@@ -73,7 +73,7 @@ public:
     {
     }
 
-    void collectLineNamesForIndex(Vector<String>&, unsigned index) const override;
+    void collectLineNamesForIndex(Vector<Style::CustomIdent>&, unsigned index) const override;
 
 private:
     unsigned m_insertionPoint { 0 };
@@ -102,7 +102,7 @@ public:
         m_autoRepeatTotalLineSets *= m_autoRepeatLineSetListLength;
     }
 
-    void collectLineNamesForIndex(Vector<String>&, unsigned index) const override;
+    void collectLineNamesForIndex(Vector<Style::CustomIdent>&, unsigned index) const override;
     int namedGridLineCount() const override { return m_totalLines; }
 
 private:
@@ -112,7 +112,7 @@ private:
     unsigned m_totalLines { 0 };
 };
 
-inline void OrderedNamedLinesCollector::appendLines(Vector<String>& lineNames, unsigned index, NamedLinesType type) const
+inline void OrderedNamedLinesCollector::appendLines(Vector<Style::CustomIdent>& lineNames, unsigned index, NamedLinesType type) const
 {
     auto& map = (type == NamedLinesType::NamedLines ? m_orderedNamedGridLines : m_orderedNamedAutoRepeatGridLines).map;
     auto it = map.find(index);
@@ -122,7 +122,7 @@ inline void OrderedNamedLinesCollector::appendLines(Vector<String>& lineNames, u
         lineNames.append(name);
 }
 
-inline void OrderedNamedLinesCollectorInGridLayout::collectLineNamesForIndex(Vector<String>& lineNamesValue, unsigned i) const
+inline void OrderedNamedLinesCollectorInGridLayout::collectLineNamesForIndex(Vector<Style::CustomIdent>& lineNamesValue, unsigned i) const
 {
     ASSERT(!isEmpty());
     if (!m_autoRepeatTrackListLength || i < m_insertionPoint) {
@@ -155,7 +155,7 @@ inline void OrderedNamedLinesCollectorInGridLayout::collectLineNamesForIndex(Vec
     appendLines(lineNamesValue, autoRepeatIndexInFirstRepetition, NamedLinesType::AutoRepeatNamedLines);
 }
 
-inline void OrderedNamedLinesCollectorInSubgridLayout::collectLineNamesForIndex(Vector<String>& lineNamesValue, unsigned i) const
+inline void OrderedNamedLinesCollectorInSubgridLayout::collectLineNamesForIndex(Vector<Style::CustomIdent>& lineNamesValue, unsigned i) const
 {
     if (!m_autoRepeatLineSetListLength || i < m_insertionPoint) {
         appendLines(lineNamesValue, i, NamedLinesType::NamedLines);

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -883,7 +883,7 @@ void Styleable::updateCSSScrollTimelines(const RenderStyle* currentStyle, const 
             [](CSS::Keyword::None) {
                 // Nothing to register.
             },
-            [&](const CustomIdentifier& identifier) {
+            [&](const Style::CustomIdent& identifier) {
                 styleOriginatedTimelinesController->registerNamedScrollTimeline(identifier.value, *this, scrollTimeline.axis());
                 registeredScrollTimelineNames.add(identifier.value);
             }
@@ -898,7 +898,7 @@ void Styleable::updateCSSScrollTimelines(const RenderStyle* currentStyle, const 
             [](CSS::Keyword::None) {
                 // Nothing to unregister.
             },
-            [&](const CustomIdentifier& identifier) {
+            [&](const Style::CustomIdent& identifier) {
                 if (!registeredScrollTimelineNames.contains(identifier.value))
                     styleOriginatedTimelinesController->unregisterNamedTimeline(identifier.value, *this);
             }
@@ -920,7 +920,7 @@ void Styleable::updateCSSViewTimelines(const RenderStyle* currentStyle, const Re
             [](CSS::Keyword::None) {
                 // Nothing to register.
             },
-            [&](const CustomIdentifier& identifier) {
+            [&](const Style::CustomIdent& identifier) {
                 styleOriginatedTimelinesController->registerNamedViewTimeline(identifier.value, *this, viewTimeline.axis(), viewTimeline.inset());
                 registeredViewTimelineNames.add(identifier.value);
             }
@@ -935,7 +935,7 @@ void Styleable::updateCSSViewTimelines(const RenderStyle* currentStyle, const Re
             [](CSS::Keyword::None) {
                 // Nothing to unregister.
             },
-            [&](const CustomIdentifier& identifier) {
+            [&](const Style::CustomIdent& identifier) {
                 if (!registeredViewTimelineNames.contains(identifier.value))
                     styleOriginatedTimelinesController->unregisterNamedTimeline(identifier.value, *this);
             }

--- a/Source/WebCore/style/calc/StyleCalculationTree+Conversion.cpp
+++ b/Source/WebCore/style/calc/StyleCalculationTree+Conversion.cpp
@@ -223,16 +223,30 @@ auto toStyle(const CSSCalc::Random::Sharing& randomSharing, const ToStyleConvers
 
     return WTF::switchOn(randomSharing,
         [&](const CSSCalc::Random::SharingOptions& sharingOptions) -> Random::Fixed {
+            CheckedPtr builderState = options.evaluation.conversionData->styleBuilderState();
+
             if (!sharingOptions.elementScoped.has_value()) {
-                ASSERT(options.evaluation.conversionData->styleBuilderState()->element());
+                ASSERT(builderState->element());
             }
 
-            auto baseValue = protect(options.evaluation.conversionData->styleBuilderState())->lookupCSSRandomBaseValue(
-                sharingOptions.identifier,
-                sharingOptions.elementScoped
+            return WTF::switchOn(sharingOptions.identifier,
+                [&](const CSSCalc::Random::SharingOptions::Auto& autoValue) {
+                    return Random::Fixed {
+                        builderState->lookupCSSRandomBaseValue(
+                            autoValue,
+                            sharingOptions.elementScoped
+                        )
+                    };
+                },
+                [&](const CSS::CustomIdent& customIdent) {
+                    return Random::Fixed {
+                        builderState->lookupCSSRandomBaseValue(
+                            Style::toStyle(customIdent, *builderState),
+                            sharingOptions.elementScoped
+                        )
+                    };
+                }
             );
-
-            return Random::Fixed { baseValue };
         },
         [&](const CSSCalc::Random::SharingFixed& sharingFixed) -> Random::Fixed {
             return WTF::switchOn(sharingFixed.value,

--- a/Source/WebCore/style/values/StyleValueTypes+CSSValueConversion.h
+++ b/Source/WebCore/style/values/StyleValueTypes+CSSValueConversion.h
@@ -70,25 +70,6 @@ template<> struct CSSValueConversion<AtomString> {
     }
 };
 
-// Specialization for `CustomIdentifier`.
-template<> struct CSSValueConversion<CustomIdentifier> {
-    CustomIdentifier operator()(BuilderState& state, const CSSPrimitiveValue& value)
-    {
-        if (!value.isCustomIdent()) [[unlikely]] {
-            state.setCurrentPropertyInvalidAtComputedValueTime();
-            return { .value = emptyAtom() };
-        }
-        return { .value = AtomString { value.customIdent() } };
-    }
-    CustomIdentifier operator()(BuilderState& state, const CSSValue& value)
-    {
-        RefPtr primitiveValue = requiredDowncast<CSSPrimitiveValue>(state, value);
-        if (!primitiveValue) [[unlikely]]
-            return { .value = emptyAtom() };
-        return this->operator()(state, *primitiveValue);
-    }
-};
-
 // Specialization for `PropertyIdentifier`.
 template<> struct CSSValueConversion<PropertyIdentifier> {
     PropertyIdentifier operator()(BuilderState& state, const CSSPrimitiveValue& value)
@@ -109,7 +90,9 @@ template<> struct CSSValueConversion<PropertyIdentifier> {
 };
 
 // Specialization for `TupleLike` (wrapper).
-template<TupleLike StyleType> requires (std::tuple_size_v<StyleType> == 1) struct CSSValueConversion<StyleType> {
+template<TupleLike StyleType>
+    requires(std::tuple_size_v<StyleType> == 1)
+struct CSSValueConversion<StyleType> {
     template<typename... Rest> StyleType operator()(BuilderState& state, const CSSValue& value, Rest&&... rest)
     {
         return { toStyleFromCSSValue<std::remove_cvref_t<std::tuple_element_t<0, StyleType>>>(state, value, std::forward<Rest>(rest)...) };

--- a/Source/WebCore/style/values/StyleValueTypes.h
+++ b/Source/WebCore/style/values/StyleValueTypes.h
@@ -106,9 +106,6 @@ template<typename> struct ToStyle;
 // Specialize `TreatAsNonConverting` for `Constant<C>`, to indicate that its type does not change from the CSS representation.
 template<CSSValueID C> inline constexpr bool TreatAsNonConverting<Constant<C>> = true;
 
-// Specialize `TreatAsNonConverting` for `CustomIdentifier`, to indicate that its type does not change from the CSS representation.
-template<> inline constexpr bool TreatAsNonConverting<CustomIdentifier> = true;
-
 // Specialize `TreatAsNonConverting` for `PropertyIdentifier`, to indicate that its type does not change from the CSS representation.
 template<> inline constexpr bool TreatAsNonConverting<PropertyIdentifier> = true;
 

--- a/Source/WebCore/style/values/anchor-position/StylePositionTryFallback.cpp
+++ b/Source/WebCore/style/values/anchor-position/StylePositionTryFallback.cpp
@@ -28,11 +28,13 @@
 #include "StylePositionTryFallback.h"
 
 #include "StyleBuilderChecking.h"
+#include "StyleCustomIdent.h"
 #include "StylePrimitiveKeyword+CSSValueConversion.h"
 #include "StylePrimitiveKeyword+CSSValueCreation.h"
 #include "StylePrimitiveKeyword+Logging.h"
 #include "StylePrimitiveKeyword+Serialization.h"
 #include "StylePropertiesInlines.h"
+#include "StyleValueTypes+CSSValueConversion.h"
 
 namespace WebCore {
 namespace Style {
@@ -101,9 +103,12 @@ auto CSSValueConversion<PositionTryFallback>::operator()(BuilderState& state, co
                 tactics.value.append(PositionTryFallbackTactic::FlipY);
                 break;
             case CSSValueInvalid:
-                if (item->isCustomIdent() && !rule) {
-                    rule = ScopedName { AtomString { item->customIdent() }, state.styleScopeOrdinal() };
-                    break;
+                if (!rule) {
+                    auto customIdent = toStyleFromCSSValue<CustomIdent>(state, item.get());
+                    if (!customIdent.value.isNull()) {
+                        rule = ScopedName { WTF::move(customIdent.value), state.styleScopeOrdinal() };
+                        break;
+                    }
                 }
                 [[fallthrough]];
             default:

--- a/Source/WebCore/style/values/animations/StyleSingleAnimationName.cpp
+++ b/Source/WebCore/style/values/animations/StyleSingleAnimationName.cpp
@@ -28,6 +28,8 @@
 
 #include "CSSPrimitiveValue.h"
 #include "StyleBuilderChecking.h"
+#include "StyleCustomIdent.h"
+#include "StyleValueTypes+CSSValueConversion.h"
 
 namespace WebCore {
 namespace Style {
@@ -36,14 +38,17 @@ namespace Style {
 
 auto CSSValueConversion<SingleAnimationName>::operator()(BuilderState& state, const CSSValue& value) -> SingleAnimationName
 {
-    RefPtr primitiveValue = requiredDowncast<CSSPrimitiveValue>(state, value);
-    if (!primitiveValue)
-        return SingleAnimationName { CSS::Keyword::None { } };
+    if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
+        if (primitiveValue->valueID() == CSSValueNone)
+            return SingleAnimationName { CSS::Keyword::None { } };
 
-    if (primitiveValue->valueID() == CSSValueNone)
-        return SingleAnimationName { CSS::Keyword::None { } };
+        return SingleAnimationName { ScopedName { AtomString { primitiveValue->stringValue() }, state.styleScopeOrdinal(), false } };
+    }
 
-    return SingleAnimationName { ScopedName { AtomString { primitiveValue->stringValue() }, state.styleScopeOrdinal(), primitiveValue->isCustomIdent() } };
+    auto customIdent = toStyleFromCSSValue<CustomIdent>(state, value);
+    if (customIdent.value.isNull())
+        return SingleAnimationName { CSS::Keyword::None { } };
+    return SingleAnimationName { ScopedName { WTF::move(customIdent.value), state.styleScopeOrdinal(), true } };
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/animations/StyleSingleAnimationTimeline.cpp
+++ b/Source/WebCore/style/values/animations/StyleSingleAnimationTimeline.cpp
@@ -39,26 +39,27 @@ namespace Style {
 
 auto CSSValueConversion<SingleAnimationTimeline>::operator()(BuilderState& state, const CSSValue& value) -> SingleAnimationTimeline
 {
+    if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
+        switch (value.valueID()) {
+        case CSSValueAuto:
+            return CSS::Keyword::Auto { };
+        case CSSValueNone:
+            return CSS::Keyword::None { };
+        default:
+            break;
+        }
+
+        state.setCurrentPropertyInvalidAtComputedValueTime();
+        return CSS::Keyword::None { };
+    }
+
     if (RefPtr scrollValue = dynamicDowncast<CSSScrollValue>(value))
         return toStyleFromCSSValue<ScrollFunction>(state, *scrollValue);
 
     if (RefPtr viewValue = dynamicDowncast<CSSViewValue>(value))
         return toStyleFromCSSValue<ViewFunction>(state, *viewValue);
 
-    RefPtr primitiveValue = requiredDowncast<CSSPrimitiveValue>(state, value);
-    if (!primitiveValue)
-        return CSS::Keyword::Auto { };
-
-    switch (value.valueID()) {
-    case CSSValueAuto:
-        return CSS::Keyword::Auto { };
-    case CSSValueNone:
-        return CSS::Keyword::None { };
-    default:
-        break;
-    }
-
-    return toStyleFromCSSValue<CustomIdentifier>(state, value);
+    return toStyleFromCSSValue<CustomIdent>(state, value);
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/animations/StyleSingleAnimationTimeline.h
+++ b/Source/WebCore/style/values/animations/StyleSingleAnimationTimeline.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <WebCore/StyleCustomIdent.h>
 #include <WebCore/StyleScrollFunction.h>
 #include <WebCore/StyleValueTypes.h>
 #include <WebCore/StyleViewFunction.h>
@@ -44,7 +45,7 @@ struct SingleAnimationTimeline {
     {
     }
 
-    SingleAnimationTimeline(CustomIdentifier&& identifier)
+    SingleAnimationTimeline(CustomIdent&& identifier)
         : m_value { identifier }
     {
     }
@@ -61,8 +62,8 @@ struct SingleAnimationTimeline {
 
     bool isAuto() const { return std::holds_alternative<CSS::Keyword::Auto>(m_value); }
     bool isNone() const { return std::holds_alternative<CSS::Keyword::None>(m_value); }
-    bool isCustomIdentifier() const { return std::holds_alternative<CustomIdentifier>(m_value); }
-    std::optional<CustomIdentifier> tryCustomIdentifier() const { return isCustomIdentifier() ? std::make_optional(std::get<CustomIdentifier>(m_value)) : std::nullopt; }
+    bool isCustomIdent() const { return std::holds_alternative<CustomIdent>(m_value); }
+    std::optional<CustomIdent> tryCustomIdent() const { return isCustomIdent() ? std::make_optional(std::get<CustomIdent>(m_value)) : std::nullopt; }
     bool isScrollFunction() const { return std::holds_alternative<ScrollFunction>(m_value); }
     std::optional<ScrollFunction> tryScrollFunction() const { return isScrollFunction() ? std::make_optional(std::get<ScrollFunction>(m_value)) : std::nullopt; }
     bool isViewFunction() const { return std::holds_alternative<ViewFunction>(m_value); }
@@ -76,7 +77,7 @@ struct SingleAnimationTimeline {
     bool operator==(const SingleAnimationTimeline&) const = default;
 
 private:
-    Variant<CSS::Keyword::Auto, CSS::Keyword::None, CustomIdentifier, ScrollFunction, ViewFunction> m_value;
+    Variant<CSS::Keyword::Auto, CSS::Keyword::None, CustomIdent, ScrollFunction, ViewFunction> m_value;
 };
 
 // MARK: - Conversion

--- a/Source/WebCore/style/values/color-adjust/StyleColorScheme.h
+++ b/Source/WebCore/style/values/color-adjust/StyleColorScheme.h
@@ -29,6 +29,7 @@
 
 #include <WebCore/CSSColorScheme.h>
 #include <WebCore/RenderStyleConstants.h>
+#include <WebCore/StyleCustomIdent.h>
 #include <WebCore/StyleValueTypes.h>
 #include <wtf/OptionSet.h>
 
@@ -39,9 +40,9 @@ namespace Style {
 
 struct ColorScheme {
     ColorScheme(CSS::Keyword::Normal) : schemes { }, only { std::nullopt } { }
-    ColorScheme(SpaceSeparatedVector<CustomIdentifier>&& schemes, std::optional<CSS::Keyword::Only> only) : schemes { WTF::move(schemes) }, only { only } { }
+    ColorScheme(SpaceSeparatedVector<CustomIdent>&& schemes, std::optional<CSS::Keyword::Only> only) : schemes { WTF::move(schemes) }, only { only } { }
 
-    SpaceSeparatedVector<CustomIdentifier> schemes;
+    SpaceSeparatedVector<CustomIdent> schemes;
     std::optional<CSS::Keyword::Only> only;
 
     // As an optimization, if `schemes` is empty, that indicates the

--- a/Source/WebCore/style/values/content/StyleContent.cpp
+++ b/Source/WebCore/style/values/content/StyleContent.cpp
@@ -33,6 +33,7 @@
 #include "RenderStyle+GettersInlines.h"
 #include "RenderStyle+SettersInlines.h"
 #include "StyleBuilderChecking.h"
+#include "StyleValueTypes+CSSValueConversion.h"
 
 namespace WebCore {
 namespace Style {
@@ -120,8 +121,13 @@ auto CSSValueConversion<Content>::operator()(BuilderState& state, const CSSValue
                 return Content::Text { emptyString() };
             }
 
-            if (RefPtr counter = dynamicDowncast<CSSCounterValue>(item))
-                return Content::Counter { counter->identifier(), counter->separator(), toStyleFromCSSValue<CounterStyle>(state, counter->counterStyle()) };
+            if (RefPtr counter = dynamicDowncast<CSSCounterValue>(item)) {
+                return Content::Counter {
+                    toStyle(counter->identifier(), state),
+                    toStyle(counter->separator(), state),
+                    toStyle(counter->counterStyle(), state),
+                };
+            }
 
             state.setCurrentPropertyInvalidAtComputedValueTime();
             return Content::Text { emptyString() };
@@ -149,9 +155,13 @@ auto CSSValueConversion<Content>::operator()(BuilderState& state, const CSSValue
     return Content::Data { computeContentList(), computeAltText() };
 }
 
-Ref<CSSValue> CSSValueCreation<Content::Counter>::operator()(CSSValuePool& pool, const RenderStyle& style, const Content::Counter& value)
+Ref<CSSValue> CSSValueCreation<Content::Counter>::operator()(CSSValuePool&, const RenderStyle& style, const Content::Counter& value)
 {
-    return CSSCounterValue::create(AtomString { value.identifier }, AtomString { value.separator }, createCSSValue(pool, style, value.style));
+    return CSSCounterValue::create(
+        toCSS(value.identifier, style),
+        AtomString { value.separator },
+        toCSS(value.style, style)
+    );
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/content/StyleContent.h
+++ b/Source/WebCore/style/values/content/StyleContent.h
@@ -64,7 +64,7 @@ struct Content {
         bool operator==(const Image&) const = default;
     };
     struct Counter {
-        AtomString identifier;
+        CustomIdent identifier;
         AtomString separator;
         CounterStyle style;
 
@@ -142,16 +142,16 @@ template<typename... F> decltype(auto) Content::Counter::switchOn(F&&... f) cons
 {
     auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
 
-    using CounterFunction = FunctionNotation<CSSValueCounter, CommaSeparatedTuple<CustomIdentifier, std::optional<CounterStyle>>>;
-    using CountersFunction = FunctionNotation<CSSValueCounters, CommaSeparatedTuple<CustomIdentifier, AtomString, std::optional<CounterStyle>>>;
+    using CounterFunction = FunctionNotation<CSSValueCounter, CommaSeparatedTuple<CustomIdent, std::optional<CounterStyle>>>;
+    using CountersFunction = FunctionNotation<CSSValueCounters, CommaSeparatedTuple<CustomIdent, AtomString, std::optional<CounterStyle>>>;
 
     if (separator.isEmpty()) {
         return visitor(CounterFunction {
-            .parameters = { CustomIdentifier { identifier }, style != nameString(CSSValueDecimal) ? std::make_optional(style) : std::nullopt }
+            .parameters = { CustomIdent { identifier }, style != nameString(CSSValueDecimal) ? std::make_optional(style) : std::nullopt }
         });
     } else {
         return visitor(CountersFunction {
-            .parameters = { CustomIdentifier { identifier }, separator, style != nameString(CSSValueDecimal) ? std::make_optional(style) : std::nullopt }
+            .parameters = { CustomIdent { identifier }, separator, style != nameString(CSSValueDecimal) ? std::make_optional(style) : std::nullopt }
         });
     }
 }

--- a/Source/WebCore/style/values/counter-styles/StyleCounterStyle.cpp
+++ b/Source/WebCore/style/values/counter-styles/StyleCounterStyle.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,8 @@
 #include "config.h"
 #include "StyleCounterStyle.h"
 
-#include "CSSPrimitiveValue.h"
+#include "CSSPropertyParserConsumer+CounterStyles.h"
+#include "CSSValueKeywords.h"
 #include "StyleBuilderChecking.h"
 
 namespace WebCore {
@@ -34,13 +35,34 @@ namespace Style {
 
 // MARK: - Conversion
 
+auto ToCSS<CounterStyle>::operator()(const CounterStyle& value, const RenderStyle& style) -> CSS::CounterStyle
+{
+    return { toCSS(value.identifier, style) };
+}
+
+auto ToStyle<CSS::CounterStyle>::operator()(const CSS::CounterStyle& value, const BuilderState& state) -> CounterStyle
+{
+    return WTF::switchOn(value.identifier,
+        [&](CSSValueID predefinedKeyword) -> CounterStyle {
+            return { CustomIdent { nameStringForSerialization(predefinedKeyword) } };
+        },
+        [&](const CSS::CustomIdent& customIdent) -> CounterStyle {
+            return { toStyle(customIdent, state) };
+        }
+    );
+}
+
 auto CSSValueConversion<CounterStyle>::operator()(BuilderState& state, const CSSValue& value) -> CounterStyle
 {
-    RefPtr primitiveValue = requiredDowncast<CSSPrimitiveValue>(state, value);
-    if (!primitiveValue)
-        return CounterStyle { nameString(CSSValueDecimal) };
+    if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
+        if (auto valueID = primitiveValue->valueID(); CSSPropertyParserHelpers::isPredefinedCounterStyle(valueID))
+            return { CustomIdent { nameStringForSerialization(valueID) } };
 
-    return CounterStyle { { AtomString { primitiveValue->stringValue() } } };
+        state.setCurrentPropertyInvalidAtComputedValueTime();
+        return { CustomIdent { nullAtom() } };
+    }
+
+    return { toStyleFromCSSValue<CustomIdent>(state, value) };
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/counter-styles/StyleCounterStyle.h
+++ b/Source/WebCore/style/values/counter-styles/StyleCounterStyle.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,18 +25,24 @@
 
 #pragma once
 
+#include <WebCore/StyleCustomIdent.h>
 #include <WebCore/StyleValueTypes.h>
 
 namespace WebCore {
+
+namespace CSS {
+struct CounterStyle;
+}
+
 namespace Style {
 
 // <counter-style> = <custom-ident excluding=none>
 // https://drafts.csswg.org/css-counter-styles-3/#typedef-counter-style
 struct CounterStyle {
-    CustomIdentifier identifier;
+    CustomIdent identifier;
 
     bool operator==(const CounterStyle&) const = default;
-    bool operator==(const CustomIdentifier& other) const { return identifier == other; }
+    bool operator==(const CustomIdent& other) const { return identifier == other; }
     bool operator==(const AtomString& other) const { return identifier.value == other; }
     bool operator==(CSSValueID other) const { return identifier.value == nameString(other); }
 };
@@ -44,6 +50,8 @@ DEFINE_TYPE_WRAPPER_GET(CounterStyle, identifier);
 
 // MARK: - Conversion
 
+template<> struct ToCSS<CounterStyle> { auto operator()(const CounterStyle&, const RenderStyle&) -> CSS::CounterStyle; };
+template<> struct ToStyle<CSS::CounterStyle> { auto operator()(const CSS::CounterStyle&, const BuilderState&) -> CounterStyle; };
 template<> struct CSSValueConversion<CounterStyle> { auto operator()(BuilderState&, const CSSValue&) -> CounterStyle; };
 
 } // namespace Style

--- a/Source/WebCore/style/values/fonts/StyleFontPalette.cpp
+++ b/Source/WebCore/style/values/fonts/StyleFontPalette.cpp
@@ -37,26 +37,24 @@ namespace Style {
 
 auto CSSValueConversion<FontPalette>::operator()(BuilderState& state, const CSSValue& value) -> FontPalette
 {
-    RefPtr primitiveValue = requiredDowncast<CSSPrimitiveValue>(state, value);
-    if (!primitiveValue)
-        return CSS::Keyword::Normal { };
-
-    switch (auto valueID = primitiveValue->valueID(); valueID) {
-    case CSSValueNormal:
-        return CSS::Keyword::Normal { };
-    case CSSValueLight:
-        return CSS::Keyword::Light { };
-    case CSSValueDark:
-        return CSS::Keyword::Dark { };
-    case CSSValueInvalid:
-        return toStyleFromCSSValue<CustomIdentifier>(state, *primitiveValue);
-    default:
-        if (CSSPropertyParserHelpers::isSystemFontShorthand(valueID))
+    if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
+        switch (auto valueID = primitiveValue->valueID(); valueID) {
+        case CSSValueNormal:
             return CSS::Keyword::Normal { };
+        case CSSValueLight:
+            return CSS::Keyword::Light { };
+        case CSSValueDark:
+            return CSS::Keyword::Dark { };
+        default:
+            if (CSSPropertyParserHelpers::isSystemFontShorthand(valueID))
+                return CSS::Keyword::Normal { };
 
-        state.setCurrentPropertyInvalidAtComputedValueTime();
-        return CSS::Keyword::Normal { };
+            state.setCurrentPropertyInvalidAtComputedValueTime();
+            return CSS::Keyword::Normal { };
+        }
     }
+
+    return toStyleFromCSSValue<CustomIdent>(state, value);
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/fonts/StyleFontPalette.h
+++ b/Source/WebCore/style/values/fonts/StyleFontPalette.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/FontPalette.h>
+#include <WebCore/StyleCustomIdent.h>
 #include <WebCore/StyleValueTypes.h>
 
 namespace WebCore {
@@ -50,7 +51,7 @@ struct FontPalette {
     {
     }
 
-    FontPalette(CustomIdentifier&& identifier)
+    FontPalette(CustomIdent&& identifier)
         : m_platform { .type = WebCore::FontPalette::Type::Custom, .identifier = WTF::move(identifier.value) }
     {
     }
@@ -77,7 +78,7 @@ struct FontPalette {
         case WebCore::FontPalette::Type::Dark:
             return visitor(CSS::Keyword::Dark { });
         case WebCore::FontPalette::Type::Custom:
-            return visitor(CustomIdentifier { m_platform.identifier });
+            return visitor(CustomIdent { m_platform.identifier });
         }
         RELEASE_ASSERT_NOT_REACHED();
     }

--- a/Source/WebCore/style/values/fonts/StyleFontVariantAlternates.cpp
+++ b/Source/WebCore/style/values/fonts/StyleFontVariantAlternates.cpp
@@ -30,6 +30,7 @@
 #include "CSSPropertyParserConsumer+Font.h"
 #include "CSSValueList.h"
 #include "StyleBuilderChecking.h"
+#include "StyleValueTypes+CSSValueConversion.h"
 
 namespace WebCore {
 namespace Style {
@@ -43,12 +44,10 @@ auto CSSValueConversion<FontVariantAlternates>::operator()(BuilderState& state, 
             state.setCurrentPropertyInvalidAtComputedValueTime();
             return false;
         }
-        RefPtr primitiveArgument = dynamicDowncast<CSSPrimitiveValue>(function[0]);
-        if (!primitiveArgument || !primitiveArgument->isCustomIdent()) {
-            state.setCurrentPropertyInvalidAtComputedValueTime();
+        auto customIdent = toStyleFromCSSValue<CustomIdent>(state, protect(function[0]));
+        if (customIdent.value.isNull())
             return false;
-        }
-        parameterToSet = primitiveArgument->customIdent();
+        parameterToSet = customIdent.value;
         return true;
     };
 
@@ -58,12 +57,10 @@ auto CSSValueConversion<FontVariantAlternates>::operator()(BuilderState& state, 
             return false;
         }
         for (Ref argument : function) {
-            RefPtr primitiveArgument = dynamicDowncast<CSSPrimitiveValue>(argument);
-            if (!primitiveArgument || !primitiveArgument->isCustomIdent()) {
-                state.setCurrentPropertyInvalidAtComputedValueTime();
+            auto customIdent = toStyleFromCSSValue<CustomIdent>(state, argument);
+            if (customIdent.value.isNull())
                 return false;
-            }
-            parameterToSet.append(primitiveArgument->customIdent());
+            parameterToSet.append(customIdent.value);
         }
         return true;
     };
@@ -148,13 +145,13 @@ Ref<CSSValue> CSSValueCreation<FontVariantAlternates>::operator()(CSSValuePool& 
     };
     auto appendSingleItemFunction = [&](auto name, const auto& value) {
         if (!value.isNull())
-            valueList.append(CSSFunctionValue::create(name.value, createCSSValue(pool, style, CustomIdentifier { AtomString { value } })));
+            valueList.append(CSSFunctionValue::create(name.value, createCSSValue(pool, style, CustomIdent { AtomString { value } })));
     };
     auto appendListFunction = [&](auto name, const auto& value) {
         if (!value.isEmpty()) {
             CSSValueListBuilder functionArguments;
             for (auto& argument : value)
-                functionArguments.append(createCSSValue(pool, style, CustomIdentifier { AtomString { argument } }));
+                functionArguments.append(createCSSValue(pool, style, CustomIdent { AtomString { argument } }));
             valueList.append(CSSFunctionValue::create(name.value, WTF::move(functionArguments)));
         }
     };
@@ -196,7 +193,7 @@ void Serialize<FontVariantAlternates>::operator()(StringBuilder& builder, const 
 
             serializationForCSS(builder, context, style, name);
             builder.append('(');
-            serializationForCSS(builder, context, style, CustomIdentifier { AtomString { value } });
+            serializationForCSS(builder, context, style, CustomIdent { AtomString { value } });
             builder.append(')');
 
             needsSpace = true;
@@ -210,7 +207,7 @@ void Serialize<FontVariantAlternates>::operator()(StringBuilder& builder, const 
             serializationForCSS(builder, context, style, name);
             builder.append('(');
             builder.append(interleave(value, [&](auto& builder, const auto& argument) {
-                serializationForCSS(builder, context, style, CustomIdentifier { AtomString { argument } });
+                serializationForCSS(builder, context, style, CustomIdent { AtomString { argument } });
             }, ", "_s));
             builder.append(')');
 

--- a/Source/WebCore/style/values/grid/StyleGridNamedLinesMap.h
+++ b/Source/WebCore/style/values/grid/StyleGridNamedLinesMap.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <WebCore/StyleCustomIdent.h>
 #include <wtf/HashMap.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
@@ -32,7 +33,7 @@ namespace WebCore {
 namespace Style {
 
 struct GridNamedLinesMap {
-    HashMap<String, Vector<unsigned>> map;
+    HashMap<Style::CustomIdent, Vector<unsigned>> map;
 
     bool operator==(const GridNamedLinesMap&) const = default;
 };

--- a/Source/WebCore/style/values/grid/StyleGridOrderedNamedLinesMap.h
+++ b/Source/WebCore/style/values/grid/StyleGridOrderedNamedLinesMap.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <WebCore/StyleCustomIdent.h>
 #include <wtf/HashMap.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
@@ -32,7 +33,7 @@ namespace WebCore {
 namespace Style {
 
 struct GridOrderedNamedLinesMap {
-    HashMap<unsigned, Vector<String>, IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> map;
+    HashMap<unsigned, Vector<CustomIdent>, IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> map;
 
     bool operator==(const GridOrderedNamedLinesMap&) const = default;
 };

--- a/Source/WebCore/style/values/grid/StyleGridPosition.cpp
+++ b/Source/WebCore/style/values/grid/StyleGridPosition.cpp
@@ -32,6 +32,7 @@
 #include "config.h"
 #include "StyleGridPosition.h"
 
+#include "CSSCustomIdentValue.h"
 #include "CSSGridLineValue.h"
 #include "CSSPrimitiveValue.h"
 #include "StyleBuilderChecking.h"
@@ -69,7 +70,7 @@ GridPosition::GridPosition(GridPosition::Span&& spanPosition)
 {
 }
 
-GridPosition::GridPosition(CustomIdentifier&& namedGridAreaPosition)
+GridPosition::GridPosition(CustomIdent&& namedGridAreaPosition)
     : m_type { GridPositionType::NamedGridArea }
     , m_namedGridLine { WTF::move(namedGridAreaPosition.value) }
 {
@@ -112,32 +113,51 @@ void GridPosition::setMaxPositionForTesting(unsigned maxPosition)
 
 auto CSSValueConversion<GridPosition>::operator()(BuilderState& state, const CSSValue& value) -> GridPosition
 {
+    using namespace CSS::Literals;
+
     if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
         if (isValueID(*primitiveValue, CSSValueAuto))
             return CSS::Keyword::Auto { };
-
-        if (primitiveValue->isCustomIdent())
-            return CustomIdentifier { AtomString { primitiveValue->stringValue() } };
 
         state.setCurrentPropertyInvalidAtComputedValueTime();
         return CSS::Keyword::Auto { };
     }
 
+    if (RefPtr customIdentValue = dynamicDowncast<CSSCustomIdentValue>(value))
+        return toStyleFromCSSValue<CustomIdent>(state, *customIdentValue);
+
     RefPtr gridLineValue = requiredDowncast<CSSGridLineValue>(state, value);
     if (!gridLineValue)
         return CSS::Keyword::Auto { };
 
-    RefPtr uncheckedSpanValue = gridLineValue->spanValue();
-    RefPtr uncheckedNumericValue = gridLineValue->numericValue();
-    RefPtr uncheckedGridLineName = gridLineValue->gridLineName();
+    auto resolveGridLineNumberForSpan = [&] -> GridPosition::Span::Position {
+        if (!gridLineValue->numeric())
+            return 1_css_integer;
+        auto unclampedInteger = toStyle(*gridLineValue->numeric(), state);
+        return { CSS::clampToRangeOf<GridPosition::Span::Position>(unclampedInteger.value) };
+    };
 
-    auto gridLineNumber = uncheckedNumericValue && uncheckedNumericValue->isInteger() ? uncheckedNumericValue->resolveAsInteger(state.cssToLengthConversionData()) : 0;
-    auto gridLineName = uncheckedGridLineName && uncheckedGridLineName->isCustomIdent() ? AtomString { uncheckedGridLineName->stringValue() } : nullAtom();
+    auto resolveGridLineNumberForExplicit = [&] -> GridPosition::Explicit::Position {
+        if (!gridLineValue->numeric())
+            return 1_css_integer;
+        return toStyle(*gridLineValue->numeric(), state);
+    };
 
-    if (isValueID(uncheckedSpanValue, CSSValueSpan))
-        return GridPosition::Span { { gridLineNumber > 0 ? gridLineNumber : 1 }, CustomIdentifier { WTF::move(gridLineName) } };
+    auto resolveGridLineName = [&] {
+        return toStyle(gridLineValue->gridLineName(), state).value_or(CustomIdent { nullAtom() });
+    };
 
-    return GridPosition::Explicit { { gridLineNumber }, CustomIdentifier { WTF::move(gridLineName) } };
+    if (gridLineValue->span()) {
+        return GridPosition::Span {
+            resolveGridLineNumberForSpan(),
+            resolveGridLineName(),
+        };
+    }
+
+    return GridPosition::Explicit {
+        resolveGridLineNumberForExplicit(),
+        resolveGridLineName(),
+    };
 }
 
 // MARK: - Logging
@@ -154,8 +174,8 @@ TextStream& operator<<(TextStream& ts, const GridPosition& value)
         [&](const Style::GridPosition::Span& spanPosition) {
             ts << "span"_s << ' ' << spanPosition.name << ' ' << spanPosition.position;
         },
-        [&](const CustomIdentifier& namedGridAreaPosition) {
-            ts << namedGridAreaPosition.value;
+        [&](const CustomIdent& namedGridAreaPosition) {
+            ts << namedGridAreaPosition;
         }
     );
     return ts;

--- a/Source/WebCore/style/values/grid/StyleGridPosition.h
+++ b/Source/WebCore/style/values/grid/StyleGridPosition.h
@@ -32,6 +32,7 @@
 
 #pragma once
 
+#include <WebCore/StyleCustomIdent.h>
 #include <WebCore/StyleGridPositionSide.h>
 #include <WebCore/StylePrimitiveNumeric.h>
 #include <WebCore/StyleValueTypes.h>
@@ -45,7 +46,7 @@ struct GridPositionExplicit {
     using Position = Integer<>;
 
     Position position { 1 };
-    CustomIdentifier name { nullAtom() };
+    CustomIdent name { nullAtom() };
 
     template<typename... F> decltype(auto) switchOn(F&&... f) const
     {
@@ -64,7 +65,7 @@ struct GridPositionSpan {
     using Position = Integer<CSS::Range{1,CSS::Range::infinity}>;
 
     Position position { 1 };
-    CustomIdentifier name { nullAtom() };
+    CustomIdent name { nullAtom() };
 
     template<typename... F> decltype(auto) switchOn(F&&... f) const
     {
@@ -90,7 +91,7 @@ struct GridPosition {
     GridPosition(CSS::Keyword::Auto) { }
     WEBCORE_EXPORT GridPosition(Explicit&&);
     WEBCORE_EXPORT GridPosition(Span&&);
-    GridPosition(CustomIdentifier&&);
+    GridPosition(CustomIdent&&);
 
     bool isAuto() const { return m_type == GridPositionType::Auto; }
     bool isExplicit() const { return m_type == GridPositionType::Explicit; }
@@ -141,7 +142,7 @@ private:
 
     GridPositionType m_type { GridPositionType::Auto };
     int m_integerPosition { 1 };
-    CustomIdentifier m_namedGridLine;
+    CustomIdent m_namedGridLine;
 };
 
 // MARK: - Conversion

--- a/Source/WebCore/style/values/grid/StyleGridPositionsResolver.cpp
+++ b/Source/WebCore/style/values/grid/StyleGridPositionsResolver.cpp
@@ -52,7 +52,7 @@ namespace {
 class NamedLineCollectionBase {
     WTF_MAKE_NONCOPYABLE(NamedLineCollectionBase);
 public:
-    NamedLineCollectionBase(const RenderGrid&, const String& name, GridPositionSide, bool nameIsAreaName);
+    NamedLineCollectionBase(const RenderGrid&, const CustomIdent& name, GridPositionSide, bool nameIsAreaName);
 
     bool NODELETE hasNamedLines() const;
     bool NODELETE hasExplicitNamedLines() const;
@@ -78,7 +78,7 @@ protected:
 class NamedLineCollection : public NamedLineCollectionBase {
     WTF_MAKE_NONCOPYABLE(NamedLineCollection);
 public:
-    NamedLineCollection(const RenderGrid&, const String& name, GridPositionSide, bool nameIsAreaName = false);
+    NamedLineCollection(const RenderGrid&, const CustomIdent& name, GridPositionSide, bool nameIsAreaName = false);
 
     int firstPosition() const;
 
@@ -100,9 +100,9 @@ static inline GridTrackSizingDirection NODELETE directionFromSide(GridPositionSi
     return side == GridPositionSide::ColumnStartSide || side == GridPositionSide::ColumnEndSide ? GridTrackSizingDirection::Columns : GridTrackSizingDirection::Rows;
 }
 
-static String implicitNamedGridLineForSide(const String& lineName, GridPositionSide side)
+static CustomIdent implicitNamedGridLineForSide(const CustomIdent& lineName, GridPositionSide side)
 {
-    return makeString(lineName, isStartSide(side) ? "-start"_s : "-end"_s);
+    return { makeAtomString(lineName.value, isStartSide(side) ? "-start"_s : "-end"_s) };
 }
 
 static unsigned explicitGridSizeForSide(const RenderGrid& gridContainer, GridPositionSide side)
@@ -120,10 +120,10 @@ static inline GridPositionSide NODELETE transposedSide(GridPositionSide side)
     }
 }
 
-static std::optional<int> clampedImplicitLineForArea(const RenderStyle& style, const String& name, int min, int max, GridTrackSizingDirection direction, bool isStartSide)
+static std::optional<int> clampedImplicitLineForArea(const RenderStyle& style, const CustomIdent& name, int min, int max, GridTrackSizingDirection direction, bool isStartSide)
 {
     auto& areas = style.gridTemplateAreas().map.map;
-    auto gridAreaIt = areas.find(name);
+    auto gridAreaIt = areas.find(name.value);
     if (gridAreaIt != areas.end()) {
         auto& gridArea = gridAreaIt->value;
         auto gridSpan = gridArea.span(direction);
@@ -133,9 +133,9 @@ static std::optional<int> clampedImplicitLineForArea(const RenderStyle& style, c
     return std::nullopt;
 }
 
-NamedLineCollectionBase::NamedLineCollectionBase(const RenderGrid& initialGrid, const String& name, GridPositionSide side, bool nameIsAreaName)
+NamedLineCollectionBase::NamedLineCollectionBase(const RenderGrid& initialGrid, const CustomIdent& name, GridPositionSide side, bool nameIsAreaName)
 {
-    String lineName = nameIsAreaName ? implicitNamedGridLineForSide(name, side) : name;
+    auto lineName = nameIsAreaName ? implicitNamedGridLineForSide(name, side) : name;
     auto direction = directionFromSide(side);
     const auto* grid = &initialGrid;
     const auto* gridContainerStyle = &grid->style();
@@ -184,17 +184,17 @@ NamedLineCollectionBase::NamedLineCollectionBase(const RenderGrid& initialGrid, 
         // then we can use that, otherwise we need to choose the substring and infer which side the input specified.
         // It's possible for authors to manually name a *-start implicit line name for the end line search, and vice-versa,
         // so we need to remember which side we inferred from the name, separately from the side we're searching for.
-        String areaName = name;
+        auto areaName = name;
         bool startSide = isStartSide(side);
         if (!nameIsAreaName) {
-            size_t suffix = name.find("-start"_s);
+            size_t suffix = name.value.find("-start"_s);
             if (suffix == notFound) {
-                suffix = name.find("-end"_s);
+                suffix = name.value.find("-end"_s);
                 ASSERT(suffix != notFound);
                 startSide = false;
             } else
                 startSide = true;
-            areaName = name.left(suffix);
+            areaName = CustomIdent { AtomString { name.value.string().left(suffix) } };
         }
         auto implicitLine = clampedImplicitLineForArea(*gridContainerStyle, areaName, 0, m_lastLine, direction, startSide);
         if (implicitLine)
@@ -269,7 +269,7 @@ bool NamedLineCollectionBase::contains(unsigned line) const
     return contains(m_autoRepeatNamedLinesIndices, autoRepeatIndexInFirstRepetition);
 }
 
-NamedLineCollection::NamedLineCollection(const RenderGrid& initialGrid, const String& name, GridPositionSide side, bool nameIsAreaName)
+NamedLineCollection::NamedLineCollection(const RenderGrid& initialGrid, const CustomIdent& name, GridPositionSide side, bool nameIsAreaName)
     : NamedLineCollectionBase(initialGrid, name, side, nameIsAreaName)
 {
     if (!m_lastLine)
@@ -492,9 +492,9 @@ static int lookBackForNamedGridLine(int end, unsigned numberOfLines, NamedLineCo
     return start + 1;
 }
 
-static int resolveNamedGridLinePositionFromStyle(const RenderGrid& gridContainer, const CustomIdentifier& name, const GridPosition::Explicit::Position& explicitPosition, GridPositionSide side)
+static int resolveNamedGridLinePositionFromStyle(const RenderGrid& gridContainer, const CustomIdent& name, const GridPosition::Explicit::Position& explicitPosition, GridPositionSide side)
 {
-    NamedLineCollection linesCollection(gridContainer, name.value, side);
+    NamedLineCollection linesCollection(gridContainer, name, side);
 
     if (explicitPosition.value > 0)
         return lookAheadForNamedGridLine(0, std::abs(explicitPosition.value), linesCollection);
@@ -515,9 +515,9 @@ static GridSpan definiteGridSpanWithNamedLineSpanAgainstOpposite(int oppositeLin
     return GridSpan::untranslatedDefiniteGridSpan(start, end);
 }
 
-static GridSpan resolveNamedGridLinePositionAgainstOppositePosition(const RenderGrid& gridContainer, int oppositeLine, const CustomIdentifier& name, const GridPosition::Span::Position& spanPosition, GridPositionSide side)
+static GridSpan resolveNamedGridLinePositionAgainstOppositePosition(const RenderGrid& gridContainer, int oppositeLine, const CustomIdent& name, const GridPosition::Span::Position& spanPosition, GridPositionSide side)
 {
-    NamedLineCollection linesCollection(gridContainer, name.value, side);
+    NamedLineCollection linesCollection(gridContainer, name, side);
 
     return definiteGridSpanWithNamedLineSpanAgainstOpposite(oppositeLine, spanPosition, side, linesCollection);
 }
@@ -549,7 +549,7 @@ static GridSpan resolveGridPositionAgainstOppositePosition(const RenderGrid& gri
             ASSERT_NOT_REACHED();
             return GridSpan::indefiniteGridSpan();
         },
-        [&](const CustomIdentifier&) -> GridSpan {
+        [&](const CustomIdent&) -> GridSpan {
             ASSERT_NOT_REACHED();
             return GridSpan::indefiniteGridSpan();
         }
@@ -601,20 +601,19 @@ static int resolveGridPositionFromStyle(const RenderGrid& gridContainer, const G
 
             return endOfTrack - resolvedPosition;
         },
-        [&](const CustomIdentifier& namedGridAreaPosition) -> int {
+        [&](const CustomIdent& namedGridAreaPosition) -> int {
             // First attempt to match the grid area's edge to a named grid area: if there is a named line with the name
             // ''<custom-ident>-start (for grid-*-start) / <custom-ident>-end'' (for grid-*-end), contributes the first such
             // line to the grid item's placement.
-            auto namedGridLine = namedGridAreaPosition.value;
-            ASSERT(!namedGridLine.isNull());
+            ASSERT(!namedGridAreaPosition.value.isNull());
 
-            NamedLineCollection implicitLines(gridContainer, namedGridLine, side, true);
+            NamedLineCollection implicitLines(gridContainer, namedGridAreaPosition, side, true);
             if (implicitLines.hasNamedLines())
                 return implicitLines.firstPosition();
 
             // Otherwise, if there is a named line with the specified name, contributes the first such line to the grid
             // item's placement.
-            NamedLineCollection explicitLines(gridContainer, namedGridLine, side);
+            NamedLineCollection explicitLines(gridContainer, namedGridAreaPosition, side);
             if (explicitLines.hasNamedLines())
                 return explicitLines.firstPosition();
 

--- a/Source/WebCore/style/values/grid/StyleGridTemplateAreas.cpp
+++ b/Source/WebCore/style/values/grid/StyleGridTemplateAreas.cpp
@@ -40,12 +40,12 @@ static GridNamedLinesMap initializeImplicitNamedGridLines(const GridNamedAreaMap
     for (auto& area : namedGridAreas.map) {
         auto areaSpan = direction == GridTrackSizingDirection::Rows ? area.value.rows : area.value.columns;
         {
-            auto& startVector = namedGridLines.map.add(makeString(area.key, "-start"_s), Vector<unsigned>()).iterator->value;
+            auto& startVector = namedGridLines.map.add(CustomIdent { makeAtomString(area.key, "-start"_s) }, Vector<unsigned>()).iterator->value;
             startVector.append(areaSpan.startLine());
             std::ranges::sort(startVector);
         }
         {
-            auto& endVector = namedGridLines.map.add(makeString(area.key, "-end"_s), Vector<unsigned>()).iterator->value;
+            auto& endVector = namedGridLines.map.add(CustomIdent { makeAtomString(area.key, "-end"_s) }, Vector<unsigned>()).iterator->value;
             endVector.append(areaSpan.endLine());
             std::ranges::sort(endVector);
         }

--- a/Source/WebCore/style/values/grid/StyleGridTemplateList.cpp
+++ b/Source/WebCore/style/values/grid/StyleGridTemplateList.cpp
@@ -49,7 +49,7 @@ GridTemplateList::GridTemplateList(GridTrackList&& entries)
         return;
 
     auto createGridLineNamesList = [](const auto& names, auto currentNamedGridLine, auto& namedGridLines, auto& orderedNamedGridLines) {
-        auto orderedResult = orderedNamedGridLines.map.add(currentNamedGridLine, Vector<String>());
+        auto orderedResult = orderedNamedGridLines.map.add(currentNamedGridLine, Vector<CustomIdent>());
         for (auto& name : names) {
             auto result = namedGridLines.map.add(name, Vector<unsigned> { });
             result.iterator->value.append(currentNamedGridLine);
@@ -66,7 +66,7 @@ GridTemplateList::GridTemplateList(GridTrackList&& entries)
                 ++currentNamedGridLine;
                 sizes.append(size);
             },
-            [&](const Vector<String>& names) {
+            [&](const Vector<CustomIdent>& names) {
                 createGridLineNamesList(names, currentNamedGridLine, namedLines, orderedNamedLines);
                 // Subgrids only have line names defined, not track sizes, so we want our count
                 // to be the number of lines named rather than number of sized tracks.
@@ -76,8 +76,8 @@ GridTemplateList::GridTemplateList(GridTrackList&& entries)
             [&](const GridTrackEntryRepeat& repeat) {
                 for (size_t i = 0; i < repeat.repeats; ++i) {
                     for (auto& repeatEntry : repeat.list) {
-                        if (std::holds_alternative<Vector<String>>(repeatEntry)) {
-                            createGridLineNamesList(std::get<Vector<String>>(repeatEntry), currentNamedGridLine, namedLines, orderedNamedLines);
+                        if (std::holds_alternative<Vector<CustomIdent>>(repeatEntry)) {
+                            createGridLineNamesList(std::get<Vector<CustomIdent>>(repeatEntry), currentNamedGridLine, namedLines, orderedNamedLines);
                             // Subgrids only have line names defined, not track sizes, so we want our count
                             // to be the number of lines named rather than number of sized tracks.
                             if (subgrid)
@@ -94,8 +94,8 @@ GridTemplateList::GridTemplateList(GridTrackList&& entries)
                 autoRepeatIndex = 0;
                 autoRepeatType = repeat.type;
                 for (auto& autoRepeatEntry : repeat.list) {
-                    if (std::holds_alternative<Vector<String>>(autoRepeatEntry)) {
-                        createGridLineNamesList(std::get<Vector<String>>(autoRepeatEntry), autoRepeatIndex, autoRepeatNamedLines, autoRepeatOrderedNamedLines);
+                    if (std::holds_alternative<Vector<CustomIdent>>(autoRepeatEntry)) {
+                        createGridLineNamesList(std::get<Vector<CustomIdent>>(autoRepeatEntry), autoRepeatIndex, autoRepeatNamedLines, autoRepeatOrderedNamedLines);
                         if (subgrid)
                             ++autoRepeatIndex;
                         continue;
@@ -145,8 +145,8 @@ auto CSSValueConversion<GridTemplateList>::operator()(BuilderState& state, const
     auto ensureLineNames = [&](auto& list) {
         if (subgridValue)
             return;
-        if (list.isEmpty() || !std::holds_alternative<Vector<String>>(list.last()))
-            list.append(Vector<String>());
+        if (list.isEmpty() || !std::holds_alternative<Vector<CustomIdent>>(list.last()))
+            list.append(Vector<CustomIdent>());
     };
 
     auto buildRepeatList = [&](const CSSValue& repeatValue, RepeatTrackList& repeatList) {
@@ -156,7 +156,7 @@ auto CSSValueConversion<GridTemplateList>::operator()(BuilderState& state, const
 
         for (Ref currentValue : *vectorValue) {
             if (RefPtr namesValue = dynamicDowncast<CSSGridLineNamesValue>(currentValue))
-                repeatList.append(Vector<String>(namesValue->names()));
+                repeatList.append(toStyle(namesValue->names(), state).value);
             else {
                 ensureLineNames(repeatList);
                 repeatList.append(toStyleFromCSSValue<GridTrackSize>(state, currentValue));
@@ -169,7 +169,7 @@ auto CSSValueConversion<GridTemplateList>::operator()(BuilderState& state, const
 
     auto addOne = [&](const CSSValue& currentValue) {
         if (RefPtr namesValue = dynamicDowncast<CSSGridLineNamesValue>(currentValue)) {
-            trackList.append(Vector<String>(namesValue->names()));
+            trackList.append(toStyle(namesValue->names(), state).value);
             return;
         }
 
@@ -220,11 +220,11 @@ static RepeatTrackList blendRepeatList(const RepeatTrackList& from, const Repeat
         [&](const GridTrackSize& size) {
             result.append(Style::blend(size, std::get<GridTrackSize>(to[i]), context));
         },
-        [&](const Vector<String>& names) {
+        [&](const Vector<CustomIdent>& names) {
             if (context.progress < 0.5)
                 result.append(names);
             else
-                result.append(std::get<Vector<String>>(to[i]));
+                result.append(std::get<Vector<CustomIdent>>(to[i]));
         }
     );
 
@@ -244,8 +244,8 @@ auto Blending<GridTemplateList>::canBlend(const GridTemplateList& from, const Gr
         [&](const GridTrackSize&) {
             return std::holds_alternative<GridTrackSize>(to.list[i]);
         },
-        [&](const Vector<String>&) {
-            return std::holds_alternative<Vector<String>>(to.list[i]);
+        [&](const Vector<CustomIdent>&) {
+            return std::holds_alternative<Vector<CustomIdent>>(to.list[i]);
         },
         [&](const GridTrackEntryRepeat& repeat) {
             if (!std::holds_alternative<GridTrackEntryRepeat>(to.list[i]))
@@ -281,11 +281,11 @@ auto Blending<GridTemplateList>::blend(const GridTemplateList& from, const GridT
         [&](const GridTrackSize& size) {
             result.append(Style::blend(size, std::get<GridTrackSize>(to.list[i]), context));
         },
-        [&](const Vector<String>& names) {
+        [&](const Vector<CustomIdent>& names) {
             if (context.progress < 0.5)
                 result.append(names);
             else
-                result.append(std::get<Vector<String>>(to.list[i]));
+                result.append(std::get<Vector<CustomIdent>>(to.list[i]));
         },
         [&](const GridTrackEntryRepeat& repeatFrom) {
             auto& repeatTo = std::get<GridTrackEntryRepeat>(to.list[i]);
@@ -324,7 +324,7 @@ TextStream& operator<<(TextStream& ts, const RepeatEntry& entry)
         [&](const GridTrackSize& size) {
             ts << size;
         },
-        [&](const Vector<String>& names) {
+        [&](const Vector<CustomIdent>& names) {
             ts << names;
         }
     );
@@ -337,7 +337,7 @@ TextStream& operator<<(TextStream& ts, const GridTrackEntry& entry)
         [&](const GridTrackSize& size) {
             ts << size;
         },
-        [&](const Vector<String>& names) {
+        [&](const Vector<CustomIdent>& names) {
             ts << names;
         },
         [&](const GridTrackEntryRepeat& repeat) {

--- a/Source/WebCore/style/values/grid/StyleGridTemplateList.h
+++ b/Source/WebCore/style/values/grid/StyleGridTemplateList.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <WebCore/RenderStyleConstants.h>
+#include <WebCore/StyleCustomIdent.h>
 #include <WebCore/StyleGridNamedLinesMap.h>
 #include <WebCore/StyleGridOrderedNamedLinesMap.h>
 #include <WebCore/StyleGridTrackSize.h>
@@ -34,7 +35,7 @@
 namespace WebCore {
 namespace Style {
 
-using RepeatEntry = Variant<GridTrackSize, Vector<String>>;
+using RepeatEntry = Variant<GridTrackSize, Vector<CustomIdent>>;
 using RepeatTrackList = Vector<RepeatEntry>;
 
 struct GridTrackEntryRepeat {
@@ -55,7 +56,7 @@ struct GridTrackEntrySubgrid { bool operator==(const GridTrackEntrySubgrid&) con
 
 using GridTrackEntry = Variant<
     GridTrackSize,
-    Vector<String>,
+    Vector<CustomIdent>,
     GridTrackEntryRepeat,
     GridTrackEntryAutoRepeat,
     GridTrackEntrySubgrid

--- a/Source/WebCore/style/values/line-grid/StyleWebKitLineGrid.h
+++ b/Source/WebCore/style/values/line-grid/StyleWebKitLineGrid.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/StyleCustomIdent.h>
 #include <WebCore/StyleValueTypes.h>
 
 namespace WebCore {
@@ -32,11 +33,11 @@ namespace Style {
 
 // <'-webkit-line-grid'> = none | <custom-ident excluding=none>
 // NOTE: While it has the same name, the standardized `line-grid` property is quite a bit different. See https://drafts.csswg.org/css-line-grid/#propdef-line-grid.
-struct WebkitLineGrid : ValueOrKeyword<CustomIdentifier, CSS::Keyword::None> {
+struct WebkitLineGrid : ValueOrKeyword<CustomIdent, CSS::Keyword::None> {
     using Base::Base;
 
     bool isNone() const { return isKeyword(); }
-    bool isCustomIdentifier() const { return isValue(); }
+    bool isCustomIdent() const { return isValue(); }
 };
 
 } // namespace Style

--- a/Source/WebCore/style/values/lists/StyleCounterIncrement.cpp
+++ b/Source/WebCore/style/values/lists/StyleCounterIncrement.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "StyleCounterIncrement.h"
 
+#include "CSSCustomIdentValue.h"
 #include "StyleBuilderChecking.h"
 #include "StylePrimitiveNumericTypes+CSSValueConversion.h"
 #include "StyleValueTypes+CSSValueConversion.h"
@@ -39,12 +40,12 @@ using namespace CSS::Literals;
 
 auto CSSValueConversion<CounterIncrementValue>::operator()(BuilderState& state, const CSSValue& value) -> CounterIncrementValue
 {
-    auto pair = requiredPairDowncast<CSSPrimitiveValue>(state, value);
+    auto pair = requiredPairDowncast<CSSCustomIdentValue, CSSPrimitiveValue>(state, value);
     if (!pair)
-        return { CustomIdentifier { emptyAtom() }, 1_css_integer };
+        return { CustomIdent { emptyAtom() }, 1_css_integer };
 
     return {
-        toStyleFromCSSValue<CustomIdentifier>(state, pair->first),
+        toStyleFromCSSValue<CustomIdent>(state, pair->first),
         toStyleFromCSSValue<Integer<>>(state, pair->second),
     };
 }

--- a/Source/WebCore/style/values/lists/StyleCounterIncrement.h
+++ b/Source/WebCore/style/values/lists/StyleCounterIncrement.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/StyleCustomIdent.h>
 #include <WebCore/StylePrimitiveNumericTypes.h>
 
 namespace WebCore {
@@ -35,7 +36,7 @@ namespace Style {
 
 // <counter-increment-value> = [ <counter-name> <integer>?@(default=1) ]
 struct CounterIncrementValue {
-    CustomIdentifier name;
+    CustomIdent name;
     Integer<> value;
 
     bool operator==(const CounterIncrementValue&) const = default;

--- a/Source/WebCore/style/values/lists/StyleCounterReset.cpp
+++ b/Source/WebCore/style/values/lists/StyleCounterReset.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "StyleCounterReset.h"
 
+#include "CSSCustomIdentValue.h"
 #include "StyleBuilderChecking.h"
 #include "StylePrimitiveNumericTypes+CSSValueConversion.h"
 #include "StyleValueTypes+CSSValueConversion.h"
@@ -39,12 +40,12 @@ using namespace CSS::Literals;
 
 auto CSSValueConversion<CounterResetValue>::operator()(BuilderState& state, const CSSValue& value) -> CounterResetValue
 {
-    auto pair = requiredPairDowncast<CSSPrimitiveValue>(state, value);
+    auto pair = requiredPairDowncast<CSSCustomIdentValue, CSSPrimitiveValue>(state, value);
     if (!pair)
-        return { CustomIdentifier { emptyAtom() }, 1_css_integer };
+        return { CustomIdent { emptyAtom() }, 1_css_integer };
 
     return {
-        toStyleFromCSSValue<CustomIdentifier>(state, pair->first),
+        toStyleFromCSSValue<CustomIdent>(state, pair->first),
         toStyleFromCSSValue<Integer<>>(state, pair->second),
     };
 }

--- a/Source/WebCore/style/values/lists/StyleCounterReset.h
+++ b/Source/WebCore/style/values/lists/StyleCounterReset.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/StyleCustomIdent.h>
 #include <WebCore/StylePrimitiveNumericTypes.h>
 
 namespace WebCore {
@@ -35,7 +36,7 @@ namespace Style {
 
 // <counter-reset-value> = [ <counter-name> <integer>?@(default=0) ]
 struct CounterResetValue {
-    CustomIdentifier name;
+    CustomIdent name;
     Integer<> value;
 
     bool operator==(const CounterResetValue&) const = default;

--- a/Source/WebCore/style/values/lists/StyleCounterSet.cpp
+++ b/Source/WebCore/style/values/lists/StyleCounterSet.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "StyleCounterSet.h"
 
+#include "CSSCustomIdentValue.h"
 #include "StyleBuilderChecking.h"
 #include "StylePrimitiveNumericTypes+CSSValueConversion.h"
 #include "StyleValueTypes+CSSValueConversion.h"
@@ -39,12 +40,12 @@ using namespace CSS::Literals;
 
 auto CSSValueConversion<CounterSetValue>::operator()(BuilderState& state, const CSSValue& value) -> CounterSetValue
 {
-    auto pair = requiredPairDowncast<CSSPrimitiveValue>(state, value);
+    auto pair = requiredPairDowncast<CSSCustomIdentValue, CSSPrimitiveValue>(state, value);
     if (!pair)
-        return { CustomIdentifier { emptyAtom() }, 1_css_integer };
+        return { CustomIdent { emptyAtom() }, 1_css_integer };
 
     return {
-        toStyleFromCSSValue<CustomIdentifier>(state, pair->first),
+        toStyleFromCSSValue<CustomIdent>(state, pair->first),
         toStyleFromCSSValue<Integer<>>(state, pair->second),
     };
 }

--- a/Source/WebCore/style/values/lists/StyleCounterSet.h
+++ b/Source/WebCore/style/values/lists/StyleCounterSet.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/StyleCustomIdent.h>
 #include <WebCore/StylePrimitiveNumericTypes.h>
 
 namespace WebCore {
@@ -35,7 +36,7 @@ namespace Style {
 
 // <counter-set-value> = [ <counter-name> <integer>?@(default=0) ]
 struct CounterSetValue {
-    CustomIdentifier name;
+    CustomIdent name;
     Integer<> value;
 
     bool operator==(const CounterSetValue&) const = default;

--- a/Source/WebCore/style/values/lists/StyleListStyleType.cpp
+++ b/Source/WebCore/style/values/lists/StyleListStyleType.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2023 Apple Inc. All rights reserved.
- * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2025-2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,9 +27,9 @@
 #include "config.h"
 #include "StyleListStyleType.h"
 
-#include "CSSPrimitiveValue.h"
+#include "CSSPropertyParserConsumer+CounterStyles.h"
+#include "CSSValueKeywords.h"
 #include "StyleBuilderChecking.h"
-#include "StyleValueTypes.h"
 #include <wtf/StdLibExtras.h>
 
 namespace WebCore {
@@ -107,19 +107,22 @@ bool ListStyleType::isSquare() const
 
 auto CSSValueConversion<ListStyleType>::operator()(BuilderState& state, const CSSValue& value) -> ListStyleType
 {
-    RefPtr primitiveValue = requiredDowncast<CSSPrimitiveValue>(state, value);
-    if (!primitiveValue)
+    if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
+        if (primitiveValue->isValueID()) {
+            auto valueID = primitiveValue->valueID();
+            if (valueID == CSSValueNone)
+                return CSS::Keyword::None { };
+            return CounterStyle { CustomIdent { nameStringForSerialization(valueID) } };
+        }
+
+        if (primitiveValue->isString())
+            return AtomString { primitiveValue->stringValue() };
+
+        state.setCurrentPropertyInvalidAtComputedValueTime();
         return CSS::Keyword::None { };
-
-    if (primitiveValue->isValueID()) {
-        if (primitiveValue->valueID() == CSSValueNone)
-            return CSS::Keyword::None { };
-        return CounterStyle { { AtomString { primitiveValue->stringValue() } } };
     }
-    if (primitiveValue->isCustomIdent())
-        return CounterStyle { { AtomString { primitiveValue->stringValue() } } };
 
-    return AtomString { primitiveValue->stringValue() };
+    return CounterStyle { toStyleFromCSSValue<CustomIdent>(state, value) };
 }
 
 auto CSSValueCreation<ListStyleType>::operator()(CSSValuePool& pool, const RenderStyle& style, const ListStyleType& value) -> Ref<CSSValue>

--- a/Source/WebCore/style/values/non-standard/StyleWebKitLocale.h
+++ b/Source/WebCore/style/values/non-standard/StyleWebKitLocale.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/StyleCustomIdent.h>
 #include <WebCore/StyleValueTypes.h>
 #include <wtf/text/AtomString.h>
 
@@ -51,7 +52,7 @@ struct WebkitLocale {
             return visitor(CSS::Keyword::Auto { });
 
         // FIXME: It seems wrong that we extract/serialize the value as a <custom-ident>, given it is parsed as a <string>, but this maintains existing behavior. See https://bugs.webkit.org/show_bug.cgi?id=302724.
-        return visitor(CustomIdentifier { m_platform });
+        return visitor(CustomIdent { m_platform });
     }
 
     bool operator==(const WebkitLocale&) const = default;

--- a/Source/WebCore/style/values/primitives/StyleCustomIdent.cpp
+++ b/Source/WebCore/style/values/primitives/StyleCustomIdent.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2026 saku
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleCustomIdent.h"
+
+#include "CSSCustomIdentValue.h"
+#include "CSSMarkup.h"
+#include "StyleBuilderChecking.h"
+#include "StyleValueTypes.h"
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+namespace Style {
+
+// MARK: - Conversion
+
+auto ToCSS<CustomIdent>::operator()(const CustomIdent& value, const RenderStyle&) -> CSS::CustomIdent
+{
+    return { .value = value.value };
+}
+
+auto ToStyle<CSS::CustomIdent>::operator()(const CSS::CustomIdent& value, const BuilderState&) -> CustomIdent
+{
+    return { .value = value.value };
+}
+
+Ref<CSSValue> CSSValueCreation<CustomIdent>::operator()(CSSValuePool&, const RenderStyle& style, const CustomIdent& value)
+{
+    return CSSCustomIdentValue::create(toCSS(value, style));
+}
+
+auto CSSValueConversion<CustomIdent>::operator()(BuilderState& state, const CSSCustomIdentValue& value) -> CustomIdent
+{
+    return toStyle(value.customIdent(), state);
+}
+
+auto CSSValueConversion<CustomIdent>::operator()(BuilderState& state, const CSSValue& value) -> CustomIdent
+{
+    if (RefPtr customIdentValue = requiredDowncast<CSSCustomIdentValue>(state, value))
+        return toStyle(customIdentValue->customIdent(), state);
+    return { .value = nullAtom() };
+}
+
+// MARK: - Serialization
+
+void Serialize<CustomIdent>::operator()(StringBuilder& builder, const CSS::SerializationContext&, const RenderStyle&, const CustomIdent& value)
+{
+    WebCore::serializeIdentifier(builder, value.value);
+}
+
+// MARK: - Logging
+
+TextStream& operator<<(TextStream& ts, const CustomIdent& value)
+{
+    return ts << value.value;
+}
+
+// MARK: - Hashing
+
+void add(Hasher& hasher, const CustomIdent& value)
+{
+    add(hasher, value.value);
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/primitives/StyleCustomIdent.h
+++ b/Source/WebCore/style/values/primitives/StyleCustomIdent.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2026 saku
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/CSSCustomIdent.h>
+#include <WebCore/StyleValueTypes.h>
+
+namespace WebCore {
+
+class CSSCustomIdentValue;
+
+namespace Style {
+
+struct CustomIdent {
+    AtomString value;
+
+    bool operator==(const CustomIdent&) const = default;
+    bool operator==(const AtomString& other) const { return value == other; }
+};
+
+// MARK: - Conversion
+
+template<> struct ToCSS<CustomIdent> { auto operator()(const CustomIdent&, const RenderStyle&) -> CSS::CustomIdent; };
+template<> struct ToStyle<CSS::CustomIdent> { auto operator()(const CSS::CustomIdent&, const BuilderState&) -> CustomIdent; };
+
+// `CustomIdent` is special-cased to return a `CSSCustomIdentValue`.
+template<> struct CSSValueCreation<CustomIdent> {
+    Ref<CSSValue> operator()(CSSValuePool&, const RenderStyle&, const CustomIdent&);
+};
+template<> struct CSSValueConversion<CustomIdent> {
+    auto operator()(BuilderState&, const CSSCustomIdentValue&) -> CustomIdent;
+    auto operator()(BuilderState&, const CSSValue&) -> CustomIdent;
+};
+
+// MARK: - Serialization
+
+template<> struct Serialize<CustomIdent> { void operator()(StringBuilder&, const CSS::SerializationContext&, const RenderStyle&, const CustomIdent&); };
+
+// MARK: - Logging
+
+TextStream& operator<<(TextStream&, const CustomIdent&);
+
+// MARK: - Hashing
+
+void NODELETE add(Hasher&, const CustomIdent&);
+
+} // namespace Style
+} // namespace WebCore
+
+namespace WTF {
+
+template<>
+struct MarkableTraits<WebCore::Style::CustomIdent> {
+    static bool isEmptyValue(const WebCore::Style::CustomIdent& value) { return value.value.isNull(); }
+    static WebCore::Style::CustomIdent emptyValue() { return WebCore::Style::CustomIdent { nullAtom() }; }
+};
+
+template<>
+struct HashTraits<WebCore::Style::CustomIdent> : GenericHashTraits<WebCore::Style::CustomIdent> {
+    using EmptyValueType = WebCore::Style::CustomIdent;
+    static constexpr bool emptyValueIsZero = true;
+    static constexpr bool hasIsEmptyValueFunction = true;
+    static bool isEmptyValue(const WebCore::Style::CustomIdent& value) { return value.value.isNull(); }
+    static EmptyValueType emptyValue() { return WebCore::Style::CustomIdent { nullAtom() }; }
+
+    static void constructDeletedValue(WebCore::Style::CustomIdent& value) { new (NotNull, std::addressof(value.value)) AtomString { HashTableDeletedValue }; }
+    static bool isDeletedValue(const WebCore::Style::CustomIdent& value) { return value.value.isHashTableDeletedValue(); }
+};
+
+} // namespace WTF

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h
@@ -128,7 +128,7 @@ float canonicalizeAndClampLength(double, CSS::LengthUnit, const CSSToLengthConve
 
 template<auto R, typename V, typename... Rest> constexpr Integer<R, V> canonicalize(const CSS::IntegerRaw<R, V>& raw, NoConversionDataRequiredToken, Rest&&...)
 {
-    return { roundForImpreciseConversion<V>(raw.value) };
+    return { clampTo<V>(raw.value) };
 }
 
 template<auto R, typename V, typename... Rest> constexpr Integer<R, V> canonicalize(const CSS::IntegerRaw<R, V>& raw, const CSSToLengthConversionData&, Rest&&... rest)

--- a/Source/WebCore/style/values/scroll-animations/StyleProgressTimelineName.h
+++ b/Source/WebCore/style/values/scroll-animations/StyleProgressTimelineName.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <WebCore/StyleCustomIdent.h>
 #include <WebCore/StyleValueTypes.h>
 
 namespace WebCore {
@@ -31,7 +32,7 @@ namespace Style {
 
 // <single-progress-timeline-name> = none | <dashed-ident>
 // https://drafts.csswg.org/scroll-animations/#propdef-scroll-timeline-name
-struct ProgressTimelineName : ValueOrKeyword<CustomIdentifier, CSS::Keyword::None> {
+struct ProgressTimelineName : ValueOrKeyword<CustomIdent, CSS::Keyword::None> {
     using Base::Base;
 
     bool isNone() const { return isKeyword(); }

--- a/Source/WebCore/style/values/transitions/StyleSingleTransitionProperty.cpp
+++ b/Source/WebCore/style/values/transitions/StyleSingleTransitionProperty.cpp
@@ -37,24 +37,24 @@ namespace Style {
 
 auto CSSValueConversion<SingleTransitionProperty>::operator()(BuilderState& state, const CSSValue& value) -> SingleTransitionProperty
 {
-    RefPtr primitiveValue = requiredDowncast<CSSPrimitiveValue>(state, value);
-    if (!primitiveValue)
-        return CSS::Keyword::All { };
+    if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
+        switch (primitiveValue->valueID()) {
+        case CSSValueAll:
+            return CSS::Keyword::All { };
+        case CSSValueNone:
+            return CSS::Keyword::None { };
+        default:
+            break;
+        }
 
-    switch (primitiveValue->valueID()) {
-    case CSSValueAll:
-        return CSS::Keyword::All { };
-    case CSSValueNone:
-        return CSS::Keyword::None { };
-    default:
-        break;
+        auto propertyID = primitiveValue->propertyID();
+        if (propertyID == CSSPropertyInvalid)
+            return CustomIdent { AtomString { primitiveValue->stringValue() } };
+
+        return propertyID;
     }
 
-    auto propertyID = primitiveValue->propertyID();
-    if (propertyID == CSSPropertyInvalid)
-        return CustomIdentifier { AtomString { primitiveValue->stringValue() } };
-
-    return propertyID;
+    return toStyleFromCSSValue<CustomIdent>(state, value);
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/transitions/StyleSingleTransitionProperty.h
+++ b/Source/WebCore/style/values/transitions/StyleSingleTransitionProperty.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <WebCore/CSSPropertyParser.h>
+#include <WebCore/StyleCustomIdent.h>
 #include <WebCore/StyleValueTypes.h>
 #include <WebCore/WebAnimationTypes.h>
 #include <WebCore/WebAnimationUtilities.h>
@@ -36,7 +37,7 @@ namespace Style {
 // https://www.w3.org/TR/css-transitions-1/#single-transition-property
 struct SingleTransitionProperty {
     struct UnknownProperty {
-        CustomIdentifier value;
+        CustomIdent value;
 
         bool operator==(const UnknownProperty&) const = default;
     };
@@ -46,7 +47,7 @@ struct SingleTransitionProperty {
         template<typename... F> decltype(auto) switchOn(F&&... f) const
         {
             auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
-            return visitor(CustomIdentifier { animatablePropertyAsString(value) });
+            return visitor(CustomIdent { animatablePropertyAsString(value) });
         }
 
         bool operator==(const SingleProperty&) const = default;
@@ -62,8 +63,8 @@ struct SingleTransitionProperty {
     {
     }
 
-    SingleTransitionProperty(CustomIdentifier&& identifier)
-        : m_value { fromCustomIdentifier(WTF::move(identifier)) }
+    SingleTransitionProperty(CustomIdent&& customIdent)
+        : m_value { fromCustomIdent(WTF::move(customIdent)) }
     {
     }
 
@@ -87,11 +88,11 @@ struct SingleTransitionProperty {
 private:
     using Kind = Variant<CSS::Keyword::All, CSS::Keyword::None, UnknownProperty, SingleProperty>;
 
-    static Kind fromCustomIdentifier(CustomIdentifier&& identifier)
+    static Kind fromCustomIdent(CustomIdent&& customIdent)
     {
-        if (isCustomPropertyName(identifier.value))
-            return Kind { SingleProperty { .value = WTF::move(identifier.value) } };
-        return Kind { UnknownProperty { .value = WTF::move(identifier) } };
+        if (isCustomPropertyName(customIdent.value))
+            return Kind { SingleProperty { .value = WTF::move(customIdent.value) } };
+        return Kind { UnknownProperty { .value = WTF::move(customIdent) } };
     }
 
     Kind m_value;

--- a/Source/WebCore/style/values/view-transitions/StyleViewTransitionName.cpp
+++ b/Source/WebCore/style/values/view-transitions/StyleViewTransitionName.cpp
@@ -35,22 +35,23 @@ namespace Style {
 
 auto CSSValueConversion<ViewTransitionName>::operator()(BuilderState& state, const CSSValue& value) -> ViewTransitionName
 {
-    RefPtr primitiveValue = requiredDowncast<CSSPrimitiveValue>(state, value);
-    if (!primitiveValue)
-        return CSS::Keyword::None { };
+    if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
+        switch (primitiveValue->valueID()) {
+        case CSSValueNone:
+            return CSS::Keyword::None { };
+        case CSSValueAuto:
+            return { CSS::Keyword::Auto { }, state.styleScopeOrdinal() };
+        case CSSValueMatchElement:
+            return { CSS::Keyword::MatchElement { }, state.styleScopeOrdinal() };
+        default:
+            break;
+        }
 
-    switch (primitiveValue->valueID()) {
-    case CSSValueNone:
+        state.setCurrentPropertyInvalidAtComputedValueTime();
         return CSS::Keyword::None { };
-    case CSSValueAuto:
-        return { CSS::Keyword::Auto { }, state.styleScopeOrdinal() };
-    case CSSValueMatchElement:
-        return { CSS::Keyword::MatchElement { }, state.styleScopeOrdinal() };
-    default:
-        break;
     }
 
-    return { CustomIdentifier { AtomString { primitiveValue->stringValue() } }, state.styleScopeOrdinal() };
+    return { toStyleFromCSSValue<CustomIdent>(state, value), state.styleScopeOrdinal() };
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/view-transitions/StyleViewTransitionName.h
+++ b/Source/WebCore/style/values/view-transitions/StyleViewTransitionName.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/StyleCustomIdent.h>
 #include <WebCore/StyleScopeOrdinal.h>
 #include <WebCore/StyleValueTypes.h>
 
@@ -51,8 +52,8 @@ struct ViewTransitionName {
     {
     }
 
-    ViewTransitionName(CustomIdentifier&& customIdentifier, ScopeOrdinal ordinal)
-        : m_value { WTF::move(customIdentifier) }
+    ViewTransitionName(CustomIdent&& customIdent, ScopeOrdinal ordinal)
+        : m_value { WTF::move(customIdent) }
         , m_scopeOrdinal { ordinal }
     {
     }
@@ -60,7 +61,7 @@ struct ViewTransitionName {
     bool isNone() const { return WTF::holdsAlternative<CSS::Keyword::None>(m_value); }
     bool isAuto() const { return WTF::holdsAlternative<CSS::Keyword::Auto>(m_value); }
     bool isMatchElement() const { return WTF::holdsAlternative<CSS::Keyword::MatchElement>(m_value); }
-    bool isCustomIdentifier() const { return WTF::holdsAlternative<CustomIdentifier>(m_value); }
+    bool isCustomIdent() const { return WTF::holdsAlternative<CustomIdent>(m_value); }
 
     ScopeOrdinal scopeOrdinal() const { ASSERT(!isNone()); return m_scopeOrdinal; }
 
@@ -72,7 +73,7 @@ struct ViewTransitionName {
     bool operator==(const ViewTransitionName&) const = default;
 
 private:
-    Variant<CSS::Keyword::None, CSS::Keyword::Auto, CSS::Keyword::MatchElement, CustomIdentifier> m_value;
+    Variant<CSS::Keyword::None, CSS::Keyword::Auto, CSS::Keyword::MatchElement, CustomIdent> m_value;
     ScopeOrdinal m_scopeOrdinal { ScopeOrdinal::Element };
 };
 


### PR DESCRIPTION
#### 125597185d4fd58193e9cf35ec5e1a5c6417143b
<pre>
Split WebCore::CustomIdentifier into separate CSS::CustomIdent/Style::CustomIdent types
<a href="https://bugs.webkit.org/show_bug.cgi?id=311269">https://bugs.webkit.org/show_bug.cgi?id=311269</a>

Reviewed by Darin Adler.

This extends a PR from @sakupi01 (<a href="https://github.com/WebKit/WebKit/pull/59674)">https://github.com/WebKit/WebKit/pull/59674)</a>, adding
and adopting new CSS::CustomIdent/Style::CustomIdent types in preparation for adding
support for the CSS ident() function.

In addition to the CSS::CustomIdent/Style::CustomIdent types, a number of additional
types were also needed.

- CSSCustomIdentValue was added, replacing usage of CSSPrimitiveValue for custom idents.
- CSSCounterStyle was renamed to CSSRegisteredCounterStyle, freeing up CSSCounterStyle.h
  for CSS::CounterStyle.

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/animation/CSSAnimation.cpp:
* Source/WebCore/animation/StyleOriginatedTimelinesController.cpp:
* Source/WebCore/animation/StyleOriginatedTimelinesController.h:
* Source/WebCore/css/CSSCounterStyleDescriptors.cpp:
* Source/WebCore/css/CSSCounterStyleRegistry.cpp:
* Source/WebCore/css/CSSCounterStyleRegistry.h:
* Source/WebCore/css/CSSCounterStyleRule.h:
* Source/WebCore/css/CSSCounterValue.cpp:
* Source/WebCore/css/CSSCounterValue.h:
* Source/WebCore/css/CSSCustomIdentValue.cpp: Added.
* Source/WebCore/css/CSSCustomIdentValue.h: Added.
* Source/WebCore/css/CSSGridLineNamesValue.cpp:
* Source/WebCore/css/CSSGridLineNamesValue.h:
* Source/WebCore/css/CSSGridLineValue.cpp:
* Source/WebCore/css/CSSGridLineValue.h:
* Source/WebCore/css/CSSPrimitiveValue.cpp:
* Source/WebCore/css/CSSPrimitiveValue.h:
* Source/WebCore/css/CSSRegisteredCounterStyle.cpp: Renamed from Source/WebCore/css/CSSCounterStyle.cpp.
* Source/WebCore/css/CSSRegisteredCounterStyle.h: Renamed from Source/WebCore/css/CSSCounterStyle.h.
* Source/WebCore/css/CSSUnits.cpp:
* Source/WebCore/css/CSSUnits.h:
* Source/WebCore/css/CSSValue.cpp:
* Source/WebCore/css/CSSValue.h:
* Source/WebCore/css/CSSViewTransitionRule.cpp:
* Source/WebCore/css/DeprecatedCSSOMPrimitiveValue.cpp:
* Source/WebCore/css/ShorthandSerializer.cpp:
* Source/WebCore/css/calc/CSSCalcRandomCachingKey.h:
* Source/WebCore/css/calc/CSSCalcTree+Evaluation.cpp:
* Source/WebCore/css/calc/CSSCalcTree+NumericIdentity.h:
* Source/WebCore/css/calc/CSSCalcTree+Parser.cpp:
* Source/WebCore/css/calc/CSSCalcTree+Serialization.cpp:
* Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp:
* Source/WebCore/css/calc/CSSCalcTree.cpp:
* Source/WebCore/css/calc/CSSCalcTree.h:
* Source/WebCore/css/calc/CSSCalcType.cpp:
* Source/WebCore/css/parser/CSSCustomPropertySyntax.cpp:
* Source/WebCore/css/parser/CSSCustomPropertySyntax.h:
* Source/WebCore/css/parser/CSSParser.cpp:
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Animations.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+ColorAdjust.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Content.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+CounterStyles.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+CounterStyles.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Ident.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Ident.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Lists.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+PositionTry.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Transitions.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+ViewTransition.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+WillChange.cpp:
* Source/WebCore/css/parser/CSSPropertyParserCustom.h:
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
* Source/WebCore/css/query/ContainerQueryParser.cpp:
* Source/WebCore/css/scripts/process-css-properties.py:
* Source/WebCore/css/typedom/CSSKeywordValue.cpp:
* Source/WebCore/css/values/CSSValueAggregates.cpp:
* Source/WebCore/css/values/CSSValueAggregates.h:
* Source/WebCore/css/values/CSSValueTypes.cpp:
* Source/WebCore/css/values/CSSValueTypes.h:
* Source/WebCore/css/values/color-adjust/CSSColorScheme.h:
* Source/WebCore/css/values/counter-styles/CSSCounterStyle.h: Added.
* Source/WebCore/css/values/grid/CSSGridNamedAreaMap.h:
* Source/WebCore/css/values/primitives/CSSCustomIdent.cpp: Added.
* Source/WebCore/css/values/primitives/CSSCustomIdent.h: Added.
* Source/WebCore/css/values/primitives/CSSPrimitiveNumeric.h:
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h:
* Source/WebCore/dom/ViewTransition.cpp:
* Source/WebCore/inspector/InspectorOverlay.cpp:
* Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp:
* Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp:
* Source/WebCore/rendering/RenderCounter.cpp:
* Source/WebCore/rendering/RenderCounter.h:
* Source/WebCore/rendering/RenderListMarker.cpp:
* Source/WebCore/rendering/RenderListMarker.h:
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
* Source/WebCore/style/ScopedName.cpp:
* Source/WebCore/style/ScopedName.h:
* Source/WebCore/style/StyleBuilderChecking.h:
* Source/WebCore/style/StyleCustomProperty.h:
* Source/WebCore/style/StyleExtractorCustom.h:
* Source/WebCore/style/StyleInterpolation.cpp:
* Source/WebCore/style/StyleNameScope.cpp:
* Source/WebCore/style/StyleNameScope.h:
* Source/WebCore/style/StyleOrderedNamedLinesCollector.h:
* Source/WebCore/style/Styleable.cpp:
* Source/WebCore/style/calc/StyleCalculationTree+Conversion.cpp:
* Source/WebCore/style/values/StyleValueTypes+CSSValueConversion.h:
* Source/WebCore/style/values/StyleValueTypes.h:
* Source/WebCore/style/values/anchor-position/StylePositionTryFallback.cpp:
* Source/WebCore/style/values/animations/StyleSingleAnimationName.cpp:
* Source/WebCore/style/values/animations/StyleSingleAnimationTimeline.cpp:
* Source/WebCore/style/values/animations/StyleSingleAnimationTimeline.h:
* Source/WebCore/style/values/color-adjust/StyleColorScheme.h:
* Source/WebCore/style/values/content/StyleContent.cpp:
* Source/WebCore/style/values/content/StyleContent.h:
* Source/WebCore/style/values/counter-styles/StyleCounterStyle.h:
* Source/WebCore/style/values/fonts/StyleFontPalette.cpp:
* Source/WebCore/style/values/fonts/StyleFontPalette.h:
* Source/WebCore/style/values/fonts/StyleFontVariantAlternates.cpp:
* Source/WebCore/style/values/grid/StyleGridNamedLinesMap.h:
* Source/WebCore/style/values/grid/StyleGridOrderedNamedLinesMap.h:
* Source/WebCore/style/values/grid/StyleGridPosition.cpp:
* Source/WebCore/style/values/grid/StyleGridPosition.h:
* Source/WebCore/style/values/grid/StyleGridPositionsResolver.cpp:
* Source/WebCore/style/values/grid/StyleGridTemplateAreas.cpp:
* Source/WebCore/style/values/grid/StyleGridTemplateList.cpp:
* Source/WebCore/style/values/grid/StyleGridTemplateList.h:
* Source/WebCore/style/values/line-grid/StyleWebKitLineGrid.h:
* Source/WebCore/style/values/lists/StyleCounterIncrement.cpp:
* Source/WebCore/style/values/lists/StyleCounterIncrement.h:
* Source/WebCore/style/values/lists/StyleCounterReset.cpp:
* Source/WebCore/style/values/lists/StyleCounterReset.h:
* Source/WebCore/style/values/lists/StyleCounterSet.cpp:
* Source/WebCore/style/values/lists/StyleCounterSet.h:
* Source/WebCore/style/values/lists/StyleListStyleType.cpp:
* Source/WebCore/style/values/non-standard/StyleWebKitLocale.h:
* Source/WebCore/style/values/primitives/StyleCustomIdent.cpp: Added.
* Source/WebCore/style/values/primitives/StyleCustomIdent.h: Added.
* Source/WebCore/style/values/scroll-animations/StyleProgressTimelineName.h:
* Source/WebCore/style/values/transitions/StyleSingleTransitionProperty.cpp:
* Source/WebCore/style/values/transitions/StyleSingleTransitionProperty.h:
* Source/WebCore/style/values/view-transitions/StyleViewTransitionName.cpp:
* Source/WebCore/style/values/view-transitions/StyleViewTransitionName.h:

Canonical link: <a href="https://commits.webkit.org/310915@main">https://commits.webkit.org/310915@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b8f82f2646987a5a504dbb2af51b2e2b26edc2e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155179 "14 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28439 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21598 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163939 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108821 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157052 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28579 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28287 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120069 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84816 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158138 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22324 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139356 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100764 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21410 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19460 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11765 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131073 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17195 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166417 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/10561 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18894 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128173 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27983 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23496 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128310 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34849 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27907 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138988 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84616 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23175 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15784 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27600 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91704 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27178 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27408 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27251 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->