### PR TITLE
[GTK][WPE] /TestWebCore:ImageBufferTests API tests fails

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebCore/glib/GraphicsContextGLTextureMapper.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/glib/GraphicsContextGLTextureMapper.cpp
@@ -32,7 +32,6 @@
 #include "WebCoreTestUtilities.h"
 #include <WebCore/Color.h>
 #include <WebCore/GraphicsContextGLTextureMapperANGLE.h>
-#include <WebCore/PlatformDisplaySurfaceless.h>
 #include <WebCore/ProcessIdentity.h>
 #include <atomic>
 #include <limits>
@@ -47,20 +46,10 @@ using namespace WebCore;
 
 namespace {
 
-static void initializePlatformDisplayIfNeeded()
-{
-    if (PlatformDisplay::sharedDisplayIfExists())
-        return;
-    auto display = PlatformDisplaySurfaceless::create();
-    RELEASE_ASSERT(display);
-    PlatformDisplay::setSharedDisplay(WTF::move(display));
-}
-
 using TestedGraphicsContextGLTextureMapper = GraphicsContextGLTextureMapperANGLE;
 
 static RefPtr<TestedGraphicsContextGLTextureMapper> createTestedGraphicsContextGL(GraphicsContextGLAttributes attribute)
 {
-    initializePlatformDisplayIfNeeded();
     return TestedGraphicsContextGLTextureMapper::create(WTF::move(attribute));
 }
 

--- a/Tools/TestWebKitAPI/WebCoreTestUtilities.cpp
+++ b/Tools/TestWebKitAPI/WebCoreTestUtilities.cpp
@@ -28,7 +28,27 @@
 
 #include <wtf/MemoryFootprint.h>
 
+#if PLATFORM(GTK) || PLATFORM(WPE)
+#include <WebCore/PlatformDisplaySurfaceless.h>
+#endif
+
 namespace TestWebKitAPI {
+
+#if PLATFORM(GTK) || PLATFORM(WPE)
+class PlatformDisplayEnvironment : public testing::Environment {
+public:
+    void SetUp() override
+    {
+        if (WebCore::PlatformDisplay::sharedDisplayIfExists())
+            return;
+        auto display = WebCore::PlatformDisplaySurfaceless::create();
+        RELEASE_ASSERT(display);
+        WebCore::PlatformDisplay::setSharedDisplay(WTF::move(display));
+    }
+};
+
+static testing::Environment* const platformDisplayEnvironment = testing::AddGlobalTestEnvironment(new PlatformDisplayEnvironment);
+#endif // PLATFORM(GTK) || PLATFORM(WPE)
 
 ::testing::AssertionResult memoryFootprintChangedBy(size_t& lastFootprint, double expectedChange, double error)
 {

--- a/Tools/TestWebKitAPI/glib/TestExpectations.json
+++ b/Tools/TestWebKitAPI/glib/TestExpectations.json
@@ -232,45 +232,6 @@
             },
             "ComplexTextControllerTest.TotalWidthWithJustification": {
                 "expected": {"gtk": {"status": ["FAIL", "PASS"], "bug":"webkit.org/b/284628"}}
-            },
-            "ImageBufferTests.ImageBufferSubTypeCreateCreatesSubtypes": {
-                "expected": {"all": {"status": ["SKIP"], "bug":"webkit.org/b/286456"}}
-            },
-            "ImageBufferTests.ImageBufferSubPixelDrawing": {
-                "expected": {"all": {"status": ["SKIP"], "bug":"webkit.org/b/286456"}}
-            },
-            "ImageBufferTests/AnyScaleTest.SinkIntoNativeImageWorks/051byteobject01": {
-                "expected": {"all": {"status": ["SKIP"], "bug":"webkit.org/b/286456"}}
-            },
-            "ImageBufferTests/AnyScaleTest.SinkIntoNativeImageWorks/11byteobject01": {
-                "expected": {"all": {"status": ["SKIP"], "bug":"webkit.org/b/286456"}}
-            },
-            "ImageBufferTests/AnyScaleTest.SinkIntoNativeImageWorks/21byteobject01": {
-                "expected": {"all": {"status": ["SKIP"], "bug":"webkit.org/b/286456"}}
-            },
-            "ImageBufferTests/AnyScaleTest.SinkIntoNativeImageWorks/51byteobject01": {
-                "expected": {"all": {"status": ["SKIP"], "bug":"webkit.org/b/286456"}}
-            },
-            "ImageBufferTests/AnyScaleTest.GetPixelBufferDimensionsContainScale/051byteobject01": {
-                "expected": {"all": {"status": ["SKIP"], "bug":"webkit.org/b/286456"}}
-            },
-            "ImageBufferTests/AnyScaleTest.GetPixelBufferDimensionsContainScale/11byteobject01": {
-                "expected": {"all": {"status": ["SKIP"], "bug":"webkit.org/b/286456"}}
-            },
-            "ImageBufferTests/AnyScaleTest.GetPixelBufferDimensionsContainScale/21byteobject01": {
-                "expected": {"all": {"status": ["SKIP"], "bug":"webkit.org/b/286456"}}
-            },
-            "ImageBufferTests/AnyScaleTest.GetPixelBufferDimensionsContainScale/51byteobject01": {
-                "expected": {"all": {"status": ["SKIP"], "bug":"webkit.org/b/286456"}}
-            },
-            "ImageBufferTests/AnyTwoImageBufferOptionsTest.PutPixelBufferAffectsDrawOutput/1byteobject001byteobject01": {
-                "expected": {"all": {"status": ["SKIP"], "bug":"webkit.org/b/286456"}}
-            },
-            "ImageBufferTests/AnyTwoImageBufferOptionsTest.PutPixelBufferAffectsDrawOutput/1byteobject011byteobject00": {
-                "expected": {"all": {"status": ["SKIP"], "bug":"webkit.org/b/286456"}}
-            },
-            "ImageBufferTests/AnyTwoImageBufferOptionsTest.PutPixelBufferAffectsDrawOutput/1byteobject011byteobject01": {
-                "expected": {"all": {"status": ["SKIP"], "bug":"webkit.org/b/286456"}}
             }
         }
     },


### PR DESCRIPTION
#### 165552430f4326a6b006c31c29e06e552727f164
<pre>
[GTK][WPE] /TestWebCore:ImageBufferTests API tests fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=286456">https://bugs.webkit.org/show_bug.cgi?id=286456</a>

Reviewed by Adrian Perez de Castro.

Set up a PlatformDisplaySurfaceless as the shared display in a gtest
global Environment so that accelerated ImageBuffer tests (and any
future tests needing a display) no longer hit the RELEASE_ASSERT in
PlatformDisplay::sharedDisplay(). Remove the per-test initialization
from GraphicsContextGLTextureMapper and unskip the 13 ImageBuffer
tests that were disabled for webkit.org/b/286456.

* Tools/TestWebKitAPI/Tests/WebCore/glib/GraphicsContextGLTextureMapper.cpp:
(TestWebKitAPI::WebCore::createTestedGraphicsContextGL):
(TestWebKitAPI::WebCore::initializePlatformDisplayIfNeeded): Deleted.
* Tools/TestWebKitAPI/WebCoreTestUtilities.cpp:
* Tools/TestWebKitAPI/glib/TestExpectations.json:

Canonical link: <a href="https://commits.webkit.org/310395@main">https://commits.webkit.org/310395@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64eecc1cd10fef5e337b6b9f3b0cecc881b46c20

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153732 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26516 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20133 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162482 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107190 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155605 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27044 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26838 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118865 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/107190 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156691 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21129 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/138037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99575 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/20208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/18159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10315 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/129857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15896 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164953 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17490 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126941 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26313 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/22190 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127108 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34472 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26315 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137691 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82993 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22013 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/14473 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25932 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25623 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25783 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25683 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->