### PR TITLE
[Cocoa] 309140@main causes crashes in recovery mode

### DIFF
--- a/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.h
+++ b/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.h
@@ -56,6 +56,8 @@ public:
     explicit AudioFileReader(std::span<const uint8_t> data);
     ~AudioFileReader();
 
+    static bool isAvailable();
+
     RefPtr<AudioBus> createBus(float sampleRate, bool mixToMono); // Returns nullptr on error
 
 #if !RELEASE_LOG_DISABLED
@@ -66,6 +68,7 @@ public:
 #endif
 
 private:
+
 #if ENABLE(MEDIA_SOURCE)
     bool NODELETE isMaybeWebM(std::span<const uint8_t>) const;
     std::unique_ptr<AudioFileReaderData> demuxWebMData(std::span<const uint8_t>) const;

--- a/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.mm
@@ -277,6 +277,11 @@ public:
     const size_t numberOfFrames { 0 };
 };
 
+bool AudioFileReader::isAvailable()
+{
+    return PAL::isAVFoundationFrameworkAvailable() && PAL::isCoreMediaFrameworkAvailable() && PAL::isAudioToolboxFrameworkAvailable();
+}
+
 AudioFileReader::AudioFileReader(std::span<const uint8_t> data)
     : m_data(data)
 #if !RELEASE_LOG_DISABLED
@@ -848,6 +853,9 @@ RefPtr<AudioBus> AudioFileReader::createBus(float sampleRate, bool mixToMono)
 
 RefPtr<AudioBus> createBusFromInMemoryAudioFile(std::span<const uint8_t> data, bool mixToMono, float sampleRate)
 {
+    if (!AudioFileReader::isAvailable())
+        return nullptr;
+
     AudioFileReader reader(data);
     return reader.createBus(sampleRate, mixToMono);
 }


### PR DESCRIPTION
#### 2479ebe515f0674dc6b559f08a9248e4c4d7f95b
<pre>
[Cocoa] 309140@main causes crashes in recovery mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=311273">https://bugs.webkit.org/show_bug.cgi?id=311273</a>
<a href="https://rdar.apple.com/173344940">rdar://173344940</a>

Reviewed by Jer Noble.

AudioFileReader uses AVFoundation.framework, CoreMedia.framework, and AudioToolbox.framework.
Each of these frameworks is soft linked, so check for their availability and have
createBusFromInMemoryAudioFile return nullptr if any is not available.

* Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.h:
* Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.mm:
(WebCore::AudioFileReader::isAvailable):
(WebCore::createBusFromInMemoryAudioFile):

Canonical link: <a href="https://commits.webkit.org/310392@main">https://commits.webkit.org/310392@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89f1ba0e92efece8debd54c63840fcff6703ab49

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153698 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26482 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20099 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162448 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107156 "An unexpected error occured. Recent messages:Printed configuration") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f981cb76-ff27-4baa-aa80-fa0baf6b2d85) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155571 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27010 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26804 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118837 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/107156 "An unexpected error occured. Recent messages:Printed configuration") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/27ec8461-0ba5-4b47-9058-f2cf851955fb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156657 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21095 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137999 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99547 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7197cac0-e005-4f9f-9885-1fffc4deddfb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20174 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18121 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10281 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129823 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15858 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164919 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8053 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17452 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126910 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26279 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22153 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127077 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34468 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26281 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137653 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82959 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21987 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14435 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25898 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90186 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25589 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25749 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25649 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->