### PR TITLE
[IndexedDB API] Implement IDBObjectStore::getAllRecords()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAllRecords.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAllRecords.any-expected.txt
@@ -1,29 +1,27 @@
 
-FAIL Single item getAllRecords is not yet supported
-FAIL Single item with generated key getAllRecords is not yet supported
-FAIL Empty object store getAllRecords is not yet supported
-FAIL Get all records getAllRecords is not yet supported
-FAIL Get all records with empty options getAllRecords is not yet supported
-FAIL Get all records with large values getAllRecords is not yet supported
-FAIL Count getAllRecords is not yet supported
-FAIL Query with bound range getAllRecords is not yet supported
-FAIL Query with bound range and count getAllRecords is not yet supported
-FAIL Query with upper excluded bound range getAllRecords is not yet supported
-FAIL Query with lower excluded bound range getAllRecords is not yet supported
-FAIL Query with bound range and count for generated keys getAllRecords is not yet supported
-FAIL Query with nonexistent key getAllRecords is not yet supported
-FAIL Zero count getAllRecords is not yet supported
-FAIL Max value count getAllRecords is not yet supported
-FAIL Query with empty range where first key < upperBound getAllRecords is not yet supported
-FAIL Query with empty range where lowerBound < last key getAllRecords is not yet supported
-FAIL Direction: next getAllRecords is not yet supported
-FAIL Direction: prev getAllRecords is not yet supported
-FAIL Direction: nextunique getAllRecords is not yet supported
-FAIL Direction: prevunique getAllRecords is not yet supported
-FAIL Direction and query getAllRecords is not yet supported
-FAIL Direction, query and count getAllRecords is not yet supported
-FAIL Get all records with transaction.commit() getAllRecords is not yet supported
-FAIL Get all records with invalid query keys assert_throws_dom: An invalid Date(NaN) key must throw an exception. function "() => {
-        queryTarget[getAllFunctionName](argument);
-      }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0
+PASS Single item
+PASS Single item with generated key
+PASS Empty object store
+PASS Get all records
+PASS Get all records with empty options
+PASS Get all records with large values
+PASS Count
+PASS Query with bound range
+PASS Query with bound range and count
+PASS Query with upper excluded bound range
+PASS Query with lower excluded bound range
+PASS Query with bound range and count for generated keys
+PASS Query with nonexistent key
+PASS Zero count
+PASS Max value count
+PASS Query with empty range where first key < upperBound
+PASS Query with empty range where lowerBound < last key
+PASS Direction: next
+PASS Direction: prev
+PASS Direction: nextunique
+PASS Direction: prevunique
+PASS Direction and query
+PASS Direction, query and count
+PASS Get all records with transaction.commit()
+PASS Get all records with invalid query keys
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAllRecords.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAllRecords.any.serviceworker-expected.txt
@@ -1,29 +1,27 @@
 
-FAIL Single item getAllRecords is not yet supported
-FAIL Single item with generated key getAllRecords is not yet supported
-FAIL Empty object store getAllRecords is not yet supported
-FAIL Get all records getAllRecords is not yet supported
-FAIL Get all records with empty options getAllRecords is not yet supported
-FAIL Get all records with large values getAllRecords is not yet supported
-FAIL Count getAllRecords is not yet supported
-FAIL Query with bound range getAllRecords is not yet supported
-FAIL Query with bound range and count getAllRecords is not yet supported
-FAIL Query with upper excluded bound range getAllRecords is not yet supported
-FAIL Query with lower excluded bound range getAllRecords is not yet supported
-FAIL Query with bound range and count for generated keys getAllRecords is not yet supported
-FAIL Query with nonexistent key getAllRecords is not yet supported
-FAIL Zero count getAllRecords is not yet supported
-FAIL Max value count getAllRecords is not yet supported
-FAIL Query with empty range where first key < upperBound getAllRecords is not yet supported
-FAIL Query with empty range where lowerBound < last key getAllRecords is not yet supported
-FAIL Direction: next getAllRecords is not yet supported
-FAIL Direction: prev getAllRecords is not yet supported
-FAIL Direction: nextunique getAllRecords is not yet supported
-FAIL Direction: prevunique getAllRecords is not yet supported
-FAIL Direction and query getAllRecords is not yet supported
-FAIL Direction, query and count getAllRecords is not yet supported
-FAIL Get all records with transaction.commit() getAllRecords is not yet supported
-FAIL Get all records with invalid query keys assert_throws_dom: An invalid Date(NaN) key must throw an exception. function "() => {
-        queryTarget[getAllFunctionName](argument);
-      }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0
+PASS Single item
+PASS Single item with generated key
+PASS Empty object store
+PASS Get all records
+PASS Get all records with empty options
+PASS Get all records with large values
+PASS Count
+PASS Query with bound range
+PASS Query with bound range and count
+PASS Query with upper excluded bound range
+PASS Query with lower excluded bound range
+PASS Query with bound range and count for generated keys
+PASS Query with nonexistent key
+PASS Zero count
+PASS Max value count
+PASS Query with empty range where first key < upperBound
+PASS Query with empty range where lowerBound < last key
+PASS Direction: next
+PASS Direction: prev
+PASS Direction: nextunique
+PASS Direction: prevunique
+PASS Direction and query
+PASS Direction, query and count
+PASS Get all records with transaction.commit()
+PASS Get all records with invalid query keys
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAllRecords.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAllRecords.any.sharedworker-expected.txt
@@ -1,29 +1,27 @@
 
-FAIL Single item getAllRecords is not yet supported
-FAIL Single item with generated key getAllRecords is not yet supported
-FAIL Empty object store getAllRecords is not yet supported
-FAIL Get all records getAllRecords is not yet supported
-FAIL Get all records with empty options getAllRecords is not yet supported
-FAIL Get all records with large values getAllRecords is not yet supported
-FAIL Count getAllRecords is not yet supported
-FAIL Query with bound range getAllRecords is not yet supported
-FAIL Query with bound range and count getAllRecords is not yet supported
-FAIL Query with upper excluded bound range getAllRecords is not yet supported
-FAIL Query with lower excluded bound range getAllRecords is not yet supported
-FAIL Query with bound range and count for generated keys getAllRecords is not yet supported
-FAIL Query with nonexistent key getAllRecords is not yet supported
-FAIL Zero count getAllRecords is not yet supported
-FAIL Max value count getAllRecords is not yet supported
-FAIL Query with empty range where first key < upperBound getAllRecords is not yet supported
-FAIL Query with empty range where lowerBound < last key getAllRecords is not yet supported
-FAIL Direction: next getAllRecords is not yet supported
-FAIL Direction: prev getAllRecords is not yet supported
-FAIL Direction: nextunique getAllRecords is not yet supported
-FAIL Direction: prevunique getAllRecords is not yet supported
-FAIL Direction and query getAllRecords is not yet supported
-FAIL Direction, query and count getAllRecords is not yet supported
-FAIL Get all records with transaction.commit() getAllRecords is not yet supported
-FAIL Get all records with invalid query keys assert_throws_dom: An invalid Date(NaN) key must throw an exception. function "() => {
-        queryTarget[getAllFunctionName](argument);
-      }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0
+PASS Single item
+PASS Single item with generated key
+PASS Empty object store
+PASS Get all records
+PASS Get all records with empty options
+PASS Get all records with large values
+PASS Count
+PASS Query with bound range
+PASS Query with bound range and count
+PASS Query with upper excluded bound range
+PASS Query with lower excluded bound range
+PASS Query with bound range and count for generated keys
+PASS Query with nonexistent key
+PASS Zero count
+PASS Max value count
+PASS Query with empty range where first key < upperBound
+PASS Query with empty range where lowerBound < last key
+PASS Direction: next
+PASS Direction: prev
+PASS Direction: nextunique
+PASS Direction: prevunique
+PASS Direction and query
+PASS Direction, query and count
+PASS Get all records with transaction.commit()
+PASS Get all records with invalid query keys
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAllRecords.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAllRecords.any.worker-expected.txt
@@ -1,29 +1,27 @@
 
-FAIL Single item getAllRecords is not yet supported
-FAIL Single item with generated key getAllRecords is not yet supported
-FAIL Empty object store getAllRecords is not yet supported
-FAIL Get all records getAllRecords is not yet supported
-FAIL Get all records with empty options getAllRecords is not yet supported
-FAIL Get all records with large values getAllRecords is not yet supported
-FAIL Count getAllRecords is not yet supported
-FAIL Query with bound range getAllRecords is not yet supported
-FAIL Query with bound range and count getAllRecords is not yet supported
-FAIL Query with upper excluded bound range getAllRecords is not yet supported
-FAIL Query with lower excluded bound range getAllRecords is not yet supported
-FAIL Query with bound range and count for generated keys getAllRecords is not yet supported
-FAIL Query with nonexistent key getAllRecords is not yet supported
-FAIL Zero count getAllRecords is not yet supported
-FAIL Max value count getAllRecords is not yet supported
-FAIL Query with empty range where first key < upperBound getAllRecords is not yet supported
-FAIL Query with empty range where lowerBound < last key getAllRecords is not yet supported
-FAIL Direction: next getAllRecords is not yet supported
-FAIL Direction: prev getAllRecords is not yet supported
-FAIL Direction: nextunique getAllRecords is not yet supported
-FAIL Direction: prevunique getAllRecords is not yet supported
-FAIL Direction and query getAllRecords is not yet supported
-FAIL Direction, query and count getAllRecords is not yet supported
-FAIL Get all records with transaction.commit() getAllRecords is not yet supported
-FAIL Get all records with invalid query keys assert_throws_dom: An invalid Date(NaN) key must throw an exception. function "() => {
-        queryTarget[getAllFunctionName](argument);
-      }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0
+PASS Single item
+PASS Single item with generated key
+PASS Empty object store
+PASS Get all records
+PASS Get all records with empty options
+PASS Get all records with large values
+PASS Count
+PASS Query with bound range
+PASS Query with bound range and count
+PASS Query with upper excluded bound range
+PASS Query with lower excluded bound range
+PASS Query with bound range and count for generated keys
+PASS Query with nonexistent key
+PASS Zero count
+PASS Max value count
+PASS Query with empty range where first key < upperBound
+PASS Query with empty range where lowerBound < last key
+PASS Direction: next
+PASS Direction: prev
+PASS Direction: nextunique
+PASS Direction: prevunique
+PASS Direction and query
+PASS Direction, query and count
+PASS Get all records with transaction.commit()
+PASS Get all records with invalid query keys
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any-expected.txt
@@ -22,9 +22,7 @@ PASS IDBIndex openCursor() method with throwing/invalid keys
 PASS IDBIndex openKeyCursor() method with throwing/invalid keys
 PASS IDBObjectStore getAll() method with throwing/invalid keys
 PASS IDBObjectStore getAllKeys() method with throwing/invalid keys
-FAIL IDBObjectStore getAllRecords() method with throwing/invalid keys assert_throws_dom: options query key conversion with invalid key should throw DataError function "() => {
-    receiver[method]({query: invalid_key});
-  }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0
+PASS IDBObjectStore getAllRecords() method with throwing/invalid keys
 PASS IDBIndex getAll() method with throwing/invalid keys
 PASS IDBIndex getAllKeys() method with throwing/invalid keys
 PASS IDBIndex getAllRecords() method with throwing/invalid keys

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.serviceworker-expected.txt
@@ -22,9 +22,7 @@ PASS IDBIndex openCursor() method with throwing/invalid keys
 PASS IDBIndex openKeyCursor() method with throwing/invalid keys
 PASS IDBObjectStore getAll() method with throwing/invalid keys
 PASS IDBObjectStore getAllKeys() method with throwing/invalid keys
-FAIL IDBObjectStore getAllRecords() method with throwing/invalid keys assert_throws_dom: options query key conversion with invalid key should throw DataError function "() => {
-    receiver[method]({query: invalid_key});
-  }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0
+PASS IDBObjectStore getAllRecords() method with throwing/invalid keys
 PASS IDBIndex getAll() method with throwing/invalid keys
 PASS IDBIndex getAllKeys() method with throwing/invalid keys
 PASS IDBIndex getAllRecords() method with throwing/invalid keys

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.sharedworker-expected.txt
@@ -22,9 +22,7 @@ PASS IDBIndex openCursor() method with throwing/invalid keys
 PASS IDBIndex openKeyCursor() method with throwing/invalid keys
 PASS IDBObjectStore getAll() method with throwing/invalid keys
 PASS IDBObjectStore getAllKeys() method with throwing/invalid keys
-FAIL IDBObjectStore getAllRecords() method with throwing/invalid keys assert_throws_dom: options query key conversion with invalid key should throw DataError function "() => {
-    receiver[method]({query: invalid_key});
-  }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0
+PASS IDBObjectStore getAllRecords() method with throwing/invalid keys
 PASS IDBIndex getAll() method with throwing/invalid keys
 PASS IDBIndex getAllKeys() method with throwing/invalid keys
 PASS IDBIndex getAllRecords() method with throwing/invalid keys

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.worker-expected.txt
@@ -22,9 +22,7 @@ PASS IDBIndex openCursor() method with throwing/invalid keys
 PASS IDBIndex openKeyCursor() method with throwing/invalid keys
 PASS IDBObjectStore getAll() method with throwing/invalid keys
 PASS IDBObjectStore getAllKeys() method with throwing/invalid keys
-FAIL IDBObjectStore getAllRecords() method with throwing/invalid keys assert_throws_dom: options query key conversion with invalid key should throw DataError function "() => {
-    receiver[method]({query: invalid_key});
-  }" threw object "NotSupportedError: getAllRecords is not yet supported" that is not a DOMException DataError: property "code" is equal to 9, expected 0
+PASS IDBObjectStore getAllRecords() method with throwing/invalid keys
 PASS IDBIndex getAll() method with throwing/invalid keys
 PASS IDBIndex getAllKeys() method with throwing/invalid keys
 PASS IDBIndex getAllRecords() method with throwing/invalid keys

--- a/Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp
@@ -41,6 +41,7 @@
 #include "IDBRequest.h"
 #include "IDBTransaction.h"
 #include "IndexedDB.h"
+#include "JSIDBKeyRange.h"
 #include "Logging.h"
 #include "Page.h"
 #include "ScriptExecutionContext.h"
@@ -618,7 +619,8 @@ ExceptionOr<Ref<IDBRequest>> IDBObjectStore::doGetAllShared(IndexedDB::GetAllTyp
         callingFunctionExceptionMessagePrefix = "Failed to execute 'getAllKeys' on IDBObjectStore': "_s;
         break;
     case IndexedDB::GetAllType::Records:
-        return Exception { ExceptionCode::NotSupportedError, "getAllRecords is not yet supported"_s };
+        callingFunctionExceptionMessagePrefix = "Failed to execute 'getAllRecords' on IDBObjectStore': "_s;
+        break;
     }
 
     Ref transaction = m_transaction.get();
@@ -701,9 +703,25 @@ ExceptionOr<Ref<IDBRequest>> IDBObjectStore::getAllKeys(JSGlobalObject& execStat
     });
 }
 
-ExceptionOr<Ref<IDBRequest>> IDBObjectStore::getAllRecords(JSGlobalObject&, IDBGetAllOptions&&)
+ExceptionOr<Ref<IDBRequest>> IDBObjectStore::getAllRecords(JSGlobalObject& execState, IDBGetAllOptions&& options)
 {
-    return Exception { ExceptionCode::NotSupportedError, "getAllRecords is not yet supported"_s };
+    LOG(IndexedDB, "IDBObjectStore::getAllRecords");
+
+    return doGetAllShared(IndexedDB::GetAllType::Records, std::nullopt, [execState = &execState, options]() -> ExceptionOr<ParsedGetAllQueryOrOptions> {
+        auto query = options.query;
+
+        if (query.isUndefinedOrNull())
+            return ParsedGetAllQueryOrOptions { nullptr, options.count, options.direction };
+
+        if (RefPtr keyRange = JSIDBKeyRange::toWrapped(execState->vm(), query))
+            return ParsedGetAllQueryOrOptions { WTF::move(keyRange), options.count, options.direction };
+
+        auto onlyResultFromQuery = IDBKeyRange::only(*execState, query);
+        if (onlyResultFromQuery.hasException())
+            return Exception(ExceptionCode::DataError, "The query specified in options is not a valid key."_s);
+
+        return ParsedGetAllQueryOrOptions { onlyResultFromQuery.releaseReturnValue(), options.count, options.direction };
+    });
 }
 
 void IDBObjectStore::markAsDeleted()

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
@@ -2263,9 +2263,13 @@ IDBError SQLiteIDBBackingStore::getAllObjectStoreRecords(const IDBResourceIdenti
             LOG_ERROR("Unable to deserialize key data from database while getting all records");
             return IDBError { ExceptionCode::UnknownError, "Unable to deserialize key data while getting all records"_s };
         }
+
+        if (getAllRecordsData.getAllType == IndexedDB::GetAllType::Records)
+            result.addPrimaryKey(IDBKeyData(keyData));
+
         result.addKey(WTF::move(keyData));
 
-        if (getAllRecordsData.getAllType == IndexedDB::GetAllType::Values) {
+        if (getAllRecordsData.getAllType == IndexedDB::GetAllType::Values || getAllRecordsData.getAllType == IndexedDB::GetAllType::Records) {
             ThreadSafeDataBuffer valueResultBuffer = ThreadSafeDataBuffer::create(statement->columnBlob(1));
 
             auto recordID = statement->columnInt64(2);


### PR DESCRIPTION
#### a244eb057f532f4cacc4971da778b9a0f4a4b7fc
<pre>
[IndexedDB API] Implement IDBObjectStore::getAllRecords()
<a href="https://bugs.webkit.org/show_bug.cgi?id=311275">https://bugs.webkit.org/show_bug.cgi?id=311275</a>
<a href="https://rdar.apple.com/173871211">rdar://173871211</a>

Reviewed by Sihui Liu.

The IndexedDB API (<a href="https://w3c.github.io/IndexedDB/#object-store-interface)">https://w3c.github.io/IndexedDB/#object-store-interface)</a> has
specified a new function getAllRecords() on IDBObjectStore. This takes in an
IDBGetAllOptions and returns an array of IDBRecords which contain the key,
primaryKey, and value of the record. Both the key and primary key are the same
(the key of the record).

This patch implements this.

<a href="https://commits.webkit.org/310374@main">https://commits.webkit.org/310374@main</a> implemented this for IDBIndex. That patch
already added much of the infrastructure we need (GetAllType::Records and IDBRecord).

The spec (<a href="https://w3c.github.io/IndexedDB/#dom-idbobjectstore-getallrecords)">https://w3c.github.io/IndexedDB/#dom-idbobjectstore-getallrecords)</a> says to run
these steps: <a href="https://w3c.github.io/IndexedDB/#create-a-request-to-retrieve-multiple-items">https://w3c.github.io/IndexedDB/#create-a-request-to-retrieve-multiple-items</a>

This follows the same steps as getAll() and getAllKeys().

We carry out steps 1-9 by calling doGetAllShared() with this new type. Since the input
passed in is already IDBGetAllOptions, we obtain the query, count, and direction
directly from it (step 9).

doGetAllShared() calls requestGetAllObjectStoreRecords which stores in the
IDBGetAllRecordsData object that our type is Records. This is already plumbed all
the way down to SQLiteIDBBackingStore::getAllObjectStoreRecords().

We modify getAllObjectStoreRecords() to ensure that it adds the primarykey and
the value to the IDBGetAllResult in the case of Records.

Then, when the JS accesses the result of the IDBRequest returned by getAllRecords(),
JSIDBRequestCustom will create the IDBRecords from the IDBGetAllResult and
JSIDBRecordCustom will allow the JS to access the key, primaryKey, and value fields.
The previous patch mentioned above added this functionality.

* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAllRecords.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAllRecords.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAllRecords.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_getAllRecords.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.any.worker-expected.txt:
* Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp:
(WebCore::IDBObjectStore::doGetAllShared):
(WebCore::IDBObjectStore::getAllRecords):
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp:
(WebCore::IDBServer::SQLiteIDBBackingStore::getAllObjectStoreRecords):

Canonical link: <a href="https://commits.webkit.org/310412@main">https://commits.webkit.org/310412@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11f6a51bc76f89e46942ee2ea1ee85be64ec3d9d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153706 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26490 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20107 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162456 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107164 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155579 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27018 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26812 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118843 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84047 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9283a648-657e-43d4-8a8f-32c8fc99416e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156665 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21100 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138009 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99553 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20179 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18130 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10289 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129828 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15868 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164927 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8061 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17462 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126916 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26287 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22162 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127083 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26289 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137663 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82967 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23499 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21990 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14445 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25906 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90194 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25597 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25757 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25657 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->