### PR TITLE
Some main frame and same-site loads are blocked with `scriptTrackingPrivacyNetworkRequestBlockingLatchEnabled`

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
@@ -42,6 +42,7 @@
 #include <WebCore/HTTPStatusCodes.h>
 #include <WebCore/LegacySchemeRegistry.h>
 #include <WebCore/OriginAccessPatterns.h>
+#include <WebCore/RegistrableDomain.h>
 #include <wtf/Scope.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
@@ -354,6 +355,11 @@ bool NetworkLoadChecker::shouldBlockForTrackingPolicy(const ResourceRequest& req
     auto mayBlock = networkResourceLoader->parameters().mayBlockNetworkRequest;
     if (!mayBlock)
         return false;
+
+    if (RefPtr topOrigin = networkResourceLoader->parameters().topOrigin) {
+        if (RegistrableDomain(request.url()).matches(topOrigin->data()))
+            return false;
+    }
 
     if (*mayBlock && networkResourceLoader->parameters().options.destination != FetchOptionsDestination::Script) {
         LOAD_CHECKER_RELEASE_LOG("shouldBlockForTrackingPolicy - Blocked non-script load by tracking protections");

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -400,7 +400,7 @@ static void addParametersShared(const LocalFrame* frame, NetworkResourceLoadPara
         parameters.crossOriginEmbedderPolicy = document->crossOriginEmbedderPolicy();
         parameters.isClearSiteDataHeaderEnabled = document->settings().clearSiteDataHTTPHeaderEnabled();
         parameters.isClearSiteDataExecutionContextEnabled = document->settings().clearSiteDataExecutionContextsSupportEnabled();
-        parameters.mayBlockNetworkRequest = document->settings().scriptTrackingPrivacyNetworkRequestBlockingLatchEnabled() ?
+        parameters.mayBlockNetworkRequest = (!isMainFrameNavigation && document->settings().scriptTrackingPrivacyNetworkRequestBlockingLatchEnabled()) ?
             std::optional { WebProcess::singleton().shouldBlockRequest(parameters.request.url(), protect(document->topOrigin())) } : std::nullopt;
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ScriptTrackingPrivacyTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ScriptTrackingPrivacyTests.mm
@@ -1233,6 +1233,125 @@ TEST(ScriptTrackingPrivacyTests, BlockSubsequent2Element)
     EXPECT_TRUE([taintedLoadResult2 hasPrefix:@"error"]);
 }
 
+TEST(ScriptTrackingPrivacyTests, SameSiteFetchNotBlocked)
+{
+    if (!supportsFingerprintingScriptRequests())
+        return;
+
+    FingerprintingScriptsRequestSwizzler swizzler { @[ @"tainted.example" ] };
+
+    static constexpr auto taintedSiteIndexHTML = R"markup(
+        <!DOCTYPE html>
+        <html>
+            <body>
+                <script src="http://tainted.example/script.js"></script>
+            </body>
+        </html>
+    )markup"_s;
+
+    auto server = HTTPServer(HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> ConnectionTask {
+        while (1) {
+            auto request = co_await connection.awaitableReceiveHTTPRequest();
+            auto path = HTTPServer::parsePath(request);
+
+            if (path.endsWith("/script.js"_s)) {
+                co_await connection.awaitableSend(HTTPResponse({ { "Content-Type"_s, "text/javascript"_s } },
+                    "async function doFetch() {"
+                    "  try {"
+                    "    const response = await fetch('http://tainted.example/data.json');"
+                    "    const data = await response.text();"
+                    "    window.fetchResult = 'success: ' + data;"
+                    "  } catch (e) {"
+                    "    window.fetchResult = 'error: ' + e.message;"
+                    "  }"
+                    "}"
+                    "doFetch();"_s).serialize());
+                continue;
+            }
+            if (path.endsWith("/index.html"_s)) {
+                co_await connection.awaitableSend(HTTPResponse({ { "Content-Type"_s, "text/html"_s } }, String { taintedSiteIndexHTML }).serialize());
+                continue;
+            }
+            if (path.endsWith("/data.json"_s)) {
+                co_await connection.awaitableSend(HTTPResponse({ { "Content-Type"_s, "text/plain"_s } }, "{\"value\": 42}"_s).serialize());
+                continue;
+            }
+
+            EXPECT_FALSE(true);
+        }
+    }, HTTPServer::Protocol::Http);
+
+    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    [storeConfiguration setProxyConfiguration:@{
+        (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
+        (NSString *)kCFStreamPropertyHTTPProxyPort: @(server.port())
+    }];
+
+    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+
+    RetainPtr webView = setUpWebViewForFingerprintingTests(@"http://tainted.example/index.html", dataStore.get());
+
+    Util::waitForConditionWithLogging([&] -> bool {
+        return [[webView stringByEvaluatingJavaScript:@"window.fetchResult || ''"] length] > 0;
+    }, 10, @"Timed out waiting for fetch result.");
+
+    RetainPtr fetchResult = [webView stringByEvaluatingJavaScript:@"window.fetchResult"];
+    EXPECT_TRUE([fetchResult hasPrefix:@"success:"]);
+}
+
+TEST(ScriptTrackingPrivacyTests, MainFrameNavigationNotBlocked)
+{
+    if (!supportsFingerprintingScriptRequests())
+        return;
+
+    FingerprintingScriptsRequestSwizzler swizzler { @[ @"tainted.example" ] };
+
+    bool receivedNavigationRequest = false;
+
+    auto server = HTTPServer(HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> ConnectionTask {
+        while (1) {
+            auto request = co_await connection.awaitableReceiveHTTPRequest();
+            auto path = HTTPServer::parsePath(request);
+
+            if (path.endsWith("/script.js"_s)) {
+                co_await connection.awaitableSend(HTTPResponse({ { "Content-Type"_s, "text/javascript"_s } }, ""_s).serialize());
+                continue;
+            }
+            if (path.contains("top-domain.org"_s) && path.endsWith("/index.html"_s)) {
+                String document = makeStringByReplacingAll(String { simpleIndexHTML }, "test://"_s, "http://"_s);
+                co_await connection.awaitableSend(HTTPResponse({ { "Content-Type"_s, "text/html"_s } }, document).serialize());
+                continue;
+            }
+            if (path.contains("tainted.example"_s) && path.endsWith("/page.html"_s)) {
+                receivedNavigationRequest = true;
+                co_await connection.awaitableSend(HTTPResponse({ { "Content-Type"_s, "text/html"_s } },
+                    "<html><body><script>window.navigationResult = 'loaded';</script></body></html>"_s).serialize());
+                continue;
+            }
+
+            co_await connection.awaitableSend(HTTPResponse({ { "Content-Type"_s, "text/plain"_s } }, ""_s).serialize());
+        }
+    }, HTTPServer::Protocol::Http);
+
+    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    [storeConfiguration setProxyConfiguration:@{
+        (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
+        (NSString *)kCFStreamPropertyHTTPProxyPort: @(server.port())
+    }];
+
+    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+
+    RetainPtr webView = setUpWebViewForFingerprintingTests(@"http://top-domain.org/index.html", dataStore.get());
+
+    [webView evaluateJavaScript:@"window.location.href = 'http://tainted.example/page.html'" completionHandler:nil];
+
+    Util::waitForConditionWithLogging([&] -> bool {
+        return receivedNavigationRequest;
+    }, 10, @"Timed out waiting for main frame navigation to tainted.example.");
+
+    EXPECT_TRUE(receivedNavigationRequest);
+}
+
 } // namespace TestWebKitAPI
 
 #endif // ENABLE(SCRIPT_TRACKING_PRIVACY_PROTECTIONS)


### PR DESCRIPTION
#### b244674d9d56612a17cd4460690ffad1c4239332
<pre>
Some main frame and same-site loads are blocked with `scriptTrackingPrivacyNetworkRequestBlockingLatchEnabled`
<a href="https://bugs.webkit.org/show_bug.cgi?id=311274">https://bugs.webkit.org/show_bug.cgi?id=311274</a>
<a href="https://rdar.apple.com/173870962">rdar://173870962</a>

Reviewed by Matthew Finkel.

This protection shouldn’t apply when the site has been loaded into the main frame.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/ScriptTrackingPrivacyTests.mm

* Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp:
(WebKit::NetworkLoadChecker::shouldBlockForTrackingPolicy):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::addParametersShared):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ScriptTrackingPrivacyTests.mm:
(TestWebKitAPI::(ScriptTrackingPrivacyTests, SameSiteFetchNotBlocked)):
(TestWebKitAPI::(ScriptTrackingPrivacyTests, MainFrameNavigationNotBlocked)):

Canonical link: <a href="https://commits.webkit.org/310741@main">https://commits.webkit.org/310741@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6e029e96afe0ccd1d1e3556e4cb1eb6c3d0511f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153696 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26480 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20097 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162446 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107154 "An unexpected error occured. Recent messages:Printed configuration") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155569 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27008 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26802 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118834 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/107154 "An unexpected error occured. Recent messages:Printed configuration") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/76071372-20a1-44ce-88f6-b5e0851f99fe) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156655 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21096 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138003 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99544 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/54eb9fa0-02cf-4ff6-806c-e3c11a0cc8d1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20175 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18123 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10279 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129824 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15862 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164917 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8051 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17456 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126908 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26277 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22155 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127075 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26279 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137657 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82957 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23611 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21983 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14439 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25896 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90184 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25587 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25747 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25647 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->