### PR TITLE
[Site Isolation] Fix timeout for http/tests/security/mixedContent/secure-page-navigates-to-basic-auth-secure-page-via-insecure-redirect.https.html

### DIFF
--- a/LayoutTests/platform/ios-site-isolation/TestExpectations
+++ b/LayoutTests/platform/ios-site-isolation/TestExpectations
@@ -82,7 +82,6 @@ http/tests/security/contentSecurityPolicy/1.1/frame-ancestors/report-frame-ances
 http/tests/security/contentSecurityPolicy/1.1/frame-ancestors/report-frame-ancestors-same-origin-https.html [ Timeout ]
 http/tests/security/contentSecurityPolicy/script-redirect-blocked.html [ Timeout ]
 http/tests/security/contentSecurityPolicy/stylesheet-redirect-blocked.html [ Timeout ]
-http/tests/security/mixedContent/secure-page-navigates-to-basic-auth-secure-page-via-insecure-redirect.https.html [ Timeout ]
 http/tests/security/strip-referrer-to-origin-for-third-party-redirects-in-private-mode.html [ Timeout ]
 http/tests/security/xss-DENIED-mime-type-execute-as-html.html [ Timeout ]
 http/tests/security/xss-DENIED-script-inject-into-inactive-window2-pson.html [ Timeout ]

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -93,7 +93,6 @@ http/tests/security/contentSecurityPolicy/1.1/frame-ancestors/report-frame-ances
 http/tests/security/contentSecurityPolicy/1.1/frame-ancestors/report-frame-ancestors-same-origin-https.html [ Timeout ]
 http/tests/security/contentSecurityPolicy/script-redirect-blocked.html [ Timeout ]
 http/tests/security/contentSecurityPolicy/stylesheet-redirect-blocked.html [ Timeout ]
-http/tests/security/mixedContent/secure-page-navigates-to-basic-auth-secure-page-via-insecure-redirect.https.html [ Timeout ]
 http/tests/security/xss-DENIED-script-inject-into-inactive-window2-pson.html [ Timeout ]
 http/tests/security/xss-DENIED-script-inject-into-inactive-window2.html [ Timeout ]
 http/tests/security/xss-DENIED-script-inject-into-inactive-window3.html [ Timeout ]

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -582,7 +582,7 @@ WKRetainPtr<WKTypeRef> TestInvocation::didReceiveSynchronousMessageFromInjectedB
         return nullptr;
     }
     if (WKStringIsEqualToUTF8CString(messageName, "GetWaitUntilDone"))
-        return adoptWK(WKBooleanCreate(m_waitUntilDone));
+        return adoptWK(WKBooleanCreate(m_waitUntilDone || m_notifyDoneMessageSent));
 
     if (WKStringIsEqualToUTF8CString(messageName, "SetDumpFrameLoadCallbacks")) {
         m_dumpFrameLoadCallbacks = booleanValue(messageBody);
@@ -1428,6 +1428,7 @@ bool TestInvocation::resolveNotifyDone()
         return false;
     m_waitUntilDone = false;
     if (m_options.siteIsolationEnabled()) {
+        m_notifyDoneMessageSent = true;
         postPageMessage("NotifyDone");
         return false;
     }
@@ -1440,6 +1441,7 @@ bool TestInvocation::resolveForceImmediateCompletion()
         return false;
     m_waitUntilDone = false;
     if (m_options.siteIsolationEnabled()) {
+        m_notifyDoneMessageSent = true;
         postPageMessage("ForceImmediateCompletion");
         return false;
     }

--- a/Tools/WebKitTestRunner/TestInvocation.h
+++ b/Tools/WebKitTestRunner/TestInvocation.h
@@ -147,6 +147,7 @@ private:
     bool m_error { false };
 
     bool m_waitUntilDone { false };
+    bool m_notifyDoneMessageSent { false };
     bool m_dumpFrameLoadCallbacks { false };
     bool m_globalFlag { false };
     bool m_dumpPixels { false };


### PR DESCRIPTION
#### 1f66070d175937904c415b86f73a195d35a06f18
<pre>
[Site Isolation] Fix timeout for http/tests/security/mixedContent/secure-page-navigates-to-basic-auth-secure-page-via-insecure-redirect.https.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=311281">https://bugs.webkit.org/show_bug.cgi?id=311281</a>
<a href="https://rdar.apple.com/173881378">rdar://173881378</a>

Reviewed by Sihui Liu.

This patch fixes a timeout in http/tests/security/mixedContent/secure-page-navigates-to-basic-auth-secure-page-via-insecure-redirect.https.html
with site isolation enabled.

resolveNotifyDone() was clearing m_waitUntilDone before the async
NotifyDone message arrived. When didFinishLoadForFrame fired in
between, frameDidChangeLocation saw shouldWaitUntilDone=false and raced
to dump, sending a Done message that was lost since at that point
m_testRunner was set to null.

Add m_notifyDoneMessageSent flag, set when the async NotifyDone is
sent. Return m_waitUntilDone || m_notifyDoneMessageSent from
GetWaitUntilDone so frameDidChangeLocation defers to the async
NotifyDone path. Apply the same fix to resolveForceImmediateCompletion.

* LayoutTests/platform/ios-site-isolation/TestExpectations:
* LayoutTests/platform/mac-site-isolation/TestExpectations:
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveSynchronousMessageFromInjectedBundle):
(WTR::TestInvocation::resolveNotifyDone):
(WTR::TestInvocation::resolveForceImmediateCompletion):
* Tools/WebKitTestRunner/TestInvocation.h:

Canonical link: <a href="https://commits.webkit.org/310929@main">https://commits.webkit.org/310929@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/572908922f8cad7291cdc120bdbfd6971c1b9983

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155073 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28333 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21492 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163833 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108544 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156946 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28472 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28181 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119975 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84777 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158032 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22237 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139261 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100668 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21322 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19360 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11659 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130984 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17104 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166309 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18713 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128076 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27877 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23399 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128214 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34859 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27801 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138897 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84510 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23086 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15692 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27493 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27072 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27302 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27144 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->