### PR TITLE
[IndexedDB API] Enable getAllRecords() and IDBGetAllOptions in Preview

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3901,12 +3901,12 @@ IndexedDBAPIEnabled:
   sharedPreferenceForWebProcess: true
   richJavaScript: true
 
-IndexedDBGetAllRecordsEnabled:
+IndexedDBGetAllRecordsAndGetAllOptionsEnabled:
   type: bool
   category: dom
-  status: testable
-  humanReadableName: "IndexedDB getAllRecords() API"
-  humanReadableDescription: "Enable getAllRecords() on IDBIndex"
+  status: preview
+  humanReadableName: "IndexedDB getAllRecords() API and IDBGetAllOptions"
+  humanReadableDescription: "Enable the getAllRecords() API on IDBObjectStore/IDBIndex and enable getAll()/getAllKeys() to accept IDBGetAllOptions and support direction"
   defaultValue:
     WebKitLegacy:
       default: false
@@ -3914,8 +3914,6 @@ IndexedDBGetAllRecordsEnabled:
       default: false
     WebCore:
       default: false
-  sharedPreferenceForWebProcess: true
-  richJavaScript: true
 
 IndexedDBSQLiteMemoryBackingStoreEnabled:
   type: bool

--- a/Source/WebCore/Modules/indexeddb/IDBGetAllOptions.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBGetAllOptions.idl
@@ -25,7 +25,7 @@
 
 // https://w3c.github.io/IndexedDB/#dictdef-idbgetalloptions
 [
-    EnabledBySetting=IndexedDBGetAllRecordsEnabled
+    EnabledBySetting=IndexedDBGetAllRecordsAndGetAllOptionsEnabled
 ] dictionary IDBGetAllOptions {
     any query = null;
     [EnforceRange] unsigned long count;

--- a/Source/WebCore/Modules/indexeddb/IDBIndex.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBIndex.cpp
@@ -408,7 +408,7 @@ ExceptionOr<Ref<IDBRequest>> IDBIndex::getAll(JSGlobalObject& execState, JSValue
             return ParsedGetAllQueryOrOptions { onlyResult.releaseReturnValue(), count };
         }
 
-        if (!context || !context->settingsValues().indexedDBGetAllRecordsEnabled)
+        if (!context || !context->settingsValues().indexedDBGetAllRecordsAndGetAllOptionsEnabled)
             return Exception(ExceptionCode::DataError, "The parameter is not a valid key."_s);
 
         return parseGetAllOptions(*execState, keyOrOptions);
@@ -437,7 +437,7 @@ ExceptionOr<Ref<IDBRequest>> IDBIndex::getAllKeys(JSGlobalObject& execState, JSV
             return ParsedGetAllQueryOrOptions { onlyResult.releaseReturnValue(), count };
         }
 
-        if (!context || !context->settingsValues().indexedDBGetAllRecordsEnabled)
+        if (!context || !context->settingsValues().indexedDBGetAllRecordsAndGetAllOptionsEnabled)
             return Exception(ExceptionCode::DataError, "The parameter is not a valid key."_s);
 
         return parseGetAllOptions(*execState, keyOrOptions);

--- a/Source/WebCore/Modules/indexeddb/IDBIndex.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBIndex.idl
@@ -53,7 +53,7 @@ typedef (DOMString or sequence<DOMString>) IDBKeyPath;
     [NewObject] IDBRequest getAllKeys(optional IDBKeyRange? range = null, optional [EnforceRange] unsigned long count);
     [NewObject, CallWith=CurrentGlobalObject] IDBRequest getAllKeys(any keyOrOptions, optional [EnforceRange] unsigned long count);
 
-    [NewObject, CallWith=CurrentGlobalObject, EnabledBySetting=IndexedDBGetAllRecordsEnabled] IDBRequest getAllRecords(optional IDBGetAllOptions options = {});
+    [NewObject, CallWith=CurrentGlobalObject, EnabledBySetting=IndexedDBGetAllRecordsAndGetAllOptionsEnabled] IDBRequest getAllRecords(optional IDBGetAllOptions options = {});
 
     [NewObject] IDBRequest count(optional IDBKeyRange? range = null);
     [NewObject, CallWith=CurrentGlobalObject] IDBRequest count(any key);

--- a/Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp
@@ -667,7 +667,7 @@ ExceptionOr<Ref<IDBRequest>> IDBObjectStore::getAll(JSGlobalObject& execState, J
             return ParsedGetAllQueryOrOptions { onlyResult.releaseReturnValue(), count };
         }
 
-        if (!context || !context->settingsValues().indexedDBGetAllRecordsEnabled)
+        if (!context || !context->settingsValues().indexedDBGetAllRecordsAndGetAllOptionsEnabled)
             return Exception(ExceptionCode::DataError, "The parameter is not a valid key."_s);
 
         return parseGetAllOptions(*execState, keyOrOptions);
@@ -696,7 +696,7 @@ ExceptionOr<Ref<IDBRequest>> IDBObjectStore::getAllKeys(JSGlobalObject& execStat
             return ParsedGetAllQueryOrOptions { onlyResult.releaseReturnValue(), count };
         }
 
-        if (!context || !context->settingsValues().indexedDBGetAllRecordsEnabled)
+        if (!context || !context->settingsValues().indexedDBGetAllRecordsAndGetAllOptionsEnabled)
             return Exception(ExceptionCode::DataError, "The parameter is not a valid key."_s);
 
         return parseGetAllOptions(*execState, keyOrOptions);

--- a/Source/WebCore/Modules/indexeddb/IDBObjectStore.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBObjectStore.idl
@@ -61,7 +61,7 @@ typedef (DOMString or sequence<DOMString>) IDBKeyPath;
     [NewObject] IDBRequest getAllKeys(optional IDBKeyRange? range = null, optional [EnforceRange] unsigned long count);
     [NewObject, CallWith=CurrentGlobalObject] IDBRequest getAllKeys(any keyOrOptions, optional [EnforceRange] unsigned long count);
 
-    [NewObject, CallWith=CurrentGlobalObject, EnabledBySetting=IndexedDBGetAllRecordsEnabled] IDBRequest getAllRecords(optional IDBGetAllOptions options = {});
+    [NewObject, CallWith=CurrentGlobalObject, EnabledBySetting=IndexedDBGetAllRecordsAndGetAllOptionsEnabled] IDBRequest getAllRecords(optional IDBGetAllOptions options = {});
 
     [NewObject] IDBRequest count(optional IDBKeyRange? range = null);
     [NewObject, CallWith=CurrentGlobalObject] IDBRequest count(any key);

--- a/Source/WebCore/Modules/indexeddb/IDBRecord.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBRecord.idl
@@ -25,7 +25,7 @@
 
 // https://w3c.github.io/IndexedDB/#idbrecord
 [
-    EnabledBySetting=IndexedDBGetAllRecordsEnabled,
+    EnabledBySetting=IndexedDBGetAllRecordsAndGetAllOptionsEnabled,
     Exposed=(Window,Worker)
 ] interface IDBRecord {
     [CustomGetter] readonly attribute any key;


### PR DESCRIPTION
#### fcb6dde552d08ee313a877685459bb02022d490e
<pre>
[IndexedDB API] Enable getAllRecords() and IDBGetAllOptions in Preview
<a href="https://bugs.webkit.org/show_bug.cgi?id=311282">https://bugs.webkit.org/show_bug.cgi?id=311282</a>
<a href="https://rdar.apple.com/173881825">rdar://173881825</a>

Reviewed by Tim Nguyen.

Full support for getAllRecords() on IDBObjectStore and IDBIndex has been added.
Full support for getAll()/getAllKeys() accepting IDBGetAllOptions and supporting
direction has been added.

So we can enable these in Preview.

We also rename the feature flag to reflect the full functionality it guards.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/indexeddb/IDBGetAllOptions.idl:
* Source/WebCore/Modules/indexeddb/IDBIndex.cpp:
(WebCore::IDBIndex::getAll):
(WebCore::IDBIndex::getAllKeys):
* Source/WebCore/Modules/indexeddb/IDBIndex.idl:
* Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp:
(WebCore::IDBObjectStore::getAll):
(WebCore::IDBObjectStore::getAllKeys):
* Source/WebCore/Modules/indexeddb/IDBObjectStore.idl:
* Source/WebCore/Modules/indexeddb/IDBRecord.idl:

Canonical link: <a href="https://commits.webkit.org/310462@main">https://commits.webkit.org/310462@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa64c11ad96edb9e1988b278a747c70632e128de

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153758 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26542 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20159 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162509 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107219 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155631 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27070 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26864 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118883 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84062 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d5a9da53-fa24-4b76-9a88-d0171b996d4c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156717 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21142 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138069 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99593 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20222 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18181 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10341 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/145771 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129870 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15928 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164979 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/14582 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8113 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17522 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126962 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26339 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22212 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127129 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26341 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137723 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83019 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23515 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22038 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14506 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/185394 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25958 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90246 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47553 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25649 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25809 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25709 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->